### PR TITLE
feat(bench): MemCorrect via Correction Contract + Tier-L artifacts + paper \u00a73/\u00a76.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- MemCorrect now routes Remnic corrections through the Correction Contract
+  (plan + confirmed apply) via the public access-service surface, with an
+  explicit turn-path fallback when the planner produces no applicable action.
+  `remnic bench run memcorrect-v1 --memcorrect-adapter <remnic|prompt-only>`
+  selects the adapter from the CLI.
+
 ## [v9.3.764] — 2026-07-11
 
 ### Changed

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -293,12 +293,32 @@ re-ingest, collateral damage to unrelated memories, scope precision,
 false-apply, and re-assertion. It is system-agnostic — any memory system
 that implements the `MemCorrectSystemAdapter` interface can be scored.
 Methodology, metric definitions, and the submission contract are in
-[`docs/benchmarks/memcorrect.md`](./benchmarks/memcorrect.md). Lab
-artifacts land in `docs/benchmarks/results/` once the local-lab Tier-L run
-completes; until then the hermetic synthetic-corpus smoke (`remnic bench run
-memcorrect-v1 --quick`) is the reproducible in-tree check. By default this
-exercises the Remnic-native adapter (the bench `system`); the prompt-only
-baseline is a programmatic adapter (see `runner.test.ts`), not a CLI mode.
+[`docs/benchmarks/memcorrect.md`](./benchmarks/memcorrect.md).
+
+**Tier-L full-matrix artifacts (2026-07-13, commit `9485f448`, RTX 3090):**
+two committed 40-scenario `mode: full` runs (seed `0xc077e7`) —
+`results/2026-07-13-memcorrect-v1-remnic-native-9485f44.json`
+(runtime profile `real`: Remnic's shipped defaults with the fact pipeline
+and Correction Contract active; extraction + correction classification on
+`qwen2.5-7b-32k:latest`; pinned config in
+`configs/memcorrect-lab-remnic-config.json`) and
+`results/2026-07-13-memcorrect-v1-prompt-only-baseline-9485f44.json`
+(the hermetic append-only floor). Adapter selection is a CLI mode:
+`remnic bench run memcorrect-v1 --memcorrect-adapter <remnic|prompt-only>`;
+the Remnic adapter routes `correct()` through the Correction Contract
+(plan + confirmed apply) with the plain turn path as fallback.
+
+**Honest reading of the Tier-L numbers:** both adapters land on the floor
+for the containment-scored metrics (`uptake_at_next = 0`,
+`non_resurrection = 0`, `false_apply = 1`). Per-scenario tracing shows the
+Remnic correction path itself works — the fact is extracted, the contract
+plan applies, the stored fact is retired — but stale content still reaches
+recall through the 7B classify model drafting retire-only actions (no
+corrected replacement fact), surviving behavioral-profile lines, and
+verbatim LCM turn evidence quoting the outdated statement. MemCorrect is
+deliberately strict: serving a stale value anywhere in recall context fails
+the probe. These artifacts are the reproducibility anchor for that finding,
+not a leaderboard bragging number.
 
 ## Ethics
 

--- a/docs/benchmarks/artifact-manifest.json
+++ b/docs/benchmarks/artifact-manifest.json
@@ -3,6 +3,11 @@
     "2026-04-20-locomo-gpt-4o-mini-mock000.json",
     "2026-04-20-longmemeval-gpt-4o-mini-mock000.json",
     "2026-07-07-locomo-qwen2.5-7b-32k_latest-47aae03.json",
-    "2026-07-07-longmemeval-qwen2.5-7b-32k_latest-47aae03.json"
+    "2026-07-07-locomo-qwen2.5-7b-32k_latest-c67c2c7-contradiction-scan-on.json",
+    "2026-07-07-locomo-qwen2.5-7b-32k_latest-c67c2c7-graph-recall-on.json",
+    "2026-07-07-locomo-qwen2.5-7b-32k_latest-c67c2c7-memory-worth-off.json",
+    "2026-07-07-longmemeval-qwen2.5-7b-32k_latest-47aae03.json",
+    "2026-07-08-locomo-opus-via-claude-code-trial100-798fe8a.json",
+    "2026-07-08-longmemeval-opus-via-claude-code-trial50-798fe8a.json"
   ]
 }

--- a/docs/benchmarks/artifact-manifest.json
+++ b/docs/benchmarks/artifact-manifest.json
@@ -8,6 +8,8 @@
     "2026-07-07-locomo-qwen2.5-7b-32k_latest-c67c2c7-memory-worth-off.json",
     "2026-07-07-longmemeval-qwen2.5-7b-32k_latest-47aae03.json",
     "2026-07-08-locomo-opus-via-claude-code-trial100-798fe8a.json",
-    "2026-07-08-longmemeval-opus-via-claude-code-trial50-798fe8a.json"
+    "2026-07-08-longmemeval-opus-via-claude-code-trial50-798fe8a.json",
+    "2026-07-13-memcorrect-v1-prompt-only-baseline-9485f44.json",
+    "2026-07-13-memcorrect-v1-remnic-native-9485f44.json"
   ]
 }

--- a/docs/benchmarks/configs/local-lab-3090.json
+++ b/docs/benchmarks/configs/local-lab-3090.json
@@ -1,0 +1,26 @@
+{
+  "profile": "local-lab",
+  "responder": {
+    "provider": "ollama",
+    "baseUrl": "http://127.0.0.1:11434",
+    "model": "qwen2.5-7b-32k:latest",
+    "quantization": "Q4_K_M",
+    "ctx": 32768,
+    "temperature": 0,
+    "seed": 47
+  },
+  "judge": {
+    "provider": "ollama",
+    "baseUrl": "http://127.0.0.1:11434",
+    "model": "qwen2.5-7b-32k:latest",
+    "quantization": "Q4_K_M",
+    "ctx": 32768,
+    "temperature": 0,
+    "seed": 47
+  },
+  "phases": "sequential",
+  "notes": {
+    "host": "RTX 3090 lab box (24 GB VRAM), Ollama transport",
+    "usage": "Tier-L local-lab runs and `remnic bench judge-calibrate` (the judge role is the Tier-L side of the Cohen's-kappa cross-tier calibration; the Tier-F gold judge is supplied via --judge-provider/--judge-model)."
+  }
+}

--- a/docs/benchmarks/configs/memcorrect-lab-remnic-config.json
+++ b/docs/benchmarks/configs/memcorrect-lab-remnic-config.json
@@ -1,0 +1,10 @@
+{
+  "$comment": "Pinned Remnic config for the MemCorrect v1 lab run (issue #1725 / plan item 2b). Used with `remnic bench run memcorrect-v1 --runtime-profile real --remnic-config <this file> --memcorrect-adapter remnic` on the RTX 3090 lab host. The real profile preserves Remnic's shipped defaults (full fact pipeline, contradiction detection, tombstones, correction contract); this file pins only the local-LLM endpoint and the extraction gates so the run is hermetic and reproducible without environment-variable templating.",
+  "modelSource": "plugin",
+  "localLlmEnabled": true,
+  "localLlmFallback": false,
+  "localLlmUrl": "http://127.0.0.1:11434",
+  "localLlmModel": "qwen2.5-7b-32k:latest",
+  "extractionMinUserTurns": 0,
+  "extractionMinChars": 10
+}

--- a/docs/benchmarks/results/2026-07-13-memcorrect-v1-prompt-only-baseline-9485f44.json
+++ b/docs/benchmarks/results/2026-07-13-memcorrect-v1-prompt-only-baseline-9485f44.json
@@ -82,7 +82,7 @@
       "leaderboardArtifacts": [
         {
           "benchmark": "memcorrect-v1",
-          "path": "/home/joshuawarren/.remnic/bench/results/leaderboard/memcorrect-prompt-only-baseline-2026-07-13T20-47-40-328Z.jsonl",
+          "path": "~/.remnic/bench/results/leaderboard/memcorrect-prompt-only-baseline-2026-07-13T20-47-40-328Z.jsonl",
           "format": "memcorrect-adapter-metrics-jsonl",
           "records": 1
         }
@@ -105,7 +105,7 @@
         "taskId": "memcorrect-12613607-0",
         "question": "what is my database preference?",
         "expected": "{\"correctedContent\":[\"neovim\"],\"retiredContent\":[\"nine-am\"]}",
-        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"Correction: my database record saying nine-am is wrong. It is now neovim.\",\"Got it — noting nine-am for database.\",\"My database preference is nine-am.\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"Correction: my database record saying nine-am is wrong. It is now neovim.\",\"Got it \u2014 noting nine-am for database.\",\"My database preference is nine-am.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -143,7 +143,7 @@
         "taskId": "memcorrect-12613607-1",
         "question": "what is my notebook preference?",
         "expected": "{\"correctedContent\":[\"neovim\"],\"retiredContent\":[\"postgres\"]}",
-        "actual": "{\"shape\":\"conversational\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched notebook from postgres to neovim last month.\",\"Got it — noting postgres for notebook.\",\"My notebook preference is postgres.\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched notebook from postgres to neovim last month.\",\"Got it \u2014 noting postgres for notebook.\",\"My notebook preference is postgres.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -181,7 +181,7 @@
         "taskId": "memcorrect-12613607-2",
         "question": "what is my notebook preference?",
         "expected": "{\"correctedContent\":[\"lined\"],\"retiredContent\":[\"nine-am\"]}",
-        "actual": "{\"shape\":\"scoped\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"For this project, notebook is lined now, not nine-am.\",\"Got it — noting nine-am for notebook.\",\"My notebook preference is nine-am.\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"For this project, notebook is lined now, not nine-am.\",\"Got it \u2014 noting nine-am for notebook.\",\"My notebook preference is nine-am.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -220,7 +220,7 @@
         "taskId": "memcorrect-12613607-3",
         "question": "what is my standup preference?",
         "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"mechanical\"]}",
-        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"Update: standup is mysql going forward instead of mechanical.\",\"Got it — noting mechanical for standup.\",\"My standup preference is mechanical.\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"Update: standup is mysql going forward instead of mechanical.\",\"Got it \u2014 noting mechanical for standup.\",\"My standup preference is mechanical.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -259,7 +259,7 @@
         "taskId": "memcorrect-12613607-4",
         "question": "what is my keyboard preference?",
         "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"monday\"]}",
-        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"Correction: my keyboard record saying monday is wrong. It is now canary.\",\"Got it — noting monday for keyboard.\",\"My keyboard preference is monday.\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"Correction: my keyboard record saying monday is wrong. It is now canary.\",\"Got it \u2014 noting monday for keyboard.\",\"My keyboard preference is monday.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -297,7 +297,7 @@
         "taskId": "memcorrect-12613607-5",
         "question": "what is my database preference?",
         "expected": "{\"correctedContent\":[\"ten-am\"],\"retiredContent\":[\"postgres\"]}",
-        "actual": "{\"shape\":\"conversational\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched database from postgres to ten-am last month.\",\"Got it — noting postgres for database.\",\"My database preference is postgres.\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched database from postgres to ten-am last month.\",\"Got it \u2014 noting postgres for database.\",\"My database preference is postgres.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -335,7 +335,7 @@
         "taskId": "memcorrect-12613607-6",
         "question": "what is my calendar preference?",
         "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"mechanical\"]}",
-        "actual": "{\"shape\":\"scoped\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"For this project, calendar is wednesday now, not mechanical.\",\"Got it — noting mechanical for calendar.\",\"My calendar preference is mechanical.\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"For this project, calendar is wednesday now, not mechanical.\",\"Got it \u2014 noting mechanical for calendar.\",\"My calendar preference is mechanical.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -374,7 +374,7 @@
         "taskId": "memcorrect-12613607-7",
         "question": "what is my coffee preference?",
         "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"nine-am\"]}",
-        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"Update: coffee is wednesday going forward instead of nine-am.\",\"Got it — noting nine-am for coffee.\",\"My coffee preference is nine-am.\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"Update: coffee is wednesday going forward instead of nine-am.\",\"Got it \u2014 noting nine-am for coffee.\",\"My coffee preference is nine-am.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -413,7 +413,7 @@
         "taskId": "memcorrect-12613607-8",
         "question": "what is my database preference?",
         "expected": "{\"correctedContent\":[\"ten-am\"],\"retiredContent\":[\"nine-am\"]}",
-        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"Correction: my database record saying nine-am is wrong. It is now ten-am.\",\"Got it — noting nine-am for database.\",\"My database preference is nine-am.\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"Correction: my database record saying nine-am is wrong. It is now ten-am.\",\"Got it \u2014 noting nine-am for database.\",\"My database preference is nine-am.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -451,7 +451,7 @@
         "taskId": "memcorrect-12613607-9",
         "question": "what is my editor preference?",
         "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"postgres\"]}",
-        "actual": "{\"shape\":\"conversational\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched editor from postgres to canary last month.\",\"Got it — noting postgres for editor.\",\"My editor preference is postgres.\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched editor from postgres to canary last month.\",\"Got it \u2014 noting postgres for editor.\",\"My editor preference is postgres.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -489,7 +489,7 @@
         "taskId": "memcorrect-12613607-a",
         "question": "what is my calendar preference?",
         "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"postgres\"]}",
-        "actual": "{\"shape\":\"scoped\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"For this project, calendar is canary now, not postgres.\",\"Got it — noting postgres for calendar.\",\"My calendar preference is postgres.\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"For this project, calendar is canary now, not postgres.\",\"Got it \u2014 noting postgres for calendar.\",\"My calendar preference is postgres.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -528,7 +528,7 @@
         "taskId": "memcorrect-12613607-b",
         "question": "what is my editor preference?",
         "expected": "{\"correctedContent\":[\"ten-am\"],\"retiredContent\":[\"nine-am\"]}",
-        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"Update: editor is ten-am going forward instead of nine-am.\",\"Got it — noting nine-am for editor.\",\"My editor preference is nine-am.\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"Update: editor is ten-am going forward instead of nine-am.\",\"Got it \u2014 noting nine-am for editor.\",\"My editor preference is nine-am.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -567,7 +567,7 @@
         "taskId": "memcorrect-12613607-c",
         "question": "what is my deploy preference?",
         "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"monday\"]}",
-        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"Correction: my deploy record saying monday is wrong. It is now black-coffee.\",\"Got it — noting monday for deploy.\",\"My deploy preference is monday.\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"Correction: my deploy record saying monday is wrong. It is now black-coffee.\",\"Got it \u2014 noting monday for deploy.\",\"My deploy preference is monday.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -605,7 +605,7 @@
         "taskId": "memcorrect-12613607-d",
         "question": "what is my keyboard preference?",
         "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"monday\"]}",
-        "actual": "{\"shape\":\"conversational\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched keyboard from monday to mysql last month.\",\"Got it — noting monday for keyboard.\",\"My keyboard preference is monday.\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched keyboard from monday to mysql last month.\",\"Got it \u2014 noting monday for keyboard.\",\"My keyboard preference is monday.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -643,7 +643,7 @@
         "taskId": "memcorrect-12613607-e",
         "question": "what is my deploy preference?",
         "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"helix\"]}",
-        "actual": "{\"shape\":\"scoped\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"For this project, deploy is black-coffee now, not helix.\",\"Got it — noting helix for deploy.\",\"My deploy preference is helix.\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"For this project, deploy is black-coffee now, not helix.\",\"Got it \u2014 noting helix for deploy.\",\"My deploy preference is helix.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -682,7 +682,7 @@
         "taskId": "memcorrect-12613607-f",
         "question": "what is my standup preference?",
         "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"mechanical\"]}",
-        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"Update: standup is black-coffee going forward instead of mechanical.\",\"Got it — noting mechanical for standup.\",\"My standup preference is mechanical.\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"Update: standup is black-coffee going forward instead of mechanical.\",\"Got it \u2014 noting mechanical for standup.\",\"My standup preference is mechanical.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -721,7 +721,7 @@
         "taskId": "memcorrect-12613607-10",
         "question": "what is my deploy preference?",
         "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"nine-am\"]}",
-        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"Correction: my deploy record saying nine-am is wrong. It is now mysql.\",\"Got it — noting nine-am for deploy.\",\"My deploy preference is nine-am.\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"Correction: my deploy record saying nine-am is wrong. It is now mysql.\",\"Got it \u2014 noting nine-am for deploy.\",\"My deploy preference is nine-am.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -759,7 +759,7 @@
         "taskId": "memcorrect-12613607-11",
         "question": "what is my notebook preference?",
         "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"mechanical\"]}",
-        "actual": "{\"shape\":\"conversational\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched notebook from mechanical to mysql last month.\",\"Got it — noting mechanical for notebook.\",\"My notebook preference is mechanical.\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched notebook from mechanical to mysql last month.\",\"Got it \u2014 noting mechanical for notebook.\",\"My notebook preference is mechanical.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -797,7 +797,7 @@
         "taskId": "memcorrect-12613607-12",
         "question": "what is my notebook preference?",
         "expected": "{\"correctedContent\":[\"membrane\"],\"retiredContent\":[\"oat-milk\"]}",
-        "actual": "{\"shape\":\"scoped\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"For this project, notebook is membrane now, not oat-milk.\",\"Got it — noting oat-milk for notebook.\",\"My notebook preference is oat-milk.\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"For this project, notebook is membrane now, not oat-milk.\",\"Got it \u2014 noting oat-milk for notebook.\",\"My notebook preference is oat-milk.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -836,7 +836,7 @@
         "taskId": "memcorrect-12613607-13",
         "question": "what is my keyboard preference?",
         "expected": "{\"correctedContent\":[\"lined\"],\"retiredContent\":[\"nine-am\"]}",
-        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"Update: keyboard is lined going forward instead of nine-am.\",\"Got it — noting nine-am for keyboard.\",\"My keyboard preference is nine-am.\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"Update: keyboard is lined going forward instead of nine-am.\",\"Got it \u2014 noting nine-am for keyboard.\",\"My keyboard preference is nine-am.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -875,7 +875,7 @@
         "taskId": "memcorrect-12613607-14",
         "question": "what is my deploy preference?",
         "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"postgres\"]}",
-        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"Correction: my deploy record saying postgres is wrong. It is now canary.\",\"Got it — noting postgres for deploy.\",\"My deploy preference is postgres.\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"Correction: my deploy record saying postgres is wrong. It is now canary.\",\"Got it \u2014 noting postgres for deploy.\",\"My deploy preference is postgres.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -913,7 +913,7 @@
         "taskId": "memcorrect-12613607-15",
         "question": "what is my coffee preference?",
         "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"nine-am\"]}",
-        "actual": "{\"shape\":\"conversational\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched coffee from nine-am to wednesday last month.\",\"Got it — noting nine-am for coffee.\",\"My coffee preference is nine-am.\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched coffee from nine-am to wednesday last month.\",\"Got it \u2014 noting nine-am for coffee.\",\"My coffee preference is nine-am.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -951,7 +951,7 @@
         "taskId": "memcorrect-12613607-16",
         "question": "what is my coffee preference?",
         "expected": "{\"correctedContent\":[\"membrane\"],\"retiredContent\":[\"blue-green\"]}",
-        "actual": "{\"shape\":\"scoped\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"For this project, coffee is membrane now, not blue-green.\",\"Got it — noting blue-green for coffee.\",\"My coffee preference is blue-green.\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"For this project, coffee is membrane now, not blue-green.\",\"Got it \u2014 noting blue-green for coffee.\",\"My coffee preference is blue-green.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -990,7 +990,7 @@
         "taskId": "memcorrect-12613607-17",
         "question": "what is my keyboard preference?",
         "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"nine-am\"]}",
-        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"Update: keyboard is black-coffee going forward instead of nine-am.\",\"Got it — noting nine-am for keyboard.\",\"My keyboard preference is nine-am.\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"Update: keyboard is black-coffee going forward instead of nine-am.\",\"Got it \u2014 noting nine-am for keyboard.\",\"My keyboard preference is nine-am.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1029,7 +1029,7 @@
         "taskId": "memcorrect-12613607-18",
         "question": "what is my standup preference?",
         "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"dotgrid\"]}",
-        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"Correction: my standup record saying dotgrid is wrong. It is now black-coffee.\",\"Got it — noting dotgrid for standup.\",\"My standup preference is dotgrid.\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"Correction: my standup record saying dotgrid is wrong. It is now black-coffee.\",\"Got it \u2014 noting dotgrid for standup.\",\"My standup preference is dotgrid.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1067,7 +1067,7 @@
         "taskId": "memcorrect-12613607-19",
         "question": "what is my database preference?",
         "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"helix\"]}",
-        "actual": "{\"shape\":\"conversational\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched database from helix to wednesday last month.\",\"Got it — noting helix for database.\",\"My database preference is helix.\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched database from helix to wednesday last month.\",\"Got it \u2014 noting helix for database.\",\"My database preference is helix.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1105,7 +1105,7 @@
         "taskId": "memcorrect-12613607-1a",
         "question": "what is my keyboard preference?",
         "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"oat-milk\"]}",
-        "actual": "{\"shape\":\"scoped\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"For this project, keyboard is wednesday now, not oat-milk.\",\"Got it — noting oat-milk for keyboard.\",\"My keyboard preference is oat-milk.\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"For this project, keyboard is wednesday now, not oat-milk.\",\"Got it \u2014 noting oat-milk for keyboard.\",\"My keyboard preference is oat-milk.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1144,7 +1144,7 @@
         "taskId": "memcorrect-12613607-1b",
         "question": "what is my database preference?",
         "expected": "{\"correctedContent\":[\"lined\"],\"retiredContent\":[\"postgres\"]}",
-        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"Update: database is lined going forward instead of postgres.\",\"Got it — noting postgres for database.\",\"My database preference is postgres.\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"Update: database is lined going forward instead of postgres.\",\"Got it \u2014 noting postgres for database.\",\"My database preference is postgres.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1183,7 +1183,7 @@
         "taskId": "memcorrect-12613607-1c",
         "question": "what is my editor preference?",
         "expected": "{\"correctedContent\":[\"membrane\"],\"retiredContent\":[\"helix\"]}",
-        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"Correction: my editor record saying helix is wrong. It is now membrane.\",\"Got it — noting helix for editor.\",\"My editor preference is helix.\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"Correction: my editor record saying helix is wrong. It is now membrane.\",\"Got it \u2014 noting helix for editor.\",\"My editor preference is helix.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1221,7 +1221,7 @@
         "taskId": "memcorrect-12613607-1d",
         "question": "what is my standup preference?",
         "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"postgres\"]}",
-        "actual": "{\"shape\":\"conversational\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched standup from postgres to mysql last month.\",\"Got it — noting postgres for standup.\",\"My standup preference is postgres.\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched standup from postgres to mysql last month.\",\"Got it \u2014 noting postgres for standup.\",\"My standup preference is postgres.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1259,7 +1259,7 @@
         "taskId": "memcorrect-12613607-1e",
         "question": "what is my standup preference?",
         "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"postgres\"]}",
-        "actual": "{\"shape\":\"scoped\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"For this project, standup is black-coffee now, not postgres.\",\"Got it — noting postgres for standup.\",\"My standup preference is postgres.\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"For this project, standup is black-coffee now, not postgres.\",\"Got it \u2014 noting postgres for standup.\",\"My standup preference is postgres.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1298,7 +1298,7 @@
         "taskId": "memcorrect-12613607-1f",
         "question": "what is my calendar preference?",
         "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"mechanical\"]}",
-        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"Update: calendar is canary going forward instead of mechanical.\",\"Got it — noting mechanical for calendar.\",\"My calendar preference is mechanical.\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"Update: calendar is canary going forward instead of mechanical.\",\"Got it \u2014 noting mechanical for calendar.\",\"My calendar preference is mechanical.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1337,7 +1337,7 @@
         "taskId": "memcorrect-12613607-20",
         "question": "what is my editor preference?",
         "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"nine-am\"]}",
-        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"Correction: my editor record saying nine-am is wrong. It is now mysql.\",\"Got it — noting nine-am for editor.\",\"My editor preference is nine-am.\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"Correction: my editor record saying nine-am is wrong. It is now mysql.\",\"Got it \u2014 noting nine-am for editor.\",\"My editor preference is nine-am.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1375,7 +1375,7 @@
         "taskId": "memcorrect-12613607-21",
         "question": "what is my database preference?",
         "expected": "{\"correctedContent\":[\"neovim\"],\"retiredContent\":[\"dotgrid\"]}",
-        "actual": "{\"shape\":\"conversational\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched database from dotgrid to neovim last month.\",\"Got it — noting dotgrid for database.\",\"My database preference is dotgrid.\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched database from dotgrid to neovim last month.\",\"Got it \u2014 noting dotgrid for database.\",\"My database preference is dotgrid.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1413,7 +1413,7 @@
         "taskId": "memcorrect-12613607-22",
         "question": "what is my keyboard preference?",
         "expected": "{\"correctedContent\":[\"membrane\"],\"retiredContent\":[\"dotgrid\"]}",
-        "actual": "{\"shape\":\"scoped\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"For this project, keyboard is membrane now, not dotgrid.\",\"Got it — noting dotgrid for keyboard.\",\"My keyboard preference is dotgrid.\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"For this project, keyboard is membrane now, not dotgrid.\",\"Got it \u2014 noting dotgrid for keyboard.\",\"My keyboard preference is dotgrid.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1452,7 +1452,7 @@
         "taskId": "memcorrect-12613607-23",
         "question": "what is my deploy preference?",
         "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"monday\"]}",
-        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"Update: deploy is canary going forward instead of monday.\",\"Got it — noting monday for deploy.\",\"My deploy preference is monday.\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"Update: deploy is canary going forward instead of monday.\",\"Got it \u2014 noting monday for deploy.\",\"My deploy preference is monday.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1491,7 +1491,7 @@
         "taskId": "memcorrect-12613607-24",
         "question": "what is my coffee preference?",
         "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"blue-green\"]}",
-        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"Correction: my coffee record saying blue-green is wrong. It is now mysql.\",\"Got it — noting blue-green for coffee.\",\"My coffee preference is blue-green.\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"Correction: my coffee record saying blue-green is wrong. It is now mysql.\",\"Got it \u2014 noting blue-green for coffee.\",\"My coffee preference is blue-green.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1529,7 +1529,7 @@
         "taskId": "memcorrect-12613607-25",
         "question": "what is my editor preference?",
         "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"monday\"]}",
-        "actual": "{\"shape\":\"conversational\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched editor from monday to black-coffee last month.\",\"Got it — noting monday for editor.\",\"My editor preference is monday.\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched editor from monday to black-coffee last month.\",\"Got it \u2014 noting monday for editor.\",\"My editor preference is monday.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1567,7 +1567,7 @@
         "taskId": "memcorrect-12613607-26",
         "question": "what is my editor preference?",
         "expected": "{\"correctedContent\":[\"lined\"],\"retiredContent\":[\"helix\"]}",
-        "actual": "{\"shape\":\"scoped\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"For this project, editor is lined now, not helix.\",\"Got it — noting helix for editor.\",\"My editor preference is helix.\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"For this project, editor is lined now, not helix.\",\"Got it \u2014 noting helix for editor.\",\"My editor preference is helix.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,
@@ -1606,7 +1606,7 @@
         "taskId": "memcorrect-12613607-27",
         "question": "what is my keyboard preference?",
         "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"mechanical\"]}",
-        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"Update: keyboard is black-coffee going forward instead of mechanical.\",\"Got it — noting mechanical for keyboard.\",\"My keyboard preference is mechanical.\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"Update: keyboard is black-coffee going forward instead of mechanical.\",\"Got it \u2014 noting mechanical for keyboard.\",\"My keyboard preference is mechanical.\"]}",
         "scores": {
           "uptake_at_next": 0,
           "uptake_latency": 8,

--- a/docs/benchmarks/results/2026-07-13-memcorrect-v1-prompt-only-baseline-9485f44.json
+++ b/docs/benchmarks/results/2026-07-13-memcorrect-v1-prompt-only-baseline-9485f44.json
@@ -1,0 +1,1706 @@
+{
+  "meta": {
+    "id": "e588ff22-fb56-464c-ad45-600ae16eb69d",
+    "benchmark": "memcorrect-v1",
+    "benchmarkTier": "remnic",
+    "version": "1.0.0",
+    "remnicVersion": "9.6.10",
+    "gitSha": "9485f4482",
+    "timestamp": "2026-07-13T20:47:40.328Z",
+    "mode": "full",
+    "runCount": 1,
+    "seeds": [
+      12613607
+    ],
+    "datasetHash": "ebbb5889561188354171d3f1323b1284e6c6dc36e40d5fd5cf718ec722401acb"
+  },
+  "config": {
+    "runtimeProfile": "baseline",
+    "systemProvider": null,
+    "judgeProvider": null,
+    "adapterMode": "prompt-only-baseline",
+    "remnicConfig": {
+      "qmdEnabled": false,
+      "qmdColdTierEnabled": false,
+      "transcriptEnabled": false,
+      "hourlySummariesEnabled": false,
+      "daySummaryEnabled": false,
+      "identityEnabled": false,
+      "identityContinuityEnabled": false,
+      "namespacesEnabled": false,
+      "sharedContextEnabled": false,
+      "workTasksEnabled": false,
+      "workProjectsEnabled": false,
+      "commitmentLedgerEnabled": false,
+      "resumeBundlesEnabled": false,
+      "nativeKnowledge": {
+        "enabled": false
+      },
+      "lcmLeafBatchSize": 64,
+      "lcmRollupFanIn": 8,
+      "lcmFreshTailTurns": 64,
+      "lcmMaxDepth": 4,
+      "lcmDeterministicMaxTokens": 512,
+      "lcmRecallBudgetShare": 1,
+      "queryExpansionEnabled": false,
+      "rerankEnabled": false,
+      "memoryBoxesEnabled": false,
+      "traceWeaverEnabled": false,
+      "threadingEnabled": false,
+      "factDeduplicationEnabled": false,
+      "knowledgeIndexEnabled": false,
+      "entityRetrievalEnabled": false,
+      "verifiedRecallEnabled": false,
+      "queryAwareIndexingEnabled": false,
+      "contradictionDetectionEnabled": false,
+      "memoryLinkingEnabled": false,
+      "topicExtractionEnabled": false,
+      "chunkingEnabled": true,
+      "episodeNoteModeEnabled": false,
+      "extractionDedupeEnabled": true,
+      "extractionMinChars": 10,
+      "extractionMinUserTurns": 0,
+      "recallPlannerEnabled": true,
+      "lcmEnabled": true
+    },
+    "benchmarkOptions": {
+      "personaCount": 5,
+      "factsPerPersona": 8,
+      "maintenanceCycles": 5,
+      "uptakeLatencyCap": 8,
+      "aggregateMetrics": {
+        "uptake_at_next": 0,
+        "uptake_latency": 8,
+        "uptake_latency_censored": 40,
+        "non_resurrection": 0,
+        "collateral_delta": 0,
+        "scope_precision": 0,
+        "false_apply": 1,
+        "reassertion": 1,
+        "provenance_fidelity": null
+      },
+      "leaderboardArtifacts": [
+        {
+          "benchmark": "memcorrect-v1",
+          "path": "/home/joshuawarren/.remnic/bench/results/leaderboard/memcorrect-prompt-only-baseline-2026-07-13T20-47-40-328Z.jsonl",
+          "format": "memcorrect-adapter-metrics-jsonl",
+          "records": 1
+        }
+      ]
+    },
+    "internalProvider": null
+  },
+  "cost": {
+    "totalTokens": 0,
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "estimatedCostUsd": 0,
+    "totalLatencyMs": 6,
+    "meanQueryLatencyMs": 0.15,
+    "judgeModelCalls": 0
+  },
+  "results": {
+    "tasks": [
+      {
+        "taskId": "memcorrect-12613607-0",
+        "question": "what is my database preference?",
+        "expected": "{\"correctedContent\":[\"neovim\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"Correction: my database record saying nine-am is wrong. It is now neovim.\",\"Got it — noting nine-am for database.\",\"My database preference is nine-am.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 2,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-0",
+          "shape": "explicit-targeted",
+          "category": "fact",
+          "namespace": "avery-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1",
+        "question": "what is my notebook preference?",
+        "expected": "{\"correctedContent\":[\"neovim\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched notebook from postgres to neovim last month.\",\"Got it — noting postgres for notebook.\",\"My notebook preference is postgres.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1",
+          "shape": "conversational",
+          "category": "preference",
+          "namespace": "avery-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-2",
+        "question": "what is my notebook preference?",
+        "expected": "{\"correctedContent\":[\"lined\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"For this project, notebook is lined now, not nine-am.\",\"Got it — noting nine-am for notebook.\",\"My notebook preference is nine-am.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-2",
+          "shape": "scoped",
+          "category": "decision",
+          "namespace": "avery-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-3",
+        "question": "what is my standup preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"mechanical\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"Update: standup is mysql going forward instead of mechanical.\",\"Got it — noting mechanical for standup.\",\"My standup preference is mechanical.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-3",
+          "shape": "re-assertion",
+          "category": "commitment",
+          "namespace": "avery-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-4",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"monday\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"Correction: my keyboard record saying monday is wrong. It is now canary.\",\"Got it — noting monday for keyboard.\",\"My keyboard preference is monday.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 1,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-4",
+          "shape": "explicit-targeted",
+          "category": "relationship",
+          "namespace": "avery-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-5",
+        "question": "what is my database preference?",
+        "expected": "{\"correctedContent\":[\"ten-am\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched database from postgres to ten-am last month.\",\"Got it — noting postgres for database.\",\"My database preference is postgres.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-5",
+          "shape": "conversational",
+          "category": "fact",
+          "namespace": "avery-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-6",
+        "question": "what is my calendar preference?",
+        "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"mechanical\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"For this project, calendar is wednesday now, not mechanical.\",\"Got it — noting mechanical for calendar.\",\"My calendar preference is mechanical.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-6",
+          "shape": "scoped",
+          "category": "preference",
+          "namespace": "avery-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-7",
+        "question": "what is my coffee preference?",
+        "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"Update: coffee is wednesday going forward instead of nine-am.\",\"Got it — noting nine-am for coffee.\",\"My coffee preference is nine-am.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-7",
+          "shape": "re-assertion",
+          "category": "decision",
+          "namespace": "avery-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-8",
+        "question": "what is my database preference?",
+        "expected": "{\"correctedContent\":[\"ten-am\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"Correction: my database record saying nine-am is wrong. It is now ten-am.\",\"Got it — noting nine-am for database.\",\"My database preference is nine-am.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-8",
+          "shape": "explicit-targeted",
+          "category": "commitment",
+          "namespace": "blair-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-9",
+        "question": "what is my editor preference?",
+        "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched editor from postgres to canary last month.\",\"Got it — noting postgres for editor.\",\"My editor preference is postgres.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-9",
+          "shape": "conversational",
+          "category": "relationship",
+          "namespace": "blair-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-a",
+        "question": "what is my calendar preference?",
+        "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"For this project, calendar is canary now, not postgres.\",\"Got it — noting postgres for calendar.\",\"My calendar preference is postgres.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-a",
+          "shape": "scoped",
+          "category": "fact",
+          "namespace": "blair-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-b",
+        "question": "what is my editor preference?",
+        "expected": "{\"correctedContent\":[\"ten-am\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"Update: editor is ten-am going forward instead of nine-am.\",\"Got it — noting nine-am for editor.\",\"My editor preference is nine-am.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-b",
+          "shape": "re-assertion",
+          "category": "preference",
+          "namespace": "blair-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-c",
+        "question": "what is my deploy preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"monday\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"Correction: my deploy record saying monday is wrong. It is now black-coffee.\",\"Got it — noting monday for deploy.\",\"My deploy preference is monday.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-c",
+          "shape": "explicit-targeted",
+          "category": "decision",
+          "namespace": "blair-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-d",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"monday\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched keyboard from monday to mysql last month.\",\"Got it — noting monday for keyboard.\",\"My keyboard preference is monday.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-d",
+          "shape": "conversational",
+          "category": "commitment",
+          "namespace": "blair-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-e",
+        "question": "what is my deploy preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"helix\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"For this project, deploy is black-coffee now, not helix.\",\"Got it — noting helix for deploy.\",\"My deploy preference is helix.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-e",
+          "shape": "scoped",
+          "category": "relationship",
+          "namespace": "blair-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-f",
+        "question": "what is my standup preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"mechanical\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"Update: standup is black-coffee going forward instead of mechanical.\",\"Got it — noting mechanical for standup.\",\"My standup preference is mechanical.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-f",
+          "shape": "re-assertion",
+          "category": "fact",
+          "namespace": "blair-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-10",
+        "question": "what is my deploy preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"Correction: my deploy record saying nine-am is wrong. It is now mysql.\",\"Got it — noting nine-am for deploy.\",\"My deploy preference is nine-am.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-10",
+          "shape": "explicit-targeted",
+          "category": "preference",
+          "namespace": "cassidy-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-11",
+        "question": "what is my notebook preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"mechanical\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched notebook from mechanical to mysql last month.\",\"Got it — noting mechanical for notebook.\",\"My notebook preference is mechanical.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-11",
+          "shape": "conversational",
+          "category": "decision",
+          "namespace": "cassidy-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-12",
+        "question": "what is my notebook preference?",
+        "expected": "{\"correctedContent\":[\"membrane\"],\"retiredContent\":[\"oat-milk\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"For this project, notebook is membrane now, not oat-milk.\",\"Got it — noting oat-milk for notebook.\",\"My notebook preference is oat-milk.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-12",
+          "shape": "scoped",
+          "category": "commitment",
+          "namespace": "cassidy-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-13",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"lined\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"Update: keyboard is lined going forward instead of nine-am.\",\"Got it — noting nine-am for keyboard.\",\"My keyboard preference is nine-am.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 3,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-13",
+          "shape": "re-assertion",
+          "category": "relationship",
+          "namespace": "cassidy-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-14",
+        "question": "what is my deploy preference?",
+        "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"Correction: my deploy record saying postgres is wrong. It is now canary.\",\"Got it — noting postgres for deploy.\",\"My deploy preference is postgres.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-14",
+          "shape": "explicit-targeted",
+          "category": "fact",
+          "namespace": "cassidy-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-15",
+        "question": "what is my coffee preference?",
+        "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched coffee from nine-am to wednesday last month.\",\"Got it — noting nine-am for coffee.\",\"My coffee preference is nine-am.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-15",
+          "shape": "conversational",
+          "category": "preference",
+          "namespace": "cassidy-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-16",
+        "question": "what is my coffee preference?",
+        "expected": "{\"correctedContent\":[\"membrane\"],\"retiredContent\":[\"blue-green\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"For this project, coffee is membrane now, not blue-green.\",\"Got it — noting blue-green for coffee.\",\"My coffee preference is blue-green.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-16",
+          "shape": "scoped",
+          "category": "decision",
+          "namespace": "cassidy-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-17",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"Update: keyboard is black-coffee going forward instead of nine-am.\",\"Got it — noting nine-am for keyboard.\",\"My keyboard preference is nine-am.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-17",
+          "shape": "re-assertion",
+          "category": "commitment",
+          "namespace": "cassidy-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-18",
+        "question": "what is my standup preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"dotgrid\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"Correction: my standup record saying dotgrid is wrong. It is now black-coffee.\",\"Got it — noting dotgrid for standup.\",\"My standup preference is dotgrid.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-18",
+          "shape": "explicit-targeted",
+          "category": "relationship",
+          "namespace": "dakota-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-19",
+        "question": "what is my database preference?",
+        "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"helix\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched database from helix to wednesday last month.\",\"Got it — noting helix for database.\",\"My database preference is helix.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-19",
+          "shape": "conversational",
+          "category": "fact",
+          "namespace": "dakota-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1a",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"oat-milk\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"For this project, keyboard is wednesday now, not oat-milk.\",\"Got it — noting oat-milk for keyboard.\",\"My keyboard preference is oat-milk.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1a",
+          "shape": "scoped",
+          "category": "preference",
+          "namespace": "dakota-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1b",
+        "question": "what is my database preference?",
+        "expected": "{\"correctedContent\":[\"lined\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"Update: database is lined going forward instead of postgres.\",\"Got it — noting postgres for database.\",\"My database preference is postgres.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1b",
+          "shape": "re-assertion",
+          "category": "decision",
+          "namespace": "dakota-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1c",
+        "question": "what is my editor preference?",
+        "expected": "{\"correctedContent\":[\"membrane\"],\"retiredContent\":[\"helix\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"Correction: my editor record saying helix is wrong. It is now membrane.\",\"Got it — noting helix for editor.\",\"My editor preference is helix.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1c",
+          "shape": "explicit-targeted",
+          "category": "commitment",
+          "namespace": "dakota-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1d",
+        "question": "what is my standup preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched standup from postgres to mysql last month.\",\"Got it — noting postgres for standup.\",\"My standup preference is postgres.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1d",
+          "shape": "conversational",
+          "category": "relationship",
+          "namespace": "dakota-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1e",
+        "question": "what is my standup preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"For this project, standup is black-coffee now, not postgres.\",\"Got it — noting postgres for standup.\",\"My standup preference is postgres.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1e",
+          "shape": "scoped",
+          "category": "fact",
+          "namespace": "dakota-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1f",
+        "question": "what is my calendar preference?",
+        "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"mechanical\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"Update: calendar is canary going forward instead of mechanical.\",\"Got it — noting mechanical for calendar.\",\"My calendar preference is mechanical.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1f",
+          "shape": "re-assertion",
+          "category": "preference",
+          "namespace": "dakota-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-20",
+        "question": "what is my editor preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"Correction: my editor record saying nine-am is wrong. It is now mysql.\",\"Got it — noting nine-am for editor.\",\"My editor preference is nine-am.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-20",
+          "shape": "explicit-targeted",
+          "category": "decision",
+          "namespace": "emerson-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-21",
+        "question": "what is my database preference?",
+        "expected": "{\"correctedContent\":[\"neovim\"],\"retiredContent\":[\"dotgrid\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched database from dotgrid to neovim last month.\",\"Got it — noting dotgrid for database.\",\"My database preference is dotgrid.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-21",
+          "shape": "conversational",
+          "category": "commitment",
+          "namespace": "emerson-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-22",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"membrane\"],\"retiredContent\":[\"dotgrid\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"For this project, keyboard is membrane now, not dotgrid.\",\"Got it — noting dotgrid for keyboard.\",\"My keyboard preference is dotgrid.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-22",
+          "shape": "scoped",
+          "category": "relationship",
+          "namespace": "emerson-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-23",
+        "question": "what is my deploy preference?",
+        "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"monday\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"Update: deploy is canary going forward instead of monday.\",\"Got it — noting monday for deploy.\",\"My deploy preference is monday.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-23",
+          "shape": "re-assertion",
+          "category": "fact",
+          "namespace": "emerson-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-24",
+        "question": "what is my coffee preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"blue-green\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"Correction: my coffee record saying blue-green is wrong. It is now mysql.\",\"Got it — noting blue-green for coffee.\",\"My coffee preference is blue-green.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-24",
+          "shape": "explicit-targeted",
+          "category": "preference",
+          "namespace": "emerson-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-25",
+        "question": "what is my editor preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"monday\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"Oh by the way, we switched editor from monday to black-coffee last month.\",\"Got it — noting monday for editor.\",\"My editor preference is monday.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-25",
+          "shape": "conversational",
+          "category": "decision",
+          "namespace": "emerson-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-26",
+        "question": "what is my editor preference?",
+        "expected": "{\"correctedContent\":[\"lined\"],\"retiredContent\":[\"helix\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"For this project, editor is lined now, not helix.\",\"Got it — noting helix for editor.\",\"My editor preference is helix.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-26",
+          "shape": "scoped",
+          "category": "commitment",
+          "namespace": "emerson-work",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-27",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"mechanical\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"Update: keyboard is black-coffee going forward instead of mechanical.\",\"Got it — noting mechanical for keyboard.\",\"My keyboard preference is mechanical.\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-27",
+          "shape": "re-assertion",
+          "category": "relationship",
+          "namespace": "emerson-home",
+          "adapter": "prompt-only-baseline",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      }
+    ],
+    "aggregates": {
+      "uptake_at_next": {
+        "mean": 0,
+        "median": 0,
+        "stdDev": 0,
+        "min": 0,
+        "max": 0
+      },
+      "uptake_latency": {
+        "mean": 8,
+        "median": 8,
+        "stdDev": 0,
+        "min": 8,
+        "max": 8
+      },
+      "uptake_latency_censored": {
+        "mean": 1,
+        "median": 1,
+        "stdDev": 0,
+        "min": 1,
+        "max": 1
+      },
+      "non_resurrection": {
+        "mean": 0,
+        "median": 0,
+        "stdDev": 0,
+        "min": 0,
+        "max": 0
+      },
+      "false_apply": {
+        "mean": 1,
+        "median": 1,
+        "stdDev": 0,
+        "min": 1,
+        "max": 1
+      },
+      "scope_precision": {
+        "mean": 0,
+        "median": 0,
+        "stdDev": 0,
+        "min": 0,
+        "max": 0
+      },
+      "reassertion": {
+        "mean": 1,
+        "median": 1,
+        "stdDev": 0,
+        "min": 1,
+        "max": 1
+      }
+    },
+    "statistics": {
+      "confidenceIntervals": {},
+      "bootstrapSamples": 0
+    }
+  },
+  "environment": {
+    "os": "linux",
+    "nodeVersion": "v22.22.0",
+    "hardware": "x64"
+  }
+}

--- a/docs/benchmarks/results/2026-07-13-memcorrect-v1-remnic-native-9485f44.json
+++ b/docs/benchmarks/results/2026-07-13-memcorrect-v1-remnic-native-9485f44.json
@@ -1,0 +1,1673 @@
+{
+  "meta": {
+    "id": "cb03e09d-b468-4aab-9788-71bff31b95e1",
+    "benchmark": "memcorrect-v1",
+    "benchmarkTier": "remnic",
+    "version": "1.0.0",
+    "remnicVersion": "9.6.10",
+    "gitSha": "9485f4482",
+    "timestamp": "2026-07-13T20:47:36.910Z",
+    "mode": "full",
+    "runCount": 1,
+    "seeds": [
+      12613607
+    ],
+    "datasetHash": "ebbb5889561188354171d3f1323b1284e6c6dc36e40d5fd5cf718ec722401acb"
+  },
+  "config": {
+    "runtimeProfile": "real",
+    "systemProvider": null,
+    "judgeProvider": null,
+    "adapterMode": "remnic-native",
+    "remnicConfig": {
+      "$comment": "Pinned Remnic config for the MemCorrect v1 lab run (issue #1725 / plan item 2b). Used with `remnic bench run memcorrect-v1 --runtime-profile real --remnic-config <this file> --memcorrect-adapter remnic` on the RTX 3090 lab host. The real profile preserves Remnic's shipped defaults (full fact pipeline, contradiction detection, tombstones, correction contract); this file pins only the local-LLM endpoint and the extraction gates so the run is hermetic and reproducible without environment-variable templating.",
+      "modelSource": "plugin",
+      "localLlmEnabled": true,
+      "localLlmFallback": false,
+      "localLlmUrl": "http://127.0.0.1:11434",
+      "localLlmModel": "qwen2.5-7b-32k:latest",
+      "extractionMinUserTurns": 0,
+      "extractionMinChars": 10,
+      "lcmEnabled": true
+    },
+    "benchmarkOptions": {
+      "personaCount": 5,
+      "factsPerPersona": 8,
+      "maintenanceCycles": 5,
+      "uptakeLatencyCap": 8,
+      "aggregateMetrics": {
+        "uptake_at_next": 0,
+        "uptake_latency": 8,
+        "uptake_latency_censored": 40,
+        "non_resurrection": 0,
+        "collateral_delta": 0,
+        "scope_precision": 0,
+        "false_apply": 1,
+        "reassertion": 1,
+        "provenance_fidelity": null
+      },
+      "leaderboardArtifacts": [
+        {
+          "benchmark": "memcorrect-v1",
+          "path": "/home/joshuawarren/.remnic/bench/results/leaderboard/memcorrect-remnic-native-2026-07-13T20-47-36-910Z.jsonl",
+          "format": "memcorrect-adapter-metrics-jsonl",
+          "records": 1
+        }
+      ]
+    },
+    "internalProvider": null
+  },
+  "cost": {
+    "totalTokens": 0,
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "estimatedCostUsd": 0,
+    "totalLatencyMs": 521270,
+    "meanQueryLatencyMs": 13031.75,
+    "judgeModelCalls": 0
+  },
+  "results": {
+    "tasks": [
+      {
+        "taskId": "memcorrect-12613607-0",
+        "question": "what is my database preference?",
+        "expected": "{\"correctedContent\":[\"neovim\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:39:03.468Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 14478,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-0",
+          "shape": "explicit-targeted",
+          "category": "fact",
+          "namespace": "avery-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1",
+        "question": "what is my notebook preference?",
+        "expected": "{\"correctedContent\":[\"neovim\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:39:15.313Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 11900,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1",
+          "shape": "conversational",
+          "category": "preference",
+          "namespace": "avery-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-2",
+        "question": "what is my notebook preference?",
+        "expected": "{\"correctedContent\":[\"lined\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:39:30.335Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 15021,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-2",
+          "shape": "scoped",
+          "category": "decision",
+          "namespace": "avery-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-3",
+        "question": "what is my standup preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"mechanical\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:39:42.995Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 13163,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-3",
+          "shape": "re-assertion",
+          "category": "commitment",
+          "namespace": "avery-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-4",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"monday\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:39:54.800Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 10646,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-4",
+          "shape": "explicit-targeted",
+          "category": "relationship",
+          "namespace": "avery-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-5",
+        "question": "what is my database preference?",
+        "expected": "{\"correctedContent\":[\"ten-am\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:40:07.777Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 14767,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-5",
+          "shape": "conversational",
+          "category": "fact",
+          "namespace": "avery-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-6",
+        "question": "what is my calendar preference?",
+        "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"mechanical\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"avery-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:40:22.770Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 14101,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-6",
+          "shape": "scoped",
+          "category": "preference",
+          "namespace": "avery-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-7",
+        "question": "what is my coffee preference?",
+        "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"avery-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:40:36.473Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 11089,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-7",
+          "shape": "re-assertion",
+          "category": "decision",
+          "namespace": "avery-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-8",
+        "question": "what is my database preference?",
+        "expected": "{\"correctedContent\":[\"ten-am\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:40:47.058Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 13310,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-8",
+          "shape": "explicit-targeted",
+          "category": "commitment",
+          "namespace": "blair-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-9",
+        "question": "what is my editor preference?",
+        "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:41:00.948Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 12996,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-9",
+          "shape": "conversational",
+          "category": "relationship",
+          "namespace": "blair-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-a",
+        "question": "what is my calendar preference?",
+        "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:41:14.729Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 14469,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-a",
+          "shape": "scoped",
+          "category": "fact",
+          "namespace": "blair-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-b",
+        "question": "what is my editor preference?",
+        "expected": "{\"correctedContent\":[\"ten-am\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:41:26.545Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 13386,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-b",
+          "shape": "re-assertion",
+          "category": "preference",
+          "namespace": "blair-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-c",
+        "question": "what is my deploy preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"monday\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:41:40.097Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 11499,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-c",
+          "shape": "explicit-targeted",
+          "category": "decision",
+          "namespace": "blair-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-d",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"monday\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:41:51.083Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 10806,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-d",
+          "shape": "conversational",
+          "category": "commitment",
+          "namespace": "blair-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-e",
+        "question": "what is my deploy preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"helix\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"blair-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:42:05.008Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 14259,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-e",
+          "shape": "scoped",
+          "category": "relationship",
+          "namespace": "blair-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-f",
+        "question": "what is my standup preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"mechanical\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"blair-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:42:17.349Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 13101,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-f",
+          "shape": "re-assertion",
+          "category": "fact",
+          "namespace": "blair-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-10",
+        "question": "what is my deploy preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:42:31.020Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 12812,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-10",
+          "shape": "explicit-targeted",
+          "category": "preference",
+          "namespace": "cassidy-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-11",
+        "question": "what is my notebook preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"mechanical\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:42:43.399Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 11535,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-11",
+          "shape": "conversational",
+          "category": "decision",
+          "namespace": "cassidy-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-12",
+        "question": "what is my notebook preference?",
+        "expected": "{\"correctedContent\":[\"membrane\"],\"retiredContent\":[\"oat-milk\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:42:55.683Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 13269,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-12",
+          "shape": "scoped",
+          "category": "commitment",
+          "namespace": "cassidy-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-13",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"lined\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:43:09.624Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 12743,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-13",
+          "shape": "re-assertion",
+          "category": "relationship",
+          "namespace": "cassidy-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-14",
+        "question": "what is my deploy preference?",
+        "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:43:21.118Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 14058,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-14",
+          "shape": "explicit-targeted",
+          "category": "fact",
+          "namespace": "cassidy-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-15",
+        "question": "what is my coffee preference?",
+        "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:43:37.332Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 11972,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-15",
+          "shape": "conversational",
+          "category": "preference",
+          "namespace": "cassidy-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-16",
+        "question": "what is my coffee preference?",
+        "expected": "{\"correctedContent\":[\"membrane\"],\"retiredContent\":[\"blue-green\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"cassidy-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:43:50.822Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 13466,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-16",
+          "shape": "scoped",
+          "category": "decision",
+          "namespace": "cassidy-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-17",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"cassidy-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:44:01.595Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 12460,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-17",
+          "shape": "re-assertion",
+          "category": "commitment",
+          "namespace": "cassidy-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-18",
+        "question": "what is my standup preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"dotgrid\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:44:14.036Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 13913,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-18",
+          "shape": "explicit-targeted",
+          "category": "relationship",
+          "namespace": "dakota-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-19",
+        "question": "what is my database preference?",
+        "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"helix\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:44:26.939Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 12549,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-19",
+          "shape": "conversational",
+          "category": "fact",
+          "namespace": "dakota-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1a",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"wednesday\"],\"retiredContent\":[\"oat-milk\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:44:39.273Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 11129,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1a",
+          "shape": "scoped",
+          "category": "preference",
+          "namespace": "dakota-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1b",
+        "question": "what is my database preference?",
+        "expected": "{\"correctedContent\":[\"lined\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:44:52.600Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 17288,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1b",
+          "shape": "re-assertion",
+          "category": "decision",
+          "namespace": "dakota-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1c",
+        "question": "what is my editor preference?",
+        "expected": "{\"correctedContent\":[\"membrane\"],\"retiredContent\":[\"helix\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:45:06.898Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 11762,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1c",
+          "shape": "explicit-targeted",
+          "category": "commitment",
+          "namespace": "dakota-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1d",
+        "question": "what is my standup preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:45:19.645Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 12252,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1d",
+          "shape": "conversational",
+          "category": "relationship",
+          "namespace": "dakota-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1e",
+        "question": "what is my standup preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"postgres\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"dakota-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:45:31.480Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 13876,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1e",
+          "shape": "scoped",
+          "category": "fact",
+          "namespace": "dakota-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-1f",
+        "question": "what is my calendar preference?",
+        "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"mechanical\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"dakota-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:45:44.991Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 13338,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-1f",
+          "shape": "re-assertion",
+          "category": "preference",
+          "namespace": "dakota-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-20",
+        "question": "what is my editor preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"nine-am\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:45:58.286Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 11639,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-20",
+          "shape": "explicit-targeted",
+          "category": "decision",
+          "namespace": "emerson-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-21",
+        "question": "what is my database preference?",
+        "expected": "{\"correctedContent\":[\"neovim\"],\"retiredContent\":[\"dotgrid\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:46:10.462Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 11725,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-21",
+          "shape": "conversational",
+          "category": "commitment",
+          "namespace": "emerson-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-22",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"membrane\"],\"retiredContent\":[\"dotgrid\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:46:23.167Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 13999,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-22",
+          "shape": "scoped",
+          "category": "relationship",
+          "namespace": "emerson-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-23",
+        "question": "what is my deploy preference?",
+        "expected": "{\"correctedContent\":[\"canary\"],\"retiredContent\":[\"monday\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:46:36.513Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 14126,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-23",
+          "shape": "re-assertion",
+          "category": "fact",
+          "namespace": "emerson-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-24",
+        "question": "what is my coffee preference?",
+        "expected": "{\"correctedContent\":[\"mysql\"],\"retiredContent\":[\"blue-green\"]}",
+        "actual": "{\"shape\":\"explicit-targeted\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:46:51.283Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 12071,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-24",
+          "shape": "explicit-targeted",
+          "category": "preference",
+          "namespace": "emerson-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-25",
+        "question": "what is my editor preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"monday\"]}",
+        "actual": "{\"shape\":\"conversational\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:47:01.959Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1
+        },
+        "latencyMs": 12718,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-25",
+          "shape": "conversational",
+          "category": "decision",
+          "namespace": "emerson-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-26",
+        "question": "what is my editor preference?",
+        "expected": "{\"correctedContent\":[\"lined\"],\"retiredContent\":[\"helix\"]}",
+        "actual": "{\"shape\":\"scoped\",\"namespace\":\"emerson-work\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:47:16.565Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "scope_precision": 0
+        },
+        "latencyMs": 13520,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-26",
+          "shape": "scoped",
+          "category": "commitment",
+          "namespace": "emerson-work",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": 0,
+              "false_apply": 1,
+              "reassertion": null,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      },
+      {
+        "taskId": "memcorrect-12613607-27",
+        "question": "what is my keyboard preference?",
+        "expected": "{\"correctedContent\":[\"black-coffee\"],\"retiredContent\":[\"mechanical\"]}",
+        "actual": "{\"shape\":\"re-assertion\",\"namespace\":\"emerson-home\",\"postCorrectionRecall\":[\"## Remnic recall pipeline\\n## User Profile\",\"# Behavioral Profile\",\"*Last updated: 2026-07-13T20:47:29.432Z*\"]}",
+        "scores": {
+          "uptake_at_next": 0,
+          "uptake_latency": 8,
+          "uptake_latency_censored": 1,
+          "non_resurrection": 0,
+          "false_apply": 1,
+          "reassertion": 1
+        },
+        "latencyMs": 14059,
+        "tokens": {
+          "input": 0,
+          "output": 0
+        },
+        "details": {
+          "scenarioId": "memcorrect-12613607-27",
+          "shape": "re-assertion",
+          "category": "relationship",
+          "namespace": "emerson-home",
+          "adapter": "remnic-native",
+          "metrics": {
+            "memcorrect": {
+              "uptake_at_next": 0,
+              "uptake_latency": 8,
+              "uptake_latency_censored": 1,
+              "non_resurrection": 0,
+              "collateral_delta": 0,
+              "scope_precision": null,
+              "false_apply": 1,
+              "reassertion": 1,
+              "provenance_fidelity": null
+            }
+          }
+        }
+      }
+    ],
+    "aggregates": {
+      "uptake_at_next": {
+        "mean": 0,
+        "median": 0,
+        "stdDev": 0,
+        "min": 0,
+        "max": 0
+      },
+      "uptake_latency": {
+        "mean": 8,
+        "median": 8,
+        "stdDev": 0,
+        "min": 8,
+        "max": 8
+      },
+      "uptake_latency_censored": {
+        "mean": 1,
+        "median": 1,
+        "stdDev": 0,
+        "min": 1,
+        "max": 1
+      },
+      "non_resurrection": {
+        "mean": 0,
+        "median": 0,
+        "stdDev": 0,
+        "min": 0,
+        "max": 0
+      },
+      "false_apply": {
+        "mean": 1,
+        "median": 1,
+        "stdDev": 0,
+        "min": 1,
+        "max": 1
+      },
+      "scope_precision": {
+        "mean": 0,
+        "median": 0,
+        "stdDev": 0,
+        "min": 0,
+        "max": 0
+      },
+      "reassertion": {
+        "mean": 1,
+        "median": 1,
+        "stdDev": 0,
+        "min": 1,
+        "max": 1
+      }
+    },
+    "statistics": {
+      "confidenceIntervals": {},
+      "bootstrapSamples": 0
+    }
+  },
+  "environment": {
+    "os": "linux",
+    "nodeVersion": "v22.22.0",
+    "hardware": "x64"
+  }
+}

--- a/docs/benchmarks/results/2026-07-13-memcorrect-v1-remnic-native-9485f44.json
+++ b/docs/benchmarks/results/2026-07-13-memcorrect-v1-remnic-native-9485f44.json
@@ -49,7 +49,7 @@
       "leaderboardArtifacts": [
         {
           "benchmark": "memcorrect-v1",
-          "path": "/home/joshuawarren/.remnic/bench/results/leaderboard/memcorrect-remnic-native-2026-07-13T20-47-36-910Z.jsonl",
+          "path": "~/.remnic/bench/results/leaderboard/memcorrect-remnic-native-2026-07-13T20-47-36-910Z.jsonl",
           "format": "memcorrect-adapter-metrics-jsonl",
           "records": 1
         }

--- a/docs/paper/figures/README.md
+++ b/docs/paper/figures/README.md
@@ -19,7 +19,7 @@ across runs — asserted by `tests/paper-figures.test.mjs`). The generator is
 | Figure | File | Real data | Pending data |
 |---|---|---|---|
 | 1 — LoCoMo / LongMemEval | `fig1-locomo-longmemeval.svg` | Remnic Tier-L (both benchmarks) | Remnic Tier-F (#1728); Mem0 / Zep / Letta (#1747) |
-| 2 — MemCorrect 8 metrics | `fig2-memcorrect-metrics.svg` | — (no artifact committed) | all adapters (#1584 Tier-L run + #1747 third-party) |
+| 2 — MemCorrect 8 metrics | `fig2-memcorrect-metrics.svg` | Remnic-native + prompt-only baseline (Tier-L full matrix, 2026-07-13) | Mem0 / Zep / Letta (#1747, API-key-gated) |
 | 3 — TrustScore 8 components | `fig3-trustscore-components.svg` | all 8 (source-extracted weights) | — |
 
 **Legend.** Solid bars are real — every value traces to a committed artifact or
@@ -53,14 +53,19 @@ run (#1728) and the third-party recall adapters (#1747). Competitor
 self-reported numbers are **not** echoed here — they are cited-not-reproduced
 until the harness reproduces them.
 
-**Figure 2.** No `memcorrect-v1` artifact is committed yet, so **all** adapter
-bars (Remnic-native, prompt-only baseline, Mem0, Zep, Letta) are pending. The
-eight metric axes, their directions (`↑ higher` / `↓ lower` / `→ 0`), and the
-adapter row layout are keyed to the `MemCorrectLeaderboardRow` schema
-(`packages/bench/src/leaderboard-export.ts`) — the public submission format the
-#1747 adapters emit. When a `memcorrect-v1` artifact lands under
-`docs/benchmarks/results/`, the generator reads its
-`config.benchmarkOptions.aggregateMetrics` and renders real bars automatically.
+**Figure 2.** The Remnic-native and prompt-only-baseline bars are real —
+two committed 40-scenario Tier-L full-matrix artifacts
+(`docs/benchmarks/results/2026-07-13-memcorrect-v1-remnic-native-9485f44.json`,
+`docs/benchmarks/results/2026-07-13-memcorrect-v1-prompt-only-baseline-9485f44.json`;
+see `docs/benchmarks.md` for the run commands and the honest reading of the
+floor-identical containment metrics). Mem0 / Zep / Letta bars remain pending
+on the #1747 adapter runs (API-key-gated). The eight metric axes, their
+directions (`↑ higher` / `↓ lower` / `→ 0`), and the adapter row layout are
+keyed to the `MemCorrectLeaderboardRow` schema
+(`packages/bench/src/leaderboard-export.ts`) — the public submission format
+the #1747 adapters emit. The generator reads
+`config.benchmarkOptions.aggregateMetrics` from each committed artifact and
+renders real bars automatically.
 
 **Figure 3.** The eight weighted components are extracted at render time from
 `DEFAULT_TRUST_WEIGHTS` in `packages/remnic-core/src/trust-score.ts` and

--- a/docs/paper/figures/fig1-locomo-longmemeval.svg
+++ b/docs/paper/figures/fig1-locomo-longmemeval.svg
@@ -24,29 +24,29 @@
 <line x1="62" y1="98" x2="62" y2="342" stroke="#555555" stroke-width="1"/>
 <line x1="62" y1="342" x2="496" y2="342" stroke="#555555" stroke-width="1"/>
 <text x="28" y="220" font-size="10" text-anchor="start" fill="#555555" font-weight="400" transform="rotate(-90 28 220)">score (0–1)</text>
-<rect x="65" y="321.72809667673715" width="18.1" height="20.27190332326284" fill="#0072B2"/>
-<text x="74.05" y="317.72809667673715" font-size="8.5" text-anchor="middle" fill="#0072B2" font-weight="600">0.083</text>
+<rect x="65" y="321.2366565961732" width="18.1" height="20.763343403826788" fill="#0072B2"/>
+<text x="74.05" y="317.2366565961732" font-size="8.5" text-anchor="middle" fill="#0072B2" font-weight="600">0.085</text>
 <rect x="86.1" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <rect x="107.2" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <rect x="128.3" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <rect x="149.4" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="116.25" y="356" font-size="9.5" text-anchor="middle" fill="#555555" font-weight="400">contains_answer</text>
-<rect x="173.5" y="312.2933144926115" width="18.1" height="29.706685507388524" fill="#0072B2"/>
-<text x="182.55" y="308.2933144926115" font-size="8.5" text-anchor="middle" fill="#0072B2" font-weight="600">0.122</text>
+<rect x="173.5" y="312.2241667132096" width="18.1" height="29.77583328679035" fill="#0072B2"/>
+<text x="182.55" y="308.2241667132096" font-size="8.5" text-anchor="middle" fill="#0072B2" font-weight="600">0.122</text>
 <rect x="194.6" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <rect x="215.7" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <rect x="236.8" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <rect x="257.9" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="224.75" y="356" font-size="9.5" text-anchor="middle" fill="#555555" font-weight="400">f1</text>
-<rect x="282" y="287.27814702920443" width="18.1" height="54.721852970795595" fill="#0072B2"/>
-<text x="291.05" y="283.27814702920443" font-size="8.5" text-anchor="middle" fill="#0072B2" font-weight="600">0.224</text>
+<rect x="282" y="287.4501510574018" width="18.1" height="54.5498489425982" fill="#0072B2"/>
+<text x="291.05" y="283.4501510574018" font-size="8.5" text-anchor="middle" fill="#0072B2" font-weight="600">0.224</text>
 <rect x="303.1" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <rect x="324.2" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <rect x="345.3" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <rect x="366.4" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="333.25" y="356" font-size="9.5" text-anchor="middle" fill="#555555" font-weight="400">llm_judge</text>
-<rect x="390.5" y="313.27620145119175" width="18.1" height="28.723798548808226" fill="#0072B2"/>
-<text x="399.55" y="309.27620145119175" font-size="8.5" text-anchor="middle" fill="#0072B2" font-weight="600">0.118</text>
+<rect x="390.5" y="313.1878032198576" width="18.1" height="28.8121967801424" fill="#0072B2"/>
+<text x="399.55" y="309.1878032198576" font-size="8.5" text-anchor="middle" fill="#0072B2" font-weight="600">0.118</text>
 <rect x="411.6" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <rect x="432.7" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <rect x="453.8" y="98" width="18.1" height="244" fill="url(#pendingHatch1)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
@@ -127,7 +127,7 @@
 <text x="836" y="390" font-size="9.5" text-anchor="start" fill="#555555" font-weight="400">Letta</text>
 <text x="836" y="401" font-size="8" text-anchor="start" fill="#888888" font-weight="400">(#1747)</text>
 <text x="532" y="408" font-size="8.5" text-anchor="start" fill="#888888" font-weight="400">non-axis metrics (separate scale): search_hits=8.520</text>
-<text x="16" y="434" font-size="9.5" text-anchor="start" fill="#888888" font-weight="400">Sources: locomo 2026-07-07-locomo-qwen2.5-7b-32k_latest-47aae03.json · longmemeval 2026-07-07-longmemeval-qwen2.5-7b-32k_latest-47aae03.json · Tier-F pending #1728 · third-party pending #1747</text>
+<text x="16" y="434" font-size="9.5" text-anchor="start" fill="#888888" font-weight="400">Sources: locomo 2026-07-07-locomo-qwen2.5-7b-32k_latest-c67c2c7-graph-recall-on.json · longmemeval 2026-07-07-longmemeval-qwen2.5-7b-32k_latest-47aae03.json · Tier-F pending #1728 · third-party pending #1747</text>
 <text x="16" y="447" font-size="9.5" text-anchor="start" fill="#888888" font-weight="400">Pending panels (hatched) await committed artifacts — no value rendered until an artifact exists (rule 55).</text>
 
 </svg>

--- a/docs/paper/figures/fig2-memcorrect-metrics.svg
+++ b/docs/paper/figures/fig2-memcorrect-metrics.svg
@@ -8,17 +8,17 @@
 <line x1="0" y1="0" x2="0" y2="6" stroke="#B0B0B0" stroke-width="1.4"/>
 </pattern></defs>
 <text x="16" y="30" font-size="17" text-anchor="start" fill="#1a1a1a" font-weight="700">Figure 2 — MemCorrect: 8 metrics across adapters</text>
-<text x="16" y="50" font-size="10.5" text-anchor="start" fill="#555555" font-weight="400">No MemCorrect artifact committed yet (#1584 Tier-L run + #1747 adapter runs pending). All bars are DATA-PENDING placeholders keyed to the MemCorrectLeaderboardRow schema — no value is rendered.</text>
+<text x="16" y="50" font-size="10.5" text-anchor="start" fill="#555555" font-weight="400">2 committed MemCorrect artifact(s). Bars are real where an artifact exists; hatched bars await the run.</text>
 <text x="16" y="82" font-size="10.5" text-anchor="start" fill="#555555" font-weight="600">metric · direction</text>
 <text x="988" y="82" font-size="10.5" text-anchor="start" fill="#555555" font-weight="600">value</text>
 <text x="16" y="122" font-size="11" text-anchor="start" fill="#1a1a1a" font-weight="600">uptake_at_next</text>
 <text x="16" y="135" font-size="9" text-anchor="start" fill="#888888" font-weight="400">↑ higher</text>
 <rect x="200" y="102" width="780" height="34" fill="#F7F7F7" stroke="#EDEDED" stroke-width="1"/>
 <line x1="590" y1="102" x2="590" y2="136" stroke="#EDEDED" stroke-width="1" stroke-dasharray="2 3"/>
-<rect x="200" y="104" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="106" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
-<rect x="200" y="111" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="113" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
+<rect x="200" y="104" width="0" height="4" fill="#0072B2"/>
+<text x="988" y="106" font-size="9" text-anchor="start" fill="#1a1a1a" font-weight="400">0.000</text>
+<rect x="200" y="111" width="0" height="4" fill="#999999"/>
+<text x="988" y="113" font-size="9" text-anchor="start" fill="#1a1a1a" font-weight="400">0.000</text>
 <rect x="200" y="118" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="988" y="120" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
 <rect x="200" y="125" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
@@ -29,10 +29,8 @@
 <text x="16" y="181" font-size="9" text-anchor="start" fill="#888888" font-weight="400">↓ lower</text>
 <rect x="200" y="148" width="780" height="34" fill="#FAFAFA" stroke="#EDEDED" stroke-width="1"/>
 <text x="590" y="168" font-size="9" text-anchor="middle" fill="#888888" font-weight="400">raw value (scale varies) — see methodology</text>
-<rect x="200" y="150" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="152" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
-<rect x="200" y="157" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="159" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
+<text x="206" y="152" font-size="9" text-anchor="start" fill="#0072B2" font-weight="600">Remnic: 8.000</text>
+<text x="206" y="159" font-size="9" text-anchor="start" fill="#999999" font-weight="600">Prompt-only: 8.000</text>
 <rect x="200" y="164" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="988" y="166" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
 <rect x="200" y="171" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
@@ -43,10 +41,10 @@
 <text x="16" y="227" font-size="9" text-anchor="start" fill="#888888" font-weight="400">↑ higher</text>
 <rect x="200" y="194" width="780" height="34" fill="#F7F7F7" stroke="#EDEDED" stroke-width="1"/>
 <line x1="590" y1="194" x2="590" y2="228" stroke="#EDEDED" stroke-width="1" stroke-dasharray="2 3"/>
-<rect x="200" y="196" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="198" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
-<rect x="200" y="203" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="205" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
+<rect x="200" y="196" width="0" height="4" fill="#0072B2"/>
+<text x="988" y="198" font-size="9" text-anchor="start" fill="#1a1a1a" font-weight="400">0.000</text>
+<rect x="200" y="203" width="0" height="4" fill="#999999"/>
+<text x="988" y="205" font-size="9" text-anchor="start" fill="#1a1a1a" font-weight="400">0.000</text>
 <rect x="200" y="210" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="988" y="212" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
 <rect x="200" y="217" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
@@ -57,10 +55,8 @@
 <text x="16" y="273" font-size="9" text-anchor="start" fill="#888888" font-weight="400">→ 0</text>
 <rect x="200" y="240" width="780" height="34" fill="#FAFAFA" stroke="#EDEDED" stroke-width="1"/>
 <text x="590" y="260" font-size="9" text-anchor="middle" fill="#888888" font-weight="400">raw value (scale varies) — see methodology</text>
-<rect x="200" y="242" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="244" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
-<rect x="200" y="249" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="251" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
+<text x="206" y="244" font-size="9" text-anchor="start" fill="#0072B2" font-weight="600">Remnic: 0.000</text>
+<text x="206" y="251" font-size="9" text-anchor="start" fill="#999999" font-weight="600">Prompt-only: 0.000</text>
 <rect x="200" y="256" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="988" y="258" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
 <rect x="200" y="263" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
@@ -71,10 +67,10 @@
 <text x="16" y="319" font-size="9" text-anchor="start" fill="#888888" font-weight="400">↑ higher</text>
 <rect x="200" y="286" width="780" height="34" fill="#F7F7F7" stroke="#EDEDED" stroke-width="1"/>
 <line x1="590" y1="286" x2="590" y2="320" stroke="#EDEDED" stroke-width="1" stroke-dasharray="2 3"/>
-<rect x="200" y="288" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="290" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
-<rect x="200" y="295" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="297" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
+<rect x="200" y="288" width="0" height="4" fill="#0072B2"/>
+<text x="988" y="290" font-size="9" text-anchor="start" fill="#1a1a1a" font-weight="400">0.000</text>
+<rect x="200" y="295" width="0" height="4" fill="#999999"/>
+<text x="988" y="297" font-size="9" text-anchor="start" fill="#1a1a1a" font-weight="400">0.000</text>
 <rect x="200" y="302" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="988" y="304" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
 <rect x="200" y="309" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
@@ -85,10 +81,10 @@
 <text x="16" y="365" font-size="9" text-anchor="start" fill="#888888" font-weight="400">↓ lower</text>
 <rect x="200" y="332" width="780" height="34" fill="#F7F7F7" stroke="#EDEDED" stroke-width="1"/>
 <line x1="590" y1="332" x2="590" y2="366" stroke="#EDEDED" stroke-width="1" stroke-dasharray="2 3"/>
-<rect x="200" y="334" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="336" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
-<rect x="200" y="341" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="343" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
+<rect x="200" y="334" width="780" height="4" fill="#0072B2"/>
+<text x="988" y="336" font-size="9" text-anchor="start" fill="#1a1a1a" font-weight="400">1.000</text>
+<rect x="200" y="341" width="780" height="4" fill="#999999"/>
+<text x="988" y="343" font-size="9" text-anchor="start" fill="#1a1a1a" font-weight="400">1.000</text>
 <rect x="200" y="348" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="988" y="350" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
 <rect x="200" y="355" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
@@ -99,10 +95,10 @@
 <text x="16" y="411" font-size="9" text-anchor="start" fill="#888888" font-weight="400">↑ higher</text>
 <rect x="200" y="378" width="780" height="34" fill="#F7F7F7" stroke="#EDEDED" stroke-width="1"/>
 <line x1="590" y1="378" x2="590" y2="412" stroke="#EDEDED" stroke-width="1" stroke-dasharray="2 3"/>
-<rect x="200" y="380" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="382" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
-<rect x="200" y="387" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="389" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
+<rect x="200" y="380" width="780" height="4" fill="#0072B2"/>
+<text x="988" y="382" font-size="9" text-anchor="start" fill="#1a1a1a" font-weight="400">1.000</text>
+<rect x="200" y="387" width="780" height="4" fill="#999999"/>
+<text x="988" y="389" font-size="9" text-anchor="start" fill="#1a1a1a" font-weight="400">1.000</text>
 <rect x="200" y="394" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="988" y="396" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
 <rect x="200" y="401" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
@@ -113,27 +109,25 @@
 <text x="16" y="457" font-size="9" text-anchor="start" fill="#888888" font-weight="400">↑ higher</text>
 <rect x="200" y="424" width="780" height="34" fill="#F7F7F7" stroke="#EDEDED" stroke-width="1"/>
 <line x1="590" y1="424" x2="590" y2="458" stroke="#EDEDED" stroke-width="1" stroke-dasharray="2 3"/>
-<rect x="200" y="426" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="428" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
-<rect x="200" y="433" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
-<text x="988" y="435" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
+<text x="204" y="428" font-size="9" text-anchor="start" fill="#888888" font-weight="400">Remnic: n/a</text>
+<text x="204" y="435" font-size="9" text-anchor="start" fill="#888888" font-weight="400">Prompt-only: n/a</text>
 <rect x="200" y="440" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="988" y="442" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
 <rect x="200" y="447" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="988" y="449" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
 <rect x="200" y="454" width="780" height="4" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="3 2"/>
 <text x="988" y="456" font-size="9" text-anchor="start" fill="#888888" font-weight="400">pending</text>
-<rect x="16" y="515" width="12" height="10" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="2 2"/>
-<text x="32" y="524" font-size="9.5" text-anchor="start" fill="#555555" font-weight="400">Remnic (pending #1584)</text>
-<rect x="166.8" y="515" width="12" height="10" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="2 2"/>
-<text x="182.8" y="524" font-size="9.5" text-anchor="start" fill="#555555" font-weight="400">Prompt-only (pending #1584)</text>
-<rect x="344.6" y="515" width="12" height="10" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="2 2"/>
-<text x="360.6" y="524" font-size="9.5" text-anchor="start" fill="#555555" font-weight="400">Mem0 (pending #1747)</text>
-<rect x="484.6" y="515" width="12" height="10" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="2 2"/>
-<text x="500.6" y="524" font-size="9.5" text-anchor="start" fill="#555555" font-weight="400">Zep (pending #1747)</text>
-<rect x="619.2" y="515" width="12" height="10" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="2 2"/>
-<text x="635.2" y="524" font-size="9.5" text-anchor="start" fill="#555555" font-weight="400">Letta (pending #1747)</text>
-<text x="16" y="544" font-size="9.5" text-anchor="start" fill="#888888" font-weight="400">Sources: memcorrect: no real artifact committed (#1584) · schema: MemCorrectLeaderboardRow (packages/bench/src/leaderboard-export.ts) · third-party adapters pending #1747</text>
+<rect x="16" y="515" width="12" height="10" fill="#0072B2"/>
+<text x="32" y="524" font-size="9.5" text-anchor="start" fill="#555555" font-weight="400">Remnic (real)</text>
+<rect x="118.2" y="515" width="12" height="10" fill="#999999"/>
+<text x="134.2" y="524" font-size="9.5" text-anchor="start" fill="#555555" font-weight="400">Prompt-only (real)</text>
+<rect x="247.39999999999998" y="515" width="12" height="10" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="2 2"/>
+<text x="263.4" y="524" font-size="9.5" text-anchor="start" fill="#555555" font-weight="400">Mem0 (pending #1747)</text>
+<rect x="387.4" y="515" width="12" height="10" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="2 2"/>
+<text x="403.4" y="524" font-size="9.5" text-anchor="start" fill="#555555" font-weight="400">Zep (pending #1747)</text>
+<rect x="522" y="515" width="12" height="10" fill="url(#pendingHatch2)" stroke="#B0B0B0" stroke-width="1" stroke-dasharray="2 2"/>
+<text x="538" y="524" font-size="9.5" text-anchor="start" fill="#555555" font-weight="400">Letta (pending #1747)</text>
+<text x="16" y="544" font-size="9.5" text-anchor="start" fill="#888888" font-weight="400">Sources: memcorrect real: prompt-only-baseline, remnic-native · schema: MemCorrectLeaderboardRow (packages/bench/src/leaderboard-export.ts) · third-party adapters pending #1747</text>
 <text x="16" y="557" font-size="9.5" text-anchor="start" fill="#888888" font-weight="400">Pending panels (hatched) await committed artifacts — no value rendered until an artifact exists (rule 55).</text>
 
 </svg>

--- a/docs/paper/main.md
+++ b/docs/paper/main.md
@@ -323,27 +323,62 @@ new ones.
 ## 5. Experimental Setup
 
 **Intent.** The protocol that makes every number in §6 independently
-reproducible on one GPU. Lift from `docs/benchmarks/sota-readiness.md`.
-Cover: the two-tier protocol (Tier L local / Tier F frontier), runtime
-profiles (`runtime-profiles.ts`), the judge cache + Cohen's-κ cross-tier
-calibration, repro manifests (`repro-manifest.ts`), and seed / model / dataset
-/ commit-SHA pinning. State the **publishability rubric** (non-mock; repro
-manifest present; judge calibration reported; honest framing attached;
-leaderboard-safety / explicit-cue guards; reproducible on one GPU).
+reproducible on one GPU.
 
-- `TODO(#1573)`: cite the local-lab harness + judge cache + calibration
-  mechanism (RTX 3090 box, `local-lab` profile).
-- `TODO(#1574)`: cite the runtime profiles used (baseline / real /
-  openclaw-chain / local-lab) and the existing single-flag ablation profiles.
-- `TODO(#1728)`: define the Tier-F responder configuration honestly —
-  **Opus 4.8 via Claude Code (`claude -p`)**, `--tools ""` + `--safe-mode` +
-  isolated cwd + `--append-system-prompt`, local 3090 as judge (calibrated
-  against a small Opus-judged slice for Cohen's κ). State explicitly that this
-  is "Opus 4.8 via Claude Code," **not** a raw-API frontier number, and that
-  `tier` stays `"frontier"` with the label in the artifact `note`/model
-  metadata.
-- `TODO(#1735)`: gate the Tier-F description on the `claude-cli` bench
-  provider landing — it is a hard prerequisite, not assumed-present.
+**Two-tier protocol.** Every published number carries a tier. **Tier L
+(local)** runs entirely on one consumer GPU — an RTX 3090 (24 GB) driving
+`qwen2.5-7b-32k:latest` (Q4_K_M, 32k context) over Ollama — and exists as
+the reproducibility anchor: anyone with one GPU can rerun it. Tier-L
+artifacts must carry a hardware envelope (GPU, VRAM, quantization); the
+promotion bridge refuses a local-tier artifact without one. **Tier F
+(frontier)** carries the head-to-head accuracy claim. The Tier-F responder
+is **Opus 4.8 via Claude Code (`claude -p`)** through the `claude-cli`
+bench provider — a valid research harness and a distinct provenance path
+from the raw Anthropic API; the artifact records provider, model, harness,
+isolation settings, and invocation so the measurement path is explicit.
+Isolation is mandatory and implemented by the provider: a freshly created
+empty temp workspace, tools disabled, user/project configuration skipped,
+session persistence off, and an environment allowlist that excludes memory
+directories and unrelated secrets — without this, Claude Code inherits
+user-level instructions and silently contaminates every answer.
+
+**Runtime profiles.** The system under test is pinned by a named runtime
+profile (`runtime-profiles.ts`): `baseline` (deterministic pinned Remnic
+configuration, LCM stack), `real` (Remnic's shipped defaults plus a pinned
+config file — the MemCorrect lab profile,
+`docs/benchmarks/configs/memcorrect-lab-remnic-config.json`), `local-lab`
+(manifest-pinned operator-hosted models, temperature 0, fixed seed —
+`docs/benchmarks/configs/local-lab-3090.json`), and `openclaw-chain` (the
+full host chain). The §7 ablations flip exactly one flag against `baseline`
+per cell.
+
+**Judging and cross-tier calibration.** LoCoMo and LongMemEval judging runs
+on the local 3090 judge; judge verdicts are content-cached so re-scoring
+cached answers is free. Cross-tier credibility comes from Cohen's-κ
+calibration (`remnic bench judge-calibrate`): the local judge and the
+Tier-F gold judge (Opus via `claude -p`) re-judge a deterministic
+50-question slice of a benchmark's cached answers, and the resulting κ —
+with sample size, threshold, and a warning flag when κ falls below it — is
+persisted and stamped into every subsequent stored result whose judge
+matches the calibrated pair (`judgeCalibration` on the artifact schema).
+
+**Pinning and manifests.** Every stored result records the git commit SHA,
+seed, dataset version, runtime profile, provider/model identities, and
+benchmark options; a reproducibility manifest (`repro-manifest.ts`)
+accompanies each results directory. Artifacts are SHA-256-hashed over
+canonical JSON, and the figure pipeline renders only manifest-tracked,
+non-mock artifacts (§6), byte-identically on regeneration.
+
+**Publishability rubric.** A number enters this paper only if: (1) the
+artifact is real and committed, never a mock fixture; (2) its repro
+manifest pins seed, model + quantization, context window, dataset version,
+and runtime profile; (3) judge calibration is reported wherever a judge is
+used; (4) a one-paragraph honest framing accompanies it (what the number
+is and is not); (5) leaderboard-safety guards (explicit-cue recall rules,
+no train/test leakage) are respected; and (6) the Tier-L path is
+re-runnable on one GPU. Bounded (`--limit`/`--trial-limit`) runs are
+partial-coverage evidence and are never presented as full leaderboard
+results — the promotion bridge rejects them outright.
 
 ---
 

--- a/docs/paper/main.md
+++ b/docs/paper/main.md
@@ -99,31 +99,180 @@ each one.
 §6's results score. Walk the recall path top-down: three-tier retrieval
 (explicit-cue → targeted-fact → response-guidance, unified on the #1539 recall
 spine), then the glass-box layers that make recalls explainable and
-correctable. Each subsystem is a `TODO` to its owning issue for the
-mechanism description; this skeleton does not restate mechanism details.
+correctable. Every mechanism claim below cites the shipped module; nothing is
+aspirational.
 
-- **3.1 Three-tier retrieval** — `TODO(#1539)`: describe the recall spine and
-  the four thin-config pipeline stages, with the declared event-order budget
-  fix.
-- **3.2 Provenance spans** — `TODO(#1575)`: span model, storage, read surfaces.
-  Cite the shipped `provenance.ts` surfaces, not orchestrator internals.
-- **3.3 Faithfulness gate** — `TODO(#1576)`: extraction-time gate; shadow mode
-  enables the harvest stream for the #1585 model lab.
-- **3.4 TrustScore** — `TODO(#1577)`: the recall-stage trust signal
-  (`trust-zones.ts`/`provenance.ts`). **Note for §3 vs §6:** TrustScore is a
-  shipped *recall-stage feature*, **not yet a benchmark metric** — describe it
-  as a system capability here; do not score it in §6 until surfacing work
-  exists (flag in §6 TODO).
-- **3.5 Correction Contract + passive detection + memory handles** —
-  `TODO(#1580)` Correction Contract (4-PR order); `TODO(#1581)` passive
-  correction detection; `TODO(#1582)` memory handles `[m:xxxx]`;
-  `TODO(#1583)` the chat surface that exercises correction end-to-end.
-- **3.6 Bi-temporal validity + tombstones / non-resurrection** —
-  `TODO(#1578)` bi-temporal frontmatter + recall filter;
-  `TODO(#1579)` tombstones and the 5-path resurrection matrix (the guarantee
-  §4's `non_resurrection` metric measures).
-- `TODO(#1726)`: assemble §3 once the subsystem issues above have merged; until
-  then this section is a structural placeholder.
+**Substrate.** Remnic is files-first: every memory is a markdown file with
+YAML frontmatter in a plain directory tree, and every index — the tombstone
+log, search collections, projections — is an explicitly rebuildable cache of
+that file truth. All durable writes funnel through a single storage
+chokepoint, so cross-cutting invariants (tombstone checks, dedup, cataloging)
+are enforced once rather than re-implemented per write path. This one
+decision does a lot of quiet work: §3.6's non-resurrection guarantee holds
+for write paths that did not exist when the guarantee was written.
+
+### 3.1 Three-tier retrieval
+
+Recall runs as tiered pipelines — explicit-cue (verbatim turn references),
+targeted-fact (entity- and claim-directed lookup), and response-guidance
+(behavioral steering), plus an event-order pipeline for chronology questions.
+All tiers instantiate one shared stage sequence: intent classification →
+candidate collection → dedup → rank → filter → slice → metadata → token
+budgeting (`recall-pipeline-stages.ts`). A single `unifiedDedupeAndRank`
+stage owns scoring, thresholding, and ordering behind a declared
+configuration object, so behavioral differences between tiers — most
+dangerously, recency-descending versus chronology-ascending turn ordering —
+are declared fields rather than divergent copies of comparator code. The
+pipeline order itself is a repository contract: candidate headroom first,
+then policy filters, then rerank/boost, then the user-facing cap — a cap
+applied before final filtering is treated as a bug class, not a tuning
+choice. Above the spine, an episode/note classification layer routes
+experiential episodes and semantic notes into different consolidation
+behavior (`himem.ts`), and Memory Boxes group related episodes for
+verified recall (`boxes.ts`, `verified-recall.ts`).
+
+### 3.2 Provenance spans
+
+Every extracted claim can carry claim-level source spans: session key, turn
+id, observation timestamp, and the verbatim quote with character offsets
+(`provenance.ts`). A coarse tag (`verified` | `unverified` | `none`)
+summarizes span state for cheap filtering. The load-bearing invariant is
+enforced symmetrically at write and read: a `verified` or `unverified` tag
+never survives without at least one structurally valid span — it is
+downgraded to `none`; a corrupt span drops to absent rather than poisoning
+the memory. With the feature disabled, serialized output is byte-identical
+to pre-provenance behavior, which is what makes incremental adoption safe.
+
+### 3.3 Faithfulness gate
+
+At extraction time, each candidate fact is entailment-checked against its
+own verified source span — the §3.2 quote, deliberately not the whole
+conversation, both for latency and because re-reading the full transcript
+would reintroduce the hallucination surface the gate exists to close
+(`extraction-faithfulness.ts`). This is distinct from fact-worthiness
+judging: the gate asks "is this claim supported by what was actually said,"
+targeting the highest-severity memory failure — a hallucinated extraction
+becoming a confident durable memory. Verdicts are `entailed`,
+`contradicted`, or `unsupported`; a backend failure is a tagged bypass
+(`unchecked`), never a silent verdict, and never blocks the write. Shadow
+mode records verdicts without enforcement, which is the harvest stream the
+model lab uses to train the local gate model (Appendix A.4.3).
+
+### 3.4 TrustScore
+
+TrustScore is a pure, deterministic blend of up to eight per-memory signals
+— memory-worth, faithfulness verdict, provenance strength, corroboration,
+contradiction state, operator feedback, recency, and domain calibration —
+with declared default weights that are sum-normalized over the signals
+actually present (`trust-score.ts`). Its contract is epistemically
+conservative: a memory with no instrumentation scores exactly neutral (0.5,
+recall multiplier 1.0) rather than being penalized for missing data; a
+corrupt component contributes neutrally, never an extreme; absent components
+redistribute their weight. Scores map to bands (high / medium / low /
+quarantine), where quarantine is reserved for hard negatives — a
+`contradicted` faithfulness verdict or an unresolved contradiction — and
+quarantined memories are excluded from injection but always visible in
+recall X-ray output with the reason attached. At injection time the score
+becomes a bounded recall multiplier and, in the low bands, a deterministic
+epistemic hedge that names the actual weakest signals instead of a generic
+"low confidence" disclaimer. **Note for §3 vs §6:** TrustScore is a shipped
+*recall-stage feature*, **not yet a benchmark metric** — it is described
+here as a system capability and is not scored in §6.
+
+### 3.5 Correction Contract, passive detection, memory handles
+
+Correction is a first-class write path, not an `update()` API. A
+natural-language correction becomes a `CorrectionPlan`: the planner resolves
+targets (searched or explicitly named), classifies the correction (`wrong`,
+`outdated`, `incomplete`, `wrong_scope`, `never_store`), drafts per-memory
+actions, and renders a human-readable diff with a confidence score and an
+expiry (`correction-contract.ts`). Planning is read-only by construction —
+with no LLM available the planner degrades to zero actions and "located for
+review," never to a guessed mutation. Apply is confirm-gated and
+exactly-once; a plan interrupted mid-apply is detected at startup and
+scrubbed rather than silently retried. The executor is the only writer and
+follows a non-destructive order: replacement memories are written first
+(page-versioned, revertable), only then are predecessors superseded,
+validity-stamped, and tombstoned, then changes propagate to the search
+index, graph edges, belief ledger, and profile, and finally an audit record
+— itself a searchable memory — lands in `corrections/`. A failed
+replacement write never destroys the old state.
+
+Two adjacent mechanisms make the contract reachable in practice. Passive
+correction detection watches user turns with a morphology-aware heuristic —
+no additional LLM call — and is deliberately conservative: hypotheticals,
+quoted speech, and third-party corrections are rejected by anti-fixture
+guards, with the contradiction scan and the chat surface as backstops
+(`passive-correction-detector.ts`). Memory handles render every injected
+memory with a short id-derived token (`[m:4f2a]`) so an agent or user can
+say "`[m:4f2a]` is stale" and route the correction to an exact target;
+handles are derived from ids (never content), widened on collision, and
+resolved per-session against the injection snapshot, so no global handle
+table exists to leak across sessions (`recall-handles.ts`). The chat
+surface (#1583) exercises the full loop end-to-end: recall with handles,
+passive detection, plan preview, confirm, apply.
+
+### 3.6 Bi-temporal validity and tombstoned non-resurrection
+
+Memories carry two independent time axes: transaction time (when the system
+learned/updated the record) and validity time (`valid_at` / `invalid_at`,
+half-open) describing when the fact was true in the world
+(`temporal-validity.ts`). Supersession stamps the predecessor's
+`invalid_at`, and `as_of` recall answers "what did we believe was true at
+time T" — the corrected past stays queryable instead of being overwritten.
+A corrupt validity timestamp conservatively evaluates to not-valid, never
+to always-true.
+
+Retirement is enforced by an append-only tombstone log keyed by content
+hash, normalized text, and entity reference (`lifecycle/tombstones.ts`).
+Because the check runs at the single write chokepoint, one mechanism blocks
+all five known resurrection paths — re-extraction from old transcripts,
+importers, consolidation merges, dream/REM re-derivation, and pattern
+reinforcement — without per-path code. Reversal is itself an append
+(`kind: revocation`); history is never rewritten. A blocked write is parked
+as `pending_review` with the blocking tombstone recorded, never silently
+dropped. This mechanism is exactly what §4's `non_resurrection` metric
+measures from the outside.
+
+### 3.7 Recall X-ray
+
+Every recall can be replayed as a per-result attribution: which tier served
+it, the score decomposition, the graph path when graph retrieval fired, the
+filter ladder that admitted or rejected it, and the audit entry id
+(`recall-xray.ts`), rendered identically across CLI, HTTP, and MCP. The
+design rule is that an exclusion must never look like an absence: a
+quarantined memory shows up in the X-ray with its quarantine reason rather
+than disappearing.
+
+### 3.8 What makes this architecture different
+
+Read together, the subsystems implement one discipline rather than eight
+features:
+
+1. **Correction is an auditable write path.** A plan/apply contract with
+   non-destructive ordering, revertable page-versioned edits, and a
+   substrate-level non-resurrection invariant. Contemporary memory systems
+   expose add/update/delete APIs; we are not aware of a published
+   resurrection-blocking guarantee or confirm-gated correction protocol
+   among them (§2).
+2. **Recall is glass-box end-to-end.** Claim-level source spans →
+   entailment verdict → multi-signal TrustScore with component echo →
+   named epistemic hedges → X-ray filter ladder. "Why is this memory in my
+   context" has a mechanical answer at every layer.
+3. **Fail-safe epistemics are a recurring contract shape.** Neutral on
+   absent signals, drop-corrupt-never-poison, tagged backend-failure versus
+   verdict, byte-identical output when disabled, exclusions never invisible.
+   The system prefers admitting ignorance to manufacturing confidence.
+4. **The substrate is bi-temporal, human-readable, and reproducible.**
+   Markdown files as truth, rebuildable indexes, `as_of` history, and a
+   benchmark protocol that reruns on a single consumer GPU (§5).
+
+These are engineering claims, and §8 states their limits honestly:
+TrustScore is not yet a scored benchmark metric, the fine-tuned faithfulness
+gate model's final manifest is pending (#1737), and §4's uptake metrics are
+strict by design — a system that keeps quoting the outdated turn in recall
+context fails the probe even when a corrected fact also surfaces.
+
 
 ---
 
@@ -217,18 +366,46 @@ passes the §5 publishability rubric.** Until then, every block is a TODO.
     Real = Remnic Tier-L anchor; pending = Tier-F (#1728) + Mem0/Zep/Letta
     (#1747).
   - **Figure 2** — `figures/fig2-memcorrect-metrics.svg`: the 8 MemCorrect
-    metrics. All adapter bars pending until a `memcorrect-v1` artifact is
-    committed (#1584 run + #1747 adapters).
+    metrics. Remnic-native and prompt-only-baseline bars are real (Tier-L
+    artifacts committed 2026-07-13); Mem0/Zep/Letta bars remain pending
+    (#1747 adapter runs are API-key-gated and deliberately not run here).
   - **Figure 3** — `figures/fig3-trustscore-components.svg`: the 8 TrustScore
     weighted components, source-extracted from `DEFAULT_TRUST_WEIGHTS`. A system
     illustration, not a benchmark metric (#1577).
 
-- **6.1 MemCorrect — Remnic vs baselines vs third-party adapters.**
-  - `TODO(#1584)`: commit a real `memcorrect-v1` Tier-L artifact
-    (`docs/benchmarks/results/`). As of this skeleton **no MemCorrect artifact
-    is committed** — only the harness + generator + metrics exist.
-  - `TODO(#1727)`: add the Mem0 / Zep / Letta adapter rows. Until the adapters
-    exist, §6.1 can only report Remnic-native vs the `PromptOnlyBaselineAdapter`
+- **6.1 MemCorrect — Remnic vs the prompt-only floor (Tier L).**
+  Two full-matrix (40-scenario, `mode: full`, seed `0xc077e7`) artifacts are
+  committed:
+  `docs/benchmarks/results/2026-07-13-memcorrect-v1-remnic-native-9485f44.json`
+  (runtime profile `real` — Remnic's shipped defaults with the fact pipeline
+  and Correction Contract active; extraction and correction classification on
+  `qwen2.5-7b-32k:latest`, RTX 3090; pinned config in
+  `docs/benchmarks/configs/memcorrect-lab-remnic-config.json`) and
+  `docs/benchmarks/results/2026-07-13-memcorrect-v1-prompt-only-baseline-9485f44.json`
+  (the hermetic append-only floor). Corrections in the Remnic run route
+  through the Correction Contract (plan + confirmed apply) via the public
+  access-service surface, with the plain turn path as fallback.
+
+  **Headline finding (honest):** at Tier L, Remnic's containment-scored
+  metrics land on the same floor as the prompt-only baseline
+  (`uptake_at_next = 0`, `non_resurrection = 0`, `false_apply = 1` for both
+  adapters). Per-scenario tracing shows this is not a harness artifact and
+  not a dead correction path: extraction does produce the target fact, the
+  contract plan applies (`applied: true`), and the stored fact is retired.
+  The probes still fail because stale content keeps reaching the serving
+  layer through three side channels: (a) the 7B classify model drafts
+  retire-only actions instead of supersede-with-replacement, so no corrected
+  fact exists for the probe to contain; (b) behavioral-profile lines derived
+  from the original fact survive the correction; and (c) verbatim LCM turn
+  evidence quotes the outdated statement into recall context. MemCorrect is
+  strict by design — a system that keeps serving the stale value anywhere in
+  its recall context fails the probe — and this result is exactly the
+  failure class the benchmark exists to expose: **fact-store correction is
+  necessary but not sufficient; correction must propagate to every serving
+  surface.** §8 discusses the classify-model capability axis (Tier F) and
+  the serving-surface propagation follow-up this measurement motivates.
+  - `TODO(#1727)`: add the Mem0 / Zep / Letta adapter rows. Until those runs
+    exist, §6.1 reports Remnic-native vs the `PromptOnlyBaselineAdapter`
     floor — clearly labeled as such, not as a "we beat X" claim.
 - **6.2 LoCoMo / LongMemEval — head-to-head at Tier F, Tier L as anchor.**
   - `TODO(#1728)`: produce the Tier-F run. As of this skeleton **no Tier-F

--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -28,6 +28,7 @@ import {
   buildBenchBaselineRemnicConfig,
   createLightweightAdapter,
   createRemnicAdapter,
+  resolveSessionScopedCorrectionDecision,
 } from "./remnic-adapter.ts";
 import { createTimeoutGuardedAdapter } from "./timeout-guard.ts";
 
@@ -3756,4 +3757,89 @@ test("lightweight adapter suppresses real Remnic pipeline even when feature over
   } finally {
     await adapter.destroy();
   }
+});
+
+// ---------------------------------------------------------------------------
+// Session-scoped correction decisions (PR #1862 review — codex P1 ×2, cursor)
+// ---------------------------------------------------------------------------
+
+test("correction scoping: fully-owned plan proceeds", () => {
+  const owned = new Set(["m-1", "m-2"]);
+  const decision = resolveSessionScopedCorrectionDecision(
+    {
+      affected: [{ memoryId: "m-1" }, { memoryId: "m-2" }],
+      actions: [
+        { kind: "supersede", loserId: "m-1" },
+        { kind: "retract", memoryId: "m-2" },
+      ],
+    },
+    owned,
+    "initial",
+  );
+  assert.deepEqual(decision, { kind: "proceed" });
+});
+
+test("correction scoping: foreign-only plan reports no owned target", () => {
+  const decision = resolveSessionScopedCorrectionDecision(
+    {
+      affected: [{ memoryId: "twin-1" }],
+      actions: [{ kind: "retract", memoryId: "twin-1" }],
+    },
+    new Set(["m-1"]),
+    "initial",
+  );
+  assert.deepEqual(decision, { kind: "no-owned-target" });
+});
+
+test("correction scoping: mixed ownership demands a replan with the owned subset", () => {
+  const decision = resolveSessionScopedCorrectionDecision(
+    {
+      affected: [{ memoryId: "m-1" }, { memoryId: "twin-1" }],
+      actions: [{ kind: "retract", memoryId: "m-1" }],
+    },
+    new Set(["m-1"]),
+    "initial",
+  );
+  assert.deepEqual(decision, { kind: "replan", targetIds: ["m-1"] });
+});
+
+test("correction scoping: replanned plan with foreign action targets is rejected", () => {
+  // Neighbor expansion pulled a same-entityRef twin back in despite explicit
+  // targetIds — the caller must fail loudly, never apply.
+  const decision = resolveSessionScopedCorrectionDecision(
+    {
+      affected: [{ memoryId: "m-1" }, { memoryId: "twin-1" }],
+      actions: [
+        { kind: "edit", memoryId: "m-1" },
+        { kind: "retract", memoryId: "twin-1" },
+      ],
+    },
+    new Set(["m-1"]),
+    "replanned",
+  );
+  assert.deepEqual(decision, { kind: "foreign-actions", foreignIds: ["twin-1"] });
+});
+
+test("correction scoping: targetless redaction rules are never foreign", () => {
+  const decision = resolveSessionScopedCorrectionDecision(
+    {
+      affected: [{ memoryId: "m-1" }],
+      actions: [{ kind: "redaction_rule" }],
+    },
+    new Set(["m-1"]),
+    "replanned",
+  );
+  assert.deepEqual(decision, { kind: "proceed" });
+});
+
+test("correction scoping: initial fully-owned plan with a foreign rescope target is rejected", () => {
+  const decision = resolveSessionScopedCorrectionDecision(
+    {
+      affected: [{ memoryId: "m-1" }],
+      actions: [{ kind: "rescope", memoryId: "twin-1" }],
+    },
+    new Set(["m-1"]),
+    "initial",
+  );
+  assert.deepEqual(decision, { kind: "foreign-actions", foreignIds: ["twin-1"] });
 });

--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -362,6 +362,31 @@ test("direct adapter can use a caller-owned memory directory", async () => {
   }
 });
 
+test("direct adapter correct() reports not-applied when the planner finds nothing", async () => {
+  const adapter = await createRemnicAdapter({});
+
+  try {
+    // Empty store + no classify LLM → the correction planner deterministically
+    // produces zero actions; correct() must report { applied: false } so the
+    // MemCorrect wrapper falls back to the turn path, and the adapter must
+    // stay fully usable afterwards.
+    assert.ok(adapter.correct, "direct adapter must expose the correction surface");
+    const outcome = await adapter.correct(
+      "correct-session",
+      "Correction: the deploy target is canary, not production.",
+    );
+    assert.deepEqual(outcome, { applied: false });
+
+    await adapter.store("correct-session", [
+      { role: "user", content: "The deploy target is canary." },
+    ]);
+    const recalled = await adapter.recall("correct-session", "What is the deploy target?");
+    assert.match(recalled, /canary/);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
 test("direct adapter observes timeout guard abort control before storing messages", async () => {
   const adapter = await createRemnicAdapter({
     configOverrides: {

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -25,6 +25,7 @@ import {
   buildExplicitCueRecallSection,
   buildTrajectoryAnalysisRecallSection,
   collectExplicitTurnReferences,
+  EngramAccessService,
   expandTildePath,
   normalizeTurnExpansionEnd,
   Orchestrator,
@@ -1712,6 +1713,26 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       void trackedCleanup;
     };
 
+    // Correction-contract surface (issue #1584 plan item 2a). Built lazily and
+    // rebound whenever rebuild() swaps the orchestrator; this is the same
+    // public access layer the MCP/HTTP memory_correct_plan/apply tools use,
+    // so the benchmark exercises the real correction path, not internals.
+    let correctionAccess:
+      | { service: EngramAccessService; orchestrator: unknown }
+      | undefined;
+    const getCorrectionAccess = (): EngramAccessService => {
+      if (
+        !correctionAccess ||
+        correctionAccess.orchestrator !== state.orchestrator
+      ) {
+        correctionAccess = {
+          service: new EngramAccessService(state.orchestrator),
+          orchestrator: state.orchestrator,
+        };
+      }
+      return correctionAccess.service;
+    };
+
     return {
       async store(
         sessionId: string,
@@ -2411,6 +2432,44 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           waitForCompletionOnAbort: true,
         });
         sessionTurnCounters.clear();
+      },
+
+      async correct(
+        sessionId: string,
+        text: string,
+        _at?: string,
+        control?: BenchPhaseControl,
+      ): Promise<{ applied: boolean }> {
+        // The correction executor stamps its own audit timestamps; the seeded
+        // corpus timestamp (`_at`) is honored by the turn-path fallback the
+        // caller runs when this resolves `{ applied: false }`.
+        throwIfBenchPhaseAborted(control, "correct");
+        sessionId = normalizeBenchSessionId(sessionId);
+        const access = getCorrectionAccess();
+        const plan = await withBenchPhaseAbort(
+          access.correctionPlan({ text, sessionKey: sessionId }),
+          control,
+          "correct",
+        );
+        if (plan.actions.length === 0) {
+          // Planner found nothing to change (no matching memory yet, or a
+          // purely additive correction). Discard the empty pending plan and
+          // report not-applied so the caller can deliver the correction
+          // through the plain turn path instead.
+          await access
+            .correctionDiscard(plan.planId, { sessionKey: sessionId })
+            .catch(() => undefined);
+          return { applied: false };
+        }
+        await withBenchPhaseAbort(
+          access.correctionApply(plan.planId, {
+            confirm: true,
+            sessionKey: sessionId,
+          }),
+          control,
+          "correct",
+        );
+        return { applied: true };
       },
 
       async drain(control?: BenchPhaseControl): Promise<void> {

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -772,6 +772,72 @@ function benchCoreMemorySource(sessionId: string): string {
   return `bench-replay-${createHash("sha256").update(sessionId).digest("hex").slice(0, 16)}`;
 }
 
+/** Structural view of a correction plan for session-scoping decisions. */
+export interface SessionScopedCorrectionPlanView {
+  affected: ReadonlyArray<{ memoryId: string }>;
+  actions: ReadonlyArray<
+    | { kind: "supersede"; loserId: string }
+    | { kind: "edit"; memoryId: string }
+    | { kind: "retract"; memoryId: string }
+    | { kind: "rescope"; memoryId: string }
+    | { kind: "redaction_rule" }
+  >;
+}
+
+export type SessionScopedCorrectionDecision =
+  | { kind: "proceed" }
+  /** Everything the planner located belongs to another benchmark session. */
+  | { kind: "no-owned-target" }
+  /** Mixed ownership — re-plan restricted to these session-owned ids. */
+  | { kind: "replan"; targetIds: string[] }
+  /** The plan drafts mutations against foreign-session memories. */
+  | { kind: "foreign-actions"; foreignIds: string[] };
+
+/**
+ * Decide how a correction plan may proceed under the bench session-scoping
+ * contract (codex P1 ×2 + cursor Medium on PR #1862). Bench "namespaces" are
+ * distinct session ids inside ONE store (real namespaces are disabled), so a
+ * plan must never mutate memories that were not extracted for the calling
+ * session:
+ *
+ *   - initial phase, everything located is foreign → `no-owned-target`
+ *     (for THIS session the correction has no target; turn-path fallback).
+ *   - initial phase, mixed ownership → `replan` with the owned subset as
+ *     explicit target ids.
+ *   - ANY phase, an action targets a foreign memory (the planner's neighbor
+ *     expansion can pull same-`entityRef` siblings from another session even
+ *     under explicit targetIds) → `foreign-actions`; the caller must fail
+ *     loudly, never apply, never silently downgrade to the turn path.
+ *
+ * `redaction_rule` actions are targetless (future-extraction rules) and are
+ * never treated as foreign.
+ */
+export function resolveSessionScopedCorrectionDecision(
+  plan: SessionScopedCorrectionPlanView,
+  ownedIds: ReadonlySet<string>,
+  phase: "initial" | "replanned",
+): SessionScopedCorrectionDecision {
+  const actionTargets: string[] = [];
+  for (const action of plan.actions) {
+    if (action.kind === "supersede") actionTargets.push(action.loserId);
+    else if (action.kind !== "redaction_rule") actionTargets.push(action.memoryId);
+  }
+  const foreignIds = actionTargets.filter((id) => !ownedIds.has(id));
+  if (phase === "initial") {
+    const ownedAffected = plan.affected.filter((entry) => ownedIds.has(entry.memoryId));
+    if (plan.affected.length > 0 && ownedAffected.length === 0) {
+      return { kind: "no-owned-target" };
+    }
+    if (ownedAffected.length < plan.affected.length) {
+      return { kind: "replan", targetIds: ownedAffected.map((entry) => entry.memoryId) };
+    }
+  }
+  if (foreignIds.length > 0) {
+    return { kind: "foreign-actions", foreignIds };
+  }
+  return { kind: "proceed" };
+}
+
 function benchEntityStructuredFactSourceDir(memoryDir: string): string {
   return path.join(memoryDir, "state", "bench-entity-structured-facts");
 }
@@ -2462,57 +2528,75 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         // for THIS session (their frontmatter.source carries the per-session
         // replay tag) so a correction can never plan/apply against another
         // benchmark session's memories and corrupt scope_precision /
-        // collateral measurements (codex P1). Limitation: replacement
-        // memories written by a previous correction carry the executor's
-        // source, not the session tag; MemCorrect issues one correct() per
-        // scenario, so no scenario re-corrects its own replacement.
-        if (plan.affected.length > 0) {
-          const sessionSource = benchCoreMemorySource(sessionId);
-          const owned = new Set(
-            (await readBenchCoreMemories(state.orchestrator))
-              .filter((memory) => memory.frontmatter.source === sessionSource)
-              .map((memory) => memory.frontmatter.id),
+        // collateral measurements (codex P1). The scoping decisions live in
+        // resolveSessionScopedCorrectionDecision (pure, unit-tested).
+        // Limitation: replacement memories written by a previous correction
+        // carry the executor's source, not the session tag; MemCorrect
+        // issues one correct() per scenario, so no scenario re-corrects its
+        // own replacement.
+        const sessionSource = benchCoreMemorySource(sessionId);
+        const owned = new Set(
+          (await readBenchCoreMemories(state.orchestrator))
+            .filter((memory) => memory.frontmatter.source === sessionSource)
+            .map((memory) => memory.frontmatter.id),
+        );
+        let replanned = false;
+        const decision = resolveSessionScopedCorrectionDecision(plan, owned, "initial");
+        if (decision.kind === "no-owned-target") {
+          // Everything the planner located belongs to another benchmark
+          // session — for THIS session the correction has no target.
+          await discardPlan(plan.planId);
+          return { applied: false };
+        }
+        if (decision.kind === "replan") {
+          // Re-plan restricted to this session's memories via explicit
+          // target ids (the planner resolves those directly).
+          await discardPlan(plan.planId);
+          replanned = true;
+          plan = await withBenchPhaseAbort(
+            access.correctionPlan({
+              text,
+              sessionKey: sessionId,
+              targetIds: decision.targetIds,
+            }),
+            control,
+            "correct",
           );
-          const ownedAffected = plan.affected.filter((entry) => owned.has(entry.memoryId));
-          if (ownedAffected.length === 0) {
-            // Everything the planner located belongs to another benchmark
-            // session — for THIS session the correction has no target.
-            await discardPlan(plan.planId);
-            return { applied: false };
-          }
-          if (ownedAffected.length < plan.affected.length) {
-            // Re-plan restricted to this session's memories via explicit
-            // target ids (the planner resolves those directly).
-            await discardPlan(plan.planId);
-            plan = await withBenchPhaseAbort(
-              access.correctionPlan({
-                text,
-                sessionKey: sessionId,
-                targetIds: ownedAffected.map((entry) => entry.memoryId),
-              }),
-              control,
-              "correct",
-            );
-          }
+        }
+        // Re-check ownership on the FINAL plan: even under explicit
+        // targetIds the planner's neighbor expansion can pull same-entityRef
+        // siblings from another session into the drafted actions (codex P1).
+        // Applying such a plan would mutate a foreign session; silently
+        // falling back to the turn path would mislabel the measurement —
+        // fail loudly instead.
+        const finalDecision = resolveSessionScopedCorrectionDecision(
+          plan,
+          owned,
+          replanned ? "replanned" : "initial",
+        );
+        if (finalDecision.kind === "foreign-actions") {
+          await discardPlan(plan.planId);
+          throw new Error(
+            `correction plan drafts actions against ${finalDecision.foreignIds.length} foreign-session memory(ies) (${finalDecision.foreignIds.join(", ")}) — the bench harness cannot scope this correction; refusing to apply or mismeasure`,
+          );
         }
         if (plan.actions.length === 0) {
-          if (plan.affected.length > 0) {
-            // The planner LOCATED candidates but drafted no action — the
-            // deterministic manual-selection fallback (classify LLM
-            // unavailable or unparsable). Silently falling back to the turn
-            // path here would measure non-contract behavior while labeling
-            // the run contract-routed (codex P1) — fail loudly instead so a
-            // misconfigured lab run cannot mismeasure.
-            await discardPlan(plan.planId);
+          await discardPlan(plan.planId);
+          if (replanned || plan.affected.length > 0) {
+            // Session-owned targets were identified (or candidates were
+            // located and the classify LLM drafted nothing — the
+            // deterministic manual-selection fallback). Silently falling
+            // back to the turn path here would measure non-contract
+            // behavior while labeling the run contract-routed (codex P1 +
+            // cursor Medium on the empty re-plan) — fail loudly instead so
+            // a degraded lab run cannot mismeasure.
             throw new Error(
-              `correction planner degraded to the manual-selection fallback (no applicable action drafted for ${plan.affected.length} candidate(s); warnings: ${plan.warnings.join("; ") || "none"}) — refusing to measure the turn path as contract behavior`,
+              `correction planner drafted no applicable action (${replanned ? "re-planned with explicit session-owned targets" : `${plan.affected.length} candidate(s) located`}; warnings: ${plan.warnings.join("; ") || "none"}) — refusing to measure the turn path as contract behavior`,
             );
           }
           // Planner found nothing to change (no matching memory yet, or a
-          // purely additive correction). Discard the empty pending plan and
-          // report not-applied so the caller can deliver the correction
-          // through the plain turn path instead.
-          await discardPlan(plan.planId);
+          // purely additive correction). Report not-applied so the caller
+          // can deliver the correction through the plain turn path instead.
           return { applied: false };
         }
         const outcome = await withBenchPhaseAbort(

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -2452,6 +2452,20 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           "correct",
         );
         if (plan.actions.length === 0) {
+          if (plan.affected.length > 0) {
+            // The planner LOCATED candidates but drafted no action — the
+            // deterministic manual-selection fallback (classify LLM
+            // unavailable or unparsable). Silently falling back to the turn
+            // path here would measure non-contract behavior while labeling
+            // the run contract-routed (codex P1) — fail loudly instead so a
+            // misconfigured lab run cannot mismeasure.
+            await access
+              .correctionDiscard(plan.planId, { sessionKey: sessionId })
+              .catch(() => undefined);
+            throw new Error(
+              `correction planner degraded to the manual-selection fallback (no applicable action drafted for ${plan.affected.length} candidate(s); warnings: ${plan.warnings.join("; ") || "none"}) — refusing to measure the turn path as contract behavior`,
+            );
+          }
           // Planner found nothing to change (no matching memory yet, or a
           // purely additive correction). Discard the empty pending plan and
           // report not-applied so the caller can deliver the correction
@@ -2461,7 +2475,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
             .catch(() => undefined);
           return { applied: false };
         }
-        await withBenchPhaseAbort(
+        const outcome = await withBenchPhaseAbort(
           access.correctionApply(plan.planId, {
             confirm: true,
             sessionKey: sessionId,
@@ -2469,7 +2483,12 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           control,
           "correct",
         );
-        return { applied: true };
+        // A `partial` outcome means at least one action failed — report
+        // not-fully-applied so the MemCorrect wrapper also delivers the
+        // correction through the turn path (mirrors a user restating after a
+        // partial fix) instead of counting a partial apply as full uptake
+        // (cursor Medium).
+        return { applied: outcome.status === "applied" };
       },
 
       async drain(control?: BenchPhaseControl): Promise<void> {

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -2446,11 +2446,55 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         throwIfBenchPhaseAborted(control, "correct");
         sessionId = normalizeBenchSessionId(sessionId);
         const access = getCorrectionAccess();
-        const plan = await withBenchPhaseAbort(
+        const discardPlan = async (planId: string): Promise<void> => {
+          await access
+            .correctionDiscard(planId, { sessionKey: sessionId })
+            .catch(() => undefined);
+        };
+        let plan = await withBenchPhaseAbort(
           access.correctionPlan({ text, sessionKey: sessionId }),
           control,
           "correct",
         );
+        // Bench "namespaces" are distinct session ids inside ONE store (real
+        // namespaces are disabled), but the correction planner searches the
+        // whole default namespace — restrict the plan to memories extracted
+        // for THIS session (their frontmatter.source carries the per-session
+        // replay tag) so a correction can never plan/apply against another
+        // benchmark session's memories and corrupt scope_precision /
+        // collateral measurements (codex P1). Limitation: replacement
+        // memories written by a previous correction carry the executor's
+        // source, not the session tag; MemCorrect issues one correct() per
+        // scenario, so no scenario re-corrects its own replacement.
+        if (plan.affected.length > 0) {
+          const sessionSource = benchCoreMemorySource(sessionId);
+          const owned = new Set(
+            (await readBenchCoreMemories(state.orchestrator))
+              .filter((memory) => memory.frontmatter.source === sessionSource)
+              .map((memory) => memory.frontmatter.id),
+          );
+          const ownedAffected = plan.affected.filter((entry) => owned.has(entry.memoryId));
+          if (ownedAffected.length === 0) {
+            // Everything the planner located belongs to another benchmark
+            // session — for THIS session the correction has no target.
+            await discardPlan(plan.planId);
+            return { applied: false };
+          }
+          if (ownedAffected.length < plan.affected.length) {
+            // Re-plan restricted to this session's memories via explicit
+            // target ids (the planner resolves those directly).
+            await discardPlan(plan.planId);
+            plan = await withBenchPhaseAbort(
+              access.correctionPlan({
+                text,
+                sessionKey: sessionId,
+                targetIds: ownedAffected.map((entry) => entry.memoryId),
+              }),
+              control,
+              "correct",
+            );
+          }
+        }
         if (plan.actions.length === 0) {
           if (plan.affected.length > 0) {
             // The planner LOCATED candidates but drafted no action — the
@@ -2459,9 +2503,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
             // path here would measure non-contract behavior while labeling
             // the run contract-routed (codex P1) — fail loudly instead so a
             // misconfigured lab run cannot mismeasure.
-            await access
-              .correctionDiscard(plan.planId, { sessionKey: sessionId })
-              .catch(() => undefined);
+            await discardPlan(plan.planId);
             throw new Error(
               `correction planner degraded to the manual-selection fallback (no applicable action drafted for ${plan.affected.length} candidate(s); warnings: ${plan.warnings.join("; ") || "none"}) — refusing to measure the turn path as contract behavior`,
             );
@@ -2470,9 +2512,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           // purely additive correction). Discard the empty pending plan and
           // report not-applied so the caller can deliver the correction
           // through the plain turn path instead.
-          await access
-            .correctionDiscard(plan.planId, { sessionKey: sessionId })
-            .catch(() => undefined);
+          await discardPlan(plan.planId);
           return { applied: false };
         }
         const outcome = await withBenchPhaseAbort(

--- a/packages/bench/src/adapters/timeout-guard.test.ts
+++ b/packages/bench/src/adapters/timeout-guard.test.ts
@@ -45,6 +45,50 @@ test("timeout guard rejects a stuck adapter phase", async () => {
   assert.equal(timedOutPhase, "timeout-test:recall session=s");
 });
 
+test("timeout guard forwards the optional correct surface with phase guarding", async () => {
+  const adapter = makeAdapter();
+  const correctCalls: Array<{ session: string; text: string; at?: string }> = [];
+  adapter.correct = async (sessionId, text, at) => {
+    correctCalls.push({ session: sessionId, text, ...(at !== undefined ? { at } : {}) });
+    return { applied: true };
+  };
+  const guarded = createTimeoutGuardedAdapter(adapter, {
+    benchmarkId: "timeout-test",
+    timeoutMs: 1000,
+  });
+
+  assert.ok(guarded.correct, "guarded adapter must preserve correct()");
+  const outcome = await guarded.correct("s", "fix this", "2026-07-05T00:00:00Z");
+  assert.deepEqual(outcome, { applied: true });
+  assert.deepEqual(correctCalls, [
+    { session: "s", text: "fix this", at: "2026-07-05T00:00:00Z" },
+  ]);
+});
+
+test("timeout guard omits correct when the adapter has none", () => {
+  const guarded = createTimeoutGuardedAdapter(makeAdapter(), {
+    benchmarkId: "timeout-test",
+    timeoutMs: 1000,
+  });
+  assert.equal(guarded.correct, undefined);
+});
+
+test("timeout guard rejects a stuck correct phase", async () => {
+  const adapter = makeAdapter();
+  adapter.correct = () => {
+    const { promise } = Promise.withResolvers<{ applied: boolean }>();
+    return promise;
+  };
+  const guarded = createTimeoutGuardedAdapter(adapter, {
+    benchmarkId: "timeout-test",
+    timeoutMs: 5,
+  });
+  await assert.rejects(
+    () => guarded.correct!("s", "fix this"),
+    /benchmark phase timed out after 5ms: timeout-test:correct session=s/,
+  );
+});
+
 test("timeout guard aborts adapter phase work on timeout", async () => {
   const adapter = makeAdapter();
   let sawAbort = false;

--- a/packages/bench/src/adapters/timeout-guard.ts
+++ b/packages/bench/src/adapters/timeout-guard.ts
@@ -197,6 +197,28 @@ export function createTimeoutGuardedAdapter(
           drainTimeoutMs,
         );
   }
+  if (adapter.correct) {
+    // Preserve the optional correction-contract surface (issue #1584 plan
+    // item 2a) — dropping it here would silently downgrade guarded MemCorrect
+    // runs to the turn-store fallback while still labeling the run
+    // contract-routed (codex P1).
+    wrapped.correct = (
+      sessionId: string,
+      text: string,
+      at?: string,
+      control?: BenchPhaseControl,
+    ): Promise<{ applied: boolean }> =>
+      phaseTimeoutMs === undefined
+        ? adapter.correct!(sessionId, text, at, control)
+        : run(`correct session=${sessionId}`, async (signal) => {
+          const merged = mergeBenchPhaseControl(signal, control);
+          try {
+            return await adapter.correct!(sessionId, text, at, merged.control);
+          } finally {
+            merged.cleanup();
+          }
+        });
+  }
   if (adapter.responder) {
     wrapped.responder =
       phaseTimeoutMs === undefined

--- a/packages/bench/src/adapters/types.ts
+++ b/packages/bench/src/adapters/types.ts
@@ -100,6 +100,20 @@ export interface BenchMemoryAdapter {
     sessionId?: string,
     control?: BenchPhaseControl,
   ): Promise<SearchResult[]>;
+  /**
+   * Optional explicit-correction surface (issue #1584 plan item 2a). Routes a
+   * natural-language correction through the system's correction contract
+   * (plan + confirmed apply) instead of a plain turn store. Resolves
+   * `{ applied: false }` when the planner produced no applicable actions so
+   * the caller can fall back to the turn path. Adapters without an explicit
+   * correction surface omit this method entirely.
+   */
+  correct?(
+    sessionId: string,
+    text: string,
+    at?: string,
+    control?: BenchPhaseControl,
+  ): Promise<{ applied: boolean }>;
   reset(sessionId?: string, control?: BenchPhaseControl): Promise<void>;
   getStats(sessionId?: string, control?: BenchPhaseControl): Promise<MemoryStats>;
   /** Wait for background summarization (e.g. LCM) to finish after store(). */

--- a/packages/bench/src/benchmarks/remnic/memcorrect/adapters.test.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/adapters.test.ts
@@ -115,6 +115,36 @@ test("remnic wrapper: correct() observes the correction as a user turn", async (
   assert.equal(captured.storeCalls[0].messages.length, 1);
 });
 
+test("remnic wrapper: correct() prefers the adapter's correction-contract surface", async () => {
+  const captured = newCaptured();
+  const correctCalls: Array<{ session: string; text: string; at?: string }> = [];
+  const base = fakeBenchAdapter(captured);
+  base.correct = async (sessionId, text, at) => {
+    correctCalls.push({ session: sessionId, text, ...(at !== undefined ? { at } : {}) });
+    return { applied: true };
+  };
+  const adapter = createRemnicMemCorrectAdapter(base, { sessionPrefix: "mc" });
+  await adapter.correct("fix this", "ns-a", "2026-07-05T00:02:00Z");
+  assert.equal(correctCalls.length, 1);
+  assert.equal(correctCalls[0].session, "mc:ns-a");
+  assert.equal(correctCalls[0].text, "fix this");
+  assert.equal(correctCalls[0].at, "2026-07-05T00:02:00Z");
+  // The contract applied — the correction must NOT also land as a turn.
+  assert.equal(captured.storeCalls.length, 0);
+});
+
+test("remnic wrapper: correct() falls back to the turn path when the contract plans nothing", async () => {
+  const captured = newCaptured();
+  const base = fakeBenchAdapter(captured);
+  base.correct = async () => ({ applied: false });
+  const adapter = createRemnicMemCorrectAdapter(base, { sessionPrefix: "mc" });
+  await adapter.correct("fix this", "ns-a", "2026-07-05T00:02:00Z");
+  // Unapplied contract → delivered exactly once as a user turn.
+  assert.equal(captured.storeCalls.length, 1);
+  assert.equal(captured.storeCalls[0].session, "mc:ns-a");
+  assert.equal(captured.storeCalls[0].messages.length, 1);
+});
+
 test("remnic wrapper: runMaintenance forces a drain", async () => {
   const captured = newCaptured();
   const adapter = createRemnicMemCorrectAdapter(fakeBenchAdapter(captured));

--- a/packages/bench/src/benchmarks/remnic/memcorrect/adapters.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/adapters.ts
@@ -18,11 +18,12 @@
  *      `BenchMemoryAdapter` (the access-service-level abstraction other
  *      Remnic benchmarks use) into the MemCorrect contract. Per the issue,
  *      the Remnic adapter must use only public surfaces; reaching into
- *      orchestrator internals makes the benchmark meaningless. Full
- *      correction-contract exercise (forced dreams + consolidation +
- *      reinforcement + contradiction scan) lands with #1580/#1579; this
- *      wrapper maps correct() to observe + drain today and documents the
- *      upgrade path.
+ *      orchestrator internals makes the benchmark meaningless. When the
+ *      wrapped adapter exposes the optional `correct()` surface (the
+ *      Correction Contract plan/apply path from #1580), corrections route
+ *      through it; the plain turn-store path remains the fallback for
+ *      adapters without an explicit correction surface and for corrections
+ *      the planner could not apply.
  */
 
 import type { BenchMemoryAdapter } from "../../../adapters/types.js";
@@ -347,13 +348,19 @@ export function createRemnicMemCorrectAdapter(
         .filter((s) => s.length > 0);
     },
     async correct(text, sessionKey, at) {
-      // Today: observe the correction as a user turn through the public
-      // store path. When #1580's correction contract is available, this
-      // routes through the contract tool instead (the adapter surface is
-      // unchanged; only the internal call differs). The seeded corpus
+      // Prefer the explicit Correction Contract surface (#1580 / plan item
+      // 2a): plan + confirmed apply through the same public access layer the
+      // MCP/HTTP correction tools use. When the planner produces no
+      // applicable action (or the adapter has no correction surface), fall
+      // back to delivering the correction as a user turn — the seeded corpus
       // timestamp is preserved so temporal reasoning is evaluated against
       // the scenario timeline, not wall-clock ingestion time.
-      await adapter.store(`${sessionPrefix}:${sessionKey}`, [
+      const scopedSession = `${sessionPrefix}:${sessionKey}`;
+      if (adapter.correct) {
+        const outcome = await adapter.correct(scopedSession, text, at);
+        if (outcome.applied) return;
+      }
+      await adapter.store(scopedSession, [
         { role: "user", content: text, timestamp: at },
       ]);
     },

--- a/packages/bench/src/benchmarks/remnic/memcorrect/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/runner.test.ts
@@ -58,6 +58,38 @@ test("registry: memcorrect-v1 is tier=remnic, status=ready, runnerAvailable", ()
   assert.equal(memcorrectDefinition.runnerAvailable, true);
 });
 
+test('runner: benchmarkOptions.adapter "prompt-only" selects the baseline adapter', async () => {
+  const result = await runMemCorrectBenchmark(
+    options({
+      benchmarkOptions: { adapter: "prompt-only" },
+      limit: 1,
+    }),
+  );
+  assert.equal(result.config.adapterMode, "prompt-only-baseline");
+});
+
+test('runner: benchmarkOptions.adapter "remnic" wraps the bench system adapter', async () => {
+  const result = await runMemCorrectBenchmark(
+    options({
+      benchmarkOptions: { adapter: "remnic" },
+      limit: 1,
+    }),
+  );
+  assert.equal(result.config.adapterMode, "remnic-native");
+});
+
+test("runner: an unknown string adapter mode is rejected with the valid options listed", async () => {
+  await assert.rejects(
+    runMemCorrectBenchmark(
+      options({
+        benchmarkOptions: { adapter: "mem0ish" },
+        limit: 1,
+      }),
+    ),
+    /must be one of \["remnic", "prompt-only"\]/,
+  );
+});
+
 // ---------------------------------------------------------------------------
 // End-to-end with the prompt-only baseline
 // ---------------------------------------------------------------------------

--- a/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
@@ -100,16 +100,30 @@ const FULL_OPTIONS = {
  * Resolve the adapter to drive. The lab run is explicit about which adapter
  * MemCorrect exercises:
  *   - `benchmarkOptions.adapter` (a `MemCorrectSystemAdapter`) → use directly.
- *     This is how the prompt-only baseline, the Remnic-native adapter, and
- *     any third-party adapter are selected.
- *   - Otherwise, wrap the bench `system` adapter (a `BenchMemoryAdapter`)
- *     into the MemCorrect contract via the public access-service surface.
+ *     This is how any in-process custom or third-party adapter is selected.
+ *   - `benchmarkOptions.adapter === "prompt-only"` → the hermetic
+ *     `PromptOnlyBaselineAdapter` floor (CLI: `--memcorrect-adapter prompt-only`).
+ *   - `benchmarkOptions.adapter === "remnic"` or absent → wrap the bench
+ *     `system` adapter (a `BenchMemoryAdapter`) into the MemCorrect contract
+ *     via the public access-service surface.
+ *   - Any other string is rejected with the valid options listed (rule 51) —
+ *     never silently reinterpreted.
  */
 function resolveAdapter(
   options: ResolvedRunBenchmarkOptions,
 ): { adapter: MemCorrectSystemAdapter; adapterLabel: string } {
   const override = options.benchmarkOptions?.["adapter"];
-  if (
+  if (typeof override === "string") {
+    if (override === "prompt-only") {
+      const adapter = new PromptOnlyBaselineAdapter();
+      return { adapter, adapterLabel: adapter.label };
+    }
+    if (override !== "remnic") {
+      throw new Error(
+        `memcorrect-v1 adapter must be one of ["remnic", "prompt-only"] (or an in-process MemCorrectSystemAdapter object); received "${override}"`,
+      );
+    }
+  } else if (
     override &&
     typeof override === "object" &&
     "reset" in override &&

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -102,6 +102,8 @@ export interface ParsedBenchArgs {
   publishedIngestConcurrency?: number;
   /** `bench published` — benchmark-specific task/ability filter for diagnostic runs. */
   publishedTaskFilter?: string;
+  /** `bench run memcorrect-v1` — adapter mode ("remnic" | "prompt-only"). */
+  memcorrectAdapter?: "remnic" | "prompt-only";
   /** `bench published` — published artifact output directory. */
   publishedOut?: string;
   /** `bench published` — dry-run: validate + load but do NOT call the model. */
@@ -374,6 +376,7 @@ const BENCH_VALUE_FLAGS = Object.freeze([
   "--ama-bench-cross-judge-api-key",
   "--ama-bench-cross-judge-codex-reasoning-effort",
   "--local-lab-manifest",
+  "--memcorrect-adapter",
 ] as const);
 
 const BENCH_BOOLEAN_FLAGS = Object.freeze([
@@ -455,6 +458,7 @@ const RUN_VALUE_FLAGS = Object.freeze([
   "--ama-bench-cross-judge-api-key",
   "--ama-bench-cross-judge-codex-reasoning-effort",
   "--local-lab-manifest",
+  "--memcorrect-adapter",
 ] as const satisfies readonly BenchValueFlag[]);
 
 const RUN_BOOLEAN_FLAGS = Object.freeze([
@@ -1148,6 +1152,18 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     publishedTaskFilter = trimmed;
   }
 
+  const memcorrectAdapterRaw = readBenchOptionValue(args, "--memcorrect-adapter");
+  let memcorrectAdapter: "remnic" | "prompt-only" | undefined;
+  if (memcorrectAdapterRaw !== undefined) {
+    if (memcorrectAdapterRaw !== "remnic" && memcorrectAdapterRaw !== "prompt-only") {
+      // Rule 51: reject invalid enum values with the valid options listed.
+      throw new Error(
+        'ERROR: --memcorrect-adapter must be "remnic" or "prompt-only".',
+      );
+    }
+    memcorrectAdapter = memcorrectAdapterRaw;
+  }
+
   let publishedSeed: number | undefined;
   if (publishedSeedRaw !== undefined) {
     const parsed = Number(publishedSeedRaw);
@@ -1342,6 +1358,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     publishedTrialConcurrency,
     publishedIngestConcurrency,
     publishedTaskFilter,
+    memcorrectAdapter,
     publishedOut: publishedOutRaw
       ? path.resolve(expandTilde(publishedOutRaw))
       : undefined,

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -1161,6 +1161,19 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
         'ERROR: --memcorrect-adapter must be "remnic" or "prompt-only".',
       );
     }
+    // Mirror the other benchmark-specific flag checks (--task-filter,
+    // --ingest-concurrency): an explicit adapter choice on a non-MemCorrect
+    // run would be silently ignored downstream — reject instead (codex P2).
+    const targetsMemcorrect =
+      action !== "published" &&
+      !args.includes("--all") &&
+      benchmarks.length === 1 &&
+      benchmarks[0] === "memcorrect-v1";
+    if (!targetsMemcorrect) {
+      throw new Error(
+        "ERROR: --memcorrect-adapter is only supported for a single-benchmark memcorrect-v1 run.",
+      );
+    }
     memcorrectAdapter = memcorrectAdapterRaw;
   }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2948,6 +2948,7 @@ function buildPublishedBenchmarkOptions(
     publishedTrialLimit?: number;
     publishedTrialConcurrency?: number;
     publishedTaskFilter?: string;
+    memcorrectAdapter?: "remnic" | "prompt-only";
   },
 ): Record<string, unknown> | undefined {
   const trialLimitOptions =
@@ -2973,6 +2974,9 @@ function buildPublishedBenchmarkOptions(
   }
   if (benchmarkId === "beam" && args.publishedTaskFilter !== undefined) {
     return { taskFilter: args.publishedTaskFilter };
+  }
+  if (benchmarkId === "memcorrect-v1" && args.memcorrectAdapter !== undefined) {
+    return { adapter: args.memcorrectAdapter };
   }
   return undefined;
 }

--- a/scripts/bench/run-tierf-opus.sh
+++ b/scripts/bench/run-tierf-opus.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Tier-F run via Opus 4.8 / Claude Code (`claude -p`) — issue #1728.
+#
+# Responder: claude-cli / opus (Claude Max entitlement; the claude-cli bench
+# provider runs from an isolated empty temp workspace with tools disabled).
+# Judge: local RTX 3090 ollama qwen2.5-7b-32k:latest — the Tier-L judge role
+# pinned in docs/benchmarks/configs/local-lab-3090.json, calibrated against
+# an Opus-judged slice (Cohen's kappa) BEFORE the full runs so every stored
+# result carries `judgeCalibration` (PR #1709 gap).
+#
+# Prerequisites (operator):
+#   1. `claude /login` completed on this host (Claude Max).
+#   2. Datasets under ./bench-datasets/{locomo,longmemeval}.
+#   3. Ollama serving qwen2.5-7b-32k:latest on 127.0.0.1:11434.
+#
+# Order matters: judge-calibrate persists the kappa state that
+# attachPersistedJudgeCalibration stamps into subsequent run results at
+# write time — calibrate first, then run. LongMemEval (500 tasks, ~1.3 h of
+# responder time) runs before LoCoMo (1986 tasks, ~4 h) so a Claude Max
+# window cap hits the smaller run last. The claude-cli provider serializes
+# to concurrency 1 and backs off on usage-limit responses; if the weekly
+# quota trips mid-run, rerun this script after the window resets — the
+# judge cache makes re-judging cached answers free, but responder calls for
+# incomplete tasks are re-paid (no per-task checkpoint exists yet).
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+LOG_DIR="${TIERF_LOG_DIR:-$HOME/tierf-logs}"
+mkdir -p "$LOG_DIR"
+MANIFEST="docs/benchmarks/configs/local-lab-3090.json"
+JUDGE_ARGS=(--judge-provider ollama --judge-model "qwen2.5-7b-32k:latest" --judge-base-url "http://127.0.0.1:11434")
+SEED=1
+
+step() { printf '\n=== %s — %s ===\n' "$(date -u +%FT%TZ)" "$1"; }
+
+step "preflight: claude auth"
+AUTH_OUT="$(cd /tmp && timeout 180 claude -p "Reply with exactly: pong" --max-turns 1 2>&1 | tail -1)"
+printf 'claude probe: %s\n' "$AUTH_OUT"
+if [[ "$AUTH_OUT" != *pong* ]]; then
+  echo "BLOCKED: claude CLI is not authenticated on this host. Run: claude /login" >&2
+  exit 2
+fi
+
+step "judge calibration (Cohen's kappa) — locomo"
+node scripts/run-bench-cli.mjs judge-calibrate --benchmark locomo \
+  --local-lab-manifest "$MANIFEST" \
+  --judge-provider claude-cli --judge-model opus \
+  2>&1 | tee "$LOG_DIR/judge-calibrate-locomo.log"
+
+step "judge calibration (Cohen's kappa) — longmemeval"
+node scripts/run-bench-cli.mjs judge-calibrate --benchmark longmemeval \
+  --local-lab-manifest "$MANIFEST" \
+  --judge-provider claude-cli --judge-model opus \
+  2>&1 | tee "$LOG_DIR/judge-calibrate-longmemeval.log"
+
+step "full LongMemEval (500 tasks) — Opus responder, local judge"
+node scripts/run-bench-cli.mjs run longmemeval \
+  --runtime-profile baseline \
+  --system-provider claude-cli --system-model opus \
+  "${JUDGE_ARGS[@]}" \
+  --dataset-dir bench-datasets/longmemeval \
+  --seed "$SEED" \
+  2>&1 | tee "$LOG_DIR/longmemeval-full.log"
+
+step "full LoCoMo (1986 tasks) — Opus responder, local judge"
+node scripts/run-bench-cli.mjs run locomo \
+  --runtime-profile baseline \
+  --system-provider claude-cli --system-model opus \
+  "${JUDGE_ARGS[@]}" \
+  --dataset-dir bench-datasets/locomo \
+  --seed "$SEED" \
+  2>&1 | tee "$LOG_DIR/locomo-full.log"
+
+step "done — results in ~/.remnic/bench/results/"
+ls -t "$HOME/.remnic/bench/results/" | head -6

--- a/scripts/bench/run-tierf-opus.sh
+++ b/scripts/bench/run-tierf-opus.sh
@@ -28,7 +28,10 @@ cd "$(dirname "$0")/../.."
 LOG_DIR="${TIERF_LOG_DIR:-$HOME/tierf-logs}"
 mkdir -p "$LOG_DIR"
 MANIFEST="docs/benchmarks/configs/local-lab-3090.json"
-JUDGE_ARGS=(--judge-provider ollama --judge-model "qwen2.5-7b-32k:latest" --judge-base-url "http://127.0.0.1:11434")
+# The bench ollama provider appends /generate and /tags directly to baseUrl —
+# it needs the /api form (the local-lab manifest path normalizes this, the raw
+# CLI flag does not).
+JUDGE_ARGS=(--judge-provider ollama --judge-model "qwen2.5-7b-32k:latest" --judge-base-url "http://127.0.0.1:11434/api")
 SEED=1
 
 step() { printf '\n=== %s — %s ===\n' "$(date -u +%FT%TZ)" "$1"; }

--- a/scripts/bench/run-tierf-opus.sh
+++ b/scripts/bench/run-tierf-opus.sh
@@ -34,6 +34,18 @@ MANIFEST="docs/benchmarks/configs/local-lab-3090.json"
 JUDGE_ARGS=(--judge-provider ollama --judge-model "qwen2.5-7b-32k:latest" --judge-base-url "http://127.0.0.1:11434/api")
 SEED=1
 
+# judge-calibrate does NOT generate answers — it re-judges a benchmark's
+# CACHED answers from an existing FULL stored result in ~/.remnic/bench/results
+# (the Tier-L pass produced these on the lab host). Fail up front with a clear
+# message instead of erroring mid-script on a clean runner (codex P2).
+preflight_calibration_inputs() {
+  local benchmark="$1"
+  if ! ls "$HOME/.remnic/bench/results/${benchmark}-v"*.json >/dev/null 2>&1; then
+    echo "BLOCKED: judge-calibrate needs an existing FULL stored ${benchmark} result (cached answers) in ~/.remnic/bench/results — run the Tier-L pass first (see docs/benchmarks.md)." >&2
+    exit 3
+  fi
+}
+
 step() { printf '\n=== %s — %s ===\n' "$(date -u +%FT%TZ)" "$1"; }
 
 step "preflight: claude auth"
@@ -43,6 +55,10 @@ if [[ "$AUTH_OUT" != *pong* ]]; then
   echo "BLOCKED: claude CLI is not authenticated on this host. Run: claude /login" >&2
   exit 2
 fi
+
+step "preflight: cached answers for calibration"
+preflight_calibration_inputs locomo
+preflight_calibration_inputs longmemeval
 
 step "judge calibration (Cohen's kappa) — locomo"
 node scripts/run-bench-cli.mjs judge-calibrate --benchmark locomo \


### PR DESCRIPTION
## Summary
- Route the Remnic MemCorrect adapter's correct() through the Correction Contract (plan + confirmed apply) via the public access-service surface (evidence-sprint plan item 2a); plain turn path remains the fallback when the planner produces no applicable action
- `--memcorrect-adapter <remnic|prompt-only>` CLI mode selects the adapter (rule-51 validated)
- Commit two full 40-scenario Tier-L memcorrect-v1 artifacts (remnic-native under shipped defaults with local qwen classify LLM on the RTX 3090; prompt-only floor) + pinned lab config + local-lab 3090 manifest
- Figure 2 now renders real MemCorrect bars; figures README provenance updated
- Paper §3 drafted from the shipped modules (recall spine, provenance spans, faithfulness gate, TrustScore, Correction Contract, bi-temporal tombstones, X-ray) with an architecture-differentiation subsection; §6.1 reports the floor-identical containment metrics honestly with the serving-layer leakage mechanism analysis

## Verification
- pnpm exec tsx --test packages/bench/src/benchmarks/remnic/memcorrect/adapters.test.ts packages/bench/src/benchmarks/remnic/memcorrect/runner.test.ts (25/25)
- pnpm exec tsx --test --test-name-pattern "correct() reports not-applied" packages/bench/src/adapters/remnic-adapter.test.ts (real-orchestrator integration, 1/1)
- pnpm --filter @remnic/bench run check-types && pnpm --filter @remnic/cli run check-types
- pnpm run figures:paper → fig2 REAL (both adapters); pnpm exec tsx --test tests/paper-figures.test.mjs (11/11)
- End-to-end contract probe on jarvis-ml: fact extracted → plan applied → fact superseded/forgotten (receipts in PR discussion via issue updates)

Part of #1725; figures issue #1731 (Figure 2 panel now real).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds bench correction execution with strict session scoping and hard failures on foreign or empty replans, which could break MemCorrect runs if mis-scoped; large committed benchmark artifacts and paper claims depend on correct harness labeling.
> 
> **Overview**
> MemCorrect’s Remnic path now exercises **real correction behavior**: optional `correct()` on `BenchMemoryAdapter` runs plan + confirmed apply through `EngramAccessService`, with session-scoped ownership checks so one benchmark session cannot mutate another’s memories. The MemCorrect wrapper uses that surface when present and only falls back to storing a user turn when the contract does not apply; timeout guarding forwards `correct()` so timed runs stay labeled honestly.
> 
> **Published reproducibility:** Tier-L full-matrix `memcorrect-v1` JSON for remnic-native and prompt-only baseline, pinned lab configs, expanded artifact manifest, regenerated Figure 2 (and related figure/README updates), and changelog/docs/paper updates—§3 drafted from shipped modules; §6.1 documents floor-identical containment metrics and recall-side stale leakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ddd6fb1bf79370cc96a7ed386cbcf445e6c2ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->