### PR TITLE
docs(hackathon): Build Week 2026 scope doc + Devpost copy

### DIFF
--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -1,0 +1,126 @@
+# OpenAI Build Week 2026 submission scope
+
+Project: MemCorrect / Remnic Bench. A tool that benchmarks any AI agent's memory system.
+Track: Developer Tools.
+Event: OpenAI Build Week Challenge at openai.devpost.com. The window runs July 13 (9:00 AM PT) through July 21, 2026 (5:00 PM PT).
+Entrant: Joshua Warren ([@joshuaswarren](https://github.com/joshuaswarren)).
+
+Remnic is a pre-existing project. The Build Week rules say pre-existing
+projects "will be evaluated only on work added during the Submission Period."
+They also require clear documentation that separates prior work from new
+work, with evidence that Codex and GPT-5.6 were used within the period. This
+document is that documentation. Judges: everything you are asked to evaluate
+is listed under "Work built during the submission period" below. Nothing
+else counts.
+
+## What the submission is
+
+A one-command harness that benchmarks the memory system behind an AI agent.
+It asks three questions. Does the agent recall the right things? Does it
+accept corrections? Does it stop serving stale facts after a correction?
+It runs against any memory backend through a generic MCP adapter, not just
+Remnic. It uses GPT-5.6 as the grading judge. It produces a shareable
+scored report card.
+
+The pitch in one line: agent memory without evals is vibes with a database.
+
+## Prior work (not part of this submission)
+
+Everything committed before the Codex sessions listed below is prior work.
+That includes work merged in the first hours of the window, which came out
+of ongoing research rather than hackathon Codex sessions. We draw the line
+conservatively. If it was not built in a Codex session during the window,
+we do not claim it.
+
+Prior work includes, at minimum:
+
+- The Remnic memory engine, CLI, server, and host plugins. That covers all
+  of `packages/` except the files named in the next section.
+- The `@remnic/bench` package as of `v9.6.13`. That covers the benchmark
+  runners (`longmemeval`, `locomo`, `memory-arena`, `amemgym`, `ama-bench`,
+  smoke fixtures), the results store, reproducibility manifests, baselines,
+  regression gates, export, the publish feed, and provider discovery.
+- The MemCorrect benchmark design and its Correction Contract routing
+  (PR #1862, merged 2026-07-13). Also the Tier-F frontier artifacts
+  (PR #1863) and the temporal-reasoning heuristic (PR #1864, merged
+  2026-07-14). These merged after the window opened but were not built
+  with Codex, so we classify them as prior work.
+- The Glass-Box Memory paper draft under `docs/paper/`. Also every
+  committed benchmark artifact under `docs/benchmarks/results/` dated on
+  or before 2026-07-14.
+
+The dated commit history on `main` is the audit trail for this line.
+
+## Work built during the submission period
+
+Every item below is built in Codex sessions with GPT-5.6 during the window.
+Status boxes get checked as the work lands. Each item links to its commits
+and Codex session evidence at submission time.
+
+- [ ] Generic MCP memory adapter (`packages/bench/src/adapters/`). A
+  benchmark adapter that speaks the Model Context Protocol, so the harness
+  can score any MCP memory server: Mem0, Zep, LangMem, or a bare RAG
+  store. This is the core new functionality of the submission.
+- [ ] GPT-5.6 judge provider (`packages/bench/src/providers/`). Wires
+  GPT-5.6 through the OpenAI Responses API as the grading model. It scores
+  benchmark answers, correction acceptance, and stale-memory harm.
+- [ ] GPT-5.6 frontier-tier run. A full Tier-F benchmark run with GPT-5.6
+  as the system under test. Committed as a reproducible artifact under
+  `docs/benchmarks/results/` with its manifest.
+- [ ] Memory report card. Extends `remnic bench export --format html` into
+  a single shareable scored report with per-dimension scores, correction
+  behavior, and provenance. Published through the existing feed to
+  remnic.ai.
+- [ ] Judge sandbox instructions. A documented five-minute test path (see
+  below), so judges can run the tool without rebuilding anything.
+
+Commits for these items: added at submission time.
+Codex `/feedback` session ID for the core functionality: added at
+submission time.
+
+## How Codex and GPT-5.6 were used
+
+Codex built the adapter, provider, report card, and sandbox work above.
+Exploration of the existing adapter seam, implementation, tests, and
+iteration all ran inside Codex sessions during the window. The README and
+the `/feedback` session ID document where Codex sped up the work. They also
+record the key design calls: the adapter contract shape, the scoring
+rubric, and the report layout.
+
+GPT-5.6 is load-bearing inside the product twice. It is the benchmark judge
+that grades memory answers. It is also a benchmarked system in the
+frontier-tier run. Both uses produce committed, hash-locked artifacts.
+
+## How to test it in five minutes
+
+No datasets, no API keys, no network:
+
+```bash
+npm install -g @remnic/cli @remnic/bench
+remnic bench run --quick longmemeval   # ~60s against the bundled fixture
+remnic bench runs list
+remnic bench export <run-id> --format html
+```
+
+With an OpenAI API key, the same commands run the real datasets with the
+GPT-5.6 judge. `scripts/bench/fetch-datasets.sh` prints the dataset
+download commands. Full reproduction paths live in
+`docs/paper/repro-appendix.md`.
+
+## Honest framing of the novelty claim
+
+MemCorrect's contribution is a composition and protocol claim. It is a
+one-command harness that scores any memory backend on correction acceptance
+and stale-memory harm, with provenance-locked artifacts. It is not a claim
+to be first to measure memory correction. StateBench, STALE, MemSyco-Bench,
+MemStrata, and MemoryAgentBench are prior art. We engage them in
+`docs/paper/related-work.md`.
+
+## Compliance checklist
+
+- [ ] Free Codex credits requested by July 17, 12:00 PM PT.
+- [ ] Core functionality built in Codex sessions, with the `/feedback` session ID captured.
+- [ ] Demo video under 3 minutes, public on YouTube. Audio covers Codex and GPT-5.6 usage.
+- [ ] Repository public with MIT license (already true).
+- [ ] README documents where Codex sped up the work and how GPT-5.6 is used.
+- [ ] Devpost submission filed before July 21, 5:00 PM PT.

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -116,8 +116,11 @@ remnic bench run longmemeval \
 
 Without the judge flags, the run falls back to the unjudged scoring
 path, and the key must go through `--judge-api-key` (the provider does
-not read the env var on its own). Full reproduction paths live in
-`docs/paper/repro-appendix.md`.
+not read the env var on its own). One caveat until #1870 lands: today
+`--judge-provider openai` routes through the existing chat-completions
+compatible provider. The Responses API judge provider is part of the
+in-window work, and the same command exercises it once merged. Full
+reproduction paths live in `docs/paper/repro-appendix.md`.
 
 ## Honest framing of the novelty claim
 

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -102,9 +102,16 @@ remnic bench runs list
 remnic bench export <run-id> --format html
 ```
 
-With an OpenAI API key, the same commands run the real datasets with the
-GPT-5.6 judge. `scripts/bench/fetch-datasets.sh` prints the dataset
-download commands. Full reproduction paths live in
+The quick run always uses the bundled fixture; that is the zero-setup
+path. To score the real datasets with the GPT-5.6 judge, download them
+first, then drop the `--quick` flag:
+
+```bash
+scripts/bench/fetch-datasets.sh --target ./bench-datasets   # from a repo checkout
+remnic bench run longmemeval --dataset-dir ./bench-datasets/longmemeval
+```
+
+This path needs an OpenAI API key. Full reproduction paths live in
 `docs/paper/repro-appendix.md`.
 
 ## Honest framing of the novelty claim
@@ -118,7 +125,7 @@ MemStrata, and MemoryAgentBench are prior art. We engage them in
 
 ## Compliance checklist
 
-- [ ] Free Codex credits requested by July 17, 12:00 PM PT.
+- [x] Free Codex credits requested by July 17, 12:00 PM PT (requested 2026-07-14).
 - [ ] Core functionality built in Codex sessions, with the `/feedback` session ID captured.
 - [ ] Demo video under 3 minutes, public on YouTube. Audio covers Codex and GPT-5.6 usage.
 - [ ] Repository public with MIT license (already true).

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -107,14 +107,16 @@ path. To score the real datasets with the GPT-5.6 judge, download them
 first, then drop the `--quick` flag:
 
 ```bash
-scripts/bench/fetch-datasets.sh --target ./bench-datasets   # from a repo checkout
-OPENAI_API_KEY=sk-... remnic bench run longmemeval \
-  --dataset-dir ./bench-datasets/longmemeval \
-  --judge-provider openai --judge-model gpt-5.6
+export OPENAI_API_KEY=sk-...
+remnic bench datasets download longmemeval
+remnic bench run longmemeval \
+  --judge-provider openai --judge-model gpt-5.6 \
+  --judge-api-key "$OPENAI_API_KEY"
 ```
 
-Without `--judge-provider` and `--judge-model`, the run falls back to the
-unjudged scoring path. Full reproduction paths live in
+Without the judge flags, the run falls back to the unjudged scoring
+path, and the key must go through `--judge-api-key` (the provider does
+not read the env var on its own). Full reproduction paths live in
 `docs/paper/repro-appendix.md`.
 
 ## Honest framing of the novelty claim

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -51,8 +51,7 @@ Prior work includes, at minimum:
 
 The dated commit history on `main` is the audit trail for this line.
 
-## Work built during the submission period (PENDING: entries below are
-committed in #1869 to #1873)
+## Work built during the submission period (PENDING: entries below are committed in #1869 to #1873)
 
 Status boxes get checked as the work lands. Each item links to its commits
 and Codex session evidence at submission time.

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -51,9 +51,9 @@ Prior work includes, at minimum:
 
 The dated commit history on `main` is the audit trail for this line.
 
-## Work built during the submission period
+## Work built during the submission period (PENDING: entries below are
+committed in #1869 to #1873)
 
-Every item below is built in Codex sessions with GPT-5.6 during the window.
 Status boxes get checked as the work lands. Each item links to its commits
 and Codex session evidence at submission time.
 

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -108,10 +108,13 @@ first, then drop the `--quick` flag:
 
 ```bash
 scripts/bench/fetch-datasets.sh --target ./bench-datasets   # from a repo checkout
-remnic bench run longmemeval --dataset-dir ./bench-datasets/longmemeval
+OPENAI_API_KEY=sk-... remnic bench run longmemeval \
+  --dataset-dir ./bench-datasets/longmemeval \
+  --judge-provider openai --judge-model gpt-5.6
 ```
 
-This path needs an OpenAI API key. Full reproduction paths live in
+Without `--judge-provider` and `--judge-model`, the run falls back to the
+unjudged scoring path. Full reproduction paths live in
 `docs/paper/repro-appendix.md`.
 
 ## Honest framing of the novelty claim

--- a/docs/hackathon/devpost-description.md
+++ b/docs/hackathon/devpost-description.md
@@ -1,10 +1,11 @@
 # Devpost submission text (OpenAI Build Week 2026)
 
-Status: DRAFT. This copy describes the finished submission and its
-deliverables land through #1869 to #1873. It is NOT paste-ready until the
-final verification pass (#1873) confirms every claim against shipped code
-and strikes anything that did not land. HACKATHON.md tracks that line.
-Gated with voice-lint (article mode) before each revision ships.
+Status: DRAFT. This copy describes the finished submission and the
+deliverables that will land through #1869 to #1873. It is NOT paste-ready
+until the final verification pass (#1873) confirms every claim against
+shipped code and strikes anything that did not land. HACKATHON.md
+tracks that line. Gated with voice-lint (article mode) before each
+revision ships.
 
 Project name: MemCorrect: benchmark any AI agent's memory.
 

--- a/docs/hackathon/devpost-description.md
+++ b/docs/hackathon/devpost-description.md
@@ -1,7 +1,10 @@
 # Devpost submission text (OpenAI Build Week 2026)
 
-Paste-ready copy for the Devpost form. Gated with voice-lint (article mode)
-before each revision ships.
+Status: DRAFT. This copy describes the finished submission and its
+deliverables land through #1869 to #1873. It is NOT paste-ready until the
+final verification pass (#1873) confirms every claim against shipped code
+and strikes anything that did not land. HACKATHON.md tracks that line.
+Gated with voice-lint (article mode) before each revision ships.
 
 Project name: MemCorrect: benchmark any AI agent's memory.
 

--- a/docs/hackathon/devpost-description.md
+++ b/docs/hackathon/devpost-description.md
@@ -1,0 +1,109 @@
+# Devpost submission text (OpenAI Build Week 2026)
+
+Paste-ready copy for the Devpost form. Gated with voice-lint (article mode)
+before each revision ships.
+
+Project name: MemCorrect: benchmark any AI agent's memory.
+
+Tagline: Agent memory without evals is vibes with a database. MemCorrect
+scores any agent memory backend with one command. It checks recall quality,
+correction handling, and stale-memory harm. GPT-5.6 does the grading.
+
+Built with: typescript, node.js, gpt-5.6, codex, openai-responses-api, mcp,
+sqlite.
+
+## Inspiration
+
+Everyone is shipping agent memory right now. Almost nobody tests it. The
+demos all show an agent that remembers your name. None of them show what
+happens three weeks later. You tell it "actually, we moved off PostgreSQL"
+and it keeps citing the old choice. Stale memory is not a cosmetic bug. An
+agent that acts on facts you already fixed is worse than an agent with no
+memory at all.
+
+We build Remnic, an open-source memory engine. We got tired of memory
+systems (ours included) making accuracy claims with no receipts. So we
+built the receipts machine.
+
+## What it does
+
+MemCorrect tests the memory system behind an AI agent with one command:
+
+```bash
+remnic bench run --quick longmemeval   # 60-second smoke run, no keys, no network
+```
+
+It scores three things most memory benchmarks skip. First, recall: does the
+agent surface the right fact at the right time? We measure that on
+LongMemEval, LoCoMo, and friends. Second, corrections: when the user fixes
+a stored fact, does the memory actually update? Third, stale-memory harm:
+after a fix, does the old fact ever come back?
+
+It runs against any memory backend, not just ours. A generic MCP adapter
+lets you point it at Mem0, Zep, LangMem, or your homegrown RAG store.
+GPT-5.6 grades every answer through the OpenAI Responses API. Every run
+writes a locked manifest: dataset hashes, seeds, git state, config. The
+output is a memory report card you can share. "Our memory is good" becomes
+a scored claim anyone can re-run.
+
+## How we built it
+
+The new work for Build Week was built in Codex sessions with GPT-5.6. The
+session ID is in the form. The line between prior work and hackathon work
+is drawn commit-by-commit in
+[HACKATHON.md](https://github.com/joshuaswarren/remnic/blob/main/HACKATHON.md).
+
+Codex studied our adapter seam first. Then it built the generic MCP memory
+adapter, its tests, and the checks that decide if a backend can be scored
+at all. It wired GPT-5.6 in as the judge and iterated on the rubric with
+us. We also flipped the table: we ran GPT-5.6 as the system under test and
+committed that run as an artifact anyone can re-check. Codex then polished
+the HTML export into one scored report card you can hand to your team.
+
+GPT-5.6 does double duty here. It is the judge inside the tool, and it is a
+scored system in our published results.
+
+## Challenges we ran into
+
+Benchmark harnesses lie by accident. Two problems were hard. A dead
+endpoint must not score as "recalled nothing, gracefully," so empty results
+and backend failures are distinct shapes in the code. And correction tests
+must stay inside the benchmark session, so the harness can never pollute a
+real memory store. Both cost us real design time. Both are now hard
+contracts in the code.
+
+## Accomplishments we're proud of
+
+A memory benchmark you can run in 60 seconds with zero setup. A correction
+score no other one-command harness gives you. And the discipline behind it:
+no number ships in our docs without a committed artifact behind it.
+
+## What we learned
+
+Grading corrections is a judge-quality problem. We had to get GPT-5.6 to
+agree with human judgment on one question: did the system really accept the
+fix? That taught us more about prompt design than any new feature would
+have.
+
+## What's next
+
+A public results page at remnic.ai, fed by the publish pipeline that
+already exists. More backend adapters from the community. And the full
+write-up: MemCorrect is part of our Glass-Box Memory paper (draft in the
+repo). The paper engages prior art like StateBench and MemoryAgentBench
+honestly. This is a protocol claim, not a "first to think of it" claim.
+
+## Try it (judges)
+
+No datasets, no API keys, no network needed for the smoke path:
+
+```bash
+npm install -g @remnic/cli @remnic/bench
+remnic bench run --quick longmemeval
+remnic bench runs list
+remnic bench export <run-id> --format html
+```
+
+With an OPENAI_API_KEY, the same commands run real datasets with the
+GPT-5.6 judge. Setup details live in `packages/bench/README.md`.
+Reproduction paths live in `docs/paper/repro-appendix.md`.

--- a/docs/hackathon/devpost-description.md
+++ b/docs/hackathon/devpost-description.md
@@ -105,8 +105,8 @@ remnic bench export <run-id> --format html
 ```
 
 The quick run always uses a bundled fixture. That is what makes it
-zero-setup. Real-dataset runs take two more steps: download the datasets
-(see "Running on real datasets" in `packages/bench/README.md`), then run
-again without `--quick`, passing `--dataset-dir` plus the judge flags
-`--judge-provider openai --judge-model gpt-5.6` with an OPENAI_API_KEY
-set. Reproduction paths live in `docs/paper/repro-appendix.md`.
+zero-setup. Real-dataset runs take two more steps. First,
+`remnic bench datasets download longmemeval`. Then the same run command
+without `--quick`, adding `--judge-provider openai --judge-model gpt-5.6
+--judge-api-key "$OPENAI_API_KEY"`. Reproduction paths live in
+`docs/paper/repro-appendix.md`.

--- a/docs/hackathon/devpost-description.md
+++ b/docs/hackathon/devpost-description.md
@@ -107,6 +107,6 @@ remnic bench export <run-id> --format html
 The quick run always uses a bundled fixture. That is what makes it
 zero-setup. Real-dataset runs take two more steps: download the datasets
 (see "Running on real datasets" in `packages/bench/README.md`), then run
-again without `--quick`, passing `--dataset-dir` and an OPENAI_API_KEY for
-the GPT-5.6 judge. Reproduction paths live in
-`docs/paper/repro-appendix.md`.
+again without `--quick`, passing `--dataset-dir` plus the judge flags
+`--judge-provider openai --judge-model gpt-5.6` with an OPENAI_API_KEY
+set. Reproduction paths live in `docs/paper/repro-appendix.md`.

--- a/docs/hackathon/devpost-description.md
+++ b/docs/hackathon/devpost-description.md
@@ -104,6 +104,9 @@ remnic bench runs list
 remnic bench export <run-id> --format html
 ```
 
-With an OPENAI_API_KEY, the same commands run real datasets with the
-GPT-5.6 judge. Setup details live in `packages/bench/README.md`.
-Reproduction paths live in `docs/paper/repro-appendix.md`.
+The quick run always uses a bundled fixture. That is what makes it
+zero-setup. Real-dataset runs take two more steps: download the datasets
+(see "Running on real datasets" in `packages/bench/README.md`), then run
+again without `--quick`, passing `--dataset-dir` and an OPENAI_API_KEY for
+the GPT-5.6 judge. Reproduction paths live in
+`docs/paper/repro-appendix.md`.


### PR DESCRIPTION
Part of #1868.

Adds the OpenAI Build Week 2026 submission scope contract (`HACKATHON.md`) and the paste-ready Devpost description (`docs/hackathon/devpost-description.md`). Both passed the voice-lint gate (report / article modes, exit 0).

The child issues #1869-#1873 reference these files as required reading; merging this makes those links resolve on `main`. Docs only, no code paths touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no application logic, auth, or data paths changed.
> 
> **Overview**
> Adds **OpenAI Build Week 2026** documentation only: no runtime or benchmark code changes.
> 
> **`HACKATHON.md`** is the submission scope contract for judges. It states what MemCorrect is, draws a conservative **prior work vs in-window work** line (including PRs #1862–#1864 as prior), lists pending deliverables tied to **#1869–#1873** with unchecked boxes, documents Codex/GPT-5.6 usage expectations, a **five-minute judge smoke path** (`remnic bench run --quick`, export HTML), honest novelty framing, and a compliance checklist.
> 
> **`docs/hackathon/devpost-description.md`** is **DRAFT** Devpost copy (inspiration through “Try it”) that mirrors the same story and links to `HACKATHON.md`; it is explicitly not paste-ready until **#1873** verifies claims against shipped code.
> 
> Merging unblocks child issues that reference these paths on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e394adedb83c32fee6901bce1ef0079eb7bb964c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->