### PR TITLE
feat(bench): add deterministic LoCoMo recall diagnosis

### DIFF
--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -390,6 +390,27 @@ export type {
   LoComoTaskRegression,
 } from "./stats/locomo-profile-delta.js";
 export {
+  LOCOMO_FULL_TASK_COUNT,
+  LOCOMO_RECALL_DIFF_LINE_LIMIT,
+  LOCOMO_RECALL_EXCERPT_CHARS,
+  diagnoseLoComoRecallDelta,
+  renderLoComoRecallDeltaMarkdown,
+  sanitizeLoComoResultReference,
+} from "./stats/locomo-recall-delta.js";
+export type {
+  DiagnoseLoComoRecallDeltaOptions,
+  LoComoFinalContextRegression,
+  LoComoRawResultEvidence,
+  LoComoRecallCategoryDelta,
+  LoComoRecallContextSummary,
+  LoComoRecallDeltaReport,
+  LoComoRecallLineDelta,
+  LoComoRecallLineEvidence,
+  LoComoRecallMetricDelta,
+  LoComoRecallResultProvenance,
+  LoComoRecallTextDigest,
+} from "./stats/locomo-recall-delta.js";
+export {
   assertPublishableIntegrity,
   buildBenchmarkPublishFeed,
   deleteBenchmarkResults,

--- a/packages/bench/src/stats/locomo-recall-delta.test.ts
+++ b/packages/bench/src/stats/locomo-recall-delta.test.ts
@@ -1,0 +1,378 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+
+import type { BenchmarkResult, TaskResult } from "../types.js";
+import {
+  LOCOMO_FULL_TASK_COUNT,
+  diagnoseLoComoRecallDelta,
+  renderLoComoRecallDeltaMarkdown,
+  sanitizeLoComoResultReference,
+} from "./locomo-recall-delta.js";
+
+function task(args: {
+  id: string;
+  score: number;
+  recall: string;
+  answer?: string;
+  question?: string;
+  expected?: string;
+  evidence?: unknown;
+}): TaskResult {
+  return {
+    taskId: args.id,
+    question: args.question ?? "What is the answer?",
+    expected: args.expected ?? "needle answer",
+    actual: args.answer ?? "answer",
+    scores: { f1: args.score, llm_judge: args.score },
+    latencyMs: 1,
+    tokens: { input: 0, output: 0 },
+    details: {
+      categoryName: args.id.split("-").at(-1),
+      recalledText: args.recall,
+      answeredText: args.answer ?? "answer",
+      evidence: args.evidence,
+    },
+  };
+}
+
+function result(
+  profile: "baseline" | "real",
+  tasks: TaskResult[],
+  overrides: Partial<BenchmarkResult> = {}
+): BenchmarkResult {
+  const complete = completeTasks(tasks);
+  const aggregates = Object.fromEntries(
+    Object.keys(complete[0]?.scores ?? {}).map((metric) => {
+      const values = complete
+        .map((entry) => entry.scores[metric])
+        .filter((value): value is number => Number.isFinite(value));
+      const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+      return [metric, { mean, median: mean, stdDev: 0, min: Math.min(...values), max: Math.max(...values) }];
+    })
+  );
+  const value: BenchmarkResult = {
+    meta: {
+      id: `${profile}-id`,
+      benchmark: "locomo",
+      benchmarkTier: "published",
+      version: "2.0.0",
+      remnicVersion: "9.6.10",
+      gitSha: "abc123",
+      timestamp: "2026-07-14T00:00:00.000Z",
+      mode: "full",
+      runCount: 1,
+      seeds: [1],
+    },
+    config: {
+      runtimeProfile: profile,
+      systemProvider: { provider: "claude-cli", model: "opus" },
+      judgeProvider: { provider: "ollama", model: "qwen" },
+      adapterMode: "direct",
+      remnicConfig: {},
+      benchmarkOptions: {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs: 0,
+      meanQueryLatencyMs: 0,
+    },
+    results: { tasks: complete, aggregates },
+    environment: { os: "linux", nodeVersion: "v22" },
+  };
+  return { ...value, ...overrides };
+}
+
+function completeTasks(tasks: TaskResult[]): TaskResult[] {
+  const complete = [...tasks];
+  for (let index = complete.length; index < LOCOMO_FULL_TASK_COUNT; index += 1) {
+    complete.push(
+      task({
+        id: `fixture-conv-q${index}-single_hop`,
+        score: 0.5,
+        recall: "shared filler evidence",
+        question: `Filler question ${index}?`,
+        expected: `filler-${index}`,
+        answer: `filler-${index}`,
+      })
+    );
+  }
+  return complete;
+}
+
+function evidence(value: BenchmarkResult, label: string) {
+  return {
+    result: value,
+    reference: `${label}.json`,
+    sha256: createHash("sha256").update(label).digest("hex"),
+  };
+}
+
+test("joins complete raw results and emits deterministic final-context displacement receipts", () => {
+  const baselineTasks = [
+    task({
+      id: "conv-1-q0-single_hop",
+      score: 1,
+      recall: "## LoCoMo Question-Focused Evidence\r\n[conv-1-session_1, turn 3, user, score 9.1]: needle answer",
+      answer: "needle answer",
+    }),
+    task({ id: "conv-1-q1-multi_hop", score: 0.5, recall: "## Evidence\nshared line" }),
+  ];
+  const realTasks = [
+    task({ id: "conv-1-q1-multi_hop", score: 0.5, recall: "## Evidence\nshared line" }),
+    task({
+      id: "conv-1-q0-single_hop",
+      score: 0,
+      recall: "## LoCoMo Question-Focused Evidence\nunrelated summary",
+      answer: "unknown",
+    }),
+  ];
+  const options = {
+    baseline: evidence(result("baseline", baselineTasks), "b"),
+    real: evidence(result("real", realTasks), "r"),
+  };
+  const first = diagnoseLoComoRecallDelta(options);
+  const second = diagnoseLoComoRecallDelta(options);
+
+  assert.deepEqual(first, second);
+  assert.equal(first.taskCount, LOCOMO_FULL_TASK_COUNT);
+  assert.deepEqual(
+    first.categories.map((entry) => entry.category),
+    ["single_hop", "multi_hop"]
+  );
+  assert.ok(Math.abs(first.overall.delta + 1 / LOCOMO_FULL_TASK_COUNT) < Number.EPSILON);
+  assert.equal(first.topRegressions[0]?.taskId, "conv-1-q0-single_hop");
+  assert.equal(first.topRegressions[0]?.baseline.recall.expectedTokenCoverage, 1);
+  assert.equal(first.topRegressions[0]?.real.recall.expectedTokenCoverage, 0);
+  assert.equal(first.topRegressions[0]?.displacedLines.lines[0]?.sourceRef, "conv-1-session_1:turn-3:user");
+  assert.equal(first.topRegressions[0]?.displacedLines.lines[0]?.ordinal, 1);
+  assert.equal(first.comparison.baseline.taskPayloadSha256, first.comparison.real.taskPayloadSha256);
+  assert.equal(first.evidenceBoundary.retrievalTierAttribution, "unavailable-in-cached-results");
+});
+
+test("sorts tied regressions by task id and bounds excerpts and line counts", () => {
+  const longLine = `baseline-only ${"x".repeat(400)}`;
+  const displaced = Array.from({ length: 21 }, (_, index) => `${longLine}-${index}`).join("\n");
+  const baselineTasks = [
+    task({ id: "conv-1-q1-multi_hop", score: 1, recall: displaced }),
+    task({ id: "conv-1-q0-single_hop", score: 1, recall: longLine }),
+  ];
+  const realTasks = [
+    task({ id: "conv-1-q0-single_hop", score: 0, recall: "real-only" }),
+    task({ id: "conv-1-q1-multi_hop", score: 0, recall: "real-only\nsecond-real" }),
+  ];
+  const report = diagnoseLoComoRecallDelta({
+    baseline: evidence(result("baseline", baselineTasks), "b"),
+    real: evidence(result("real", realTasks), "r"),
+  });
+
+  assert.deepEqual(
+    report.topRegressions.map((entry) => entry.taskId),
+    ["conv-1-q0-single_hop", "conv-1-q1-multi_hop"]
+  );
+  assert.equal(report.topRegressions[1]?.displacedLines.totalCount, 21);
+  assert.equal(report.topRegressions[1]?.displacedLines.shownCount, 20);
+  assert.equal(report.topRegressions[1]?.displacedLines.lines[0]?.excerpt.length, 240);
+});
+
+test("never consumes or emits hidden details.evidence", () => {
+  const hidden = "DO-NOT-EMIT-HIDDEN-EVIDENCE-ID";
+  const baseline = result("baseline", [
+    task({ id: "conv-1-q0-single_hop", score: 1, recall: "needle answer", evidence: [hidden] }),
+  ]);
+  const real = result("real", [
+    task({ id: "conv-1-q0-single_hop", score: 0, recall: "unknown", evidence: { hidden } }),
+  ]);
+  const report = diagnoseLoComoRecallDelta({
+    baseline: evidence(baseline, "b"),
+    real: evidence(real, "r"),
+  });
+  assert.equal(JSON.stringify(report).includes(hidden), false);
+  assert.equal(renderLoComoRecallDeltaMarkdown(report).includes(hidden), false);
+  assert.equal(report.evidenceBoundary.hiddenEvidenceUsed, false);
+});
+
+test("rejects partial, limited, failed, wrong-profile, or wrong-sized results", () => {
+  const baseTask = task({ id: "conv-1-q0-single_hop", score: 1, recall: "needle answer" });
+  const baseline = result("baseline", [baseTask]);
+  const real = result("real", [baseTask]);
+  const diagnose = (left: BenchmarkResult, right: BenchmarkResult) =>
+    diagnoseLoComoRecallDelta({
+      baseline: evidence(left, "b"),
+      real: evidence(right, "r"),
+    });
+
+  assert.throws(
+    () => diagnose({ ...baseline, meta: { ...baseline.meta, status: "partial" } }, real),
+    /complete full-mode/
+  );
+  assert.throws(
+    () =>
+      diagnose(
+        {
+          ...baseline,
+          config: { ...baseline.config, benchmarkOptions: { limit: 1 } },
+        },
+        real
+      ),
+    /limited/
+  );
+  const failedTask = {
+    ...baseTask,
+    details: {
+      ...baseTask.details,
+      benchmarkFailure: { kind: "trial_execution_failure" },
+    },
+  };
+  assert.throws(() => diagnose(result("baseline", [failedTask]), real), /contains failed task/);
+  assert.throws(() => diagnose(result("real", [baseTask]), real), /baseline result runtimeProfile/);
+  assert.throws(
+    () =>
+      diagnose(
+        {
+          ...baseline,
+          config: { ...baseline.config, systemProvider: null },
+        },
+        real
+      ),
+    /identify both system and judge providers/
+  );
+  assert.throws(
+    () => diagnose({ ...baseline, results: { ...baseline.results, tasks: [] } }, real),
+    /exactly 1986 tasks/
+  );
+});
+
+test("rejects mismatched task payloads, metrics, providers, duplicate ids, and invalid hashes", () => {
+  const baseTask = task({ id: "conv-1-q0-single_hop", score: 1, recall: "needle answer" });
+  const baseline = result("baseline", [baseTask]);
+  const real = result("real", [baseTask]);
+  const diagnose = (left: BenchmarkResult, right: BenchmarkResult) =>
+    diagnoseLoComoRecallDelta({
+      baseline: evidence(left, "b"),
+      real: evidence(right, "r"),
+    });
+
+  assert.throws(
+    () => diagnose(baseline, result("real", [{ ...baseTask, question: "changed" }])),
+    /mismatched question/
+  );
+  assert.throws(
+    () => diagnose(baseline, result("real", [{ ...baseTask, scores: { f1: 1 } }])),
+    /mismatched metric sets/
+  );
+  assert.throws(
+    () =>
+      diagnose(
+        baseline,
+        result("real", [baseTask], {
+          config: { ...real.config, systemProvider: { provider: "claude-cli", model: "sonnet" } },
+        })
+      ),
+    /systemProvider differs/
+  );
+  assert.throws(
+    () =>
+      diagnose(
+        {
+          ...baseline,
+          config: {
+            ...baseline.config,
+            systemProvider: {
+              provider: "codex-cli",
+              model: "gpt-5.6-luna",
+              providerRequestTimeoutMs: 180_000,
+            },
+          },
+        },
+        result("real", [baseTask], {
+          config: {
+            ...real.config,
+            systemProvider: {
+              provider: "codex-cli",
+              model: "gpt-5.6-luna",
+              providerRequestTimeoutMs: 240_000,
+            },
+          },
+        })
+      ),
+    /systemProvider differs/
+  );
+  assert.throws(
+    () =>
+      diagnose(
+        baseline,
+        result("real", [baseTask], {
+          config: {
+            ...real.config,
+            internalProvider: { provider: "codex-cli", model: "gpt-5.6", temperature: 0 },
+          },
+        })
+      ),
+    /internalProvider differs/
+  );
+  const inconsistentMetricTask = { ...baseTask, taskId: "conv-1-q1-multi_hop", scores: { f1: 1 } };
+  assert.throws(
+    () =>
+      diagnose(
+        result("baseline", [baseTask, inconsistentMetricTask]),
+        result("real", [baseTask, inconsistentMetricTask])
+      ),
+    /inconsistent metric set/
+  );
+  const corruptedReal = result("real", [baseTask]);
+  assert.throws(
+    () =>
+      diagnose(baseline, {
+        ...corruptedReal,
+        results: {
+          ...corruptedReal.results,
+          aggregates: {
+            ...corruptedReal.results.aggregates,
+            f1: { mean: 0, median: 0, stdDev: 0, min: 0, max: 0 },
+          },
+        },
+      }),
+    /does not match task mean/
+  );
+  assert.throws(
+    () =>
+      diagnoseLoComoRecallDelta({
+        baseline: evidence(result("baseline", [baseTask, baseTask]), "b"),
+        real: evidence(result("real", [baseTask, baseTask]), "r"),
+      }),
+    /duplicate or empty task id/
+  );
+  assert.throws(
+    () =>
+      diagnoseLoComoRecallDelta({
+        baseline: { result: baseline, reference: "b", sha256: "BAD" },
+        real: evidence(real, "r"),
+      }),
+    /sha256/
+  );
+});
+
+test("sanitizes result provenance references without exposing caller directories", () => {
+  const reference = sanitizeLoComoResultReference("/home/private/benchmark-results/baseline`receipt.json");
+
+  assert.equal(reference, "baseline_receipt.json");
+  assert.equal(reference.includes("/home/private"), false);
+});
+
+test("markdown is deterministic and states the final-context evidence boundary", () => {
+  const baseline = result("baseline", [task({ id: "conv-1-q0-single_hop", score: 1, recall: "needle answer" })]);
+  const real = result("real", [task({ id: "conv-1-q0-single_hop", score: 0, recall: "unrelated | summary" })]);
+  const report = diagnoseLoComoRecallDelta({
+    baseline: evidence(baseline, "b"),
+    real: evidence(real, "r"),
+  });
+  const first = renderLoComoRecallDeltaMarkdown(report);
+  assert.equal(first, renderLoComoRecallDeltaMarkdown(report));
+  assert.match(first, /single_hop \| 1986 \| 0\.5003 \| 0\.4997 \| -0\.0005/);
+  assert.match(first, /Retrieval-tier attribution is unavailable/);
+  assert.match(first, /unrelated \\| summary/);
+});

--- a/packages/bench/src/stats/locomo-recall-delta.ts
+++ b/packages/bench/src/stats/locomo-recall-delta.ts
@@ -1,0 +1,729 @@
+import { createHash } from "node:crypto";
+import { basename } from "node:path";
+
+import type { BenchmarkResult, ProviderConfig, TaskResult } from "../types.js";
+
+export const LOCOMO_FULL_TASK_COUNT = 1_986;
+export const LOCOMO_RECALL_EXCERPT_CHARS = 240;
+export const LOCOMO_RECALL_DIFF_LINE_LIMIT = 20;
+
+const LOCOMO_CATEGORY_ORDER = ["single_hop", "multi_hop", "temporal", "open_domain", "adversarial"] as const;
+const LOCOMO_TASK_CATEGORY_PATTERN = /-(single_hop|multi_hop|temporal|open_domain|adversarial)$/;
+const SOURCE_TURN_PATTERN = /^\[([^,\]\s]+),\s*turn\s+(\d+),\s*([^,\]]+?)(?:,\s*score\s+[^\]]+)?\]/i;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+export interface LoComoRawResultEvidence {
+  result: BenchmarkResult;
+  reference: string;
+  /** SHA-256 of the exact result-file bytes, computed before JSON parsing. */
+  sha256: string;
+}
+
+export interface LoComoRecallTextDigest {
+  sha256: string;
+  charCount: number;
+  excerpt: string;
+}
+
+export interface LoComoRecallLineEvidence extends LoComoRecallTextDigest {
+  ordinal: number;
+  sourceRef?: string;
+}
+
+export interface LoComoRecallLineDelta {
+  totalCount: number;
+  shownCount: number;
+  lines: LoComoRecallLineEvidence[];
+}
+
+export interface LoComoRecallContextSummary {
+  sha256: string;
+  charCount: number;
+  lineCount: number;
+  headings: string[];
+  sourceRefs: string[];
+  expectedTokenCoverage: number;
+}
+
+export interface LoComoRecallMetricDelta {
+  baselineMean: number;
+  realMean: number;
+  delta: number;
+  wins: number;
+  losses: number;
+  ties: number;
+}
+
+export interface LoComoRecallCategoryDelta extends LoComoRecallMetricDelta {
+  category: string;
+  taskCount: number;
+}
+
+export interface LoComoFinalContextRegression {
+  taskId: string;
+  category: string;
+  baselineScore: number;
+  realScore: number;
+  delta: number;
+  questionSha256: string;
+  expectedAnswerSha256: string;
+  baseline: {
+    answer: LoComoRecallTextDigest;
+    recall: LoComoRecallContextSummary;
+  };
+  real: {
+    answer: LoComoRecallTextDigest;
+    recall: LoComoRecallContextSummary;
+  };
+  displacedLines: LoComoRecallLineDelta;
+  introducedLines: LoComoRecallLineDelta;
+}
+
+export interface LoComoRecallResultProvenance {
+  reference: string;
+  sha256: string;
+  resultId: string;
+  gitSha: string;
+  remnicVersion: string;
+  runtimeProfile: "baseline" | "real";
+  systemProvider: string;
+  systemModel: string;
+  judgeProvider: string;
+  judgeModel: string;
+  seeds: number[];
+  taskPayloadSha256: string;
+}
+
+export interface LoComoRecallDeltaReport {
+  schemaVersion: 1;
+  benchmarkId: "locomo";
+  comparison: {
+    baseline: LoComoRecallResultProvenance;
+    real: LoComoRecallResultProvenance;
+  };
+  taskCount: number;
+  primaryMetric: string;
+  overall: LoComoRecallMetricDelta;
+  categories: LoComoRecallCategoryDelta[];
+  topRegressions: LoComoFinalContextRegression[];
+  evidenceBoundary: {
+    finalContextComparison: "complete";
+    retrievalTierAttribution: "unavailable-in-cached-results";
+    hiddenEvidenceUsed: false;
+    explanation: string;
+  };
+}
+
+export interface DiagnoseLoComoRecallDeltaOptions {
+  baseline: LoComoRawResultEvidence;
+  real: LoComoRawResultEvidence;
+  primaryMetric?: string;
+  maxRegressions?: number;
+}
+
+/**
+ * Return a stable provenance label without exposing the caller's directory
+ * layout. CLI callers should use this instead of persisting an input path.
+ */
+export function sanitizeLoComoResultReference(path: string): string {
+  const reference = basename(path).replace(/[\u0000-\u001f\u007f`]/g, "_");
+  if (!reference) throw new Error("Result path must identify a file.");
+  return reference;
+}
+
+interface JoinedTask {
+  taskId: string;
+  category: string;
+  baseline: TaskResult;
+  real: TaskResult;
+}
+
+interface IndexedRecallLine {
+  text: string;
+  ordinal: number;
+}
+
+export function diagnoseLoComoRecallDelta(options: DiagnoseLoComoRecallDeltaOptions): LoComoRecallDeltaReport {
+  const primaryMetric = options.primaryMetric ?? "llm_judge";
+  const maxRegressions = parseNonNegativeInteger(options.maxRegressions ?? 20, "maxRegressions");
+
+  assertEvidenceEnvelope(options.baseline, "baseline");
+  assertEvidenceEnvelope(options.real, "real");
+  assertCompleteResult(options.baseline.result, "baseline");
+  assertCompleteResult(options.real.result, "real");
+  assertComparableResults(options.baseline.result, options.real.result);
+
+  const joined = joinTasks(options.baseline.result, options.real.result);
+  assertMetricSets(joined, primaryMetric);
+  verifyAggregateMeans(options.baseline.result, joined, "baseline");
+  verifyAggregateMeans(options.real.result, joined, "real");
+  const overall = summarizeMetric(joined, primaryMetric);
+  const categories = [...new Set(joined.map((task) => task.category))].sort(compareLoComoCategories).map((category) => {
+    const tasks = joined.filter((task) => task.category === category);
+    return {
+      category,
+      taskCount: tasks.length,
+      ...summarizeMetric(tasks, primaryMetric),
+    };
+  });
+
+  const topRegressions = joined
+    .map((task) => buildRegression(task, primaryMetric, LOCOMO_RECALL_EXCERPT_CHARS, LOCOMO_RECALL_DIFF_LINE_LIMIT))
+    .filter((task) => task.delta < 0)
+    .sort((left, right) => left.delta - right.delta || compareStrings(left.taskId, right.taskId))
+    .slice(0, maxRegressions);
+
+  return {
+    schemaVersion: 1,
+    benchmarkId: "locomo",
+    comparison: {
+      baseline: buildProvenance(options.baseline, "baseline", joined, "baseline"),
+      real: buildProvenance(options.real, "real", joined, "real"),
+    },
+    taskCount: joined.length,
+    primaryMetric,
+    overall,
+    categories,
+    topRegressions,
+    evidenceBoundary: {
+      finalContextComparison: "complete",
+      retrievalTierAttribution: "unavailable-in-cached-results",
+      hiddenEvidenceUsed: false,
+      explanation:
+        "Cached BenchmarkResult files preserve the final transformed recall context, " +
+        "but not pre-transform candidates, section provenance, filter traces, or served-by tiers.",
+    },
+  };
+}
+
+export function renderLoComoRecallDeltaMarkdown(report: LoComoRecallDeltaReport): string {
+  const lines = [
+    "# LoCoMo paired final-context diagnosis",
+    "",
+    `Joined ${report.taskCount} complete paired tasks. The primary metric is ` +
+      `\`${report.primaryMetric}\` (real minus baseline).`,
+    "",
+    "| Category | Tasks | Baseline | Real | Delta | Wins | Losses | Ties |",
+    "|---|---:|---:|---:|---:|---:|---:|---:|",
+  ];
+  for (const category of report.categories) {
+    lines.push(
+      `| ${escapeMarkdownCell(category.category)} | ${category.taskCount} | ` +
+        `${formatScore(category.baselineMean)} | ${formatScore(category.realMean)} | ` +
+        `${formatSignedScore(category.delta)} | ${category.wins} | ${category.losses} | ` +
+        `${category.ties} |`
+    );
+  }
+  lines.push(
+    `| **Overall** | **${report.taskCount}** | **${formatScore(report.overall.baselineMean)}** | ` +
+      `**${formatScore(report.overall.realMean)}** | **${formatSignedScore(report.overall.delta)}** | ` +
+      `**${report.overall.wins}** | **${report.overall.losses}** | **${report.overall.ties}** |`,
+    "",
+    "## Highest-priority final-context regressions",
+    ""
+  );
+
+  for (const task of report.topRegressions) {
+    lines.push(
+      `### ${escapeMarkdownCell(task.taskId)}`,
+      "",
+      `Category: \`${task.category}\`; baseline ${formatScore(task.baselineScore)}, ` +
+        `real ${formatScore(task.realScore)}, delta ${formatSignedScore(task.delta)}.`,
+      "",
+      `Recall: baseline ${task.baseline.recall.charCount} chars ` +
+        `(expected-token coverage ${formatScore(task.baseline.recall.expectedTokenCoverage)}), ` +
+        `real ${task.real.recall.charCount} chars ` +
+        `(coverage ${formatScore(task.real.recall.expectedTokenCoverage)}).`,
+      "",
+      `Displaced lines: ${task.displacedLines.totalCount}; introduced lines: ` + `${task.introducedLines.totalCount}.`,
+      ""
+    );
+    const displaced = task.displacedLines.lines[0];
+    if (displaced) {
+      lines.push(
+        `- Baseline-only evidence: ${escapeMarkdownCell(displaced.excerpt)} ` + `(sha256 \`${displaced.sha256}\`)`
+      );
+    }
+    const introduced = task.introducedLines.lines[0];
+    if (introduced) {
+      lines.push(
+        `- Real-only evidence: ${escapeMarkdownCell(introduced.excerpt)} ` + `(sha256 \`${introduced.sha256}\`)`
+      );
+    }
+    if (displaced || introduced) lines.push("");
+  }
+
+  lines.push(
+    "## Evidence boundary",
+    "",
+    "The final responder contexts are compared completely by hash, length, headings, source " +
+      "references, and bounded line-difference receipts. Retrieval-tier attribution is " +
+      "unavailable because the cached results do not preserve served-by or candidate traces. " +
+      "Hidden `details.evidence` metadata is not read or emitted.",
+    "",
+    `Baseline: \`${report.comparison.baseline.reference}\` ` + `(sha256 \`${report.comparison.baseline.sha256}\`)`,
+    "",
+    `Real: \`${report.comparison.real.reference}\` ` + `(sha256 \`${report.comparison.real.sha256}\`)`,
+    ""
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+function assertEvidenceEnvelope(evidence: LoComoRawResultEvidence, label: "baseline" | "real"): void {
+  if (!evidence.reference.trim()) {
+    throw new Error(`${label} result reference must not be empty.`);
+  }
+  if (!SHA256_PATTERN.test(evidence.sha256)) {
+    throw new Error(`${label} result sha256 must be 64 lowercase hexadecimal characters.`);
+  }
+}
+
+function assertCompleteResult(result: BenchmarkResult, label: "baseline" | "real"): void {
+  if (result.meta.benchmark !== "locomo") {
+    throw new Error(`${label} result must be a locomo benchmark result.`);
+  }
+  if (result.meta.mode !== "full" || result.meta.status === "partial") {
+    throw new Error(`${label} result must be a complete full-mode run.`);
+  }
+  if (!result.config.systemProvider || !result.config.judgeProvider) {
+    throw new Error(`${label} result must identify both system and judge providers.`);
+  }
+  const limit = result.config.benchmarkOptions?.limit;
+  const trialLimit = result.config.benchmarkOptions?.trialLimit;
+  if (limit !== undefined || trialLimit !== undefined) {
+    throw new Error(`${label} result is limited and cannot be used as complete evidence.`);
+  }
+  if (result.results.tasks.length !== LOCOMO_FULL_TASK_COUNT) {
+    throw new Error(
+      `${label} result must contain exactly ${LOCOMO_FULL_TASK_COUNT} tasks; got ${result.results.tasks.length}.`
+    );
+  }
+  for (const task of result.results.tasks) {
+    const details = asRecord(task.details);
+    const failure = details?.benchmarkFailure;
+    const legacyError = details?.error;
+    if ((failure !== undefined && failure !== null) || (typeof legacyError === "string" && legacyError.length > 0)) {
+      throw new Error(`${label} result contains failed task ${JSON.stringify(task.taskId)}.`);
+    }
+  }
+}
+
+function assertComparableResults(baseline: BenchmarkResult, real: BenchmarkResult): void {
+  if (baseline.config.runtimeProfile !== "baseline") {
+    throw new Error('baseline result runtimeProfile must be "baseline".');
+  }
+  if (real.config.runtimeProfile !== "real") {
+    throw new Error('real result runtimeProfile must be "real".');
+  }
+  const checks: Array<[string, unknown, unknown]> = [
+    ["meta.version", baseline.meta.version, real.meta.version],
+    ["meta.remnicVersion", baseline.meta.remnicVersion, real.meta.remnicVersion],
+    ["meta.gitSha", baseline.meta.gitSha, real.meta.gitSha],
+    ["meta.runCount", baseline.meta.runCount, real.meta.runCount],
+    ["meta.seeds", baseline.meta.seeds, real.meta.seeds],
+    ["meta.datasetHash", baseline.meta.datasetHash ?? null, real.meta.datasetHash ?? null],
+    ["config.adapterMode", baseline.config.adapterMode, real.config.adapterMode],
+    [
+      "config.systemProvider",
+      providerIdentity(baseline.config.systemProvider),
+      providerIdentity(real.config.systemProvider),
+    ],
+    [
+      "config.judgeProvider",
+      providerIdentity(baseline.config.judgeProvider),
+      providerIdentity(real.config.judgeProvider),
+    ],
+    [
+      "config.internalProvider",
+      providerIdentity(baseline.config.internalProvider),
+      providerIdentity(real.config.internalProvider),
+    ],
+  ];
+  for (const [field, baselineValue, realValue] of checks) {
+    if (stableJson(baselineValue) !== stableJson(realValue)) {
+      throw new Error(
+        `Results are not comparable: ${field} differs ` + `(${stableJson(baselineValue)} vs ${stableJson(realValue)}).`
+      );
+    }
+  }
+}
+
+function joinTasks(baseline: BenchmarkResult, real: BenchmarkResult): JoinedTask[] {
+  const baselineTasks = indexTasks(baseline.results.tasks, "baseline");
+  const realTasks = indexTasks(real.results.tasks, "real");
+  const missingFromReal = [...baselineTasks.keys()].filter((id) => !realTasks.has(id)).sort(compareStrings);
+  const missingFromBaseline = [...realTasks.keys()].filter((id) => !baselineTasks.has(id)).sort(compareStrings);
+  if (missingFromReal.length > 0 || missingFromBaseline.length > 0) {
+    throw new Error(
+      `Results do not contain identical task-id sets: ${missingFromReal.length} missing from real, ` +
+        `${missingFromBaseline.length} missing from baseline.`
+    );
+  }
+  return [...baselineTasks.keys()].sort(compareStrings).map((taskId) => {
+    const baselineTask = baselineTasks.get(taskId);
+    const realTask = realTasks.get(taskId);
+    if (!baselineTask || !realTask) {
+      throw new Error(`Task ${JSON.stringify(taskId)} disappeared during the validated join.`);
+    }
+    for (const [field, baselineValue, realValue] of [
+      ["question", baselineTask.question, realTask.question],
+      ["expected", baselineTask.expected, realTask.expected],
+    ] as const) {
+      if (baselineValue !== realValue) {
+        throw new Error(`Task ${JSON.stringify(taskId)} has mismatched ${field} payloads.`);
+      }
+    }
+    const baselineCategory = resolveCategory(baselineTask);
+    const realCategory = resolveCategory(realTask);
+    if (baselineCategory !== realCategory) {
+      throw new Error(`Task ${JSON.stringify(taskId)} has mismatched categories.`);
+    }
+    return { taskId, category: baselineCategory, baseline: baselineTask, real: realTask };
+  });
+}
+
+function indexTasks(tasks: TaskResult[], label: string): Map<string, TaskResult> {
+  const result = new Map<string, TaskResult>();
+  for (const task of tasks) {
+    if (!task.taskId || result.has(task.taskId)) {
+      throw new Error(`${label} result contains duplicate or empty task id ${JSON.stringify(task.taskId)}.`);
+    }
+    if (!task.question || !task.expected) {
+      throw new Error(`${label} task ${JSON.stringify(task.taskId)} has an empty question or expected answer.`);
+    }
+    const recalledText = asRecord(task.details)?.recalledText;
+    if (typeof recalledText !== "string") {
+      throw new Error(`${label} task ${JSON.stringify(task.taskId)} has no final recalledText.`);
+    }
+    result.set(task.taskId, task);
+  }
+  return result;
+}
+
+function assertMetricSets(joined: JoinedTask[], primaryMetric: string): void {
+  const first = joined[0];
+  if (!first) throw new Error("Cannot validate metric sets for an empty paired result.");
+  const expectedMetrics = Object.keys(first.baseline.scores).sort(compareStrings);
+  for (const task of joined) {
+    const baselineMetrics = Object.keys(task.baseline.scores).sort(compareStrings);
+    const realMetrics = Object.keys(task.real.scores).sort(compareStrings);
+    if (stableJson(baselineMetrics) !== stableJson(realMetrics)) {
+      throw new Error(`Task ${JSON.stringify(task.taskId)} has mismatched metric sets.`);
+    }
+    if (stableJson(baselineMetrics) !== stableJson(expectedMetrics)) {
+      throw new Error(`Task ${JSON.stringify(task.taskId)} has an inconsistent metric set.`);
+    }
+    if (!baselineMetrics.includes(primaryMetric)) {
+      throw new Error(`Task ${JSON.stringify(task.taskId)} is missing metric ${JSON.stringify(primaryMetric)}.`);
+    }
+    for (const [side, scores] of [
+      ["baseline", task.baseline.scores],
+      ["real", task.real.scores],
+    ] as const) {
+      for (const [metric, score] of Object.entries(scores)) {
+        if (!Number.isFinite(score)) {
+          throw new Error(`${side} task ${JSON.stringify(task.taskId)} metric ${metric} is not finite.`);
+        }
+      }
+    }
+  }
+}
+
+function buildRegression(
+  task: JoinedTask,
+  metric: string,
+  excerptChars: number,
+  maxDiffLines: number
+): LoComoFinalContextRegression {
+  const baselineRecall = finalRecallText(task.baseline);
+  const realRecall = finalRecallText(task.real);
+  const baselineLines = contentLines(baselineRecall);
+  const realLines = contentLines(realRecall);
+  const displaced = subtractLineMultiset(baselineLines, realLines);
+  const introduced = subtractLineMultiset(realLines, baselineLines);
+  const baselineScore = requireMetricScore(task.baseline, metric, "baseline");
+  const realScore = requireMetricScore(task.real, metric, "real");
+  return {
+    taskId: task.taskId,
+    category: task.category,
+    baselineScore,
+    realScore,
+    delta: realScore - baselineScore,
+    questionSha256: sha256(normalizeText(task.baseline.question)),
+    expectedAnswerSha256: sha256(normalizeText(task.baseline.expected)),
+    baseline: {
+      answer: textDigest(task.baseline.actual, excerptChars),
+      recall: recallSummary(baselineRecall, task.baseline.expected),
+    },
+    real: {
+      answer: textDigest(task.real.actual, excerptChars),
+      recall: recallSummary(realRecall, task.real.expected),
+    },
+    displacedLines: lineDelta(displaced, maxDiffLines, excerptChars),
+    introducedLines: lineDelta(introduced, maxDiffLines, excerptChars),
+  };
+}
+
+function buildProvenance(
+  evidence: LoComoRawResultEvidence,
+  profile: "baseline" | "real",
+  joined: JoinedTask[],
+  side: "baseline" | "real"
+): LoComoRecallResultProvenance {
+  const system = requireProvider(evidence.result.config.systemProvider, profile, "system");
+  const judge = requireProvider(evidence.result.config.judgeProvider, profile, "judge");
+  const payload = joined.map((task) => ({
+    taskId: task.taskId,
+    category: task.category,
+    question: task[side].question,
+    expected: task[side].expected,
+  }));
+  return {
+    reference: evidence.reference,
+    sha256: evidence.sha256,
+    resultId: evidence.result.meta.id,
+    gitSha: evidence.result.meta.gitSha,
+    remnicVersion: evidence.result.meta.remnicVersion,
+    runtimeProfile: profile,
+    systemProvider: system.provider,
+    systemModel: system.model,
+    judgeProvider: judge.provider,
+    judgeModel: judge.model,
+    seeds: [...evidence.result.meta.seeds],
+    taskPayloadSha256: sha256(stableJson(payload)),
+  };
+}
+
+function summarizeMetric(tasks: JoinedTask[], metric: string): LoComoRecallMetricDelta {
+  let baselineSum = 0;
+  let realSum = 0;
+  let wins = 0;
+  let losses = 0;
+  let ties = 0;
+  for (const task of tasks) {
+    const baseline = requireMetricScore(task.baseline, metric, "baseline");
+    const real = requireMetricScore(task.real, metric, "real");
+    baselineSum += baseline;
+    realSum += real;
+    if (real > baseline) wins += 1;
+    else if (real < baseline) losses += 1;
+    else ties += 1;
+  }
+  const baselineMean = baselineSum / tasks.length;
+  const realMean = realSum / tasks.length;
+  return { baselineMean, realMean, delta: realMean - baselineMean, wins, losses, ties };
+}
+
+function lineDelta(lines: IndexedRecallLine[], maxDiffLines: number, excerptChars: number): LoComoRecallLineDelta {
+  return {
+    totalCount: lines.length,
+    shownCount: Math.min(lines.length, maxDiffLines),
+    lines: lines.slice(0, maxDiffLines).map((line) => {
+      const parsedSourceRef = sourceRef(line.text);
+      return {
+        ordinal: line.ordinal,
+        ...textDigest(line.text, excerptChars),
+        ...(parsedSourceRef ? { sourceRef: parsedSourceRef } : {}),
+      };
+    }),
+  };
+}
+
+function recallSummary(text: string, expected: string): LoComoRecallContextSummary {
+  const normalized = normalizeText(text);
+  const lines = normalized
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return {
+    sha256: sha256(normalized),
+    charCount: normalized.length,
+    lineCount: lines.length,
+    headings: [...new Set(lines.filter(isHeading))],
+    sourceRefs: [...new Set(lines.map(sourceRef).filter((value): value is string => !!value))].sort(compareStrings),
+    expectedTokenCoverage: tokenCoverage(expected, normalized),
+  };
+}
+
+function textDigest(text: string, excerptChars: number): LoComoRecallTextDigest {
+  const normalized = normalizeText(text);
+  return {
+    sha256: sha256(normalized),
+    charCount: normalized.length,
+    excerpt: normalized.slice(0, excerptChars),
+  };
+}
+
+function contentLines(text: string): IndexedRecallLine[] {
+  return normalizeText(text)
+    .split("\n")
+    .map((line, ordinal) => ({ text: line.trim(), ordinal }))
+    .filter((line) => line.text.length > 0 && !isHeading(line.text));
+}
+
+function subtractLineMultiset(source: IndexedRecallLine[], comparison: IndexedRecallLine[]): IndexedRecallLine[] {
+  const remaining = new Map<string, number>();
+  for (const line of comparison) {
+    remaining.set(line.text, (remaining.get(line.text) ?? 0) + 1);
+  }
+  return source.filter((line) => {
+    const count = remaining.get(line.text) ?? 0;
+    if (count === 0) return true;
+    remaining.set(line.text, count - 1);
+    return false;
+  });
+}
+
+function verifyAggregateMeans(result: BenchmarkResult, joined: JoinedTask[], side: "baseline" | "real"): void {
+  const first = joined[0];
+  if (!first) throw new Error("Cannot verify aggregates for an empty paired result.");
+  const metrics = Object.keys(first[side].scores).sort(compareStrings);
+  for (const metric of metrics) {
+    const aggregate = result.results.aggregates[metric];
+    if (!aggregate || !Number.isFinite(aggregate.mean)) {
+      throw new Error(`${side} result has no finite aggregate mean for ${JSON.stringify(metric)}.`);
+    }
+    const computed =
+      joined.reduce((sum, task) => sum + requireMetricScore(task[side], metric, side), 0) / joined.length;
+    if (Math.abs(aggregate.mean - computed) > 1e-12) {
+      throw new Error(`${side} aggregate ${metric}=${aggregate.mean} does not match task mean ${computed}.`);
+    }
+  }
+}
+
+function tokenCoverage(expected: string, recalled: string): number {
+  const expectedTokens = new Set(tokenize(expected));
+  if (expectedTokens.size === 0) return 0;
+  const recalledTokens = new Set(tokenize(recalled));
+  let matched = 0;
+  for (const token of expectedTokens) {
+    if (recalledTokens.has(token)) matched += 1;
+  }
+  return matched / expectedTokens.size;
+}
+
+function tokenize(value: string): string[] {
+  return (
+    normalizeText(value)
+      .toLocaleLowerCase("en-US")
+      .match(/[\p{L}\p{N}]+/gu) ?? []
+  );
+}
+
+function resolveCategory(task: TaskResult): string {
+  const categoryName = asRecord(task.details)?.categoryName;
+  if (typeof categoryName === "string" && categoryName.trim()) return categoryName;
+  const match = task.taskId.match(LOCOMO_TASK_CATEGORY_PATTERN);
+  if (!match?.[1]) {
+    throw new Error(`Cannot derive LoCoMo category from task id ${JSON.stringify(task.taskId)}.`);
+  }
+  return match[1];
+}
+
+function finalRecallText(task: TaskResult): string {
+  const recalledText = asRecord(task.details)?.recalledText;
+  if (typeof recalledText !== "string") {
+    throw new Error(`Task ${JSON.stringify(task.taskId)} has no final recalledText.`);
+  }
+  return recalledText;
+}
+
+function providerIdentity(provider: ProviderConfig | null | undefined): unknown {
+  if (!provider) return null;
+  return {
+    provider: provider.provider,
+    model: provider.model,
+    rubricVersion: provider.rubricVersion ?? null,
+    baseUrl: provider.baseUrl ?? null,
+    providerRequestTimeoutMs: provider.providerRequestTimeoutMs ?? null,
+    retryOptions: provider.retryOptions
+      ? {
+          maxAttempts: provider.retryOptions.maxAttempts ?? null,
+          baseBackoffMs: provider.retryOptions.baseBackoffMs ?? null,
+          timeoutMs: provider.retryOptions.timeoutMs ?? null,
+          retryOnTimeout: provider.retryOptions.retryOnTimeout ?? null,
+          max429WaitMs: provider.retryOptions.max429WaitMs ?? null,
+        }
+      : null,
+    disableThinking: provider.disableThinking ?? null,
+    reasoningEffort: provider.reasoningEffort ?? null,
+    responderContextBudgetChars: provider.responderContextBudgetChars ?? null,
+    responderPromptBudgetChars: provider.responderPromptBudgetChars ?? null,
+    temperature: provider.temperature ?? null,
+    seed: provider.seed ?? null,
+  };
+}
+
+function sourceRef(line: string): string | undefined {
+  const match = line.match(SOURCE_TURN_PATTERN);
+  const sessionId = match?.[1];
+  const turn = match?.[2];
+  const role = match?.[3];
+  if (!sessionId || !turn || !role) return undefined;
+  return `${sessionId}:turn-${turn}:${role.trim().toLowerCase()}`;
+}
+
+function requireMetricScore(task: TaskResult, metric: string, side: string): number {
+  const score = task.scores[metric];
+  if (typeof score !== "number" || !Number.isFinite(score)) {
+    throw new Error(`${side} task ${JSON.stringify(task.taskId)} metric ${metric} is not finite.`);
+  }
+  return score;
+}
+
+function requireProvider(provider: ProviderConfig | null | undefined, profile: string, role: string): ProviderConfig {
+  if (!provider) throw new Error(`${profile} result has no ${role} provider identity.`);
+  return provider;
+}
+
+function isHeading(line: string): boolean {
+  return /^##\s+/.test(line);
+}
+
+function normalizeText(value: string): string {
+  return value.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function parseNonNegativeInteger(value: number, label: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer.`);
+  }
+  return value;
+}
+
+function compareLoComoCategories(left: string, right: string): number {
+  const leftIndex = LOCOMO_CATEGORY_ORDER.indexOf(left as (typeof LOCOMO_CATEGORY_ORDER)[number]);
+  const rightIndex = LOCOMO_CATEGORY_ORDER.indexOf(right as (typeof LOCOMO_CATEGORY_ORDER)[number]);
+  if (leftIndex >= 0 && rightIndex >= 0) return leftIndex - rightIndex;
+  if (leftIndex >= 0) return -1;
+  if (rightIndex >= 0) return 1;
+  return compareStrings(left, right);
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function escapeMarkdownCell(value: string): string {
+  return value.replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function formatScore(value: number): string {
+  return value.toFixed(4);
+}
+
+function formatSignedScore(value: number): string {
+  return `${value >= 0 ? "+" : ""}${formatScore(value)}`;
+}

--- a/scripts/bench/diagnose-locomo-recall-delta.ts
+++ b/scripts/bench/diagnose-locomo-recall-delta.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env -S npx tsx
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+import {
+  diagnoseLoComoRecallDelta,
+  loadBenchmarkResult,
+  renderLoComoRecallDeltaMarkdown,
+  sanitizeLoComoResultReference,
+} from "@remnic/bench";
+
+interface CliOptions {
+  baselinePath: string;
+  realPath: string;
+  format: "json" | "markdown";
+  metric: string;
+  top: number;
+}
+
+async function main(args: string[]): Promise<number> {
+  const options = parseArgs(args);
+  const [baseline, real] = await Promise.all([loadEvidence(options.baselinePath), loadEvidence(options.realPath)]);
+  const report = diagnoseLoComoRecallDelta({
+    baseline,
+    real,
+    primaryMetric: options.metric,
+    maxRegressions: options.top,
+  });
+  process.stdout.write(
+    options.format === "json" ? `${JSON.stringify(report, null, 2)}\n` : renderLoComoRecallDeltaMarkdown(report)
+  );
+  return 0;
+}
+
+async function loadEvidence(path: string) {
+  const [bytes, result] = await Promise.all([readFile(path), loadBenchmarkResult(path)]);
+  return {
+    result,
+    reference: sanitizeLoComoResultReference(path),
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+  };
+}
+
+function parseArgs(args: string[]): CliOptions {
+  if (args.length < 2) {
+    throw new Error(
+      "usage: diagnose-locomo-recall-delta.ts <baseline-result.json> <real-result.json> " +
+        "[--metric llm_judge] [--top 20] [--format markdown|json]"
+    );
+  }
+  const [baselinePath, realPath, ...flags] = args;
+  if (!baselinePath || !realPath) {
+    throw new Error("Both baseline and real raw BenchmarkResult paths are required.");
+  }
+  let format: CliOptions["format"] = "markdown";
+  let metric = "llm_judge";
+  let top = 20;
+  for (let index = 0; index < flags.length; index += 1) {
+    const flag = flags[index];
+    if (flag === undefined) continue;
+    const value = flags[index + 1];
+    if (flag === "--format") {
+      if (value !== "markdown" && value !== "json") {
+        throw new Error('--format must be "markdown" or "json".');
+      }
+      format = value;
+      index += 1;
+    } else if (flag === "--metric") {
+      if (!value || value.startsWith("--")) throw new Error("--metric requires a value.");
+      metric = value;
+      index += 1;
+    } else if (flag === "--top") {
+      if (!value || value.startsWith("--")) throw new Error("--top requires a value.");
+      top = Number(value);
+      if (!Number.isInteger(top) || top < 0) {
+        throw new Error("--top must be a non-negative integer.");
+      }
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument ${JSON.stringify(flag)}.`);
+    }
+  }
+  return { baselinePath, realPath, format, metric, top };
+}
+
+main(process.argv.slice(2))
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
## Summary
- add a deterministic, no-model-call analyzer for complete paired LoCoMo baseline/real raw results
- emit bounded final-context displacement receipts with stable hashes and explicit evidence boundaries
- validate provider/runtime parity, including transport-only provider timeouts, and sanitize CLI provenance references so caller directories are not emitted

Supports #1879.

## Verification
- npx tsx --test packages/bench/src/stats/locomo-recall-delta.test.ts
- npm run check-types --workspace=@remnic/bench
- npm run build --workspace=@remnic/bench
- git diff --check
- npm run preflight:quick

No model calls were run; the analyzer operates only on cached BenchmarkResult files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New offline analysis tooling and exports only; no runtime benchmark or production paths change, with heavy input validation and tests.
> 
> **Overview**
> Adds a **deterministic, no-model-call** LoCoMo analyzer that compares paired **baseline** vs **real** cached `BenchmarkResult` JSON (full 1,986-task runs) and explains score deltas via **final `details.recalledText`** context, not published artifacts.
> 
> **`diagnoseLoComoRecallDelta`** joins tasks by id, enforces strict comparability (runtime profiles, seeds, provider identity including timeouts, matching questions/aggregates, file **sha256** envelopes), and emits category/overall metric deltas plus **top regressions** with bounded **displaced/introduced line** receipts (hashes, excerpts, optional turn `sourceRef`). It explicitly does **not** read or emit `details.evidence` and documents that retrieval-tier attribution is unavailable from cached results.
> 
> **`renderLoComoRecallDeltaMarkdown`** and **`sanitizeLoComoResultReference`** support human-readable reports without leaking caller paths. New **`scripts/bench/diagnose-locomo-recall-delta.ts`** CLI loads raw files, hashes bytes, and outputs markdown or JSON. Public API is re-exported from `@remnic/bench` with tests covering determinism, validation, and privacy boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 672d6b9f503008d969484370ad94cd1b8ed08ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->