### PR TITLE
fix(coding-graph): derive CALLS edges from parsed call sites — Phase A heuristic resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- coding-graph indexing now derives CALLS edges from parsed call sites
+  (Phase A heuristic resolution, issue #1891). Previously `codegraph_index`
+  produced nodes but zero edges, leaving `trace_path`, blast radius, and
+  dead-code detection degenerate. The reindex pipeline resolves each call
+  site to its innermost enclosing symbol (src) and a unique same-file or
+  import-bound name (dst); the stale-edge delete is provenance-scoped
+  (`StoreFileIR.assertedEdgeProvenances`) so re-derivation never removes
+  `trace`/`lsp` edges.
+
 ## [v9.6.11] — 2026-07-13
 
 ### Added

--- a/docs/coding-graph.md
+++ b/docs/coding-graph.md
@@ -259,9 +259,15 @@ mines `FILE_CHANGES_WITH`-style file-to-file co-change edges from bounded
 
 ## Type resolution (phased)
 
-- **Phase A — heuristic** (shipped with the store): resolution from the syntax
-  graph — import/export matching, scope, qualified names, arity. Edges carry
-  `provenance: "heuristic"`.
+- **Phase A — heuristic**
+  ([`heuristic-resolution.ts`](../packages/coding-graph/src/heuristic-resolution.ts),
+  wired into the reindex ingest path, issue #1891): CALLS edges are derived
+  from the fresh parse — src is the innermost symbol enclosing the call
+  site, dst is a unique same-file name or an import-bound name; ambiguous
+  and evidence-free bare names are skipped conservatively. Edges carry
+  `provenance: "heuristic"`. The stale-edge delete is provenance-scoped
+  (`StoreFileIR.assertedEdgeProvenances`), so re-derivation never removes
+  `trace`/`lsp` edges.
 - **Phase B — LSP client layer** ([`lsp/`](../packages/coding-graph/src/lsp/)):
   a minimal JSON-RPC-over-stdio client driving **already-installed** language
   servers (typescript-language-server, pyright, gopls, rust-analyzer, …) as

--- a/packages/coding-graph/src/edge-provenance-scope.test.ts
+++ b/packages/coding-graph/src/edge-provenance-scope.test.ts
@@ -211,3 +211,63 @@ test("edges undefined still preserves all prior edges (early return)", async () 
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("scoped re-assertion never downgrades an lsp-upgraded row on the same key", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    const heuristicEdge = {
+      srcQualifiedName: "greet",
+      dstQualifiedName: "format",
+      type: "CALLS",
+      confidence: 0.9,
+      provenance: "heuristic" as const,
+    };
+    const seeded = await store.upsertFileBatch([{ ...twoSymbolFile(), edges: [heuristicEdge] }]);
+    assert.ok(seeded.ok);
+    // LSP layer upgrades the same (src, dst, type) row.
+    const upgraded = await store.upsertEdges([
+      { ...heuristicEdge, confidence: 1, provenance: "lsp" },
+    ]);
+    assert.ok(upgraded.ok);
+
+    // Reindex re-derives the same heuristic key with provenance scoping:
+    // the assertion keeps the row alive but must NOT overwrite the
+    // stronger out-of-scope provenance back to heuristic.
+    const reingested = await store.upsertFileBatch([
+      {
+        ...twoSymbolFile({ contentHash: "hash-2" }),
+        edges: [heuristicEdge],
+        assertedEdgeProvenances: ["heuristic"],
+      },
+    ]);
+    assert.ok(reingested.ok);
+
+    const trace = store.traverse({ start: "greet", direction: "outgoing", maxDepth: 1 });
+    assert.ok(trace.ok);
+    const stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.deepEqual(stats.stats.edgesByType, { CALLS: 1 });
+    // Provenance must still be lsp. schemaStats has no provenance split, so
+    // assert via a scoped-delete probe: an assertion of [] with heuristic
+    // scope must PRESERVE the row (it is lsp-owned now) — which is only
+    // true if the earlier re-assertion did not downgrade it.
+    const probe = await store.upsertFileBatch([
+      {
+        ...twoSymbolFile({ contentHash: "hash-3" }),
+        edges: [],
+        assertedEdgeProvenances: ["heuristic"],
+      },
+    ]);
+    assert.ok(probe.ok);
+    const after = await store.schemaStats();
+    assert.ok(after.ok);
+    assert.deepEqual(
+      after.stats.edgesByType,
+      { CALLS: 1 },
+      "lsp-provenance row survived a scoped empty assertion — no downgrade happened",
+    );
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/coding-graph/src/edge-provenance-scope.test.ts
+++ b/packages/coding-graph/src/edge-provenance-scope.test.ts
@@ -21,6 +21,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { openBetterSqlite3 } from "@remnic/core/runtime/better-sqlite";
+
 import { GraphStore, type FileIR } from "./graph-store.js";
 
 const span = (startByte: number, endByte: number) => ({ startByte, endByte });
@@ -42,10 +44,24 @@ function twoSymbolFile(overrides?: Partial<FileIR>): FileIR {
   } as FileIR;
 }
 
-async function openTempStore(): Promise<{ store: GraphStore; dir: string }> {
+async function openTempStore(): Promise<{ store: GraphStore; dir: string; dbPath: string }> {
   const dir = await mkdtemp(path.join(tmpdir(), "cg-prov-scope-"));
-  const store = await GraphStore.open({ dbPath: path.join(dir, "graph.sqlite") });
-  return { store, dir };
+  const dbPath = path.join(dir, "graph.sqlite");
+  const store = await GraphStore.open({ dbPath });
+  return { store, dir, dbPath };
+}
+
+/** Direct provenance read — the store has no provenance-split surface. */
+function readEdgeProvenances(dbPath: string): string[] {
+  const db = openBetterSqlite3(dbPath, { readonly: true });
+  try {
+    const rows = db.prepare("SELECT provenance FROM edges ORDER BY provenance").all() as Array<{
+      provenance: string;
+    }>;
+    return rows.map((r) => r.provenance);
+  } finally {
+    db.close();
+  }
 }
 
 test("scoped assertion preserves trace edges while deleting stale heuristic edges", async () => {
@@ -213,7 +229,7 @@ test("edges undefined still preserves all prior edges (early return)", async () 
 });
 
 test("scoped re-assertion never downgrades an lsp-upgraded row on the same key", async () => {
-  const { store, dir } = await openTempStore();
+  const { store, dir, dbPath } = await openTempStore();
   try {
     const heuristicEdge = {
       srcQualifiedName: "greet",
@@ -237,35 +253,128 @@ test("scoped re-assertion never downgrades an lsp-upgraded row on the same key",
       {
         ...twoSymbolFile({ contentHash: "hash-2" }),
         edges: [heuristicEdge],
-        assertedEdgeProvenances: ["heuristic"],
+        assertedEdgeProvenances: ["heuristic", "lsp"],
       },
     ]);
     assert.ok(reingested.ok);
 
-    const trace = store.traverse({ start: "greet", direction: "outgoing", maxDepth: 1 });
-    assert.ok(trace.ok);
     const stats = await store.schemaStats();
     assert.ok(stats.ok);
     assert.deepEqual(stats.stats.edgesByType, { CALLS: 1 });
-    // Provenance must still be lsp. schemaStats has no provenance split, so
-    // assert via a scoped-delete probe: an assertion of [] with heuristic
-    // scope must PRESERVE the row (it is lsp-owned now) — which is only
-    // true if the earlier re-assertion did not downgrade it.
-    const probe = await store.upsertFileBatch([
+    // Provenance must still be lsp: read it directly from the DB (the
+    // store exposes no provenance-split read surface, and an indirect
+    // probe would conflate this with the retire-on-vanish behavior).
+    assert.deepEqual(readEdgeProvenances(dbPath), ["lsp"]);
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("an lsp row is retired when the call disappears from the parse (codex review)", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    const heuristicEdge = {
+      srcQualifiedName: "greet",
+      dstQualifiedName: "format",
+      type: "CALLS",
+      confidence: 0.9,
+      provenance: "heuristic" as const,
+    };
+    const seeded = await store.upsertFileBatch([{ ...twoSymbolFile(), edges: [heuristicEdge] }]);
+    assert.ok(seeded.ok);
+    const upgraded = await store.upsertEdges([
+      { ...heuristicEdge, confidence: 1, provenance: "lsp" },
+    ]);
+    assert.ok(upgraded.ok);
+
+    // Fresh parse no longer supports the call: scoped assertion includes
+    // lsp, so the upgraded row retires with its heuristic ancestor.
+    const reingested = await store.upsertFileBatch([
       {
-        ...twoSymbolFile({ contentHash: "hash-3" }),
+        ...twoSymbolFile({ contentHash: "hash-2" }),
         edges: [],
-        assertedEdgeProvenances: ["heuristic"],
+        assertedEdgeProvenances: ["heuristic", "lsp"],
       },
     ]);
-    assert.ok(probe.ok);
-    const after = await store.schemaStats();
-    assert.ok(after.ok);
-    assert.deepEqual(
-      after.stats.edgesByType,
-      { CALLS: 1 },
-      "lsp-provenance row survived a scoped empty assertion — no downgrade happened",
-    );
+    assert.ok(reingested.ok);
+    const stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.equal(stats.stats.edges, 0, "vanished call retires the lsp-upgraded row too");
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a path-hinted edge binds only inside its declared target file", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    // Two files each declaring a `greet`; the hinted edge must bind the
+    // one in lib/main.ts, never the decoy.
+    const seeded = await store.upsertFileBatch([
+      twoSymbolFile(),
+      {
+        ...twoSymbolFile({ path: "lib/main.ts", contentHash: "hash-lib" }),
+        symbols: [
+          { kind: "function", name: "helper", qualifiedName: "lib.helper", span: span(0, 40) },
+        ],
+      },
+      {
+        ...twoSymbolFile({ path: "util.ts", contentHash: "hash-util" }),
+        symbols: [
+          { kind: "function", name: "shout", qualifiedName: "shout", span: span(0, 40) },
+        ],
+        edges: [
+          {
+            srcQualifiedName: "shout",
+            dstQualifiedName: "greet",
+            type: "CALLS",
+            confidence: 0.8,
+            provenance: "heuristic",
+            dstPathHint: "main",
+          },
+        ],
+      },
+    ]);
+    assert.ok(seeded.ok);
+    const stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.deepEqual(stats.stats.edgesByType, { CALLS: 1 }, "hint matched main.ts");
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a path-hinted edge whose target file is not indexed is dropped, never globally resolved", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    const seeded = await store.upsertFileBatch([
+      // A decoy `greet` exists in an UNRELATED file...
+      twoSymbolFile(),
+      {
+        ...twoSymbolFile({ path: "util.ts", contentHash: "hash-util" }),
+        symbols: [
+          { kind: "function", name: "shout", qualifiedName: "shout", span: span(0, 40) },
+        ],
+        edges: [
+          {
+            srcQualifiedName: "shout",
+            dstQualifiedName: "greet",
+            type: "CALLS",
+            confidence: 0.8,
+            provenance: "heuristic",
+            // ...but the import pointed at ./missing, which is not indexed.
+            dstPathHint: "missing",
+          },
+        ],
+      },
+    ]);
+    assert.ok(seeded.ok);
+    const stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.equal(stats.stats.edges, 0, "hinted edge dropped instead of binding the decoy");
   } finally {
     await store.close();
     await rm(dir, { recursive: true, force: true });

--- a/packages/coding-graph/src/edge-provenance-scope.test.ts
+++ b/packages/coding-graph/src/edge-provenance-scope.test.ts
@@ -424,3 +424,34 @@ test("a path hint never matches test/declaration filename variants (codex review
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("an empty assertedEdgeProvenances array behaves like an absent one (cursor review round 9)", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    const seeded = await store.upsertFileBatch([
+      {
+        ...twoSymbolFile(),
+        edges: [
+          {
+            srcQualifiedName: "greet",
+            dstQualifiedName: "format",
+            type: "CALLS",
+            confidence: 0.9,
+            provenance: "heuristic",
+          },
+        ],
+      },
+    ]);
+    assert.ok(seeded.ok);
+    const reingested = await store.upsertFileBatch([
+      { ...twoSymbolFile({ contentHash: "hash-2" }), edges: [], assertedEdgeProvenances: [] },
+    ]);
+    assert.ok(reingested.ok);
+    const stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.equal(stats.stats.edges, 0, "empty scope = legacy delete-all-stale, not protect-all");
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/coding-graph/src/edge-provenance-scope.test.ts
+++ b/packages/coding-graph/src/edge-provenance-scope.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Provenance-scoped stale-edge deletion (issue #1891).
+ *
+ * The reindex pipeline re-derives heuristic edges from every fresh parse
+ * and asserts them via `StoreFileIR.edges`. Without scoping, that
+ * assertion would delete OTHER provenances' edges owned by the same file
+ * (trace edges from `ingest_traces`, lsp-upgraded edges) on every
+ * re-ingest — destroying state the parse says nothing about (rule 25).
+ *
+ * Contract under test:
+ *  - `assertedEdgeProvenances: ["heuristic"]` + `edges: []` deletes stale
+ *    heuristic edges but PRESERVES trace/lsp edges owned by the file;
+ *  - absent `assertedEdgeProvenances` keeps the legacy behavior (all
+ *    stale src-owned edges deleted) so existing callers are unchanged;
+ *  - `edges` undefined keeps the existing early return (no deletes at
+ *    all), regardless of the new field.
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { GraphStore, type FileIR } from "./graph-store.js";
+
+const span = (startByte: number, endByte: number) => ({ startByte, endByte });
+
+function twoSymbolFile(overrides?: Partial<FileIR>): FileIR {
+  return {
+    path: "main.ts",
+    language: "typescript",
+    contentHash: "hash-1",
+    symbols: [
+      { kind: "function", name: "greet", qualifiedName: "greet", span: span(0, 70) },
+      { kind: "function", name: "format", qualifiedName: "format", span: span(71, 132) },
+    ],
+    imports: [],
+    exports: [],
+    callSites: [],
+    routes: [],
+    ...overrides,
+  } as FileIR;
+}
+
+async function openTempStore(): Promise<{ store: GraphStore; dir: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "cg-prov-scope-"));
+  const store = await GraphStore.open({ dbPath: path.join(dir, "graph.sqlite") });
+  return { store, dir };
+}
+
+test("scoped assertion preserves trace edges while deleting stale heuristic edges", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    // Seed: file with a heuristic edge asserted by ingest.
+    const seeded = await store.upsertFileBatch([
+      {
+        ...twoSymbolFile(),
+        edges: [
+          {
+            srcQualifiedName: "greet",
+            dstQualifiedName: "format",
+            type: "CALLS",
+            confidence: 0.9,
+            provenance: "heuristic",
+          },
+        ],
+      },
+    ]);
+    assert.ok(seeded.ok);
+    // Add a trace edge owned by the same file via the standalone path.
+    const traced = await store.upsertEdges([
+      {
+        srcQualifiedName: "greet",
+        dstQualifiedName: "format",
+        type: "HTTP_CALLS",
+        confidence: 1,
+        provenance: "trace",
+      },
+    ]);
+    assert.ok(traced.ok && traced.persisted === 1);
+
+    let stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.equal(stats.stats.edges, 2, "seed state: heuristic CALLS + trace HTTP_CALLS");
+
+    // Re-ingest: fresh parse supports NO heuristic edges (call removed),
+    // asserted with provenance scoping.
+    const reingested = await store.upsertFileBatch([
+      {
+        ...twoSymbolFile({ contentHash: "hash-2" }),
+        edges: [],
+        assertedEdgeProvenances: ["heuristic"],
+      },
+    ]);
+    assert.ok(reingested.ok);
+
+    stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.equal(stats.stats.edges, 1, "heuristic edge deleted, trace edge preserved");
+    assert.deepEqual(stats.stats.edgesByType, { HTTP_CALLS: 1 });
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("scoped re-assertion keeps the still-supported heuristic edge (no churn)", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    const edge = {
+      srcQualifiedName: "greet",
+      dstQualifiedName: "format",
+      type: "CALLS",
+      confidence: 0.9,
+      provenance: "heuristic" as const,
+    };
+    const first = await store.upsertFileBatch([{ ...twoSymbolFile(), edges: [edge] }]);
+    assert.ok(first.ok);
+    const second = await store.upsertFileBatch([
+      {
+        ...twoSymbolFile({ contentHash: "hash-2" }),
+        edges: [edge],
+        assertedEdgeProvenances: ["heuristic"],
+      },
+    ]);
+    assert.ok(second.ok);
+    const stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.deepEqual(stats.stats.edgesByType, { CALLS: 1 });
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("legacy behavior unchanged: absent assertedEdgeProvenances deletes all stale src-owned edges", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    const seeded = await store.upsertFileBatch([
+      {
+        ...twoSymbolFile(),
+        edges: [
+          {
+            srcQualifiedName: "greet",
+            dstQualifiedName: "format",
+            type: "CALLS",
+            confidence: 0.9,
+            provenance: "heuristic",
+          },
+        ],
+      },
+    ]);
+    assert.ok(seeded.ok);
+    const traced = await store.upsertEdges([
+      {
+        srcQualifiedName: "greet",
+        dstQualifiedName: "format",
+        type: "HTTP_CALLS",
+        confidence: 1,
+        provenance: "trace",
+      },
+    ]);
+    assert.ok(traced.ok);
+
+    // Legacy caller: empty edges array, NO provenance scoping.
+    const reingested = await store.upsertFileBatch([
+      { ...twoSymbolFile({ contentHash: "hash-2" }), edges: [] },
+    ]);
+    assert.ok(reingested.ok);
+
+    const stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.equal(stats.stats.edges, 0, "legacy: every stale src-owned edge deleted");
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("edges undefined still preserves all prior edges (early return)", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    const seeded = await store.upsertFileBatch([
+      {
+        ...twoSymbolFile(),
+        edges: [
+          {
+            srcQualifiedName: "greet",
+            dstQualifiedName: "format",
+            type: "CALLS",
+            confidence: 0.9,
+            provenance: "heuristic",
+          },
+        ],
+      },
+    ]);
+    assert.ok(seeded.ok);
+
+    // Bare IR re-upsert (no edges field): must not wipe anything, even
+    // with the scoping field present — the early return wins.
+    const reingested = await store.upsertFileBatch([
+      { ...twoSymbolFile({ contentHash: "hash-2" }), assertedEdgeProvenances: ["heuristic"] },
+    ]);
+    assert.ok(reingested.ok);
+
+    const stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.deepEqual(stats.stats.edgesByType, { CALLS: 1 });
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/coding-graph/src/edge-provenance-scope.test.ts
+++ b/packages/coding-graph/src/edge-provenance-scope.test.ts
@@ -380,3 +380,47 @@ test("a path-hinted edge whose target file is not indexed is dropped, never glob
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("a path hint never matches test/declaration filename variants (codex review)", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    const seeded = await store.upsertFileBatch([
+      // main.test.ts exports a greet too — a module resolver would never
+      // load it for "./main", so the hint must ignore it.
+      {
+        ...twoSymbolFile({ path: "main.test.ts", contentHash: "hash-test" }),
+        symbols: [
+          { kind: "function", name: "greet", qualifiedName: "greet", span: span(0, 40) },
+        ],
+      },
+      twoSymbolFile(),
+      {
+        ...twoSymbolFile({ path: "util.ts", contentHash: "hash-util" }),
+        symbols: [
+          { kind: "function", name: "shout", qualifiedName: "shout", span: span(0, 40) },
+        ],
+        edges: [
+          {
+            srcQualifiedName: "shout",
+            dstQualifiedName: "greet",
+            type: "CALLS",
+            confidence: 0.8,
+            provenance: "heuristic",
+            dstPathHint: "main",
+          },
+        ],
+      },
+    ]);
+    assert.ok(seeded.ok);
+    const stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.deepEqual(
+      stats.stats.edgesByType,
+      { CALLS: 1 },
+      "bound main.ts despite the main.test.ts decoy (not ambiguous-dropped)",
+    );
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/coding-graph/src/engine/emit.ts
+++ b/packages/coding-graph/src/engine/emit.ts
@@ -199,6 +199,9 @@ function extractImports(root: TSNode, language: Language, lang: CodingGraphLangu
       let stmtStart = -1;
       let stmtEnd = -1;
       const names: string[] = [];
+      // Default/namespace import locals: informational only, never
+      // call-bindable (issue #1894 round 12).
+      const unboundNames: string[] = [];
       // local -> exported for aliased named imports (issue #1894 review).
       let aliasExported = "";
       let aliasLocal = "";
@@ -208,6 +211,8 @@ function extractImports(root: TSNode, language: Language, lang: CodingGraphLangu
           moduleText = cleanModuleSpecifier(cap.node.text);
         } else if (cap.name === "import.name") {
           names.push(cap.node.text);
+        } else if (cap.name === "import.unboundName") {
+          unboundNames.push(cap.node.text);
         } else if (cap.name === "import.aliasExported") {
           aliasExported = cap.node.text;
         } else if (cap.name === "import.aliasLocal") {
@@ -246,6 +251,9 @@ function extractImports(root: TSNode, language: Language, lang: CodingGraphLangu
         // Non-aliased: local === exported. May be overwritten below when
         // the alias pattern also matched this specifier.
         if (!group.bindings.has(n)) group.bindings.set(n, n);
+      }
+      for (const n of unboundNames) {
+        group.names.add(n);
       }
       if (aliasExported && aliasLocal) {
         group.names.add(aliasExported);

--- a/packages/coding-graph/src/engine/emit.ts
+++ b/packages/coding-graph/src/engine/emit.ts
@@ -185,7 +185,13 @@ function extractImports(root: TSNode, language: Language, lang: CodingGraphLangu
     // all captures share the same module.
     const groups = new Map<
       string,
-      { module: string; names: Set<string>; startByte: number; endByte: number }
+      {
+        module: string;
+        names: Set<string>;
+        bindings: Map<string, string>; // local -> exported (issue #1894 review)
+        startByte: number;
+        endByte: number;
+      }
     >();
 
     for (const match of matches) {
@@ -193,12 +199,19 @@ function extractImports(root: TSNode, language: Language, lang: CodingGraphLangu
       let stmtStart = -1;
       let stmtEnd = -1;
       const names: string[] = [];
+      // local -> exported for aliased named imports (issue #1894 review).
+      let aliasExported = "";
+      let aliasLocal = "";
 
       for (const cap of match.captures) {
         if (cap.name === "import.module") {
           moduleText = cleanModuleSpecifier(cap.node.text);
         } else if (cap.name === "import.name") {
           names.push(cap.node.text);
+        } else if (cap.name === "import.aliasExported") {
+          aliasExported = cap.node.text;
+        } else if (cap.name === "import.aliasLocal") {
+          aliasLocal = cap.node.text;
         } else if (cap.name === "__import.stmt") {
           stmtStart = cap.node.startIndex;
           stmtEnd = cap.node.endIndex;
@@ -217,16 +230,30 @@ function extractImports(root: TSNode, language: Language, lang: CodingGraphLangu
       }
 
       const key = `${stmtStart}:${moduleText}`;
-      const existing = groups.get(key);
-      if (existing) {
-        for (const n of names) existing.names.add(n);
-      } else {
-        groups.set(key, {
+      let group = groups.get(key);
+      if (!group) {
+        group = {
           module: moduleText,
-          names: new Set(names),
+          names: new Set<string>(),
+          bindings: new Map<string, string>(),
           startByte: stmtStart,
           endByte: stmtEnd,
-        });
+        };
+        groups.set(key, group);
+      }
+      for (const n of names) {
+        group.names.add(n);
+        // Non-aliased: local === exported. May be overwritten below when
+        // the alias pattern also matched this specifier.
+        if (!group.bindings.has(n)) group.bindings.set(n, n);
+      }
+      if (aliasExported && aliasLocal) {
+        group.names.add(aliasExported);
+        // The plain-name pattern also matched this specifier and recorded
+        // exported->exported; the alias binding replaces it: the LOCAL
+        // identifier is what call sites use.
+        group.bindings.delete(aliasExported);
+        group.bindings.set(aliasLocal, aliasExported);
       }
     }
 
@@ -234,6 +261,9 @@ function extractImports(root: TSNode, language: Language, lang: CodingGraphLangu
       .map((g) => ({
         module: g.module,
         importedNames: Array.from(g.names).sort(),
+        bindings: Array.from(g.bindings.entries())
+          .map(([local, exported]) => ({ exported, local }))
+          .sort((a, b) => a.local.localeCompare(b.local)),
         span: { startByte: g.startByte, endByte: g.endByte },
       }))
       .sort((a, b) => a.span.startByte - b.span.startByte || a.module.localeCompare(b.module));
@@ -316,6 +346,15 @@ function extractCallSites(root: TSNode, language: Language, lang: CodingGraphLan
       if (cap.name === "call.callee") {
         callSites.push({
           calleeNameCandidates: [cap.node.text],
+          span: { startByte: cap.node.startIndex, endByte: cap.node.endIndex },
+        });
+      } else if (cap.name === "call.member") {
+        // Member/property call (issue #1894 review): the bare property
+        // name must never bind a visible symbol — mark it so the
+        // heuristic resolver skips it (LSP owns method dispatch).
+        callSites.push({
+          calleeNameCandidates: [cap.node.text],
+          memberAccess: true,
           span: { startByte: cap.node.startIndex, endByte: cap.node.endIndex },
         });
       }

--- a/packages/coding-graph/src/engine/extractors.ts
+++ b/packages/coding-graph/src/engine/extractors.ts
@@ -208,7 +208,7 @@ const PYTHON_EXTRACTOR: LanguageExtractor = {
   exportsQuery: ``,
   callSitesQuery: `
 (call function: (identifier) @call.callee)
-(call function: (attribute attribute: (identifier) @call.callee))
+(call function: (attribute attribute: (identifier) @call.member))
 `.trim(),
   routesQuery: `
 (decorated_definition
@@ -301,7 +301,8 @@ const JAVA_EXTRACTOR: LanguageExtractor = {
 `.trim(),
   exportsQuery: ``,
   callSitesQuery: `
-(method_invocation name: (identifier) @call.callee)
+(method_invocation !object name: (identifier) @call.callee)
+(method_invocation object: (_) name: (identifier) @call.member)
 `.trim(),
   routesQuery: ``,
 };
@@ -361,7 +362,7 @@ const CSHARP_EXTRACTOR: LanguageExtractor = {
   exportsQuery: ``,
   callSitesQuery: `
 (invocation_expression function: (identifier) @call.callee)
-(invocation_expression function: (member_access_expression name: (identifier) @call.callee))
+(invocation_expression function: (member_access_expression name: (identifier) @call.member))
 `.trim(),
   routesQuery: ``,
 };
@@ -381,7 +382,8 @@ const RUBY_EXTRACTOR: LanguageExtractor = {
 `.trim(),
   exportsQuery: ``,
   callSitesQuery: `
-(call method: (identifier) @call.callee)
+(call !receiver method: (identifier) @call.callee)
+(call receiver: (_) method: (identifier) @call.member)
 `.trim(),
   routesQuery: ``,
 };

--- a/packages/coding-graph/src/engine/extractors.ts
+++ b/packages/coding-graph/src/engine/extractors.ts
@@ -56,11 +56,14 @@ const JS_FAMILY_DEFINITIONS = `
 const JS_IMPORTS = `
 (import_statement
   source: (string (string_fragment) @import.module)) @__import.stmt
+; Default and namespace imports bind LOCAL aliases whose exported symbol
+; is unknowable to Phase A (issue #1894 round 12): they appear in
+; importedNames (informational) but never in bindings (call-bindable).
 (import_statement
-  (import_clause (identifier) @import.name)
+  (import_clause (identifier) @import.unboundName)
   source: (string (string_fragment) @import.module)) @__import.stmt
 (import_statement
-  (import_clause (namespace_import (identifier) @import.name))
+  (import_clause (namespace_import (identifier) @import.unboundName))
   source: (string (string_fragment) @import.module)) @__import.stmt
 (import_statement
   (import_clause (named_imports (import_specifier name: (identifier) @import.name)))

--- a/packages/coding-graph/src/engine/extractors.ts
+++ b/packages/coding-graph/src/engine/extractors.ts
@@ -65,6 +65,13 @@ const JS_IMPORTS = `
 (import_statement
   (import_clause (named_imports (import_specifier name: (identifier) @import.name)))
   source: (string (string_fragment) @import.module)) @__import.stmt
+; Aliased named import (issue #1894 review): import { foo as bar } — the
+; local binding is the alias; the exported name stays the binding target.
+(import_statement
+  (import_clause (named_imports (import_specifier
+    name: (identifier) @import.aliasExported
+    alias: (identifier) @import.aliasLocal)))
+  source: (string (string_fragment) @import.module)) @__import.stmt
 
 ; CommonJS require("...") — capture the module specifier so dependency
 ; edges exist for Node/CommonJS codebases, not just ES-module imports.
@@ -130,7 +137,10 @@ const JS_EXPORTS = `
 
 const JS_CALLS = `
 (call_expression function: (identifier) @call.callee)
-(call_expression function: (member_expression property: (property_identifier) @call.callee))
+; Member calls are captured separately (issue #1894 review): obj.save()'s
+; \`save\` must never bind a bare visible symbol — method dispatch is
+; Phase B (LSP) territory. The emit layer marks these memberAccess: true.
+(call_expression function: (member_expression property: (property_identifier) @call.member))
 `.trim();
 
 const JS_ROUTES = `
@@ -235,7 +245,7 @@ const GO_EXTRACTOR: LanguageExtractor = {
   exportsQuery: ``,
   callSitesQuery: `
 (call_expression function: (identifier) @call.callee)
-(call_expression function: (selector_expression field: (field_identifier) @call.callee))
+(call_expression function: (selector_expression field: (field_identifier) @call.member))
 `.trim(),
   routesQuery: ``,
 };
@@ -271,7 +281,7 @@ const RUST_EXTRACTOR: LanguageExtractor = {
   exportsQuery: ``,
   callSitesQuery: `
 (call_expression function: (identifier) @call.callee)
-(call_expression function: (field_expression field: (field_identifier) @call.callee))
+(call_expression function: (field_expression field: (field_identifier) @call.member))
 (call_expression function: (scoped_identifier) @call.callee)
 `.trim(),
   routesQuery: ``,
@@ -331,7 +341,7 @@ const CPP_EXTRACTOR: LanguageExtractor = {
   exportsQuery: ``,
   callSitesQuery: `
 (call_expression function: (identifier) @call.callee)
-(call_expression function: (field_expression field: (field_identifier) @call.callee))
+(call_expression function: (field_expression field: (field_identifier) @call.member))
 `.trim(),
   routesQuery: ``,
 };
@@ -390,7 +400,7 @@ const PHP_EXTRACTOR: LanguageExtractor = {
   exportsQuery: ``,
   callSitesQuery: `
 (function_call_expression function: (name) @call.callee)
-(member_call_expression (name) @call.callee)
+(member_call_expression (name) @call.member)
 `.trim(),
   routesQuery: ``,
 };

--- a/packages/coding-graph/src/engine/extractors.ts
+++ b/packages/coding-graph/src/engine/extractors.ts
@@ -197,6 +197,17 @@ const PYTHON_EXTRACTOR: LanguageExtractor = {
   importsQuery: `
 (import_statement (dotted_name) @import.module) @__import.stmt
 (import_from_statement module_name: (dotted_name) @import.module) @__import.stmt
+; Imported names (issue #1894 review round 7): without these captures,
+; extractImports emits importedNames: [] and the heuristic resolver's
+; import bindings never fire for real Python parses.
+(import_from_statement
+  module_name: (dotted_name) @import.module
+  name: (dotted_name) @import.name) @__import.stmt
+(import_from_statement
+  module_name: (dotted_name) @import.module
+  name: (aliased_import
+    name: (dotted_name) @import.aliasExported
+    alias: (identifier) @import.aliasLocal)) @__import.stmt
 ; Python relative imports: from .models import User / from ..parent import X
 ; tree-sitter-python wraps the module inside a relative_import node, so the
 ; module_name field is NOT set. Capture the relative_import node itself so
@@ -204,6 +215,14 @@ const PYTHON_EXTRACTOR: LanguageExtractor = {
 ; relative levels must not collapse to the same module name
 ; (chatgpt-codex-connector #1688 P2: 'Preserve dots in Python relative imports').
 (import_from_statement (relative_import) @import.module) @__import.stmt
+(import_from_statement
+  (relative_import) @import.module
+  name: (dotted_name) @import.name) @__import.stmt
+(import_from_statement
+  (relative_import) @import.module
+  name: (aliased_import
+    name: (dotted_name) @import.aliasExported
+    alias: (identifier) @import.aliasLocal)) @__import.stmt
 `.trim(),
   exportsQuery: ``,
   callSitesQuery: `

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -138,7 +138,8 @@ export interface EdgeIR {
    * Repo-relative, extension-stripped path the dst must live in (issue
    * #1894 review): derived from a relative import's module specifier. A
    * hinted edge resolves ONLY among nodes whose file path matches the
-   * hint (`<hint>`, `<hint>.<ext>`, or `<hint>/index.<ext>`) — never via
+   * hint (`<hint>`, `<hint>.<ext>`, `<hint>/index.<ext>`, or
+   * `<hint>/__init__.<ext>`) — never via
    * the global bare-name fallback — so `import { foo } from "./missing"`
    * can never bind an unrelated same-named symbol elsewhere in the repo.
    */
@@ -3338,7 +3339,8 @@ function resolveNodeId(
 /**
  * Resolve a dst node constrained to a path hint (issue #1894 review): the
  * node's file path must be the hint verbatim, `<hint>.<ext>`, or
- * `<hint>/index.<ext>`. `substr` prefix comparisons (not LIKE) so hint
+ * `<hint>/index.<ext>`, or `<hint>/__init__.<ext>` (Python packages).
+ * `substr` prefix comparisons (not LIKE) so hint
  * characters are never pattern metacharacters. Zero or multiple matches
  * return `undefined` — the edge is dropped rather than guessed (same
  * conservative policy as {@link resolveNodeId}).
@@ -3355,6 +3357,7 @@ function resolveNodeIdWithPathHint(
           WHERE n.qualified_name = ?
             AND (f.path = ?
               OR substr(f.path, 1, ?) = ?
+              OR substr(f.path, 1, ?) = ?
               OR substr(f.path, 1, ?) = ?)
           ORDER BY f.path, n.id`,
       )
@@ -3365,6 +3368,8 @@ function resolveNodeIdWithPathHint(
         `${pathHint}.`,
         pathHint.length + 7,
         `${pathHint}/index.`,
+        pathHint.length + 10,
+        `${pathHint}/__init__.`,
       ),
     ["id"],
   );

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -144,6 +144,13 @@ export interface EdgeIR {
    * can never bind an unrelated same-named symbol elsewhere in the repo.
    */
   readonly dstPathHint?: string;
+  /**
+   * Language of the importing file (issue #1894 round 13): constrains the
+   * hinted dst's file extension to that language's module-resolution set
+   * so a polyglot repo cannot cross-bind a JS import to a same-named .py
+   * file.
+   */
+  readonly dstImporterLanguage?: string;
 }
 
 /**
@@ -1777,7 +1784,12 @@ export class GraphStore {
       // file — never via the global bare-name fallback; unhinted edges
       // keep the batch-map + full-DB fallback.
       const dstId = edge.dstPathHint
-        ? resolveNodeIdWithPathHint(edge.dstQualifiedName, edge.dstPathHint, this.db)
+        ? resolveNodeIdWithPathHint(
+            edge.dstQualifiedName,
+            edge.dstPathHint,
+            this.db,
+            edge.dstImporterLanguage,
+          )
         : resolveNodeId(edge.dstQualifiedName, qualifiedNameToId, this.db);
       if (!dstId) continue;
       const key = `${srcId}\u0000${dstId}\u0000${edge.type}`;
@@ -3355,11 +3367,52 @@ function resolveNodeId(
  * matches return `undefined` — the edge is dropped rather than guessed
  * (same conservative policy as {@link resolveNodeId}).
  */
+/**
+ * Language families and the file extensions a module resolver in that
+ * family accepts (issue #1894 round 13). A polyglot repo cannot let a
+ * JS import bind a same-named .py file: constrain by importer language.
+ */
+const LANG_FAMILY_EXTENSIONS: Record<string, ReadonlySet<string>> = {
+  js: new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs"]),
+  python: new Set(["py", "pyi"]),
+  ruby: new Set(["rb"]),
+  go: new Set(["go"]),
+  rust: new Set(["rs"]),
+  php: new Set(["php"]),
+  java: new Set(["java"]),
+  csharp: new Set(["cs"]),
+  cpp: new Set(["cc", "cpp", "cxx", "c", "hh", "hpp", "hxx", "h"]),
+  kotlin: new Set(["kt"]),
+  swift: new Set(["swift"]),
+  bash: new Set(["sh", "bash"]),
+};
+
+const IMPORTER_LANG_FAMILY: Record<string, keyof typeof LANG_FAMILY_EXTENSIONS> = {
+  typescript: "js",
+  tsx: "js",
+  javascript: "js",
+  python: "python",
+  ruby: "ruby",
+  go: "go",
+  rust: "rust",
+  php: "php",
+  java: "java",
+  csharp: "csharp",
+  c: "cpp",
+  cpp: "cpp",
+  kotlin: "kotlin",
+  swift: "swift",
+  bash: "bash",
+};
+
 function resolveNodeIdWithPathHint(
   qualifiedName: string,
   pathHint: string,
   db: BetterSqlite3Database,
+  importerLanguage?: string,
 ): string | undefined {
+  const family = importerLanguage ? IMPORTER_LANG_FAMILY[importerLanguage] : undefined;
+  const allowedExts = family ? LANG_FAMILY_EXTENSIONS[family] : undefined;
   const rows = expectRows<{ id: string; path: string }>(
     db
       .prepare(
@@ -3374,9 +3427,12 @@ function resolveNodeIdWithPathHint(
     if (row.path === pathHint) return true;
     if (!row.path.startsWith(pathHint)) return false;
     const rest = row.path.slice(pathHint.length);
-    // ".<ext>" | "/index.<ext>" | "/__init__.<ext>" — single extension
-    // segment only (no further dots or separators).
-    return /^(?:\.[^./]+|\/(?:index|__init__)\.[^./]+)$/.test(rest);
+    const m = /^(?:\.([^./]+)|\/(?:index|__init__)\.([^./]+))$/.exec(rest);
+    if (!m) return false;
+    const ext = m[1] ?? m[2];
+    // When the importer's language family is known, only that family's
+    // extensions may satisfy the hint; otherwise any single extension.
+    return !allowedExts || allowedExts.has(ext);
   });
   if (matches.length !== 1) return undefined;
   return matches[0]?.id;

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -3373,7 +3373,7 @@ function resolveNodeId(
  * JS import bind a same-named .py file: constrain by importer language.
  */
 const LANG_FAMILY_EXTENSIONS: Record<string, ReadonlySet<string>> = {
-  js: new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs"]),
+  js: new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs", "mts", "cts"]),
   python: new Set(["py", "pyi"]),
   ruby: new Set(["rb"]),
   go: new Set(["go"]),
@@ -3424,7 +3424,15 @@ function resolveNodeIdWithPathHint(
     ["id", "path"],
   );
   const matches = rows.filter((row) => {
-    if (row.path === pathHint) return true;
+    if (row.path === pathHint) {
+      // Language filter still applies on exact match: a TS import whose
+      // normalized hint happens to equal a bare directory name must not
+      // bind a same-named .py file (codex review round 15).
+      if (allowedExts) {
+        return false; // bare hint with no extension cannot match a family
+      }
+      return true;
+    }
     if (!row.path.startsWith(pathHint)) return false;
     const rest = row.path.slice(pathHint.length);
     const m = /^(?:\.([^./]+)|\/(?:index|__init__)\.([^./]+))$/.exec(rest);

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -1867,6 +1867,19 @@ export class GraphStore {
         // stale keys.
         continue;
       }
+      // Provenance scoping also protects the UPDATE path (issue #1891,
+      // codex P2): a prior row whose provenance is OUTSIDE the asserted
+      // scope (e.g. an lsp-upgraded row on the same key) must not be
+      // downgraded by re-deriving the heuristic assertion. The assertion
+      // already kept the row out of the stale-delete set; leaving the
+      // stronger row untouched is the whole point of the scope.
+      if (
+        prior &&
+        scoped &&
+        !(scoped as readonly string[]).includes(prior.provenance)
+      ) {
+        continue;
+      }
       const r = insertEdge.run(srcId, dstId, edge.type, edge.confidence, edge.provenance);
       edgeCount += r.changes;
     }

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -160,6 +160,16 @@ export interface StoreFileIR {
   /** Store-specific edges derived from the IR by the caller. */
   readonly edges?: readonly EdgeIR[];
   /**
+   * When present, the stale-edge delete in `upsertFileEdges` is scoped to
+   * edges whose provenance is in this list: prior src-owned edges of OTHER
+   * provenances survive un-asserted (issue #1891). The reindex pipeline
+   * asserts `["heuristic"]` because a fresh parse says nothing about
+   * `trace`/`lsp` edges; deleting them on every re-ingest would destroy
+   * state the parse never contradicted (rule 25). Absent = legacy
+   * behavior: every stale src-owned edge is deleted.
+   */
+  readonly assertedEdgeProvenances?: readonly EdgeProvenance[];
+  /**
    * Per-file export list (mirrors core FileIR.exports). When present,
    * the write pipeline marks every node in this file whose `name`
    * matches an ExportIR.name as `is_exported=1` in `node_attributes`.
@@ -1788,12 +1798,17 @@ export class GraphStore {
     );
     const priorByKey = new Map<string, { confidence: number; provenance: string }>();
     const staleSrcDstTypes: Array<{ src: string; dst: string; type: string }> = [];
+    // Provenance scoping (issue #1891): when the IR declares which
+    // provenances it asserts, stale edges of OTHER provenances are not
+    // this ingest's to delete — a fresh parse contradicts only its own
+    // derivation class (rule 25). Absent = legacy delete-all-stale.
+    const scoped = ir.assertedEdgeProvenances;
     for (const p of priorEdges) {
       const key = `${p.src}\u0000${p.dst}\u0000${p.type}`;
       priorByKey.set(key, { confidence: p.confidence, provenance: p.provenance });
-      if (!assertedKeys.has(key)) {
-        staleSrcDstTypes.push({ src: p.src, dst: p.dst, type: p.type });
-      }
+      if (assertedKeys.has(key)) continue;
+      if (scoped && !(scoped as readonly string[]).includes(p.provenance)) continue;
+      staleSrcDstTypes.push({ src: p.src, dst: p.dst, type: p.type });
     }
 
     // Delete only the stale src-owned edges (prior-but-not-asserted).

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -3338,43 +3338,41 @@ function resolveNodeId(
 
 /**
  * Resolve a dst node constrained to a path hint (issue #1894 review): the
- * node's file path must be the hint verbatim, `<hint>.<ext>`, or
- * `<hint>/index.<ext>`, or `<hint>/__init__.<ext>` (Python packages).
- * `substr` prefix comparisons (not LIKE) so hint
- * characters are never pattern metacharacters. Zero or multiple matches
- * return `undefined` — the edge is dropped rather than guessed (same
- * conservative policy as {@link resolveNodeId}).
+ * node's file path must be the hint verbatim, `<hint>.<ext>`,
+ * `<hint>/index.<ext>`, or `<hint>/__init__.<ext>` (Python packages) —
+ * where `<ext>` is a SINGLE dot-free extension segment, so `main.test.ts`
+ * and `main.d.ts` never satisfy a `main` hint (they are not what a module
+ * resolver would load for `./main`). Candidate rows are fetched by
+ * qualified name and the path shape is checked in JS: no LIKE/GLOB, so
+ * hint characters are never pattern metacharacters. Zero or multiple
+ * matches return `undefined` — the edge is dropped rather than guessed
+ * (same conservative policy as {@link resolveNodeId}).
  */
 function resolveNodeIdWithPathHint(
   qualifiedName: string,
   pathHint: string,
   db: BetterSqlite3Database,
 ): string | undefined {
-  const rows = expectRows<{ id: string }>(
+  const rows = expectRows<{ id: string; path: string }>(
     db
       .prepare(
-        `SELECT n.id FROM nodes n JOIN files f ON n.file_id = f.id
+        `SELECT n.id, f.path FROM nodes n JOIN files f ON n.file_id = f.id
           WHERE n.qualified_name = ?
-            AND (f.path = ?
-              OR substr(f.path, 1, ?) = ?
-              OR substr(f.path, 1, ?) = ?
-              OR substr(f.path, 1, ?) = ?)
           ORDER BY f.path, n.id`,
       )
-      .all(
-        qualifiedName,
-        pathHint,
-        pathHint.length + 1,
-        `${pathHint}.`,
-        pathHint.length + 7,
-        `${pathHint}/index.`,
-        pathHint.length + 10,
-        `${pathHint}/__init__.`,
-      ),
-    ["id"],
+      .all(qualifiedName),
+    ["id", "path"],
   );
-  if (rows.length !== 1) return undefined;
-  return rows[0]?.id;
+  const matches = rows.filter((row) => {
+    if (row.path === pathHint) return true;
+    if (!row.path.startsWith(pathHint)) return false;
+    const rest = row.path.slice(pathHint.length);
+    // ".<ext>" | "/index.<ext>" | "/__init__.<ext>" — single extension
+    // segment only (no further dots or separators).
+    return /^(?:\.[^./]+|\/(?:index|__init__)\.[^./]+)$/.test(rest);
+  });
+  if (matches.length !== 1) return undefined;
+  return matches[0]?.id;
 }
 
 /**

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -134,6 +134,15 @@ export interface EdgeIR {
   readonly srcNodeId?: string;
   /** Optional content-derived destination node id — see {@link EdgeIR.srcNodeId}. */
   readonly dstNodeId?: string;
+  /**
+   * Repo-relative, extension-stripped path the dst must live in (issue
+   * #1894 review): derived from a relative import's module specifier. A
+   * hinted edge resolves ONLY among nodes whose file path matches the
+   * hint (`<hint>`, `<hint>.<ext>`, or `<hint>/index.<ext>`) — never via
+   * the global bare-name fallback — so `import { foo } from "./missing"`
+   * can never bind an unrelated same-named symbol elsewhere in the repo.
+   */
+  readonly dstPathHint?: string;
 }
 
 /**
@@ -1762,12 +1771,13 @@ export class GraphStore {
       // re-ingest (chatgpt-codex-connector P2).
       const srcId = qualifiedNameToId.get(edge.srcQualifiedName);
       if (!srcId) continue;
-      // DST may be cross-file — use the full-DB fallback.
-      const dstId = resolveNodeId(
-        edge.dstQualifiedName,
-        qualifiedNameToId,
-        this.db,
-      );
+      // DST may be cross-file. A path-hinted edge (relative import,
+      // issue #1894 review) resolves ONLY within its declared target
+      // file — never via the global bare-name fallback; unhinted edges
+      // keep the batch-map + full-DB fallback.
+      const dstId = edge.dstPathHint
+        ? resolveNodeIdWithPathHint(edge.dstQualifiedName, edge.dstPathHint, this.db)
+        : resolveNodeId(edge.dstQualifiedName, qualifiedNameToId, this.db);
       if (!dstId) continue;
       const key = `${srcId}\u0000${dstId}\u0000${edge.type}`;
       assertedKeys.add(key);
@@ -1867,16 +1877,24 @@ export class GraphStore {
         // stale keys.
         continue;
       }
-      // Provenance scoping also protects the UPDATE path (issue #1891,
-      // codex P2): a prior row whose provenance is OUTSIDE the asserted
-      // scope (e.g. an lsp-upgraded row on the same key) must not be
-      // downgraded by re-deriving the heuristic assertion. The assertion
-      // already kept the row out of the stale-delete set; leaving the
-      // stronger row untouched is the whole point of the scope.
+      // Two update-path protections under provenance scoping (issue
+      // #1891 + #1894 review rounds):
+      //  1. a prior row whose provenance is OUTSIDE the asserted scope
+      //     is not this assertion's to modify (defense in depth — in
+      //     practice cross-provenance key collisions are heuristic/lsp
+      //     only, handled by 2);
+      //  2. an lsp row is a strictly stronger derivation of the SAME
+      //     source-derived edge: re-asserting the heuristic key keeps
+      //     the row alive (it is not stale) but must never downgrade it.
+      //     Retirement of lsp rows happens through the stale-delete when
+      //     the call disappears from the parse — lsp IS in the reindex
+      //     assertion scope precisely so vanished calls retire their
+      //     upgraded rows too.
       if (
         prior &&
         scoped &&
-        !(scoped as readonly string[]).includes(prior.provenance)
+        (!(scoped as readonly string[]).includes(prior.provenance) ||
+          (prior.provenance === "lsp" && edge.provenance === "heuristic"))
       ) {
         continue;
       }
@@ -3314,6 +3332,43 @@ function resolveNodeId(
     // EdgeIR with file identity material.
     return undefined;
   }
+  return rows[0]?.id;
+}
+
+/**
+ * Resolve a dst node constrained to a path hint (issue #1894 review): the
+ * node's file path must be the hint verbatim, `<hint>.<ext>`, or
+ * `<hint>/index.<ext>`. `substr` prefix comparisons (not LIKE) so hint
+ * characters are never pattern metacharacters. Zero or multiple matches
+ * return `undefined` — the edge is dropped rather than guessed (same
+ * conservative policy as {@link resolveNodeId}).
+ */
+function resolveNodeIdWithPathHint(
+  qualifiedName: string,
+  pathHint: string,
+  db: BetterSqlite3Database,
+): string | undefined {
+  const rows = expectRows<{ id: string }>(
+    db
+      .prepare(
+        `SELECT n.id FROM nodes n JOIN files f ON n.file_id = f.id
+          WHERE n.qualified_name = ?
+            AND (f.path = ?
+              OR substr(f.path, 1, ?) = ?
+              OR substr(f.path, 1, ?) = ?)
+          ORDER BY f.path, n.id`,
+      )
+      .all(
+        qualifiedName,
+        pathHint,
+        pathHint.length + 1,
+        `${pathHint}.`,
+        pathHint.length + 7,
+        `${pathHint}/index.`,
+      ),
+    ["id"],
+  );
+  if (rows.length !== 1) return undefined;
   return rows[0]?.id;
 }
 

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -1813,7 +1813,14 @@ export class GraphStore {
     // provenances it asserts, stale edges of OTHER provenances are not
     // this ingest's to delete — a fresh parse contradicts only its own
     // derivation class (rule 25). Absent = legacy delete-all-stale.
-    const scoped = ir.assertedEdgeProvenances;
+    // An EMPTY scope array is treated as absent (cursor review round 9):
+    // "[]" would otherwise be truthy, protect every prior edge from
+    // deletion AND from updates, and silently disable cleanup — an
+    // assertion that scopes nothing scopes nothing.
+    const scoped =
+      ir.assertedEdgeProvenances && ir.assertedEdgeProvenances.length > 0
+        ? ir.assertedEdgeProvenances
+        : undefined;
     for (const p of priorEdges) {
       const key = `${p.src}\u0000${p.dst}\u0000${p.type}`;
       priorByKey.set(key, { confidence: p.confidence, provenance: p.provenance });

--- a/packages/coding-graph/src/heuristic-resolution.test.ts
+++ b/packages/coding-graph/src/heuristic-resolution.test.ts
@@ -523,3 +523,22 @@ test("pure parent-package python imports hint the package directory (codex revie
     ],
   );
 });
+
+test("implicit-this languages bind sibling methods on bare calls (codex review round 11)", () => {
+  const ir = fileIR({
+    path: "C.java",
+    language: "java",
+    symbols: [
+      { kind: "class", name: "C", qualifiedName: "C", span: span(0, 200) },
+      { kind: "method", name: "run", qualifiedName: "C.run", span: span(10, 100) },
+      { kind: "method", name: "helper", qualifiedName: "C.helper", span: span(110, 190) },
+    ],
+    // Java: helper() inside run() legally targets the sibling method.
+    callSites: [{ calleeNameCandidates: ["helper"], span: span(40, 48) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.deepEqual(
+    firstFile(result).edges.map((e: EdgeIR) => [e.srcQualifiedName, e.dstQualifiedName]),
+    [["C.run", "C.helper"]],
+  );
+});

--- a/packages/coding-graph/src/heuristic-resolution.test.ts
+++ b/packages/coding-graph/src/heuristic-resolution.test.ts
@@ -497,3 +497,29 @@ test("empty bindings array falls back to importedNames (cursor review round 9)",
   assert.equal(firstFile(result).edges.length, 1);
   assert.equal(firstFile(result).edges[0]?.dstQualifiedName, "greet");
 });
+
+test("pure parent-package python imports hint the package directory (codex review round 10)", () => {
+  const ir = fileIR({
+    path: "pkg/app/views.py",
+    language: "python",
+    symbols: [
+      { kind: "function", name: "render", qualifiedName: "render", span: span(30, 110) },
+    ],
+    imports: [
+      { module: ".", importedNames: ["sibling"], span: span(0, 20) },
+      { module: "..", importedNames: ["helper"], span: span(21, 45) },
+    ],
+    callSites: [
+      { calleeNameCandidates: ["sibling"], span: span(60, 67) },
+      { calleeNameCandidates: ["helper"], span: span(70, 76) },
+    ],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.deepEqual(
+    firstFile(result).edges.map((e: EdgeIR) => [e.dstQualifiedName, e.dstPathHint]),
+    [
+      ["sibling", "pkg/app"],
+      ["helper", "pkg"],
+    ],
+  );
+});

--- a/packages/coding-graph/src/heuristic-resolution.test.ts
+++ b/packages/coding-graph/src/heuristic-resolution.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Phase A heuristic edge resolution tests (issue #1891).
+ *
+ * deriveHeuristicEdges: pure function FileIR[] → per-file EdgeIR[] + stats.
+ * The store's pass-2 (batch map + full-DB dst fallback, conservative
+ * ambiguity drops) does final id resolution; this module only decides
+ * WHICH (srcQualifiedName → dstQualifiedName, CALLS) assertions a fresh
+ * parse supports, so every emitted edge must be derivable from the IR
+ * alone.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  deriveHeuristicEdges,
+  HEURISTIC_CONFIDENCE_SAME_FILE,
+  HEURISTIC_CONFIDENCE_IMPORT_BOUND,
+} from "./heuristic-resolution.js";
+import type { EdgeIR, FileIR } from "./graph-store.js";
+
+function firstFile(result: { files: readonly { edges: readonly EdgeIR[] }[] }): { edges: readonly EdgeIR[] } {
+  const file = result.files[0];
+  assert.ok(file, "expected at least one file in the result");
+  return file;
+}
+
+function fileIR(overrides: Partial<FileIR> & { path: string }): FileIR {
+  return {
+    language: "typescript",
+    contentHash: `h-${overrides.path}`,
+    symbols: [],
+    imports: [],
+    exports: [],
+    callSites: [],
+    routes: [],
+    ...overrides,
+  } as FileIR;
+}
+
+const span = (startByte: number, endByte: number) => ({ startByte, endByte });
+
+test("same-file call resolves to a CALLS edge with heuristic provenance", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "function", name: "greet", qualifiedName: "greet", span: span(0, 70) },
+      { kind: "function", name: "format", qualifiedName: "format", span: span(71, 132) },
+    ],
+    callSites: [{ calleeNameCandidates: ["format"], span: span(40, 46) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const { stats } = result;
+  assert.equal(result.files.length, 1);
+  assert.deepEqual(firstFile(result).edges, [
+    {
+      srcQualifiedName: "greet",
+      dstQualifiedName: "format",
+      type: "CALLS",
+      confidence: HEURISTIC_CONFIDENCE_SAME_FILE,
+      provenance: "heuristic",
+    },
+  ]);
+  assert.equal(stats.callSites, 1);
+  assert.equal(stats.resolved, 1);
+});
+
+test("import-bound cross-file call emits an edge for the store to resolve", () => {
+  const ir = fileIR({
+    path: "util.ts",
+    symbols: [
+      { kind: "function", name: "shout", qualifiedName: "shout", span: span(30, 110) },
+    ],
+    imports: [{ module: "./main", importedNames: ["greet"], span: span(0, 29) }],
+    callSites: [{ calleeNameCandidates: ["greet"], span: span(60, 67) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.deepEqual(firstFile(result).edges, [
+    {
+      srcQualifiedName: "shout",
+      dstQualifiedName: "greet",
+      type: "CALLS",
+      confidence: HEURISTIC_CONFIDENCE_IMPORT_BOUND,
+      provenance: "heuristic",
+    },
+  ]);
+});
+
+test("unresolvable bare names are skipped and counted, never emitted", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "function", name: "greet", qualifiedName: "greet", span: span(0, 70) },
+    ],
+    callSites: [{ calleeNameCandidates: ["log"], span: span(20, 25) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const { stats } = result;
+  assert.deepEqual(firstFile(result).edges, []);
+  assert.equal(stats.skippedUnresolved, 1);
+  assert.equal(stats.resolved, 0);
+});
+
+test("call site outside any symbol span is skipped and counted", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "function", name: "format", qualifiedName: "format", span: span(50, 100) },
+    ],
+    // Top-level call before the first symbol.
+    callSites: [{ calleeNameCandidates: ["format"], span: span(0, 8) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const { stats } = result;
+  assert.deepEqual(firstFile(result).edges, []);
+  assert.equal(stats.skippedNoEnclosingSymbol, 1);
+});
+
+test("innermost enclosing symbol wins as src (nested spans)", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "class", name: "Outer", qualifiedName: "Outer", span: span(0, 200) },
+      { kind: "method", name: "run", qualifiedName: "Outer.run", span: span(20, 120) },
+      { kind: "function", name: "helper", qualifiedName: "helper", span: span(210, 260) },
+    ],
+    callSites: [{ calleeNameCandidates: ["helper"], span: span(60, 68) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.equal(firstFile(result).edges.length, 1);
+  assert.equal(firstFile(result).edges[0]?.srcQualifiedName, "Outer.run");
+});
+
+test("ambiguous same-file name is skipped conservatively and counted", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "function", name: "run", qualifiedName: "run", span: span(0, 50) },
+      // Same bare name at a different span (e.g. overload-style duplicate).
+      { kind: "function", name: "format", qualifiedName: "a.format", span: span(60, 100) },
+      { kind: "function", name: "format", qualifiedName: "b.format", span: span(110, 150) },
+    ],
+    callSites: [{ calleeNameCandidates: ["format"], span: span(20, 28) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const { stats } = result;
+  assert.deepEqual(firstFile(result).edges, []);
+  assert.equal(stats.skippedAmbiguous, 1);
+});
+
+test("second callee candidate is tried when the first cannot resolve", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "function", name: "run", qualifiedName: "run", span: span(0, 50) },
+      { kind: "function", name: "fallback", qualifiedName: "fallback", span: span(60, 100) },
+    ],
+    callSites: [{ calleeNameCandidates: ["missing", "fallback"], span: span(10, 20) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const { stats } = result;
+  assert.equal(firstFile(result).edges.length, 1);
+  assert.equal(firstFile(result).edges[0]?.dstQualifiedName, "fallback");
+  assert.equal(stats.resolved, 1);
+});
+
+test("recursive self-call emits a self edge", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "function", name: "walk", qualifiedName: "walk", span: span(0, 90) },
+    ],
+    callSites: [{ calleeNameCandidates: ["walk"], span: span(40, 46) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.deepEqual(firstFile(result).edges.map((e: EdgeIR) => [e.srcQualifiedName, e.dstQualifiedName]), [
+    ["walk", "walk"],
+  ]);
+});
+
+test("duplicate src→dst call sites are deduped to one edge", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "function", name: "greet", qualifiedName: "greet", span: span(0, 90) },
+      { kind: "function", name: "format", qualifiedName: "format", span: span(100, 150) },
+    ],
+    callSites: [
+      { calleeNameCandidates: ["format"], span: span(20, 26) },
+      { calleeNameCandidates: ["format"], span: span(50, 56) },
+    ],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const { stats } = result;
+  assert.equal(firstFile(result).edges.length, 1);
+  assert.equal(stats.callSites, 2);
+  assert.equal(stats.resolved, 2);
+});
+
+test("files with no call sites assert an explicit empty edge set", () => {
+  const ir = fileIR({
+    path: "empty.ts",
+    symbols: [
+      { kind: "function", name: "solo", qualifiedName: "solo", span: span(0, 20) },
+    ],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  // Empty ARRAY (not undefined): the fresh parse asserts "no heuristic
+  // edges", so stale heuristic edges from a prior version are cleaned up.
+  assert.deepEqual(firstFile(result).edges, []);
+});
+
+test("output is deterministic and byte-stable across runs (rule 38)", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "function", name: "a", qualifiedName: "a", span: span(0, 40) },
+      { kind: "function", name: "b", qualifiedName: "b", span: span(50, 90) },
+      { kind: "function", name: "c", qualifiedName: "c", span: span(100, 140) },
+    ],
+    callSites: [
+      { calleeNameCandidates: ["c"], span: span(10, 12) },
+      { calleeNameCandidates: ["b"], span: span(20, 22) },
+    ],
+  });
+  const one = JSON.stringify(deriveHeuristicEdges([ir]));
+  const two = JSON.stringify(deriveHeuristicEdges([ir]));
+  assert.equal(one, two);
+});

--- a/packages/coding-graph/src/heuristic-resolution.test.ts
+++ b/packages/coding-graph/src/heuristic-resolution.test.ts
@@ -295,9 +295,9 @@ test("external-package imports never bind bare names (no false in-repo edges)", 
   assert.equal(stats.skippedUnresolved, 1);
 });
 
-test("relative-module imports still bind (in-repo resolvable)", () => {
+test("relative-module imports bind with a normalized in-repo hint", () => {
   const ir = fileIR({
-    path: "util.ts",
+    path: "src/util.ts",
     symbols: [
       { kind: "function", name: "shout", qualifiedName: "shout", span: span(30, 110) },
     ],
@@ -307,7 +307,65 @@ test("relative-module imports still bind (in-repo resolvable)", () => {
   const result = deriveHeuristicEdges([ir]);
   assert.equal(firstFile(result).edges.length, 1);
   assert.equal(firstFile(result).edges[0]?.confidence, HEURISTIC_CONFIDENCE_IMPORT_BOUND);
-  assert.equal(firstFile(result).edges[0]?.dstPathHint, "../lib/main");
+  assert.equal(firstFile(result).edges[0]?.dstPathHint, "lib/main");
+});
+
+test("an import escaping the repo root never binds (cursor review)", () => {
+  const ir = fileIR({
+    path: "util.ts",
+    symbols: [
+      { kind: "function", name: "shout", qualifiedName: "shout", span: span(30, 110) },
+    ],
+    // dirname("util.ts") = "." so ../lib escapes the repo root — files.path
+    // is canonical and can never match a "../" hint.
+    imports: [{ module: "../lib/main.js", importedNames: ["greet"], span: span(0, 29) }],
+    callSites: [{ calleeNameCandidates: ["greet"], span: span(60, 67) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const { stats } = result;
+  assert.deepEqual(firstFile(result).edges, []);
+  assert.equal(stats.skippedUnresolved, 1);
+});
+
+test("member-access call sites never bind bare names (codex review)", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "function", name: "run", qualifiedName: "run", span: span(0, 90) },
+      { kind: "function", name: "connect", qualifiedName: "connect", span: span(100, 150) },
+    ],
+    // client.connect() — the property name matches a visible bare symbol
+    // but the receiver decides the target; Phase A must skip it.
+    callSites: [{ calleeNameCandidates: ["connect"], memberAccess: true, span: span(30, 40) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const { stats } = result;
+  assert.deepEqual(firstFile(result).edges, []);
+  assert.equal(stats.skippedMemberAccess, 1);
+});
+
+test("aliased imports bind by local name and emit the exported dst (codex review)", () => {
+  const ir = fileIR({
+    path: "util.ts",
+    symbols: [
+      { kind: "function", name: "shout", qualifiedName: "shout", span: span(30, 110) },
+    ],
+    imports: [
+      {
+        module: "./main",
+        importedNames: ["greet"],
+        bindings: [{ exported: "greet", local: "salute" }],
+        span: span(0, 29),
+      },
+    ],
+    // Call site uses the LOCAL alias...
+    callSites: [{ calleeNameCandidates: ["salute"], span: span(60, 68) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.equal(firstFile(result).edges.length, 1);
+  // ...but the edge's dst is the EXPORTED name in the target file.
+  assert.equal(firstFile(result).edges[0]?.dstQualifiedName, "greet");
+  assert.equal(firstFile(result).edges[0]?.dstPathHint, "main");
 });
 
 test("an ambiguous first candidate does not block a later candidate's import binding (cursor review)", () => {

--- a/packages/coding-graph/src/heuristic-resolution.test.ts
+++ b/packages/coding-graph/src/heuristic-resolution.test.ts
@@ -447,3 +447,39 @@ test("same exported name from two modules yields two hinted edges (codex review)
     ],
   );
 });
+
+test("a bare call inside a method never binds a sibling method (codex review round 8)", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "class", name: "C", qualifiedName: "C", span: span(0, 200) },
+      { kind: "method", name: "run", qualifiedName: "C.run", span: span(10, 100) },
+      { kind: "method", name: "helper", qualifiedName: "C.helper", span: span(110, 190) },
+      { kind: "function", name: "helper", qualifiedName: "helper", span: span(210, 260) },
+    ],
+    // bare helper() inside C.run — this.helper() would be memberAccess.
+    callSites: [{ calleeNameCandidates: ["helper"], span: span(40, 48) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.deepEqual(
+    firstFile(result).edges.map((e: EdgeIR) => [e.srcQualifiedName, e.dstQualifiedName]),
+    [["C.run", "helper"]],
+    "binds the file-level function, never the sibling method C.helper",
+  );
+});
+
+test("with only a sibling method available, a bare call stays unresolved", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "class", name: "C", qualifiedName: "C", span: span(0, 200) },
+      { kind: "method", name: "run", qualifiedName: "C.run", span: span(10, 100) },
+      { kind: "method", name: "helper", qualifiedName: "C.helper", span: span(110, 190) },
+    ],
+    callSites: [{ calleeNameCandidates: ["helper"], span: span(40, 48) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const { stats } = result;
+  assert.deepEqual(firstFile(result).edges, []);
+  assert.equal(stats.skippedUnresolved, 1);
+});

--- a/packages/coding-graph/src/heuristic-resolution.test.ts
+++ b/packages/coding-graph/src/heuristic-resolution.test.ts
@@ -384,3 +384,41 @@ test("an ambiguous first candidate does not block a later candidate's import bin
   assert.equal(firstFile(result).edges[0]?.dstQualifiedName, "greet");
   assert.equal(firstFile(result).edges[0]?.dstPathHint, "main");
 });
+
+test("python dot-style relative imports bind with package-path hints (cursor review)", () => {
+  const ir = fileIR({
+    path: "pkg/app/views.py",
+    language: "python",
+    symbols: [
+      { kind: "function", name: "render", qualifiedName: "render", span: span(30, 110) },
+    ],
+    imports: [
+      { module: ".models", importedNames: ["User"], span: span(0, 25) },
+      { module: "..lib.utils", importedNames: ["helper"], span: span(26, 55) },
+    ],
+    callSites: [
+      { calleeNameCandidates: ["User"], span: span(60, 64) },
+      { calleeNameCandidates: ["helper"], span: span(70, 76) },
+    ],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const hints = firstFile(result).edges.map((e: EdgeIR) => [e.dstQualifiedName, e.dstPathHint]);
+  assert.deepEqual(hints, [
+    ["User", "pkg/app/models"],
+    ["helper", "pkg/lib/utils"],
+  ]);
+});
+
+test("python dot-style import escaping the root never binds", () => {
+  const ir = fileIR({
+    path: "views.py",
+    language: "python",
+    symbols: [
+      { kind: "function", name: "render", qualifiedName: "render", span: span(30, 110) },
+    ],
+    imports: [{ module: "..outside", importedNames: ["thing"], span: span(0, 25) }],
+    callSites: [{ calleeNameCandidates: ["thing"], span: span(60, 65) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.deepEqual(firstFile(result).edges, []);
+});

--- a/packages/coding-graph/src/heuristic-resolution.test.ts
+++ b/packages/coding-graph/src/heuristic-resolution.test.ts
@@ -82,6 +82,7 @@ test("import-bound cross-file call emits an edge for the store to resolve", () =
       confidence: HEURISTIC_CONFIDENCE_IMPORT_BOUND,
       provenance: "heuristic",
       dstPathHint: "main",
+      dstImporterLanguage: "typescript",
     },
   ]);
 });

--- a/packages/coding-graph/src/heuristic-resolution.test.ts
+++ b/packages/coding-graph/src/heuristic-resolution.test.ts
@@ -484,18 +484,28 @@ test("with only a sibling method available, a bare call stays unresolved", () =>
   assert.equal(stats.skippedUnresolved, 1);
 });
 
-test("empty bindings array falls back to importedNames (cursor review round 9)", () => {
-  const ir = fileIR({
+test("absent bindings falls back to importedNames; explicit [] binds nothing (rounds 9 + 12)", () => {
+  const base = {
     path: "util.ts",
     symbols: [
-      { kind: "function", name: "shout", qualifiedName: "shout", span: span(30, 110) },
+      { kind: "function" as const, name: "shout", qualifiedName: "shout", span: span(30, 110) },
     ],
-    imports: [{ module: "./main", importedNames: ["greet"], bindings: [], span: span(0, 29) }],
     callSites: [{ calleeNameCandidates: ["greet"], span: span(60, 67) }],
-  });
-  const result = deriveHeuristicEdges([ir]);
-  assert.equal(firstFile(result).edges.length, 1);
-  assert.equal(firstFile(result).edges[0]?.dstQualifiedName, "greet");
+  };
+  // Absent field (pre-bindings emitter / hand-built IR) -> fallback binds.
+  const absent = deriveHeuristicEdges([
+    fileIR({ ...base, imports: [{ module: "./main", importedNames: ["greet"], span: span(0, 29) }] }),
+  ]);
+  assert.equal(firstFile(absent).edges.length, 1);
+  // Explicit [] (default/namespace import: exported symbol unknowable) ->
+  // never re-bound through the fallback.
+  const explicit = deriveHeuristicEdges([
+    fileIR({
+      ...base,
+      imports: [{ module: "./main", importedNames: ["greet"], bindings: [], span: span(0, 29) }],
+    }),
+  ]);
+  assert.deepEqual(firstFile(explicit).edges, []);
 });
 
 test("pure parent-package python imports hint the package directory (codex review round 10)", () => {
@@ -541,4 +551,45 @@ test("implicit-this languages bind sibling methods on bare calls (codex review r
     firstFile(result).edges.map((e: EdgeIR) => [e.srcQualifiedName, e.dstQualifiedName]),
     [["C.run", "C.helper"]],
   );
+});
+
+test("php bare calls inside methods never bind sibling methods (codex review round 12)", () => {
+  const ir = fileIR({
+    path: "C.php",
+    language: "php",
+    symbols: [
+      { kind: "class", name: "C", qualifiedName: "C", span: span(0, 200) },
+      { kind: "method", name: "run", qualifiedName: "C.run", span: span(10, 100) },
+      { kind: "method", name: "helper", qualifiedName: "C.helper", span: span(110, 190) },
+    ],
+    callSites: [{ calleeNameCandidates: ["helper"], span: span(40, 48) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.deepEqual(firstFile(result).edges, []);
+});
+
+test("function-local imports bind only within their enclosing symbol (codex review round 12)", () => {
+  const ir = fileIR({
+    path: "app.py",
+    language: "python",
+    symbols: [
+      { kind: "function", name: "setup", qualifiedName: "setup", span: span(0, 100) },
+      { kind: "function", name: "run", qualifiedName: "run", span: span(110, 200) },
+    ],
+    // from .dep import helper INSIDE setup's span.
+    imports: [{ module: ".dep", importedNames: ["helper"], span: span(10, 40) }],
+    callSites: [
+      // Inside setup: binds.
+      { calleeNameCandidates: ["helper"], span: span(60, 66) },
+      // Inside sibling run: must NOT bind.
+      { calleeNameCandidates: ["helper"], span: span(140, 146) },
+    ],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const { stats } = result;
+  assert.deepEqual(
+    firstFile(result).edges.map((e: EdgeIR) => e.srcQualifiedName),
+    ["setup"],
+  );
+  assert.equal(stats.skippedUnresolved, 1);
 });

--- a/packages/coding-graph/src/heuristic-resolution.test.ts
+++ b/packages/coding-graph/src/heuristic-resolution.test.ts
@@ -226,3 +226,84 @@ test("output is deterministic and byte-stable across runs (rule 38)", () => {
   const two = JSON.stringify(deriveHeuristicEdges([ir]));
   assert.equal(one, two);
 });
+
+test("a nested symbol under a different parent is NOT visible to a sibling caller", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "function", name: "outer", qualifiedName: "outer", span: span(0, 100) },
+      { kind: "function", name: "helper", qualifiedName: "outer.helper", span: span(10, 60) },
+      { kind: "function", name: "run", qualifiedName: "run", span: span(110, 180) },
+    ],
+    callSites: [{ calleeNameCandidates: ["helper"], span: span(130, 138) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const { stats } = result;
+  assert.deepEqual(firstFile(result).edges, [], "outer.helper is not in run's lexical scope");
+  assert.equal(stats.skippedUnresolved, 1);
+});
+
+test("shadowing: the innermost visible declaration wins over a top-level one", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "function", name: "greet", qualifiedName: "greet", span: span(0, 100) },
+      { kind: "function", name: "format", qualifiedName: "greet.format", span: span(10, 50) },
+      { kind: "function", name: "format", qualifiedName: "format", span: span(110, 160) },
+    ],
+    callSites: [{ calleeNameCandidates: ["format"], span: span(60, 68) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.equal(firstFile(result).edges.length, 1);
+  assert.equal(
+    firstFile(result).edges[0]?.dstQualifiedName,
+    "greet.format",
+    "the nested declaration shadows the top-level one for calls inside greet",
+  );
+});
+
+test("a caller's own nested declaration is visible to it", () => {
+  const ir = fileIR({
+    path: "main.ts",
+    symbols: [
+      { kind: "function", name: "outer", qualifiedName: "outer", span: span(0, 100) },
+      { kind: "function", name: "helper", qualifiedName: "outer.helper", span: span(10, 40) },
+    ],
+    // Call inside outer but outside helper.
+    callSites: [{ calleeNameCandidates: ["helper"], span: span(60, 68) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.deepEqual(
+    firstFile(result).edges.map((e: EdgeIR) => [e.srcQualifiedName, e.dstQualifiedName]),
+    [["outer", "outer.helper"]],
+  );
+});
+
+test("external-package imports never bind bare names (no false in-repo edges)", () => {
+  const ir = fileIR({
+    path: "util.ts",
+    symbols: [
+      { kind: "function", name: "shout", qualifiedName: "shout", span: span(30, 110) },
+    ],
+    imports: [{ module: "lodash", importedNames: ["map"], span: span(0, 29) }],
+    callSites: [{ calleeNameCandidates: ["map"], span: span(60, 65) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  const { stats } = result;
+  assert.deepEqual(firstFile(result).edges, [], "lodash's map must not bind an in-repo symbol");
+  assert.equal(stats.skippedUnresolved, 1);
+});
+
+test("relative-module imports still bind (in-repo resolvable)", () => {
+  const ir = fileIR({
+    path: "util.ts",
+    symbols: [
+      { kind: "function", name: "shout", qualifiedName: "shout", span: span(30, 110) },
+    ],
+    imports: [{ module: "../lib/main.js", importedNames: ["greet"], span: span(0, 29) }],
+    callSites: [{ calleeNameCandidates: ["greet"], span: span(60, 67) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.equal(firstFile(result).edges.length, 1);
+  assert.equal(firstFile(result).edges[0]?.confidence, HEURISTIC_CONFIDENCE_IMPORT_BOUND);
+});

--- a/packages/coding-graph/src/heuristic-resolution.test.ts
+++ b/packages/coding-graph/src/heuristic-resolution.test.ts
@@ -483,3 +483,17 @@ test("with only a sibling method available, a bare call stays unresolved", () =>
   assert.deepEqual(firstFile(result).edges, []);
   assert.equal(stats.skippedUnresolved, 1);
 });
+
+test("empty bindings array falls back to importedNames (cursor review round 9)", () => {
+  const ir = fileIR({
+    path: "util.ts",
+    symbols: [
+      { kind: "function", name: "shout", qualifiedName: "shout", span: span(30, 110) },
+    ],
+    imports: [{ module: "./main", importedNames: ["greet"], bindings: [], span: span(0, 29) }],
+    callSites: [{ calleeNameCandidates: ["greet"], span: span(60, 67) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.equal(firstFile(result).edges.length, 1);
+  assert.equal(firstFile(result).edges[0]?.dstQualifiedName, "greet");
+});

--- a/packages/coding-graph/src/heuristic-resolution.test.ts
+++ b/packages/coding-graph/src/heuristic-resolution.test.ts
@@ -422,3 +422,28 @@ test("python dot-style import escaping the root never binds", () => {
   const result = deriveHeuristicEdges([ir]);
   assert.deepEqual(firstFile(result).edges, []);
 });
+
+test("same exported name from two modules yields two hinted edges (codex review)", () => {
+  const ir = fileIR({
+    path: "util.ts",
+    symbols: [
+      { kind: "function", name: "run", qualifiedName: "run", span: span(60, 160) },
+    ],
+    imports: [
+      { module: "./a", importedNames: ["foo"], bindings: [{ exported: "foo", local: "fooA" }], span: span(0, 28) },
+      { module: "./b", importedNames: ["foo"], bindings: [{ exported: "foo", local: "fooB" }], span: span(29, 57) },
+    ],
+    callSites: [
+      { calleeNameCandidates: ["fooA"], span: span(80, 86) },
+      { calleeNameCandidates: ["fooB"], span: span(100, 106) },
+    ],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.deepEqual(
+    firstFile(result).edges.map((e: EdgeIR) => [e.dstQualifiedName, e.dstPathHint]),
+    [
+      ["foo", "a"],
+      ["foo", "b"],
+    ],
+  );
+});

--- a/packages/coding-graph/src/heuristic-resolution.test.ts
+++ b/packages/coding-graph/src/heuristic-resolution.test.ts
@@ -81,6 +81,7 @@ test("import-bound cross-file call emits an edge for the store to resolve", () =
       type: "CALLS",
       confidence: HEURISTIC_CONFIDENCE_IMPORT_BOUND,
       provenance: "heuristic",
+      dstPathHint: "main",
     },
   ]);
 });
@@ -306,4 +307,22 @@ test("relative-module imports still bind (in-repo resolvable)", () => {
   const result = deriveHeuristicEdges([ir]);
   assert.equal(firstFile(result).edges.length, 1);
   assert.equal(firstFile(result).edges[0]?.confidence, HEURISTIC_CONFIDENCE_IMPORT_BOUND);
+  assert.equal(firstFile(result).edges[0]?.dstPathHint, "../lib/main");
+});
+
+test("an ambiguous first candidate does not block a later candidate's import binding (cursor review)", () => {
+  const ir = fileIR({
+    path: "util.ts",
+    symbols: [
+      { kind: "function", name: "shout", qualifiedName: "shout", span: span(40, 120) },
+      { kind: "function", name: "dup", qualifiedName: "a.dup", span: span(130, 160) },
+      { kind: "function", name: "dup", qualifiedName: "b.dup", span: span(170, 200) },
+    ],
+    imports: [{ module: "./main", importedNames: ["greet"], span: span(0, 29) }],
+    callSites: [{ calleeNameCandidates: ["dup", "greet"], span: span(60, 70) }],
+  });
+  const result = deriveHeuristicEdges([ir]);
+  assert.equal(firstFile(result).edges.length, 1);
+  assert.equal(firstFile(result).edges[0]?.dstQualifiedName, "greet");
+  assert.equal(firstFile(result).edges[0]?.dstPathHint, "main");
 });

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -44,6 +44,20 @@ import { posix } from "node:path";
 
 import type { EdgeIR, FileIR, StoreFileIR } from "./graph-store.js";
 
+/**
+ * Languages where a method call on the enclosing instance REQUIRES an
+ * explicit receiver (this./self.) — a bare identifier call can never mean
+ * a sibling method, so class-like scopes are excluded from bare-call
+ * resolution. Implicit-this languages (Java, C#, Kotlin, Swift, Ruby,
+ * PHP, C++, Go methods via receivers, ...) keep their class scopes.
+ */
+const EXPLICIT_RECEIVER_LANGUAGES: ReadonlySet<string> = new Set([
+  "typescript",
+  "tsx",
+  "javascript",
+  "python",
+]);
+
 /** Confidence for a call resolved to a unique same-file symbol. */
 export const HEURISTIC_CONFIDENCE_SAME_FILE = 0.9;
 /** Confidence for a call resolved through an import binding. */
@@ -220,18 +234,24 @@ export function deriveHeuristicEdges(
       // Visible scope levels for this call site, innermost first: the
       // caller's own children, then each ancestor's children, ending at
       // the file level. Symbols nested under unrelated parents are never
-      // consulted. Class-like ancestors (class/interface/enum) are NOT
-      // bare-call scopes (codex review round 8): a bare helper() inside a
-      // method cannot mean the sibling method C.helper — that call would
-      // be this.helper()/self.helper(), i.e. a member access Phase A
-      // skips. Function/method/module ancestors DO contribute (nested
-      // functions and module-local functions are bare-callable).
+      // consulted. In EXPLICIT-receiver languages (JS/TS/Python),
+      // class-like ancestors are NOT bare-call scopes (codex review
+      // round 8): a bare helper() inside a method cannot mean the
+      // sibling method C.helper — that call would be
+      // this.helper()/self.helper(), i.e. a member access Phase A
+      // skips. Implicit-this languages (Java/C#/Kotlin/Swift/Ruby/...)
+      // DO allow an unqualified call to target a same-type method, so
+      // their class scopes contribute (codex review round 11).
+      // Function/method/module ancestors always contribute.
+      const excludeClassScopes = EXPLICIT_RECEIVER_LANGUAGES.has(ir.language);
       const scopeLevels: string[] = [src.qualifiedName];
       let cursor: string | undefined = src.qualifiedName;
       while (cursor !== undefined && cursor !== "") {
         cursor = parentOf.get(cursor) ?? "";
-        const kind = cursor === "" ? undefined : kindOf.get(cursor);
-        if (kind === "class" || kind === "interface" || kind === "enum") continue;
+        if (excludeClassScopes) {
+          const kind = cursor === "" ? undefined : kindOf.get(cursor);
+          if (kind === "class" || kind === "interface" || kind === "enum") continue;
+        }
         scopeLevels.push(cursor);
       }
 

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -166,7 +166,11 @@ export function deriveHeuristicEdges(
       }
       if (specifier === undefined) continue;
       const joined = posix.join(posix.dirname(ir.path), specifier);
-      const hint = joined.replace(/\.[cm]?[jt]sx?$/, "");
+      // Strip any trailing slash BEFORE extension-stripping: a pure
+      // parent-package import (python "from .. import x") joins to
+      // "pkg/" and the store's hint patterns match "pkg" /
+      // "pkg/__init__.<ext>", never "pkg/" (codex review round 10).
+      const hint = joined.replace(/\/+$/, "").replace(/\.[cm]?[jt]sx?$/, "");
       // A normalized hint still starting with "../" escapes the repo root:
       // files.path values are canonical (no ".." segments), so such an
       // edge could never resolve — skip the binding here so the call site

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -175,8 +175,13 @@ export function deriveHeuristicEdges(
       if (hint.startsWith("../")) continue;
       // Alias-aware (codex review on #1894): call sites use the LOCAL
       // identifier; the dst in the target file is the EXPORTED name.
+      // An empty bindings array falls back to importedNames like an
+      // absent one (cursor review round 9): emitters that populate names
+      // but not bindings must still bind.
       const bindings =
-        imp.bindings ?? imp.importedNames.map((name) => ({ exported: name, local: name }));
+        imp.bindings && imp.bindings.length > 0
+          ? imp.bindings
+          : imp.importedNames.map((name) => ({ exported: name, local: name }));
       for (const b of bindings) importBindings.set(b.local, { exported: b.exported, hint });
     }
 

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -40,6 +40,8 @@
  * store's provenance-scoped stale delete (`assertedEdgeProvenances`),
  * re-derivation never destroys `trace`/`lsp` edges (rule 25).
  */
+import { posix } from "node:path";
+
 import type { EdgeIR, FileIR, StoreFileIR } from "./graph-store.js";
 
 /** Confidence for a call resolved to a unique same-file symbol. */
@@ -49,9 +51,13 @@ export const HEURISTIC_CONFIDENCE_IMPORT_BOUND = 0.8;
 
 /**
  * The provenance scope reindex asserts for derived edges: a fresh parse
- * contradicts only heuristic derivations, never trace/lsp edges.
+ * owns its own derivations AND their lsp upgrades (an lsp row is the
+ * same source-derived edge, upgraded — when the call disappears from the
+ * parse, the upgraded row is stale too). It never owns `trace` (runtime
+ * observation) or semantic edges. The store's update guard separately
+ * ensures a re-asserted key never DOWNGRADES an lsp row to heuristic.
  */
-export const HEURISTIC_PROVENANCE_SCOPE = ["heuristic"] as const;
+export const HEURISTIC_PROVENANCE_SCOPE = ["heuristic", "lsp"] as const;
 
 /** Per-batch resolution counters — surfaced by callers for observability. */
 export interface HeuristicResolutionStats {
@@ -130,12 +136,16 @@ export function deriveHeuristicEdges(
         names.set(sym.name, { qualifiedName: sym.qualifiedName, count: 1 });
       }
     }
-    // Only imports with a relative module specifier bind bare names —
-    // an external package's names must never resolve to in-repo symbols.
-    const importedNames = new Set<string>();
+    // name → repo-relative extension-stripped target path. Only relative
+    // specifiers bind (an external package's names must never resolve to
+    // in-repo symbols); the hint travels on the edge so the store resolves
+    // the dst ONLY within the declared target file (#1894 review).
+    const importBindings = new Map<string, string>();
     for (const imp of ir.imports) {
       if (!imp.module.startsWith("./") && !imp.module.startsWith("../")) continue;
-      for (const name of imp.importedNames) importedNames.add(name);
+      const joined = posix.join(posix.dirname(ir.path), imp.module);
+      const hint = joined.replace(/\.[cm]?[jt]sx?$/, "");
+      for (const name of imp.importedNames) importBindings.set(name, hint);
     }
 
     const edges: EdgeIR[] = [];
@@ -169,11 +179,16 @@ export function deriveHeuristicEdges(
         scopeLevels.push(cursor);
       }
 
-      // dst: first candidate with in-IR evidence.
+      // dst: first candidate with in-IR evidence. Ambiguity is tracked
+      // PER CANDIDATE (cursor review on #1894): an ambiguous same-file
+      // match for candidate A must not block candidate B's import
+      // binding.
       let dstQualifiedName: string | undefined;
+      let dstPathHint: string | undefined;
       let confidence = 0;
       let sawAmbiguous = false;
       for (const candidate of site.calleeNameCandidates) {
+        let candidateAmbiguous = false;
         for (const level of scopeLevels) {
           const match = scopeByName.get(level)?.get(candidate);
           if (!match) continue;
@@ -181,14 +196,19 @@ export function deriveHeuristicEdges(
             dstQualifiedName = match.qualifiedName;
             confidence = HEURISTIC_CONFIDENCE_SAME_FILE;
           } else {
-            sawAmbiguous = true;
+            candidateAmbiguous = true;
           }
           break; // innermost level with the name decides (shadowing).
         }
         if (dstQualifiedName !== undefined) break;
-        if (sawAmbiguous) continue;
-        if (importedNames.has(candidate)) {
+        if (candidateAmbiguous) {
+          sawAmbiguous = true;
+          continue;
+        }
+        const hint = importBindings.get(candidate);
+        if (hint !== undefined) {
           dstQualifiedName = candidate;
+          dstPathHint = hint;
           confidence = HEURISTIC_CONFIDENCE_IMPORT_BOUND;
           break;
         }
@@ -209,6 +229,7 @@ export function deriveHeuristicEdges(
         type: "CALLS",
         confidence,
         provenance: "heuristic",
+        ...(dstPathHint !== undefined ? { dstPathHint } : {}),
       });
     }
 

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -342,7 +342,7 @@ export function deriveHeuristicEdges(
             }
             if (ancestorChain.has(c.enclosing)) {
               const depth = [...ancestorChain].indexOf(c.enclosing);
-              if (depth > chosenDepth) { chosen = c; chosenDepth = depth; }
+              if (chosenDepth < 0 || depth < chosenDepth) { chosen = c; chosenDepth = depth; }
             }
           }
           if (chosen) {

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -56,6 +56,10 @@ const EXPLICIT_RECEIVER_LANGUAGES: ReadonlySet<string> = new Set([
   "tsx",
   "javascript",
   "python",
+  // PHP method dispatch requires $this->/self:: — both arrive as
+  // member_call_expression (memberAccess) — so a bare helper() inside a
+  // method never means a sibling method (codex review round 12).
+  "php",
 ]);
 
 /** Confidence for a call resolved to a unique same-file symbol. */
@@ -163,7 +167,10 @@ export function deriveHeuristicEdges(
     // specifiers bind (an external package's names must never resolve to
     // in-repo symbols); the hint travels on the edge so the store resolves
     // the dst ONLY within the declared target file (#1894 review).
-    const importBindings = new Map<string, { exported: string; hint: string }>();
+    const importBindings = new Map<
+      string,
+      { exported: string; hint: string; enclosing: string | undefined }
+    >();
     for (const imp of ir.imports) {
       // Two relative-import spellings bind (cursor review on #1894):
       //  - path style ("./x", "../x") — JS/TS and friends;
@@ -193,14 +200,32 @@ export function deriveHeuristicEdges(
       if (hint.startsWith("../")) continue;
       // Alias-aware (codex review on #1894): call sites use the LOCAL
       // identifier; the dst in the target file is the EXPORTED name.
-      // An empty bindings array falls back to importedNames like an
-      // absent one (cursor review round 9): emitters that populate names
-      // but not bindings must still bind.
+      // Fallback semantics sharpened across rounds 9 and 12: an ABSENT
+      // bindings field means a pre-bindings emitter (or hand-built IR) —
+      // fall back to importedNames as local===exported. An EXPLICIT empty
+      // array is the parser saying "no call-bindable names" (default /
+      // namespace imports whose exported symbol Phase A cannot know) and
+      // must NOT re-bind through the fallback.
       const bindings =
-        imp.bindings && imp.bindings.length > 0
-          ? imp.bindings
-          : imp.importedNames.map((name) => ({ exported: name, local: name }));
-      for (const b of bindings) importBindings.set(b.local, { exported: b.exported, hint });
+        imp.bindings ?? imp.importedNames.map((name) => ({ exported: name, local: name }));
+      // A function-local import binds only within its enclosing symbol
+      // (codex review round 12): find the innermost symbol containing the
+      // import's span; undefined = file level (binds everywhere).
+      let enclosing: { qualifiedName: string; size: number } | undefined;
+      for (const sym of ir.symbols) {
+        if (sym.span.startByte > imp.span.startByte || imp.span.endByte > sym.span.endByte) continue;
+        const size = sym.span.endByte - sym.span.startByte;
+        if (!enclosing || size < enclosing.size) {
+          enclosing = { qualifiedName: sym.qualifiedName, size };
+        }
+      }
+      for (const b of bindings) {
+        importBindings.set(b.local, {
+          exported: b.exported,
+          hint,
+          enclosing: enclosing?.qualifiedName,
+        });
+      }
     }
 
     const edges: EdgeIR[] = [];
@@ -245,9 +270,14 @@ export function deriveHeuristicEdges(
       // Function/method/module ancestors always contribute.
       const excludeClassScopes = EXPLICIT_RECEIVER_LANGUAGES.has(ir.language);
       const scopeLevels: string[] = [src.qualifiedName];
+      // Full ancestor chain (class levels included) — used for
+      // function-local import visibility, which is lexical containment,
+      // not bare-call scoping.
+      const ancestorChain = new Set<string>([src.qualifiedName]);
       let cursor: string | undefined = src.qualifiedName;
       while (cursor !== undefined && cursor !== "") {
         cursor = parentOf.get(cursor) ?? "";
+        if (cursor !== "") ancestorChain.add(cursor);
         if (excludeClassScopes) {
           const kind = cursor === "" ? undefined : kindOf.get(cursor);
           if (kind === "class" || kind === "interface" || kind === "enum") continue;
@@ -282,7 +312,13 @@ export function deriveHeuristicEdges(
           continue;
         }
         const binding = importBindings.get(candidate);
-        if (binding !== undefined) {
+        if (
+          binding !== undefined &&
+          // Function-local imports are visible only inside the symbol that
+          // contains them: the call's ancestor chain must include the
+          // import's enclosing symbol (file-level imports always bind).
+          (binding.enclosing === undefined || ancestorChain.has(binding.enclosing))
+        ) {
           dstQualifiedName = binding.exported;
           dstPathHint = binding.hint;
           confidence = HEURISTIC_CONFIDENCE_IMPORT_BOUND;

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -254,7 +254,10 @@ export function deriveHeuristicEdges(
       }
 
       resolved += 1;
-      const key = `${src.qualifiedName}\u0000${dstQualifiedName}`;
+      // The hint is part of edge identity (codex review on #1894): two
+      // aliased imports of the same exported name from different modules
+      // resolve to different nodes at the store, so both must survive.
+      const key = `${src.qualifiedName}\u0000${dstQualifiedName}\u0000${dstPathHint ?? ""}`;
       if (seenKeys.has(key)) continue;
       seenKeys.add(key);
       edges.push({

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -71,6 +71,8 @@ export interface HeuristicResolutionStats {
   readonly skippedAmbiguous: number;
   /** Call sites with no enclosing symbol (module-level calls). */
   readonly skippedNoEnclosingSymbol: number;
+  /** Member/property calls — Phase B (LSP) territory, never bare-bound. */
+  readonly skippedMemberAccess: number;
 }
 
 /** A FileIR enriched with the store-consumable edge assertions. */
@@ -94,6 +96,7 @@ export function deriveHeuristicEdges(
   let skippedUnresolved = 0;
   let skippedAmbiguous = 0;
   let skippedNoEnclosingSymbol = 0;
+  let skippedMemberAccess = 0;
 
   const files: ResolvedFileIR[] = [];
 
@@ -140,12 +143,22 @@ export function deriveHeuristicEdges(
     // specifiers bind (an external package's names must never resolve to
     // in-repo symbols); the hint travels on the edge so the store resolves
     // the dst ONLY within the declared target file (#1894 review).
-    const importBindings = new Map<string, string>();
+    const importBindings = new Map<string, { exported: string; hint: string }>();
     for (const imp of ir.imports) {
       if (!imp.module.startsWith("./") && !imp.module.startsWith("../")) continue;
       const joined = posix.join(posix.dirname(ir.path), imp.module);
       const hint = joined.replace(/\.[cm]?[jt]sx?$/, "");
-      for (const name of imp.importedNames) importBindings.set(name, hint);
+      // A normalized hint still starting with "../" escapes the repo root:
+      // files.path values are canonical (no ".." segments), so such an
+      // edge could never resolve — skip the binding here so the call site
+      // is honestly counted as unresolved instead of emitting a
+      // guaranteed-dead edge (cursor review on #1894).
+      if (hint.startsWith("../")) continue;
+      // Alias-aware (codex review on #1894): call sites use the LOCAL
+      // identifier; the dst in the target file is the EXPORTED name.
+      const bindings =
+        imp.bindings ?? imp.importedNames.map((name) => ({ exported: name, local: name }));
+      for (const b of bindings) importBindings.set(b.local, { exported: b.exported, hint });
     }
 
     const edges: EdgeIR[] = [];
@@ -153,6 +166,14 @@ export function deriveHeuristicEdges(
 
     for (const site of ir.callSites) {
       callSites += 1;
+
+      // Member/property calls (obj.save()) never bind bare names in
+      // Phase A: the receiver decides the target, and only Phase B (LSP)
+      // can resolve dispatch (codex review on #1894).
+      if (site.memberAccess === true) {
+        skippedMemberAccess += 1;
+        continue;
+      }
 
       // src: innermost enclosing symbol (smallest containing span).
       let src: { qualifiedName: string; size: number } | undefined;
@@ -205,10 +226,10 @@ export function deriveHeuristicEdges(
           sawAmbiguous = true;
           continue;
         }
-        const hint = importBindings.get(candidate);
-        if (hint !== undefined) {
-          dstQualifiedName = candidate;
-          dstPathHint = hint;
+        const binding = importBindings.get(candidate);
+        if (binding !== undefined) {
+          dstQualifiedName = binding.exported;
+          dstPathHint = binding.hint;
           confidence = HEURISTIC_CONFIDENCE_IMPORT_BOUND;
           break;
         }
@@ -244,6 +265,7 @@ export function deriveHeuristicEdges(
       skippedUnresolved,
       skippedAmbiguous,
       skippedNoEnclosingSymbol,
+      skippedMemberAccess,
     },
   };
 }

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -145,8 +145,21 @@ export function deriveHeuristicEdges(
     // the dst ONLY within the declared target file (#1894 review).
     const importBindings = new Map<string, { exported: string; hint: string }>();
     for (const imp of ir.imports) {
-      if (!imp.module.startsWith("./") && !imp.module.startsWith("../")) continue;
-      const joined = posix.join(posix.dirname(ir.path), imp.module);
+      // Two relative-import spellings bind (cursor review on #1894):
+      //  - path style ("./x", "../x") — JS/TS and friends;
+      //  - Python dot style (".models", "..parent.sub") — one leading dot
+      //    is the current package, each extra dot goes one level up, and
+      //    interior dots are path separators.
+      let specifier: string | undefined;
+      if (imp.module.startsWith("./") || imp.module.startsWith("../")) {
+        specifier = imp.module;
+      } else if (ir.language === "python" && imp.module.startsWith(".")) {
+        const dots = (/^\.+/.exec(imp.module))?.[0].length ?? 1;
+        const rest = imp.module.slice(dots).replace(/\./g, "/");
+        specifier = `${"../".repeat(dots - 1)}${rest}` || ".";
+      }
+      if (specifier === undefined) continue;
+      const joined = posix.join(posix.dirname(ir.path), specifier);
       const hint = joined.replace(/\.[cm]?[jt]sx?$/, "");
       // A normalized hint still starting with "../" escapes the repo root:
       // files.path values are canonical (no ".." segments), so such an

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -169,7 +169,7 @@ export function deriveHeuristicEdges(
     // the dst ONLY within the declared target file (#1894 review).
     const importBindings = new Map<
       string,
-      { exported: string; hint: string; enclosing: string | undefined }
+      Array<{ exported: string; hint: string; enclosing: string | undefined }>
     >();
     for (const imp of ir.imports) {
       // Two relative-import spellings bind (cursor review on #1894):
@@ -219,12 +219,29 @@ export function deriveHeuristicEdges(
           enclosing = { qualifiedName: sym.qualifiedName, size };
         }
       }
+      // A local name can be imported in more than one scope (codex review
+      // round 13); keep them all and choose the innermost matching one at
+      // the call site. Class-body imports are class attributes and are NOT
+      // bare-call-visible, so a class-kind enclosing is filtered out at
+      // lookup time.
+      const enclosingKind =
+        enclosing === undefined ? undefined : kindOf.get(enclosing.qualifiedName);
+      const visible =
+        enclosingKind === undefined ||
+        (enclosingKind !== "class" &&
+          enclosingKind !== "interface" &&
+          enclosingKind !== "enum");
       for (const b of bindings) {
-        importBindings.set(b.local, {
+        const list = importBindings.get(b.local) ?? [];
+        list.push({
           exported: b.exported,
           hint,
-          enclosing: enclosing?.qualifiedName,
+          enclosing: visible ? enclosing?.qualifiedName : undefined,
+          // A class-body import is genuinely invisible: store it with a
+          // sentinel that can never match an ancestor chain.
+          invisible: !visible,
         });
+        importBindings.set(b.local, list);
       }
     }
 
@@ -311,18 +328,30 @@ export function deriveHeuristicEdges(
           sawAmbiguous = true;
           continue;
         }
-        const binding = importBindings.get(candidate);
-        if (
-          binding !== undefined &&
-          // Function-local imports are visible only inside the symbol that
-          // contains them: the call's ancestor chain must include the
-          // import's enclosing symbol (file-level imports always bind).
-          (binding.enclosing === undefined || ancestorChain.has(binding.enclosing))
-        ) {
-          dstQualifiedName = binding.exported;
-          dstPathHint = binding.hint;
-          confidence = HEURISTIC_CONFIDENCE_IMPORT_BOUND;
-          break;
+        const candidates = importBindings.get(candidate);
+        if (candidates !== undefined) {
+          // Innermost visible binding wins (codex review round 13):
+          // a function-local import shadows a same-name file-level one
+          // inside that function; class-body imports are never visible.
+          let chosen: { exported: string; hint: string } | undefined;
+          let chosenDepth = -1;
+          for (const c of candidates) {
+            if (c.invisible) continue;
+            if (c.enclosing === undefined) {
+              if (chosenDepth < 0) { chosen = c; chosenDepth = 0; }
+              continue;
+            }
+            if (ancestorChain.has(c.enclosing)) {
+              const depth = [...ancestorChain].indexOf(c.enclosing);
+              if (depth > chosenDepth) { chosen = c; chosenDepth = depth; }
+            }
+          }
+          if (chosen) {
+            dstQualifiedName = chosen.exported;
+            dstPathHint = chosen.hint;
+            confidence = HEURISTIC_CONFIDENCE_IMPORT_BOUND;
+            break;
+          }
         }
       }
       if (dstQualifiedName === undefined) {
@@ -344,7 +373,9 @@ export function deriveHeuristicEdges(
         type: "CALLS",
         confidence,
         provenance: "heuristic",
-        ...(dstPathHint !== undefined ? { dstPathHint } : {}),
+        ...(dstPathHint !== undefined
+          ? { dstPathHint, dstImporterLanguage: ir.language }
+          : {}),
       });
     }
 

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -1,0 +1,177 @@
+/**
+ * Phase A heuristic edge resolution (issue #1891).
+ *
+ * The parser engine emits raw call candidates (`FileIR.callSites`); the
+ * graph store persists only pre-resolved `EdgeIR[]`. This module is the
+ * bridge the docs call "Phase A — heuristic": a PURE function that derives
+ * CALLS edge assertions from a freshly parsed batch, using only evidence
+ * present in the IR itself:
+ *
+ *   - src: the innermost same-file symbol whose span contains the call
+ *     site (half-open spans, rule 35). Top-level calls (no enclosing
+ *     symbol) are skipped and counted — module-level side effects are not
+ *     a caller symbol.
+ *   - dst, in candidate order:
+ *       1. the unique same-file symbol with that bare name
+ *         (confidence {@link HEURISTIC_CONFIDENCE_SAME_FILE});
+ *       2. an import-bound name (`imports[].importedNames`), emitted by
+ *         bare name for the store's cross-file/full-DB resolution
+ *         (confidence {@link HEURISTIC_CONFIDENCE_IMPORT_BOUND}).
+ *     A bare name with neither anchor (e.g. `console.log`'s `log`) is
+ *     skipped — emitting it would delegate a guess, not evidence, and the
+ *     store's dst fallback would happily attach it to any same-named
+ *     symbol anywhere in the graph.
+ *   - Ambiguity is dropped conservatively (same policy as the store's
+ *     pass-2): a bare name matching two same-file symbols resolves to
+ *     neither; the next candidate is tried.
+ *
+ * Final id resolution (batch map + full-DB dst fallback + ambiguity
+ * drops) stays in `GraphStore.upsertFileEdges`; this module never touches
+ * the DB. Every file in the output carries an explicit `edges` array —
+ * `[]` asserts "this parse supports no heuristic edges" so stale edges
+ * from a prior version of the file are cleaned up. Paired with the
+ * store's provenance-scoped stale delete (`assertedEdgeProvenances`),
+ * re-derivation never destroys `trace`/`lsp` edges (rule 25).
+ */
+import type { EdgeIR, FileIR, StoreFileIR } from "./graph-store.js";
+
+/** Confidence for a call resolved to a unique same-file symbol. */
+export const HEURISTIC_CONFIDENCE_SAME_FILE = 0.9;
+/** Confidence for a call resolved through an import binding. */
+export const HEURISTIC_CONFIDENCE_IMPORT_BOUND = 0.8;
+
+/**
+ * The provenance scope reindex asserts for derived edges: a fresh parse
+ * contradicts only heuristic derivations, never trace/lsp edges.
+ */
+export const HEURISTIC_PROVENANCE_SCOPE = ["heuristic"] as const;
+
+/** Per-batch resolution counters — surfaced by callers for observability. */
+export interface HeuristicResolutionStats {
+  /** Total call sites examined across the batch. */
+  readonly callSites: number;
+  /** Call sites that produced an edge assertion. */
+  readonly resolved: number;
+  /** Call sites whose candidates matched nothing (no evidence). */
+  readonly skippedUnresolved: number;
+  /** Call sites whose best candidate was ambiguous in-file. */
+  readonly skippedAmbiguous: number;
+  /** Call sites with no enclosing symbol (module-level calls). */
+  readonly skippedNoEnclosingSymbol: number;
+}
+
+/** A FileIR enriched with the store-consumable edge assertions. */
+export type ResolvedFileIR = StoreFileIR & { readonly edges: readonly EdgeIR[] };
+
+export interface HeuristicResolutionResult {
+  readonly files: readonly ResolvedFileIR[];
+  readonly stats: HeuristicResolutionStats;
+}
+
+/**
+ * Derive CALLS edge assertions for a freshly parsed batch. Pure and
+ * deterministic: output order follows input order (files, then call
+ * sites), so repeated runs over the same IR are byte-identical (rule 38).
+ */
+export function deriveHeuristicEdges(
+  batch: readonly FileIR[],
+): HeuristicResolutionResult {
+  let callSites = 0;
+  let resolved = 0;
+  let skippedUnresolved = 0;
+  let skippedAmbiguous = 0;
+  let skippedNoEnclosingSymbol = 0;
+
+  const files: ResolvedFileIR[] = [];
+
+  for (const ir of batch) {
+    // Bare-name → symbols map for this file. Names binding more than one
+    // symbol are ambiguous and resolve to nothing (conservative drop).
+    const byName = new Map<string, { qualifiedName: string; count: number }>();
+    for (const sym of ir.symbols) {
+      const prior = byName.get(sym.name);
+      if (prior) {
+        prior.count += 1;
+      } else {
+        byName.set(sym.name, { qualifiedName: sym.qualifiedName, count: 1 });
+      }
+    }
+    const importedNames = new Set<string>();
+    for (const imp of ir.imports) {
+      for (const name of imp.importedNames) importedNames.add(name);
+    }
+
+    const edges: EdgeIR[] = [];
+    const seenKeys = new Set<string>();
+
+    for (const site of ir.callSites) {
+      callSites += 1;
+
+      // src: innermost enclosing symbol (smallest containing span).
+      let src: { qualifiedName: string; size: number } | undefined;
+      for (const sym of ir.symbols) {
+        if (sym.span.startByte > site.span.startByte || site.span.endByte > sym.span.endByte) continue;
+        const size = sym.span.endByte - sym.span.startByte;
+        if (!src || size < src.size) {
+          src = { qualifiedName: sym.qualifiedName, size };
+        }
+      }
+      if (!src) {
+        skippedNoEnclosingSymbol += 1;
+        continue;
+      }
+
+      // dst: first candidate with in-IR evidence.
+      let dstQualifiedName: string | undefined;
+      let confidence = 0;
+      let sawAmbiguous = false;
+      for (const candidate of site.calleeNameCandidates) {
+        const local = byName.get(candidate);
+        if (local) {
+          if (local.count === 1) {
+            dstQualifiedName = local.qualifiedName;
+            confidence = HEURISTIC_CONFIDENCE_SAME_FILE;
+            break;
+          }
+          sawAmbiguous = true;
+          continue;
+        }
+        if (importedNames.has(candidate)) {
+          dstQualifiedName = candidate;
+          confidence = HEURISTIC_CONFIDENCE_IMPORT_BOUND;
+          break;
+        }
+      }
+      if (dstQualifiedName === undefined) {
+        if (sawAmbiguous) skippedAmbiguous += 1;
+        else skippedUnresolved += 1;
+        continue;
+      }
+
+      resolved += 1;
+      const key = `${src.qualifiedName}\u0000${dstQualifiedName}`;
+      if (seenKeys.has(key)) continue;
+      seenKeys.add(key);
+      edges.push({
+        srcQualifiedName: src.qualifiedName,
+        dstQualifiedName,
+        type: "CALLS",
+        confidence,
+        provenance: "heuristic",
+      });
+    }
+
+    files.push({ ...ir, edges });
+  }
+
+  return {
+    files,
+    stats: {
+      callSites,
+      resolved,
+      skippedUnresolved,
+      skippedAmbiguous,
+      skippedNoEnclosingSymbol,
+    },
+  };
+}

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -108,7 +108,6 @@ export interface HeuristicResolutionResult {
 /**
  * Derive CALLS edge assertions for a freshly parsed batch. Pure and
  * deterministic: output order follows input order (files, then call
- * sites), so repeated runs over the same IR are byte-identical (rule 38).
  */
 export function deriveHeuristicEdges(
   batch: readonly FileIR[],
@@ -169,7 +168,7 @@ export function deriveHeuristicEdges(
     // the dst ONLY within the declared target file (#1894 review).
     const importBindings = new Map<
       string,
-      Array<{ exported: string; hint: string; enclosing: string | undefined }>
+      Array<{ exported: string; hint: string; enclosing: string | undefined; invisible?: boolean }>
     >();
     for (const imp of ir.imports) {
       // Two relative-import spellings bind (cursor review on #1894):

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -12,18 +12,25 @@
  *     symbol) are skipped and counted — module-level side effects are not
  *     a caller symbol.
  *   - dst, in candidate order:
- *       1. the unique same-file symbol with that bare name
- *         (confidence {@link HEURISTIC_CONFIDENCE_SAME_FILE});
- *       2. an import-bound name (`imports[].importedNames`), emitted by
- *         bare name for the store's cross-file/full-DB resolution
- *         (confidence {@link HEURISTIC_CONFIDENCE_IMPORT_BOUND}).
+ *       1. a same-file symbol VISIBLE from the call site under lexical
+ *         scoping approximated by span containment: the caller's own
+ *         nested symbols first, then each enclosing scope's children out
+ *         to the file level. Innermost match wins (shadowing); a nested
+ *         symbol under an unrelated parent is not visible (codex P2 on
+ *         #1894). Confidence {@link HEURISTIC_CONFIDENCE_SAME_FILE}.
+ *       2. an import-bound name (`imports[].importedNames`) whose module
+ *         specifier is RELATIVE ("./", "../") — i.e. resolvable inside
+ *         the repo. External-package imports (lodash, node:fs) never
+ *         bind: emitting their bare names would let the store's
+ *         qualified-name fallback attach them to unrelated in-repo
+ *         symbols (codex P2 on #1894). Confidence
+ *         {@link HEURISTIC_CONFIDENCE_IMPORT_BOUND}; the store's
+ *         cross-file/full-DB resolution finds the exporting file.
  *     A bare name with neither anchor (e.g. `console.log`'s `log`) is
- *     skipped — emitting it would delegate a guess, not evidence, and the
- *     store's dst fallback would happily attach it to any same-named
- *     symbol anywhere in the graph.
+ *     skipped — emitting it would delegate a guess, not evidence.
  *   - Ambiguity is dropped conservatively (same policy as the store's
- *     pass-2): a bare name matching two same-file symbols resolves to
- *     neither; the next candidate is tried.
+ *     pass-2): a bare name matching two symbols in the SAME scope level
+ *     resolves to neither; the next candidate is tried.
  *
  * Final id resolution (batch map + full-DB dst fallback + ambiguity
  * drops) stays in `GraphStore.upsertFileEdges`; this module never touches
@@ -85,19 +92,49 @@ export function deriveHeuristicEdges(
   const files: ResolvedFileIR[] = [];
 
   for (const ir of batch) {
-    // Bare-name → symbols map for this file. Names binding more than one
-    // symbol are ambiguous and resolve to nothing (conservative drop).
-    const byName = new Map<string, { qualifiedName: string; count: number }>();
+    // Lexical-scope approximation from span containment: each symbol's
+    // parent is the innermost OTHER symbol strictly containing its span;
+    // no parent = file level (empty-string key).
+    const parentOf = new Map<string, string>();
     for (const sym of ir.symbols) {
-      const prior = byName.get(sym.name);
+      let parent: { qualifiedName: string; size: number } | undefined;
+      for (const other of ir.symbols) {
+        if (other === sym) continue;
+        const contains =
+          other.span.startByte <= sym.span.startByte &&
+          sym.span.endByte <= other.span.endByte;
+        const identical =
+          other.span.startByte === sym.span.startByte &&
+          other.span.endByte === sym.span.endByte;
+        if (!contains || identical) continue;
+        const size = other.span.endByte - other.span.startByte;
+        if (!parent || size < parent.size) {
+          parent = { qualifiedName: other.qualifiedName, size };
+        }
+      }
+      parentOf.set(sym.qualifiedName, parent ? parent.qualifiedName : "");
+    }
+    // scope level (parent qualifiedName or "" = file) → name → matches.
+    const scopeByName = new Map<string, Map<string, { qualifiedName: string; count: number }>>();
+    for (const sym of ir.symbols) {
+      const level = parentOf.get(sym.qualifiedName) ?? "";
+      let names = scopeByName.get(level);
+      if (!names) {
+        names = new Map();
+        scopeByName.set(level, names);
+      }
+      const prior = names.get(sym.name);
       if (prior) {
         prior.count += 1;
       } else {
-        byName.set(sym.name, { qualifiedName: sym.qualifiedName, count: 1 });
+        names.set(sym.name, { qualifiedName: sym.qualifiedName, count: 1 });
       }
     }
+    // Only imports with a relative module specifier bind bare names —
+    // an external package's names must never resolve to in-repo symbols.
     const importedNames = new Set<string>();
     for (const imp of ir.imports) {
+      if (!imp.module.startsWith("./") && !imp.module.startsWith("../")) continue;
       for (const name of imp.importedNames) importedNames.add(name);
     }
 
@@ -121,21 +158,35 @@ export function deriveHeuristicEdges(
         continue;
       }
 
+      // Visible scope levels for this call site, innermost first: the
+      // caller's own children, then each ancestor's children, ending at
+      // the file level. Symbols nested under unrelated parents are never
+      // consulted.
+      const scopeLevels: string[] = [src.qualifiedName];
+      let cursor: string | undefined = src.qualifiedName;
+      while (cursor !== undefined && cursor !== "") {
+        cursor = parentOf.get(cursor) ?? "";
+        scopeLevels.push(cursor);
+      }
+
       // dst: first candidate with in-IR evidence.
       let dstQualifiedName: string | undefined;
       let confidence = 0;
       let sawAmbiguous = false;
       for (const candidate of site.calleeNameCandidates) {
-        const local = byName.get(candidate);
-        if (local) {
-          if (local.count === 1) {
-            dstQualifiedName = local.qualifiedName;
+        for (const level of scopeLevels) {
+          const match = scopeByName.get(level)?.get(candidate);
+          if (!match) continue;
+          if (match.count === 1) {
+            dstQualifiedName = match.qualifiedName;
             confidence = HEURISTIC_CONFIDENCE_SAME_FILE;
-            break;
+          } else {
+            sawAmbiguous = true;
           }
-          sawAmbiguous = true;
-          continue;
+          break; // innermost level with the name decides (shadowing).
         }
+        if (dstQualifiedName !== undefined) break;
+        if (sawAmbiguous) continue;
         if (importedNames.has(candidate)) {
           dstQualifiedName = candidate;
           confidence = HEURISTIC_CONFIDENCE_IMPORT_BOUND;

--- a/packages/coding-graph/src/heuristic-resolution.ts
+++ b/packages/coding-graph/src/heuristic-resolution.ts
@@ -50,14 +50,18 @@ export const HEURISTIC_CONFIDENCE_SAME_FILE = 0.9;
 export const HEURISTIC_CONFIDENCE_IMPORT_BOUND = 0.8;
 
 /**
- * The provenance scope reindex asserts for derived edges: a fresh parse
- * owns its own derivations AND their lsp upgrades (an lsp row is the
- * same source-derived edge, upgraded — when the call disappears from the
- * parse, the upgraded row is stale too). It never owns `trace` (runtime
- * observation) or semantic edges. The store's update guard separately
- * ensures a re-asserted key never DOWNGRADES an lsp row to heuristic.
+ * The provenance scope reindex asserts for derived edges: ONLY its own
+ * heuristic derivations. Each provenance layer owns its lifecycle
+ * (issue #1894 review rounds 3/7/8): `lsp` rows include member-dispatch
+ * resolutions Phase A deliberately never re-asserts, so including `lsp`
+ * here would retire still-valid method-call edges on every edit of their
+ * file. Vanished-call `lsp` rows are the LSP pass's job to retire when it
+ * re-derives from the current parse (its edges die with their src nodes on
+ * symbol pruning regardless). `trace` (runtime observation) and semantic
+ * edges are likewise never this scope's to touch. The store's update guard
+ * separately ensures a re-asserted key never DOWNGRADES an lsp row.
  */
-export const HEURISTIC_PROVENANCE_SCOPE = ["heuristic", "lsp"] as const;
+export const HEURISTIC_PROVENANCE_SCOPE = ["heuristic"] as const;
 
 /** Per-batch resolution counters — surfaced by callers for observability. */
 export interface HeuristicResolutionStats {
@@ -105,6 +109,8 @@ export function deriveHeuristicEdges(
     // parent is the innermost OTHER symbol strictly containing its span;
     // no parent = file level (empty-string key).
     const parentOf = new Map<string, string>();
+    const kindOf = new Map<string, string>();
+    for (const sym of ir.symbols) kindOf.set(sym.qualifiedName, sym.kind);
     for (const sym of ir.symbols) {
       let parent: { qualifiedName: string; size: number } | undefined;
       for (const other of ir.symbols) {
@@ -205,11 +211,18 @@ export function deriveHeuristicEdges(
       // Visible scope levels for this call site, innermost first: the
       // caller's own children, then each ancestor's children, ending at
       // the file level. Symbols nested under unrelated parents are never
-      // consulted.
+      // consulted. Class-like ancestors (class/interface/enum) are NOT
+      // bare-call scopes (codex review round 8): a bare helper() inside a
+      // method cannot mean the sibling method C.helper — that call would
+      // be this.helper()/self.helper(), i.e. a member access Phase A
+      // skips. Function/method/module ancestors DO contribute (nested
+      // functions and module-local functions are bare-callable).
       const scopeLevels: string[] = [src.qualifiedName];
       let cursor: string | undefined = src.qualifiedName;
       while (cursor !== undefined && cursor !== "") {
         cursor = parentOf.get(cursor) ?? "";
+        const kind = cursor === "" ? undefined : kindOf.get(cursor);
+        if (kind === "class" || kind === "interface" || kind === "enum") continue;
         scopeLevels.push(cursor);
       }
 

--- a/packages/coding-graph/src/reindex.test.ts
+++ b/packages/coding-graph/src/reindex.test.ts
@@ -1036,3 +1036,60 @@ test("executor: explicit empty candidatePaths ([]) is treated as insufficient â€
     await dispose(store, dir);
   }
 });
+
+test("executor: an lsp-only edge on an UNCHANGED file survives incremental reindex (issue #1894 round 7)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    await writeFiles(dir, {
+      "src/a.ts": "export function foo() {}",
+      "src/b.ts": "export function bar() {}",
+    });
+    const git1 = mockGit({ head: SHA_A });
+    await executeReindex({
+      store,
+      git: git1,
+      repoRoot: dir,
+      parseFile: mockParseFile,
+      candidatePaths: ["src/a.ts", "src/b.ts"],
+    });
+    // LSP resolves a member call Phase A skipped: an lsp-ONLY edge owned
+    // by src/a.ts (never asserted by any heuristic derivation).
+    const upgraded = await store.upsertEdges([
+      {
+        srcQualifiedName: "src/a.ts::foo",
+        dstQualifiedName: "src/b.ts::foo",
+        type: "CALLS",
+        confidence: 1,
+        provenance: "lsp",
+      },
+    ]);
+    assert.ok(upgraded.ok && upgraded.persisted === 1);
+
+    // Only src/b.ts changes; src/a.ts is NOT re-ingested, so its lsp-only
+    // edge must survive â€” ingested files are changed-or-fresh by
+    // construction, which is the invariant that keeps the [heuristic, lsp]
+    // assertion scope safe for lsp-only edges on untouched files.
+    await writeFiles(dir, { "src/b.ts": "export function bar() { return 2; }" });
+    const git2 = mockGit({
+      head: SHA_B,
+      reachable: true,
+      changedFiles: [{ status: "M", path: "src/b.ts" }],
+    });
+    const result = await executeReindex({
+      store,
+      git: git2,
+      repoRoot: dir,
+      parseFile: mockParseFile,
+      candidatePaths: ["src/a.ts", "src/b.ts"],
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.mode, "incremental");
+    assert.equal(result.filesIngested, 1);
+    const stats = store.schemaStats();
+    assert.ok(stats.ok);
+    assert.deepEqual(stats.stats.edgesByType, { CALLS: 1 }, "lsp-only edge on unchanged src/a.ts survived");
+  } finally {
+    await dispose(store, dir);
+  }
+});

--- a/packages/coding-graph/src/reindex.ts
+++ b/packages/coding-graph/src/reindex.ts
@@ -41,12 +41,17 @@ import type { ParseFileInput, ParseResult } from "@remnic/core";
 
 import type { CodingGitInvoker, GitFailure, NameStatusEntry } from "./git-invoker.js";
 import type {
+  FileIR,
   GraphStore,
   StoreFileIR,
   ReadMetaResult,
   ReadFileHashesResult,
+  GraphStoreFailure,
 } from "./graph-store.js";
-import type { GraphStoreFailure } from "./graph-store.js";
+import {
+  deriveHeuristicEdges,
+  HEURISTIC_PROVENANCE_SCOPE,
+} from "./heuristic-resolution.js";
 
 // ──────────────────────────────────────────────────────────────────────────
 // Public types — the planner's input and output
@@ -854,7 +859,7 @@ async function ingestFiles(
   paths: readonly string[],
   deletePaths: readonly string[] = [],
 ): Promise<IngestResult> {
-  const batch: StoreFileIR[] = [];
+  const parsed: FileIR[] = [];
   const parseFailedPaths: string[] = [];
   for (const relPath of paths) {
     if (!isCanonicalRelativePath(relPath)) {
@@ -887,11 +892,18 @@ async function ingestFiles(
       parseFailedPaths.push(relPath);
       continue;
     }
-    // FileIR is structurally assignable to StoreFileIR — the store only
-    // reads the fields it needs and ignores extra FileIR fields (imports,
-    // callSites). No cast needed.
-    batch.push(parseResult.ir);
+    parsed.push(parseResult.ir);
   }
+  // Phase A heuristic resolution (issue #1891): derive CALLS edge
+  // assertions from the fresh parse before ingest. Each file carries an
+  // explicit edges array plus a provenance scope of ["heuristic"], so
+  // stale heuristic edges from a prior version are cleaned up while
+  // trace/lsp edges owned by the file survive (rule 25).
+  const derived = deriveHeuristicEdges(parsed);
+  const batch: StoreFileIR[] = derived.files.map((file) => ({
+    ...file,
+    assertedEdgeProvenances: HEURISTIC_PROVENANCE_SCOPE,
+  }));
   // Even when batch is empty we must run the upsert so deletePaths are
   // pruned atomically (the store's transaction wraps both). A zero-file,
   // zero-delete call is a cheap no-op.

--- a/packages/remnic-core/src/coding/coding-graph-types.ts
+++ b/packages/remnic-core/src/coding/coding-graph-types.ts
@@ -145,8 +145,24 @@ export interface SymbolIR {
 export interface ImportIR {
   /** Raw module specifier as written in source. */
   readonly module: string;
+  /** Exported names as declared by the source module (pre-alias). */
   readonly importedNames: readonly string[];
+  /**
+   * Alias-aware bindings (issue #1894 review): `local` is the identifier
+   * usable at call sites in THIS file; `exported` is the name in the
+   * source module. For non-aliased imports the two are equal. Optional so
+   * pre-existing IR consumers and JSON fixtures stay valid; when absent,
+   * consumers treat every `importedNames` entry as `local === exported`.
+   */
+  readonly bindings?: readonly ImportBindingIR[];
   readonly span: { readonly startByte: number; readonly endByte: number };
+}
+
+export interface ImportBindingIR {
+  /** Name exported by the source module. */
+  readonly exported: string;
+  /** Local identifier bound in the importing file. */
+  readonly local: string;
 }
 
 export interface ExportIR {
@@ -156,6 +172,13 @@ export interface ExportIR {
 
 export interface CallSiteIR {
   readonly calleeNameCandidates: readonly string[];
+  /**
+   * True when the callee is a member/property access (`obj.save()`,
+   * `recv.field()`), issue #1894 review: bare-name heuristics must never
+   * bind these — method dispatch is Phase B (LSP) territory. Optional so
+   * pre-existing IR stays valid; absent = false.
+   */
+  readonly memberAccess?: boolean;
   readonly span: { readonly startByte: number; readonly endByte: number };
 }
 


### PR DESCRIPTION
## Summary

Closes #1891. `codegraph_index` produced nodes but **zero edges** on every repository: the engine emits raw `callSites`, the store persists only pre-resolved `ir.edges`, and the Phase A resolver the docs described was never implemented (`reindex.ts` said it out loud: "ignores extra FileIR fields (imports, callSites)"). Result: `trace_path` always returned one node, blast radius was empty, dead-code flagged everything.

## Change

- **`heuristic-resolution.ts` (new, pure):** derives CALLS edge assertions from a freshly parsed batch. src = innermost same-file symbol containing the call-site span (half-open); dst tried per candidate: unique same-file bare name (confidence 0.9) → import-bound name (0.8, final cross-file/DB resolution stays in the store's pass-2). Ambiguous names and evidence-free bare names (`console.log`) skipped conservatively, all skips counted in stats. Deterministic/byte-stable output.
- **`reindex.ts`:** derives edges for every ingest batch at the single chokepoint both full and incremental paths share; every file asserts `edges` (possibly `[]`) with provenance scope `["heuristic"]`.
- **`graph-store.ts`:** new optional `StoreFileIR.assertedEdgeProvenances` scopes the stale-edge delete — a fresh parse contradicts only its own derivation class, so `trace` (ingest_traces) and `lsp`-upgraded edges survive re-ingest instead of being destroyed. Absent field = legacy delete-all behavior, unchanged for existing callers.
- Internal module (not exported from the package index — same pattern as `detect-changes.ts`/`co-change.ts`). Docs Phase A section rewritten to describe the real mechanism; changelog entry added.

## Verification

- 15 new tests (11 resolver + 4 store scoping); the trace-preservation test **fails before** the store change (prove-fail-before) — re-ingest previously deleted a trace edge owned by the file.
- Full package suite: 447/447 → 462/462 pass; `pnpm --filter @remnic/coding-graph run build` green (ESM + DTS).
- End-to-end against the real engine + store + `executeReindex` on a two-file TS fixture: `edgesByType {CALLS: 2}` (same-file `greet→format` + cross-file `shout→greet` via import), `trace_path greet` returns callee and caller at depth 1, `deadCode` correctly excludes exported and called symbols. Before the fix the identical fixture yielded `edges: 0` (repro in #1891).
- `npm run preflight:quick` → `[preflight] OK (quick)`

## Scenario matrix (stateful-subsystem rule)

fresh file with calls → edges created · re-ingest unchanged → no-op (idempotent) · call removed → stale heuristic edge deleted · file owning trace edges re-ingested → trace edges preserved · `edges` undefined (bare IR callers) → early-return preserve-all unchanged · legacy callers without the scoping field → delete-all-stale unchanged · full reindex after LSP upgrades → heuristic re-assertion is re-upgraded by the next LSP pass (file changed ⇒ prior resolution stale by definition).

Found while enabling `codingKnowledge`/`codegraphTools` on the fleet daemons. Part of #1548 hygiene.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core graph ingest and edge lifecycle (stale delete, cross-file binding, lsp coexistence); mistakes could corrupt or drop edges, but behavior is heavily tested and legacy callers without provenance scoping are unchanged.
> 
> **Overview**
> Fixes **degenerate coding-graph indexing** where parses produced nodes but no `CALLS` edges, breaking `trace_path`, blast radius, and dead-code queries.
> 
> **Phase A heuristic resolution** is added and wired into the shared reindex ingest path: each call site becomes a `CALLS` edge with `src` = innermost enclosing symbol and `dst` from conservative same-file or relative-import binding (member calls, externals, and ambiguous names are skipped). Reindex now attaches derived `edges` plus `assertedEdgeProvenances: ["heuristic"]` so stale heuristic rows are replaced without wiping `trace`/`lsp` edges; the store gains path-hinted cross-file resolution and guards against downgrading stronger `lsp` rows.
> 
> Parser/IR work expands import **alias bindings**, Python import names, and **`memberAccess`** call sites across languages; core `ImportIR` / `CallSiteIR` types are extended accordingly. Large test suites cover resolver behavior, provenance-scoped deletion, and incremental reindex preserving `lsp`-only edges on unchanged files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93465e9cd3bf62d38f391ce2d34aead31ada191f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->