### PR TITLE
bench: baseline-profile Tier-F artifacts (git-history home) — PR 1/2

### DIFF
--- a/docs/benchmarks/results/2026-07-14-locomo-opus-0676347-baseline.json
+++ b/docs/benchmarks/results/2026-07-14-locomo-opus-0676347-baseline.json
@@ -1,0 +1,19897 @@
+{
+  "benchmarkId": "locomo",
+  "datasetVersion": "locomo-10",
+  "durationMs": 10741876,
+  "env": {
+    "arch": "x64",
+    "node": "v22.22.0",
+    "os": "linux"
+  },
+  "finishedAt": "2026-07-14T11:01:20.872Z",
+  "judgeCalibration": {
+    "kappa": 0.76,
+    "sampleSize": 50,
+    "threshold": 0.7,
+    "warning": false
+  },
+  "metrics": {
+    "contains_answer": 0.1973816717019134,
+    "f1": 0.3042677291493393,
+    "llm_judge": 0.4739274924471322,
+    "locomo_hidden_evidence_id_leak": 1,
+    "rouge_l": 0.2927608954345048
+  },
+  "model": "opus",
+  "note": "Opus 4.8 via Claude Code (claude -p), BASELINE profile (LCM stack only): the anchor-comparable pass. Companion to the real-profile 2026-07-14-locomo-opus-0676347 artifact; note the real profile scores LOWER on LoCoMo (0.444 vs 0.474), see issue #1879.",
+  "perTaskScores": [
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-26-q2-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q4-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q5-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-26-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666667
+      },
+      "taskId": "conv-26-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-26-q13-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.039215686274509796,
+        "llm_judge": 0.65,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.039215686274509796
+      },
+      "taskId": "conv-26-q14-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-26-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1111111111111111
+      },
+      "taskId": "conv-26-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7499999999999999,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7499999999999999
+      },
+      "taskId": "conv-26-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666665,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666665
+      },
+      "taskId": "conv-26-q22-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-26-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1904761904761905
+      },
+      "taskId": "conv-26-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-26-q27-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-26-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09523809523809525,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809525
+      },
+      "taskId": "conv-26-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2564102564102564,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.20512820512820512
+      },
+      "taskId": "conv-26-q30-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1724137931034483,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1724137931034483
+      },
+      "taskId": "conv-26-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18604651162790697,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13953488372093023
+      },
+      "taskId": "conv-26-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.0816326530612245,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.0816326530612245
+      },
+      "taskId": "conv-26-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-26-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4166666666666667
+      },
+      "taskId": "conv-26-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-26-q37-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.4,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q38-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23255813953488372,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13953488372093023
+      },
+      "taskId": "conv-26-q39-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615383
+      },
+      "taskId": "conv-26-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-26-q42-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q43-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-26-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-26-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-26-q46-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13793103448275862,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13793103448275862
+      },
+      "taskId": "conv-26-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q49-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q50-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.35294117647058826,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-26-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-26-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.06896551724137931,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06896551724137931
+      },
+      "taskId": "conv-26-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q55-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-26-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4705882352941177,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4705882352941177
+      },
+      "taskId": "conv-26-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q59-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q61-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q62-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.17647058823529413,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1176470588235294
+      },
+      "taskId": "conv-26-q64-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07228915662650602,
+        "llm_judge": 0.35,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.04819277108433735
+      },
+      "taskId": "conv-26-q65-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q66-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q67-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q69-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q70-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q71-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q72-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q73-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-26-q74-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q75-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q76-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08695652173913043,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08695652173913043
+      },
+      "taskId": "conv-26-q77-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q78-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q79-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q80-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13953488372093023,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09302325581395347
+      },
+      "taskId": "conv-26-q81-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-26-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-26-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27586206896551724,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.27586206896551724
+      },
+      "taskId": "conv-26-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12500000000000003,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08333333333333333
+      },
+      "taskId": "conv-26-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-26-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 0.95,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18750000000000003
+      },
+      "taskId": "conv-26-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666667,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5999999999999999
+      },
+      "taskId": "conv-26-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-26-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.9523809523809523,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9523809523809523
+      },
+      "taskId": "conv-26-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.29268292682926833,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14634146341463417
+      },
+      "taskId": "conv-26-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9411764705882353,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9411764705882353
+      },
+      "taskId": "conv-26-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9473684210526316,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9473684210526316
+      },
+      "taskId": "conv-26-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-26-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08695652173913043,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08695652173913043
+      },
+      "taskId": "conv-26-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7499999999999999,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7499999999999999
+      },
+      "taskId": "conv-26-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-26-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8695652173913043,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8695652173913043
+      },
+      "taskId": "conv-26-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5581395348837209,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4651162790697674
+      },
+      "taskId": "conv-26-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5333333333333333
+      },
+      "taskId": "conv-26-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-26-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-26-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-26-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-26-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2666666666666667,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2666666666666667
+      },
+      "taskId": "conv-26-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-26-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666667,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666667
+      },
+      "taskId": "conv-26-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-26-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11764705882352942,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352942
+      },
+      "taskId": "conv-26-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-26-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05555555555555555
+      },
+      "taskId": "conv-26-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8333333333333334,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8333333333333334
+      },
+      "taskId": "conv-26-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13793103448275862,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13793103448275862
+      },
+      "taskId": "conv-26-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.046511627906976744,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.046511627906976744
+      },
+      "taskId": "conv-26-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7142857142857143,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7142857142857143
+      },
+      "taskId": "conv-26-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.26666666666666666
+      },
+      "taskId": "conv-26-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.32,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24000000000000005
+      },
+      "taskId": "conv-26-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13793103448275862,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13793103448275862
+      },
+      "taskId": "conv-26-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2962962962962963,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14814814814814814
+      },
+      "taskId": "conv-26-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4615384615384615
+      },
+      "taskId": "conv-26-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9411764705882353,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9411764705882353
+      },
+      "taskId": "conv-26-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7142857142857143,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7142857142857143
+      },
+      "taskId": "conv-26-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5333333333333333
+      },
+      "taskId": "conv-26-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3636363636363636,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3636363636363636
+      },
+      "taskId": "conv-26-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14634146341463414,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.0975609756097561
+      },
+      "taskId": "conv-26-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-26-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-26-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666667,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666667
+      },
+      "taskId": "conv-26-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-26-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3636363636363636,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3636363636363636
+      },
+      "taskId": "conv-26-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7826086956521738,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7826086956521738
+      },
+      "taskId": "conv-26-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1481481481481481,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1481481481481481
+      },
+      "taskId": "conv-26-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12500000000000003,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12500000000000003
+      },
+      "taskId": "conv-26-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-26-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-30-q2-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5833333333333334,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.41666666666666663
+      },
+      "taskId": "conv-30-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.17857142857142858
+      },
+      "taskId": "conv-30-q4-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4800000000000001,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.32
+      },
+      "taskId": "conv-30-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-30-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14814814814814814
+      },
+      "taskId": "conv-30-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q11-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-30-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-30-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-30-q14-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-30-q15-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-30-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25806451612903225,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25806451612903225
+      },
+      "taskId": "conv-30-q17-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q19-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.95,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-30-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1951219512195122,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14634146341463417
+      },
+      "taskId": "conv-30-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.42857142857142855
+      },
+      "taskId": "conv-30-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-30-q25-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-30-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09523809523809525,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809525
+      },
+      "taskId": "conv-30-q31-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-30-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714285
+      },
+      "taskId": "conv-30-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-30-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q39-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q40-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q41-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q42-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q43-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q44-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q45-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q46-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.0625
+      },
+      "taskId": "conv-30-q47-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714285
+      },
+      "taskId": "conv-30-q48-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q49-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14814814814814814
+      },
+      "taskId": "conv-30-q50-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14814814814814814
+      },
+      "taskId": "conv-30-q51-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-30-q52-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2631578947368421,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2631578947368421
+      },
+      "taskId": "conv-30-q53-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-30-q54-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615383,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615383
+      },
+      "taskId": "conv-30-q55-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q56-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08333333333333334,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08333333333333334
+      },
+      "taskId": "conv-30-q57-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.42857142857142855,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.42857142857142855
+      },
+      "taskId": "conv-30-q58-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-30-q59-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q60-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q61-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8125000000000001,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.75
+      },
+      "taskId": "conv-30-q62-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-30-q63-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.923076923076923,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.923076923076923
+      },
+      "taskId": "conv-30-q64-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q65-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.631578947368421,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.631578947368421
+      },
+      "taskId": "conv-30-q66-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11111111111111112,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11111111111111112
+      },
+      "taskId": "conv-30-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-30-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.08695652173913045,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08695652173913045
+      },
+      "taskId": "conv-30-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-30-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11111111111111112,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11111111111111112
+      },
+      "taskId": "conv-30-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.07692307692307693,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307693
+      },
+      "taskId": "conv-30-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q79-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2631578947368421,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2105263157894737
+      },
+      "taskId": "conv-30-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-30-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q82-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4761904761904762,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.380952380952381
+      },
+      "taskId": "conv-30-q83-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q84-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q85-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q86-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q87-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q88-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q89-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09523809523809523,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809523
+      },
+      "taskId": "conv-30-q90-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12121212121212122,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06060606060606061
+      },
+      "taskId": "conv-30-q91-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q92-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q93-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q94-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q95-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q96-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q97-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q98-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q99-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q100-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q101-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q102-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q103-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q104-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q5-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-41-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q8-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q12-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727272,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727272
+      },
+      "taskId": "conv-41-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q14-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7499999999999999,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21052631578947367,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.21052631578947367
+      },
+      "taskId": "conv-41-q17-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-41-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-41-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-41-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-41-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q25-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-41-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-41-q27-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.30769230769230765
+      },
+      "taskId": "conv-41-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-41-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q33-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q35-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-41-q37-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5714285714285715,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-41-q39-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q41-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-41-q44-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09999999999999999
+      },
+      "taskId": "conv-41-q45-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615383
+      },
+      "taskId": "conv-41-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.4,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q50-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473684,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473684
+      },
+      "taskId": "conv-41-q51-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q56-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.26666666666666666
+      },
+      "taskId": "conv-41-q57-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q64-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7272727272727273,
+        "llm_judge": 0.95,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727273
+      },
+      "taskId": "conv-41-q65-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q66-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-41-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.888888888888889,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.888888888888889
+      },
+      "taskId": "conv-41-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2641509433962264,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1509433962264151
+      },
+      "taskId": "conv-41-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19999999999999998
+      },
+      "taskId": "conv-41-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1904761904761905
+      },
+      "taskId": "conv-41-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.888888888888889,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.888888888888889
+      },
+      "taskId": "conv-41-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-41-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-41-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-41-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.30769230769230765
+      },
+      "taskId": "conv-41-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8181818181818181,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8181818181818181
+      },
+      "taskId": "conv-41-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5555555555555556,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-41-q91-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.65,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5555555555555556,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-41-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-41-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08695652173913045,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08695652173913045
+      },
+      "taskId": "conv-41-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23076923076923078,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.23076923076923078
+      },
+      "taskId": "conv-41-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5806451612903226,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.45161290322580644
+      },
+      "taskId": "conv-41-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-41-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.0909090909090909,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.0909090909090909
+      },
+      "taskId": "conv-41-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47619047619047616,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.47619047619047616
+      },
+      "taskId": "conv-41-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.35294117647058826,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.35294117647058826
+      },
+      "taskId": "conv-41-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19047619047619047,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19047619047619047
+      },
+      "taskId": "conv-41-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666669
+      },
+      "taskId": "conv-41-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1818181818181818
+      },
+      "taskId": "conv-41-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-41-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2105263157894737,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2105263157894737
+      },
+      "taskId": "conv-41-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7000000000000001,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7000000000000001
+      },
+      "taskId": "conv-41-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.14285714285714288,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714288
+      },
+      "taskId": "conv-41-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-41-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285714
+      },
+      "taskId": "conv-41-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-41-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14814814814814814
+      },
+      "taskId": "conv-41-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.888888888888889,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.888888888888889
+      },
+      "taskId": "conv-41-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9411764705882353,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9411764705882353
+      },
+      "taskId": "conv-41-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.34782608695652173,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-41-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.0909090909090909
+      },
+      "taskId": "conv-41-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2727272727272727,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2727272727272727
+      },
+      "taskId": "conv-41-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q0-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-42-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-42-q2-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3478260869565218,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3478260869565218
+      },
+      "taskId": "conv-42-q3-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q4-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-42-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1224489795918367,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1224489795918367
+      },
+      "taskId": "conv-42-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.37499999999999994,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.37499999999999994
+      },
+      "taskId": "conv-42-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666665,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666665
+      },
+      "taskId": "conv-42-q10-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-42-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q12-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-42-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q14-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q15-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-42-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-42-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-42-q18-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-42-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16000000000000003,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16000000000000003
+      },
+      "taskId": "conv-42-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727273,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-42-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-42-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-42-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-42-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-42-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.38095238095238093,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.38095238095238093
+      },
+      "taskId": "conv-42-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.35294117647058826,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.35294117647058826
+      },
+      "taskId": "conv-42-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-42-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-42-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-42-q40-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-42-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-42-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-42-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-42-q46-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5333333333333333
+      },
+      "taskId": "conv-42-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714285
+      },
+      "taskId": "conv-42-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-42-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q53-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.45161290322580644,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3870967741935484
+      },
+      "taskId": "conv-42-q55-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q58-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q59-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.24000000000000002,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16
+      },
+      "taskId": "conv-42-q60-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-42-q61-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q63-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q64-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-42-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q66-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q67-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q68-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q69-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-42-q70-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q71-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q72-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q73-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q74-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q75-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2608695652173913,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2608695652173913
+      },
+      "taskId": "conv-42-q76-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-42-q77-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.4,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q78-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q79-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.53,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q80-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15789473684210525,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15789473684210525
+      },
+      "taskId": "conv-42-q81-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1111111111111111
+      },
+      "taskId": "conv-42-q82-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.21052631578947367
+      },
+      "taskId": "conv-42-q83-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-42-q84-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q85-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q86-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q87-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.888888888888889,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.888888888888889
+      },
+      "taskId": "conv-42-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-42-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.41666666666666663,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-42-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.26666666666666666
+      },
+      "taskId": "conv-42-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-42-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-42-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-42-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7692307692307693,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7692307692307693
+      },
+      "taskId": "conv-42-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-42-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.888888888888889,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-42-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1111111111111111
+      },
+      "taskId": "conv-42-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-42-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07692307692307693,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307693
+      },
+      "taskId": "conv-42-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7826086956521738,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7826086956521738
+      },
+      "taskId": "conv-42-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-42-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-42-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473682,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473682
+      },
+      "taskId": "conv-42-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.888888888888889,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.888888888888889
+      },
+      "taskId": "conv-42-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-42-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4000000000000001,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4000000000000001
+      },
+      "taskId": "conv-42-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-42-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.45454545454545453,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.45454545454545453
+      },
+      "taskId": "conv-42-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428572,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428572
+      },
+      "taskId": "conv-42-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5925925925925926,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5925925925925926
+      },
+      "taskId": "conv-42-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1111111111111111
+      },
+      "taskId": "conv-42-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1818181818181818
+      },
+      "taskId": "conv-42-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-42-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-42-q158-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q159-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q160-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q161-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q162-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q163-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q164-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q165-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-42-q166-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-42-q167-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666665,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-42-q168-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7058823529411765,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7058823529411765
+      },
+      "taskId": "conv-42-q169-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q170-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q171-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.06451612903225806,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06451612903225806
+      },
+      "taskId": "conv-42-q172-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09523809523809523,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809523
+      },
+      "taskId": "conv-42-q173-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q174-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16
+      },
+      "taskId": "conv-42-q175-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-42-q176-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.17647058823529413
+      },
+      "taskId": "conv-42-q177-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.631578947368421,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.631578947368421
+      },
+      "taskId": "conv-42-q178-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q179-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q180-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q181-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q182-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q183-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1111111111111111
+      },
+      "taskId": "conv-42-q184-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q185-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.888888888888889,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.888888888888889
+      },
+      "taskId": "conv-42-q186-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q187-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q188-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07142857142857142,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07142857142857142
+      },
+      "taskId": "conv-42-q189-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-42-q190-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q191-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-42-q192-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.45454545454545453,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.45454545454545453
+      },
+      "taskId": "conv-42-q193-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818185,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09090909090909093
+      },
+      "taskId": "conv-42-q194-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09523809523809525,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809525
+      },
+      "taskId": "conv-42-q195-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-42-q196-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7333333333333334
+      },
+      "taskId": "conv-42-q197-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-42-q198-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.888888888888889,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.888888888888889
+      },
+      "taskId": "conv-42-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q203-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q204-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q205-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q206-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q207-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q208-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q209-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q210-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-42-q211-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q212-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q213-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q214-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q215-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q216-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q217-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q218-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q219-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q220-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q221-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q222-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q223-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q224-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q225-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q226-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q227-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q228-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.058823529411764705,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.058823529411764705
+      },
+      "taskId": "conv-42-q229-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q230-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q231-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q232-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q233-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q234-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q235-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q236-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q237-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q238-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714288
+      },
+      "taskId": "conv-42-q239-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1176470588235294,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1176470588235294
+      },
+      "taskId": "conv-42-q240-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q241-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q242-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-42-q243-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-42-q244-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.0909090909090909,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.0909090909090909
+      },
+      "taskId": "conv-42-q245-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q246-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q247-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q248-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-42-q249-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q250-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q251-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q252-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q253-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q254-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-42-q255-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-42-q256-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q257-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q258-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q259-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q0-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12903225806451613,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12903225806451613
+      },
+      "taskId": "conv-43-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-43-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.24000000000000002,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24000000000000002
+      },
+      "taskId": "conv-43-q3-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14545454545454545,
+        "llm_judge": 0.56,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10909090909090909
+      },
+      "taskId": "conv-43-q4-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q5-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q8-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666667,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4242424242424242
+      },
+      "taskId": "conv-43-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-43-q13-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.24242424242424243,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-43-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3
+      },
+      "taskId": "conv-43-q15-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q17-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.31578947368421056,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.31578947368421056
+      },
+      "taskId": "conv-43-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.0945945945945946,
+        "llm_judge": 0.65,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05405405405405406
+      },
+      "taskId": "conv-43-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-43-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q23-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q25-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-43-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q27-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q28-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4117647058823529,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.29411764705882354
+      },
+      "taskId": "conv-43-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-43-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-43-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-43-q32-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473685,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-43-q34-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q35-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-43-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q38-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q40-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-43-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q43-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.10256410256410257,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10256410256410257
+      },
+      "taskId": "conv-43-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08695652173913045,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08695652173913045
+      },
+      "taskId": "conv-43-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q51-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q53-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q56-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-43-q57-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q59-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q60-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q61-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-43-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q64-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-43-q65-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q66-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-43-q67-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-43-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q69-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q70-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-43-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4761904761904762
+      },
+      "taskId": "conv-43-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7407407407407408,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7407407407407408
+      },
+      "taskId": "conv-43-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-43-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-43-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-43-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-43-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428572,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428572
+      },
+      "taskId": "conv-43-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15
+      },
+      "taskId": "conv-43-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-43-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.88,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1875,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1875
+      },
+      "taskId": "conv-43-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7666666666666667,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-43-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-43-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6086956521739131,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6086956521739131
+      },
+      "taskId": "conv-43-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08333333333333334,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08333333333333334
+      },
+      "taskId": "conv-43-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1111111111111111
+      },
+      "taskId": "conv-43-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08695652173913045,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08695652173913045
+      },
+      "taskId": "conv-43-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14814814814814814
+      },
+      "taskId": "conv-43-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-43-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23076923076923078,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307693
+      },
+      "taskId": "conv-43-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.26666666666666666
+      },
+      "taskId": "conv-43-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08333333333333334,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08333333333333334
+      },
+      "taskId": "conv-43-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.17391304347826086,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08695652173913043
+      },
+      "taskId": "conv-43-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.9090909090909091,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9090909090909091
+      },
+      "taskId": "conv-43-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8461538461538461,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8461538461538461
+      },
+      "taskId": "conv-43-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12500000000000003,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12500000000000003
+      },
+      "taskId": "conv-43-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07142857142857142,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07142857142857142
+      },
+      "taskId": "conv-43-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3571428571428571,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3571428571428571
+      },
+      "taskId": "conv-43-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7142857142857143
+      },
+      "taskId": "conv-43-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q158-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q159-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q160-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q161-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07407407407407408,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407408
+      },
+      "taskId": "conv-43-q162-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q163-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q164-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q165-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q166-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q167-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q168-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6153846153846153,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6153846153846153
+      },
+      "taskId": "conv-43-q169-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-43-q170-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q171-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-43-q172-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q173-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q174-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q175-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-43-q176-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q177-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4848484848484849,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-43-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-43-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-43-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428572,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428572
+      },
+      "taskId": "conv-43-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18749999999999997,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18749999999999997
+      },
+      "taskId": "conv-43-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q203-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1875
+      },
+      "taskId": "conv-43-q204-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q205-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q206-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q207-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q208-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q209-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q210-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q211-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q212-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q213-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q214-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q215-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q216-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q217-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q218-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09999999999999999
+      },
+      "taskId": "conv-43-q219-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3846153846153846,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3846153846153846
+      },
+      "taskId": "conv-43-q220-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q221-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q222-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q223-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q224-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q225-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q226-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-43-q227-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q228-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q229-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q230-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-43-q231-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q232-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q233-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q234-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q235-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07692307692307691,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307691
+      },
+      "taskId": "conv-43-q236-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-43-q237-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q238-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q239-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q240-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21052631578947364,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.21052631578947364
+      },
+      "taskId": "conv-43-q241-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.37499999999999994,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.37499999999999994
+      },
+      "taskId": "conv-44-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3809523809523809,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3809523809523809
+      },
+      "taskId": "conv-44-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473685,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-44-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-44-q5-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-44-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16
+      },
+      "taskId": "conv-44-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-44-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q11-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-44-q12-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2608695652173913,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1739130434782609
+      },
+      "taskId": "conv-44-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q17-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-44-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q20-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-44-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7499999999999999,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7499999999999999
+      },
+      "taskId": "conv-44-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-44-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.07692307692307693,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307693
+      },
+      "taskId": "conv-44-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1142857142857143,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05714285714285715
+      },
+      "taskId": "conv-44-q31-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727272,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727272
+      },
+      "taskId": "conv-44-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.32432432432432434,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18918918918918917
+      },
+      "taskId": "conv-44-q33-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q35-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-44-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-44-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q39-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q43-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q44-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-44-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-44-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21052631578947367,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.21052631578947367
+      },
+      "taskId": "conv-44-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.375,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.31250000000000006
+      },
+      "taskId": "conv-44-q52-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.26666666666666666
+      },
+      "taskId": "conv-44-q53-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-44-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-44-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.05714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05714285714285715
+      },
+      "taskId": "conv-44-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q61-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-44-q62-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q63-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q64-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26086956521739135,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1739130434782609
+      },
+      "taskId": "conv-44-q65-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.0625,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.0625
+      },
+      "taskId": "conv-44-q66-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-44-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809525
+      },
+      "taskId": "conv-44-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-44-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-44-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5142857142857142
+      },
+      "taskId": "conv-44-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.380952380952381,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.380952380952381
+      },
+      "taskId": "conv-44-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16
+      },
+      "taskId": "conv-44-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05405405405405406,
+        "llm_judge": 0.3,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05405405405405406
+      },
+      "taskId": "conv-44-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.9090909090909091,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9090909090909091
+      },
+      "taskId": "conv-44-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8000000000000002,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-44-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-44-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47058823529411764,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.47058823529411764
+      },
+      "taskId": "conv-44-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5217391304347825,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5217391304347825
+      },
+      "taskId": "conv-44-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-44-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615383,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615383
+      },
+      "taskId": "conv-44-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-44-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.43750000000000006,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.43750000000000006
+      },
+      "taskId": "conv-44-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-44-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q123-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q124-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q125-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08695652173913045,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08695652173913045
+      },
+      "taskId": "conv-44-q126-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q127-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q128-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q129-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q130-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q131-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q132-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q133-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q134-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1111111111111111
+      },
+      "taskId": "conv-44-q135-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q136-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q137-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.9090909090909091,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9090909090909091
+      },
+      "taskId": "conv-44-q138-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q139-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4210526315789473,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4210526315789473
+      },
+      "taskId": "conv-44-q140-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q141-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q142-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q143-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q144-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q145-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q146-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q147-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q148-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q149-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q150-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q151-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08333333333333334,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08333333333333334
+      },
+      "taskId": "conv-44-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q0-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-47-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q6-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q7-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q8-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-47-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-47-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q11-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q12-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q14-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q15-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q16-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q17-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1111111111111111,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1111111111111111
+      },
+      "taskId": "conv-47-q20-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q22-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q23-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q25-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666665,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-47-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q30-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q33-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q35-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q36-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428564,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.20408163265306123
+      },
+      "taskId": "conv-47-q38-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q42-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-47-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q44-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-47-q45-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-47-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q50-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.4,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.86,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-47-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727273,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-47-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q62-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09523809523809525,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809525
+      },
+      "taskId": "conv-47-q64-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-47-q66-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-47-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08
+      },
+      "taskId": "conv-47-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12121212121212123
+      },
+      "taskId": "conv-47-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.17777777777777776,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-47-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.42857142857142855
+      },
+      "taskId": "conv-47-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-47-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727272,
+        "llm_judge": 0.95,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-47-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3636363636363636,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3636363636363636
+      },
+      "taskId": "conv-47-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.06451612903225806,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06451612903225806
+      },
+      "taskId": "conv-47-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8333333333333334,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8333333333333334
+      },
+      "taskId": "conv-47-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-47-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3636363636363636
+      },
+      "taskId": "conv-47-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.75,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.75
+      },
+      "taskId": "conv-47-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.631578947368421,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5263157894736842
+      },
+      "taskId": "conv-47-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3870967741935483,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3870967741935483
+      },
+      "taskId": "conv-47-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.23529411764705882
+      },
+      "taskId": "conv-47-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6363636363636364,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6363636363636364
+      },
+      "taskId": "conv-47-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-47-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q150-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q151-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.631578947368421,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.631578947368421
+      },
+      "taskId": "conv-47-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.75,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.75
+      },
+      "taskId": "conv-47-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-47-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-47-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-47-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-47-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-47-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1739130434782609,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08695652173913045
+      },
+      "taskId": "conv-47-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-48-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3636363636363636,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3636363636363636
+      },
+      "taskId": "conv-48-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q2-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q3-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q5-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-48-q8-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q11-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4705882352941176,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.29411764705882354
+      },
+      "taskId": "conv-48-q13-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-48-q15-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q16-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q18-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-48-q20-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-48-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-48-q23-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-48-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q25-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-48-q27-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q28-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-48-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-48-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q33-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q36-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-48-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.625,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.625
+      },
+      "taskId": "conv-48-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.46511627906976744,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4186046511627907
+      },
+      "taskId": "conv-48-q39-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q40-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.04651162790697674,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.04651162790697674
+      },
+      "taskId": "conv-48-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q42-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-48-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-48-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q48-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-48-q49-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q50-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q51-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.38095238095238093,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.38095238095238093
+      },
+      "taskId": "conv-48-q56-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q58-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-48-q59-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-48-q60-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q61-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q62-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.625,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.625
+      },
+      "taskId": "conv-48-q63-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q64-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q66-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1739130434782609,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1739130434782609
+      },
+      "taskId": "conv-48-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q70-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-48-q71-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q73-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q75-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-48-q76-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q77-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-48-q78-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q79-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q80-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q81-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11111111111111112
+      },
+      "taskId": "conv-48-q82-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-48-q83-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.26666666666666666
+      },
+      "taskId": "conv-48-q84-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-48-q85-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.0909090909090909
+      },
+      "taskId": "conv-48-q86-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q87-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19047619047619047,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809523
+      },
+      "taskId": "conv-48-q88-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.625,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.625
+      },
+      "taskId": "conv-48-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1739130434782609,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1739130434782609
+      },
+      "taskId": "conv-48-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-48-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-48-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-48-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5454545454545454,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-48-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-48-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8235294117647058,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8235294117647058
+      },
+      "taskId": "conv-48-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08695652173913045,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08695652173913045
+      },
+      "taskId": "conv-48-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8275862068965517,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8275862068965517
+      },
+      "taskId": "conv-48-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12121212121212123
+      },
+      "taskId": "conv-48-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-48-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-48-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-48-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-48-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9333333333333333
+      },
+      "taskId": "conv-48-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22857142857142856,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.17142857142857143
+      },
+      "taskId": "conv-48-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8750000000000001,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8750000000000001
+      },
+      "taskId": "conv-48-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.46153846153846156,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.30769230769230765
+      },
+      "taskId": "conv-48-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9473684210526316,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9473684210526316
+      },
+      "taskId": "conv-48-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-48-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-48-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2758620689655173,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2758620689655173
+      },
+      "taskId": "conv-48-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7499999999999999,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-48-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-48-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08333333333333333,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08333333333333333
+      },
+      "taskId": "conv-48-q158-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q159-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-48-q160-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q161-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-48-q162-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q163-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q164-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q165-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7142857142857143,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.42857142857142855
+      },
+      "taskId": "conv-48-q166-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q167-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q168-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-48-q169-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q170-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q171-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q172-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-48-q173-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q174-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q175-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-48-q176-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q177-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q178-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q179-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q180-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.30769230769230765
+      },
+      "taskId": "conv-48-q181-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q182-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q183-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q184-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q185-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q186-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q187-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q188-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q189-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q190-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q203-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-48-q204-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q205-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q206-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q207-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q208-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q209-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q210-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-48-q211-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-48-q212-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9333333333333333
+      },
+      "taskId": "conv-48-q213-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.24,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16
+      },
+      "taskId": "conv-48-q214-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.0625,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.0625
+      },
+      "taskId": "conv-48-q215-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-48-q216-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q217-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q218-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-48-q219-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q220-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q221-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q222-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q223-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q224-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q225-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q226-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-48-q227-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q228-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q229-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q230-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q231-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q232-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q233-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q234-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q235-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q236-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q237-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q238-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q0-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-49-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q5-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20000000000000004,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.20000000000000004
+      },
+      "taskId": "conv-49-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q8-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q10-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-49-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.75,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.75
+      },
+      "taskId": "conv-49-q16-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7499999999999999,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7499999999999999
+      },
+      "taskId": "conv-49-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12499999999999997,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12499999999999997
+      },
+      "taskId": "conv-49-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18032786885245902,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16393442622950818
+      },
+      "taskId": "conv-49-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12244897959183673,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12244897959183673
+      },
+      "taskId": "conv-49-q20-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26415094339622636,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11320754716981134
+      },
+      "taskId": "conv-49-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q23-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09090909090909091,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09090909090909091
+      },
+      "taskId": "conv-49-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-49-q27-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-49-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3225806451612903,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2580645161290323
+      },
+      "taskId": "conv-49-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2162162162162162,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13513513513513514
+      },
+      "taskId": "conv-49-q31-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-49-q33-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7499999999999999,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.64,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.64
+      },
+      "taskId": "conv-49-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q37-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18750000000000003
+      },
+      "taskId": "conv-49-q38-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-49-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5882352941176471,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5882352941176471
+      },
+      "taskId": "conv-49-q40-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.058823529411764705
+      },
+      "taskId": "conv-49-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q43-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-49-q44-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21276595744680854,
+        "llm_judge": 0.65,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10638297872340427
+      },
+      "taskId": "conv-49-q46-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-49-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.37499999999999994,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.37499999999999994
+      },
+      "taskId": "conv-49-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19999999999999998
+      },
+      "taskId": "conv-49-q51-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5185185185185185,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5185185185185185
+      },
+      "taskId": "conv-49-q55-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7058823529411765,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5882352941176471
+      },
+      "taskId": "conv-49-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q57-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q60-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-49-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5544554455445544,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.297029702970297
+      },
+      "taskId": "conv-49-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q64-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q65-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q66-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q67-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727272,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727272
+      },
+      "taskId": "conv-49-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-49-q69-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q70-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q71-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q72-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q73-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q74-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q75-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.65,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-49-q76-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q77-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-49-q78-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q79-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q80-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q81-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.2,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-49-q82-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-49-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.06896551724137931,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06896551724137931
+      },
+      "taskId": "conv-49-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.0909090909090909,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.0909090909090909
+      },
+      "taskId": "conv-49-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4285714285714285,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4285714285714285
+      },
+      "taskId": "conv-49-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1111111111111111
+      },
+      "taskId": "conv-49-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7692307692307693,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7692307692307693
+      },
+      "taskId": "conv-49-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727273,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-49-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473684,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473684
+      },
+      "taskId": "conv-49-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20689655172413796,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.20689655172413796
+      },
+      "taskId": "conv-49-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-49-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.42857142857142855
+      },
+      "taskId": "conv-49-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7142857142857143,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7142857142857143
+      },
+      "taskId": "conv-49-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-49-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20000000000000004,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.20000000000000004
+      },
+      "taskId": "conv-49-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.26666666666666666
+      },
+      "taskId": "conv-49-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1875,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1875
+      },
+      "taskId": "conv-49-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-49-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.16,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16
+      },
+      "taskId": "conv-49-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.923076923076923,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.923076923076923
+      },
+      "taskId": "conv-49-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2727272727272727,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2727272727272727
+      },
+      "taskId": "conv-49-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.30769230769230765
+      },
+      "taskId": "conv-49-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6249999999999999,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2727272727272727,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2727272727272727
+      },
+      "taskId": "conv-49-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7499999999999999,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7499999999999999
+      },
+      "taskId": "conv-49-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-49-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.631578947368421,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.631578947368421
+      },
+      "taskId": "conv-49-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-49-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.0392156862745098,
+        "llm_judge": 0.65,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.0392156862745098
+      },
+      "taskId": "conv-49-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9090909090909091,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9090909090909091
+      },
+      "taskId": "conv-49-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-49-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.21052631578947367,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.21052631578947367
+      },
+      "taskId": "conv-49-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-49-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19999999999999998,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19999999999999998
+      },
+      "taskId": "conv-49-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-49-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-49-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727273,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-49-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.24,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24
+      },
+      "taskId": "conv-49-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08695652173913045,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08695652173913045
+      },
+      "taskId": "conv-49-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7142857142857143,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7142857142857143
+      },
+      "taskId": "conv-49-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.923076923076923,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.923076923076923
+      },
+      "taskId": "conv-49-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-49-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-49-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.42857142857142855
+      },
+      "taskId": "conv-49-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9090909090909091,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9090909090909091
+      },
+      "taskId": "conv-49-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-49-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-50-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-50-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q2-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-50-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q4-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5185185185185186,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5185185185185186
+      },
+      "taskId": "conv-50-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-50-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q7-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-50-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3846153846153846,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3846153846153846
+      },
+      "taskId": "conv-50-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6250000000000001,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6250000000000001
+      },
+      "taskId": "conv-50-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.17647058823529413,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.17647058823529413
+      },
+      "taskId": "conv-50-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.30303030303030304,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24242424242424246
+      },
+      "taskId": "conv-50-q13-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-50-q14-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714288,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714288
+      },
+      "taskId": "conv-50-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.26666666666666666
+      },
+      "taskId": "conv-50-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q20-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q21-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q22-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-50-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.98,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-50-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q27-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09523809523809525,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809525
+      },
+      "taskId": "conv-50-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.35294117647058826,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.35294117647058826
+      },
+      "taskId": "conv-50-q33-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3076923076923077
+      },
+      "taskId": "conv-50-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-50-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q37-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q39-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-50-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q42-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-50-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q45-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-50-q46-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-50-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-50-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-50-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q50-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q51-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q53-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08695652173913042,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08695652173913042
+      },
+      "taskId": "conv-50-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-50-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21818181818181817,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818185
+      },
+      "taskId": "conv-50-q58-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q59-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10810810810810811,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10810810810810811
+      },
+      "taskId": "conv-50-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q62-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q63-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4516129032258065,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4516129032258065
+      },
+      "taskId": "conv-50-q64-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666669
+      },
+      "taskId": "conv-50-q66-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q67-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q69-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q70-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2666666666666667,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2666666666666667
+      },
+      "taskId": "conv-50-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-50-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.9090909090909091,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9090909090909091
+      },
+      "taskId": "conv-50-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-50-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3
+      },
+      "taskId": "conv-50-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4615384615384615
+      },
+      "taskId": "conv-50-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-50-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-50-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-50-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.923076923076923,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.923076923076923
+      },
+      "taskId": "conv-50-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-50-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3076923076923077,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3076923076923077
+      },
+      "taskId": "conv-50-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.33333333333333337,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-50-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08888888888888889,
+        "llm_judge": 0.35,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08888888888888889
+      },
+      "taskId": "conv-50-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.47619047619047616
+      },
+      "taskId": "conv-50-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6086956521739131,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6086956521739131
+      },
+      "taskId": "conv-50-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-50-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-50-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.75,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.75
+      },
+      "taskId": "conv-50-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12903225806451613,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12903225806451613
+      },
+      "taskId": "conv-50-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.06896551724137932,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06896551724137932
+      },
+      "taskId": "conv-50-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-50-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11538461538461539,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307693
+      },
+      "taskId": "conv-50-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-50-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.923076923076923,
+        "llm_judge": 0.98,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.923076923076923
+      },
+      "taskId": "conv-50-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.9090909090909091,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9090909090909091
+      },
+      "taskId": "conv-50-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307693
+      },
+      "taskId": "conv-50-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-50-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9333333333333333
+      },
+      "taskId": "conv-50-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-50-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9090909090909091,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9090909090909091
+      },
+      "taskId": "conv-50-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9523809523809523,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9523809523809523
+      },
+      "taskId": "conv-50-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11111111111111112,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11111111111111112
+      },
+      "taskId": "conv-50-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.782608695652174,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.782608695652174
+      },
+      "taskId": "conv-50-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2105263157894737,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2105263157894737
+      },
+      "taskId": "conv-50-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-50-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-50-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.38095238095238093,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.38095238095238093
+      },
+      "taskId": "conv-50-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714285
+      },
+      "taskId": "conv-50-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-50-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-50-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1142857142857143,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05714285714285715
+      },
+      "taskId": "conv-50-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-50-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.782608695652174,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.782608695652174
+      },
+      "taskId": "conv-50-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-50-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q203-adversarial"
+    }
+  ],
+  "schemaVersion": 1,
+  "seed": 1,
+  "startedAt": "2026-07-14T08:02:18.996Z",
+  "system": {
+    "gitSha": "067634700",
+    "name": "remnic",
+    "version": "9.6.10"
+  },
+  "tier": "frontier"
+}

--- a/docs/benchmarks/results/2026-07-14-longmemeval-opus-0676347-baseline.json
+++ b/docs/benchmarks/results/2026-07-14-longmemeval-opus-0676347-baseline.json
@@ -1,0 +1,5037 @@
+{
+  "benchmarkId": "longmemeval",
+  "datasetVersion": "longmemeval-oracle",
+  "durationMs": 3050154,
+  "env": {
+    "arch": "x64",
+    "node": "v22.22.0",
+    "os": "linux"
+  },
+  "finishedAt": "2026-07-14T08:02:06.744Z",
+  "judgeCalibration": {
+    "kappa": 0.5591939546599496,
+    "sampleSize": 50,
+    "threshold": 0.7,
+    "warning": true
+  },
+  "metrics": {
+    "contains_answer": 0.494,
+    "f1": 0.4940832987481399,
+    "judge_accuracy": 0.75,
+    "llm_judge": 0.75,
+    "search_hits": 8.52
+  },
+  "model": "opus",
+  "note": "Opus 4.8 via Claude Code (claude -p), BASELINE profile (LCM stack only, fact-pipeline features off): the anchor-comparable pass. Companion to the real-profile 2026-07-14-longmemeval-opus-0676347 artifact.",
+  "perTaskScores": [
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12121212121212122,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2655b836"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.9090909090909091,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2487a7cb"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_76048e76"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2312f94c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0bb5a684"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q08f4fc43"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2c63a862"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.10526315789473684,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_385a5000"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2a1811e2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qbbf86515"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_5dcc0aab"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_0b2f1d21"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf0853d11"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2285714285714286,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_6ed717ea"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qgpt4_70e84552"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qa3838d2b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4166666666666667,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_93159ced"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2d58bcd6"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_65aabe59"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q982b5123"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07692307692307691,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qb9cfe692"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_4edbafa2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc8090214"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_483dd43c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2666666666666667,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe4e14d04"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.038461538461538464,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qc9f37c46"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2608695652173913,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2c50253f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qdcfa8644"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_b4a80587"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_9a159967"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.0851063829787234,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcc6d1ec1"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_8c8961ae"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_d9af6064"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7de946e7"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd01c6aa8"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.0816326530612245,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q993da5e2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa3045048"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_d31cdae3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_cd90e484"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_88806d6e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_4cd9eba1"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_93f6379c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.0909090909090909,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qb29f3365"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2f56ae70"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6613b389"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8333333333333333,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_78cf46a3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4615384615384615,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_0a05b494"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qgpt4_1a1dc16d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2f584639"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.09523809523809523,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_213fd887"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_5438fa52"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.9090909090909091,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_c27434e8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.0625,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_fe651585"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q8c18457d"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2727272727272727,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "qgpt4_70e84552_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "qgpt4_93159ced_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q982b5123_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "qc8090214_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_c27434e8_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_fe651585_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q0a995998"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.02222222222222222,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q6d550036"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7126436781609194,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_59c863d7"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.10256410256410257,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qb5ef892d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe831120c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q3a704032"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_d84a3211"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qaae3761f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 1
+      },
+      "taskId": "qgpt4_f2262a51"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qdd2973ad"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc4a1ceb8"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qgpt4_a56e767c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6cb6f249"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q46a3abf7"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.0425531914893617,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q36b9f61e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.08888888888888888,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q28dc39ac"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 8
+      },
+      "taskId": "qgpt4_2f8be40d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.044444444444444446,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2e6d26dc"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_15e38248"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "q88432d0a"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q80ec1f4f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd23cf73b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7fce9456"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd682f1a2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q7024f17c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_5501fe77"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2ba83207"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.11764705882352941,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2318644b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2ce6a0f2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "qgpt4_d12ceb0e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q00ca467f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qb3c15d39"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.07142857142857142,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_31ff4165"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qeeda8a6d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.10526315789473684,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2788b940"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q60bf93ed"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q9d25d4e0"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.16,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q129d1232"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q60472f9c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.042553191489361694,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qgpt4_194be4b3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa9f6b44c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.06666666666666667,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qd851d5ba"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09302325581395349,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q5a7937c8"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_ab202e7f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.07692307692307693,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_e05b82a6"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_731e37d7"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2666666666666667,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qedced276"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 7
+      },
+      "taskId": "q10d9b85a"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qe3038f8c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.0909090909090909,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2b8f3739"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q1a8a66a6"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc2ac3c61"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qbf659f65"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_372c3eed"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1111111111111111,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_2f91af09"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q81507db6"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q88432d0a_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q80ec1f4f_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qeeda8a6d_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q60bf93ed_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qedced276_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20689655172413796,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_372c3eed_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q6a1eabeb"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6aeb4375"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q830ce83f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 8
+      },
+      "taskId": "q852ce960"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q945e3d21"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.07407407407407407,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd7c942c3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q71315a70"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q89941a93"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qce6d2d27"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q9ea5eabc"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q07741c44"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa1eacc2a"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q184da446"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666665,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q031748ae"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q4d6b87c8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.07692307692307693,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q0f05491a"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q08e075c7"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qf9e8c073"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.888888888888889,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q41698283"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.09523809523809523,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q2698e78f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "qb6019101"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q45dc21b6"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q5a4f22c0"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5806451612903226,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6071bd76"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe493bb7c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q618f13b2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q72e3ee87"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.06666666666666667,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "qc4ea545c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q01493427"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6a27ffc2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q2133c1b5"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7499999999999999,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q18bc8abd"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qdb467c8c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q7a87bd0c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe61a7584"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1cea1afa"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qed4ddc30"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q8fb83627"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qb01defab"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q22d2cb42"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q0e4e4c46"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q4b24c848"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q7e974930"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q603deb26"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q59524333"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q5831f84d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qeace081b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qaffe2881"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q50635ada"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1739130434782609,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qe66b632c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0ddfec37"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf685340e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7499999999999999,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcc5ded98"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qdfde3500"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q69fee5aa"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q7401057b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcf22b7bf"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa2f3aa27"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc7dc5443"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q06db6396"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q3ba21379"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q9bbe84a2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q10e09553"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.14285714285714288,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qdad224aa"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.07142857142857142,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qba61f0b9"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q42ec0761"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q5c40ec5b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qc6853660"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q26bdc477"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q0977f2af"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q6aeb4375_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q031748ae_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2698e78f_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q2133c1b5_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0ddfec37_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2692307692307692,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf685340e_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.37037037037037035,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q89941a94"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q07741c45"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 6
+      },
+      "taskId": "q8a2466db"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15037593984962405,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q06878be2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1320754716981132,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q75832dbd"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q0edc2aef"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q35a27287"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11627906976744186,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q32260d93"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20740740740740743,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "q195a1a1b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16356877323420074,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qafdc33df"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15019762845849802,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcaf03d32"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.24615384615384614,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q54026fce"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21951219512195125,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 1
+      },
+      "taskId": "q06f04340"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18421052631578946,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6b7dfb22"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18571428571428575,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1a1907b4"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 6
+      },
+      "taskId": "q09d032c9"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.17647058823529413,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q38146c39"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1625,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd24813b1"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 8
+      },
+      "taskId": "q57f827a0"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1324503311258278,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q95228167"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23255813953488375,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q505af2f5"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21739130434782605,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q75f70248"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3937007874015748,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qd6233ab6"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q1da05512"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2509225092250923,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "qfca70973"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20430107526881722,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "qb6025781"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12274368231046931,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa89d7624"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1797752808988764,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "qb0479f84"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2391304347826087,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1d4e3b97"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3130434782608696,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q07b6f563"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1176470588235294,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "q1c0ddc50"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09580838323353294,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0a34ad58"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8799999999999999,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q7161e7e2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc4f10528"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 2
+      },
+      "taskId": "q89527b6b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe9327a54"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q4c36ccef"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20930232558139536,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q6ae235be"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q7e00a6cb"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q1903aded"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9090909090909091,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qceb54acb"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf523d9fe"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q0e5e2d1a"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qfea54f57"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47058823529411764,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcc539528"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qdc439ea3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q18dcd5a5"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q488d3006"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 2
+      },
+      "taskId": "q58470ed2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.49411764705882355,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 2
+      },
+      "taskId": "q8cf51dda"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6086956521739131,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q1d4da289"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q8464fc84"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 8
+      },
+      "taskId": "q8aef76bc"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q71a3fd6b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2bf43736"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q70b3e69b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 3
+      },
+      "taskId": "q8752c811"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q3249768e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q1b9b7252"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1568498a"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q6222b6eb"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "qe8a79c70"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "qd596882b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 2
+      },
+      "taskId": "qe3fc4d6e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q51b23612"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q3e321797"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qe982271f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21052631578947367,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q352ab8bd"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qfca762bc"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "q7a8d0b71"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qa40e080f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q8b9d4367"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q5809eb10"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8085106382978724,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q41275add"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7692307692307693,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q4388e9dd"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q4baee567"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q561fabcd"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qb759caee"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qac031881"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q28bcfaac"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q16c90bf4"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qc8f1aeed"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7428571428571429,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "qeaca4986"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc7cf7dfd"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qe48988bc"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1de5cff2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q65240037"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q778164c6"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qe47becba"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q118b2229"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "q51a45a95"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q58bf7951"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q1e043500"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc5e8278d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6ade9755"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q6f9b354f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q58ef2f1c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.75,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf8c5f88b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 2
+      },
+      "taskId": "q5d3d2817"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q7527f7e2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qc960da58"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7499999999999999,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q3b6f954b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q726462e0"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q94f70d80"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q66f24dbb"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "qad7109d1"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "qaf8d2e46"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "qdccbc061"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "qc8c3f81d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q8ebdbe50"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q6b168ec8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q75499fd8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q21436231"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q95bcc1c8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0862e8bf"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q853b0a1d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qa06e4cfe"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q37d43f65"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.625,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qb86304ba"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "qd52b4f67"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q25e5aa4f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcaf9ead2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q8550ddae"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q60d45044"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q3f1e9474"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q86b68151"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q577d4d32"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 4
+      },
+      "taskId": "qec81a493"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q15745da0"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe01b8e2f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "qbc8a6e93"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "qccb36322"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q001be529"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "qb320f3f8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q19b5f2b3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q4fd1909e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5714285714285715,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q545bd2b5"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q8a137a7f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q76d63226"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q86f00804"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q8e9d538c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q311778f1"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qc19f7a0b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q4100d0a0"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "q29f2956b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q1faac195"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qfaba32e5"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "qf4f1d8a4"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "qc14c00dd"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q36580ce8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 6
+      },
+      "taskId": "q3d86fd0a"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "qa82c026e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2580645161290323,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "q0862e8bf_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q15745da0_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "qbc8a6e93_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q19b5f2b3_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1935483870967742,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q29f2956b_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qf4f1d8a4_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_59149c77"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8205128205128205,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_f49edff3"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 8
+      },
+      "taskId": "q71017276"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qb46e15ed"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_fa19884c"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0bc8ad92"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "qaf082822"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_4929293a"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "qgpt4_b5700ca9"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q9a707b81"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_1d4ab0c9"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_e072b769"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0db4c65d"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_1d80365e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27027027027027023,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 7
+      },
+      "taskId": "qgpt4_7f6b06db"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_6dc9b45b"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 6
+      },
+      "taskId": "qgpt4_8279ba02"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9210526315789473,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_18c2b244"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_a1b77f9c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_1916e0ea"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7a0daae1"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 4
+      },
+      "taskId": "qgpt4_468eb063"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3486238532110092,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7abb270c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_1e4a8aeb"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_4fc4f797"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q4dfccbf7"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_61e13b3c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3516483516483517,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_45189cb4"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q2ebe6c90"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4761904761904762,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "qgpt4_e061b84f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q370a8ff4"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7079646017699115,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_d6585ce8"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_4ef30696"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_ec93e27f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "q6e984301"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "q8077ef71"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_f420262c"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_8e165409"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_74aed68e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qbcbe585f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 7
+      },
+      "taskId": "qgpt4_21adecb5"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "q5e1b23de"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_98f46fc6"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 3
+      },
+      "taskId": "qgpt4_af6db32f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qeac54adc"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7ddcf75f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "qgpt4_a2d1d1f6"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qgpt4_85da3956"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "qgpt4_b0863698"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4761904761904762,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_68e94287"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_e414231e"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7ca326fa"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_7bc6cf22"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2ebe6c92"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 6
+      },
+      "taskId": "qgpt4_e061b84g"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 2
+      },
+      "taskId": "q71017277"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qb46e15ee"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_d6585ce9"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_1e4a8aec"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_f420262d"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5000000000000001,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_59149c78"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_e414231f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "qgpt4_4929293b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 1
+      },
+      "taskId": "qgpt4_468eb064"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615383,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "qgpt4_fa19884d"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 5
+      },
+      "taskId": "q9a707b82"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.75,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 3
+      },
+      "taskId": "qeac54add"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "q4dfccbf8"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q0bc8ad93"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 7
+      },
+      "taskId": "q6e984302"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 1
+      },
+      "taskId": "qgpt4_8279ba03"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "qgpt4_b5700ca0"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 2
+      },
+      "taskId": "qgpt4_68e94288"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 2
+      },
+      "taskId": "qd3ab962e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2857142857142857,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2311e44b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qcc06de0d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.16666666666666669,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa11281a2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q4f54b7c9"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q85fa3a3f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q9aaed6a3"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1f2b8d4f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe6041065"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q51c32626"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd905b33f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q7405e8b1"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf35224e0"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.18181818181818182,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6456829e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1111111111111111,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa4996e51"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "q3c1045c8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19999999999999998,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q60036106"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q681a1674"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19999999999999998,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe25c3b8d"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q4adc0475"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q4bc144e2"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qef66a6e5"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q5025383b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 4
+      },
+      "taskId": "qa1cc6108"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q9ee3ecd6"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q3fdac837"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q91b15a6e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q27016adc"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q720133ac"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q77eafa52"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q8979f9ec"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0100672e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa96c20ee"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q92a0aa75"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q3fe836c9"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1c549ce4"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6c49646a"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.38095238095238093,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q1192316e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.13333333333333333,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q0ea62687"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q67e0d0f2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qbb7c3b45"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qba358f49"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3076923076923077,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q61f8c8f8"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q60159905"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.08695652173913045,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qef9cf60a"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2857142857142857,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q73d42213"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qbc149d6b"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q099778bb"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q09ba9854"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3636363636363636,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qd6062bb9"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 7
+      },
+      "taskId": "q157a136e"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 5
+      },
+      "taskId": "qc18a7dc8"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa3332713"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q55241a1f"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa08a253f"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qf0e564bc"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "q078150f1"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 6
+      },
+      "taskId": "q8cf4d046"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa346bb18"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 9
+      },
+      "taskId": "q37f165cf"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 1
+      },
+      "taskId": "q8e91e7d9"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q87f22b4a"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe56a43b9"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.23529411764705882,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qefc3f7c2"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 9
+      },
+      "taskId": "q21d02d0d"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q2311e44b_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3913043478260869,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "q6456829e_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qe5ba910e_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 10
+      },
+      "taskId": "qa96c20ee_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "judge_accuracy": 1,
+        "llm_judge": 1,
+        "search_hits": 8
+      },
+      "taskId": "qba358f49_abs"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12903225806451613,
+        "judge_accuracy": 0,
+        "llm_judge": 0,
+        "search_hits": 10
+      },
+      "taskId": "q09ba9854_abs"
+    }
+  ],
+  "schemaVersion": 1,
+  "seed": 1,
+  "startedAt": "2026-07-14T07:11:16.590Z",
+  "system": {
+    "gitSha": "067634700",
+    "name": "remnic",
+    "version": "9.6.10"
+  },
+  "tier": "frontier"
+}


### PR DESCRIPTION
PR 1/2, same pattern as #1867: gives the two baseline-profile Tier-F artifacts (LongMemEval 0.750, LoCoMo 0.474; verified, sha256 f46469df… / 62c32f21…) a citable home in main history. PR 2/2 untracks them so the real-profile 0676347 artifacts stay the Figure 1 anchors and the manifest stays at 10. Evidence for #1879 (baseline beats real on LoCoMo across judge-independent metrics too). Part of #1728.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds large read-only benchmark result JSON and documentation-style provenance only; no runtime, auth, or manifest/figure selection changes until the planned untrack in PR 2.
> 
> **Overview**
> **PR 1/2** adds the two verified full **Tier-F baseline-profile** benchmark JSONs (`2026-07-14-locomo-opus-0676347-baseline.json`, `2026-07-14-longmemeval-opus-0676347-baseline.json`) to `main` so they have a citable commit, mirroring the PR #1867 approach for the §6.2 temporal comparison artifact. They record Opus via Claude Code on the **baseline** runtime profile (LCM stack / anchor-comparable pass), with headline judge metrics around **LoCoMo `llm_judge` ≈ 0.474** and **LongMemEval `judge_accuracy` = 0.750**.
> 
> Follow-up **PR 2/2** is expected to **remove them from the tracked tree** again so the ten-entry `artifact-manifest.json` and Figure 1 “newest Tier-F per benchmark” logic stay anchored on the **real-profile** `2026-07-14-*-opus-0676347.json` pair; retrieval would be via `git show` on the commit that introduced them. This lands provenance for **#1879** (baseline profile outscores real on LoCoMo, including judge-independent metrics).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c18d87bb3d1983820a08c5cfd58c3a1491e003. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->