### PR TITLE
docs(paper): draft remaining sections — abstract, §1, §2 pointer, §4, §7, §8, §9

### DIFF
--- a/docs/benchmarks/ablations.md
+++ b/docs/benchmarks/ablations.md
@@ -5,7 +5,7 @@ This page reports the **single-flag ablation matrix** from issue
 / [#1725](https://github.com/joshuaswarren/remnic/issues/1725), produced on the
 RTX 3090 local-lab box under the `local-lab` runtime profile.
 
-Each ablation flips **exactly one** recall-stack flag off its default in the
+Each ablation changes **exactly one** recall-stack flag away from its default in the
 baseline run and re-runs the full LoCoMo-10 benchmark (1986 questions across
 all 10 conversations) with everything else held constant: same model
 (`qwen2.5-7b-32k:latest`, Q4_K_M), same seed (1), same responder **and** judge

--- a/docs/benchmarks/memcorrect.md
+++ b/docs/benchmarks/memcorrect.md
@@ -73,8 +73,9 @@ In-tree adapters:
 2. **`createRemnicMemCorrectAdapter`** — wraps the public `BenchMemoryAdapter`
    (the access-service-level abstraction) into the contract. `ingestTurn` →
    `store`; `recall` → `adapter.recall` split into ranked strings; `correct`
-   → observe the correction as a user turn (the correction-contract tool
-   rides here once #1580 lands); `runMaintenance` → `adapter.drain()`.
+   → routes through the Correction Contract (plan + confirmed apply) via the
+   public access-service surface, with the plain user-turn path as fallback
+   (landed in PR #1862); `runMaintenance` → `adapter.drain()`.
 
 Third-party adapters (Mem0, OpenMemory, …) are welcome follow-ups behind
 the same interface. **Do not** reach into orchestrator internals — that

--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -29,9 +29,9 @@ not the markup.
 
 | File | Owner | Status |
 |---|---|---|
-| `main.md` | #1726 (this issue) | Skeleton — abstract + §1–§9, intent + TODOs only |
-| `related-work.md` | #1729 (sibling issue) | Not created here. `main.md` §2 points at it. |
-| `repro-appendix.md` | follow-up child of the plan's execution item 8 | Not created here. `main.md` §9 points at it. |
+| `main.md` | #1726 (this issue) | Working draft — §1–§9 in prose; remaining `TODO(#NNNN)` markers inline (third-party adapters #1727/#1747, §6.3 TrustScore/faithfulness, §7.2 #1708) |
+| `related-work.md` | #1729 (landed) | Drafted — differentiation table + capability matrix. `main.md` §2 points at it. |
+| `repro-appendix.md` | plan execution item 8 | Drafted — Tier L and Tier F (§A.5) reproduction paths. `main.md` §9 points at it. |
 
 Section-level standalone files are intentionally avoided except where a sibling
 issue owns one (`related-work.md`). Keeping the rest of the skeleton in a single
@@ -42,18 +42,17 @@ issue owns one (`related-work.md`). Keeping the rest of the skeleton in a single
 1. **No fabricated numbers.** Every metric cited must trace to a committed
    artifact under `docs/benchmarks/results/` (or a sibling path). Anything not
    yet produced is a `TODO(#NNNN)`, never a placeholder value.
-2. **Cite only committed artifacts.** As of this skeleton the only real
-   (non-mock) committed artifacts are the two Tier-L local runs at
-   `docs/benchmarks/results/2026-07-07-locomo-qwen2.5-7b-32k_latest-47aae03.json`
-   and
-   `docs/benchmarks/results/2026-07-07-longmemeval-qwen2.5-7b-32k_latest-47aae03.json`
-   (both `tier: "local"`, model `qwen2.5-7b-32k:latest`). The
-   `2026-04-20-*-mock000.json` files are **mocks** and must never be cited as
-   results.
-3. **No Tier-F claim without the real run.** A complete Tier-F responder run
-   (Opus 4.8 via `claude -p`) is still pending for the full dataset. The
-   bounded artifacts and provider are available; §6 Results and §5 Tier-F rows
-   must distinguish trial coverage from full coverage.
+2. **Cite only committed artifacts.** `docs/benchmarks/results/` on `main`
+   carries ten artifacts: two mocks (`2026-04-20-*-mock000.json` — never cite
+   as results), two real Tier-L anchors (`2026-07-07-*-47aae03.json`), two
+   bounded Tier-F trials (`2026-07-08-*-798fe8a.json` — partial coverage,
+   never leaderboard numbers), two MemCorrect full-matrix runs
+   (`2026-07-13-memcorrect-v1-*-9485f44.json`), and two full Tier-F frontier
+   runs (`2026-07-14-*-opus-0676347.json`).
+3. **Distinguish trial coverage from full coverage.** The full Tier-F run
+   (Opus 4.8 via `claude -p`, `real` profile) landed 2026-07-14 and is the
+   accuracy claim; the 2026-07-08 bounded artifacts remain partial-coverage
+   evidence only.
 4. **Lead with MemCorrect (composition framing), not raw Tier-L accuracy.** Per
    Joshua's confirmed decision (2026-07-07). MemCorrect's novelty is a
    composition/protocol claim, **not** "first to measure memory correction" —

--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -48,7 +48,12 @@ issue owns one (`related-work.md`). Keeping the rest of the skeleton in a single
    bounded Tier-F trials (`2026-07-08-*-798fe8a.json` — partial coverage,
    never leaderboard numbers), two MemCorrect full-matrix runs
    (`2026-07-13-memcorrect-v1-*-9485f44.json`), and two full Tier-F frontier
-   runs (`2026-07-14-*-opus-0676347.json`).
+   runs (`2026-07-14-*-opus-0676347.json`). One recorded exception: the three
+   §7.1 ablation-cell artifacts (`…c67c2c7-*.json`) are committed in git
+   history at `dcdcb5a8` but deliberately untracked from the current tree so
+   the figure generator's newest-per-tier pick keeps the Figure 1 Tier-L
+   anchor clean; `docs/benchmarks/ablations.md` and §7.1's provenance note
+   document the retrieval path.
 3. **Distinguish trial coverage from full coverage.** The full Tier-F run
    (Opus 4.8 via `claude -p`, `real` profile) landed 2026-07-14 and is the
    accuracy claim; the 2026-07-08 bounded artifacts remain partial-coverage

--- a/docs/paper/main.md
+++ b/docs/paper/main.md
@@ -83,7 +83,7 @@ old value anywhere in recall context fails the probe. That is exactly the
 failure class the benchmark exists to expose: fact-store correction is
 necessary but not sufficient.
 
-This paper makes four contributions:
+This paper makes three contributions:
 
 1. **MemCorrect**, a benchmark that evaluates agent-memory correction as a
    complete, system-agnostic protocol. It combines five correction
@@ -93,25 +93,26 @@ This paper makes four contributions:
    a claim to be first at measuring any single behavior. StateBench, STALE,
    MemSyco-Bench, MemStrata, and MemoryAgentBench each test a slice; §2
    engages each one metric by metric so the composition claim is defensible.
-2. **Glass-box mechanisms** that make every recall explainable and every
+2. **A reproducible-on-one-GPU evaluation protocol.** A two-tier design
+   (Tier L local RTX 3090 anchor, Tier F frontier) with committed repro
+   manifests, a content-cached judge, and Cohen's-kappa cross-tier
+   calibration against an Opus-judged gold slice. §5 specifies the protocol
+   and the publishability rubric every number must pass.
+3. **Glass-box mechanisms** that make every recall explainable and every
    correction auditable: provenance spans (#1575), a faithfulness gate
    (#1576), TrustScore (#1577), bi-temporal validity with tombstoned
    non-resurrection (#1578-1579), and the Correction Contract with passive
    correction detection and memory handles `[m:xxxx]` (#1580-1583). §3
    describes the shipped system module by module; every mechanism cited
    corresponds to committed code.
-3. **A reproducible-on-one-GPU evaluation protocol.** A two-tier design
-   (Tier L local RTX 3090 anchor, Tier F frontier) with committed repro
-   manifests, a content-cached judge, and Cohen's-kappa cross-tier
-   calibration against an Opus-judged gold slice. §5 specifies the protocol
-   and the publishability rubric every number must pass.
-4. **Results** across three surfaces: MemCorrect exposes a containment-floor
-   failure class that fact-store correction alone does not close (§6.1);
-   LoCoMo and LongMemEval report Tier-F head-to-head results with the Tier-L
-   anchor as the reproducibility baseline (§6.2); TrustScore and
-   faithfulness behavior are reported as system capability (§6.3). Numeric
-   results live in §6; this introduction asserts no accuracy figure that §6
-   does not back with a committed artifact.
+
+The three contributions are evaluated across three result surfaces:
+MemCorrect exposes a containment-floor failure class that fact-store
+correction alone does not close (§6.1); LoCoMo and LongMemEval report
+Tier-F head-to-head results with the Tier-L anchor as the reproducibility
+baseline (§6.2); TrustScore and faithfulness behavior are reported as
+system capability (§6.3). Numeric results live in §6; this introduction
+asserts no accuracy figure that §6 does not back with a committed artifact.
 
 ---
 
@@ -676,8 +677,8 @@ passes the §5 publishability rubric.** Until then, every block is a TODO.
 
 This subsection reports the single-flag ablation matrix from issues
 #1730, #1574, and #1725, produced on the RTX 3090 local-lab box under the
-`local-lab` runtime profile. Each ablation flips exactly one recall-stack flag
-off its default in the baseline run and re-runs the full LoCoMo-10 benchmark
+`local-lab` runtime profile. Each ablation changes exactly one recall-stack
+flag away from its default in the baseline run and re-runs the full LoCoMo-10 benchmark
 (1986 questions across all 10 conversations) with everything else held
 constant: same model (`qwen2.5-7b-32k:latest`, Q4_K_M), same seed (1), same
 responder and judge model. The baseline is the first real Tier-L artifact,

--- a/docs/paper/main.md
+++ b/docs/paper/main.md
@@ -650,11 +650,13 @@ passes the §5 publishability rubric.** Until then, every block is a TODO.
   date-shaped queries. This is both an honest limitation and the
   concrete improvement lever documented in the Temporal Lift plan.
 
-  **`locomo_hidden_evidence_id_leak = 1.0`** on both tiers: the
-  responder always echoes the hidden evidence identifier embedded in
-  the recalled context. This is a known harness interaction (the IDs
-  are in the LCM evidence text the responder reads), not a Remnic
-  mechanism failure; it is reported honestly rather than suppressed.
+  **`locomo_hidden_evidence_id_leak = 1.0`** on both tiers: this is the
+  anti-leak guard holding, not a leak. The runner scores `1` only when
+  zero hidden evidence identifiers from the gold metadata surface in the
+  recalled context (`packages/bench/src/benchmarks/published/locomo/runner.ts`),
+  so `1.0` across every task means no run leaked gold evidence ids into
+  the answering path. This is the leaderboard-safety invariant from the
+  §5 rubric, verified per-task rather than assumed.
 
   - `TODO(#1747)`: Mem0 / Zep / Letta comparison rows are cited-not-
     reproduced until the third-party adapter runs land (API-key-gated,
@@ -672,7 +674,7 @@ passes the §5 publishability rubric.** Until then, every block is a TODO.
 
 ### 7.1 Single-flag ablations
 
-This subsection reports the committed single-flag ablation matrix from issues
+This subsection reports the single-flag ablation matrix from issues
 #1730, #1574, and #1725, produced on the RTX 3090 local-lab box under the
 `local-lab` runtime profile. Each ablation flips exactly one recall-stack flag
 off its default in the baseline run and re-runs the full LoCoMo-10 benchmark
@@ -681,9 +683,11 @@ constant: same model (`qwen2.5-7b-32k:latest`, Q4_K_M), same seed (1), same
 responder and judge model. The baseline is the first real Tier-L artifact,
 `2026-07-07-locomo-qwen2.5-7b-32k_latest-47aae03.json`, with memory-worth on,
 contradiction-scan off, and graph-recall off. The runner is
-`scripts/bench/run-ablation-matrix.ts`; each cell artifact is committed next to
-the baseline under `docs/benchmarks/results/` and verified with
-`pnpm exec tsx scripts/bench/verify-artifact.ts` before this section cites it.
+`scripts/bench/run-ablation-matrix.ts`; each cell artifact was verified with
+`pnpm exec tsx scripts/bench/verify-artifact.ts` before being cited. The
+committed source for this table is `docs/benchmarks/ablations.md`; the three
+cell artifacts themselves live in git history, not the current tree (see
+Artifact provenance below).
 
 | Cell | Flag flipped | `contains_answer` | `f1` | `llm_judge` | `rouge_l` | artifact |
 |---|---|---|---|---|---|---|
@@ -748,14 +752,18 @@ they confer is below the detection floor of this tier.
 **Artifact provenance.** The three ablation-cell artifacts
 (`…c67c2c7-memory-worth-off.json`,
 `…c67c2c7-contradiction-scan-on.json`,
-`…c67c2c7-graph-recall-on.json`) were untracked from the working tree to keep
-the Figure 1 Tier-L anchor clean. The figure generator picks the newest artifact
-per benchmark and tier, so leaving the cells tracked would have displaced the
-baseline anchor in the published figure. They remain reproducible from git
-history at commit `dcdcb5a8`
-(`git show dcdcb5a8:docs/benchmarks/results/<basename>`), on the lab host at
-`~/src/remnic/docs/benchmarks/results/`, and in the stored results at
-`~/.remnic/bench/results/`.
+`…c67c2c7-graph-recall-on.json`) were deliberately untracked from the working
+tree to keep the Figure 1 Tier-L anchor clean: the figure generator picks the
+newest artifact per benchmark and tier, so leaving the cells tracked would
+have displaced the baseline anchor in the published figure. They remain
+committed evidence in git history at commit `dcdcb5a8`: any clone can
+retrieve and re-verify them with
+`git show dcdcb5a8:docs/benchmarks/results/<basename>` followed by
+`pnpm exec tsx scripts/bench/verify-artifact.ts`. They are also present on
+the lab host at `~/src/remnic/docs/benchmarks/results/` and in the stored
+results at `~/.remnic/bench/results/`. This is the one deliberate exception
+to the "current-tree artifact" rule, and it is recorded both here and in
+`docs/benchmarks/ablations.md`.
 
 ### 7.2 Bounded-memory contract ablation
 

--- a/docs/paper/main.md
+++ b/docs/paper/main.md
@@ -1,12 +1,12 @@
 # Glass-Box Memory: Correctable, Provenance-Tracked Memory for User-Aware Agents
 
-> **Status: skeleton.** This file is section headers + a short paragraph of
-> intent per section + clearly-marked `TODO(#NNNN)` placeholders. It is **not**
-> prose and contains **no results or numbers**. See `README.md` for the
-> drafting rules (no fabricated numbers; cite only committed artifacts; lead
-> with MemCorrect, not raw accuracy).
+> **Status: working draft.** Sections §1, §3, §4, §5, §6.1, §6.2, §7.1, and §8
+> are drafted as prose. Remaining `TODO(#NNNN)` markers are inline where the
+> owning data or adapter run is still pending. The drafting rules in
+> `README.md` still bind every number and claim (no fabricated metrics; cite
+> only committed artifacts; lead with MemCorrect, not raw accuracy).
 >
-> **Source of truth for structure:**
+> **Structure source of truth:**
 > `docs/plans/2026-07-07-evidence-sprint-arxiv-outline.md` (Part 1). If this
 > file and the outline diverge, the outline wins.
 
@@ -14,57 +14,104 @@
 
 ## Abstract
 
-**Intent.** State the three contributions in one paragraph: (1) **MemCorrect**,
-a system-agnostic benchmark for memory *correction and steerability* — framed
-as a composition/protocol claim, **not** "first to measure correction"; (2) a
-**reproducible-on-consumer-hardware** two-tier (local RTX 3090 / frontier)
-evaluation protocol with committed repro manifests; (3) **glass-box trust**
-mechanisms — provenance spans, a faithfulness gate, TrustScore, and
-bi-temporal validity — that make recalls explainable and correctable, set
-against documented time-sensitive-memory failures in closed systems. Close
-with the honest scope line: Tier-L 7B-local numbers are a reproducibility
-anchor, not the accuracy headline.
+Agent memory systems fail users at the moment they need them most: when a
+stored fact goes stale. The assistant that learned the old address, the old
+employer, or the old preference keeps injecting the outdated value, and the
+user's recourse is blunt: disable memory entirely. We argue that recall
+accuracy, while necessary, is no longer the open problem. The open problems
+are correction durability (whether a fix propagates to every serving
+surface), collateral safety (whether a correction damages unrelated
+memories), scope precision (whether a correction respects namespace
+boundaries), and explainability (whether the user can inspect why a memory
+was served). This paper makes three contributions. First, we introduce
+MemCorrect, a system-agnostic benchmark for memory correction and
+steerability whose novelty is compositional: it combines adversarial
+non-resurrection, collateral safety, namespace-scoped precision, write-path
+false-apply, and revocation in one deterministic, adapter-scoreable corpus.
+Prior benchmarks each test an individual slice; none evaluates correction as
+a complete protocol (see §2). Second, we specify a two-tier evaluation
+protocol that is reproducible on consumer hardware. Tier L runs entirely on
+one RTX 3090 as the reproducibility anchor; Tier F carries the head-to-head
+accuracy claim, with Opus 4.8 via Claude Code (`claude -p`) as responder and
+the local 3090 as judge, cross-calibrated by Cohen's kappa against an
+Opus-judged gold slice. Committed repro manifests pin every number to a git
+SHA, seed, model identity, and runtime profile. Third, we describe glass-box
+trust mechanisms that make recalls explainable and correctable: provenance
+spans, a faithfulness gate, TrustScore, and bi-temporal validity with
+tombstoned non-resurrection. The Tier-L 7B-local numbers are a
+reproducibility anchor, not the accuracy headline; the accuracy claim rests
+on MemCorrect's composition framing and the Tier-F results reported in §6.
 
 - `TODO(#1584)`: land the MemCorrect one-line framing once the third-party
   adapter coverage (#1727) exists, so the comparison set is real.
-- `TODO(#1728)`: replace the Tier-F qualifier with the actual frontier-model
-  identity once the run lands (Opus 4.8 via `claude -p`).
-- `N/A` — no numbers in the abstract until every cited metric traces to a
-  committed, non-mock artifact.
 
 ---
 
 ## 1. Introduction
 
-**Intent.** Frame the agent-memory problem from the user's side: "the tool
-remembers a stale fact" is the field's #1 documented user pain, and users'
-only defense today is turning memory off. Argue that **recall accuracy is
-necessary but no longer the open problem** — correction durability, collateral
-safety, scope precision, and explainability are. Position glass-box memory as
-the response. End with an explicit **contributions list**:
+When an agent learns that a user lives in Portland, and the user later says
+they moved to Austin, the test is not whether the agent can recall an
+address. It is whether the old address stops appearing. Stale-fact memory is
+a persistent user pain: the system remembers what the user told it months ago
+and keeps injecting the outdated value, and the only widely available
+recourse is to disable memory entirely. This observation motivates the
+benchmark design documented in `docs/benchmarks/memcorrect.md`.
 
-1. **MemCorrect** — the first benchmark to evaluate agent-memory correction as
-   an end-to-end, system-agnostic protocol combining adversarial
-   non-resurrection, collateral safety, namespace-scoped precision, write-path
-   false-apply, and revocation in one deterministic, adapter-scoreable corpus
-   (composition/protocol novelty — see §2 for prior art).
-2. **Glass-box mechanisms** — provenance spans (#1575), a faithfulness gate
-   (#1576), TrustScore (#1577), bi-temporal validity + tombstones/non-
-   resurrection (#1578–1579), and the Correction Contract + passive correction
-   detection + memory handles `[m:xxxx]` (#1580–1583).
-3. **A reproducible-on-one-GPU protocol** — two-tier (Tier L local / Tier F
-   frontier) with committed repro manifests, judge cache, and Cohen's-κ
-   cross-tier calibration.
-4. **Results** — MemCorrect vs baselines and third-party adapters; LoCoMo /
-   LongMemEval head-to-head at Tier F with Tier L as the reproducibility
-   anchor; TrustScore/faithfulness behavior. *(All numeric — see §6 TODOs.)*
+Recall accuracy is necessary, but it is no longer the open problem. Standard
+long-context benchmarks (LongMemEval, LoCoMo) already measure whether the
+newest fact surfaces at answer time. The unsolved problems are downstream of
+recall. Correction durability asks whether a fix propagates to every serving
+surface or quietly survives in a behavioral profile or a verbatim transcript
+quote. Collateral safety asks whether correcting one memory damages unrelated
+ones. Scope precision asks whether a correction to one namespace stays out of
+another. Explainability asks whether the user can inspect why a memory was
+served and trust the verdict behind it. These four properties, not raw
+recall, are where current memory systems fail users.
 
-- `TODO(#1726)`: write the motivating paragraph once §6 results exist; do not
-  assert any accuracy figure in the intro that §6 does not back with a
-  committed artifact.
-- `TODO(#1729)`: cross-link the §2 prior-art engagement so the novelty claim
-  is defensible line-by-line (StateBench, STALE, MemSyco-Bench, MemStrata,
-  MemoryAgentBench FactConsolidation, RippleEdits/MQuAKE/TOFU/MUSE).
+The durability gap is concrete. At Tier L, Remnic's containment-scored
+MemCorrect metrics land on the same floor as a prompt-only baseline that
+performs no correction at all (§6.1). The failure is not a dead correction
+path. Extraction produces the target fact, the Correction Contract applies,
+and the stored fact is retired. The probes still fail because stale content
+reaches recall context
+through side channels the fact store does not control: the 7B classify model
+drafts retire-only plans that leave no corrected fact behind,
+behavioral-profile lines derived from the original fact survive, and verbatim
+LCM turn evidence quotes the outdated statement into context. MemCorrect is
+strict by design. A system that corrects its fact store but keeps serving the
+old value anywhere in recall context fails the probe. That is exactly the
+failure class the benchmark exists to expose: fact-store correction is
+necessary but not sufficient.
+
+This paper makes four contributions:
+
+1. **MemCorrect**, a benchmark that evaluates agent-memory correction as a
+   complete, system-agnostic protocol. It combines five correction
+   behaviors in one deterministic, adapter-scoreable corpus: adversarial
+   non-resurrection, collateral safety, namespace-scoped precision,
+   write-path false-apply, and revocation. The novelty is compositional, not
+   a claim to be first at measuring any single behavior. StateBench, STALE,
+   MemSyco-Bench, MemStrata, and MemoryAgentBench each test a slice; §2
+   engages each one metric by metric so the composition claim is defensible.
+2. **Glass-box mechanisms** that make every recall explainable and every
+   correction auditable: provenance spans (#1575), a faithfulness gate
+   (#1576), TrustScore (#1577), bi-temporal validity with tombstoned
+   non-resurrection (#1578-1579), and the Correction Contract with passive
+   correction detection and memory handles `[m:xxxx]` (#1580-1583). §3
+   describes the shipped system module by module; every mechanism cited
+   corresponds to committed code.
+3. **A reproducible-on-one-GPU evaluation protocol.** A two-tier design
+   (Tier L local RTX 3090 anchor, Tier F frontier) with committed repro
+   manifests, a content-cached judge, and Cohen's-kappa cross-tier
+   calibration against an Opus-judged gold slice. §5 specifies the protocol
+   and the publishability rubric every number must pass.
+4. **Results** across three surfaces: MemCorrect exposes a containment-floor
+   failure class that fact-store correction alone does not close (§6.1);
+   LoCoMo and LongMemEval report Tier-F head-to-head results with the Tier-L
+   anchor as the reproducibility baseline (§6.2); TrustScore and
+   faithfulness behavior are reported as system capability (§6.3). Numeric
+   results live in §6; this introduction asserts no accuracy figure that §6
+   does not back with a committed artifact.
 
 ---
 
@@ -72,11 +119,11 @@ the response. End with an explicit **contributions list**:
 
 Related Work is drafted standalone in [`related-work.md`](related-work.md)
 (issue #1729, landed). It positions MemCorrect as a composition/protocol
-claim, engages the closest relatives metric-by-metric (StateBench, STALE,
+claim. It engages the closest relatives metric-by-metric: StateBench, STALE,
 MemSyco-Bench, MemStrata, MemoryAgentBench FactConsolidation, and the
-weight-editing ancestors RippleEdits/MQuAKE/TOFU/MUSE), and carries the
-two load-bearing tables: **Table 1** (metric-by-metric differentiation
-with attribution) and the capability matrix against StateBench, STALE,
+weight-editing ancestors RippleEdits/MQuAKE/TOFU/MUSE. It carries the two
+load-bearing tables. Table 1 gives the metric-by-metric differentiation
+with attribution. The capability matrix compares StateBench, STALE,
 MemSyco-Bench, and the commercial systems (Mem0, Zep, Letta). The
 metric-attribution split is stated there explicitly: three metrics
 borrowed-and-attributed (`uptake_at_next`, `non_resurrection`,
@@ -271,17 +318,67 @@ context fails the probe even when a corrected fact also surfaces.
 
 ## 4. MemCorrect Benchmark
 
-**Intent.** The field-first contribution. Describe (a) **task construction**
-via the deterministic, seeded synthetic corpus generator (no real content
-committed — synthetic token pools enforced by the schema validator); (b) the
-**`MemCorrectSystemAdapter`** public interface, which makes the benchmark
-system-agnostic; (c) the **eight metrics** with direction and the
-determinism/judge split. Lift the methodology verbatim-adapted from
-`docs/benchmarks/memcorrect.md`.
+MemCorrect (`memcorrect-v1`, issue #1584, registered tier `remnic`) is a
+write-time correction benchmark built on a system-agnostic adapter contract
+and a deterministic synthetic corpus. Its claim is compositional, not "first
+to measure memory correction": the individual behaviors it scores each have
+antecedents in prior work (StateBench, STALE, MemSyco-Bench, MemStrata,
+MemoryAgentBench's FactConsolidation; see §2). The contribution is that no
+prior benchmark combines uptake, non-resurrection, collateral safety, scope
+precision, write-path false-apply, and revocation in one system-agnostic
+protocol with a hermetic corpus, and that several of its metrics
+(`uptake_latency`, `reassertion`, `provenance_fidelity`, namespace-twin
+`scope_precision`, anti-event `false_apply`) have no direct prior expression.
 
-The adapter contract (cite the committed interface in
-`packages/bench/src/benchmarks/remnic/memcorrect/adapters.ts`, do not
-re-derive):
+The motivation is not saturation. LongMemEval's knowledge-update (KU)
+category, the closest recall benchmark, checks only instantaneous answer
+correctness: does the newest fact win at answer time? The strongest systems
+score roughly 70-90% on KU, not ceiling. Our own in-repo Tier-L LongMemEval
+run (`docs/benchmarks/results/2026-07-07-longmemeval-qwen2.5-7b-32k_latest-47aae03.json`,
+full 500/500 oracle, `qwen2.5-7b-32k:latest` (Q4_K_M), tier `local`) returns
+`judge_accuracy = 0.186` across all categories, far from ceiling. Its
+`perTaskScores` carry no `question_type`, so no KU-only figure is derivable
+from it. KU is answer-time-only by design, so it cannot measure five
+behaviors users experience: how fast a correction takes effect, whether
+corrected facts resurrect after maintenance or re-ingest, whether
+corrections damage unrelated memories, whether corrections respect scope
+boundaries, and whether the system falsely applies third-party or
+hypothetical cues. "The tool remembers a stale fact" is the field's most
+documented user pain, and the only defense most systems offer is turning
+memory off. MemCorrect defines the evaluation that measures the correction
+behaviors the Correction Contract (#1580) and tombstones (#1579) exist to
+guarantee.
+
+### 4.1 Task construction: a deterministic synthetic corpus
+
+Per the repo ethics contract, no dataset file with real content is committed.
+`generateMemCorrectCorpus()`
+(`packages/bench/src/benchmarks/remnic/memcorrect/generator.ts`) is a
+deterministic, seeded synthetic corpus builder with the following structure:
+
+- **N personas × M facts** across five categories (`fact`, `preference`,
+  `decision`, `commitment`, `relationship`), each persona owning at least two
+  namespaces (work and home). The default `--quick` corpus is 2 personas × 4
+  facts (8 scenarios); `--full` is 5 × 8 (40 scenarios).
+- Every name, subject, and value is drawn from small **synthetic token pools**
+  (`token-pools.ts`). No real-world PII is possible by construction, and the
+  schema validator (`schema.ts`) enforces token-pool provenance for every fact
+  token.
+- Each fact enters the system through a natural **establishing transcript** of
+  two turns, so adapters ingest it via their normal observe path rather than a
+  backdoor write.
+
+CI runs the generator under a fixed seed and asserts the corpus hash is
+stable, the same guard pattern the published benchmarks use. Two runs with the
+same seed produce a byte-identical `meta.datasetHash` (SHA-256 of the
+canonical corpus JSON) and identical per-task deterministic metric values.
+The corpus hash is independent of the runtime profile: the profile resolves
+providers, but the scenario corpus is hermetic.
+
+### 4.2 The adapter contract
+
+MemCorrect is system-agnostic. Any memory system that implements this
+interface can be scored on identical scenarios with identical metrics:
 
 ```ts
 interface MemCorrectSystemAdapter {
@@ -294,22 +391,84 @@ interface MemCorrectSystemAdapter {
 }
 ```
 
-The eight metrics (`uptake_at_next`, `uptake_latency`, `non_resurrection`,
-`collateral_delta`, `scope_precision`, `false_apply`, `reassertion`,
-`provenance_fidelity`) — directions and definitions live in
-`docs/benchmarks/memcorrect.md`; the paper restates them, it does not invent
-new ones.
+The committed interface and both in-tree adapters live in
+`packages/bench/src/benchmarks/remnic/memcorrect/`: the typed
+`MemCorrectSystemAdapter` in `types.ts`, the adapters in `adapters.ts`. The
+listing above drops the TypeScript annotations for readability.
+`PromptOnlyBaselineAdapter` is an append-everything store with BM25-style
+term-overlap recall over raw turns; its `correct()` is just another turn and
+`runMaintenance()` is a no-op. It never retires anything, so re-ingesting the
+original transcript resurrects the retired fact. It exists as the structural
+floor so metric deltas mean something. `createRemnicMemCorrectAdapter` wraps
+the public `BenchMemoryAdapter` (the access-service-level abstraction):
+`ingestTurn` maps to `store`, `recall` maps to `adapter.recall` split into
+ranked strings, `correct` routes through the Correction Contract (plan plus
+confirmed apply) via the public access-service surface, with the plain
+turn path as fallback, and `runMaintenance` maps to `adapter.drain()`.
 
-- `TODO(#1584)`: lift the metric table and the four correction-event shapes +
-  anti-event taxonomy from `docs/benchmarks/memcorrect.md`.
-- `TODO(#1584)` **[claim already corrected — keep guard]**: `docs/benchmarks/
-  memcorrect.md` no longer says LongMemEval KU is "near ceiling"; it now reads
-  *"the strongest systems score roughly 70–90%, not ceiling"* and frames KU as
-  answer-time-only. The §4 draft must preserve this corrected framing; do not
-  re-introduce the old wording.
-- `TODO(#1727)`: name the third-party adapters scored (Mem0 → Zep → Letta
-  order) once implemented; until then §4 describes the *contract*, not a
-  comparison.
+### 4.3 Correction events and anti-events
+
+Each scenario seeds facts, then fires correction events in four shapes:
+
+1. **Explicit-targeted.** "Your record that I prefer X is wrong." The
+   correction names the target fact directly.
+2. **Conversational.** "Oh by the way, we dropped X last month." The
+   correction is embedded in ordinary dialogue, not flagged as a correction.
+3. **Scoped.** A correction valid in namespace A must not affect the same-text
+   fact seeded in namespace B. The scenario carries a namespace-B twin to
+   test boundary respect.
+4. **Re-assertion.** After a correction, the user re-asserts the original
+   ("actually, we went back to X"). This exercises the revocation path: a
+   superseded fact that the user reverses must become recallable again.
+
+A parallel anti-event taxonomy measures false-apply, mirroring the #1581
+anti-fixture design:
+
+- **Quoting-others.** The user quotes or attributes a statement to someone
+  else; the system must not store it as the user's own fact.
+- **Hypothetical.** The user reasons about a counterfactual; the system must
+  not persist it as established.
+- **Third-party-correction.** A correction aimed at another person's record
+  must not mutate the current user's memory.
+
+### 4.4 Metrics
+
+All eight metrics score through token containment in the unit-tested harness
+(`metrics.ts`, `metrics.test.ts`). The metric functions are pure functions
+over a probe log plus resolved scenario metadata, with hand-computed table
+tests. A sealed-rubric LLM judge (temperature 0, #1573 content cache) is
+reserved for paraphrase-equivalence cases, but no shipped metric routes
+through it: a benchmark whose scores move with judge temperature is not a
+benchmark. Time windows are half-open `[start, end)` everywhere.
+
+| Metric | Direction | Definition | Determinism |
+|---|---|---|---|
+| `uptake_at_next` | higher | Fraction of corrections reflected in the *first* post-correction probe (corrected content present, retired content absent). | token containment |
+| `uptake_latency` | lower | Mean interaction turns until the first correct recall, capped at K. Censored (never-correct-within-cap) corrections contribute K and are counted in `uptake_latency_censored`. | token containment; excluded from cross-run equality |
+| `non_resurrection` | higher | After correction: `runMaintenance()` ×K cycles AND re-ingest of the original establishing transcript; fraction of retired facts that stay retired. | token containment |
+| `collateral_delta` | → 0 | Recall over a fixed probe set of UNRELATED facts, before vs after corrections. Report the delta (after − before); unchanged = 0 is the target. | token containment |
+| `scope_precision` | higher | Scoped corrections: fraction where the namespace-B twin stays intact AND the namespace-A retired fact is retired. | token containment |
+| `false_apply` | lower | Anti-events that caused an undesired memory mutation (detected behaviorally: the `shouldNotAppear` token surfaces in a subsequent probe). | token containment |
+| `reassertion` | higher | Re-asserted facts recallable again after the re-assertion event. | token containment |
+| `provenance_fidelity` | higher | (Systems supporting it; else n/a) corrected state cites the correction event. | token containment; n/a if unsupported |
+
+Per-task scores carry the seven always-scored metrics under `scores`;
+`provenance_fidelity` is `null` for adapters that do not surface provenance and
+is carried in `details.metrics.memcorrect`. The headline aggregate, computed
+across the union of all scenario probe logs, attaches to
+`config.benchmarkOptions.aggregateMetrics`.
+
+### 4.5 The sanity contract
+
+The benchmark is the referee, not the marketing. The prompt-only baseline must
+score near-zero on `non_resurrection` under re-ingest, because it never
+retires anything. The design intent is that a correction-capable system clears
+that floor. When the first full-matrix Tier-L run did not (§6.1), the response
+was to trace the serving-surface leaks per scenario, not to tune the
+benchmark; §6.1 reports that trace and §8 names the follow-up work it
+motivates.
+
+- TODO(#1727): name the third-party adapters scored (Mem0 -> Zep -> Letta order) once implemented; until then §4 describes the *contract*, not a comparison.
 
 ---
 
@@ -511,46 +670,182 @@ passes the §5 publishability rubric.** Until then, every block is a TODO.
 
 ## 7. Ablations
 
-**Intent.** Two ablation families, each lifted from its owning issue — no new
-runs invented here.
+### 7.1 Single-flag ablations
 
-- **7.1 Single-flag ablations** — `TODO(#1574)`: Memory Worth multiplier,
-  contradiction scan, graph recall. Report as on/off deltas with the runtime
-  profile + seed pinned per the §5 manifest.
-- **7.2 Bounded-memory contract ablation** — `TODO(#1708)`: raw transcript vs
-  typed retrieval vs skill-triggered retrieval. **#1708 is open** — coordinate
-  rather than duplicate; this section is blocked on its data.
-- `TODO(#1726)`: assemble the ablation table once both families' artifacts are
-  committed; until then this section lists the axes only.
+This subsection reports the committed single-flag ablation matrix from issues
+#1730, #1574, and #1725, produced on the RTX 3090 local-lab box under the
+`local-lab` runtime profile. Each ablation flips exactly one recall-stack flag
+off its default in the baseline run and re-runs the full LoCoMo-10 benchmark
+(1986 questions across all 10 conversations) with everything else held
+constant: same model (`qwen2.5-7b-32k:latest`, Q4_K_M), same seed (1), same
+responder and judge model. The baseline is the first real Tier-L artifact,
+`2026-07-07-locomo-qwen2.5-7b-32k_latest-47aae03.json`, with memory-worth on,
+contradiction-scan off, and graph-recall off. The runner is
+`scripts/bench/run-ablation-matrix.ts`; each cell artifact is committed next to
+the baseline under `docs/benchmarks/results/` and verified with
+`pnpm exec tsx scripts/bench/verify-artifact.ts` before this section cites it.
+
+| Cell | Flag flipped | `contains_answer` | `f1` | `llm_judge` | `rouge_l` | artifact |
+|---|---|---|---|---|---|---|
+| **Baseline** | (defaults) | 0.0831 | 0.1217 | 0.2243 | 0.1177 | `…47aae03.json` |
+| **memory-worth-off** | Memory Worth multiplier OFF (baseline ON) | 0.0856 (Δ+0.0025 / +3.0%) | 0.1227 (Δ+0.0009 / +0.8%) | 0.2239 (Δ-0.0004 / -0.2%) | 0.1187 (Δ+0.0010 / +0.9%) | `…c67c2c7-memory-worth-off.json` |
+| **contradiction-scan-on**† | Contradiction scan ON (baseline OFF) | 0.0851 (Δ+0.0020 / +2.4%) | 0.1220 (Δ+0.0003 / +0.2%) | 0.2236 (Δ-0.0007 / -0.3%) | 0.1181 (Δ+0.0004 / +0.3%) | `…c67c2c7-contradiction-scan-on.json` |
+| **graph-recall-on**† | Graph / temporal recall ON (baseline OFF) | 0.0851 (Δ+0.0020 / +2.4%) | 0.1220 (Δ+0.0003 / +0.2%) | 0.2236 (Δ-0.0007 / -0.3%) | 0.1181 (Δ+0.0004 / +0.3%) | `…c67c2c7-graph-recall-on.json` |
+
+† `contradiction-scan-on` and `graph-recall-on` produced byte-identical
+per-task scores (see below). The fifth metric,
+`locomo_hidden_evidence_id_leak`, stays at 1.000 across every cell, confirming
+that no run leaks hidden gold evidence ids into the answer path. The
+anti-cheating invariant holds.
+
+The finding is the absence of a measurable effect. None of the three cells
+moves any metric by more than the run-to-run noise band at this scale, so no
+default is changed by this ablation. The largest move across all cells is
+`contains_answer` +0.0025 absolute (+3.0% relative) under `memory-worth-off`,
+well within the 5 to 8 percent band that single-seed Tier-L runs treat as
+indistinguishable from noise. Disabling the Memory Worth recall multiplier
+neither helps nor hurts at 7B-Q4; the default stays on. Enabling inline
+contradiction detection (`contradictionDetectionEnabled`) on the write path
+neither helps nor hurts; the default stays off. Enabling graph recall plus
+full-mode graph assist neither helps nor hurts; the default stays off.
+
+**Bit-identical pair.** `contradiction-scan-on` and `graph-recall-on` produced
+byte-identical per-task scores across all 1986 LoCoMo questions: every
+`contains_answer`, `f1`, `llm_judge`, and `rouge_l` per-task value matches to
+full float precision. They are not the same file. They carry different sha256
+hashes (`11e55bb8…` vs `bc1504a7…`), different flag envelopes, and different
+run windows, and each ran an independent ~18-minute full benchmark (18.2 min vs
+17.9 min). This is not a caching artifact. The override merge in
+`scripts/bench/run-ablation-matrix.ts` spreads each cell's flag onto the
+baseline config as `remnicConfig`, and the `memory-worth-off` cell (which flips
+a recall-time multiplier) genuinely differs from this pair on 5/1986 tasks and
+from the baseline on 109/1986 tasks. The runner is flag-aware; these two flags
+simply have zero measurable effect on the recall, answer, and score path for
+LoCoMo at 7B-Q4. The most likely reason `[INFERENCE]`: LoCoMo is replayed with
+`replayExtractionMode: "skip"`, so the memory store is loaded from a pre-built
+snapshot rather than re-ingested question by question. Inline contradiction
+detection is a write-path gate; with no fresh writes to gate during a
+skip-extraction replay it is inert. Graph recall needs a built causal or
+timeline graph; with extraction skipped there is nothing to traverse, so it is
+inert. Both flags are effectively no-ops under this replay mode. Confirming the
+exact mechanism needs a single instrumented run and is filed as a follow-up,
+not a gate on this artifact set. The bit-identity is itself the evidence that
+the effect, if any, is strictly below the detection floor at this tier.
+
+**Variance caveats.** These are Tier-L regression numbers, not capability
+claims. Responder and judge are both `qwen2.5-7b-32k:latest` (7B instruct,
+Q4_K_M) on a single RTX 3090, so the flag under test is a second-order effect dwarfed by the
+7B answer and judge quality variance. Every cell runs at seed 1 only: there is
+no multi-seed mean or confidence interval. Because the responder and judge are
+the same model, the `llm_judge` column carries a known self-preference caveat.
+A delta that looks real at this tier can vanish or invert on a rerun. A default
+change requires either a delta outside the noise band on multiple seeds or a
+Tier-F confirmation, neither of which this matrix provides. The matrix
+documents the absence of a measurable single-flag effect at 7B-Q4, which means
+these flags are safe to leave at their shipped defaults and that any benefit
+they confer is below the detection floor of this tier.
+
+**Artifact provenance.** The three ablation-cell artifacts
+(`…c67c2c7-memory-worth-off.json`,
+`…c67c2c7-contradiction-scan-on.json`,
+`…c67c2c7-graph-recall-on.json`) were untracked from the working tree to keep
+the Figure 1 Tier-L anchor clean. The figure generator picks the newest artifact
+per benchmark and tier, so leaving the cells tracked would have displaced the
+baseline anchor in the published figure. They remain reproducible from git
+history at commit `dcdcb5a8`
+(`git show dcdcb5a8:docs/benchmarks/results/<basename>`), on the lab host at
+`~/src/remnic/docs/benchmarks/results/`, and in the stored results at
+`~/.remnic/bench/results/`.
+
+### 7.2 Bounded-memory contract ablation
+
+- `TODO(#1708)`: bounded-memory contract ablation (raw transcript vs typed
+  retrieval vs skill-triggered retrieval). #1708 is open; this subsection is
+  blocked on its data.
 
 ---
 
 ## 8. Limitations & Honest Framing
 
-**Intent.** The credibility section. State plainly, with no hedging that
-softens into overclaim:
+**Tier-L numbers are the reproducibility anchor, not the accuracy claim.** The
+Tier-L 7B-local numbers (§6.2) are modest by design. They exist so that anyone
+with one consumer GPU can rerun the full benchmark and confirm the metric
+pipeline end to end. They are not the accuracy headline. The accuracy claim
+rests on MemCorrect's composition and protocol framing (§4) plus the Tier-F
+head-to-head against the frontier baseline. Treating a Tier-L `llm_judge` of
+0.224 (LoCoMo) or 0.186 (LongMemEval) as a capability statement would misread
+the two-tier protocol (§5). Tier L ranks flags and adapters against each other;
+Tier F carries the cross-system comparison. No Tier-L number should leave this
+paper as a standalone accuracy quote.
 
-- **Tier-L 7B-local numbers are modest and are *not* the accuracy claim.** They
-  are the reproducibility anchor (one-GPU, re-runnable). The accuracy headline
-  is MemCorrect (composition) + the Tier-F head-to-head.
-- **Local-judge calibration** — the local 3090 judges Tier F; Cohen's κ
-  vs an Opus-judged slice is now measured and reported (LongMemEval
-  κ=0.769 above threshold; LoCoMo κ=0.135 below — the LoCoMo
-  `llm_judge` carries a warning). The low κ on LoCoMo is a genuine
-  limitation: the local 7B judge diverges from Opus on open-ended
-  answers, so LoCoMo's `llm_judge` is approximate. State the qwen3
-  truncation + ollama context-default gotchas already documented.
-- **MemCorrect v1 synthetic-corpus limits** — deterministic, token-pool-derived
-  (no real PII by construction), but synthetic; the corpus does not capture
-  every real-world correction shape. Scope to what the corpus tests.
-- **`claude -p` is a valid research-harness path distinct from raw API.**
-  Claude Code adds system-prompt scaffolding and model-alias routing; record
-  the harness, entitlement, model, isolation, and invocation details as
-  provenance. A result may retain `tier: "frontier"` when the artifact
-  contract is satisfied; bounded trials remain partial-coverage results.
-- `TODO(#1726)`: no drafting blocker — write the prose from the bullets above
-  once §5/§6 are populated; do not add limitations that imply un-run
-  experiments.
+**Local-judge calibration.** The local RTX 3090 judges both tiers. Cohen's
+κ calibration (`remnic bench judge-calibrate`, §5) re-judges a
+deterministic 50-question slice with both the local 7B judge and Opus as the
+gold standard. LongMemEval's κ=0.769 clears the 0.7 publishability threshold,
+making the local judge a defensible proxy for that benchmark. LoCoMo's κ=0.135
+does not. The local 7B judge diverges substantially from Opus on LoCoMo's
+open-ended answers, so the LoCoMo `llm_judge` carries a warning flag in the
+artifact and should be read as approximate, not authoritative. The
+deterministic metrics (`contains_answer`, `f1`, `rouge_l`) are judge-independent
+and unaffected. Two operational gotchas compound the calibration risk. Some
+local models (for example qwen3) truncate long contexts silently, and Ollama's
+context-length default is conservative. The manifest's `ctx` field declares the
+intended serving context, and preflight verifies the model id is served, but for
+Ollama it does not verify the reported context length because Ollama's
+`/api/tags` discovery returns only model ids, not context sizes. An operator
+must confirm the context manually (the `OLLAMA_CONTEXT_LENGTH` environment
+variable or `ollama show <model> --modelfile`) before relying on a large-window
+run. The committed placeholder profile pins `ctx` to 16384; the lab manifest
+used for the committed runs (`docs/benchmarks/configs/local-lab-3090.json`)
+pins 32768.
+
+**MemCorrect v1 synthetic-corpus limits.** The MemCorrect corpus (§4) is
+deterministic and derived from synthetic token pools, so no real PII enters the
+benchmark by construction. The schema validator enforces the synthetic-only
+constraint at generation time. The trade-off is coverage: a synthetic corpus
+cannot capture every real-world correction shape. A correction that arrives as
+a nuanced paraphrase, a multi-turn negotiation, or an implicit update inferred
+from behavior may not match any of the seeded correction-event shapes the
+generator produces. The §6.1 results are scoped to what the corpus tests, not
+to the full space of correction interactions a deployed system encounters. The
+corpus is extensible (new event shapes and token pools can be added without
+changing the adapter contract), but the v1 results reflect v1 coverage.
+
+**`claude -p` as a research-harness path.** The Tier-F responder is Opus 4.8
+invoked through Claude Code (`claude -p`) via the `claude-cli` bench provider.
+This is a valid research harness, not a raw Anthropic API call. Claude Code adds
+system-prompt scaffolding and model-alias routing on top of the base model, so
+the measurement path is explicit and distinct from a direct API run. The
+artifact records provider, harness, entitlement, model, isolation settings, and
+invocation as provenance, and a result retains `tier: "frontier"` when the
+artifact contract is satisfied. Isolation is enforced by the provider: a freshly
+created empty temp workspace, tools disabled, user and project configuration
+skipped, session persistence off, and an environment allowlist that excludes
+memory directories and unrelated secrets. Without this isolation, Claude Code
+inherits user-level instructions and silently contaminates every answer. Bounded
+(`--limit` / `--trial-limit`) trials remain partial-coverage evidence and are
+never presented as full leaderboard results. The promotion bridge rejects them
+outright.
+
+**Fact-store correction is necessary but not sufficient.** The §6.1 MemCorrect
+result exposes a limitation that is also the motivation for the next stage of
+work. At Tier L, Remnic's containment-scored metrics land on the same floor as
+the prompt-only baseline (`uptake_at_next = 0`, `non_resurrection = 0`,
+`false_apply = 1` for both adapters). Per-scenario tracing confirms this is not
+a harness artifact and not a dead correction path: extraction produces the
+target fact, the Correction Contract plan applies, and the stored fact is
+retired. The probes still fail because stale content reaches the serving layer
+through three side channels. First, the 7B classify model drafts retire-only
+actions instead of supersede-with-replacement, so no corrected fact exists for
+the probe to contain. Second, behavioral-profile lines derived from the original
+fact survive the correction. Third, verbatim LCM turn evidence quotes the
+outdated statement into recall context. MemCorrect is strict by design: a system
+that keeps serving the stale value anywhere in its recall context fails the
+probe, even when a corrected fact also surfaces. The result is exactly the
+failure class the benchmark exists to expose. Fact-store correction is necessary
+but not sufficient; correction must propagate to every serving surface. The
+serving-surface propagation follow-up and the classify-model capability axis at
+Tier F are the direct consequences of this measurement.
 
 ---
 
@@ -570,7 +865,7 @@ propagates everywhere the stale fact can still be served.
 
 Reproducibility is documented in [Appendix A](repro-appendix.md): the
 repro-manifest schema (`repro-manifest.ts`), the model-lab manifests, the
-end-to-end Tier-L reproduction path on a single RTX 3090 (24 GB) with
+complete Tier-L reproduction path on a single RTX 3090 (24 GB) with
 Ollama-served models, and the Tier-F path (§A.5: `claude-cli` provider
 isolation flags, checkpoint/resume across Claude Max usage windows,
 sampled-pilot-then-full discipline). In one line: clone the repo, pin the

--- a/docs/paper/main.md
+++ b/docs/paper/main.md
@@ -70,26 +70,19 @@ the response. End with an explicit **contributions list**:
 
 ## 2. Related Work
 
-**Intent.** Seed directly from `docs/research/paper-mapping.md`
-(Memory-OS, HiMem, SwiftMem, TiMem, MAGMA/SYNAPSE, MemoryOS, ACON) and the
-competitor landscape (Mem0, Zep, Letta). Position Remnic on the axes
-competitors ignore: **correction, provenance, faithfulness**. Engage the
-prior-art named in the plan's Novelty section metric-by-metric so the
-composition novelty is defensible against a reviewer or HN commenter who finds
-each one.
-
-- **This section is drafted standalone in `related-work.md`, owned by sibling
-  issue #1729.** This file does not duplicate it. When #1729 lands, replace
-  this block with a one-line pointer to `related-work.md` plus the
-  differentiation-table reference.
-- `TODO(#1729)`: produce the differentiation table (axes: correction,
-  provenance, faithfulness, reproducibility, consumer-hardware).
-- `TODO(#1729)`: confirm the metric-attribution split — genuinely new
-  (`uptake_latency`, `reassertion`, `provenance_fidelity`, namespace-twin
-  `scope_precision`, anti-event `false_apply`) vs borrowed-but-attributed
-  (`collateral_delta` ← RippleEdits RS/PV, `uptake_at_next` ←
-  MemoryAgentBench FactConsolidation, `non_resurrection` ← StateBench SFRR /
-  MemStrata).
+Related Work is drafted standalone in [`related-work.md`](related-work.md)
+(issue #1729, landed). It positions MemCorrect as a composition/protocol
+claim, engages the closest relatives metric-by-metric (StateBench, STALE,
+MemSyco-Bench, MemStrata, MemoryAgentBench FactConsolidation, and the
+weight-editing ancestors RippleEdits/MQuAKE/TOFU/MUSE), and carries the
+two load-bearing tables: **Table 1** (metric-by-metric differentiation
+with attribution) and the capability matrix against StateBench, STALE,
+MemSyco-Bench, and the commercial systems (Mem0, Zep, Letta). The
+metric-attribution split is stated there explicitly: three metrics
+borrowed-and-attributed (`uptake_at_next`, `non_resurrection`,
+`collateral_delta`), two partly new (`scope_precision`, `false_apply`),
+three new (`uptake_latency`, `reassertion`, `provenance_fidelity`). This
+file does not duplicate that content.
 
 ---
 
@@ -563,20 +556,25 @@ softens into overclaim:
 
 ## 9. Conclusion & Reproducibility
 
-**Intent.** Restate the three contributions; point at the reproducibility
-appendix as the proof that the protocol is one-GPU-rerunnable. The appendix
-itself is a sibling file (`repro-appendix.md`, owned by the plan's execution
-item 8) and is not created in this skeleton.
+This paper made three claims. MemCorrect turns memory correction into a
+system-agnostic, deterministically scoreable protocol, and its first
+full-matrix runs expose a concrete failure class: fact-store correction
+succeeds while stale content keeps reaching the serving layer (§6.1). The
+two-tier protocol makes every published number carry its provenance: Tier F
+(Opus 4.8 via Claude Code) holds the accuracy claim, Tier L re-runs on one
+RTX 3090, and Cohen's-κ calibration connects the two judges (§5, §6.2). The
+glass-box mechanisms (§3) make each recalled memory explainable and
+correctable, and the §6 measurements show why that matters: the open problem
+is no longer whether a system can recall, but whether a correction
+propagates everywhere the stale fact can still be served.
 
-- `TODO(plan-exec-item-8)`: produce `docs/paper/repro-appendix.md` containing
-  the repro-manifest reference (`repro-manifest.ts`), the model-lab manifests
-  (#1585), and the one-GPU (RTX 3090) reproduction instructions. Until it
-  exists, §9 carries only the pointer.
-- `TODO(#1728)`: include the Tier-F repro instructions (claude-cli provider
-  from #1735, isolation flags, checkpoint/resume across Claude Max windows,
-  sampled-first → full).
-- `TODO(#1726)`: when the appendix lands, replace this block with a one-line
-  pointer and a "reproduce on one GPU" summary.
+Reproducibility is documented in [Appendix A](repro-appendix.md): the
+repro-manifest schema (`repro-manifest.ts`), the model-lab manifests, the
+end-to-end Tier-L reproduction path on a single RTX 3090 (24 GB) with
+Ollama-served models, and the Tier-F path (§A.5: `claude-cli` provider
+isolation flags, checkpoint/resume across Claude Max usage windows,
+sampled-pilot-then-full discipline). In one line: clone the repo, pin the
+manifests, and every Tier-L number in §6 re-derives on one consumer GPU.
 
 ---
 

--- a/docs/paper/repro-appendix.md
+++ b/docs/paper/repro-appendix.md
@@ -9,11 +9,12 @@
 > present; judge calibration reported; honest framing attached; leaderboard-safe;
 > reproducible on one GPU).
 >
-> **Honesty boundary.** Every command and schema below traces to code or docs
-> committed (the trained faithfulness-gate v1 weights, the Tier F frontier
-> run), this appendix says so explicitly and marks the state — it never
-> describes an un-run experiment as if it were done. The two real Tier L
-> artifacts already on `main` (§A.1.2) are cited as committed evidence.
+> **Honesty boundary.** Every command and schema below traces to committed
+> code or docs, with one exception marked pending where it appears: the
+> trained faithfulness-gate v1 weights manifest (§A.4.3, #1737). The Tier L
+> anchor artifacts, the MemCorrect full-matrix artifacts, and the Tier F
+> frontier artifacts on `main` (§A.1.2) are cited as committed evidence;
+> this appendix never describes an un-run experiment as if it were done.
 
 ---
 
@@ -167,20 +168,24 @@ size, threshold, and a `warning` flag set when κ falls below threshold. It
 lands on local artifacts after `remnic bench judge-calibrate` (§A.3.5).
 
 **What is committed today.** `docs/benchmarks/results/` on `main` carries
-four artifacts. Two are clearly-marked mock placeholders
+ten artifacts. Two are clearly-marked mock placeholders
 (`2026-04-20-locomo-gpt-4o-mini-mock000.json`,
 `2026-04-20-longmemeval-gpt-4o-mini-mock000.json`) with
 `datasetVersion: "mock-fixture"` and zeroed metrics — **do not cite**. Two are
-**real Tier L artifacts** (`2026-07-07-locomo-qwen2.5-7b-32k_latest-47aae03.json`
-for LoCoMo and `2026-07-07-longmemeval-qwen2.5-7b-32k_latest-47aae03.json` for
-LongMemEval), both `tier: "local"`, model `qwen2.5-7b-32k:latest` (Q4_K_M,
-non-thinking), seed 1, full dataset (1986/1986 LoCoMo QA across all 10
-conversations; 500/500 LongMemEval-oracle). They are the reproducibility
-anchor the paper skeleton cites — quote their metric values from §6 Results,
-not here. Neither carries `judgeCalibration` yet (the local judge has no
-frontier pair to calibrate against until the Tier F run lands). The Tier F
-frontier artifacts and the trained faithfulness-gate manifest are **not yet
-committed** — see §A.4.3 and §A.5 for their pending state.
+the **real Tier L anchors** (`2026-07-07-locomo-qwen2.5-7b-32k_latest-47aae03.json`
+and `2026-07-07-longmemeval-qwen2.5-7b-32k_latest-47aae03.json`), both
+`tier: "local"`, model `qwen2.5-7b-32k:latest` (Q4_K_M, non-thinking), seed 1,
+full dataset (1986/1986 LoCoMo QA; 500/500 LongMemEval-oracle). They predate
+the frontier judge pair, so they omit `judgeCalibration` — expected, not a
+gap. Two are **bounded Tier F trials** (`2026-07-08-*-798fe8a.json`,
+trial-limited) — partial-coverage evidence, never leaderboard numbers. Two
+are the **MemCorrect full-matrix** artifacts (`2026-07-13-memcorrect-v1-*-9485f44.json`,
+40 scenarios, `mode: full`). Two are the **full Tier F frontier runs**
+(`2026-07-14-{locomo,longmemeval}-opus-0676347.json`, Opus 4.8 via Claude
+Code, `real` runtime profile, zero task failures), each carrying a stamped
+`judgeCalibration` (LongMemEval κ=0.769, `warning: false`; LoCoMo κ=0.135,
+`warning: true`). Quote metric values from §6 Results, not here. The trained
+faithfulness-gate manifest remains pending — see §A.4.3.
 
 ---
 
@@ -431,9 +436,10 @@ jq . ~/.remnic/bench/results/MANIFEST.json
 > attached on the **next** `remnic bench run` that uses the same judge pair.
 > To produce an artifact with `judgeCalibration` populated, calibrate first,
 > then re-run the benchmark, then promote that second result. The two Tier L
-> artifacts currently on `main` were produced before any frontier judge was
-> available, so they omit `judgeCalibration` — this is expected, not a gap,
-> until the Tier F run lands.
+> anchor artifacts on `main` were produced before any frontier judge was
+> available, so they omit `judgeCalibration` — expected, not a gap. The two
+> full Tier F artifacts (`2026-07-14-*-opus-0676347.json`) followed the
+> calibrate-first ordering and carry it.
 
 The build script rejects partial and quick-mode runs and runs that record a
 `config.benchmarkOptions.limit` / `trialLimit` (issue #1712 publish-safety
@@ -648,4 +654,4 @@ Every command and schema in this appendix traces to a committed source:
 | Hardware envelope + model-size policy | `model-lab/README.md` |
 | Faithfulness-gate manifest (schema example) | `model-lab/faithfulness-gate/manifest.json` |
 | Faithfulness-record contract | `model-lab/common/jsonl_schema.py` |
-| Committed artifacts (mock placeholders + real Tier L) | `docs/benchmarks/results/2026-{04-20-mock000,07-07-qwen2.5-7b}*.json` |
+| Committed artifacts (mocks + Tier L anchors + Tier F trials + MemCorrect + Tier F full) | `docs/benchmarks/results/2026-{04-20,07-07,07-08,07-13,07-14}-*.json` |

--- a/packages/bench/src/benchmarks/remnic/memcorrect/adapters.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/adapters.ts
@@ -309,8 +309,9 @@ export class RecordingAdapter implements MemCorrectSystemAdapter {
  *
  * `ingestTurn` → `store(sessionKey, [Message])`. `recall` →
  * `adapter.recall(sessionKey, query)` split into ranked strings.
- * `correct` → observe the correction as a user turn (the correction-contract
- * tool rides here once #1580 lands). `runMaintenance` → `adapter.drain()`,
+ * `correct` → routes through the Correction Contract (plan + confirmed
+ * apply) when the wrapped adapter exposes `correct()`, with the plain
+ * user-turn path as fallback. `runMaintenance` → `adapter.drain()`,
  * which forces the background consolidation/LCM/contradiction-scan pipeline
  * to settle; a forced-dreams/REM hook lands with #1579's tombstone path.
  *


### PR DESCRIPTION
## Summary

Drafts the remaining skeleton sections of `docs/paper/main.md` into prose, resuming the evidence-sprint paper assembly (#1726, epic #1725). No new results; every number cited traces to a committed artifact under `docs/benchmarks/results/`.

- **Abstract**: number-free, three contributions, honest Tier-L scope line. Tier-F identity resolved (Opus 4.8 via Claude Code) per the landed #1863 artifacts; `TODO(#1728)` dropped, `TODO(#1584)` (third-party framing) retained.
- **§1 Introduction**: user-side stale-fact framing, four-item contributions list, motivating paragraph grounded qualitatively in the §6.1 containment-floor finding.
- **§2**: replaced skeleton block with a pointer to `related-work.md` (#1729 landed with the differentiation table and capability matrix).
- **§4 MemCorrect**: task construction, adapter contract, four event shapes + anti-event taxonomy, eight-metric table lifted from `docs/benchmarks/memcorrect.md`. Corrected KU framing ("roughly 70-90%, not ceiling", answer-time-only) preserved. §4.5 sanity contract reconciled with the §6.1 floor result. `TODO(#1727)` retained.
- **§7.1**: single-flag ablation matrix from `docs/benchmarks/ablations.md` (values verified against the doc), including the bit-identical-pair finding (marked `[INFERENCE]` where the source marks it) and variance caveats. §7.2 stays blocked on #1708.
- **§8**: limitations prose from the five claim areas, including the §6.1 fact-store-correction-is-not-sufficient finding.
- **§9**: conclusion prose + pointer to `repro-appendix.md` (§A.5 covers Tier-F repro).
- **Staleness fixes**: `repro-appendix.md` artifact inventory (10 committed artifacts incl. the 2026-07-14 Tier-F pair with stamped `judgeCalibration`), `docs/paper/README.md` layout/rules, `memcorrect.md` + `adapters.ts` doc comment now reflect the landed Correction Contract routing (#1862) — verified against `createRemnicMemCorrectAdapter.correct()`.

## Verification

- `npm run preflight:quick` → `[preflight] OK (quick)` (only non-doc change is a comment in `adapters.ts`)
- Ablation table values, κ values, artifact filenames, and `ctx` pins cross-checked against `docs/benchmarks/ablations.md`, the committed artifacts (`jq`-verified `judgeCalibration`), and both `local-lab-3090.json` profiles (fixed a 16394→16384 typo and attributed the 32768 lab-manifest pin correctly).
- Voice lint (`voice_lint.py --mode report`) on the new prose: em/en-dash, ban-list, and bold-density checks pass. Remaining flags are documented exceptions: title-case on outline-mandated academic section names and the Flesch register check (dense benchmark prose, same register as the previously committed §3/§5/§6).

Part of #1726. Part of #1725.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus comment updates in `adapters.ts`; no runtime or benchmark logic changes, so risk is limited to prose accuracy and citation consistency.
> 
> **Overview**
> Turns the glass-box memory paper from **skeleton intent blocks** into **working prose** in `docs/paper/main.md`: abstract, introduction, MemCorrect (§4), ablations (§7.1), limitations (§8), and conclusion (§9), with §2 reduced to a pointer at `related-work.md`. Numbers and claims stay tied to committed benchmark artifacts; inline `TODO`s remain for third-party adapters, TrustScore/faithfulness (§6.3), and bounded-memory ablations (#1708).
> 
> **Paper governance** updates in `docs/paper/README.md`: layout/status for `main.md`, `related-work.md`, and `repro-appendix.md`; expanded artifact inventory (ten committed results, ablation cells in git history); trial vs full Tier-F distinction; Correction Contract routing called out in benchmark docs.
> 
> **Benchmark doc alignment**: `docs/benchmarks/memcorrect.md` and the JSDoc on `createRemnicMemCorrectAdapter` now describe **`correct()`** as Correction Contract (plan + apply) with user-turn fallback (#1862), not a future #1580 hook. `repro-appendix.md` refreshes the committed-results catalog and judge-calibration notes for the 2026-07-14 Tier-F runs.
> 
> **Clarifications in existing results prose**: LoCoMo `locomo_hidden_evidence_id_leak = 1.0` is framed as the anti-leak guard **passing**, not evidence of leakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff8fcb6c31a43b8cdadd01eb0b08fec9d9bdc3b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->