### PR TITLE
bench: temporal re-run artifact — LongMemEval real profile at 151e5ef0

### DIFF
--- a/docs/benchmarks/results/2026-07-14-longmemeval-opus-151e5ef.json
+++ b/docs/benchmarks/results/2026-07-14-longmemeval-opus-151e5ef.json
@@ -1,0 +1,5037 @@
+{
+  "benchmarkId": "longmemeval",
+  "datasetVersion": "longmemeval-oracle",
+  "durationMs": 3311309,
+  "env": {
+    "arch": "x64",
+    "node": "v22.22.0",
+    "os": "linux"
+  },
+  "finishedAt": "2026-07-14T16:00:43.475Z",
+  "judgeCalibration": {
+    "kappa": 0.5591939546599496,
+    "sampleSize": 50,
+    "threshold": 0.7,
+    "warning": true
+  },
+  "metrics": {
+    "contains_answer": 0.5,
+    "f1": 0.47730203062045634,
+    "judge_accuracy": 0.768,
+    "llm_judge": 0.768,
+    "search_hits": 8.52
+  },
+  "model": "opus",
+  "note": "Opus 4.8 via Claude Code (claude -p), real profile (full feature set), broadened event-order heuristic (PR #1864); same-judge temporal-reasoning comparison vs 2026-07-14-longmemeval-opus-0676347. judgeCalibration kappa 0.559 is the persisted calibration at run time (warning: below 0.7); a post-run recalibration over this runs own cached answers measured kappa 0.444 (also warned). Treat judge-scored numbers as approximate; deterministic metrics are judge-independent.",
+  "perTaskScores": [
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12121212121212122,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2655b836"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.9090909090909091,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2487a7cb"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_76048e76"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2312f94c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0bb5a684"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q08f4fc43"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2c63a862"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_385a5000"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2a1811e2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qbbf86515"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_5dcc0aab"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_0b2f1d21"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf0853d11"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.888888888888889,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_6ed717ea"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qgpt4_70e84552"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa3838d2b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.24390243902439027,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_93159ced"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2d58bcd6"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_65aabe59"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q982b5123"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07692307692307691,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qb9cfe692"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_4edbafa2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc8090214"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_483dd43c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1111111111111111,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe4e14d04"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.04347826086956522,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc9f37c46"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2727272727272727,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2c50253f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qdcfa8644"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_b4a80587"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.05555555555555556,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_9a159967"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.09756097560975609,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcc6d1ec1"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_8c8961ae"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_d9af6064"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7de946e7"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd01c6aa8"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12903225806451615,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q993da5e2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa3045048"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_d31cdae3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.12121212121212122,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_cd90e484"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_88806d6e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_4cd9eba1"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_93f6379c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1142857142857143,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qb29f3365"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2f56ae70"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6613b389"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25806451612903225,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_78cf46a3"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_0a05b494"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4444444444444445,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qgpt4_1a1dc16d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2f584639"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_213fd887"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_5438fa52"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.9090909090909091,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_c27434e8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.04878048780487806,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_fe651585"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q8c18457d"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2727272727272727,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "qgpt4_70e84552_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "qgpt4_93159ced_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q982b5123_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.411764705882353,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "qc8090214_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_c27434e8_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_fe651585_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q0a995998"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 6
+      },
+      "taskId": "q6d550036"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6923076923076924,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_59c863d7"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qb5ef892d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.24000000000000002,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe831120c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q3a704032"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.15384615384615385,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_d84a3211"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qaae3761f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 1
+      },
+      "taskId": "qgpt4_f2262a51"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qdd2973ad"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.33333333333333337,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc4a1ceb8"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 6
+      },
+      "taskId": "qgpt4_a56e767c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6cb6f249"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.052631578947368425,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q46a3abf7"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.23529411764705882,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q36b9f61e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q28dc39ac"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 8
+      },
+      "taskId": "qgpt4_2f8be40d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.07999999999999999,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2e6d26dc"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_15e38248"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.04878048780487806,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q88432d0a"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q80ec1f4f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.02531645569620253,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd23cf73b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7fce9456"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd682f1a2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q7024f17c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_5501fe77"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2ba83207"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.08695652173913045,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2318644b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q2ce6a0f2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.14285714285714288,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "qgpt4_d12ceb0e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q00ca467f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qb3c15d39"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_31ff4165"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.06451612903225806,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qeeda8a6d"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q2788b940"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q60bf93ed"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q9d25d4e0"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.14285714285714288,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q129d1232"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q60472f9c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.042553191489361694,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qgpt4_194be4b3"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qa9f6b44c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1111111111111111,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd851d5ba"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08333333333333334,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q5a7937c8"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5238095238095238,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_ab202e7f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.07547169811320754,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_e05b82a6"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_731e37d7"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2666666666666667,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qedced276"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q10d9b85a"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qe3038f8c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q2b8f3739"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.14285714285714288,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1a8a66a6"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc2ac3c61"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qbf659f65"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_372c3eed"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2f91af09"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.03636363636363636,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q81507db6"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q88432d0a_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q80ec1f4f_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qeeda8a6d_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q60bf93ed_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qedced276_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.24000000000000005,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_372c3eed_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6a1eabeb"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q6aeb4375"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q830ce83f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 8
+      },
+      "taskId": "q852ce960"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q945e3d21"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd7c942c3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q71315a70"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q89941a93"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qce6d2d27"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q9ea5eabc"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q07741c44"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa1eacc2a"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q184da446"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8292682926829269,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q031748ae"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q4d6b87c8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.03773584905660378,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0f05491a"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q08e075c7"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qf9e8c073"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.888888888888889,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q41698283"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1142857142857143,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q2698e78f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "qb6019101"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q45dc21b6"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q5a4f22c0"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5555555555555556,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6071bd76"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe493bb7c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q618f13b2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q72e3ee87"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.06060606060606061,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "qc4ea545c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q01493427"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6a27ffc2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q2133c1b5"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q18bc8abd"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qdb467c8c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q7a87bd0c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe61a7584"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1cea1afa"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qed4ddc30"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q8fb83627"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qb01defab"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q22d2cb42"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q0e4e4c46"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 8
+      },
+      "taskId": "q4b24c848"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q7e974930"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q603deb26"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q59524333"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q5831f84d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qeace081b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qaffe2881"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q50635ada"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe66b632c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0ddfec37"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6363636363636365,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf685340e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7499999999999999,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcc5ded98"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qdfde3500"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q69fee5aa"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q7401057b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcf22b7bf"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa2f3aa27"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2857142857142857,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc7dc5443"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q06db6396"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q3ba21379"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q9bbe84a2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q10e09553"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19354838709677416,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qdad224aa"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.05555555555555556,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qba61f0b9"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.06666666666666667,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q42ec0761"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q5c40ec5b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qc6853660"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q26bdc477"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q0977f2af"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q6aeb4375_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q031748ae_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2698e78f_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q2133c1b5_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0ddfec37_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf685340e_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.43478260869565216,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q89941a94"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q07741c45"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13157894736842105,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q8a2466db"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1375,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q06878be2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12037037037037038,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q75832dbd"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.03773584905660377,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q0edc2aef"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q35a27287"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1388888888888889,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q32260d93"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1846153846153846,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "q195a1a1b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16216216216216217,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qafdc33df"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcaf03d32"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.24615384615384614,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q54026fce"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1914893617021277,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 1
+      },
+      "taskId": "q06f04340"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.17100371747211895,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6b7dfb22"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2033898305084746,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1a1907b4"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 6
+      },
+      "taskId": "q09d032c9"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.17699115044247787,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q38146c39"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10810810810810811,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd24813b1"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 8
+      },
+      "taskId": "q57f827a0"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13180515759312322,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q95228167"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2830188679245283,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q505af2f5"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1652892561983471,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q75f70248"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3969465648854962,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qd6233ab6"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15624999999999997,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q1da05512"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2624113475177305,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "qfca70973"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12355212355212356,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "qb6025781"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12195121951219512,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa89d7624"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14893617021276595,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "qb0479f84"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2608695652173913,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1d4e3b97"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2434782608695652,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q07b6f563"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13496932515337423,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "q1c0ddc50"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09742120343839543,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0a34ad58"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8799999999999999,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q7161e7e2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc4f10528"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q89527b6b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe9327a54"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q4c36ccef"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23076923076923078,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q6ae235be"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q7e00a6cb"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q1903aded"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9090909090909091,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qceb54acb"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf523d9fe"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q0e5e2d1a"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qfea54f57"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47058823529411764,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcc539528"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qdc439ea3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q18dcd5a5"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q488d3006"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 2
+      },
+      "taskId": "q58470ed2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6136363636363636,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q8cf51dda"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5217391304347825,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q1d4da289"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q8464fc84"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 8
+      },
+      "taskId": "q8aef76bc"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q71a3fd6b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2bf43736"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q70b3e69b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 3
+      },
+      "taskId": "q8752c811"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q3249768e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q1b9b7252"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1568498a"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q6222b6eb"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "qe8a79c70"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "qd596882b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qe3fc4d6e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q51b23612"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q3e321797"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qe982271f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21052631578947367,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q352ab8bd"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qfca762bc"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "q7a8d0b71"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qa40e080f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q8b9d4367"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q5809eb10"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8085106382978724,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q41275add"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7692307692307693,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q4388e9dd"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q4baee567"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q561fabcd"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qb759caee"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qac031881"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q28bcfaac"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q16c90bf4"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qc8f1aeed"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7428571428571429,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "qeaca4986"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc7cf7dfd"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qe48988bc"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1de5cff2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q65240037"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q778164c6"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qe47becba"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q118b2229"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "q51a45a95"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q58bf7951"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q1e043500"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc5e8278d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.33333333333333337,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6ade9755"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q6f9b354f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q58ef2f1c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.75,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf8c5f88b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 2
+      },
+      "taskId": "q5d3d2817"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q7527f7e2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc960da58"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7499999999999999,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q3b6f954b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q726462e0"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q94f70d80"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q66f24dbb"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "qad7109d1"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "qaf8d2e46"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "qdccbc061"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "qc8c3f81d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q8ebdbe50"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q6b168ec8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q75499fd8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q21436231"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q95bcc1c8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0862e8bf"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q853b0a1d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qa06e4cfe"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q37d43f65"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.625,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qb86304ba"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "qd52b4f67"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q25e5aa4f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcaf9ead2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q8550ddae"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q60d45044"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q3f1e9474"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q86b68151"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q577d4d32"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "qec81a493"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q15745da0"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe01b8e2f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "qbc8a6e93"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "qccb36322"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q001be529"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "qb320f3f8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q19b5f2b3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q4fd1909e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5714285714285715,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q545bd2b5"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q8a137a7f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q76d63226"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q86f00804"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q8e9d538c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q311778f1"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 8
+      },
+      "taskId": "qc19f7a0b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q4100d0a0"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q29f2956b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q1faac195"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qfaba32e5"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "qf4f1d8a4"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qc14c00dd"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q36580ce8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q3d86fd0a"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "qa82c026e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q0862e8bf_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q15745da0_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "qbc8a6e93_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q19b5f2b3_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q29f2956b_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qf4f1d8a4_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2608695652173913,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_59149c77"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6410256410256411,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_f49edff3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 8
+      },
+      "taskId": "q71017276"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qb46e15ed"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_fa19884c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0bc8ad92"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "qaf082822"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2424242424242424,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_4929293a"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05128205128205129,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "qgpt4_b5700ca9"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714288,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q9a707b81"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_1d4ab0c9"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_e072b769"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0db4c65d"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_1d80365e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5666666666666667,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "qgpt4_7f6b06db"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_6dc9b45b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 6
+      },
+      "taskId": "qgpt4_8279ba02"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7216494845360825,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_18c2b244"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_a1b77f9c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_1916e0ea"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7a0daae1"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 4
+      },
+      "taskId": "qgpt4_468eb063"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.37623762376237624,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7abb270c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_1e4a8aeb"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_4fc4f797"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q4dfccbf7"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_61e13b3c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3589743589743589,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_45189cb4"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q2ebe6c90"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5142857142857142,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "qgpt4_e061b84f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q370a8ff4"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5132743362831858,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_d6585ce8"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_4ef30696"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_ec93e27f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "q6e984301"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "q8077ef71"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_f420262c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_8e165409"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_74aed68e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qbcbe585f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.047619047619047616,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 7
+      },
+      "taskId": "qgpt4_21adecb5"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "q5e1b23de"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_98f46fc6"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22857142857142854,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 3
+      },
+      "taskId": "qgpt4_af6db32f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qeac54adc"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2727272727272727,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7ddcf75f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "qgpt4_a2d1d1f6"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qgpt4_85da3956"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "qgpt4_b0863698"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_68e94287"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_e414231e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7ca326fa"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7bc6cf22"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2ebe6c92"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 6
+      },
+      "taskId": "qgpt4_e061b84g"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 2
+      },
+      "taskId": "q71017277"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qb46e15ee"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_d6585ce9"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09523809523809523,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_1e4a8aec"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_f420262d"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727272,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_59149c78"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_e414231f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4285714285714285,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "qgpt4_4929293b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 1
+      },
+      "taskId": "qgpt4_468eb064"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_fa19884d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q9a707b82"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "qeac54add"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q4dfccbf8"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q0bc8ad93"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2105263157894737,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 7
+      },
+      "taskId": "q6e984302"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 1
+      },
+      "taskId": "qgpt4_8279ba03"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "qgpt4_b5700ca0"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5333333333333333,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qgpt4_68e94288"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 2
+      },
+      "taskId": "qd3ab962e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2311e44b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19999999999999998,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcc06de0d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa11281a2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.07142857142857142,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q4f54b7c9"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q85fa3a3f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q9aaed6a3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1f2b8d4f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe6041065"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q51c32626"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd905b33f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.0909090909090909,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q7405e8b1"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf35224e0"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.18181818181818182,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6456829e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa4996e51"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q3c1045c8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19999999999999998,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q60036106"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q681a1674"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe25c3b8d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q4adc0475"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q4bc144e2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qef66a6e5"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q5025383b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "qa1cc6108"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q9ee3ecd6"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.43749999999999994,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q3fdac837"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q91b15a6e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q27016adc"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q720133ac"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q77eafa52"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q8979f9ec"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0100672e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa96c20ee"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q92a0aa75"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q3fe836c9"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1c549ce4"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6c49646a"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.38095238095238093,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1192316e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.13333333333333333,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0ea62687"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q67e0d0f2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qbb7c3b45"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qba358f49"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2857142857142857,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q61f8c8f8"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q60159905"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.05405405405405406,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qef9cf60a"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q73d42213"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qbc149d6b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q099778bb"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q09ba9854"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.33333333333333337,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd6062bb9"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q157a136e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "qc18a7dc8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa3332713"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q55241a1f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa08a253f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf0e564bc"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q078150f1"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05263157894736842,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 6
+      },
+      "taskId": "q8cf4d046"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa346bb18"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "q37f165cf"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 1
+      },
+      "taskId": "q8e91e7d9"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19999999999999998,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q87f22b4a"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe56a43b9"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.23529411764705882,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qefc3f7c2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q21d02d0d"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2311e44b_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3902439024390244,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6456829e_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2553191489361702,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe5ba910e_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa96c20ee_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qba358f49_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.17647058823529413,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q09ba9854_abs"
+    }
+  ],
+  "schemaVersion": 1,
+  "seed": 1,
+  "startedAt": "2026-07-14T15:05:32.166Z",
+  "system": {
+    "gitSha": "151e5ef06",
+    "name": "remnic",
+    "version": "9.6.12"
+  },
+  "tier": "frontier"
+}


### PR DESCRIPTION
## Summary

PR 1/2 of the temporal re-run comparison (#1728, epic #1725). Adds the verified comparison artifact `2026-07-14-longmemeval-opus-151e5ef.json` (full 500/500, zero failures, Opus 4.8 via Claude Code, `real` profile, tier `frontier`) so it has a permanent citable home in main's history.

PR 2/2 (#1866, restructured on top of this) untracks the file again — the same recorded-exception pattern as the §7.1 ablation cells — so the κ-clean `0676347` artifact remains the newest tracked Tier-F LongMemEval artifact and the Figure 1 anchor. The split exists because a squash merge of add+untrack in one PR would leave the artifact unreachable from main (Codex P2 on #1866).

Headline: `judge_accuracy` 0.768 (0.760 pre-broadening); temporal-reasoning 0.594 (0.541). Stamped κ=0.559 (run-time persisted state, warned); post-run recalibration on this run's own answers measured κ=0.444 (also warned) — both recorded in the artifact note.

## Verification

- `pnpm exec tsx scripts/bench/verify-artifact.ts` → OK, sha256 `a415863cc222a222…`
- Source result: `longmemeval-v9.6.12-2026-07-14T16-00-43-475Z.json` on jarvis-ml; run log `~/tierf-logs/temporal-rerun.log`

Part of #1728.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of a benchmark results JSON file; no runtime, auth, or production code paths are modified.
> 
> **Overview**
> Adds a new verified benchmark result file **`2026-07-14-longmemeval-opus-151e5ef.json`** under `docs/benchmarks/results/` so the temporal re-run (epic #1728) has a citable commit in main.
> 
> The artifact records a full **500/500** LongMemEval-oracle run at **gitSha `151e5ef`**, **remnic 9.6.12**, **Opus** via Claude Code with the **`real`** profile and **frontier** tier, including aggregate metrics (**`judge_accuracy` 0.768**, F1 ~0.48, etc.), **judgeCalibration** (κ 0.559, warned), per-task scores, and a **note** tying the run to the broadened event-order heuristic (PR #1864) and same-judge comparison vs **`0676347`**.
> 
> No application or benchmark harness code changes—only this JSON artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b5e6dd7e8d9684e307cb3b5f24d9fed01174fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->