### PR TITLE
fix(bench): harden Build Week frontier runs

### DIFF
--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -207,7 +207,7 @@ export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledge
 remnic bench run longmemeval --runtime-profile real \
   --limit <LEDGER_DERIVED_LIMIT> \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
-  --request-timeout 180000 --drain-timeout 600000 \
+  --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -226,6 +226,10 @@ store with
 ledger is mode `0600` with
 `chmod 600 "$REMNIC_BENCH_CODEX_CREDIT_LEDGER"` after it is first created.
 Publish only the safe cost and token totals from the result and manifest.
+Codex CLI gets a benchmark-owned 180-second transport timeout automatically;
+do not add `--request-timeout` here because that explicit flag also enables a
+whole-phase benchmark guard. The separate drain timeout stays explicit so
+queued internal work can finish after the last scored task.
 
 ## How to test it in five minutes
 

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -193,13 +193,21 @@ also use `--trial-limit`. These flags do not cap credits. The provider has
 separate credit guards. Set them, then choose the task cap from the ledger:
 
 ```bash
+BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"
+export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"
+umask 077
+mkdir -p "$BUILD_WEEK_RUN_ROOT" "$BUILD_WEEK_RESULTS_DIR"
+chmod 700 "$BUILD_WEEK_RUN_ROOT" "$BUILD_WEEK_RESULTS_DIR"
+
 export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473
 export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473
-export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$PWD/.bench-private/codex-credit-ledger.json"
+export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"
 
 # Replace <LEDGER_DERIVED_LIMIT> after a smoke turn establishes actual cost.
 remnic bench run longmemeval --runtime-profile real \
   --limit <LEDGER_DERIVED_LIMIT> \
+  --results-dir "$BUILD_WEEK_RESULTS_DIR" \
+  --request-timeout 180000 --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -210,8 +218,14 @@ remnic bench run longmemeval --runtime-profile real \
 
 The placeholder is on purpose. There is no honest fixed task count until we
 measure this prompt and test mix. Keep the ledger private because it can hold
-local run data. Publish only the safe cost and token totals from the result and
-manifest.
+local run data. The external results directory can also contain questions,
+answers, and recalled context, so keep it private too. After each run, preserve
+the exact ID printed by the CLI; recover it without scanning another results
+store with
+`remnic bench runs list --results-dir "$BUILD_WEEK_RESULTS_DIR"`. Confirm the
+ledger is mode `0600` with
+`chmod 600 "$REMNIC_BENCH_CODEX_CREDIT_LEDGER"` after it is first created.
+Publish only the safe cost and token totals from the result and manifest.
 
 ## How to test it in five minutes
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -261,12 +261,20 @@ for each role.
 Configure the guard and run a measured smoke before selecting a task count:
 
 ```bash
+BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"
+export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"
+umask 077
+mkdir -p "$BUILD_WEEK_RUN_ROOT" "$BUILD_WEEK_RESULTS_DIR"
+chmod 700 "$BUILD_WEEK_RUN_ROOT" "$BUILD_WEEK_RESULTS_DIR"
+
 export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473
 export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473
-export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$PWD/.bench-private/codex-credit-ledger.json"
+export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"
 
 remnic bench run --quick longmemeval \
   --runtime-profile real \
+  --results-dir "$BUILD_WEEK_RESULTS_DIR" \
+  --request-timeout 180000 --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -277,6 +285,8 @@ remnic bench run --quick longmemeval \
 # Replace this only after the smoke ledger establishes observed cost.
 remnic bench run longmemeval \
   --runtime-profile real --limit <LEDGER_DERIVED_LIMIT> \
+  --results-dir "$BUILD_WEEK_RESULTS_DIR" \
+  --request-timeout 180000 --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -290,6 +300,14 @@ and MemoryAgentBench. Neither flag is a token-credit budget, so the placeholder
 cannot be replaced with a fixed universal value: derive it from the ledger's
 observed per-task cost and resize after each bounded batch. A limited run is a
 trial artifact and cannot be promoted as a full leaderboard result.
+
+Keep both the atomic ledger and stored results outside the checkout: results
+may contain questions, answers, and recalled context. The restrictive `umask`
+and explicit directory modes above protect new files; after the ledger is
+created, enforce `chmod 600 "$REMNIC_BENCH_CODEX_CREDIT_LEDGER"`. Preserve the
+exact run ID printed by the CLI, or recover it from only this store with
+`remnic bench runs list --results-dir "$BUILD_WEEK_RESULTS_DIR"`. Use that ID
+for export and promotion rather than selecting an ambiguous latest result.
 
 To build a publishable artifact from a finished run's stored result, see
 `scripts/bench/build-artifact-from-result.ts` (bridges `BenchmarkResult` →
@@ -346,15 +364,20 @@ Before trusting a Tier L judge for regression, run:
 
 ```bash
 remnic bench judge-calibrate --benchmark locomo \
-  --local-lab-manifest packages/bench/profiles/local-lab-3090.json \
+  --local-lab-manifest docs/benchmarks/configs/local-lab-3090.json \
   --judge-provider anthropic --judge-model <frontier-judge-id>
 ```
 
-This scores a fixed 50-question calibration slice with both the local
-and frontier judges and reports **Cohen's kappa**. The kappa is
-persisted (`~/.remnic/bench/calibration/`) and lands in subsequent
-Tier L artifacts as
-`judgeCalibration: { kappa, sampleSize, threshold, warning }`.
+This scores a deterministic, pinned 200-question calibration slice with both
+the local and frontier judges (or every available question when fewer than
+200 exist) and reports **Cohen's kappa** with a deterministic paired-bootstrap
+95% confidence interval. The exact stored-result source, ordered question IDs,
+and answer-set hash are pinned so later calibration runs cannot silently switch
+answer payloads. The kappa and provenance are persisted
+(`~/.remnic/bench/calibration/`) and land in subsequent Tier L artifacts as
+`judgeCalibration`, including `kappa`, `sampleSize`, `threshold`, `warning`,
+`confidenceInterval`, `bootstrapSamples`, `sourceResultId`, `answerSetHash`,
+and `sliceQuestionIds`.
 A kappa below **0.7** renders a loud "local judge unreliable for this
 benchmark" warning in the report and on the artifact. The calibration
 slice is question-ids-only — no dataset content is committed (per the

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -274,7 +274,7 @@ export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledge
 remnic bench run --quick longmemeval \
   --runtime-profile real \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
-  --request-timeout 180000 --drain-timeout 600000 \
+  --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -286,7 +286,7 @@ remnic bench run --quick longmemeval \
 remnic bench run longmemeval \
   --runtime-profile real --limit <LEDGER_DERIVED_LIMIT> \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
-  --request-timeout 180000 --drain-timeout 600000 \
+  --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -300,6 +300,12 @@ and MemoryAgentBench. Neither flag is a token-credit budget, so the placeholder
 cannot be replaced with a fixed universal value: derive it from the ledger's
 observed per-task cost and resize after each bounded batch. A limited run is a
 trial artifact and cannot be promoted as a full leaderboard result.
+
+The Codex CLI profile supplies a 180-second transport-only timeout by default.
+Do not add `--request-timeout` to this protocol: an explicit request timeout
+also becomes a whole benchmark-phase guard and can prematurely cap a long
+store, recall, or reset phase. Keep the independent 600-second drain timeout
+for queued internal work.
 
 Keep both the atomic ledger and stored results outside the checkout: results
 may contain questions, answers, and recalled context. The restrictive `umask`

--- a/docs/paper/repro-appendix.md
+++ b/docs/paper/repro-appendix.md
@@ -163,9 +163,12 @@ regression) records `tier: "local"` plus a `hardware` envelope; Tier F
 (absence is treated as frontier for backwards compatibility).
 
 **Judge calibration.** `judgeCalibration` carries the Cohen's κ between the
-local and frontier judges over a fixed calibration slice, plus the sample
-size, threshold, and a `warning` flag set when κ falls below threshold. It
-lands on local artifacts after `remnic bench judge-calibrate` (§A.3.5).
+local and frontier judges over a deterministic, pinned 200-question slice (or
+all available questions when fewer than 200 exist), plus a deterministic
+paired-bootstrap 95% confidence interval, sample size, threshold, and a
+`warning` flag set when κ falls below threshold. The stored-result source,
+ordered question IDs, and answer-set hash pin the judged payload across reruns.
+It lands on local artifacts after `remnic bench judge-calibrate` (§A.3.6).
 
 **What is committed today.** `docs/benchmarks/results/` on `main` carries
 ten artifacts. Two are clearly-marked mock placeholders
@@ -394,7 +397,12 @@ remnic bench judge-calibrate \
 
 The κ lands on the next `remnic bench run` artifact for that benchmark
 (only when the run's judge matches the calibrated pair). Absent calibration
-is the common case — the result is written unchanged.
+is the common case — the result is written unchanged. The command selects a
+deterministic 200-question slice (or all available questions when fewer than
+200 exist), pins the source result, question IDs, and exact answer-set hash,
+and reports a deterministic 2,000-resample paired-bootstrap 95% confidence
+interval. Re-running calibration reuses the pinned answer payload instead of
+silently selecting whichever stored answers are newest.
 
 ### A.3.7 Build, verify, and promote the artifact
 
@@ -650,9 +658,15 @@ normal service, not fast mode. Configure the provider's guard before the first
 turn:
 
 ```bash
+BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"
+export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"
+umask 077
+mkdir -p "$BUILD_WEEK_RUN_ROOT" "$BUILD_WEEK_RESULTS_DIR"
+chmod 700 "$BUILD_WEEK_RUN_ROOT" "$BUILD_WEEK_RESULTS_DIR"
+
 export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473
 export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473
-export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$PWD/.bench-private/codex-credit-ledger.json"
+export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"
 unset REMNIC_BENCH_CODEX_ALLOW_SOL
 ```
 
@@ -681,6 +695,8 @@ further dispatch until manual account reconciliation:
 ```bash
 remnic bench run --quick longmemeval \
   --runtime-profile real \
+  --results-dir "$BUILD_WEEK_RESULTS_DIR" \
+  --request-timeout 180000 --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -690,6 +706,8 @@ remnic bench run --quick longmemeval \
 
 remnic bench run longmemeval \
   --runtime-profile real --limit <LEDGER_DERIVED_LIMIT> \
+  --results-dir "$BUILD_WEEK_RESULTS_DIR" \
+  --request-timeout 180000 --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -704,7 +722,13 @@ token-budget flag. The existing `--limit` caps loaded items, and
 directly caps credits. The provider environment variables enforce the credit
 ceiling, while the ledger determines the next safe task bound. Label every
 bounded output as partial coverage and keep the private ledger out of the
-public artifact unless it has been sanitized.
+public artifact unless it has been sanitized. Stored results may also include
+questions, answers, and recalled context, so the external results directory is
+private state too. After the first ledger write, enforce
+`chmod 600 "$REMNIC_BENCH_CODEX_CREDIT_LEDGER"`. Preserve the exact run ID
+printed by the CLI, or recover it only from the isolated store with
+`remnic bench runs list --results-dir "$BUILD_WEEK_RESULTS_DIR"`; use that ID
+for export and artifact promotion rather than an ambiguous latest run.
 
 ---
 

--- a/docs/paper/repro-appendix.md
+++ b/docs/paper/repro-appendix.md
@@ -696,7 +696,7 @@ further dispatch until manual account reconciliation:
 remnic bench run --quick longmemeval \
   --runtime-profile real \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
-  --request-timeout 180000 --drain-timeout 600000 \
+  --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -707,7 +707,7 @@ remnic bench run --quick longmemeval \
 remnic bench run longmemeval \
   --runtime-profile real --limit <LEDGER_DERIVED_LIMIT> \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
-  --request-timeout 180000 --drain-timeout 600000 \
+  --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -729,6 +729,11 @@ private state too. After the first ledger write, enforce
 printed by the CLI, or recover it only from the isolated store with
 `remnic bench runs list --results-dir "$BUILD_WEEK_RESULTS_DIR"`; use that ID
 for export and artifact promotion rather than an ambiguous latest run.
+The Codex CLI runtime supplies a 180-second transport-only timeout when the
+flag is omitted. Do not add `--request-timeout` to these commands: an explicit
+value also becomes a whole-phase benchmark guard, which can cut off long
+store/recall/reset phases. The 600-second drain timeout is deliberately
+separate and remains explicit.
 
 ---
 

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -91,12 +91,20 @@ status` to report ChatGPT authentication. A 473-credit safety reserve leaves
 then measure a quick task before choosing a workload bound:
 
 ```bash
+BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"
+export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"
+umask 077
+mkdir -p "$BUILD_WEEK_RUN_ROOT" "$BUILD_WEEK_RESULTS_DIR"
+chmod 700 "$BUILD_WEEK_RUN_ROOT" "$BUILD_WEEK_RESULTS_DIR"
+
 export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473
 export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473
-export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$PWD/.bench-private/codex-credit-ledger.json"
+export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"
 
 remnic bench run --quick longmemeval \
   --runtime-profile real \
+  --results-dir "$BUILD_WEEK_RESULTS_DIR" \
+  --request-timeout 180000 --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -106,6 +114,8 @@ remnic bench run --quick longmemeval \
 
 remnic bench run longmemeval \
   --runtime-profile real --limit <LEDGER_DERIVED_LIMIT> \
+  --results-dir "$BUILD_WEEK_RESULTS_DIR" \
+  --request-timeout 180000 --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -123,6 +133,14 @@ manual account reconciliation.
 Rates per one million tokens are Luna: 25 input, 2.5 cached input, 150 output;
 Terra: 62.5 input, 6.25 cached input, 375 output. A bounded result is a trial,
 not a full leaderboard artifact.
+
+The ledger and results stay outside the repository because stored runs may
+contain questions, answers, and recalled context. The `umask` plus explicit
+directory modes make newly created state private. After the first ledger write,
+run `chmod 600 "$REMNIC_BENCH_CODEX_CREDIT_LEDGER"`. Preserve the exact run ID
+printed by the CLI, or recover it only from this run store with
+`remnic bench runs list --results-dir "$BUILD_WEEK_RESULTS_DIR"`; use that ID
+for export and artifact promotion rather than an ambiguous “latest” run.
 
 Codex built and adversarially reviewed the Build Week adapter, Responses
 provider, and report card. The underlying Remnic engine and original benchmark

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -104,7 +104,7 @@ export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledge
 remnic bench run --quick longmemeval \
   --runtime-profile real \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
-  --request-timeout 180000 --drain-timeout 600000 \
+  --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -115,7 +115,7 @@ remnic bench run --quick longmemeval \
 remnic bench run longmemeval \
   --runtime-profile real --limit <LEDGER_DERIVED_LIMIT> \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
-  --request-timeout 180000 --drain-timeout 600000 \
+  --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
   --system-codex-reasoning-effort medium \
   --internal-provider codex-cli --internal-model gpt-5.6-luna \
@@ -133,6 +133,12 @@ manual account reconciliation.
 Rates per one million tokens are Luna: 25 input, 2.5 cached input, 150 output;
 Terra: 62.5 input, 6.25 cached input, 375 output. A bounded result is a trial,
 not a full leaderboard artifact.
+
+Codex CLI receives a benchmark-owned 180-second transport timeout when no
+request timeout is supplied. Keep `--request-timeout` out of these commands:
+an explicit value also becomes a whole-phase guard, while the transport-only
+default lets long store/recall/reset phases complete. The 600-second drain cap
+remains explicit for queued internal work.
 
 The ledger and results stay outside the repository because stored runs may
 contain questions, answers, and recalled context. The `umask` plus explicit

--- a/packages/bench/src/adapters/timeout-guard.test.ts
+++ b/packages/bench/src/adapters/timeout-guard.test.ts
@@ -518,6 +518,24 @@ test("resolveBenchmarkPhaseTimeoutMs falls back to provider timeout", () => {
   );
 });
 
+test("resolveBenchmarkPhaseTimeoutMs ignores transport-only provider timeouts", () => {
+  assert.equal(
+    resolveBenchmarkPhaseTimeoutMs({
+      systemProvider: {
+        provider: "codex-cli",
+        model: "gpt-5.6-luna",
+        providerRequestTimeoutMs: 180_000,
+      },
+      judgeProvider: {
+        provider: "codex-cli",
+        model: "gpt-5.6-terra",
+        providerRequestTimeoutMs: 180_000,
+      },
+    }),
+    undefined,
+  );
+});
+
 test("resolveBenchmarkProgressLogging coerces boolean-like string config", () => {
   assert.equal(resolveBenchmarkProgressLogging({ benchmarkHarnessProgress: "true" }), true);
   assert.equal(resolveBenchmarkProgressLogging({ benchmarkHarnessProgress: "0" }), false);

--- a/packages/bench/src/judges/calibration-slice.ts
+++ b/packages/bench/src/judges/calibration-slice.ts
@@ -129,7 +129,7 @@ export interface RunJudgeCalibrationOptions {
    * binning function so they are compared on the same scale.
    */
   binScore?: (score: number) => JudgeCategory;
-  /** Override the slice size (default 50; mainly for tests). */
+  /** Override the slice size (default 200; mainly for tests). */
   sliceSize?: number;
   /** Override the warning threshold (default 0.7). */
   threshold?: number;

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -5,7 +5,9 @@ import path from "node:path";
 import test from "node:test";
 
 import { buildBenchBaselineRemnicConfig } from "./adapters/remnic-adapter.ts";
+import { resolveBenchmarkPhaseTimeoutMs } from "./adapters/timeout-guard.ts";
 import {
+  __runtimeProfilesTestHooks,
   createAssistantAgentFromResponder,
   deriveOpenclawRuntimeContext,
   resolveBenchRuntimeProfile,
@@ -421,15 +423,28 @@ test("provider-backed runtime resolution configures codex-cli with xhigh reasoni
   assert.deepEqual(resolved.systemProvider, {
     provider: "codex-cli",
     model: "gpt-5.5",
-    retryOptions: { timeoutMs: 180_000 },
+    providerRequestTimeoutMs: 180_000,
     reasoningEffort: "xhigh",
   });
   assert.deepEqual(resolved.judgeProvider, {
     provider: "codex-cli",
     model: "gpt-5.5",
-    retryOptions: { timeoutMs: 180_000 },
+    providerRequestTimeoutMs: 180_000,
     reasoningEffort: "xhigh",
   });
+  assert.equal(resolved.systemProvider?.retryOptions?.timeoutMs, undefined);
+  assert.equal(resolved.judgeProvider?.retryOptions?.timeoutMs, undefined);
+  assert.equal(
+    resolveBenchmarkPhaseTimeoutMs({
+      systemProvider: resolved.systemProvider,
+      judgeProvider: resolved.judgeProvider,
+    }),
+    undefined,
+  );
+  assert.equal(
+    __runtimeProfilesTestHooks.asProviderFactoryConfig(resolved.systemProvider!).retryOptions?.timeoutMs,
+    180_000,
+  );
   assert.equal(typeof resolved.adapterOptions.responder?.respond, "function");
   assert.equal(typeof resolved.adapterOptions.judge?.score, "function");
   assert.equal(resolved.adapterOptions.drainTimeoutMs, 600_000);
@@ -527,7 +542,7 @@ test("runtime profile gives Codex CLI internal fast and main tiers a safe defaul
     provider: "codex-cli",
     model: "gpt-5.6-luna",
     baseUrl: "codex-cli://local",
-    retryOptions: { timeoutMs: 180_000 },
+    providerRequestTimeoutMs: 180_000,
     reasoningEffort: "xhigh",
   });
   assert.equal(resolved.remnicConfig.localLlmTimeoutMs, 180_000);
@@ -582,8 +597,27 @@ test("runtime profile preserves an explicit drain timeout with the implicit Code
     drainTimeout: 900_000,
   });
 
-  assert.equal(resolved.internalProvider?.retryOptions?.timeoutMs, 180_000);
+  assert.equal(resolved.internalProvider?.providerRequestTimeoutMs, 180_000);
+  assert.equal(resolved.internalProvider?.retryOptions?.timeoutMs, undefined);
   assert.equal(resolved.adapterOptions.drainTimeoutMs, 900_000);
+});
+
+test("runtime profile merges implicit Codex transport timeout with max-429 retry options", async () => {
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "baseline",
+    systemProvider: "codex-cli",
+    systemModel: "gpt-5.6-luna",
+    max429WaitMs: 12_345,
+  });
+
+  assert.deepEqual(resolved.systemProvider?.retryOptions, {
+    max429WaitMs: 12_345,
+  });
+  assert.equal(resolved.systemProvider?.providerRequestTimeoutMs, 180_000);
+  assert.deepEqual(
+    __runtimeProfilesTestHooks.asProviderFactoryConfig(resolved.systemProvider!).retryOptions,
+    { max429WaitMs: 12_345, timeoutMs: 180_000 },
+  );
 });
 
 test("runtime profile can route Remnic internal LLM calls through Ollama native chat", async () => {

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -24,6 +24,7 @@ test("baseline runtime profile keeps the stripped retrieval-only config", async 
   assert.equal(resolved.remnicConfig.rerankEnabled, false);
   assert.equal(resolved.remnicConfig.verifiedRecallEnabled, false);
   assert.equal(resolved.remnicConfig.knowledgeIndexEnabled, false);
+  assert.equal(resolved.adapterOptions.drainTimeoutMs, undefined);
 });
 
 test("runtime profile forwards LCM observe concurrency override", async () => {
@@ -431,6 +432,7 @@ test("provider-backed runtime resolution configures codex-cli with xhigh reasoni
   });
   assert.equal(typeof resolved.adapterOptions.responder?.respond, "function");
   assert.equal(typeof resolved.adapterOptions.judge?.score, "function");
+  assert.equal(resolved.adapterOptions.drainTimeoutMs, 600_000);
 });
 
 test("provider-backed runtime resolution can override codex-cli reasoning effort", async () => {
@@ -532,7 +534,7 @@ test("runtime profile gives Codex CLI internal fast and main tiers a safe defaul
   assert.equal(resolved.remnicConfig.localLlmFastTimeoutMs, 180_000);
   assert.equal(resolved.effectiveRemnicConfig.localLlmTimeoutMs, 180_000);
   assert.equal(resolved.effectiveRemnicConfig.localLlmFastTimeoutMs, 180_000);
-  assert.equal(resolved.adapterOptions.drainTimeoutMs, undefined);
+  assert.equal(resolved.adapterOptions.drainTimeoutMs, 600_000);
 
   const gatewayConfig = resolved.effectiveRemnicConfig.gatewayConfig as {
     models?: { providers?: Record<string, { retryOptions?: { timeoutMs?: number } }> };
@@ -570,6 +572,18 @@ test("runtime profile can decouple provider request timeout from drain timeout",
   });
   assert.equal(resolved.remnicConfig.localLlmTimeoutMs, 120_000);
   assert.equal(resolved.effectiveRemnicConfig.localLlmTimeoutMs, 120_000);
+});
+
+test("runtime profile preserves an explicit drain timeout with the implicit Codex request timeout", async () => {
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "baseline",
+    internalProvider: "codex-cli",
+    internalModel: "gpt-5.6-luna",
+    drainTimeout: 900_000,
+  });
+
+  assert.equal(resolved.internalProvider?.retryOptions?.timeoutMs, 180_000);
+  assert.equal(resolved.adapterOptions.drainTimeoutMs, 900_000);
 });
 
 test("runtime profile can route Remnic internal LLM calls through Ollama native chat", async () => {

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -420,11 +420,13 @@ test("provider-backed runtime resolution configures codex-cli with xhigh reasoni
   assert.deepEqual(resolved.systemProvider, {
     provider: "codex-cli",
     model: "gpt-5.5",
+    retryOptions: { timeoutMs: 180_000 },
     reasoningEffort: "xhigh",
   });
   assert.deepEqual(resolved.judgeProvider, {
     provider: "codex-cli",
     model: "gpt-5.5",
+    retryOptions: { timeoutMs: 180_000 },
     reasoningEffort: "xhigh",
   });
   assert.equal(typeof resolved.adapterOptions.responder?.respond, "function");
@@ -509,6 +511,35 @@ test("runtime profile can route Remnic internal LLM calls through codex-cli", as
   assert.equal(
     gatewayConfig.models?.providers?.["remnic-bench-internal"]?.codexCliReasoningEffort,
     "xhigh",
+  );
+});
+
+test("runtime profile gives Codex CLI internal fast and main tiers a safe default timeout", async () => {
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "baseline",
+    internalProvider: "codex-cli",
+    internalModel: "gpt-5.6-luna",
+  });
+
+  assert.deepEqual(resolved.internalProvider, {
+    provider: "codex-cli",
+    model: "gpt-5.6-luna",
+    baseUrl: "codex-cli://local",
+    retryOptions: { timeoutMs: 180_000 },
+    reasoningEffort: "xhigh",
+  });
+  assert.equal(resolved.remnicConfig.localLlmTimeoutMs, 180_000);
+  assert.equal(resolved.remnicConfig.localLlmFastTimeoutMs, 180_000);
+  assert.equal(resolved.effectiveRemnicConfig.localLlmTimeoutMs, 180_000);
+  assert.equal(resolved.effectiveRemnicConfig.localLlmFastTimeoutMs, 180_000);
+  assert.equal(resolved.adapterOptions.drainTimeoutMs, undefined);
+
+  const gatewayConfig = resolved.effectiveRemnicConfig.gatewayConfig as {
+    models?: { providers?: Record<string, { retryOptions?: { timeoutMs?: number } }> };
+  };
+  assert.equal(
+    gatewayConfig.models?.providers?.["remnic-bench-internal"]?.retryOptions?.timeoutMs,
+    180_000,
   );
 });
 

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -523,10 +523,12 @@ function resolveProviderConfig(
   // Remnic's fast gateway tier. Without a provider timeout, that tier inherits
   // core's intentional 15-second local-fast default, which is too short for a
   // normal Codex turn and can terminate it after dispatch. Keep this default
-  // benchmark-specific so core's host-agnostic fast-tier contract is unchanged.
-  const effectiveRequestTimeout =
-    requestTimeout ??
-    (provider === "codex-cli" ? DEFAULT_CODEX_CLI_REQUEST_TIMEOUT_MS : undefined);
+  // benchmark-specific and transport-only so core's host-agnostic fast-tier
+  // contract and the harness's store/recall/reset phase guards are unchanged.
+  const providerRequestTimeoutMs =
+    requestTimeout === undefined && provider === "codex-cli"
+      ? DEFAULT_CODEX_CLI_REQUEST_TIMEOUT_MS
+      : undefined;
 
   return {
     provider,
@@ -536,12 +538,13 @@ function resolveProviderConfig(
       : {}),
     ...(hasBaseUrl ? { baseUrl: baseUrl!.trim() } : {}),
     ...(hasApiKey ? { apiKey: apiKey!.trim() } : {}),
-    ...(effectiveRequestTimeout != null || max429WaitMs != null
+    ...(requestTimeout != null || max429WaitMs != null
       ? { retryOptions: {
-          ...(effectiveRequestTimeout != null ? { timeoutMs: effectiveRequestTimeout } : {}),
+          ...(requestTimeout != null ? { timeoutMs: requestTimeout } : {}),
           ...(max429WaitMs != null ? { max429WaitMs } : {}),
         } }
       : {}),
+    ...(providerRequestTimeoutMs !== undefined ? { providerRequestTimeoutMs } : {}),
     ...(disableThinking ? { disableThinking: true } : {}),
     ...(provider === "codex-cli" ? { reasoningEffort: reasoningEffort ?? "xhigh" } : {}),
     ...(responderContextBudgetChars !== undefined
@@ -620,14 +623,17 @@ function buildInternalRemnicConfigOverrides(
     };
   }
 
+  const providerTimeoutMs =
+    config.retryOptions?.timeoutMs ?? config.providerRequestTimeoutMs;
+
   return {
     ...thinkingOverrides,
     modelSource: "gateway",
     localLlmEnabled: false,
-    ...(config.retryOptions?.timeoutMs
+    ...(providerTimeoutMs
       ? {
-          localLlmTimeoutMs: config.retryOptions.timeoutMs,
-          localLlmFastTimeoutMs: config.retryOptions.timeoutMs,
+          localLlmTimeoutMs: providerTimeoutMs,
+          localLlmFastTimeoutMs: providerTimeoutMs,
         }
       : {}),
     gatewayConfig: buildInternalGatewayConfig(config, options),
@@ -642,7 +648,8 @@ function buildInternalGatewayConfig(
 ): GatewayConfig {
   const providerId = INTERNAL_GATEWAY_AGENT_ID;
   const modelRef = `${providerId}/${config.model}`;
-  const timeoutMs = config.retryOptions?.timeoutMs;
+  const timeoutMs =
+    config.retryOptions?.timeoutMs ?? config.providerRequestTimeoutMs;
 
   return {
     agents: {
@@ -908,12 +915,22 @@ export function createAssistantAgentFromResponder(
 }
 
 function asProviderFactoryConfig(config: ProviderConfig): ProviderFactoryConfig {
+  const retryOptions =
+    config.retryOptions || config.providerRequestTimeoutMs !== undefined
+      ? {
+          ...config.retryOptions,
+          ...(config.retryOptions?.timeoutMs === undefined &&
+          config.providerRequestTimeoutMs !== undefined
+            ? { timeoutMs: config.providerRequestTimeoutMs }
+            : {}),
+        }
+      : undefined;
   return {
     provider: config.provider,
     model: config.model,
     ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
     ...(config.apiKey ? { apiKey: config.apiKey } : {}),
-    ...(config.retryOptions ? { retryOptions: config.retryOptions } : {}),
+    ...(retryOptions ? { retryOptions } : {}),
     ...(config.disableThinking ? { disableThinking: config.disableThinking } : {}),
     ...(config.reasoningEffort ? { reasoningEffort: config.reasoningEffort } : {}),
     ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
@@ -929,6 +946,10 @@ function asProviderFactoryConfig(config: ProviderConfig): ProviderFactoryConfig 
       : {}),
   } as ProviderFactoryConfig;
 }
+
+export const __runtimeProfilesTestHooks = {
+  asProviderFactoryConfig,
+};
 
 function asNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -139,6 +139,7 @@ export interface ResolvedBenchRuntimeProfile {
 const REDACTED_CONFIG_VALUE = "[redacted]";
 const INTERNAL_GATEWAY_AGENT_ID = "remnic-bench-internal";
 const DEFAULT_CODEX_CLI_REQUEST_TIMEOUT_MS = 180_000;
+const DEFAULT_CODEX_CLI_DRAIN_TIMEOUT_MS = 600_000;
 let codexCliFallbackRegistered = false;
 let codexCliFallbackChain: Promise<void> = Promise.resolve();
 
@@ -200,8 +201,17 @@ export async function resolveBenchRuntimeProfile(
   );
   const lcmObserveConcurrencyOverrides =
     buildLcmObserveConcurrencyOverrides(options.lcmObserveConcurrency);
+  const usesImplicitCodexRequestTimeout =
+    options.requestTimeout === undefined &&
+    [systemProvider, judgeProvider, internalProvider].some(
+      (config) => config?.provider === "codex-cli",
+    );
   const drainTimeoutMs = normalizeDrainTimeoutMs(
-    options.drainTimeout ?? options.requestTimeout,
+    options.drainTimeout ??
+      options.requestTimeout ??
+      (usesImplicitCodexRequestTimeout
+        ? DEFAULT_CODEX_CLI_DRAIN_TIMEOUT_MS
+        : undefined),
   );
   registerCodexCliFallbackRunnerIfNeeded(internalProvider);
   const responderFactoryConfig = systemProvider

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -138,6 +138,7 @@ export interface ResolvedBenchRuntimeProfile {
 
 const REDACTED_CONFIG_VALUE = "[redacted]";
 const INTERNAL_GATEWAY_AGENT_ID = "remnic-bench-internal";
+const DEFAULT_CODEX_CLI_REQUEST_TIMEOUT_MS = 180_000;
 let codexCliFallbackRegistered = false;
 let codexCliFallbackChain: Promise<void> = Promise.resolve();
 
@@ -508,6 +509,15 @@ function resolveProviderConfig(
     );
   }
 
+  // A Codex CLI completion is a subprocess-backed model turn, including for
+  // Remnic's fast gateway tier. Without a provider timeout, that tier inherits
+  // core's intentional 15-second local-fast default, which is too short for a
+  // normal Codex turn and can terminate it after dispatch. Keep this default
+  // benchmark-specific so core's host-agnostic fast-tier contract is unchanged.
+  const effectiveRequestTimeout =
+    requestTimeout ??
+    (provider === "codex-cli" ? DEFAULT_CODEX_CLI_REQUEST_TIMEOUT_MS : undefined);
+
   return {
     provider,
     model: resolvedModel!.trim(),
@@ -516,9 +526,9 @@ function resolveProviderConfig(
       : {}),
     ...(hasBaseUrl ? { baseUrl: baseUrl!.trim() } : {}),
     ...(hasApiKey ? { apiKey: apiKey!.trim() } : {}),
-    ...(requestTimeout != null || max429WaitMs != null
+    ...(effectiveRequestTimeout != null || max429WaitMs != null
       ? { retryOptions: {
-          ...(requestTimeout != null ? { timeoutMs: requestTimeout } : {}),
+          ...(effectiveRequestTimeout != null ? { timeoutMs: effectiveRequestTimeout } : {}),
           ...(max429WaitMs != null ? { max429WaitMs } : {}),
         } }
       : {}),

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -54,6 +54,12 @@ export interface ProviderConfig {
     retryOnTimeout?: boolean;
     max429WaitMs?: number;
   };
+  /**
+   * Provider transport timeout that must not be interpreted as a benchmark
+   * phase timeout. Runtime profiles use this for safe provider defaults while
+   * reserving retryOptions.timeoutMs for an explicit --request-timeout.
+   */
+  providerRequestTimeoutMs?: number;
   disableThinking?: boolean;
   reasoningEffort?: BenchReasoningEffort;
   responderContextBudgetChars?: number;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1030,7 +1030,8 @@ Options:
   --results-dir <path>     Override the stored benchmark results directory
   --baselines-dir <path>   Override the named baseline directory
   --request-timeout <ms>   Provider request timeout in milliseconds (codex-cli default: 180000)
-  --drain-timeout <ms>     Memory drain timeout in milliseconds (defaults to --request-timeout when unset)
+  --drain-timeout <ms>     Memory drain timeout in milliseconds
+                           (defaults to --request-timeout; implicit codex-cli default: 600000)
   --local-lab-manifest <path>
                            Path to a local-lab manifest JSON file (required for --runtime-profile local-lab)
   --threshold <value>      Regression threshold for compare (default: 0.05)

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1029,7 +1029,7 @@ Options:
   --custom <path>          Run a YAML-defined custom benchmark file
   --results-dir <path>     Override the stored benchmark results directory
   --baselines-dir <path>   Override the named baseline directory
-  --request-timeout <ms>   Provider request timeout in milliseconds
+  --request-timeout <ms>   Provider request timeout in milliseconds (codex-cli default: 180000)
   --drain-timeout <ms>     Memory drain timeout in milliseconds (defaults to --request-timeout when unset)
   --local-lab-manifest <path>
                            Path to a local-lab manifest JSON file (required for --runtime-profile local-lab)

--- a/scripts/bench/run-tierf-opus-real.sh
+++ b/scripts/bench/run-tierf-opus-real.sh
@@ -29,6 +29,7 @@ REMNIC_CONFIG="docs/benchmarks/configs/tierf-real-remnic-config.json"
 # CLI flag does not).
 JUDGE_ARGS=(--judge-provider ollama --judge-model "qwen2.5-7b-32k:latest" --judge-base-url "http://127.0.0.1:11434/api")
 SEED=1
+CALIBRATION_SAMPLE_SIZE=200
 
 step() { printf '\n=== %s — %s ===\n' "$(date -u +%FT%TZ)" "$1"; }
 
@@ -54,11 +55,22 @@ assert d.get('localJudgeModel') == 'qwen2.5-7b-32k:latest', f\"localJudgeModel: 
 assert d.get('frontierJudgeProvider') == 'claude-cli', f\"frontierJudgeProvider: {d.get('frontierJudgeProvider')}\"
 assert d.get('frontierJudgeModel') == 'opus', f\"frontierJudgeModel: {d.get('frontierJudgeModel')}\"
 assert isinstance(d.get('kappa'), (int, float)), f\"kappa: {d.get('kappa')}\"
-assert isinstance(d.get('sampleSize'), int), f\"sampleSize: {d.get('sampleSize')}\"
+expected_sample_size = int(sys.argv[2])
+assert d.get('sampleSize') == expected_sample_size, f\"sampleSize: {d.get('sampleSize')} (expected {expected_sample_size})\"
 assert isinstance(d.get('threshold'), (int, float)), f\"threshold: {d.get('threshold')}\"
 assert isinstance(d.get('warning'), bool), f\"warning: {d.get('warning')}\"
-" "$file" 2>/dev/null; then
-    echo "BLOCKED: calibration state for ${benchmark} is missing, corrupt, or scoped to a different judge pair - run the baseline pass first." >&2
+assert isinstance(d.get('sourceResultId'), str) and d['sourceResultId'], 'missing sourceResultId'
+answer_hash = d.get('answerSetHash')
+assert isinstance(answer_hash, str) and len(answer_hash) == 64 and all(c in '0123456789abcdef' for c in answer_hash), 'missing or invalid answerSetHash'
+assert isinstance(d.get('sliceQuestionIds'), list), 'missing sliceQuestionIds'
+assert len(d['sliceQuestionIds']) == expected_sample_size, f\"sliceQuestionIds: {len(d['sliceQuestionIds'])}\"
+assert len(set(d['sliceQuestionIds'])) == expected_sample_size, 'sliceQuestionIds contains duplicates'
+ci = d.get('confidenceInterval')
+assert isinstance(ci, dict), 'missing confidenceInterval'
+assert all(isinstance(ci.get(k), (int, float)) for k in ('lower', 'upper', 'level')), f\"confidenceInterval: {ci}\"
+assert isinstance(d.get('bootstrapSamples'), int) and d['bootstrapSamples'] > 0, f\"bootstrapSamples: {d.get('bootstrapSamples')}\"
+" "$file" "$CALIBRATION_SAMPLE_SIZE" 2>/dev/null; then
+    echo "BLOCKED: calibration state for ${benchmark} is missing, corrupt, unpinned, below the ${CALIBRATION_SAMPLE_SIZE}-question contract, or scoped to a different judge pair - rerun judge-calibrate against the pinned answer source." >&2
     exit 3
   fi
 }

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -78,7 +78,7 @@ packages/bench/src/responders.test.ts(444,21): TS18048
 packages/bench/src/responders.test.ts(446,13): TS18048
 packages/bench/src/responders.test.ts(450,24): TS18048
 packages/bench/src/results-store.test.ts(31,18): TS2352
-packages/bench/src/runtime-profiles.test.ts(54,38): TS2345
+packages/bench/src/runtime-profiles.test.ts(57,38): TS2345
 packages/bench/src/security/extraction-attack/mitigated-target.test.ts(23,5): TS2322
 packages/hermes-provider/src/index.test.ts(219,38): TS2304
 packages/import-mem0/src/adapter.test.ts(79,40): TS2304


### PR DESCRIPTION
## Summary

- default Codex CLI benchmark requests to 180 seconds so Remnic's internal fast tier cannot kill normal one-shot turns at 15 seconds
- keep drain timeout independent while documenting explicit 180-second request / 600-second drain windows for Build Week runs
- require pinned 200-question calibration provenance, answer hashes, slice IDs, and bootstrap intervals before the Tier-F run script accepts persisted state
- keep private credit ledgers and stored benchmark results outside the checkout

## Why

The first bounded GPT-5.6 Luna smoke produced four exact usage receipts, then an internal fast-tier call exceeded the generic 15-second default and exited without a terminal usage event. The credit guard correctly blocked further dispatch. This PR prevents that timeout class without weakening the ledger or changing host-agnostic core defaults.

## Verification

- `pnpm exec tsx --test packages/bench/src/runtime-profiles.test.ts packages/bench/src/judges/calibration-slice.test.ts packages/bench/src/judges/cohen-kappa.test.ts packages/remnic-cli/src/bench-args.test.ts` (133 passed)
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/cli check-types`
- `bash -n scripts/bench/run-tierf-opus-real.sh`
- `npm run preflight:quick`
- `git diff --check`

No paid calls were made while implementing or verifying this PR. The blocked private ledger was not edited or reset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes long-running benchmark timeout and drain behavior for Codex-backed runs; scope is harness/docs only, not production memory or auth paths.
> 
> **Overview**
> Hardens **Codex CLI** benchmark runs so internal fast-tier calls are not cut off at core’s 15s default, while long store/recall/reset phases are not capped by the same clock as a single model turn.
> 
> **Runtime behavior:** When `codex-cli` is used and `--request-timeout` is omitted, profiles now apply a **180s transport-only** timeout via new `providerRequestTimeoutMs` (wired into gateway/local LLM timeouts and provider factories) and a separate **600s default drain** for queued internal work. Explicit `--request-timeout` still sets `retryOptions.timeoutMs` and remains a whole-phase guard; phase resolution **ignores** transport-only timeouts so Codex defaults do not become benchmark phase caps.
> 
> **Operator docs & CLI:** Build Week / Tier-F repro docs and `packages/bench/README.md` move credit ledgers and results under `~/.remnic/bench/…`, document `umask`/`chmod`, isolated `--results-dir`, explicit `--drain-timeout 600000`, run ID recovery, and warn against adding `--request-timeout` on the Codex protocol. Judge-calibrate docs describe a **pinned 200-question** slice (up from 50), bootstrap CI, and provenance fields. `run-tierf-opus-real.sh` preflight enforces that calibration contract. CLI help clarifies implicit Codex request/drain defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2bef5789ed91dece538fad0e3c0d0d5180a9ecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->