### PR TITLE
docs(bench): pin Build Week dataset paths

### DIFF
--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -206,6 +206,7 @@ export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledge
 # Replace <LEDGER_DERIVED_LIMIT> after a smoke turn establishes actual cost.
 remnic bench run longmemeval --runtime-profile real \
   --limit <LEDGER_DERIVED_LIMIT> \
+  --dataset-dir ./bench-datasets/longmemeval \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
   --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -193,7 +193,7 @@ also use `--trial-limit`. These flags do not cap credits. The provider has
 separate credit guards. Set them, then choose the task cap from the ledger:
 
 ```bash
-BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"
+export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"
 export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"
 umask 077
 mkdir -p "$BUILD_WEEK_RUN_ROOT" "$BUILD_WEEK_RESULTS_DIR"

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -261,7 +261,7 @@ for each role.
 Configure the guard and run a measured smoke before selecting a task count:
 
 ```bash
-BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"
+export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"
 export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"
 umask 077
 mkdir -p "$BUILD_WEEK_RUN_ROOT" "$BUILD_WEEK_RESULTS_DIR"

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -271,8 +271,10 @@ export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473
 export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473
 export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"
 
-remnic bench run --quick longmemeval \
+remnic bench run longmemeval \
   --runtime-profile real \
+  --limit 1 \
+  --dataset-dir ./bench-datasets/longmemeval \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
   --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
@@ -285,6 +287,7 @@ remnic bench run --quick longmemeval \
 # Replace this only after the smoke ledger establishes observed cost.
 remnic bench run longmemeval \
   --runtime-profile real --limit <LEDGER_DERIVED_LIMIT> \
+  --dataset-dir ./bench-datasets/longmemeval \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
   --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
@@ -300,6 +303,11 @@ and MemoryAgentBench. Neither flag is a token-credit budget, so the placeholder
 cannot be replaced with a fixed universal value: derive it from the ledger's
 observed per-task cost and resize after each bounded batch. A limited run is a
 trial artifact and cannot be promoted as a full leaderboard result.
+The measured probe is a full-mode run bounded to one staged LongMemEval item.
+Full mode fails before provider dispatch if the explicit dataset directory is
+missing or unreadable; it cannot fall back to the bundled quick fixture. The
+larger bounded command uses the same gitignored source, and neither command
+auto-selects the CLI-managed dataset store.
 
 The Codex CLI profile supplies a 180-second transport-only timeout by default.
 Do not add `--request-timeout` to this protocol: an explicit request timeout

--- a/docs/paper/repro-appendix.md
+++ b/docs/paper/repro-appendix.md
@@ -658,7 +658,7 @@ normal service, not fast mode. Configure the provider's guard before the first
 turn:
 
 ```bash
-BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"
+export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"
 export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"
 umask 077
 mkdir -p "$BUILD_WEEK_RUN_ROOT" "$BUILD_WEEK_RESULTS_DIR"

--- a/docs/paper/repro-appendix.md
+++ b/docs/paper/repro-appendix.md
@@ -693,8 +693,10 @@ bound conservatively. If exact terminal usage is missing, the ledger blocks
 further dispatch until manual account reconciliation:
 
 ```bash
-remnic bench run --quick longmemeval \
+remnic bench run longmemeval \
   --runtime-profile real \
+  --limit 1 \
+  --dataset-dir ./bench-datasets/longmemeval \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
   --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
@@ -706,6 +708,7 @@ remnic bench run --quick longmemeval \
 
 remnic bench run longmemeval \
   --runtime-profile real --limit <LEDGER_DERIVED_LIMIT> \
+  --dataset-dir ./bench-datasets/longmemeval \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
   --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
@@ -734,6 +737,12 @@ flag is omitted. Do not add `--request-timeout` to these commands: an explicit
 value also becomes a whole-phase benchmark guard, which can cut off long
 store/recall/reset phases. The 600-second drain timeout is deliberately
 separate and remains explicit.
+
+Both commands select the staged, gitignored LongMemEval directory explicitly.
+The measured probe uses full mode with `--limit 1`, so a missing or unreadable
+dataset fails before provider dispatch instead of falling back to the bundled
+quick fixture. The larger bounded command uses the same source. Neither command
+can silently auto-select the CLI-managed dataset store.
 
 ---
 

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -91,7 +91,7 @@ status` to report ChatGPT authentication. A 473-credit safety reserve leaves
 then measure a quick task before choosing a workload bound:
 
 ```bash
-BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"
+export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"
 export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"
 umask 077
 mkdir -p "$BUILD_WEEK_RUN_ROOT" "$BUILD_WEEK_RESULTS_DIR"

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -101,8 +101,10 @@ export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473
 export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473
 export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"
 
-remnic bench run --quick longmemeval \
+remnic bench run longmemeval \
   --runtime-profile real \
+  --limit 1 \
+  --dataset-dir ./bench-datasets/longmemeval \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
   --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
@@ -114,6 +116,7 @@ remnic bench run --quick longmemeval \
 
 remnic bench run longmemeval \
   --runtime-profile real --limit <LEDGER_DERIVED_LIMIT> \
+  --dataset-dir ./bench-datasets/longmemeval \
   --results-dir "$BUILD_WEEK_RESULTS_DIR" \
   --drain-timeout 600000 \
   --system-provider codex-cli --system-model gpt-5.6-luna \
@@ -130,6 +133,11 @@ actual `turn.completed` JSONL usage. Stop dispatching at 2,000 spent; the
 473-credit reserve absorbs only a final in-flight call whose exact cost becomes
 known after completion. Missing exact terminal usage blocks the ledger pending
 manual account reconciliation.
+The measured probe is a full-mode run bounded to one staged LongMemEval item.
+Full mode fails before provider dispatch if that explicit dataset directory is
+missing or unreadable, so it cannot fall back to the bundled quick fixture.
+Both commands pin the same gitignored dataset source and do not fall back to
+the CLI-managed dataset store.
 Rates per one million tokens are Luna: 25 input, 2.5 cached input, 150 output;
 Terra: 62.5 input, 6.25 cached input, 375 output. A bounded result is a trial,
 not a full leaderboard artifact.

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -155,6 +155,12 @@ const BUILD_WEEK_CREDIT_ENV_CONTRACTS = Object.freeze([
       /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_LEDGER="\$BUILD_WEEK_RUN_ROOT\/codex-credit-ledger\.json"(?:[ \t]+#.*)?[ \t]*$/,
   },
 ]);
+const BUILD_WEEK_RUN_ROOT_ENV_CONTRACT = Object.freeze({
+  name: "BUILD_WEEK_RUN_ROOT",
+  expected: 'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"',
+  valid:
+    /^\s*export\s+BUILD_WEEK_RUN_ROOT="\$HOME\/\.remnic\/bench\/build-week-2026"(?:[ \t]+#.*)?[ \t]*$/,
+});
 const BUILD_WEEK_RESULTS_ENV_CONTRACT = Object.freeze({
   name: "BUILD_WEEK_RESULTS_DIR",
   expected: 'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"',
@@ -162,8 +168,13 @@ const BUILD_WEEK_RESULTS_ENV_CONTRACT = Object.freeze({
     /^\s*export\s+BUILD_WEEK_RESULTS_DIR="\$BUILD_WEEK_RUN_ROOT\/results"(?:[ \t]+#.*)?[ \t]*$/,
 });
 const BUILD_WEEK_PAID_ENV_CONTRACTS = Object.freeze([
+  BUILD_WEEK_RUN_ROOT_ENV_CONTRACT,
   ...BUILD_WEEK_CREDIT_ENV_CONTRACTS,
   BUILD_WEEK_RESULTS_ENV_CONTRACT,
+]);
+const BUILD_WEEK_ROOT_DEPENDENT_ENV_NAMES = new Set([
+  "REMNIC_BENCH_CODEX_CREDIT_LEDGER",
+  "BUILD_WEEK_RESULTS_DIR",
 ]);
 const BUILD_WEEK_SHELL_LANGS = new Set(["", "bash", "sh", "shell", "shell-session", "zsh", "console"]);
 
@@ -176,13 +187,13 @@ function containsShellCreditProtocolName(line, name) {
   return new RegExp(`\\b${name}\\b`).test(line);
 }
 
-function containsShellResultsDirMutation(line) {
-  // Ordinary reads such as `--results-dir "$BUILD_WEEK_RESULTS_DIR"` must not
-  // invalidate the export. A bare variable name, however, covers direct shell
-  // mutation forms (assignment, export/unset, declarations, arrays,
-  // arithmetic, and `printf -v`) and therefore fails closed unless it is the
-  // exact allowlisted export above.
-  return new RegExp(`(?<![\\$\\{])\\b${BUILD_WEEK_RESULTS_ENV_CONTRACT.name}\\b`).test(line);
+function containsShellPathVariableMutation(line, contract) {
+  // Ordinary reads such as `--results-dir "$BUILD_WEEK_RESULTS_DIR"` and the
+  // dependent `$BUILD_WEEK_RUN_ROOT` expansions must not invalidate an export.
+  // A bare variable name covers direct shell mutation forms (assignment,
+  // export/unset, declarations, arrays, arithmetic, and `printf -v`) and
+  // therefore fails closed unless it is the exact allowlisted export.
+  return new RegExp(`(?<![\\$\\{])\\b${contract.name}\\b`).test(line);
 }
 
 // Fenced code blocks: ```lang ... ``` or ~~~lang ... ~~~. We only extract
@@ -462,10 +473,12 @@ function extractShellPaidRunEnvMutations(src) {
     for (const [index, line] of block.text.split("\n").entries()) {
       if (/^\s*#/.test(line)) continue;
       for (const contract of BUILD_WEEK_PAID_ENV_CONTRACTS) {
-        const isMutation =
-          contract === BUILD_WEEK_RESULTS_ENV_CONTRACT
-            ? containsShellResultsDirMutation(line)
-            : containsShellCreditProtocolName(line, contract.name);
+        const isPathContract =
+          contract === BUILD_WEEK_RUN_ROOT_ENV_CONTRACT ||
+          contract === BUILD_WEEK_RESULTS_ENV_CONTRACT;
+        const isMutation = isPathContract
+          ? containsShellPathVariableMutation(line, contract)
+          : containsShellCreditProtocolName(line, contract.name);
         if (!isMutation) continue;
         mutations.push({
           name: contract.name,
@@ -563,14 +576,34 @@ function checkBuildWeekCodexDatasetPaths() {
       checkedInDoc += 1;
       const remnicCommandAt = command.search(/\bremnic\s+bench\s+run\b/);
       const commandPrefix = remnicCommandAt > 0 ? command.slice(0, remnicCommandAt) : "";
+      const lastEnvMutations = new Map(
+        BUILD_WEEK_PAID_ENV_CONTRACTS.map((contract) => [
+          contract.name,
+          paidRunEnvMutations.findLast(
+            ({ name, line }) => name === contract.name && line < commandStartLine,
+          ),
+        ]),
+      );
+      const lastRunRootMutation = lastEnvMutations.get(BUILD_WEEK_RUN_ROOT_ENV_CONTRACT.name);
       for (const contract of BUILD_WEEK_PAID_ENV_CONTRACTS) {
-        const lastMutation = paidRunEnvMutations.findLast(
-          ({ name, line }) => name === contract.name && line < commandStartLine,
-        );
-        if (!lastMutation?.valid || commandPrefix.includes(contract.name)) {
+        const lastMutation = lastEnvMutations.get(contract.name);
+        const dependsOnRunRoot = BUILD_WEEK_ROOT_DEPENDENT_ENV_NAMES.has(contract.name);
+        const followsCurrentRunRoot =
+          !dependsOnRunRoot ||
+          (lastRunRootMutation?.valid === true &&
+            lastMutation !== undefined &&
+            lastMutation.line > lastRunRootMutation.line);
+        if (
+          !lastMutation?.valid ||
+          !followsCurrentRunRoot ||
+          commandPrefix.includes(contract.name)
+        ) {
           failures.push(
             `${rel}: Build Week Codex command must follow an exact shell export of ` +
-              `\`${contract.expected}\``,
+              `\`${contract.expected}\`` +
+              (dependsOnRunRoot
+                ? ` after \`${BUILD_WEEK_RUN_ROOT_ENV_CONTRACT.expected}\``
+                : ""),
           );
         }
       }

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -655,8 +655,9 @@ function checkBuildWeekCodexDatasetPaths() {
           );
         }
       }
-      if (expectedCommands === 2) {
-        const requiredLimit = checkedInDoc === 1 ? "1" : "<LEDGER_DERIVED_LIMIT>";
+      if (expectedCommands === 1 || expectedCommands === 2) {
+        const requiredLimit =
+          expectedCommands === 1 || checkedInDoc === 2 ? "<LEDGER_DERIVED_LIMIT>" : "1";
         const roleBounds = presentBoundFlags.map((flag) => ({
           flag,
           value: extractShellOptionValue(command, flag),
@@ -665,7 +666,7 @@ function checkBuildWeekCodexDatasetPaths() {
           const acceptedFlags = supportedBoundFlags.map((flag) => `\`${flag} ${requiredLimit}\``);
           const actualBounds = roleBounds.map(({ flag, value }) => `${flag} ${value ?? "<missing>"}`);
           failures.push(
-            `${rel}: Build Week Codex command ${checkedInDoc} of 2 must include exactly one of ` +
+            `${rel}: Build Week Codex command ${checkedInDoc} of ${expectedCommands} must include exactly one of ` +
               `${acceptedFlags.join(" or ")}; got ${actualBounds.join(", ") || "no supported bound"}`,
           );
         }

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -91,10 +91,10 @@ const SKIPPED_DIR_NAMES = new Set([
 // or unreadable staged path falls back to a bundled fixture. Either source
 // silently changes the measured workload and invalidates the run receipt.
 const BUILD_WEEK_CODEX_DOCS = Object.freeze([
-  "HACKATHON.md",
-  "packages/bench/README.md",
-  "docs/benchmarks.md",
-  "docs/paper/repro-appendix.md",
+  { path: "HACKATHON.md", expectedCommands: 1 },
+  { path: "packages/bench/README.md", expectedCommands: 2 },
+  { path: "docs/benchmarks.md", expectedCommands: 2 },
+  { path: "docs/paper/repro-appendix.md", expectedCommands: 2 },
 ]);
 
 const BENCH_RUN_BOOLEAN_FLAGS = new Set([
@@ -338,7 +338,7 @@ function extractRemnicInvocations(relPath, src) {
  * are ordinary multiline shell invocations, not arbitrary shell programs.
  *
  * @param {string} src
- * @returns {string[]}
+ * @returns {Array<{ command: string; guardedBuildWeekBlock: boolean }>}
  */
 function extractLogicalShellCommands(src) {
   const shellLangs = new Set([
@@ -353,11 +353,14 @@ function extractLogicalShellCommands(src) {
   const commands = [];
   for (const block of extractFencedBlocks(src)) {
     if (!shellLangs.has(block.lang)) continue;
+    const guardedBuildWeekBlock = block.text.includes(
+      "REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+    );
     const logical = block.text.replace(/\\\s*\n/g, " ");
     for (const line of logical.split("\n")) {
       const command = line.trim();
       if (command.length > 0 && !command.startsWith("#")) {
-        commands.push(command);
+        commands.push({ command, guardedBuildWeekBlock });
       }
     }
   }
@@ -418,17 +421,22 @@ function extractShellOptionValue(command, flag) {
 function checkBuildWeekCodexDatasetPaths() {
   const failures = [];
   let checked = 0;
-  for (const rel of BUILD_WEEK_CODEX_DOCS) {
+  const completeProtocolDocSet = BUILD_WEEK_CODEX_DOCS.every(({ path: rel }) =>
+    existsSync(path.join(ROOT, ...rel.split("/"))),
+  );
+  for (const { path: rel, expectedCommands } of BUILD_WEEK_CODEX_DOCS) {
     const abs = path.join(ROOT, ...rel.split("/"));
     if (!existsSync(abs)) continue;
     const src = readFileSync(abs, "utf8");
-    for (const command of extractLogicalShellCommands(src)) {
+    let checkedInDoc = 0;
+    for (const { command, guardedBuildWeekBlock } of extractLogicalShellCommands(src)) {
       if (!/\bremnic\s+bench\s+run\b/.test(command)) continue;
-      if (!/\bcodex-cli\b/.test(command)) continue;
+      if (!guardedBuildWeekBlock && !/\bcodex-cli\b/.test(command)) continue;
       const commandTokens = command.trim().split(/\s+/);
       const datasetFlag = extractShellOptionValue(command, "--dataset-dir");
       const positionalBenchmarks = extractRunBenchmarks(command) ?? [];
       checked += 1;
+      checkedInDoc += 1;
       for (const selector of ["--all", "--custom", "--matrix"]) {
         if (commandTokens.some((token) => token === selector || token.startsWith(`${selector}=`))) {
           failures.push(
@@ -536,6 +544,16 @@ function checkBuildWeekCodexDatasetPaths() {
           );
         }
       }
+    }
+    if (checkedInDoc === 0) {
+      failures.push(
+        `${rel}: must contain at least one guarded Build Week Codex benchmark command`,
+      );
+    } else if (completeProtocolDocSet && checkedInDoc !== expectedCommands) {
+      failures.push(
+        `${rel}: expected ${expectedCommands} guarded Build Week Codex benchmark command(s); ` +
+          `found ${checkedInDoc}`,
+      );
     }
   }
   return { failures, checked };

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -130,11 +130,32 @@ const BUILD_WEEK_ALLOWED_RUN_FLAGS = new Set([
   "--judge-codex-reasoning-effort",
 ]);
 
-const BUILD_WEEK_CREDIT_GUARD_LINE_RE =
-  /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473\s*(?:#.*)?$/m;
-const BUILD_WEEK_CREDIT_BUDGET_MUTATION_RE =
-  /^\s*(?:export(?:\s+-n)?\s+REMNIC_BENCH_CODEX_CREDIT_BUDGET(?:\s*=|\s*$)|REMNIC_BENCH_CODEX_CREDIT_BUDGET\s*=|unset(?:\s+-v)?\s+REMNIC_BENCH_CODEX_CREDIT_BUDGET\b)/;
+const BUILD_WEEK_CREDIT_ENV_CONTRACTS = Object.freeze([
+  {
+    name: "REMNIC_BENCH_CODEX_CREDIT_BUDGET",
+    expected: "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+    valid: /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473\s*(?:#.*)?$/,
+  },
+  {
+    name: "REMNIC_BENCH_CODEX_CREDIT_RESERVE",
+    expected: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+    valid: /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_RESERVE=473\s*(?:#.*)?$/,
+  },
+  {
+    name: "REMNIC_BENCH_CODEX_CREDIT_LEDGER",
+    expected:
+      'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+    valid:
+      /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_LEDGER="\$BUILD_WEEK_RUN_ROOT\/codex-credit-ledger\.json"\s*(?:#.*)?$/,
+  },
+]);
 const BUILD_WEEK_SHELL_LANGS = new Set(["", "bash", "sh", "shell", "shell-session", "zsh", "console"]);
+
+function isShellEnvMutation(line, name) {
+  return new RegExp(
+    `^\\s*(?:export(?:\\s+-n)?\\s+${name}(?:\\s*=|\\s*$)|${name}\\s*=|unset(?:\\s+-v)?\\s+${name}\\b)`,
+  ).test(line);
+}
 
 // Fenced code blocks: ```lang ... ``` or ~~~lang ... ~~~. We only extract
 // from inside fences — NOT from inline code spans (`remnic <cmd>`) in
@@ -363,15 +384,17 @@ function extractRemnicInvocations(relPath, src) {
  * are ordinary multiline shell invocations, not arbitrary shell programs.
  *
  * @param {string} src
- * @returns {Array<{ command: string; commandStartLine: number; blockHasCreditBudgetMutation: boolean }>}
+ * @returns {Array<{ command: string; commandStartLine: number; blockHasCreditProtocolMutation: boolean }>}
  */
 function extractLogicalShellCommands(src) {
   const commands = [];
   for (const block of extractFencedBlocks(src)) {
     if (!BUILD_WEEK_SHELL_LANGS.has(block.lang)) continue;
     const lines = block.text.split("\n");
-    const blockHasCreditBudgetMutation = lines.some(
-      (line) => !/^\s*#/.test(line) && BUILD_WEEK_CREDIT_BUDGET_MUTATION_RE.test(line),
+    const blockHasCreditProtocolMutation = lines.some(
+      (line) =>
+        !/^\s*#/.test(line) &&
+        BUILD_WEEK_CREDIT_ENV_CONTRACTS.some(({ name }) => isShellEnvMutation(line, name)),
     );
     let logicalParts = [];
     let logicalStartIndex = 0;
@@ -386,7 +409,7 @@ function extractLogicalShellCommands(src) {
         commands.push({
           command,
           commandStartLine: block.startLine + 1 + logicalStartIndex,
-          blockHasCreditBudgetMutation,
+          blockHasCreditProtocolMutation,
         });
       }
       logicalParts = [];
@@ -401,17 +424,20 @@ function extractLogicalShellCommands(src) {
  * Prose and non-shell fences never affect executable environment state.
  *
  * @param {string} src
- * @returns {Array<{ line: number; valid: boolean }>}
+ * @returns {Array<{ name: string; line: number; valid: boolean }>}
  */
-function extractShellCreditBudgetMutations(src) {
+function extractShellCreditProtocolMutations(src) {
   const mutations = [];
   for (const block of extractFencedBlocks(src)) {
     if (!BUILD_WEEK_SHELL_LANGS.has(block.lang)) continue;
     for (const [index, line] of block.text.split("\n").entries()) {
-      if (!/^\s*#/.test(line) && BUILD_WEEK_CREDIT_BUDGET_MUTATION_RE.test(line)) {
+      if (/^\s*#/.test(line)) continue;
+      for (const contract of BUILD_WEEK_CREDIT_ENV_CONTRACTS) {
+        if (!isShellEnvMutation(line, contract.name)) continue;
         mutations.push({
+          name: contract.name,
           line: block.startLine + 1 + index,
-          valid: BUILD_WEEK_CREDIT_GUARD_LINE_RE.test(line),
+          valid: contract.valid.test(line),
         });
       }
     }
@@ -480,30 +506,29 @@ function checkBuildWeekCodexDatasetPaths() {
     const abs = path.join(ROOT, ...rel.split("/"));
     if (!existsSync(abs)) continue;
     const src = readFileSync(abs, "utf8");
-    const creditBudgetMutations = extractShellCreditBudgetMutations(src);
+    const creditProtocolMutations = extractShellCreditProtocolMutations(src);
     let checkedInDoc = 0;
-    for (const { command, commandStartLine, blockHasCreditBudgetMutation } of extractLogicalShellCommands(src)) {
+    for (const { command, commandStartLine, blockHasCreditProtocolMutation } of extractLogicalShellCommands(src)) {
       if (!/\bremnic\s+bench\s+run\b/.test(command)) continue;
       const usesCodexCli = /\bcodex-cli\b/.test(command);
-      if (!blockHasCreditBudgetMutation && !usesCodexCli) continue;
+      if (!blockHasCreditProtocolMutation && !usesCodexCli) continue;
       const commandTokens = command.trim().split(/\s+/);
       const datasetFlag = extractShellOptionValue(command, "--dataset-dir");
       const positionalBenchmarks = extractRunBenchmarks(command) ?? [];
       checked += 1;
       checkedInDoc += 1;
-      const lastCreditBudgetMutation = creditBudgetMutations.findLast(
-        ({ line }) => line < commandStartLine,
-      );
       const remnicCommandAt = command.search(/\bremnic\s+bench\s+run\b/);
       const commandPrefix = remnicCommandAt > 0 ? command.slice(0, remnicCommandAt) : "";
-      const hasSameCommandBudgetMutation = commandPrefix.includes(
-        "REMNIC_BENCH_CODEX_CREDIT_BUDGET",
-      );
-      if (!lastCreditBudgetMutation?.valid || hasSameCommandBudgetMutation) {
-        failures.push(
-          `${rel}: Build Week Codex command must follow a shell export of ` +
-            "`REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`",
+      for (const contract of BUILD_WEEK_CREDIT_ENV_CONTRACTS) {
+        const lastMutation = creditProtocolMutations.findLast(
+          ({ name, line }) => name === contract.name && line < commandStartLine,
         );
+        if (!lastMutation?.valid || commandPrefix.includes(contract.name)) {
+          failures.push(
+            `${rel}: Build Week Codex command must follow an exact shell export of ` +
+              `\`${contract.expected}\``,
+          );
+        }
       }
       const remnicAt = commandTokens.indexOf("remnic");
       const disallowedFlags = [

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -132,6 +132,7 @@ const BUILD_WEEK_ALLOWED_RUN_FLAGS = new Set([
 
 const BUILD_WEEK_CREDIT_GUARD_LINE_RE =
   /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473\s*(?:#.*)?$/m;
+const BUILD_WEEK_SHELL_LANGS = new Set(["", "bash", "sh", "shell", "shell-session", "zsh", "console"]);
 
 // Fenced code blocks: ```lang ... ``` or ~~~lang ... ~~~. We only extract
 // from inside fences — NOT from inline code spans (`remnic <cmd>`) in
@@ -363,18 +364,9 @@ function extractRemnicInvocations(relPath, src) {
  * @returns {Array<{ command: string; guardedBuildWeekBlock: boolean; blockStartLine: number }>}
  */
 function extractLogicalShellCommands(src) {
-  const shellLangs = new Set([
-    "",
-    "bash",
-    "sh",
-    "shell",
-    "shell-session",
-    "zsh",
-    "console",
-  ]);
   const commands = [];
   for (const block of extractFencedBlocks(src)) {
-    if (!shellLangs.has(block.lang)) continue;
+    if (!BUILD_WEEK_SHELL_LANGS.has(block.lang)) continue;
     const guardAt = block.text.search(BUILD_WEEK_CREDIT_GUARD_LINE_RE);
     let firstRunAt = -1;
     let offset = 0;
@@ -398,6 +390,26 @@ function extractLogicalShellCommands(src) {
     }
   }
   return commands;
+}
+
+/**
+ * Return absolute Markdown line numbers for executable credit-budget exports.
+ * Prose and non-shell fences must not authorize a later copy-pasteable command.
+ *
+ * @param {string} src
+ * @returns {number[]}
+ */
+function extractShellCreditGuardLines(src) {
+  const guardLines = [];
+  for (const block of extractFencedBlocks(src)) {
+    if (!BUILD_WEEK_SHELL_LANGS.has(block.lang)) continue;
+    for (const [index, line] of block.text.split("\n").entries()) {
+      if (BUILD_WEEK_CREDIT_GUARD_LINE_RE.test(line)) {
+        guardLines.push(block.startLine + 1 + index);
+      }
+    }
+  }
+  return guardLines;
 }
 
 /**
@@ -461,9 +473,7 @@ function checkBuildWeekCodexDatasetPaths() {
     const abs = path.join(ROOT, ...rel.split("/"));
     if (!existsSync(abs)) continue;
     const src = readFileSync(abs, "utf8");
-    const creditGuardLine = src
-      .split("\n")
-      .findIndex((line) => BUILD_WEEK_CREDIT_GUARD_LINE_RE.test(line)) + 1;
+    const creditGuardLines = extractShellCreditGuardLines(src);
     let checkedInDoc = 0;
     for (const { command, guardedBuildWeekBlock, blockStartLine } of extractLogicalShellCommands(src)) {
       if (!/\bremnic\s+bench\s+run\b/.test(command)) continue;
@@ -475,7 +485,7 @@ function checkBuildWeekCodexDatasetPaths() {
       checked += 1;
       checkedInDoc += 1;
       const creditGuardPrecedesCommand =
-        guardedBuildWeekBlock || (creditGuardLine > 0 && creditGuardLine < blockStartLine);
+        guardedBuildWeekBlock || creditGuardLines.some((line) => line < blockStartLine);
       if (!creditGuardPrecedesCommand) {
         failures.push(
           `${rel}: Build Week Codex command must follow a shell export of ` +

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -85,6 +85,32 @@ const SKIPPED_DIR_NAMES = new Set([
   "target",
 ]);
 
+// Build Week's credit-backed commands must use the operator-staged datasets.
+// Without an explicit override, full runs may auto-select the CLI-managed
+// dataset store. Quick mode is unsafe even with an override because an absent
+// or unreadable staged path falls back to a bundled fixture. Either source
+// silently changes the measured workload and invalidates the run receipt.
+const BUILD_WEEK_CODEX_DOCS = Object.freeze([
+  "HACKATHON.md",
+  "packages/bench/README.md",
+  "docs/benchmarks.md",
+  "docs/paper/repro-appendix.md",
+]);
+
+const BENCH_RUN_BOOLEAN_FLAGS = new Set([
+  "--mcp-demo",
+  "--quick",
+  "--all",
+  "--json",
+  "--internal-disable-thinking",
+  "--disable-thinking",
+  "--no-judge-cache",
+  "--resume",
+  "--retry-failed",
+  "--help",
+  "-h",
+]);
+
 // Fenced code blocks: ```lang ... ``` or ~~~lang ... ~~~. We only extract
 // from inside fences — NOT from inline code spans (`remnic <cmd>`) in
 // prose, tables, or list items. Inline code in this repo references
@@ -304,6 +330,161 @@ function extractRemnicInvocations(relPath, src) {
     }
   }
   return out;
+}
+
+/**
+ * Normalize shell-like fenced blocks into logical commands by joining lines
+ * ending in a backslash. This is intentionally small: the Build Week commands
+ * are ordinary multiline shell invocations, not arbitrary shell programs.
+ *
+ * @param {string} src
+ * @returns {string[]}
+ */
+function extractLogicalShellCommands(src) {
+  const shellLangs = new Set([
+    "",
+    "bash",
+    "sh",
+    "shell",
+    "shell-session",
+    "zsh",
+    "console",
+  ]);
+  const commands = [];
+  for (const block of extractFencedBlocks(src)) {
+    if (!shellLangs.has(block.lang)) continue;
+    const logical = block.text.replace(/\\\s*\n/g, " ");
+    for (const line of logical.split("\n")) {
+      const command = line.trim();
+      if (command.length > 0 && !command.startsWith("#")) {
+        commands.push(command);
+      }
+    }
+  }
+  return commands;
+}
+
+/**
+ * Read the positional benchmark after `remnic bench run`, skipping options
+ * that may legally precede it. This intentionally tokenizes only the simple
+ * documented shell commands handled by extractLogicalShellCommands.
+ *
+ * @param {string} command
+ * @returns {string | undefined}
+ */
+function extractRunBenchmark(command) {
+  const tokens = command.trim().split(/\s+/);
+  const remnicAt = tokens.indexOf("remnic");
+  if (remnicAt < 0 || tokens[remnicAt + 1] !== "bench" || tokens[remnicAt + 2] !== "run") {
+    return undefined;
+  }
+  for (let i = remnicAt + 3; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (BENCH_RUN_BOOLEAN_FLAGS.has(token)) continue;
+    if (token.startsWith("-")) {
+      if (!token.includes("=")) i += 1;
+      continue;
+    }
+    return token;
+  }
+  return undefined;
+}
+
+/**
+ * Read a simple, space-separated option value from a documented command.
+ * Missing values and another flag in value position both return undefined.
+ *
+ * @param {string} command
+ * @param {string} flag
+ * @returns {string | undefined}
+ */
+function extractShellOptionValue(command, flag) {
+  const tokens = command.trim().split(/\s+/);
+  const at = tokens.indexOf(flag);
+  if (at < 0) return undefined;
+  const value = tokens[at + 1];
+  if (!value || (value.startsWith("-") && !/^-\d/.test(value))) return undefined;
+  return value;
+}
+
+/**
+ * Enforce the staged-dataset contract for every documented Codex CLI
+ * LongMemEval/LoCoMo benchmark command.
+ *
+ * @returns {{ failures: string[]; checked: number }}
+ */
+function checkBuildWeekCodexDatasetPaths() {
+  const failures = [];
+  let checked = 0;
+  for (const rel of BUILD_WEEK_CODEX_DOCS) {
+    const abs = path.join(ROOT, ...rel.split("/"));
+    if (!existsSync(abs)) continue;
+    const src = readFileSync(abs, "utf8");
+    for (const command of extractLogicalShellCommands(src)) {
+      if (!/\bremnic\s+bench\s+run\b/.test(command)) continue;
+      if (!/\bcodex-cli\b/.test(command)) continue;
+      const commandTokens = command.trim().split(/\s+/);
+      const datasetFlag = extractShellOptionValue(command, "--dataset-dir");
+      const stagedBenchmark = datasetFlag?.match(
+        /^\.\/bench-datasets\/(longmemeval|locomo)$/,
+      )?.[1];
+      const positionalBenchmark = extractRunBenchmark(command);
+      if (!stagedBenchmark && positionalBenchmark !== "longmemeval" && positionalBenchmark !== "locomo") {
+        continue;
+      }
+      checked += 1;
+      if (positionalBenchmark !== "longmemeval" && positionalBenchmark !== "locomo") {
+        failures.push(
+          `${rel}: Build Week Codex command must include positional benchmark \`longmemeval\` or \`locomo\` after \`remnic bench run\``,
+        );
+        continue;
+      }
+      const benchmark = positionalBenchmark;
+      const expected = `./bench-datasets/${benchmark}`;
+      if (datasetFlag !== expected) {
+        failures.push(
+          `${rel}: Build Week Codex ${benchmark} command must include ` +
+            `\`--dataset-dir ${expected}\`; got ${datasetFlag ?? "no --dataset-dir"}`,
+        );
+      }
+      if (command.includes("evals/datasets")) {
+        failures.push(
+          `${rel}: Build Week Codex ${benchmark} command must not use the CLI-managed evals/datasets store`,
+        );
+      }
+      if (commandTokens.includes("--quick")) {
+        failures.push(
+          `${rel}: Build Week Codex ${benchmark} command must not use \`--quick\`; ` +
+            "use full mode with an explicit item bound so a bad staged path fails before provider dispatch",
+        );
+      }
+      const supportedBoundFlags =
+        benchmark === "longmemeval" ? ["--limit"] : ["--limit", "--trial-limit"];
+      const presentBoundFlags = supportedBoundFlags.filter((flag) =>
+        commandTokens.includes(flag),
+      );
+      if (presentBoundFlags.length === 0) {
+        failures.push(
+          benchmark === "longmemeval"
+            ? `${rel}: Build Week Codex longmemeval command must include an explicit \`--limit\``
+            : `${rel}: Build Week Codex locomo command must include an explicit \`--limit\` or \`--trial-limit\``,
+        );
+      }
+      for (const flag of presentBoundFlags) {
+        const value = extractShellOptionValue(command, flag);
+        if (value === undefined) {
+          failures.push(`${rel}: Build Week Codex ${benchmark} command has no value for \`${flag}\``);
+          continue;
+        }
+        if (!/^(?:[1-9]\d*|<LEDGER_DERIVED_LIMIT>)$/.test(value)) {
+          failures.push(
+            `${rel}: Build Week Codex ${benchmark} ${flag} must be a positive integer or \`<LEDGER_DERIVED_LIMIT>\`; got ${value}`,
+          );
+        }
+      }
+    }
+  }
+  return { failures, checked };
 }
 
 // ── Registered-command discovery (TODO: replace with #1532 registrar) ─────
@@ -750,6 +931,11 @@ function main() {
     );
   }
 
+  // (d) Build Week staged-dataset pinning. This gate is static and makes no
+  // provider, model, network, or dataset call.
+  const buildWeekDatasets = checkBuildWeekCodexDatasetPaths();
+  failures.push(...buildWeekDatasets.failures);
+
   // (c) No-op allowlist. Detect no-op handlers in the CLI, then require every
   // detected no-op to be in NO_OP_ALLOWLIST with a non-empty tracking issue.
   const detectedNoOps = detectNoOpHandlers(CLI_FILES);
@@ -801,7 +987,8 @@ function main() {
   console.log(
     `[docs-parity] OK — ${docCommands.length} documented command(s) resolve; ` +
       `${detectedNoOps.size} no-op(s) tracked; ` +
-      `${[...publishers.values()].filter((p) => p.isStub).length} stub publisher(s) honest.`,
+      `${[...publishers.values()].filter((p) => p.isStub).length} stub publisher(s) honest; ` +
+      `${buildWeekDatasets.checked} Build Week Codex dataset command(s) pinned.`,
   );
   if (docCommands.length > 0) {
     console.log(`[docs-parity]   commands: ${docCommands.join(", ")}`);

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -376,7 +376,18 @@ function extractLogicalShellCommands(src) {
   for (const block of extractFencedBlocks(src)) {
     if (!shellLangs.has(block.lang)) continue;
     const guardAt = block.text.search(BUILD_WEEK_CREDIT_GUARD_LINE_RE);
-    const firstRunAt = block.text.search(/\bremnic\s+bench\s+run\b/);
+    let firstRunAt = -1;
+    let offset = 0;
+    for (const line of block.text.split("\n")) {
+      if (!/^\s*#/.test(line)) {
+        const runAt = line.search(/\bremnic\s+bench\s+run\b/);
+        if (runAt >= 0) {
+          firstRunAt = offset + runAt;
+          break;
+        }
+      }
+      offset += line.length + 1;
+    }
     const guardedBuildWeekBlock = guardAt >= 0 && firstRunAt >= 0 && guardAt < firstRunAt;
     const logical = block.text.replace(/\\\s*\n/g, " ");
     for (const line of logical.split("\n")) {

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -132,6 +132,8 @@ const BUILD_WEEK_ALLOWED_RUN_FLAGS = new Set([
 
 const BUILD_WEEK_CREDIT_GUARD_LINE_RE =
   /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473\s*(?:#.*)?$/m;
+const BUILD_WEEK_CREDIT_BUDGET_MUTATION_RE =
+  /^\s*(?:export(?:\s+-n)?\s+REMNIC_BENCH_CODEX_CREDIT_BUDGET(?:\s*=|\s*$)|REMNIC_BENCH_CODEX_CREDIT_BUDGET\s*=|unset(?:\s+-v)?\s+REMNIC_BENCH_CODEX_CREDIT_BUDGET\b)/;
 const BUILD_WEEK_SHELL_LANGS = new Set(["", "bash", "sh", "shell", "shell-session", "zsh", "console"]);
 
 // Fenced code blocks: ```lang ... ``` or ~~~lang ... ~~~. We only extract
@@ -361,55 +363,60 @@ function extractRemnicInvocations(relPath, src) {
  * are ordinary multiline shell invocations, not arbitrary shell programs.
  *
  * @param {string} src
- * @returns {Array<{ command: string; guardedBuildWeekBlock: boolean; blockStartLine: number }>}
+ * @returns {Array<{ command: string; commandStartLine: number; blockHasCreditBudgetMutation: boolean }>}
  */
 function extractLogicalShellCommands(src) {
   const commands = [];
   for (const block of extractFencedBlocks(src)) {
     if (!BUILD_WEEK_SHELL_LANGS.has(block.lang)) continue;
-    const guardAt = block.text.search(BUILD_WEEK_CREDIT_GUARD_LINE_RE);
-    let firstRunAt = -1;
-    let offset = 0;
-    for (const line of block.text.split("\n")) {
-      if (!/^\s*#/.test(line)) {
-        const runAt = line.search(/\bremnic\s+bench\s+run\b/);
-        if (runAt >= 0) {
-          firstRunAt = offset + runAt;
-          break;
-        }
-      }
-      offset += line.length + 1;
-    }
-    const guardedBuildWeekBlock = guardAt >= 0 && firstRunAt >= 0 && guardAt < firstRunAt;
-    const logical = block.text.replace(/\\\s*\n/g, " ");
-    for (const line of logical.split("\n")) {
-      const command = line.trim();
+    const lines = block.text.split("\n");
+    const blockHasCreditBudgetMutation = lines.some(
+      (line) => !/^\s*#/.test(line) && BUILD_WEEK_CREDIT_BUDGET_MUTATION_RE.test(line),
+    );
+    let logicalParts = [];
+    let logicalStartIndex = 0;
+    for (let index = 0; index < lines.length; index++) {
+      const line = lines[index];
+      if (logicalParts.length === 0) logicalStartIndex = index;
+      const continues = /\\\s*$/.test(line);
+      logicalParts.push(line.replace(/\\\s*$/, ""));
+      if (continues && index + 1 < lines.length) continue;
+      const command = logicalParts.join(" ").trim();
       if (command.length > 0 && !command.startsWith("#")) {
-        commands.push({ command, guardedBuildWeekBlock, blockStartLine: block.startLine });
+        commands.push({
+          command,
+          commandStartLine: block.startLine + 1 + logicalStartIndex,
+          blockHasCreditBudgetMutation,
+        });
       }
+      logicalParts = [];
     }
   }
   return commands;
 }
 
 /**
- * Return absolute Markdown line numbers for executable credit-budget exports.
- * Prose and non-shell fences must not authorize a later copy-pasteable command.
+ * Return document-ordered shell mutations of the credit budget. The last
+ * mutation before a command determines whether its child process is guarded.
+ * Prose and non-shell fences never affect executable environment state.
  *
  * @param {string} src
- * @returns {number[]}
+ * @returns {Array<{ line: number; valid: boolean }>}
  */
-function extractShellCreditGuardLines(src) {
-  const guardLines = [];
+function extractShellCreditBudgetMutations(src) {
+  const mutations = [];
   for (const block of extractFencedBlocks(src)) {
     if (!BUILD_WEEK_SHELL_LANGS.has(block.lang)) continue;
     for (const [index, line] of block.text.split("\n").entries()) {
-      if (BUILD_WEEK_CREDIT_GUARD_LINE_RE.test(line)) {
-        guardLines.push(block.startLine + 1 + index);
+      if (!/^\s*#/.test(line) && BUILD_WEEK_CREDIT_BUDGET_MUTATION_RE.test(line)) {
+        mutations.push({
+          line: block.startLine + 1 + index,
+          valid: BUILD_WEEK_CREDIT_GUARD_LINE_RE.test(line),
+        });
       }
     }
   }
-  return guardLines;
+  return mutations;
 }
 
 /**
@@ -473,20 +480,21 @@ function checkBuildWeekCodexDatasetPaths() {
     const abs = path.join(ROOT, ...rel.split("/"));
     if (!existsSync(abs)) continue;
     const src = readFileSync(abs, "utf8");
-    const creditGuardLines = extractShellCreditGuardLines(src);
+    const creditBudgetMutations = extractShellCreditBudgetMutations(src);
     let checkedInDoc = 0;
-    for (const { command, guardedBuildWeekBlock, blockStartLine } of extractLogicalShellCommands(src)) {
+    for (const { command, commandStartLine, blockHasCreditBudgetMutation } of extractLogicalShellCommands(src)) {
       if (!/\bremnic\s+bench\s+run\b/.test(command)) continue;
       const usesCodexCli = /\bcodex-cli\b/.test(command);
-      if (!guardedBuildWeekBlock && !usesCodexCli) continue;
+      if (!blockHasCreditBudgetMutation && !usesCodexCli) continue;
       const commandTokens = command.trim().split(/\s+/);
       const datasetFlag = extractShellOptionValue(command, "--dataset-dir");
       const positionalBenchmarks = extractRunBenchmarks(command) ?? [];
       checked += 1;
       checkedInDoc += 1;
-      const creditGuardPrecedesCommand =
-        guardedBuildWeekBlock || creditGuardLines.some((line) => line < blockStartLine);
-      if (!creditGuardPrecedesCommand) {
+      const lastCreditBudgetMutation = creditBudgetMutations.findLast(
+        ({ line }) => line < commandStartLine,
+      );
+      if (!lastCreditBudgetMutation?.valid) {
         failures.push(
           `${rel}: Build Week Codex command must follow a shell export of ` +
             "`REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`",
@@ -611,6 +619,16 @@ function checkBuildWeekCodexDatasetPaths() {
         if (!/^(?:[1-9]\d*|<LEDGER_DERIVED_LIMIT>)$/.test(value)) {
           failures.push(
             `${rel}: Build Week Codex ${benchmark} ${flag} must be a positive integer or \`<LEDGER_DERIVED_LIMIT>\`; got ${value}`,
+          );
+        }
+      }
+      if (expectedCommands === 2) {
+        const limit = extractShellOptionValue(command, "--limit");
+        const requiredLimit = checkedInDoc === 1 ? "1" : "<LEDGER_DERIVED_LIMIT>";
+        if (limit !== requiredLimit) {
+          failures.push(
+            `${rel}: Build Week Codex command ${checkedInDoc} of 2 must include ` +
+              `\`--limit ${requiredLimit}\`; got ${limit ?? "no --limit"}`,
           );
         }
       }

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -131,7 +131,7 @@ const BUILD_WEEK_ALLOWED_RUN_FLAGS = new Set([
 ]);
 
 const BUILD_WEEK_CREDIT_GUARD_LINE_RE =
-  /^\s*(?:export\s+)?REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473\s*(?:#.*)?$/m;
+  /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473\s*(?:#.*)?$/m;
 
 // Fenced code blocks: ```lang ... ``` or ~~~lang ... ~~~. We only extract
 // from inside fences — NOT from inline code spans (`remnic <cmd>`) in

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -452,10 +452,22 @@ function checkBuildWeekCodexDatasetPaths() {
             "use full mode with an explicit item bound so a bad staged path fails before provider dispatch",
         );
       }
+      const allBoundFlags = ["--limit", "--trial-limit"];
       const supportedBoundFlags =
-        benchmark === "longmemeval" ? ["--limit"] : ["--limit", "--trial-limit"];
+        benchmark === "longmemeval" ? ["--limit"] : allBoundFlags;
+      const unsupportedBoundFlags = allBoundFlags.filter(
+        (flag) =>
+          !supportedBoundFlags.includes(flag) &&
+          commandTokens.some((token) => token === flag || token.startsWith(`${flag}=`)),
+      );
+      for (const flag of unsupportedBoundFlags) {
+        failures.push(
+          `${rel}: Build Week Codex ${benchmark} command must not include \`${flag}\`; ` +
+            "the benchmark CLI does not support that bound",
+        );
+      }
       const presentBoundFlags = supportedBoundFlags.filter((flag) =>
-        commandTokens.includes(flag),
+        commandTokens.some((token) => token === flag || token.startsWith(`${flag}=`)),
       );
       if (presentBoundFlags.length === 0) {
         failures.push(

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -365,29 +365,31 @@ function extractLogicalShellCommands(src) {
 }
 
 /**
- * Read the positional benchmark after `remnic bench run`, skipping options
- * that may legally precede it. This intentionally tokenizes only the simple
- * documented shell commands handled by extractLogicalShellCommands.
+ * Read every positional benchmark after `remnic bench run`, skipping options
+ * and their values. This intentionally tokenizes only the simple documented
+ * shell commands handled by extractLogicalShellCommands.
  *
  * @param {string} command
- * @returns {string | undefined}
+ * @returns {string[] | undefined}
  */
-function extractRunBenchmark(command) {
+function extractRunBenchmarks(command) {
   const tokens = command.trim().split(/\s+/);
   const remnicAt = tokens.indexOf("remnic");
   if (remnicAt < 0 || tokens[remnicAt + 1] !== "bench" || tokens[remnicAt + 2] !== "run") {
     return undefined;
   }
+  const benchmarks = [];
   for (let i = remnicAt + 3; i < tokens.length; i++) {
     const token = tokens[i];
     if (BENCH_RUN_BOOLEAN_FLAGS.has(token)) continue;
     if (token.startsWith("-")) {
-      if (!token.includes("=")) i += 1;
+      const next = tokens[i + 1];
+      if (!token.includes("=") && next && !next.startsWith("-")) i += 1;
       continue;
     }
-    return token;
+    benchmarks.push(token);
   }
-  return undefined;
+  return benchmarks;
 }
 
 /**
@@ -425,15 +427,27 @@ function checkBuildWeekCodexDatasetPaths() {
       if (!/\bcodex-cli\b/.test(command)) continue;
       const commandTokens = command.trim().split(/\s+/);
       const datasetFlag = extractShellOptionValue(command, "--dataset-dir");
-      const positionalBenchmark = extractRunBenchmark(command);
+      const positionalBenchmarks = extractRunBenchmarks(command) ?? [];
       checked += 1;
-      if (positionalBenchmark !== "longmemeval" && positionalBenchmark !== "locomo") {
+      for (const selector of ["--all", "--custom", "--matrix"]) {
+        if (commandTokens.some((token) => token === selector || token.startsWith(`${selector}=`))) {
+          failures.push(
+            `${rel}: Build Week Codex command must not include \`${selector}\`; ` +
+              "run exactly one pinned benchmark and runtime profile",
+          );
+        }
+      }
+      if (
+        positionalBenchmarks.length !== 1 ||
+        (positionalBenchmarks[0] !== "longmemeval" && positionalBenchmarks[0] !== "locomo")
+      ) {
         failures.push(
-          `${rel}: Build Week Codex command must include positional benchmark \`longmemeval\` or \`locomo\` after \`remnic bench run\``,
+          `${rel}: Build Week Codex command must include exactly one positional benchmark, ` +
+            `\`longmemeval\` or \`locomo\`, after \`remnic bench run\``,
         );
         continue;
       }
-      const benchmark = positionalBenchmark;
+      const benchmark = positionalBenchmarks[0];
       const expected = `./bench-datasets/${benchmark}`;
       if (datasetFlag !== expected) {
         failures.push(

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -496,9 +496,9 @@ function checkBuildWeekCodexDatasetPaths() {
       );
       const remnicCommandAt = command.search(/\bremnic\s+bench\s+run\b/);
       const commandPrefix = remnicCommandAt > 0 ? command.slice(0, remnicCommandAt) : "";
-      const hasSameCommandBudgetMutation = commandPrefix
-        .split(/[;&]+/)
-        .some((statement) => BUILD_WEEK_CREDIT_BUDGET_MUTATION_RE.test(statement));
+      const hasSameCommandBudgetMutation = commandPrefix.includes(
+        "REMNIC_BENCH_CODEX_CREDIT_BUDGET",
+      );
       if (!lastCreditBudgetMutation?.valid || hasSameCommandBudgetMutation) {
         failures.push(
           `${rel}: Build Week Codex command must follow a shell export of ` +
@@ -628,12 +628,17 @@ function checkBuildWeekCodexDatasetPaths() {
         }
       }
       if (expectedCommands === 2) {
-        const limit = extractShellOptionValue(command, "--limit");
         const requiredLimit = checkedInDoc === 1 ? "1" : "<LEDGER_DERIVED_LIMIT>";
-        if (limit !== requiredLimit) {
+        const roleBounds = presentBoundFlags.map((flag) => ({
+          flag,
+          value: extractShellOptionValue(command, flag),
+        }));
+        if (roleBounds.length !== 1 || roleBounds[0].value !== requiredLimit) {
+          const acceptedFlags = supportedBoundFlags.map((flag) => `\`${flag} ${requiredLimit}\``);
+          const actualBounds = roleBounds.map(({ flag, value }) => `${flag} ${value ?? "<missing>"}`);
           failures.push(
-            `${rel}: Build Week Codex command ${checkedInDoc} of 2 must include ` +
-              `\`--limit ${requiredLimit}\`; got ${limit ?? "no --limit"}`,
+            `${rel}: Build Week Codex command ${checkedInDoc} of 2 must include exactly one of ` +
+              `${acceptedFlags.join(" or ")}; got ${actualBounds.join(", ") || "no supported bound"}`,
           );
         }
       }

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -494,7 +494,12 @@ function checkBuildWeekCodexDatasetPaths() {
       const lastCreditBudgetMutation = creditBudgetMutations.findLast(
         ({ line }) => line < commandStartLine,
       );
-      if (!lastCreditBudgetMutation?.valid) {
+      const remnicCommandAt = command.search(/\bremnic\s+bench\s+run\b/);
+      const commandPrefix = remnicCommandAt > 0 ? command.slice(0, remnicCommandAt) : "";
+      const hasSameCommandBudgetMutation = commandPrefix
+        .split(/[;&]+/)
+        .some((statement) => BUILD_WEEK_CREDIT_BUDGET_MUTATION_RE.test(statement));
+      if (!lastCreditBudgetMutation?.valid || hasSameCommandBudgetMutation) {
         failures.push(
           `${rel}: Build Week Codex command must follow a shell export of ` +
             "`REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`",

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -111,8 +111,9 @@ const BENCH_RUN_BOOLEAN_FLAGS = new Set([
   "-h",
 ]);
 
-const BUILD_WEEK_ALLOWED_RUN_FLAGS = new Set([
-  "--json",
+const BUILD_WEEK_ALLOWED_RUN_BOOLEAN_FLAGS = new Set(["--json"]);
+
+const BUILD_WEEK_ALLOWED_RUN_VALUE_FLAGS = new Set([
   "--runtime-profile",
   "--limit",
   "--trial-limit",
@@ -128,6 +129,11 @@ const BUILD_WEEK_ALLOWED_RUN_FLAGS = new Set([
   "--judge-provider",
   "--judge-model",
   "--judge-codex-reasoning-effort",
+]);
+
+const BUILD_WEEK_ALLOWED_RUN_FLAGS = new Set([
+  ...BUILD_WEEK_ALLOWED_RUN_BOOLEAN_FLAGS,
+  ...BUILD_WEEK_ALLOWED_RUN_VALUE_FLAGS,
 ]);
 
 const BUILD_WEEK_CREDIT_ENV_CONTRACTS = Object.freeze([
@@ -534,19 +540,36 @@ function checkBuildWeekCodexDatasetPaths() {
         }
       }
       const remnicAt = commandTokens.indexOf("remnic");
-      const disallowedFlags = [
-        ...new Set(
-          commandTokens
-            .slice(remnicAt + 3)
-            .filter((token) => token.startsWith("--") || token === "-h")
-            .map((token) => token.split("=", 1)[0])
-            .filter((flag) => !BUILD_WEEK_ALLOWED_RUN_FLAGS.has(flag)),
-        ),
-      ];
-      for (const flag of disallowedFlags) {
-        failures.push(
-          `${rel}: Build Week Codex command must not include unpinned run flag \`${flag}\``,
-        );
+      const runOptionTokens = commandTokens.slice(remnicAt + 3);
+      const optionCounts = new Map();
+      for (let optionIndex = 0; optionIndex < runOptionTokens.length; optionIndex += 1) {
+        const token = runOptionTokens[optionIndex];
+        if (!token.startsWith("-")) continue;
+        if (!BUILD_WEEK_ALLOWED_RUN_FLAGS.has(token)) {
+          failures.push(
+            token.includes("=")
+              ? `${rel}: Build Week Codex command must use separate option/value tokens; ` +
+                `equals-form option \`${token}\` is not supported by the bench CLI`
+              : `${rel}: Build Week Codex command must not include unpinned run option \`${token}\``,
+          );
+          continue;
+        }
+        const count = (optionCounts.get(token) ?? 0) + 1;
+        optionCounts.set(token, count);
+        if (count > 1) {
+          failures.push(
+            `${rel}: Build Week Codex command must include option \`${token}\` at most once`,
+          );
+        }
+        if (BUILD_WEEK_ALLOWED_RUN_BOOLEAN_FLAGS.has(token)) continue;
+        const value = runOptionTokens[optionIndex + 1];
+        if (!value || value.startsWith("-")) {
+          failures.push(
+            `${rel}: Build Week Codex command option \`${token}\` requires a separate non-option value`,
+          );
+          continue;
+        }
+        optionIndex += 1;
       }
       for (const selector of ["--all", "--custom", "--matrix"]) {
         if (commandTokens.some((token) => token === selector || token.startsWith(`${selector}=`))) {

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -151,10 +151,13 @@ const BUILD_WEEK_CREDIT_ENV_CONTRACTS = Object.freeze([
 ]);
 const BUILD_WEEK_SHELL_LANGS = new Set(["", "bash", "sh", "shell", "shell-session", "zsh", "console"]);
 
-function isShellEnvMutation(line, name) {
-  return new RegExp(
-    `^\\s*(?:export(?:\\s+-n)?\\s+${name}(?:\\s*=|\\s*$)|${name}\\s*=|unset(?:\\s+-v)?\\s+${name}\\b)`,
-  ).test(line);
+function containsShellCreditProtocolName(line, name) {
+  // Shell offers too many mutation forms to enumerate safely (`+=`, arrays,
+  // declarations, multi-name builtins, arithmetic, `printf -v`, namerefs,
+  // and command lists). Paid-run fences therefore fail closed: the exact
+  // valid export is allowlisted below, while any other executable reference
+  // to a protected name becomes an invalid later protocol mutation.
+  return new RegExp(`\\b${name}\\b`).test(line);
 }
 
 // Fenced code blocks: ```lang ... ``` or ~~~lang ... ~~~. We only extract
@@ -394,7 +397,7 @@ function extractLogicalShellCommands(src) {
     const blockHasCreditProtocolMutation = lines.some(
       (line) =>
         !/^\s*#/.test(line) &&
-        BUILD_WEEK_CREDIT_ENV_CONTRACTS.some(({ name }) => isShellEnvMutation(line, name)),
+        BUILD_WEEK_CREDIT_ENV_CONTRACTS.some(({ name }) => containsShellCreditProtocolName(line, name)),
     );
     let logicalParts = [];
     let logicalStartIndex = 0;
@@ -433,7 +436,7 @@ function extractShellCreditProtocolMutations(src) {
     for (const [index, line] of block.text.split("\n").entries()) {
       if (/^\s*#/.test(line)) continue;
       for (const contract of BUILD_WEEK_CREDIT_ENV_CONTRACTS) {
-        if (!isShellEnvMutation(line, contract.name)) continue;
+        if (!containsShellCreditProtocolName(line, contract.name)) continue;
         mutations.push({
           name: contract.name,
           line: block.startLine + 1 + index,

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -357,7 +357,7 @@ function extractRemnicInvocations(relPath, src) {
  * are ordinary multiline shell invocations, not arbitrary shell programs.
  *
  * @param {string} src
- * @returns {Array<{ command: string; guardedBuildWeekBlock: boolean }>}
+ * @returns {Array<{ command: string; guardedBuildWeekBlock: boolean; blockStartLine: number }>}
  */
 function extractLogicalShellCommands(src) {
   const shellLangs = new Set([
@@ -372,14 +372,14 @@ function extractLogicalShellCommands(src) {
   const commands = [];
   for (const block of extractFencedBlocks(src)) {
     if (!shellLangs.has(block.lang)) continue;
-    const guardedBuildWeekBlock = block.text.includes(
-      "REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
-    );
+    const guardAt = block.text.indexOf("REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473");
+    const firstRunAt = block.text.search(/\bremnic\s+bench\s+run\b/);
+    const guardedBuildWeekBlock = guardAt >= 0 && firstRunAt >= 0 && guardAt < firstRunAt;
     const logical = block.text.replace(/\\\s*\n/g, " ");
     for (const line of logical.split("\n")) {
       const command = line.trim();
       if (command.length > 0 && !command.startsWith("#")) {
-        commands.push({ command, guardedBuildWeekBlock });
+        commands.push({ command, guardedBuildWeekBlock, blockStartLine: block.startLine });
       }
     }
   }
@@ -447,15 +447,27 @@ function checkBuildWeekCodexDatasetPaths() {
     const abs = path.join(ROOT, ...rel.split("/"));
     if (!existsSync(abs)) continue;
     const src = readFileSync(abs, "utf8");
+    const creditGuardLine = src
+      .split("\n")
+      .findIndex((line) => line.includes("REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473")) + 1;
     let checkedInDoc = 0;
-    for (const { command, guardedBuildWeekBlock } of extractLogicalShellCommands(src)) {
+    for (const { command, guardedBuildWeekBlock, blockStartLine } of extractLogicalShellCommands(src)) {
       if (!/\bremnic\s+bench\s+run\b/.test(command)) continue;
-      if (!guardedBuildWeekBlock && !/\bcodex-cli\b/.test(command)) continue;
+      const usesCodexCli = /\bcodex-cli\b/.test(command);
+      if (!guardedBuildWeekBlock && !usesCodexCli) continue;
       const commandTokens = command.trim().split(/\s+/);
       const datasetFlag = extractShellOptionValue(command, "--dataset-dir");
       const positionalBenchmarks = extractRunBenchmarks(command) ?? [];
       checked += 1;
       checkedInDoc += 1;
+      const creditGuardPrecedesCommand =
+        guardedBuildWeekBlock || (creditGuardLine > 0 && creditGuardLine < blockStartLine);
+      if (!creditGuardPrecedesCommand) {
+        failures.push(
+          `${rel}: Build Week Codex command must follow a shell export of ` +
+            "`REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`",
+        );
+      }
       const remnicAt = commandTokens.indexOf("remnic");
       const disallowedFlags = [
         ...new Set(

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -425,13 +425,7 @@ function checkBuildWeekCodexDatasetPaths() {
       if (!/\bcodex-cli\b/.test(command)) continue;
       const commandTokens = command.trim().split(/\s+/);
       const datasetFlag = extractShellOptionValue(command, "--dataset-dir");
-      const stagedBenchmark = datasetFlag?.match(
-        /^\.\/bench-datasets\/(longmemeval|locomo)$/,
-      )?.[1];
       const positionalBenchmark = extractRunBenchmark(command);
-      if (!stagedBenchmark && positionalBenchmark !== "longmemeval" && positionalBenchmark !== "locomo") {
-        continue;
-      }
       checked += 1;
       if (positionalBenchmark !== "longmemeval" && positionalBenchmark !== "locomo") {
         failures.push(

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -155,6 +155,16 @@ const BUILD_WEEK_CREDIT_ENV_CONTRACTS = Object.freeze([
       /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_LEDGER="\$BUILD_WEEK_RUN_ROOT\/codex-credit-ledger\.json"(?:[ \t]+#.*)?[ \t]*$/,
   },
 ]);
+const BUILD_WEEK_RESULTS_ENV_CONTRACT = Object.freeze({
+  name: "BUILD_WEEK_RESULTS_DIR",
+  expected: 'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"',
+  valid:
+    /^\s*export\s+BUILD_WEEK_RESULTS_DIR="\$BUILD_WEEK_RUN_ROOT\/results"(?:[ \t]+#.*)?[ \t]*$/,
+});
+const BUILD_WEEK_PAID_ENV_CONTRACTS = Object.freeze([
+  ...BUILD_WEEK_CREDIT_ENV_CONTRACTS,
+  BUILD_WEEK_RESULTS_ENV_CONTRACT,
+]);
 const BUILD_WEEK_SHELL_LANGS = new Set(["", "bash", "sh", "shell", "shell-session", "zsh", "console"]);
 
 function containsShellCreditProtocolName(line, name) {
@@ -164,6 +174,15 @@ function containsShellCreditProtocolName(line, name) {
   // valid export is allowlisted below, while any other executable reference
   // to a protected name becomes an invalid later protocol mutation.
   return new RegExp(`\\b${name}\\b`).test(line);
+}
+
+function containsShellResultsDirMutation(line) {
+  // Ordinary reads such as `--results-dir "$BUILD_WEEK_RESULTS_DIR"` must not
+  // invalidate the export. A bare variable name, however, covers direct shell
+  // mutation forms (assignment, export/unset, declarations, arrays,
+  // arithmetic, and `printf -v`) and therefore fails closed unless it is the
+  // exact allowlisted export above.
+  return new RegExp(`(?<![\\$\\{])\\b${BUILD_WEEK_RESULTS_ENV_CONTRACT.name}\\b`).test(line);
 }
 
 // Fenced code blocks: ```lang ... ``` or ~~~lang ... ~~~. We only extract
@@ -428,21 +447,26 @@ function extractLogicalShellCommands(src) {
 }
 
 /**
- * Return document-ordered shell mutations of the credit budget. The last
- * mutation before a command determines whether its child process is guarded.
- * Prose and non-shell fences never affect executable environment state.
+ * Return document-ordered shell mutations of paid-run environment contracts.
+ * The last mutation before a command determines whether its child process is
+ * guarded and writes to the private result store. Prose and non-shell fences
+ * never affect executable environment state.
  *
  * @param {string} src
  * @returns {Array<{ name: string; line: number; valid: boolean }>}
  */
-function extractShellCreditProtocolMutations(src) {
+function extractShellPaidRunEnvMutations(src) {
   const mutations = [];
   for (const block of extractFencedBlocks(src)) {
     if (!BUILD_WEEK_SHELL_LANGS.has(block.lang)) continue;
     for (const [index, line] of block.text.split("\n").entries()) {
       if (/^\s*#/.test(line)) continue;
-      for (const contract of BUILD_WEEK_CREDIT_ENV_CONTRACTS) {
-        if (!containsShellCreditProtocolName(line, contract.name)) continue;
+      for (const contract of BUILD_WEEK_PAID_ENV_CONTRACTS) {
+        const isMutation =
+          contract === BUILD_WEEK_RESULTS_ENV_CONTRACT
+            ? containsShellResultsDirMutation(line)
+            : containsShellCreditProtocolName(line, contract.name);
+        if (!isMutation) continue;
         mutations.push({
           name: contract.name,
           line: block.startLine + 1 + index,
@@ -515,7 +539,7 @@ function checkBuildWeekCodexDatasetPaths() {
     const abs = path.join(ROOT, ...rel.split("/"));
     if (!existsSync(abs)) continue;
     const src = readFileSync(abs, "utf8");
-    const creditProtocolMutations = extractShellCreditProtocolMutations(src);
+    const paidRunEnvMutations = extractShellPaidRunEnvMutations(src);
     let checkedInDoc = 0;
     for (const { command, commandStartLine, blockHasCreditProtocolMutation } of extractLogicalShellCommands(src)) {
       if (!/\bremnic\s+bench\s+run\b/.test(command)) continue;
@@ -539,8 +563,8 @@ function checkBuildWeekCodexDatasetPaths() {
       checkedInDoc += 1;
       const remnicCommandAt = command.search(/\bremnic\s+bench\s+run\b/);
       const commandPrefix = remnicCommandAt > 0 ? command.slice(0, remnicCommandAt) : "";
-      for (const contract of BUILD_WEEK_CREDIT_ENV_CONTRACTS) {
-        const lastMutation = creditProtocolMutations.findLast(
+      for (const contract of BUILD_WEEK_PAID_ENV_CONTRACTS) {
+        const lastMutation = paidRunEnvMutations.findLast(
           ({ name, line }) => name === contract.name && line < commandStartLine,
         );
         if (!lastMutation?.valid || commandPrefix.includes(contract.name)) {

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -466,6 +466,40 @@ function checkBuildWeekCodexDatasetPaths() {
             "use full mode with an explicit item bound so a bad staged path fails before provider dispatch",
         );
       }
+      const requiredProtocolOptions = new Map([
+        ["--runtime-profile", "real"],
+        ["--results-dir", '"$BUILD_WEEK_RESULTS_DIR"'],
+        ["--drain-timeout", "600000"],
+        ["--system-provider", "codex-cli"],
+        ["--system-model", "gpt-5.6-luna"],
+        ["--system-codex-reasoning-effort", "medium"],
+        ["--internal-provider", "codex-cli"],
+        ["--internal-model", "gpt-5.6-luna"],
+        ["--internal-codex-reasoning-effort", "medium"],
+        ["--judge-provider", "codex-cli"],
+        ["--judge-model", "gpt-5.6-terra"],
+        ["--judge-codex-reasoning-effort", "high"],
+      ]);
+      for (const [flag, requiredValue] of requiredProtocolOptions) {
+        const actualValue = extractShellOptionValue(command, flag);
+        if (actualValue !== requiredValue) {
+          failures.push(
+            `${rel}: Build Week Codex ${benchmark} command must include ` +
+              `\`${flag} ${requiredValue}\`; got ${actualValue ?? `no ${flag}`}`,
+          );
+        }
+      }
+      if (commandTokens.some((token) => token === "--request-timeout" || token.startsWith("--request-timeout="))) {
+        failures.push(
+          `${rel}: Build Week Codex ${benchmark} command must not include \`--request-timeout\`; ` +
+            "the Codex transport profile owns that timeout",
+        );
+      }
+      if (command.includes("gpt-5.6-sol")) {
+        failures.push(
+          `${rel}: Build Week Codex ${benchmark} command must not use \`gpt-5.6-sol\``,
+        );
+      }
       const allBoundFlags = ["--limit", "--trial-limit"];
       const supportedBoundFlags =
         benchmark === "longmemeval" ? ["--limit"] : allBoundFlags;

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -130,6 +130,9 @@ const BUILD_WEEK_ALLOWED_RUN_FLAGS = new Set([
   "--judge-codex-reasoning-effort",
 ]);
 
+const BUILD_WEEK_CREDIT_GUARD_LINE_RE =
+  /^\s*(?:export\s+)?REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473\s*(?:#.*)?$/m;
+
 // Fenced code blocks: ```lang ... ``` or ~~~lang ... ~~~. We only extract
 // from inside fences — NOT from inline code spans (`remnic <cmd>`) in
 // prose, tables, or list items. Inline code in this repo references
@@ -372,7 +375,7 @@ function extractLogicalShellCommands(src) {
   const commands = [];
   for (const block of extractFencedBlocks(src)) {
     if (!shellLangs.has(block.lang)) continue;
-    const guardAt = block.text.indexOf("REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473");
+    const guardAt = block.text.search(BUILD_WEEK_CREDIT_GUARD_LINE_RE);
     const firstRunAt = block.text.search(/\bremnic\s+bench\s+run\b/);
     const guardedBuildWeekBlock = guardAt >= 0 && firstRunAt >= 0 && guardAt < firstRunAt;
     const logical = block.text.replace(/\\\s*\n/g, " ");
@@ -449,7 +452,7 @@ function checkBuildWeekCodexDatasetPaths() {
     const src = readFileSync(abs, "utf8");
     const creditGuardLine = src
       .split("\n")
-      .findIndex((line) => line.includes("REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473")) + 1;
+      .findIndex((line) => BUILD_WEEK_CREDIT_GUARD_LINE_RE.test(line)) + 1;
     let checkedInDoc = 0;
     for (const { command, guardedBuildWeekBlock, blockStartLine } of extractLogicalShellCommands(src)) {
       if (!/\bremnic\s+bench\s+run\b/.test(command)) continue;

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -140,19 +140,19 @@ const BUILD_WEEK_CREDIT_ENV_CONTRACTS = Object.freeze([
   {
     name: "REMNIC_BENCH_CODEX_CREDIT_BUDGET",
     expected: "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
-    valid: /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473\s*(?:#.*)?$/,
+    valid: /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473(?:[ \t]+#.*)?[ \t]*$/,
   },
   {
     name: "REMNIC_BENCH_CODEX_CREDIT_RESERVE",
     expected: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
-    valid: /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_RESERVE=473\s*(?:#.*)?$/,
+    valid: /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_RESERVE=473(?:[ \t]+#.*)?[ \t]*$/,
   },
   {
     name: "REMNIC_BENCH_CODEX_CREDIT_LEDGER",
     expected:
       'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
     valid:
-      /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_LEDGER="\$BUILD_WEEK_RUN_ROOT\/codex-credit-ledger\.json"\s*(?:#.*)?$/,
+      /^\s*export\s+REMNIC_BENCH_CODEX_CREDIT_LEDGER="\$BUILD_WEEK_RUN_ROOT\/codex-credit-ledger\.json"(?:[ \t]+#.*)?[ \t]*$/,
   },
 ]);
 const BUILD_WEEK_SHELL_LANGS = new Set(["", "bash", "sh", "shell", "shell-session", "zsh", "console"]);
@@ -522,6 +522,17 @@ function checkBuildWeekCodexDatasetPaths() {
       const usesCodexCli = /\bcodex-cli\b/.test(command);
       if (!blockHasCreditProtocolMutation && !usesCodexCli) continue;
       const commandTokens = command.trim().split(/\s+/);
+      if (
+        commandTokens[0] !== "remnic" ||
+        commandTokens[1] !== "bench" ||
+        commandTokens[2] !== "run"
+      ) {
+        failures.push(
+          `${rel}: Build Week Codex benchmark must execute directly as \`remnic bench run\` ` +
+            "with no shell wrapper or command prefix",
+        );
+        continue;
+      }
       const datasetFlag = extractShellOptionValue(command, "--dataset-dir");
       const positionalBenchmarks = extractRunBenchmarks(command) ?? [];
       checked += 1;

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -111,6 +111,25 @@ const BENCH_RUN_BOOLEAN_FLAGS = new Set([
   "-h",
 ]);
 
+const BUILD_WEEK_ALLOWED_RUN_FLAGS = new Set([
+  "--json",
+  "--runtime-profile",
+  "--limit",
+  "--trial-limit",
+  "--dataset-dir",
+  "--results-dir",
+  "--drain-timeout",
+  "--system-provider",
+  "--system-model",
+  "--system-codex-reasoning-effort",
+  "--internal-provider",
+  "--internal-model",
+  "--internal-codex-reasoning-effort",
+  "--judge-provider",
+  "--judge-model",
+  "--judge-codex-reasoning-effort",
+]);
+
 // Fenced code blocks: ```lang ... ``` or ~~~lang ... ~~~. We only extract
 // from inside fences — NOT from inline code spans (`remnic <cmd>`) in
 // prose, tables, or list items. Inline code in this repo references
@@ -437,6 +456,21 @@ function checkBuildWeekCodexDatasetPaths() {
       const positionalBenchmarks = extractRunBenchmarks(command) ?? [];
       checked += 1;
       checkedInDoc += 1;
+      const remnicAt = commandTokens.indexOf("remnic");
+      const disallowedFlags = [
+        ...new Set(
+          commandTokens
+            .slice(remnicAt + 3)
+            .filter((token) => token.startsWith("--") || token === "-h")
+            .map((token) => token.split("=", 1)[0])
+            .filter((flag) => !BUILD_WEEK_ALLOWED_RUN_FLAGS.has(flag)),
+        ),
+      ];
+      for (const flag of disallowedFlags) {
+        failures.push(
+          `${rel}: Build Week Codex command must not include unpinned run flag \`${flag}\``,
+        );
+      }
       for (const selector of ["--all", "--custom", "--matrix"]) {
         if (commandTokens.some((token) => token === selector || token.startsWith(`${selector}=`))) {
           failures.push(

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -660,6 +660,7 @@ test("Build Week Codex commands accept only the matching staged dataset path", (
         "# Build Week",
         "",
         "```bash",
+        "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
         "remnic bench run --json longmemeval --limit 1 \\",
         "  --dataset-dir ./bench-datasets/longmemeval \\",
         "  --runtime-profile real --results-dir \"$BUILD_WEEK_RESULTS_DIR\" --drain-timeout 600000 \\",
@@ -681,6 +682,57 @@ test("Build Week Codex commands accept only the matching staged dataset path", (
     const result = runParity(root);
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /2 Build Week Codex dataset command\(s\) pinned/);
+  });
+});
+
+test("an otherwise valid Codex command fails without the credit-budget guard", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "remnic bench run longmemeval --limit 1 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+        "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+        "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+  });
+});
+
+test("a credit-budget guard after the Codex command does not authorize it", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "remnic bench run longmemeval --limit 1 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+        "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+        "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+        "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
   });
 });
 

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -662,11 +662,17 @@ test("Build Week Codex commands accept only the matching staged dataset path", (
         "```bash",
         "remnic bench run --json longmemeval --limit 1 \\",
         "  --dataset-dir ./bench-datasets/longmemeval \\",
-        "  --system-provider codex-cli --system-model gpt-5.6-luna",
+        "  --runtime-profile real --results-dir \"$BUILD_WEEK_RESULTS_DIR\" --drain-timeout 600000 \\",
+        "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+        "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
         "",
         "remnic bench run locomo --trial-limit 1 \\",
         "  --dataset-dir ./bench-datasets/locomo \\",
-        "  --judge-provider codex-cli --judge-model gpt-5.6-terra",
+        "  --runtime-profile real --results-dir \"$BUILD_WEEK_RESULTS_DIR\" --drain-timeout 600000 \\",
+        "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+        "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
         "```",
         "",
       ].join("\n"),
@@ -676,6 +682,49 @@ test("Build Week Codex commands accept only the matching staged dataset path", (
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /2 Build Week Codex dataset command\(s\) pinned/);
   });
+});
+
+test("Build Week Codex commands pin the complete paid-run protocol", () => {
+  const validProtocol = [
+    '--runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000',
+    "--system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium",
+    "--internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium",
+    "--judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+  ].join(" ");
+  for (const [label, protocol] of [
+    ["missing real profile", validProtocol.replace("--runtime-profile real ", "")],
+    ["baseline profile", validProtocol.replace("--runtime-profile real", "--runtime-profile baseline")],
+    ["wrong system model", validProtocol.replace("gpt-5.6-luna", "gpt-5.6-terra")],
+    ["Sol model", validProtocol.replace("gpt-5.6-luna", "gpt-5.6-sol")],
+    ["explicit request timeout", `${validProtocol} --request-timeout 180000`],
+  ]) {
+    withFixture((root) => {
+      writeFileSync(
+        path.join(root, "HACKATHON.md"),
+        [
+          "# Build Week",
+          "",
+          "```bash",
+          "remnic bench run longmemeval --limit 1 \\",
+          "  --dataset-dir ./bench-datasets/longmemeval \\",
+          "  " + protocol + " \\",
+          "  --system-provider codex-cli",
+          "```",
+          "",
+        ].join("\n"),
+      );
+
+      const result = runParity(root);
+      assert.equal(result.status, 1, `${label}: ${result.stderr}`);
+      if (label === "explicit request timeout") {
+        assert.match(result.stderr, /must not include `--request-timeout`/);
+      } else if (label === "Sol model") {
+        assert.match(result.stderr, /must not use `gpt-5\.6-sol`/);
+      } else {
+        assert.match(result.stderr, /must include `--(?:runtime-profile|system-model)/);
+      }
+    });
+  }
 });
 
 test("Build Week Codex quick mode is rejected even with a staged dataset path", () => {

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -852,6 +852,7 @@ test("a same-command credit-budget mutation before the run invalidates an earlie
   for (const prefix of [
     "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=100; ",
     "unset REMNIC_BENCH_CODEX_CREDIT_BUDGET; ",
+    "env REMNIC_BENCH_CODEX_CREDIT_BUDGET=3000 ",
   ]) {
     withFixture((root) => {
       writeFileSync(
@@ -976,7 +977,43 @@ test("the first command in a two-command paid sequence is exactly a one-item smo
 
     const result = runParity(root);
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /command 1 of 2 must include `--limit 1`; got 100/);
+    assert.match(result.stderr, /command 1 of 2 must include exactly one of `--limit 1`; got --limit 100/);
+  });
+});
+
+test("a two-command LoCoMo sequence accepts the benchmark-supported trial bound", () => {
+  withFixture((root) => {
+    const cliPath = path.join(root, "packages", "remnic-cli", "src", "index.ts");
+    writeFileSync(
+      cliPath,
+      readFileSyncSafe(cliPath).replace('"extensions" | "daemon";', '"extensions" | "daemon" | "bench";'),
+    );
+    const protocol = [
+      '--dataset-dir ./bench-datasets/locomo --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR"',
+      "--drain-timeout 600000",
+      "--system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium",
+      "--internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium",
+      "--judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+    ].join(" ");
+    const readme = path.join(root, "packages", "bench", "README.md");
+    mkdirSync(path.dirname(readme), { recursive: true });
+    writeFileSync(
+      readme,
+      [
+        "# Bench",
+        "",
+        "```bash",
+        "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        `remnic bench run locomo --trial-limit 1 ${protocol}`,
+        `remnic bench run locomo --trial-limit <LEDGER_DERIVED_LIMIT> ${protocol}`,
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /2 Build Week Codex dataset command\(s\) pinned/);
   });
 });
 

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -762,6 +762,32 @@ test("a commented credit-budget guard does not authorize a Codex command", () =>
   });
 });
 
+test("a non-exported credit-budget assignment does not authorize a Codex command", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "remnic bench run longmemeval --limit 1 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+        "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+        "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+  });
+});
+
 test("a comment mentioning bench run before the credit guard does not invalidate it", () => {
   withFixture((root) => {
     writeFileSync(

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -815,6 +815,39 @@ test("a credit-budget export in prose does not authorize a later shell command",
   });
 });
 
+test("a later credit-budget override or unset invalidates an earlier guard", () => {
+  for (const mutation of [
+    "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=100",
+    "export -n REMNIC_BENCH_CODEX_CREDIT_BUDGET",
+    "unset REMNIC_BENCH_CODEX_CREDIT_BUDGET",
+  ]) {
+    withFixture((root) => {
+      writeFileSync(
+        path.join(root, "HACKATHON.md"),
+        [
+          "# Build Week",
+          "",
+          "```bash",
+          "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+          mutation,
+          "remnic bench run longmemeval --limit 1 \\",
+          "  --dataset-dir ./bench-datasets/longmemeval \\",
+          '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+          "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+          "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+          "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+          "```",
+          "",
+        ].join("\n"),
+      );
+
+      const result = runParity(root);
+      assert.equal(result.status, 1, `${mutation}: ${result.stderr}`);
+      assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+    });
+  }
+});
+
 test("a comment mentioning bench run before the credit guard does not invalidate it", () => {
   withFixture((root) => {
     writeFileSync(
@@ -883,6 +916,37 @@ test("Build Week Codex commands pin the complete paid-run protocol", () => {
       }
     });
   }
+});
+
+test("the first command in a two-command paid sequence is exactly a one-item smoke", () => {
+  withFixture((root) => {
+    const protocol = [
+      '--dataset-dir ./bench-datasets/longmemeval --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR"',
+      "--drain-timeout 600000",
+      "--system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium",
+      "--internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium",
+      "--judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+    ].join(" ");
+    const readme = path.join(root, "packages", "bench", "README.md");
+    mkdirSync(path.dirname(readme), { recursive: true });
+    writeFileSync(
+      readme,
+      [
+        "# Bench",
+        "",
+        "```bash",
+        "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        `remnic bench run longmemeval --limit 100 ${protocol}`,
+        `remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> ${protocol}`,
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /command 1 of 2 must include `--limit 1`; got 100/);
+  });
 });
 
 test("a guarded Build Week command cannot bypass checks by dropping Codex flags", () => {

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -762,6 +762,33 @@ test("a commented credit-budget guard does not authorize a Codex command", () =>
   });
 });
 
+test("a comment mentioning bench run before the credit guard does not invalidate it", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "# The remnic bench run command below consumes Codex credits.",
+        "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "remnic bench run longmemeval --limit 1 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+        "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+        "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /1 Build Week Codex dataset command\(s\) pinned/);
+  });
+});
+
 test("Build Week Codex commands pin the complete paid-run protocol", () => {
   const validProtocol = [
     '--runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000',

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -670,6 +670,7 @@ test("Build Week Codex commands accept only the matching staged dataset path", (
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
         "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+        'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"',
         "remnic bench run --json longmemeval --limit 1 \\",
         "  --dataset-dir ./bench-datasets/longmemeval \\",
         "  --runtime-profile real --results-dir \"$BUILD_WEEK_RESULTS_DIR\" --drain-timeout 600000 \\",
@@ -890,6 +891,95 @@ test("credit protocol exports accept real shell comments and trailing whitespace
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473 # budget",
         "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473\t# reserve",
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"   ',
+        'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results" # private result store',
+        "remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+        "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+        "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /1 Build Week Codex dataset command\(s\) pinned/);
+  });
+});
+
+test("paid runs require the exact private results-directory export", () => {
+  for (const { label, resultEnvLines } of [
+    { label: "missing", resultEnvLines: [] },
+    {
+      label: "wrong path",
+      resultEnvLines: ['export BUILD_WEEK_RESULTS_DIR="/tmp/build-week-results"'],
+    },
+    {
+      label: "non-exported assignment",
+      resultEnvLines: ['BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"'],
+    },
+    {
+      label: "overridden",
+      resultEnvLines: [
+        'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"',
+        'export BUILD_WEEK_RESULTS_DIR="$HOME/other-results"',
+      ],
+    },
+    {
+      label: "unset",
+      resultEnvLines: [
+        'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"',
+        "unset BUILD_WEEK_RESULTS_DIR",
+      ],
+    },
+  ]) {
+    withFixture((root) => {
+      writeFileSync(
+        path.join(root, "HACKATHON.md"),
+        [
+          "# Build Week",
+          "",
+          "```bash",
+          "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+          "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+          'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+          ...resultEnvLines,
+          "remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> \\",
+          "  --dataset-dir ./bench-datasets/longmemeval \\",
+          '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+          "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+          "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+          "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+          "```",
+          "",
+        ].join("\n"),
+      );
+
+      const result = runParity(root);
+      assert.equal(result.status, 1, `${label}: ${result.stderr}`);
+      assert.match(
+        result.stderr,
+        /must follow an exact shell export of `export BUILD_WEEK_RESULTS_DIR="\$BUILD_WEEK_RUN_ROOT\/results"`/,
+      );
+    });
+  }
+});
+
+test("a later exact results-directory re-export restores the paid protocol", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+        'export BUILD_WEEK_RESULTS_DIR="$HOME/other-results"',
+        'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"',
         "remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> \\",
         "  --dataset-dir ./bench-datasets/longmemeval \\",
         '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
@@ -1084,6 +1174,7 @@ test("a comment mentioning bench run before the credit guard does not invalidate
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
         "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+        'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"',
         "remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> \\",
         "  --dataset-dir ./bench-datasets/longmemeval \\",
         '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
@@ -1195,6 +1286,7 @@ test("the first command in a two-command paid sequence is exactly a one-item smo
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
         "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+        'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"',
         `remnic bench run longmemeval --limit 100 ${protocol}`,
         `remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> ${protocol}`,
         "```",
@@ -1233,6 +1325,7 @@ test("a two-command LoCoMo sequence accepts the benchmark-supported trial bound"
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
         "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+        'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"',
         `remnic bench run locomo --trial-limit 1 ${protocol}`,
         `remnic bench run locomo --trial-limit <LEDGER_DERIVED_LIMIT> ${protocol}`,
         "```",

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -654,8 +654,15 @@ test("a Build Week Codex command without a staged dataset path fails", () => {
 
 test("Build Week Codex commands accept only the matching staged dataset path", () => {
   withFixture((root) => {
+    const cliPath = path.join(root, "packages", "remnic-cli", "src", "index.ts");
     writeFileSync(
-      path.join(root, "HACKATHON.md"),
+      cliPath,
+      readFileSyncSafe(cliPath).replace('"extensions" | "daemon";', '"extensions" | "daemon" | "bench";'),
+    );
+    const readme = path.join(root, "packages", "bench", "README.md");
+    mkdirSync(path.dirname(readme), { recursive: true });
+    writeFileSync(
+      readme,
       [
         "# Build Week",
         "",
@@ -670,7 +677,7 @@ test("Build Week Codex commands accept only the matching staged dataset path", (
         "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
         "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
         "",
-        "remnic bench run locomo --trial-limit 1 \\",
+        "remnic bench run locomo --trial-limit <LEDGER_DERIVED_LIMIT> \\",
         "  --dataset-dir ./bench-datasets/locomo \\",
         "  --runtime-profile real --results-dir \"$BUILD_WEEK_RESULTS_DIR\" --drain-timeout 600000 \\",
         "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
@@ -687,6 +694,37 @@ test("Build Week Codex commands accept only the matching staged dataset path", (
   });
 });
 
+test("a single-command paid run requires a ledger-derived bound", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+        "remnic bench run longmemeval --limit 500 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+        "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+        "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(
+      result.stderr,
+      /command 1 of 1 must include exactly one of `--limit <LEDGER_DERIVED_LIMIT>`; got --limit 500/,
+    );
+  });
+});
+
 test("an otherwise valid Codex command fails without the credit-budget guard", () => {
   withFixture((root) => {
     writeFileSync(
@@ -695,7 +733,7 @@ test("an otherwise valid Codex command fails without the credit-budget guard", (
         "# Build Week",
         "",
         "```bash",
-        "remnic bench run longmemeval --limit 1 \\",
+        "remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> \\",
         "  --dataset-dir ./bench-datasets/longmemeval \\",
         '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
         "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
@@ -982,7 +1020,7 @@ test("a comment mentioning bench run before the credit guard does not invalidate
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
         "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
-        "remnic bench run longmemeval --limit 1 \\",
+        "remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> \\",
         "  --dataset-dir ./bench-datasets/longmemeval \\",
         '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
         "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -661,6 +661,8 @@ test("Build Week Codex commands accept only the matching staged dataset path", (
         "",
         "```bash",
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
         "remnic bench run --json longmemeval --limit 1 \\",
         "  --dataset-dir ./bench-datasets/longmemeval \\",
         "  --runtime-profile real --results-dir \"$BUILD_WEEK_RESULTS_DIR\" --drain-timeout 600000 \\",
@@ -706,7 +708,7 @@ test("an otherwise valid Codex command fails without the credit-budget guard", (
 
     const result = runParity(root);
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+    assert.match(result.stderr, /must follow an exact shell export of `export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
   });
 });
 
@@ -732,7 +734,7 @@ test("a credit-budget guard after the Codex command does not authorize it", () =
 
     const result = runParity(root);
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+    assert.match(result.stderr, /must follow an exact shell export of `export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
   });
 });
 
@@ -758,7 +760,7 @@ test("a commented credit-budget guard does not authorize a Codex command", () =>
 
     const result = runParity(root);
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+    assert.match(result.stderr, /must follow an exact shell export of `export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
   });
 });
 
@@ -784,7 +786,7 @@ test("a non-exported credit-budget assignment does not authorize a Codex command
 
     const result = runParity(root);
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+    assert.match(result.stderr, /must follow an exact shell export of `export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
   });
 });
 
@@ -811,7 +813,7 @@ test("a credit-budget export in prose does not authorize a later shell command",
 
     const result = runParity(root);
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+    assert.match(result.stderr, /must follow an exact shell export of `export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
   });
 });
 
@@ -843,16 +845,31 @@ test("a later credit-budget override or unset invalidates an earlier guard", () 
 
       const result = runParity(root);
       assert.equal(result.status, 1, `${mutation}: ${result.stderr}`);
-      assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+      assert.match(result.stderr, /must follow an exact shell export of `export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
     });
   }
 });
 
-test("a same-command credit-budget mutation before the run invalidates an earlier guard", () => {
-  for (const prefix of [
-    "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=100; ",
-    "unset REMNIC_BENCH_CODEX_CREDIT_BUDGET; ",
-    "env REMNIC_BENCH_CODEX_CREDIT_BUDGET=3000 ",
+test("later reserve and ledger mutations invalidate the paid protocol", () => {
+  for (const { mutation, expected } of [
+    {
+      mutation: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=300",
+      expected: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+    },
+    {
+      mutation: "unset REMNIC_BENCH_CODEX_CREDIT_RESERVE",
+      expected: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+    },
+    {
+      mutation: 'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="/tmp/other-ledger.json"',
+      expected:
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+    },
+    {
+      mutation: "unset REMNIC_BENCH_CODEX_CREDIT_LEDGER",
+      expected:
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+    },
   ]) {
     withFixture((root) => {
       writeFileSync(
@@ -862,6 +879,61 @@ test("a same-command credit-budget mutation before the run invalidates an earlie
           "",
           "```bash",
           "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+          "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+          'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+          mutation,
+          "remnic bench run longmemeval --limit 1 \\",
+          "  --dataset-dir ./bench-datasets/longmemeval \\",
+          '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+          "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+          "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+          "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+          "```",
+          "",
+        ].join("\n"),
+      );
+
+      const result = runParity(root);
+      assert.equal(result.status, 1, `${mutation}: ${result.stderr}`);
+      assert.ok(result.stderr.includes(`exact shell export of \`${expected}\``));
+    });
+  }
+});
+
+test("a same-command credit-budget mutation before the run invalidates an earlier guard", () => {
+  for (const { prefix, expected } of [
+    {
+      prefix: "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=100; ",
+      expected: "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+    },
+    {
+      prefix: "unset REMNIC_BENCH_CODEX_CREDIT_BUDGET; ",
+      expected: "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+    },
+    {
+      prefix: "env REMNIC_BENCH_CODEX_CREDIT_BUDGET=3000 ",
+      expected: "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+    },
+    {
+      prefix: "env REMNIC_BENCH_CODEX_CREDIT_RESERVE=300 ",
+      expected: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+    },
+    {
+      prefix: 'env REMNIC_BENCH_CODEX_CREDIT_LEDGER="/tmp/other-ledger.json" ',
+      expected:
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+    },
+  ]) {
+    withFixture((root) => {
+      writeFileSync(
+        path.join(root, "HACKATHON.md"),
+        [
+          "# Build Week",
+          "",
+          "```bash",
+          "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+          "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+          'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
           `${prefix}remnic bench run longmemeval --limit 1 \\`,
           "  --dataset-dir ./bench-datasets/longmemeval \\",
           '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
@@ -875,7 +947,7 @@ test("a same-command credit-budget mutation before the run invalidates an earlie
 
       const result = runParity(root);
       assert.equal(result.status, 1, `${prefix}: ${result.stderr}`);
-      assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+      assert.ok(result.stderr.includes(`exact shell export of \`${expected}\``));
     });
   }
 });
@@ -890,6 +962,8 @@ test("a comment mentioning bench run before the credit guard does not invalidate
         "```bash",
         "# The remnic bench run command below consumes Codex credits.",
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
         "remnic bench run longmemeval --limit 1 \\",
         "  --dataset-dir ./bench-datasets/longmemeval \\",
         '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
@@ -968,6 +1042,8 @@ test("the first command in a two-command paid sequence is exactly a one-item smo
         "",
         "```bash",
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
         `remnic bench run longmemeval --limit 100 ${protocol}`,
         `remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> ${protocol}`,
         "```",
@@ -1004,6 +1080,8 @@ test("a two-command LoCoMo sequence accepts the benchmark-supported trial bound"
         "",
         "```bash",
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
         `remnic bench run locomo --trial-limit 1 ${protocol}`,
         `remnic bench run locomo --trial-limit <LEDGER_DERIVED_LIMIT> ${protocol}`,
         "```",

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -736,6 +736,32 @@ test("a credit-budget guard after the Codex command does not authorize it", () =
   });
 });
 
+test("a commented credit-budget guard does not authorize a Codex command", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "# REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "remnic bench run longmemeval --limit 1 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+        "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+        "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+  });
+});
+
 test("Build Week Codex commands pin the complete paid-run protocol", () => {
   const validProtocol = [
     '--runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000',

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -848,6 +848,37 @@ test("a later credit-budget override or unset invalidates an earlier guard", () 
   }
 });
 
+test("a same-command credit-budget mutation before the run invalidates an earlier guard", () => {
+  for (const prefix of [
+    "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=100; ",
+    "unset REMNIC_BENCH_CODEX_CREDIT_BUDGET; ",
+  ]) {
+    withFixture((root) => {
+      writeFileSync(
+        path.join(root, "HACKATHON.md"),
+        [
+          "# Build Week",
+          "",
+          "```bash",
+          "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+          `${prefix}remnic bench run longmemeval --limit 1 \\`,
+          "  --dataset-dir ./bench-datasets/longmemeval \\",
+          '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+          "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+          "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+          "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+          "```",
+          "",
+        ].join("\n"),
+      );
+
+      const result = runParity(root);
+      assert.equal(result.status, 1, `${prefix}: ${result.stderr}`);
+      assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+    });
+  }
+});
+
 test("a comment mentioning bench run before the credit guard does not invalidate it", () => {
   withFixture((root) => {
     writeFileSync(

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -820,6 +820,15 @@ test("a credit-budget export in prose does not authorize a later shell command",
 test("a later credit-budget override or unset invalidates an earlier guard", () => {
   for (const mutation of [
     "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=100",
+    "export REMNIC_BENCH_CODEX_CREDIT_BUDGET+=0",
+    "REMNIC_BENCH_CODEX_CREDIT_BUDGET+=0",
+    "REMNIC_BENCH_CODEX_CREDIT_BUDGET[0]=24730",
+    "declare -x REMNIC_BENCH_CODEX_CREDIT_BUDGET=24730",
+    "export OTHER=value REMNIC_BENCH_CODEX_CREDIT_BUDGET=24730",
+    "unset OTHER REMNIC_BENCH_CODEX_CREDIT_BUDGET",
+    "((REMNIC_BENCH_CODEX_CREDIT_BUDGET++))",
+    "printf -v REMNIC_BENCH_CODEX_CREDIT_BUDGET %s 24730",
+    "true; REMNIC_BENCH_CODEX_CREDIT_BUDGET=24730",
     "export -n REMNIC_BENCH_CODEX_CREDIT_BUDGET",
     "unset REMNIC_BENCH_CODEX_CREDIT_BUDGET",
   ]) {
@@ -857,11 +866,20 @@ test("later reserve and ledger mutations invalidate the paid protocol", () => {
       expected: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
     },
     {
+      mutation: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE+=0",
+      expected: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+    },
+    {
       mutation: "unset REMNIC_BENCH_CODEX_CREDIT_RESERVE",
       expected: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
     },
     {
       mutation: 'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="/tmp/other-ledger.json"',
+      expected:
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+    },
+    {
+      mutation: "REMNIC_BENCH_CODEX_CREDIT_LEDGER+=.bak",
       expected:
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
     },

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -788,6 +788,33 @@ test("a non-exported credit-budget assignment does not authorize a Codex command
   });
 });
 
+test("a credit-budget export in prose does not authorize a later shell command", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "",
+        "```bash",
+        "remnic bench run longmemeval --limit 1 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+        "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+        "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /must follow a shell export of `REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473`/);
+  });
+});
+
 test("a comment mentioning bench run before the credit guard does not invalidate it", () => {
   withFixture((root) => {
     writeFileSync(

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -667,6 +667,7 @@ test("Build Week Codex commands accept only the matching staged dataset path", (
         "# Build Week",
         "",
         "```bash",
+        'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"',
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
         "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
@@ -888,6 +889,7 @@ test("credit protocol exports accept real shell comments and trailing whitespace
         "# Build Week",
         "",
         "```bash",
+        'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026" # private root',
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473 # budget",
         "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473\t# reserve",
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"   ',
@@ -942,6 +944,7 @@ test("paid runs require the exact private results-directory export", () => {
           "# Build Week",
           "",
           "```bash",
+          'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"',
           "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
           "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
           'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
@@ -975,10 +978,129 @@ test("a later exact results-directory re-export restores the paid protocol", () 
         "# Build Week",
         "",
         "```bash",
+        'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"',
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
         "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
         'export BUILD_WEEK_RESULTS_DIR="$HOME/other-results"',
+        'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"',
+        "remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+        "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+        "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /1 Build Week Codex dataset command\(s\) pinned/);
+  });
+});
+
+test("paid runs require an exact current root before dependent path exports", () => {
+  const exactRoot = 'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"';
+  const exactLedger =
+    'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"';
+  const exactResults = 'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"';
+  for (const { label, pathEnvLines } of [
+    { label: "missing root", pathEnvLines: [exactLedger, exactResults] },
+    {
+      label: "wrong stale root",
+      pathEnvLines: [
+        'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/old-build-week"',
+        exactLedger,
+        exactResults,
+      ],
+    },
+    {
+      label: "non-exported root",
+      pathEnvLines: [
+        'BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"',
+        exactLedger,
+        exactResults,
+      ],
+    },
+    {
+      label: "root moved below dependents",
+      pathEnvLines: [exactLedger, exactResults, exactRoot],
+    },
+    {
+      label: "root unset after expansion",
+      pathEnvLines: [exactRoot, exactLedger, exactResults, "unset BUILD_WEEK_RUN_ROOT"],
+    },
+    {
+      label: "root overridden after expansion",
+      pathEnvLines: [
+        exactRoot,
+        exactLedger,
+        exactResults,
+        'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/other-run"',
+      ],
+    },
+    {
+      label: "root re-exported without dependent refresh",
+      pathEnvLines: [
+        exactRoot,
+        exactLedger,
+        exactResults,
+        'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/other-run"',
+        exactRoot,
+      ],
+    },
+  ]) {
+    withFixture((root) => {
+      writeFileSync(
+        path.join(root, "HACKATHON.md"),
+        [
+          "# Build Week",
+          "",
+          "```bash",
+          "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+          "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+          ...pathEnvLines,
+          "remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> \\",
+          "  --dataset-dir ./bench-datasets/longmemeval \\",
+          '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+          "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+          "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+          "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+          "```",
+          "",
+        ].join("\n"),
+      );
+
+      const result = runParity(root);
+      assert.equal(result.status, 1, `${label}: ${result.stderr}`);
+      assert.ok(
+        result.stderr.includes(
+          'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"',
+        ),
+        `${label}: ${result.stderr}`,
+      );
+    });
+  }
+});
+
+test("root recovery requires fresh dependent path exports", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+        'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"',
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+        'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"',
+        'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/other-run"',
+        'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"',
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
         'export BUILD_WEEK_RESULTS_DIR="$BUILD_WEEK_RUN_ROOT/results"',
         "remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> \\",
         "  --dataset-dir ./bench-datasets/longmemeval \\",
@@ -1171,6 +1293,7 @@ test("a comment mentioning bench run before the credit guard does not invalidate
         "",
         "```bash",
         "# The remnic bench run command below consumes Codex credits.",
+        'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"',
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
         "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
@@ -1283,6 +1406,7 @@ test("the first command in a two-command paid sequence is exactly a one-item smo
         "# Bench",
         "",
         "```bash",
+        'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"',
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
         "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
@@ -1322,6 +1446,7 @@ test("a two-command LoCoMo sequence accepts the benchmark-supported trial bound"
         "# Bench",
         "",
         "```bash",
+        'export BUILD_WEEK_RUN_ROOT="$HOME/.remnic/bench/build-week-2026"',
         "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
         "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
         'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -828,6 +828,85 @@ test("a non-exported credit-budget assignment does not authorize a Codex command
   });
 });
 
+test("credit protocol comments require shell whitespace before the hash", () => {
+  for (const { mutation, expected } of [
+    {
+      mutation: "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473#not-a-comment",
+      expected: "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+    },
+    {
+      mutation: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473#not-a-comment",
+      expected: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+    },
+    {
+      mutation:
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"#not-a-comment',
+      expected:
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+    },
+  ]) {
+    withFixture((root) => {
+      writeFileSync(
+        path.join(root, "HACKATHON.md"),
+        [
+          "# Build Week",
+          "",
+          "```bash",
+          mutation.includes("BUDGET")
+            ? mutation
+            : "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473 # valid comment",
+          mutation.includes("RESERVE")
+            ? mutation
+            : "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473\t# valid comment",
+          mutation.includes("LEDGER")
+            ? mutation
+            : 'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"   ',
+          "remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> \\",
+          "  --dataset-dir ./bench-datasets/longmemeval \\",
+          '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+          "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+          "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+          "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+          "```",
+          "",
+        ].join("\n"),
+      );
+
+      const result = runParity(root);
+      assert.equal(result.status, 1, `${mutation}: ${result.stderr}`);
+      assert.ok(result.stderr.includes(`exact shell export of \`${expected}\``));
+    });
+  }
+});
+
+test("credit protocol exports accept real shell comments and trailing whitespace", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473 # budget",
+        "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473\t# reserve",
+        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"   ',
+        "remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+        "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+        "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /1 Build Week Codex dataset command\(s\) pinned/);
+  });
+});
+
 test("a credit-budget export in prose does not authorize a later shell command", () => {
   withFixture((root) => {
     writeFileSync(
@@ -956,29 +1035,13 @@ test("later reserve and ledger mutations invalidate the paid protocol", () => {
   }
 });
 
-test("a same-command credit-budget mutation before the run invalidates an earlier guard", () => {
-  for (const { prefix, expected } of [
-    {
-      prefix: "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=100; ",
-      expected: "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
-    },
-    {
-      prefix: "unset REMNIC_BENCH_CODEX_CREDIT_BUDGET; ",
-      expected: "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
-    },
-    {
-      prefix: "env REMNIC_BENCH_CODEX_CREDIT_BUDGET=3000 ",
-      expected: "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
-    },
-    {
-      prefix: "env REMNIC_BENCH_CODEX_CREDIT_RESERVE=300 ",
-      expected: "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
-    },
-    {
-      prefix: 'env REMNIC_BENCH_CODEX_CREDIT_LEDGER="/tmp/other-ledger.json" ',
-      expected:
-        'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
-    },
+test("a same-command credit mutation or env wrapper before the run is rejected", () => {
+  for (const prefix of [
+    "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=100; ",
+    "unset REMNIC_BENCH_CODEX_CREDIT_BUDGET; ",
+    "env REMNIC_BENCH_CODEX_CREDIT_BUDGET=3000 ",
+    "env REMNIC_BENCH_CODEX_CREDIT_RESERVE=300 ",
+    'env REMNIC_BENCH_CODEX_CREDIT_LEDGER="/tmp/other-ledger.json" ',
   ]) {
     withFixture((root) => {
       writeFileSync(
@@ -1003,7 +1066,8 @@ test("a same-command credit-budget mutation before the run invalidates an earlie
 
       const result = runParity(root);
       assert.equal(result.status, 1, `${prefix}: ${result.stderr}`);
-      assert.ok(result.stderr.includes(`exact shell export of \`${expected}\``));
+      assert.match(result.stderr, /must execute directly as `remnic bench run`/);
+      assert.match(result.stderr, /must contain at least one guarded Build Week Codex benchmark command/);
     });
   }
 });
@@ -1035,6 +1099,37 @@ test("a comment mentioning bench run before the credit guard does not invalidate
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /1 Build Week Codex dataset command\(s\) pinned/);
   });
+});
+
+test("Build Week paid commands must execute directly without shell wrappers", () => {
+  for (const prefix of ["echo ", "printf '%s' ", "true && ", "FOO=bar ", "env "]) {
+    withFixture((root) => {
+      writeFileSync(
+        path.join(root, "HACKATHON.md"),
+        [
+          "# Build Week",
+          "",
+          "```bash",
+          "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+          "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+          'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+          `${prefix}remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> \\`,
+          "  --dataset-dir ./bench-datasets/longmemeval \\",
+          '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+          "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+          "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+          "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+          "```",
+          "",
+        ].join("\n"),
+      );
+
+      const result = runParity(root);
+      assert.equal(result.status, 1, `${prefix}: ${result.stderr}`);
+      assert.match(result.stderr, /must execute directly as `remnic bench run`/);
+      assert.match(result.stderr, /must contain at least one guarded Build Week Codex benchmark command/);
+    });
+  }
 });
 
 test("Build Week Codex commands pin the complete paid-run protocol", () => {

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -626,6 +626,153 @@ test("a bogus command in the root README fenced block is caught", () => {
   });
 });
 
+// Build Week credit-backed commands must not silently switch from staged real
+// data to the bundled quick fixture or the CLI-managed dataset store.
+test("a Build Week Codex command without a staged dataset path fails", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "remnic bench run --quick longmemeval \\",
+        "  --system-provider codex-cli --system-model gpt-5.6-luna",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(
+      result.stderr,
+      /Build Week Codex longmemeval command must include `--dataset-dir \.\/bench-datasets\/longmemeval`/,
+    );
+  });
+});
+
+test("Build Week Codex commands accept only the matching staged dataset path", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "remnic bench run --json longmemeval --limit 1 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        "  --system-provider codex-cli --system-model gpt-5.6-luna",
+        "",
+        "remnic bench run locomo --trial-limit 1 \\",
+        "  --dataset-dir ./bench-datasets/locomo \\",
+        "  --judge-provider codex-cli --judge-model gpt-5.6-terra",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /2 Build Week Codex dataset command\(s\) pinned/);
+  });
+});
+
+test("Build Week Codex quick mode is rejected even with a staged dataset path", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "remnic bench run --quick longmemeval \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        "  --system-provider codex-cli --system-model gpt-5.6-luna",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /must not use `--quick`/);
+    assert.match(result.stderr, /longmemeval command must include an explicit `--limit`/);
+  });
+});
+
+test("Build Week LongMemEval rejects LoCoMo-only --trial-limit", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "remnic bench run longmemeval --trial-limit 1 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        "  --system-provider codex-cli --system-model gpt-5.6-luna",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /longmemeval command must include an explicit `--limit`/);
+  });
+});
+
+test("Build Week dataset path cannot impersonate a missing positional benchmark", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "remnic bench run --limit 1 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        "  --system-provider codex-cli --system-model gpt-5.6-luna",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /must include positional benchmark `longmemeval` or `locomo`/);
+  });
+});
+
+test("Build Week Codex bounds reject missing, zero, and negative values", () => {
+  for (const [suffix, expected] of [
+    ["--limit", /has no value for `--limit`/],
+    ["--limit 0", /--limit must be a positive integer/],
+    ["--limit -1", /--limit must be a positive integer/],
+  ]) {
+    withFixture((root) => {
+      writeFileSync(
+        path.join(root, "HACKATHON.md"),
+        [
+          "# Build Week",
+          "",
+          "```bash",
+          `remnic bench run longmemeval ${suffix} \\`,
+          "  --dataset-dir ./bench-datasets/longmemeval \\",
+          "  --system-provider codex-cli --system-model gpt-5.6-luna",
+          "```",
+          "",
+        ].join("\n"),
+      );
+
+      const result = runParity(root);
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, expected);
+    });
+  }
+});
+
 // ── Misc ────────────────────────────────────────────────────────────────────
 
 test("unknown arguments are rejected with usage", () => {

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -894,6 +894,41 @@ test("Build Week Codex commands reject benchmark and runtime fan-out selectors",
   }
 });
 
+test("Build Week Codex commands reject every unpinned runtime override", () => {
+  for (const override of [
+    "--adapter mcp --mcp-demo",
+    "--mcp-url http://127.0.0.1:9999/mcp",
+    "--remnic-config ./alternate.json",
+    "--model-source gateway",
+    "--disable-thinking",
+    "--unknown-future-mode enabled",
+  ]) {
+    withFixture((root) => {
+      writeFileSync(
+        path.join(root, "HACKATHON.md"),
+        [
+          "# Build Week",
+          "",
+          "```bash",
+          "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+          `remnic bench run longmemeval --limit 1 ${override} \\`,
+          "  --dataset-dir ./bench-datasets/longmemeval \\",
+          '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+          "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+          "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+          "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+          "```",
+          "",
+        ].join("\n"),
+      );
+
+      const result = runParity(root);
+      assert.equal(result.status, 1, `${override}: ${result.stderr}`);
+      assert.match(result.stderr, /must not include unpinned run flag/);
+    });
+  }
+});
+
 test("Build Week Codex bounds reject missing, zero, and negative values", () => {
   for (const [suffix, expected] of [
     ["--limit", /has no value for `--limit`/],

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -1348,7 +1348,76 @@ test("Build Week Codex commands reject every unpinned runtime override", () => {
 
       const result = runParity(root);
       assert.equal(result.status, 1, `${override}: ${result.stderr}`);
-      assert.match(result.stderr, /must not include unpinned run flag/);
+      assert.match(result.stderr, /must not include unpinned run option/);
+    });
+  }
+});
+
+test("Build Week Codex commands reject equals-form and duplicate options", () => {
+  const valueFlags = [
+    "--runtime-profile",
+    "--limit",
+    "--trial-limit",
+    "--dataset-dir",
+    "--results-dir",
+    "--drain-timeout",
+    "--system-provider",
+    "--system-model",
+    "--system-codex-reasoning-effort",
+    "--internal-provider",
+    "--internal-model",
+    "--internal-codex-reasoning-effort",
+    "--judge-provider",
+    "--judge-model",
+    "--judge-codex-reasoning-effort",
+  ];
+  const cases = [
+    ...["--json=false", "--json=true", "--json="].map((suffix) => ({
+      suffix,
+      expected: new RegExp(`equals-form option \`${suffix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\``),
+    })),
+    ...valueFlags.map((flag) => ({
+      suffix: `${flag}=attached`,
+      expected: new RegExp(`equals-form option \`${flag}=attached\``),
+    })),
+    { suffix: "--runtime-profile baseline", expected: /option `--runtime-profile` at most once/ },
+    { suffix: "--limit 2", expected: /option `--limit` at most once/ },
+    { suffix: "--json --json", expected: /option `--json` at most once/ },
+    { suffix: "-x", expected: /unpinned run option `-x`/ },
+    { suffix: "-h", expected: /unpinned run option `-h`/ },
+    { suffix: "-h=foo", expected: /equals-form option `-h=foo`/ },
+    { suffix: "--", expected: /unpinned run option `--`/ },
+    { suffix: "-", expected: /unpinned run option `-`/ },
+    {
+      suffix: "--results-dir --json",
+      expected: /option `--results-dir` requires a separate non-option value/,
+    },
+  ];
+  for (const { suffix, expected } of cases) {
+    withFixture((root) => {
+      writeFileSync(
+        path.join(root, "HACKATHON.md"),
+        [
+          "# Build Week",
+          "",
+          "```bash",
+          "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+          "export REMNIC_BENCH_CODEX_CREDIT_RESERVE=473",
+          'export REMNIC_BENCH_CODEX_CREDIT_LEDGER="$BUILD_WEEK_RUN_ROOT/codex-credit-ledger.json"',
+          `remnic bench run longmemeval --limit <LEDGER_DERIVED_LIMIT> ${suffix} \\`,
+          "  --dataset-dir ./bench-datasets/longmemeval \\",
+          '  --runtime-profile real --results-dir "$BUILD_WEEK_RESULTS_DIR" --drain-timeout 600000 \\',
+          "  --system-provider codex-cli --system-model gpt-5.6-luna --system-codex-reasoning-effort medium \\",
+          "  --internal-provider codex-cli --internal-model gpt-5.6-luna --internal-codex-reasoning-effort medium \\",
+          "  --judge-provider codex-cli --judge-model gpt-5.6-terra --judge-codex-reasoning-effort high",
+          "```",
+          "",
+        ].join("\n"),
+      );
+
+      const result = runParity(root);
+      assert.equal(result.status, 1, `${suffix}: ${result.stderr}`);
+      assert.match(result.stderr, expected);
     });
   }
 });

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -745,6 +745,28 @@ test("Build Week dataset path cannot impersonate a missing positional benchmark"
   });
 });
 
+test("malformed Build Week Codex commands cannot bypass validation", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "remnic bench run --limit 1 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval-typo \\",
+        "  --system-provider codex-cli --system-model gpt-5.6-luna",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /must include positional benchmark `longmemeval` or `locomo`/);
+  });
+});
+
 test("Build Week Codex bounds reject missing, zero, and negative values", () => {
   for (const [suffix, expected] of [
     ["--limit", /has no value for `--limit`/],

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -763,7 +763,7 @@ test("Build Week dataset path cannot impersonate a missing positional benchmark"
 
     const result = runParity(root);
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /must include positional benchmark `longmemeval` or `locomo`/);
+    assert.match(result.stderr, /must include exactly one positional benchmark/);
   });
 });
 
@@ -785,8 +785,41 @@ test("malformed Build Week Codex commands cannot bypass validation", () => {
 
     const result = runParity(root);
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /must include positional benchmark `longmemeval` or `locomo`/);
+    assert.match(result.stderr, /must include exactly one positional benchmark/);
   });
+});
+
+test("Build Week Codex commands reject benchmark and runtime fan-out selectors", () => {
+  for (const [selector, command] of [
+    ["--all", "remnic bench run --all longmemeval --limit 1"],
+    ["multiple positional benchmarks", "remnic bench run longmemeval locomo --limit 1"],
+    ["--matrix", "remnic bench run longmemeval --matrix baseline,real --limit 1"],
+    ["--custom", "remnic bench run longmemeval --custom ./custom.json --limit 1"],
+  ]) {
+    withFixture((root) => {
+      writeFileSync(
+        path.join(root, "HACKATHON.md"),
+        [
+          "# Build Week",
+          "",
+          "```bash",
+          `${command} \\`,
+          "  --dataset-dir ./bench-datasets/longmemeval \\",
+          "  --system-provider codex-cli --system-model gpt-5.6-luna",
+          "```",
+          "",
+        ].join("\n"),
+      );
+
+      const result = runParity(root);
+      assert.equal(result.status, 1, `${selector}: ${result.stderr}`);
+      if (selector === "multiple positional benchmarks") {
+        assert.match(result.stderr, /must include exactly one positional benchmark/);
+      } else {
+        assert.match(result.stderr, new RegExp("must not include `" + selector + "`"));
+      }
+    });
+  }
 });
 
 test("Build Week Codex bounds reject missing, zero, and negative values", () => {

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -723,6 +723,28 @@ test("Build Week LongMemEval rejects LoCoMo-only --trial-limit", () => {
   });
 });
 
+test("Build Week LongMemEval rejects --trial-limit even when --limit is valid", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "remnic bench run longmemeval --limit 1 --trial-limit 1 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval \\",
+        "  --system-provider codex-cli --system-model gpt-5.6-luna",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /longmemeval command must not include `--trial-limit`/);
+  });
+});
+
 test("Build Week dataset path cannot impersonate a missing positional benchmark", () => {
   withFixture((root) => {
     writeFileSync(

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -727,6 +727,29 @@ test("Build Week Codex commands pin the complete paid-run protocol", () => {
   }
 });
 
+test("a guarded Build Week command cannot bypass checks by dropping Codex flags", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "HACKATHON.md"),
+      [
+        "# Build Week",
+        "",
+        "```bash",
+        "export REMNIC_BENCH_CODEX_CREDIT_BUDGET=2473",
+        "remnic bench run longmemeval --runtime-profile baseline --limit 1 \\",
+        "  --dataset-dir ./bench-datasets/longmemeval",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /must include `--runtime-profile real`/);
+    assert.match(result.stderr, /must include `--system-provider codex-cli`/);
+  });
+});
+
 test("Build Week Codex quick mode is rejected even with a staged dataset path", () => {
   withFixture((root) => {
     writeFileSync(


### PR DESCRIPTION
## Summary

- pin every documented Build Week Codex CLI LongMemEval run to `./bench-datasets/longmemeval`
- clarify that quick mode samples one staged real item while bounded full mode uses the same gitignored source
- extend the static docs parity gate to reject missing, mismatched, or CLI-managed dataset paths for Build Week Codex LongMemEval/LoCoMo commands

## Verification

- `node --test tests/check-docs-parity.test.mjs` (21 passed)
- `node scripts/check-docs-parity.mjs` (7 Build Week Codex dataset commands pinned)
- offline loader checks with `limit: 1` resolved `longmemeval_oracle.json` and `locomo10.json` as `source=dataset`
- raw inventory: LongMemEval 500 items; LoCoMo 10 conversations / 1,986 QA
- dataset SHA-256: `821a2034d219ab45846873dd14c14f12cfe7776e73527a483f9dac095d38620c` and `79fa87e90f04081343b8c8debecb80a9a6842b76a7aa537dc9fdf651ea698ff4`
- `npm run preflight:quick`

No provider/model calls were made and the Codex credit ledger was not touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation and a static docs-parity script with tests only; benchmark runtime and credit-ledger behavior are unchanged.
> 
> **Overview**
> Build Week Codex CLI benchmark examples are updated so paid runs use **operator-staged** data instead of quick fixtures or the CLI-managed dataset store. Docs now **`export BUILD_WEEK_RUN_ROOT`**, add **`--dataset-dir ./bench-datasets/longmemeval`** (and matching LoCoMo paths where applicable), and replace the credit smoke probe with **full-mode `longmemeval --limit 1`** rather than **`--quick`**, with prose that a missing staged directory fails before provider dispatch.
> 
> **`scripts/check-docs-parity.mjs`** gains a static **Build Week Codex** gate on four markdown files: it parses fenced shell blocks, requires exact credit/path **`export`** lines and ordering, validates pinned **`remnic bench run`** flags and models, enforces **`./bench-datasets/{longmemeval|locomo}`**, rejects **`--quick`**, **`evals/datasets`**, wrappers, and unpinned options, and checks smoke vs ledger-bound command counts. **`tests/check-docs-parity.test.mjs`** adds broad coverage for those rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e2ad7d2857196e5978a2a59739589a8b1516a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->