### PR TITLE
docs: complete documentation overhaul — accurate, organized, verified

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,132 +1,93 @@
-# Contributing to openclaw-engram
+# Contributing to Remnic
 
-Thanks for contributing. We welcome both issues and pull requests from humans and AI-assisted contributors.
+Thanks for contributing. Issues and pull requests are welcome from humans and AI-assisted contributors alike.
 
 ## Ways to contribute
 
-- Report bugs via GitHub Issues
-- Propose features via GitHub Issues
+- Report bugs or propose features via [GitHub Issues](https://github.com/joshuaswarren/remnic/issues)
 - Submit pull requests for fixes, docs, tests, and improvements
-- Improve examples/docs to help adoption
+- Improve examples and docs to help adoption
 
 ## Before opening a PR
 
-1. Search existing issues/PRs to avoid duplicates.
-2. For non-trivial changes, open an issue first and propose approach/scope.
-3. Keep changes focused and small when possible.
+1. Search existing issues and PRs to avoid duplicates.
+2. For non-trivial changes, open an issue first and propose the approach and scope.
+3. Keep PRs narrow: one subsystem group per PR. If work spans schema/surface contracts, storage/serialization, and retrieval behavior, split it before review.
 
 ## Development setup
 
-Requires Node.js `>=22.12.0` (aligned with OpenClaw engine support).
+Requires Node.js `>=22.12.0` and [pnpm](https://pnpm.io/).
 
 ```bash
-npm ci
+git clone https://github.com/joshuaswarren/remnic.git
+cd remnic
+pnpm install
+pnpm run build
 npm run check-types
 npm test
-npm run build
 ```
 
-Install local guard hooks (recommended):
+Install the local guard hooks (recommended):
 
 ```bash
 npm run hooks:install
 ```
 
-This enables:
-- `pre-commit`: `npm run preflight:quick`
-- `pre-push`: `npm run preflight`
+This wires `pre-commit` to `npm run preflight:quick` and `pre-push` to `npm run preflight`.
 
-Cursor headless review behavior (`npm run review:cursor`):
-- Runs only if `agent` (preferred) or `cursor-agent` is installed and callable.
-- Auto-skips (non-failing) when Cursor CLI is unavailable/unconfigured.
-- Returns non-zero when it reports findings in strict finding format.
-- Uses documented print mode (`-p`) with `--output-format text` in non-interactive flow.
-- Override knobs:
-  - `CURSOR_PREPUSH_MODEL=<model>` to pick model (default: `auto`).
-  - `CURSOR_PREPUSH_BASE_REF=<ref>` to change diff base (default: `origin/main`).
-  - `CURSOR_PREPUSH_TIMEOUT_SECONDS=<seconds>` to control headless review timeout (default: `300`).
-  - `CURSOR_PREPUSH_MAX_DIFF_CHARS=<chars>` to cap diff included in prompt (default: `120000`).
-  - `CURSOR_PREPUSH_STRICT=1` to fail when Cursor is unavailable/timed-out/unparseable (recommended for maintainers running manual pre-push review).
+## Quality gates
 
-## Install path for users
+- `npm run preflight:quick` — fast gate (types + config contract + key tests). Run before every push.
+- `npm run preflight` — full pre-PR gate (types + contract + tests + build).
+- `npm run check-config-contract` — required when you touch config types, `parseConfig`, or the plugin manifest schema.
+- `npm run check:docs-parity` — required when you touch docs that contain CLI commands; every fenced `remnic <cmd>` must be a real registered command.
+- `npm run test:entity-hardening` — required when you touch `orchestrator.ts`, `storage.ts`, `intent.ts`, `memory-cache.ts`, `entity-retrieval.ts`, `config.ts`, or anything under `storage/` or `orchestration/`.
 
-Use npm install via OpenClaw as the primary install path in docs:
-
-```bash
-openclaw plugins install openclaw-engram --pin
-```
+For retrieval/planner/cache/config changes, also run the mandatory hardening gate described in [docs/ops/pr-review-hardening-playbook.md](docs/ops/pr-review-hardening-playbook.md).
 
 ## PR quality bar
 
-A good PR should:
+A good PR:
 
-- Include tests for behavior changes
-- Keep backwards compatibility unless intentionally changed
-- Avoid unrelated refactors in the same PR
-- Update docs for user-facing/config changes
-- Update `CHANGELOG.md` (see changelog policy below)
+- Includes tests for behavior changes — tests must verify behavior, not pass vacuously
+- Keeps backwards compatibility unless the change is intentionally breaking (and labeled as such)
+- Avoids unrelated refactors
+- Updates docs for user-facing or config changes
+- Updates `CHANGELOG.md` (see below)
 
-For retrieval/planner/cache/config changes, run the mandatory hardening gate:
-
-- `docs/ops/pr-review-hardening-playbook.md`
+Reviewers of retrieval/planner/caching logic verify: flag symmetry (`enabled=false` disables write and read effects), zero semantics (`0` is never coerced to `1`), cap-after-filter ordering, cache coherence across instances, fallback parity with primary search policy, artifact isolation, planner mode reachability, and heuristic robustness across language variants.
 
 ## Changelog policy
 
-This repository uses `CHANGELOG.md` on `main` as the contributor-facing ledger for upcoming release notes.
-Published per-version notes ship through GitHub Releases from the tagged release workflow.
+`CHANGELOG.md` on `main` is the contributor-facing ledger for upcoming release notes; published per-version notes ship through GitHub Releases.
 
-- Add a concise entry in `## [Unreleased]` for user-facing changes.
-- Use one of the standard sections when possible: `Added`, `Changed`, `Fixed`, `Security`.
-- Keep entries short and outcome-focused.
-
-A CI check enforces `Unreleased` changelog updates when source/config files change.
-Maintainers can bypass for exceptional cases by applying label `skip-changelog`.
+- Add a concise entry under `## [Unreleased]` for user-facing changes, using `Added`, `Changed`, `Fixed`, or `Security`.
+- A CI check enforces this when source or config files change; maintainers can bypass with the `skip-changelog` label.
 
 ## AI-assisted contributions
 
-AI-assisted and agent-assisted PRs are welcome.
-
-Please ensure:
+AI-assisted and agent-assisted PRs are welcome. Please ensure:
 
 - A human reviews and stands behind the final PR
 - Generated code is understood, minimal, and tested
 - No secrets, tokens, or private data are introduced
-- Tooling or automation changes include clear rationale
+
+Agents working in this repo should read [AGENTS.md](AGENTS.md) — it contains the binding engineering guardrails and review-prevention patterns.
 
 ## Security
 
-- Do not submit secrets in code, issues, or PRs.
-- If you find a sensitive vulnerability, open a private security report where possible instead of posting exploit details publicly.
-
-## Review and merge process
-
-- Maintainers may request changes for scope, safety, tests, and documentation.
-- PRs require passing checks and at least one maintainer approval.
-- Significant changes may be merged in follow-up slices to reduce risk.
-- For logic changes in retrieval/planner/caching, reviewers should verify:
-  - flag symmetry (`enabled=false` disables write+read effects)
-  - zero semantics (`0` is never coerced to `1`)
-  - cap-after-filter behavior
-  - cache coherence across instances/concurrency
-  - fallback parity (same policy constraints as primary and fallback paths)
-  - artifact isolation (`artifacts/` excluded from generic memory recall path)
-  - planner mode reachability (`no_recall`, `minimal`, `full`, `graph_mode`)
-  - heuristic robustness (intent patterns cover common language variants)
+Do not submit secrets in code, issues, or PRs. For sensitive vulnerabilities, follow [SECURITY.md](SECURITY.md) instead of posting exploit details publicly.
 
 ## Release process
 
-- Merges to `main` trigger an automated release workflow.
-- The workflow validates (`check-types`, `test`, `build`), bumps a patch version, tags `vX.Y.Z`, creates a GitHub release, and publishes to npm.
-- Configure repository secret `NPM_TOKEN` (npm automation token) for publish.
-- If `NPM_TOKEN` is missing, release creation still runs but npm publish is skipped.
+Merges to `main` trigger the automated release workflow: it validates (types, tests, build), derives the version bump from PR labels (`major`/`breaking-change` → major, `feature`/`enhancement` → minor, otherwise patch), tags `vX.Y.Z`, creates a GitHub release, and publishes the public packages in dependency order. See [docs/development/release-process.md](docs/development/release-process.md).
 
-## Good first contributions
+## More
 
-Useful high-impact contributions include:
+- [docs/development/contributing.md](docs/development/contributing.md) — deeper contributor reference
+- [docs/CONVENTIONS.md](docs/CONVENTIONS.md) — code and testing conventions
+- [docs/architecture/monorepo-structure.md](docs/architecture/monorepo-structure.md) — package map
 
-- Better error messages and docs
-- Additional regression tests
-- Example configs for common providers
-- Performance/safety improvements with benchmarks/tests
+Good first contributions: better error messages, additional regression tests, example configs for common providers, and performance or safety improvements with benchmarks.
 
-Thanks again for improving openclaw-engram.
+Thanks again for improving Remnic.

--- a/README.md
+++ b/README.md
@@ -94,17 +94,17 @@ One store, many front doors. Each integration reads and writes the same memory o
 | Oh My Pi (omp) | Native extension + MCP | Every turn / every turn | [docs/integration/omp.md](docs/integration/omp.md) |
 | Any MCP client | HTTP or stdio MCP | On demand | [docs/integration/connector-setup.md](docs/integration/connector-setup.md) |
 
-Most connectors install with a single command once the daemon is running, for example:
+Once the daemon is running, register each tool with a single command:
 
 ```bash
-remnic connectors install claude-code   # hooks + MCP
-remnic connectors install codex-cli     # hooks + MCP + memory extension
-remnic connectors install pi            # extension + MCP + compaction
-remnic connectors install omp           # extension + MCP
-remnic connectors install replit        # MCP
+remnic connectors install codex-cli     # token + connector state + memory extension
+remnic connectors install claude-code   # token + connector state
+remnic connectors install pi            # token + connector state
+remnic connectors install omp           # token + connector state
+remnic connectors install replit        # token + connector state
 ```
 
-Each connector generates its own auth token, installs the right hooks or extension, and verifies the connection. See the [connector setup guide](docs/integration/connector-setup.md) for every tool, its config snippet, and multi-tenant setups.
+Each install mints a host-specific auth token and records Remnic-side connector state; for some hosts (such as Codex CLI) it also materializes the memory extension. How much of the host itself gets configured varies — Claude Code and Hermes, for example, need a few manual wiring steps documented in their plugin guides. See the [connector setup guide](docs/integration/connector-setup.md) for every tool, exactly what its install automates, its config snippet, and multi-tenant setups.
 
 Over MCP, Remnic exposes a rich tool surface beyond store and recall: entity lookup, memory correction, temporal recall, X-ray provenance, daily briefing, work-board, and continuity tools among them. Hosted clients call these directly, and the standalone HTTP endpoint (`remnic daemon start` or `@remnic/server`) serves the same tools. See the [HTTP + MCP API reference](docs/api.md).
 

--- a/README.md
+++ b/README.md
@@ -1,665 +1,137 @@
 # Remnic
+
 [![npm version](https://img.shields.io/npm/v/@remnic/cli)](https://www.npmjs.com/package/@remnic/cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink)](https://github.com/sponsors/joshuaswarren)
 
-Open-source memory and context for user-aware agents.
+Open-source, local-first memory and context for AI agents. One memory store, every agent.
 
-Remnic is for agents that need to understand the people they work with over time.
+- **Your files, your machine.** Every memory is a plain markdown file with YAML frontmatter on your disk. No database, no cloud dependency, no subscription. `cat`, `grep`, edit, and version-control your memory with the tools you already use.
+- **One memory across every tool.** OpenClaw, Claude Code, Codex CLI, Cursor, ChatGPT (developer mode), Hermes, Replit, Pi, omp, and any MCP client read and write the same store. Tell one agent a preference; every agent knows it.
+- **Automatic extraction and recall.** Remnic watches conversations, distills durable knowledge, and injects the right context back when it is needed.
+- **Sharp retrieval.** Hybrid search (BM25 + vector + reranking) over rebuildable indexes, with graph recall, memory-worth scoring, and per-result provenance you can inspect.
+- **MIT licensed.** Free, open, and built to be forked.
 
-Remnic helps AI agents understand the people they work with: their preferences, projects, constraints, decisions, patterns, and definition of good. The goal is simple: agents that remember responsibly, retrieve the right context, and ask fewer unnecessary questions.
+## Why Remnic
 
-Remnic is not just a memory store. It is an exploration of the systems layer around user-aware agents: scoped memory, provenance, retrieval quality, correction, boundaries, and evals.
+Most agents do not fail because they lack another prompt. They fail because they do not understand the user, the project, the boundaries, or what "good" means in context. Every session starts from zero: the agent forgets your name, your projects, the decisions you already made, and the bugs you already debugged. You re-explain the same context over and over, and the agent still repeats the same mistakes.
 
-## ChatGPT Integration
+There is a useful split in AI memory between **memory backends** (extract facts, store vectors, retrieve relevant ones) and **context substrates** (human-readable context that accumulates and compounds across sessions). Most tools pick one camp. Remnic does both:
 
-Remnic now works inside chatgpt.com. Connect it as a developer-mode app and your assistant can store and recall memories on your own server.
-
-OpenAI no longer blocks built-in memory or tools when you add a custom MCP server. Remnic fills that gap with MCP and OAuth 2.1 support. Your memory store stays on your disk as plain text files, and that local store is the source of truth. Note that when ChatGPT calls Remnic's tools, the memory content it reads and writes is also processed by OpenAI's tool pipeline, so treat what you surface accordingly.
-
-Setup takes a few minutes. Point your HTTPS server URL at ChatGPT, turn on OAuth, and link the app. Full guide: **[docs/integration/chatgpt.md](docs/integration/chatgpt.md)**
-
-
-## Why this matters
-
-Most agents do not fail because they lack another prompt. They fail because they do not understand the user, the project, the boundaries, or what “good” means in context.
-
-Remnic explores the systems layer needed for user-aware agents:
-
-- what to remember
-- where that memory applies
-- why it was retrieved
-- when it should expire
-- how users correct it
-- when the agent should ask instead of act
-- how to evaluate whether memory improved the outcome
-
-**The trace is noise. The primitive is the product.** Remnic's job is the pipeline that distills hours of agent conversation into compressed, searchable, durable memory primitives. ([How it works →](docs/trace-to-primitive.md))
-
-Creator and maintainer of Remnic: [Joshua Warren](https://github.com/joshuaswarren).
-
-## OpenAI / Codex / MCP
-
-Remnic exposes memory and context through HTTP and MCP surfaces and includes integrations for agentic development workflows such as Codex CLI, Claude Code, Replit, and other MCP clients.
-
-The long-term goal is to make memory inspectable, scoped, correctable, and measurable across agent workflows.
-
-Try the no-key [Coding Agent Memory Demo](examples/coding-agent-memory-demo/) for a five-minute walkthrough where real Remnic `memoryStore()` and `recallXray()` calls carry a scoped project decision/preference across two coding-agent session identities.
-
-## OpenAI Build Week: MemCorrect
-
-Remnic's Developer Tools entry is **MemCorrect**, a benchmark for the memory
-system behind an AI agent. It measures whether a backend recalls the right
-fact, accepts a correction, and stops serving the stale fact. The new MCP
-adapter lets the same contract run against Remnic or another conforming MCP
-memory server through explicit tool and argument mapping.
-
-After installing the two packages, the judge path itself needs no dataset,
-API key, or network access:
-
-```bash
-npm install -g @remnic/cli @remnic/bench
-remnic bench run --quick memcorrect-v1 --adapter mcp --mcp-demo
-remnic bench runs list
-remnic bench export <run-id> --format html --output ./memcorrect-report.html
-```
-
-The packaged MCP demo is intentionally small. Its value is that the command
-exercises the real MCP transport and correction contract, then produces a
-self-contained report card. It is a smoke test, not a publishable model or
-backend comparison.
-
-To run the same correction rubric with GPT-5.6 as the judge, opt in explicitly
-through the OpenAI Responses API:
-
-```bash
-export OPENAI_API_KEY=...
-remnic bench run --quick memcorrect-v1 --adapter mcp --mcp-demo \
-  --judge-provider openai --judge-model gpt-5.6
-```
-
-Codex was used to implement and adversarially review the in-window MCP adapter,
-Responses provider, and report card. GPT-5.6 is the optional structured-output
-judge inside the harness; the keyless command above remains deterministic and
-offline. Remnic and the original benchmark harness predate the event, so
-[`HACKATHON.md`](HACKATHON.md) draws the prior-work boundary commit by commit
-and tracks the still-pending operator evidence.
-
-Supported judge path:
-
-- Node.js 22.12 or newer.
-- Linux is verified from both a source checkout and packed tarballs installed
-  into a clean global prefix for the Build Week path.
-- macOS uses the same Node CLI and is supported; its final global-install
-  receipt is still an operator release check.
-- On Windows, use WSL2 for the claimed judge path. Native Windows is not yet
-  claimed as Build Week-verified.
-- MCP servers may use stdio or Streamable HTTP. A non-canonical tool surface
-  requires an explicit `--mcp-tool-map`; bearer tokens are read from
-  `REMNIC_BENCH_MCP_BEARER_TOKEN`, not command-line arguments.
-
-See the focused [`@remnic/bench` guide](packages/bench/README.md) and the
-[submission evidence ledger](HACKATHON.md) for source-checkout instructions,
-receipts, and the exact line between prior and new work.
-
-## Engram -> Remnic
- **Engram is now Remnic.** Canonical packages live under the `@remnic/*` scope:
- [`@remnic/core`](https://www.npmjs.com/package/@remnic/core),
- [`@remnic/server`](https://www.npmjs.com/package/@remnic/server),
- [`@remnic/cli`](https://www.npmjs.com/package/@remnic/cli).
- OpenClaw installs should use [`@remnic/plugin-openclaw`](https://www.npmjs.com/package/@remnic/plugin-openclaw).
- The legacy `engram` CLI name remains available as a forwarder during the rename window.
- Hermes users: [`remnic-hermes`](https://pypi.org/project/remnic-hermes/) v1.0.2 on PyPI.
-
-## Support Remnic
-
-Every bit of support is genuinely appreciated and helps keep this project alive and free for everyone.
-
-If you're able to, [sponsoring on GitHub](https://github.com/sponsors/joshuaswarren) or sending a Lightning donation to `joshuaswarren@strike.me` directly funds continued development, new integrations, and keeping Remnic open source.
-
-[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?style=for-the-badge)](https://github.com/sponsors/joshuaswarren)
-
-If financial support isn't an option, you can still make a big difference — [star the repo on GitHub](https://github.com/joshuaswarren/remnic), share it on social media, or recommend it to a friend or colleague. Word of mouth is how most people find Remnic, and it means the world.
-
-## The Problem
-
-Every AI agent session starts from zero. Your agent doesn't know your name, your projects, the decisions you've already made, or the bugs you already debugged. Whether it's a personal assistant, a coding agent, a research agent, or a multi-agent team — they all forget everything between conversations. You re-explain the same context over and over, and your agents still make the same mistakes.
-
-OpenClaw's built-in memory works for simple cases, but it doesn't scale. It lacks semantic search, lifecycle management, entity tracking, and governance. Third-party memory services exist, but they cost money and require sending your private data to someone else's servers.
-
-## The Solution
-
-Remnic is an open-source memory and context layer for user-aware agents. It watches agent conversations, extracts durable knowledge, and injects the right context back when it is needed. Route extraction through the OpenClaw gateway model chain, OpenAI, or a **local LLM** (Ollama, LM Studio, etc.) -- your choice.
-
-Remnic helps agents understand the people they work with: preferences, projects, constraints, decisions, patterns, and definitions of good. It works natively with **[OpenClaw](https://github.com/openclaw/openclaw)**, **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, **[Codex CLI](https://github.com/openai/codex)**, **[Pi Coding Agent](https://pi.dev)**, **[Oh My Pi (omp)](https://omp.sh)**, **[Hermes Agent](https://github.com/NousResearch/hermes-agent)**, and any **MCP-compatible client** (Replit, Cursor, etc.). When you tell any agent a preference, every agent can use the same governed memory store.
-
-Local-first storage is a trust feature. All data can stay on your machine as plain markdown files: no cloud dependency, no subscription, and no third-party memory service required.
-
-Architecture rule: standalone Remnic is first-class. `@remnic/core`, `@remnic/server`, and `@remnic/cli` own the memory engine and must stay host-agnostic. OpenClaw, Hermes, Codex, Claude Code, and future integrations are thin adapters over that shared core, and adapter work should always follow the host's current upstream SDK and documentation instead of recreating host-native behavior inside Remnic.
+- **The files are the source of truth.** The hybrid search index is downstream of your markdown, fully rebuildable from disk, never authoritative itself.
+- **Recall stays sharp.** Three retrieval tiers, opt-in graph traversal, memory-worth scoring that filters low-value facts before they reach the model, and temporal supersession that keeps stale facts out.
+- **It compounds.** Background consolidation merges duplicates, promotes recurring themes, and snapshots page versions on every overwrite. The longer you use it, the better it gets, and you can always read exactly what it knows.
 
 | Without Remnic | With Remnic |
 |---|---|
-| Re-explain who you are and what you're working on | Agent recalls your identity, projects, and preferences automatically |
+| Re-explain who you are and what you are working on | The agent recalls your identity, projects, and preferences automatically |
 | Repeat context for every task | Entity knowledge surfaces people, projects, tools, and relationships on demand |
-| Lose debugging and research context between sessions | Past root causes, dead ends, and findings are recalled — no repeated work |
+| Lose debugging and research context between sessions | Past root causes, dead ends, and findings are recalled, so work is not repeated |
 | Manually restate preferences every session | Preferences persist across sessions, agents, and projects |
-| Context-switching tax when resuming work | Session-start recall brings you back to speed instantly |
-| Default OpenClaw memory doesn't scale | Hybrid search, lifecycle management, namespaces, and governance |
-| Third-party memory services cost money and share your data | Everything stays local — your filesystem, your rules |
+| A context-switching tax when you resume work | Session-start recall brings you back up to speed |
+| Built-in agent memory that does not scale | Hybrid search, lifecycle management, namespaces, and governance |
+| Third-party memory services that cost money and hold your data | Everything stays local: your filesystem, your rules |
 
-## Memory or context substrate? Both.
+## Quick start
 
-There's a useful split in the AI-memory space between **memory backends** (extract facts → vector DB → retrieve relevant ones) and **context substrates** (structured human-readable context that accumulates across sessions and compounds over time). Most tools land firmly in one camp. Remnic does both.
+### Prerequisites
 
-**The files are the source of truth.** Every memory is a markdown file with YAML frontmatter on your filesystem. You can `cat`, `grep`, edit, version-control, back up, and reason about your memory with standard tools. The hybrid search index (QMD: BM25 + vector + reranking) is downstream of the files — fully rebuildable from disk, never the source of truth itself.
+- [Node.js](https://nodejs.org/) 22.12 or newer.
+- A model provider for extraction (an OpenAI API key, the OpenClaw gateway model chain, or a [local LLM](docs/guides/local-llm.md)). Retrieval-only mode needs none of these.
+- Optional but recommended: [QMD](https://github.com/tobi/qmd) for the highest-quality hybrid search. Without it, Remnic falls back to embedding search and then recency-ordered reads.
 
-**The recall stays sharp.** Three retrieval tiers (chunk → section → raw transcript), feature-flagged graph retrieval with Personalized PageRank, memory-worth scoring that filters low-value facts before they reach the LLM, temporal supersession that keeps stale facts out of recall, and Recall X-ray so you can see exactly which tier produced each result and why.
+### Any agent (standalone)
 
-**It compounds.** Background consolidation (the "dreams" surface) merges duplicates, promotes recurring themes, and snapshots page versions on every overwrite. Provenance fields (`derived_from`, `derived_via`) track where every consolidated memory came from. Procedural memory (on by default) captures multi-step runbooks. The longer you use it, the better it gets — and you can always read exactly what it knows.
-
-**Camp 1 asks "what should the AI remember?" Remnic answers that.** **Camp 2 asks "what context should the AI work inside?" Remnic answers that too.**
-
-## Quick install (OpenClaw)
-
-If you have OpenClaw installed, the fastest path to working Remnic memory is:
+Install the CLI, start the daemon, and verify it is running.
 
 ```bash
-# 1. Install the plugin package
-openclaw plugins install clawhub:@remnic/plugin-openclaw
-
-# 2. Wire up the memory slot automatically
-remnic openclaw install
-
-# 3. Restart the gateway
-launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
-
-# 4. Verify everything is working
-remnic doctor
-```
-
-`remnic openclaw install` writes `plugins.entries["openclaw-remnic"]` and `plugins.slots.memory = "openclaw-remnic"` to `~/.openclaw/openclaw.json`. Without the slot, hooks never fire — see [Troubleshooting: hooks aren't firing](#troubleshooting-hooks-arent-firing) for details.
-
-Migrating from the legacy `@joshuaswarren/openclaw-engram` package? Run
-`remnic openclaw migrate-engram --yes`; it backs up the legacy extension,
-installs `@remnic/plugin-openclaw`, preserves `memoryDir`, and switches the
-OpenClaw memory slot to `openclaw-remnic`. See the
-[OpenClaw Engram to Remnic migration guide](docs/guides/openclaw-engram-to-remnic.md).
-
-## Installation
-
-### Option 1: Install from the CLI
-
-```bash
-openclaw plugins install clawhub:@remnic/plugin-openclaw
-```
-
-### Option 2: Ask your OpenClaw agent to install it
-
-Tell any OpenClaw agent:
-
-> Install the @remnic/plugin-openclaw plugin and configure it as my memory system.
-
-Your agent will run the install command, update `openclaw.json`, and restart the gateway for you.
-
-### Option 3: Developer install from source
-
-```bash
-git clone https://github.com/joshuaswarren/remnic.git \
-  ~/.openclaw/extensions/remnic
-cd ~/.openclaw/extensions/remnic
-pnpm install && pnpm run build
-```
-
-> **Note:** This repo uses [pnpm](https://pnpm.io/) workspaces. `npm ci` / `npm install` will fail on `workspace:` specifiers. Install pnpm first: `npm install -g pnpm`.
-
-### Option 4: Standalone (no OpenClaw)
-
-**From npm (recommended):**
-
-```bash
-npm install -g @remnic/cli      # Installs `remnic` plus the legacy `engram` forwarder
-remnic init                     # Create remnic.config.json
-export OPENAI_API_KEY=sk-...
+npm install -g @remnic/cli       # installs `remnic` (plus the legacy `engram` forwarder)
+remnic init                      # write remnic.config.json
+export OPENAI_API_KEY=sk-...     # extraction provider (or route to a local LLM)
 export REMNIC_AUTH_TOKEN=$(openssl rand -hex 32)
-remnic daemon start             # Start background server
-remnic status                   # Verify it's running
-remnic query "hello" --explain  # Test query with tier breakdown
+remnic daemon start              # start the background server
+remnic status                    # confirm it is running
+remnic query "hello" --explain   # test a query with the tier breakdown
 ```
 
-**From source** (requires [Node.js](https://nodejs.org/) 22.12+ and [pnpm](https://pnpm.io/)):
+`remnic query --explain` prints which retrieval tier produced each result and why, so you can watch the memory pipeline work on your very first query. Run `remnic doctor` any time to check your setup, then connect a tool from the table below. Full five-minute walkthrough: [docs/guides/quickstart.md](docs/guides/quickstart.md).
+
+### OpenClaw (native plugin)
+
+OpenClaw gets the deepest integration: a memory-slot plugin that recalls every session and observes every response.
 
 ```bash
-git clone https://github.com/joshuaswarren/remnic.git
-cd remnic
-pnpm install && pnpm run build
-cd packages/remnic-cli && pnpm link --global  # Makes `remnic` and `engram` available on PATH
-cd ../..
-remnic init                     # Create remnic.config.json
-export OPENAI_API_KEY=sk-...
-export REMNIC_AUTH_TOKEN=$(openssl rand -hex 32)
-remnic daemon start             # Start background server
-remnic status                   # Verify it's running
-remnic query "hello" --explain  # Test query with tier breakdown
+openclaw plugins install clawhub:@remnic/plugin-openclaw   # install the plugin
+remnic openclaw install                                    # wire the memory slot in openclaw.json
+launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway    # restart the OpenClaw gateway (macOS)
+remnic doctor                                              # verify every check passes
 ```
 
-> **Note:** `remnic` is the canonical CLI. The legacy `engram` binary is a compatibility forwarder to the same implementation. Running `pnpm link --global` from `packages/remnic-cli/` (not the repo root) makes both names available on PATH. Alternatively, invoke directly: `npx tsx packages/remnic-cli/src/index.ts <command>`.
+`remnic openclaw install` writes `plugins.entries["openclaw-remnic"]` and sets `plugins.slots.memory = "openclaw-remnic"` in `~/.openclaw/openclaw.json`. Without the slot, OpenClaw skips plugin registration and no hooks fire, so `remnic doctor` checks the slot explicitly and points you at the fix. After the restart, confirm the plugin is live:
 
-The standalone CLI provides 15+ commands for memory management, project onboarding, curation, diff-aware sync, dedup, connectors, spaces, and benchmarks -- all without requiring OpenClaw. See the [Platform Migration Guide](docs/guides/platform-migration.md) for the full command reference.
-
-### Option 5: Connect Other AI Agents
-
-Once the Remnic daemon is running, connect any supported agent:
-
-```bash
-remnic connectors install claude-code   # Claude Code (hooks + MCP)
-remnic connectors install codex-cli     # Codex CLI (hooks + MCP + memory extension)
-remnic connectors install pi            # Pi Coding Agent (extension + MCP + compaction)
-remnic connectors install omp           # Oh My Pi / omp (extension + MCP + compaction)
-remnic connectors install replit        # Replit (MCP only)
-pip install --upgrade remnic-hermes     # Hermes Agent (Python MemoryProvider)
-remnic connectors install hermes        # Writes Hermes config + token
-```
-
-For Codex CLI, installation also drops a phase-2 memory extension at
-`<codex_home>/memories_extensions/remnic/instructions.md` so Codex's
-consolidation sub-agent auto-discovers Remnic. Opt out with
-`--config installExtension=false` if you prefer to manage Codex extensions
-yourself.
-
-For Pi Coding Agent, installation writes an auto-discovered extension under
-`~/.pi/agent/extensions/remnic/`. The extension recalls context before turns,
-observes Pi messages and tool activity into Remnic/LCM, exposes Remnic MCP
-tools as Pi tools, and coordinates `session_before_compact` with Remnic LCM
-flush/checkpoint recording. See [docs/integration/pi.md](docs/integration/pi.md).
-
-Each connector generates a unique auth token, installs the appropriate plugin/hooks, and verifies the connection. All agents share the same memory store — tell one agent your preference, and every agent remembers it.
-
-Hermes uses Remnic as a Hermes **MemoryProvider**, not a `context_engine`. Automatic recall runs in `pre_llm_call`, observations run after each turn, and the provider now registers the full Remnic parity tool surface (`remnic_lcm_search`, recall explain/X-ray, memory CRUD, continuity, identity, governance, work-board, shared-context, compounding, day-summary, briefing, checkpoint, and profiling tools) plus legacy `engram_*` aliases. Lossless Context Management is delivered through the daemon recall envelope when `lcmEnabled` is on; no Hermes `context_engine` registration is required. See [docs/plugins/hermes.md](docs/plugins/hermes.md) for the full reference.
-
-| Platform | Integration | Auto-recall | Auto-observe |
-|----------|------------|-------------|--------------|
-| **OpenClaw** | Memory slot plugin | Every session | Every response |
-| **Claude Code** | Native hooks + MCP | Every prompt | Every tool use |
-| **Codex CLI** | Native hooks + MCP | Every prompt | Every tool use |
-| **Pi Coding Agent** | Native extension + MCP | Every turn | Every turn |
-| **Hermes** | Python MemoryProvider | Every LLM call | Every turn |
-| **Replit** | MCP only | On demand | On demand |
-
-### Configure
-
-After installation, add the Remnic bridge plugin to your `openclaw.json`:
-
-```jsonc
-{
-  "plugins": {
-    "allow": ["openclaw-remnic"],
-    "slots": { "memory": "openclaw-remnic" },
-    "entries": {
-      "openclaw-remnic": {
-        "enabled": true,
-        "hooks": {
-          "allowConversationAccess": true
-        },
-        "config": {
-          // Recommended for OpenClaw: use the gateway model chain.
-          "modelSource": "gateway",
-          "gatewayAgentId": "remnic-llm",
-          "fastGatewayAgentId": "remnic-llm-fast",
-
-          // Optional: Use Remnic's local LLM path (plugin mode only; no API key needed):
-          // "openaiApiKey": false,
-          // "localLlmEnabled": true,
-          // "localLlmUrl": "http://localhost:1234/v1",
-          // "localLlmModel": "qwen2.5-32b-instruct"
-
-          // Optional: Use OpenAI directly (plugin mode only):
-          // "modelSource": "plugin",
-          // "openaiApiKey": "${OPENAI_API_KEY}"
-        }
-      }
-    }
-  }
-}
-```
-
-> **Gateway model source:** When `modelSource` is `"gateway"`, Remnic routes all LLM calls (extraction, consolidation, reranking) through an OpenClaw agent persona's model chain instead of its own config. Extraction starts on the `gatewayAgentId` chain directly in this mode; `localLlm*` settings do not control primary extraction order. Define agent personas in `openclaw.json → agents.list[]` with a `primary` model and `fallbacks[]` array — Remnic tries each in order until one succeeds. This lets you build multi-provider fallback chains like Fireworks → local LLM → cloud OpenAI. See the [Gateway Model Source](docs/config-reference.md#gateway-model-source) guide for full setup.
-
-Restart the gateway:
-
-```bash
-launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway   # macOS
-# or: systemctl restart openclaw-gateway                    # Linux
-```
-
-Start a conversation — Remnic begins learning immediately.
-
-> **Note:** This shows only the minimal config. Remnic has 60+ configuration options for search backends, capture modes, memory OS features, and more. See the [full config reference](docs/config-reference.md) for every setting.
-
-### Extraction importance gate
-
-Remnic scores every extracted fact locally (see `src/importance.ts`) and uses that score as a write gate. Facts whose level falls below `extractionMinImportanceLevel` are dropped before they ever hit disk, so turn-level chatter like `"hi"`, `"k"`, or heartbeat pings never become fact memories.
-
-Default: `"low"` — only `"trivial"` content is dropped. Raise to `"normal"` or higher for a stricter gate.
-
-```jsonc
-{
-  "plugins": {
-    "entries": {
-      "openclaw-remnic": {
-        "config": {
-          // Allowed values: "trivial" | "low" | "normal" | "high" | "critical"
-          "extractionMinImportanceLevel": "normal"
-        }
-      }
-    }
-  }
-}
-```
-
-Category boosts still apply before the gate, so corrections, principles, preferences, and commitments stay above `"normal"` even when their raw text would otherwise score low. Every gated fact increments the `importance_gated` counter (grep `metric:importance_gated` in `~/.openclaw/logs/gateway.log`) and the final extraction log line reports the gated count.
-
-### Inline source attribution (opt-in, issue #369)
-
-Extracted facts can optionally carry a compact provenance tag inline in the fact body — not just in YAML frontmatter — so the citation survives prompt injection, copy/paste, and LLM quoting. When an agent later quotes a memory back or a user asks "where did you learn that?", the source travels with the claim.
-
-Default format:
-
-```
-The foo service uses Redis for rate limiting. [Source: agent=planner, session=main, ts=2026-04-10T14:25:07Z]
-```
-
-Enable it per plugin:
-
-```jsonc
-{
-  "plugins": {
-    "entries": {
-      "openclaw-remnic": {
-        "config": {
-          "inlineSourceAttributionEnabled": true,
-          // Optional: customize the tag format.
-          // Placeholders: {agent}, {session}, {sessionId}, {ts}, {date}
-          "inlineSourceAttributionFormat": "[Source: agent={agent}, session={sessionId}, ts={ts}]"
-        }
-      }
-    }
-  }
-}
-```
-
-Properties:
-
-- **Off by default** to preserve backwards compatibility with downstream consumers that expect raw fact text.
-- **Inline** — the tag is part of the stored fact body, so it flows through every write site (direct writes, chunked writes, shared-namespace promotion, verbatim artifacts) and recall injection without special handling.
-- **Legacy-safe** — facts written before the flag was enabled still read and recall normally; nothing is retroactively rewritten.
-- **Non-destructive** — facts that already carry a citation (e.g. relayed from an upstream system) are left untouched.
-- **Machine-parseable** — `parseCitation(text)` and `stripCitation(text)` are exported from `@remnic/core` for callers that want the raw body (e.g. for dedup hashing, display, or verification tooling). Malformed citations never throw.
-
-See `packages/remnic-core/src/source-attribution.ts` for the helpers and `packages/remnic-core/src/source-attribution.test.ts` for the round-trip contract.
-
-### Verify installation
-
-```bash
-remnic doctor              # Health diagnostics with remediation hints
-remnic connectors doctor   # Connector-specific health checks
-remnic status              # Daemon status and local endpoint summary
-```
-
-## Bring your memory
-
-Remnic can import existing memory from the platforms you already use.
-Five optional importer packages ship alongside the CLI — install only the
-ones you need:
-
-```bash
-# ChatGPT (OpenAI data export: saved memories + optional conversation summaries)
-npm install -g @remnic/import-chatgpt
-remnic import --adapter chatgpt --file ~/chatgpt-export/memory.json --dry-run
-
-# Claude (Anthropic data export: project docs + prompt templates)
-npm install -g @remnic/import-claude
-remnic import --adapter claude --file ~/claude-export/projects.json
-
-# Gemini (Google Takeout "Gemini Apps Activity")
-npm install -g @remnic/import-gemini
-remnic import --adapter gemini --file "~/Takeout/Gemini/My Activity.json"
-
-# mem0 (REST API — paginated; honors --rate-limit)
-npm install -g @remnic/import-mem0
-export MEM0_API_KEY=...
-remnic import --adapter mem0 --rate-limit 2
-
-# Supermemory (JSON export)
-npm install -g @remnic/import-supermemory
-remnic import --adapter supermemory --file ./supermemory-memories.json --dry-run
-remnic import --adapter supermemory --file ./supermemory-memories.json
-```
-
-Each importer is an **optional runtime companion** — the base CLI
-install never pulls them in. If you run `remnic import --adapter <name>`
-without the matching package installed, the CLI prints a clean install
-hint. Every run supports `--dry-run` for a zero-write preview.
-
-> **Privacy note:** import parsing and storage run locally, but after
-> the orchestrator accepts a record it enters the normal extraction
-> pipeline — which calls whatever model provider you have configured.
-> If extraction is routed to a remote provider, imported content is
-> transmitted to that provider during extraction. To keep imports fully
-> local, configure a local extraction model or use `--dry-run` to
-> preview without writing.
-
-See [docs/importers.md](docs/importers.md) for per-source details, input
-formats, provenance metadata, and the full privacy breakdown.
-
-## Wear your memory
-
-Remnic also ingests AI-wearable recordings. Three optional connector
-packages pull your conversations, clean and speaker-label the
-transcripts, apply your personal corrections, store searchable
-per-day transcript files, and — under strict per-source trust gates —
-create memories:
-
-```bash
-# Limitless Pendant
-npm install -g @remnic/connector-limitless
-export LIMITLESS_API_KEY=...
-
-# Bee bracelet (via the local `bee proxy`, or direct with a token)
-npm install -g @remnic/connector-bee
-
-# Omi necklace (integration app: appId + uid + sk_ key)
-npm install -g @remnic/connector-omi
-export OMI_API_KEY=...
-
-# Then (after enabling sources in config):
-remnic wearables sync --days 7
-remnic wearables transcript --date 2026-06-10
-remnic wearables search "that solar quote"
-remnic wearables memories --source limitless --date 2026-06-10
-```
-
-Memory creation defaults to **smart mode** — a fully automated trust
-pipeline: every candidate runs through Remnic's LLM extraction judge,
-gets a per-source transcription-quality prior, and earns corroboration
-boosts when a second wearable recorded the same content or an existing
-memory supports it. High-trust facts are written active, borderline
-facts go to the review queue, ASR garbage is dropped — and the trust
-evidence (score, judge verdict, corroborating sources) persists on
-every memory. Tune per source with `sourceTrust`, `autoApproveTrust`,
-`reviewTrust`, and `maxMemoriesPerDay`, or pick `review`/`auto`/`off`.
-MCP tools (`remnic.transcript_day`, `remnic.transcript_search`,
-`remnic.transcript_memories`, `remnic.wearables_sync`,
-`remnic.wearables_status` — `engram.*` aliases included) and HTTP
-routes expose the same surface to agents.
-
-See [docs/wearables.md](docs/wearables.md) for the full pipeline,
-configuration reference, speaker labeling, corrections, redaction, and
-per-provider setup.
-
-## Troubleshooting: hooks aren't firing
-
-**Symptom:** Remnic appears installed but no memories are created. The gateway log shows no `[remnic]` lines after conversations.
-
-**Root cause:** OpenClaw gates memory plugins on `plugins.slots.memory`. If this slot is not set to the plugin's id, OpenClaw skips `register(api)` entirely — no hooks fire, no memory is stored or recalled.
-
-### Quick fix
-
-```bash
-remnic openclaw install   # Sets plugins.slots.memory = "openclaw-remnic"
-```
-
-Restart the gateway after running this command.
-
-### How to verify hooks are firing
-
-After restarting, check the gateway log for this line:
-
-```
-[remnic] gateway_start fired — Remnic memory plugin is active (id=openclaw-remnic, memoryDir=~/.openclaw/workspace/memory/local)
-```
-
-On macOS:
 ```bash
 grep "gateway_start fired" ~/.openclaw/logs/gateway.log
 ```
 
-If the line is absent, run `remnic doctor` to see which check is failing:
+A matching line means Remnic is active and hooks are firing. (The `[engram]` log prefix remains during the v1.x compatibility window.)
 
-```
-remnic doctor
-```
+Prefer to let the agent do it? Tell any OpenClaw agent: *"Install the @remnic/plugin-openclaw plugin and configure it as my memory system."* It runs the install, updates `openclaw.json`, and restarts the gateway for you. Comprehensive install and first-run guide, including QMD setup: [docs/getting-started.md](docs/getting-started.md).
 
-The doctor output will show:
-- `OpenClaw config file` — whether `openclaw.json` exists and is valid JSON
-- `OpenClaw plugins.entries` — whether the entries object is present
-- `OpenClaw plugin entry` — whether `openclaw-remnic` (or legacy `openclaw-engram`) entry exists
-- `OpenClaw plugins.slots.memory` — whether the slot is set and points to an entry
-- `OpenClaw memoryDir` — whether the configured memory directory exists on disk
+## Works with your tools
 
-Each failing check includes a remediation hint pointing to `remnic openclaw install`.
+One store, many front doors. Each integration reads and writes the same memory on your machine, so a preference you state in one tool is available in all of them.
 
-### Manual fix
+| Tool | Integration | Recall / observe | Docs |
+|------|-------------|------------------|------|
+| OpenClaw | Native memory-slot plugin | Every session / every response | [docs/plugins/openclaw.md](docs/plugins/openclaw.md) |
+| Claude Code | Native hooks + MCP | Every prompt / every tool use | [docs/plugins/claude-code.md](docs/plugins/claude-code.md) |
+| Codex CLI | Native hooks + MCP + memory extension | Every prompt / every tool use | [docs/plugins/codex.md](docs/plugins/codex.md) |
+| ChatGPT (developer mode) | MCP + OAuth 2.1 on your own server | On demand | [docs/integration/chatgpt.md](docs/integration/chatgpt.md) |
+| Cursor | Generic MCP client | On demand | [docs/integration/connector-setup.md](docs/integration/connector-setup.md) |
+| Hermes | Python `MemoryProvider` | Every LLM call / every turn | [docs/plugins/hermes.md](docs/plugins/hermes.md) |
+| Replit | MCP | On demand | [docs/plugins/replit.md](docs/plugins/replit.md) |
+| Pi Coding Agent | Native extension + MCP + compaction | Every turn / every turn | [docs/integration/pi.md](docs/integration/pi.md) |
+| Oh My Pi (omp) | Native extension + MCP | Every turn / every turn | [docs/integration/omp.md](docs/integration/omp.md) |
+| Any MCP client | HTTP or stdio MCP | On demand | [docs/integration/connector-setup.md](docs/integration/connector-setup.md) |
 
-If you prefer to edit `~/.openclaw/openclaw.json` directly:
-
-```json
-{
-  "plugins": {
-    "entries": {
-      "openclaw-remnic": {
-        "config": {
-          "memoryDir": "~/.openclaw/workspace/memory/local"
-        }
-      }
-    },
-    "slots": {
-      "memory": "openclaw-remnic"
-    }
-  }
-}
-```
-
-Both `entries["openclaw-remnic"]` and `slots.memory = "openclaw-remnic"` are required. See [docs/integration/plugin-id-and-memory-namespaces.md](docs/integration/plugin-id-and-memory-namespaces.md) for the full design note.
-
-## Using Remnic with Codex CLI
-
-Start the Remnic server directly for the current shell session:
+Most connectors install with a single command once the daemon is running, for example:
 
 ```bash
-# Generate a token
-export REMNIC_AUTH_TOKEN="$(openssl rand -base64 32)"
-
-npx remnic-server --host 127.0.0.1 --port 4318 --auth-token "$REMNIC_AUTH_TOKEN"
+remnic connectors install claude-code   # hooks + MCP
+remnic connectors install codex-cli     # hooks + MCP + memory extension
+remnic connectors install pi            # extension + MCP + compaction
+remnic connectors install omp           # extension + MCP
+remnic connectors install replit        # MCP
 ```
 
-If you want to use `remnic daemon start`, persist the token in
-`remnic.config.json` first. `daemon start` will hand off to launchd/systemd
-when a service is installed, and those service templates read `server.authToken`
-from config rather than inheriting your shell's exported token.
+Each connector generates its own auth token, installs the right hooks or extension, and verifies the connection. See the [connector setup guide](docs/integration/connector-setup.md) for every tool, its config snippet, and multi-tenant setups.
 
-The HTTP API path remains `/engram/v1/...` during the v1.x compatibility window.
+Over MCP, Remnic exposes a rich tool surface beyond store and recall: entity lookup, memory correction, temporal recall, X-ray provenance, daily briefing, work-board, and continuity tools among them. Hosted clients call these directly, and the standalone HTTP endpoint (`remnic daemon start` or `@remnic/server`) serves the same tools. See the [HTTP + MCP API reference](docs/api.md).
 
-Add to `~/.codex/config.toml`:
+## How it works
 
-```toml
-[mcp_servers.remnic]
-url = "http://127.0.0.1:4318/mcp"
-bearer_token_env_var = "REMNIC_AUTH_TOKEN"
-```
-
-That's it. Codex now has access to Remnic's recall, store, and entity tools. See the [full Codex integration guide](docs/guides/codex-cli.md) for session-start hooks, cross-machine setup, and automatic recall at session start.
-
-## Using Remnic with Any MCP Client
-
-Run the stdio MCP server:
-
-```bash
-openclaw engram access mcp-serve
-```
-
-Point your MCP client's command at `openclaw engram access mcp-serve`. This
-is the OpenClaw-hosted stdio compatibility path. For standalone Remnic installs,
-prefer the HTTP MCP endpoint exposed by `remnic daemon start` or `remnic-server`.
-
-**Claude Code (MCP over HTTP):** Start the Remnic server, then add to `~/.claude.json`:
-
-```json
-{
-  "mcpServers": {
-    "remnic": {
-      "url": "http://localhost:4318/mcp",
-      "headers": {
-        "Authorization": "Bearer ${REMNIC_AUTH_TOKEN}"
-      }
-    }
-  }
-}
-```
-
-See the [Standalone Server Guide](docs/guides/standalone-server.md) for multi-tenant setups and connecting multiple agent harnesses.
-
-## Standalone Usage
-
-Remnic also works as a standalone tool without OpenClaw. Install and run the CLI directly:
-
-```bash
-npm install -g @remnic/cli
-remnic init                     # create remnic.config.json
-export OPENAI_API_KEY=sk-...
-export REMNIC_AUTH_TOKEN=$(openssl rand -hex 32)
-remnic daemon start             # start background server
-remnic query "hello"            # verify
-```
-
-The CLI provides 15+ commands for querying, onboarding projects, curating files, managing spaces, running benchmarks, and more. See the [full CLI reference](docs/api.md#standalone-cli-commands) for all commands.
-
-### Connect to any coding tool
-
-Remnic works with 10+ coding tools via MCP or HTTP. See the [Connector Setup Guide](docs/integration/connector-setup.md) for config snippets for Claude Code, Codex CLI, Cursor, GitHub Copilot, Cline, Roo Code, Windsurf, Amp, Replit, and any generic MCP client.
-
-OpenClaw remains the recommended path for most users. The standalone CLI is useful for CI/CD pipelines, scripted memory operations, and environments without OpenClaw.
-
-### Package Architecture
+Remnic runs a continuous three-phase loop around every agent conversation:
 
 ```
-@remnic/core            — Framework-agnostic engine (re-exports orchestrator, config, storage, search, extraction, graph, trust zones)
-@remnic/cli             — Standalone CLI binary (15+ commands)
-@remnic/server          — Standalone HTTP/MCP server
-@remnic/bench           — Benchmarks + CI regression gates
-@remnic/hermes-provider — HTTP client for remote Remnic instances
+  Recall   ->  Before a conversation, inject the relevant memories into context
+  Buffer   ->  After each turn, accumulate content until a trigger fires
+  Extract  ->  Periodically, distill structured memories with an LLM and write them to disk
 ```
 
-## How It Works
+- **Recall** ranks your stored memories against the incoming context and injects a budgeted slice back into the prompt. Extraction and rerank can run through the OpenClaw gateway model chain, OpenAI (Responses API), or a local LLM. See [docs/guides/cost-control.md](docs/guides/cost-control.md).
+- **Buffer** accumulates conversation turns until a size or time trigger fires, so extraction runs on meaningful spans rather than on every message.
+- **Extract** distills durable knowledge, runs it through an importance judge, and writes accepted memories to disk. The search index is then rebuilt from those files.
 
-Remnic operates in three phases:
-
+```mermaid
+flowchart LR
+  A[Agent session] -->|recall| B[Memory store<br/>markdown + YAML]
+  A -->|buffer turns| C[Extraction]
+  C -->|write memories| B
+  B -->|index| D[Hybrid search<br/>BM25 + vector + rerank]
+  D -->|rank + explain| A
 ```
- Recall    → Before each conversation, inject relevant memories into context
- Buffer    → After each turn, accumulate content until a trigger fires
- Extract   → Periodically, extract structured memories using an LLM
-```
 
-Memories are stored as plain markdown files with YAML frontmatter — fully portable, git-friendly, no database required:
+Each memory is a portable markdown file with YAML frontmatter, so it stays git-friendly and readable with no database required:
 
 ```yaml
 ---
@@ -668,559 +140,167 @@ category: decision
 confidence: 0.92
 tags: ["architecture", "search"]
 ---
-Decided to use the port/adapter pattern for search backends
-so alternative engines can replace QMD without changing core logic.
+Use the port/adapter pattern for search backends so alternative engines
+can replace the default index without changing core logic.
 ```
 
-Memory categories include: `fact`, `decision`, `preference`, `correction`, `relationship`, `principle`, `commitment`, `moment`, `skill`, `rule`, and more.
+Categories include `fact`, `decision`, `preference`, `correction`, `relationship`, `principle`, `commitment`, `skill`, and `rule`. Files are organized on disk under your configured memory directory:
+
+```
+<memoryDir>/
+  facts/       extracted facts, decisions, preferences, corrections, ...
+  entities/    people, projects, tools, and their relationships
+  profile.md   the accumulated user profile
+```
+
+The search index lives separately and is rebuildable from these files at any time. The full storage model and retrieval flow are in [docs/architecture/overview.md](docs/architecture/overview.md).
+
+## Feature highlights
+
+**Core memory.** LLM extraction that separates durable knowledge from conversational noise, entity tracking for people, projects, tools, and relationships, a full write/consolidate/expire lifecycle, and importance gating that drops low-value facts before they are ever stored. See [docs/architecture/memory-lifecycle.md](docs/architecture/memory-lifecycle.md).
+
+**Search.** Six pluggable backends behind one interface: QMD, [Orama](https://oramasearch.com/), LanceDB, Meilisearch, a remote adapter, and a no-op. QMD is the default and highest-quality option, combining BM25, vector, and reranking. Any backend is rebuildable from your markdown at any time. See [docs/search-backends.md](docs/search-backends.md).
+
+**Memory OS.** [Namespaces](docs/namespaces.md) for multi-agent and multi-tenant isolation (opt-in via `namespacesEnabled`, default `false`), hot/cold [tiering](docs/retention-policy.md) driven by a value-score model, background consolidation via the ["dreams" surface](docs/dreams.md), opt-in [graph reasoning](docs/architecture/graph-reasoning.md) with Personalized PageRank, and transparent AES-256-GCM [at-rest encryption](docs/encryption.md) (opt-in via `secureStoreEnabled`, default `false`).
+
+**Lossless Context Management.** Archive full session transcripts and recall them losslessly through the daemon recall envelope, for when a summary is not enough. Opt-in via `lcmEnabled`, default `false`. See [docs/guides/lossless-context-management.md](docs/guides/lossless-context-management.md).
+
+**Trust and boundaries.** Scoped memory, provenance on every fact, correction handling, and boundary principles that decide when an agent should ask instead of act. See [docs/user-aware-agents.md](docs/user-aware-agents.md).
+
+**Import your memory.** Seven optional importers pull existing memory from the tools you already use. The base CLI never bundles them; install only what you need, and every run supports `--dry-run` for a zero-write preview.
+
+| Source | Package | Adapter |
+|--------|---------|---------|
+| ChatGPT | `@remnic/import-chatgpt` | `remnic import --adapter chatgpt` |
+| Claude | `@remnic/import-claude` | `remnic import --adapter claude` |
+| Gemini | `@remnic/import-gemini` | `remnic import --adapter gemini` |
+| mem0 | `@remnic/import-mem0` | `remnic import --adapter mem0` |
+| Supermemory | `@remnic/import-supermemory` | `remnic import --adapter supermemory` |
+| WeClone | `@remnic/import-weclone` | `remnic import --adapter weclone` |
+| lossless-claw | `@remnic/import-lossless-claw` | `remnic import-lossless-claw` |
+
+See [docs/importers.md](docs/importers.md) for input formats, provenance metadata, and the full privacy breakdown.
+
+**Wearables.** Three optional connectors ingest AI-wearable recordings, clean and speaker-label the transcripts, apply your personal corrections, store searchable per-day transcript files, and create memories under strict per-source trust gates: `@remnic/connector-limitless` (Limitless Pendant), `@remnic/connector-bee` (Bee bracelet), and `@remnic/connector-omi` (Omi necklace). See [docs/wearables.md](docs/wearables.md).
+
+**Glass-box tooling.** [Recall X-ray](docs/xray.md) shows which retrieval tier produced each result and why, the [daily briefing](docs/guides/daily-briefing.md) surfaces active entities and open commitments, and the [operator console](docs/console.md) gives live engine introspection with trace record and replay.
+
+**Benchmarks.** Memory quality is measured, not asserted. [MemCorrect](docs/benchmarks/memcorrect.md) checks whether a backend recalls the right fact, accepts a correction, and stops serving the stale one. The [full benchmark suite](docs/benchmarks.md) covers the rest, with reproducible artifacts and leaderboard safety.
+
+**More capabilities.** A few of the deeper features, each with its own guide:
+
+- [Procedural memory](docs/procedural-memory.md) — multi-step runbooks captured from your work (on by default outside the `conservative` preset).
+- [Temporal recall](docs/temporal-recall.md) — `valid_at` / `invalid_at` fact lifecycle and an `as_of` recall filter.
+- [Pattern reinforcement](docs/pattern-reinforcement.md) — cross-session pattern detection with a recall boost for reinforced primitives.
+- [Live connectors](docs/live-connectors.md) — a continuous-sync framework for external sources.
+- [Shared context](docs/shared-context.md) — cross-agent shared intelligence for multi-agent teams.
+- [Coding-agent memory](docs/coding-agent.md) — repo conventions, review behavior, and ask-before rules for coding tools.
+
+## Privacy and your data
+
+Local-first is a trust feature, not a tagline.
+
+- **Everything lives on your disk** as markdown you can inspect, edit, back up, and version-control. There is no Remnic cloud and no account.
+- **Retrieval never needs the network.** Recall runs entirely against your local files and index.
+- **Extraction uses the provider you choose.** When Remnic distills a memory, it calls whatever model provider you configured. To keep every byte on-device, route extraction to a [local LLM](docs/guides/local-llm.md) or use `--dry-run` on imports to preview without writing.
+- **Sensitive tools see what you surface.** When a hosted client such as ChatGPT calls Remnic's tools, the content it reads and writes also passes through that client's pipeline. Treat what you expose accordingly.
+- **Keep user data out of git.** Paths that contain memory content (`facts/`, `entities/`, `profile.md`) should never be committed. Enable [at-rest encryption](docs/encryption.md) if the disk itself is untrusted.
 
 ## Architecture
 
-Remnic is organized as a monorepo with a core engine, standalone server/CLI, and native plugins for multiple AI platforms:
+Remnic is a [pnpm](https://pnpm.io/) monorepo of **25+ published packages**. The engine is host-agnostic; every integration is a thin adapter over it, so standalone Remnic is always first-class and adapter work follows each host's upstream SDK rather than recreating host behavior inside Remnic.
 
 ```
-                         ┌─────────────────┐
-                         │  @remnic/core   │
-                         │  (engine)       │
-                         └────────┬────────┘
-                                  │
-        ┌──────────┬──────────┬───┴────┬──────────┬──────────┐
-        │          │          │        │          │          │
-  ┌─────┴─────┐ ┌─┴──────┐ ┌┴─────┐ ┌┴────────┐ │  Native  │
-  │ @remnic/  │ │@remnic/│ │remnic│ │@remnic/  │ │ Plugins  │
-  │ cli       │ │server  │ │-hermes│ │plugin-   │ │          │
-  │           │ │        │ │       │ │openclaw  │ │          │
-  └───────────┘ └────────┘ └──────┘ └─────────┘ └──────────┘
-                    │                             │
-              ┌─────┴─────┐        ┌──────────────┼──────────┐
-              │ @remnic/  │        │              │          │
-              │ bench     │   claude-code     codex     replit
-              └───────────┘
+                        @remnic/core
+             (extraction, storage, search,
+              graph, trust, consolidation)
+                            |
+        +-------------------+-------------------+
+        |                   |                   |
+   @remnic/cli        @remnic/server       plugins
+   (remnic bin)       (HTTP + MCP)      openclaw, claude-code,
+                                        codex, pi, hermes
+                            |
+                     a la carte add-ons
+              import-* (7 importers) + connector-*
+                    (3 wearable sources)
 ```
 
-| Package | npm/PyPI | Description |
-|---------|----------|-------------|
-| `@remnic/core` | [![npm](https://img.shields.io/npm/v/@remnic/core)](https://www.npmjs.com/package/@remnic/core) | Framework-agnostic engine — orchestrator, storage, search, extraction, graph, trust zones |
-| `@remnic/server` | [![npm](https://img.shields.io/npm/v/@remnic/server)](https://www.npmjs.com/package/@remnic/server) | Standalone HTTP/MCP server with multi-token auth. Run as daemon via launchd/systemd |
-| `@remnic/cli` | [![npm](https://img.shields.io/npm/v/@remnic/cli)](https://www.npmjs.com/package/@remnic/cli) | CLI binary — memory management, daemon lifecycle, connectors, tokens, spaces, benchmarks |
-| `@remnic/hermes-provider` | [![npm](https://img.shields.io/npm/v/@remnic/hermes-provider)](https://www.npmjs.com/package/@remnic/hermes-provider) | TypeScript HTTP client for remote Remnic instances |
-| `@remnic/bench` | [![npm](https://img.shields.io/npm/v/@remnic/bench)](https://www.npmjs.com/package/@remnic/bench) | Published memory benchmarks, Remnic-specific regression packs, artifact publishing, and the optional `remnic bench *` surface |
-| `@remnic/export-weclone` | [![npm](https://img.shields.io/npm/v/@remnic/export-weclone)](https://www.npmjs.com/package/@remnic/export-weclone) | WeClone fine-tuning dataset exporter — optional `remnic training:export` surface |
-| `@remnic/import-weclone` | [![npm](https://img.shields.io/npm/v/@remnic/import-weclone)](https://www.npmjs.com/package/@remnic/import-weclone) | WeClone chat-history importer — optional `remnic bulk-import` source |
-| `@remnic/connector-weclone` | [![npm](https://img.shields.io/npm/v/@remnic/connector-weclone)](https://www.npmjs.com/package/@remnic/connector-weclone) | OpenAI-compatible proxy layering Remnic memory onto WeClone avatars |
-| `@remnic/import-chatgpt` | [![npm](https://img.shields.io/npm/v/@remnic/import-chatgpt)](https://www.npmjs.com/package/@remnic/import-chatgpt) | ChatGPT saved-memory and conversation-summary importer — optional `remnic import --adapter chatgpt` surface |
-| `@remnic/import-claude` | [![npm](https://img.shields.io/npm/v/@remnic/import-claude)](https://www.npmjs.com/package/@remnic/import-claude) | Claude project docs and prompt-template importer — optional `remnic import --adapter claude` surface |
-| `@remnic/import-gemini` | [![npm](https://img.shields.io/npm/v/@remnic/import-gemini)](https://www.npmjs.com/package/@remnic/import-gemini) | Google Takeout Gemini Apps Activity importer — optional `remnic import --adapter gemini` surface |
-| `@remnic/import-mem0` | [![npm](https://img.shields.io/npm/v/@remnic/import-mem0)](https://www.npmjs.com/package/@remnic/import-mem0) | mem0 REST and JSON importer — optional `remnic import --adapter mem0` surface |
-| `@remnic/import-supermemory` | [![npm](https://img.shields.io/npm/v/@remnic/import-supermemory)](https://www.npmjs.com/package/@remnic/import-supermemory) | Supermemory JSON importer — optional `remnic import --adapter supermemory` surface |
-| `@remnic/plugin-openclaw` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-openclaw)](https://www.npmjs.com/package/@remnic/plugin-openclaw) | OpenClaw adapter — thin bridge (embedded or delegate mode) |
-| `@remnic/plugin-claude-code` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-claude-code)](https://www.npmjs.com/package/@remnic/plugin-claude-code) | Native Claude Code plugin — hooks, skills, MCP |
-| `@remnic/plugin-codex` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-codex)](https://www.npmjs.com/package/@remnic/plugin-codex) | Native Codex CLI plugin — hooks, skills, MCP |
-| `@remnic/plugin-pi` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-pi)](https://www.npmjs.com/package/@remnic/plugin-pi) | Native Pi Coding Agent extension — recall, observe, MCP tools, and compaction coordination |
-| `@remnic/replit` | [![npm](https://img.shields.io/npm/v/@remnic/replit)](https://www.npmjs.com/package/@remnic/replit) | Replit Agent MCP connector — setup snippet + token helper |
-| `remnic-hermes` | [![PyPI](https://img.shields.io/pypi/v/remnic-hermes)](https://pypi.org/project/remnic-hermes/) | Python MemoryProvider for Hermes Agent |
-
-Remnic is installed à la carte: most users start with `@remnic/cli`, while `@remnic/core` stays available for framework-agnostic embedding. Optional surfaces (bench, WeClone, plugins, and importers) are installed separately when you need them. Commands like `remnic bench *`, `remnic training:export`, and `remnic import --adapter <source>` lazy-load their companion package and print an install hint if it's missing.
-
-The old `@joshuaswarren/openclaw-engram` package is **deprecated**. Use `@remnic/plugin-openclaw` for OpenClaw installs and `@remnic/*` for standalone or multi-platform use.
-
-## Why Remnic?
-
-### Your data stays yours
-
-All memory lives on your filesystem as plain markdown files. No cloud dependency, no subscriptions, no proprietary formats, no sending your private conversations to third-party servers. Back it up with git, rsync, or Time Machine. Move it between machines with a folder copy. You own your data completely.
-
-### A real upgrade from default OpenClaw memory
-
-OpenClaw's built-in memory is basic — it works for getting started, but lacks semantic search, entity tracking, lifecycle management, governance, and multi-agent isolation. Remnic is a drop-in replacement that brings all of those capabilities while keeping the same inspectable local trust model.
-
-### Smart recall, not keyword search
-
-Remnic uses hybrid search (BM25 + vector + reranking via [QMD](https://github.com/tobilu/qmd)) to find semantically relevant memories. It doesn't just match keywords — it understands what you're working on and surfaces the right context.
-
-### Flexible LLM routing — OpenAI, local, or gateway model chain
-
-Use OpenAI for extraction and reranking, run entirely offline with a local LLM (Ollama, LM Studio), or route through the **gateway model chain** to use any provider with automatic fallback. The `local-llm-heavy` preset is optimized for fully local operation. See the [Local LLM Guide](docs/guides/local-llm.md) and the [Gateway Model Source](docs/config-reference.md#gateway-model-source) section for multi-provider setups.
-
-### Progressive complexity
-
-Start with zero config. Enable features as your needs grow:
-
-| Level | What You Get |
-|-------|-------------|
-| **Defaults** | Automatic extraction, recall injection, entity tracking, lifecycle management |
-| **+ Search tuning** | Choose from 6 search backends (QMD, Orama, LanceDB, Meilisearch, remote, noop) |
-| **+ Capture control** | `implicit`, `explicit`, or `hybrid` capture modes for memory write policy |
-| **+ Memory OS** | Memory boxes, graph reasoning, compounding, shared context, identity continuity |
-| **+ LCM** | Lossless Context Management — never lose conversation context to compaction |
-| **+ Parallel retrieval** | Three specialized agents (DirectFact, Contextual, Temporal) run in parallel — same latency, broader coverage |
-| **+ Quality gates** | Extraction judge, semantic chunking, MECE taxonomy, page versioning |
-| **+ Advanced** | Trust zones, causal trajectories, harmonic retrieval, evaluation harness, poisoning defense |
-
-Use a preset to jump to a recommended level: `conservative`, `balanced`, `research-max`, or `local-llm-heavy`.
-
-### Works with your tools
-
-- **[OpenClaw](https://github.com/openclaw/openclaw)** — Native plugin with automatic extraction and recall injection
-- **[Codex CLI](https://github.com/openai/codex)** — MCP-over-HTTP with session-start hooks for automatic recall
-- **[Pi Coding Agent](https://pi.dev)** — Native extension with turn recall, observation, MCP tools, and LCM-aware compaction
-- **Any MCP client** — stdio or HTTP transport, 8 tools available
-- **Scripts & automation** — Authenticated REST API for custom integrations
-- **Local LLMs** — Run extraction and reranking with local models (Ollama, LM Studio, etc.)
-
-### Standalone Multi-Tenant Server
-
-Run Remnic as a standalone HTTP server that multiple agent harnesses share. Isolate tenants with namespace policies, feed conversations from any client via the observe endpoint, and search archived history with LCM full-text search. Works with OpenClaw, Codex CLI, Claude Code, and custom HTTP agents. See the [Standalone Server Guide](docs/guides/standalone-server.md).
-
-### Built for production
-
-- **672 tests** with CI enforcement
-- **Evaluation harness** with benchmark packs, shadow recall recording, and CI delta gates
-- **Governance system** with review queues, shadow/apply modes, and reversible transitions
-- **Namespace isolation** for multi-agent deployments
-- **Rate limiting** on write paths with idempotency support
-
-## Features
-
-### Core
-
-- **Automatic memory extraction** — Facts, decisions, preferences, corrections extracted from conversations
-- **Observe endpoint** — Feed conversation messages from any agent into the extraction pipeline via HTTP or MCP
-- **Recall injection** — Relevant memories injected before each agent turn
-- **Entity tracking** — People, projects, tools, companies tracked as structured entities
-- **Lifecycle management** — Memories age through active, validated, stale, archived states
-- **Episode/Note model** — Memories classified as time-specific events or stable beliefs
-
-### Extraction & Processing (opt-in)
-
-- **Extraction Judge** — LLM-as-judge post-extraction filter that evaluates fact durability before write. Has shadow mode for calibration. Opt-in via `extractionJudgeEnabled`. (issue #376)
-- **Semantic Chunking** — Smoothing-based topic boundary detection using sentence embeddings and cosine similarity, as an alternative to recursive chunking. Opt-in via `semanticChunkingEnabled`. (issue #368)
-- **OAI-mem-citation Blocks** — Recall responses emit `<oai-mem-citation>` blocks matching the Codex citation format for memory attribution and usage tracking. Opt-in via `citationsEnabled`. (issue #379)
-- **Procedural memory** — Stores repeatable **how-to** memories as `category: procedure` markdown under `procedures/`, mines candidates from causal trajectories, and can inject a **Relevant procedures** section on task-initiation prompts. **On by default** since issue #567 PR 4/5 (previously off); set `procedural.enabled` to `false` in plugin config to opt out. See [Procedural memory](docs/procedural-memory.md). (issue #519)
-- **Peer registry** — Multi-peer identity schema that generalizes the singular identity-anchor into a versioned registry. Supports `self`, `human`, `agent`, and `integration` peer kinds. Each peer has an identity kernel (`peers/{id}/identity.md`), an async profile reasoner that derives structured fields from interaction signals, and recall injection that injects a brief profile excerpt into recall context. `remnic peer migrate` seeds `peers/self/identity.md` from existing legacy identity-anchor data. `remnic peer list/show/set/delete/profile` manage the registry. HTTP endpoints and MCP tools under `peer_*`. See [Peer Registry](docs/peers.md). (issue #679)
-- **Coding agent mode** — Auto-scopes memory to the current git project (origin-URL hash) and optionally to the current branch, so memories from project A never surface in project B and feature-branch experiments don't leak into `main`. Claude Code and Codex CLI session-start hooks detect git context automatically; the `recall` and `observe` endpoints also accept `cwd` for server-side auto-resolution. Non-git sessions (OpenClaw, task agents) can pass `projectTag` to scope by name instead. Cross-project knowledge (framework bugs, user preferences) is classified as `"global"` during extraction and promoted to the shared namespace; recall global fallback ensures it surfaces across all projects (`codingMode.globalFallback`, default `true`). Diff-aware review-context recall tier boosts memories touching the files in a reviewed diff. `remnic doctor` prints detected `projectId`, branch, and effective namespace. Opt out with `codingMode.projectScope: false`. See [Coding agent mode](docs/coding-agent.md). (issues #569, #702, #703, #704)
-- **Recall X-ray** — `remnic xray "<query>"` prints a per-result breakdown showing which retrieval tier served each memory, the score decomposition, the graph path (when graph retrieval fired), the filter ladder that admitted it, and the audit entry ID. Same snapshot via HTTP `GET /engram/v1/recall/xray` and MCP tool `remnic.recall_xray`. Legacy `/recall/explain` gains a markdown mode that delegates to the same renderer (backwards-compatible). See [Recall X-ray](docs/xray.md). (issue #570)
-- **Disclosure depth on recall** — `remnic recall "<q>" --disclosure chunk|section|raw` controls payload depth: cheap semantic chunks first, escalate to full sections or raw transcripts only when needed. Same field exposed via HTTP `?disclosure=` and MCP `disclosure`. Default `chunk` preserves prior behavior; token-cost telemetry surfaces in Recall X-ray. (issue #677)
-- **Temporal recall (`validAt` / `invalidAt`)** — Optional `validAt` and `invalidAt` YAML frontmatter fields scope a fact to a validity window; `remnic recall "<q>" --as-of <timestamp>` returns the fact valid at that time, ignoring later supersessions. Supersession writes flip `invalidAt` automatically. Backfill defaults `validAt` to the file's `created` timestamp when missing. See [Temporal Recall](docs/temporal-recall.md). (issue #680)
-- **Free-form tag filter on recall** — `remnic recall "<q>" --tag q2-planning [--tag <t> ...] [--tag-match all|any]`. Tags are flat strings additive to the MECE taxonomy, persisted on memory frontmatter via the store API. Tags surface in Recall X-ray output. See [Tags](docs/tags.md). (issue #689)
-
-### Organization & Taxonomy (opt-in)
-
-- **MECE Taxonomy** — Mutually Exclusive, Collectively Exhaustive knowledge directory with resolver decision tree for deterministic memory categorization. Opt-in via `taxonomyEnabled`. (issue #366)
-- **Enrichment Pipeline** — Importance-tiered API spend for entity enrichment from external sources with a provider registry. Opt-in via `enrichmentEnabled`. (issue #365)
-
-### Storage & Lifecycle (opt-in)
-
-- **Page Versioning** — Snapshot-based history for memory files. Every overwrite saves a numbered snapshot in a sidecar directory. List, inspect, diff, and revert. Opt-in via `versioningEnabled`. (issue #371)
-- **Binary Lifecycle Management** — Three-stage pipeline (mirror, redirect, clean) for binary files in the memory directory with configurable storage backends. Opt-in via `binaryLifecycleEnabled`. (issue #367)
-
-### Integrations & Extensions
-
-- **Codex Marketplace** — Install Remnic via `codex marketplace add joshuaswarren/remnic`. Marketplace manifest at repo root. (issue #418)
-- **Memory Extension Publisher Contract** — Pluggable contract for installing host-specific instruction files into any AI agent host's extension directory. Generalizes the pattern previously hard-coded for Codex. (issue #381)
-- **Memory Extension Discovery** — Third-party memory extensions provide structured instructions that influence consolidation, auto-discovered from extension directories. (issue #382)
-
-### Search Backends
-
-| Backend | Type | Best For |
-|---------|------|----------|
-| **QMD** (default) | Hybrid BM25+vector+reranking | Best recall quality |
-| **Orama** | Embedded, pure JS | Zero native deps |
-| **LanceDB** | Embedded, native Arrow | Large collections |
-| **Meilisearch** | Server-based | Shared search |
-| **Remote** | HTTP REST | Custom services |
-| **Noop** | No-op | Extraction only |
-
-See the [Search Backends Guide](docs/search-backends.md) or [write your own](docs/writing-a-search-backend.md).
-
-### Memory OS (opt-in)
-
-These capabilities can be enabled progressively:
-
-- **Memory Boxes** — Groups related memories into topic-windowed episodes
-- **Graph Recall** — Entity-relationship graph for causal and timeline queries
-- **Compounding** — Weekly synthesis surfaces patterns and recurring mistakes
-- **Shared Context** — Cross-agent memory sharing for multi-agent setups
-- **Identity Continuity** — Consistent agent personality across sessions
-- **Hot/Cold Tiering** — Automatic migration of aging memories to cold storage
-- **Memory Cache** — Process-level singleton cache for `readAllMemories()` — turns 15s disk scans into <100ms cache hits, shared across all sessions
-- **Semantic Consolidation** — Finds clusters of semantically similar memories, synthesizes canonical versions via LLM, archives originals to reduce bloat
-- **Native Knowledge** — Search curated markdown (workspace docs, Obsidian vaults) without extracting into memory
-- **Behavior Loop Tuning** — Runtime self-tuning of extraction and recall parameters
-
-### Lossless Context Management (LCM)
-
-When your AI agent hits its context window limit, the runtime silently compresses old messages — and that context is gone forever. LCM fixes this by proactively archiving every message into a local SQLite database and building a hierarchical summary DAG (directed acyclic graph) alongside it. When context gets compacted, LCM injects compressed session history back into recall, so your agent never loses track of what happened earlier in the conversation.
-
-- **Proactive archiving** — Every message is indexed with full-text search before compaction can discard it
-- **Hierarchical summaries** — Leaf summaries cover ~8 turns, depth-1 covers ~32, depth-2 ~128, etc.
-- **Fresh tail protection** — Recent turns always use the most detailed (leaf-level) summaries
-- **Three-level summarization** — Normal LLM summary, aggressive bullet compression, and deterministic truncation (guaranteed convergence, no LLM needed)
-- **MCP expansion tools** — Agents can search, describe, or expand any part of conversation history on demand
-- **Zero data loss** — Raw messages are retained for the configured retention period (default 90 days)
-
-Enable it in your `openclaw.json`:
-
-```jsonc
-{
-  "plugins": {
-    "entries": {
-      "openclaw-remnic": {
-        "config": {
-          "lcmEnabled": true
-          // All other LCM settings have sensible defaults
-        }
-      }
-    }
-  }
-}
-```
-
-See the [LCM Guide](docs/guides/lossless-context-management.md) for architecture details, configuration options, and how it complements native compaction.
-
-### Parallel Specialized Retrieval (opt-in)
-
-Remnic's default retrieval runs a single hybrid search pass. Parallel Specialized Retrieval (inspired by [Supermemory's ASMR technique](https://blog.supermemory.ai/we-broke-the-frontier-in-agent-memory-introducing-99-sota-memory-system/)) runs three specialized agents in parallel so total latency equals `max(agents)` not `sum(agents)`.
-
-| Agent | What It Does | Cost |
-|-------|-------------|------|
-| **DirectFact** | Scans entity filenames for keyword overlap with the query | File I/O only, <5ms |
-| **Contextual** | Existing hybrid BM25+vector search (unchanged) | Same as current |
-| **Temporal** | Reads the temporal date index, returns recent memories with recency decay scoring | File I/O + math, <10ms |
-
-**Zero additional LLM cost.** The DirectFact and Temporal agents reuse existing indexes with no new embeddings or inference. The Contextual agent is the same hybrid search already running.
-
-Results from all three agents are merged by path, deduplicated, and weighted (`direct=1.0×, temporal=0.85×, contextual=0.7×`) before returning the top N results. Any agent error degrades gracefully without blocking the others.
-
-Enable it in your `openclaw.json`:
-
-```jsonc
-{
-  "plugins": {
-    "entries": {
-      "openclaw-remnic": {
-        "config": {
-          "parallelRetrievalEnabled": true
-          // Optional tuning:
-          // "parallelMaxResultsPerAgent": 20,
-          // "parallelAgentWeights": { "direct": 1.0, "contextual": 0.7, "temporal": 0.85 }
-        }
-      }
-    }
-  }
-}
-```
-
-Set `parallelMaxResultsPerAgent: 0` to disable an individual agent's results without disabling the feature entirely.
-
-### Semantic Consolidation (opt-in)
-
-Over time, memory stores accumulate redundant facts — the same information extracted multiple times across sessions, expressed slightly differently. Semantic consolidation finds clusters of similar memories using token overlap, synthesizes a single canonical version via LLM, and archives the originals. This reduces storage bloat, speeds up recall, and improves memory quality.
-
-- **Conservative by default** — Only merges when 80%+ token overlap is detected across 3+ memories
-- **LLM synthesis** — Uses your configured model to combine unique information from all cluster members
-- **Safe archival** — Originals are archived (not deleted) with full provenance tracking
-- **Configurable** — Adjust threshold, cluster size, excluded categories, model, and schedule
-- **Excluded categories** — Corrections and commitments are never consolidated (configurable)
-
-Enable it in your `openclaw.json`:
-
-```jsonc
-{
-  "plugins": {
-    "entries": {
-      "openclaw-remnic": {
-        "config": {
-          "semanticConsolidationEnabled": true
-          // Optional tuning:
-          // "semanticConsolidationThreshold": 0.8,    // 0.8=conservative, 0.6=aggressive
-          // "semanticConsolidationModel": "fast",      // "auto", "fast", or specific model
-          // "semanticConsolidationIntervalHours": 168, // weekly (default)
-          // "semanticConsolidationMaxPerRun": 100
-        }
-      }
-    }
-  }
-}
-```
-
-Run manually from the CLI:
-
-```bash
-openclaw engram semantic-consolidate --dry-run    # Preview what would be merged
-openclaw engram semantic-consolidate --verbose     # Run with detailed output
-openclaw engram semantic-consolidate --threshold 0.6  # Override threshold
-```
-
-### Advanced (opt-in)
-
-- **Objective-State Recall** — Surfaces file/process/tool state snapshots alongside semantic memory
-- **Causal Trajectories** — Typed `goal -> action -> observation -> outcome` chains
-- **Trust Zones** — Quarantine/working/trusted tiers with promotion rules and poisoning defense
-- **Harmonic Retrieval** — Blends abstraction nodes with cue-anchor matches
-- **Verified Recall** — Only surfaces memory boxes whose source memories still verify
-- **Semantic Rule Promotion** — Promotes `IF ... THEN` rules from verified episodes
-- **Creation Memory** — Work-product ledger tracking agent outputs
-- **Commitment Lifecycle** — Tracks promises, deadlines, and obligations
-- **Resume Bundles** — Crash-recovery context for interrupted sessions
-- **Utility Learning** — Learns promotion/ranking weights from downstream outcomes
-
-See [Enable All Features](docs/enable-all-v8.md) for a full-feature config profile.
-
-## Access Layer
-
-Remnic exposes one shared service layer through multiple transports. During the
-v1.x compatibility window, the HTTP API path remains `/engram/v1/...` and the
-legacy `engram.*` MCP aliases still work.
-
-### HTTP API
-
-```bash
-remnic daemon start
-```
-
-Key endpoints: `GET /engram/v1/health`, `POST /engram/v1/recall`, `POST /engram/v1/memories`, `GET /engram/v1/entities/:name`, and more. Full reference in [API docs](docs/api.md).
-
-The HTTP server also hosts a lightweight operator UI at `http://127.0.0.1:4318/engram/ui/` for memory browsing, recall inspection, governance review, trust-zone promotion, and entity exploration.
-
-### MCP Tools
-
-Available via both stdio and HTTP transports:
-
-| Tool | Purpose |
-|------|---------|
-| `engram.recall` | Retrieve relevant memories for a query |
-| `engram.recall_explain` | Debug the last recall |
-| `engram.day_summary` | Generate structured end-of-day summary from memory content |
-| `engram.memory_get` | Fetch a specific memory by ID |
-| `engram.memory_timeline` | View a memory's lifecycle history |
-| `engram.memory_store` | Store a new memory |
-| `engram.suggestion_submit` | Queue a memory for review |
-| `engram.entity_get` | Look up a known entity |
-| `engram.review_queue_list` | View the governance review queue |
-| `engram.observe` | Feed conversation messages into memory pipeline (LCM + extraction) |
-| `engram.lcm_search` | Full-text search over LCM-archived conversations |
-| `engram.lcm_compaction_flush` | Flush pending LCM work before host context compaction |
-| `engram.lcm_compaction_record` | Record host context compaction token deltas |
-| `engram_context_search` | Full-text search across all archived conversation history (LCM) |
-| `engram_context_describe` | Get a compressed summary of a turn range (LCM) |
-| `engram_context_expand` | Retrieve raw lossless messages for a turn range (LCM) |
-
-### MCP over HTTP
-
-The HTTP server exposes an MCP JSON-RPC endpoint at `POST /mcp`, allowing remote MCP clients to use Remnic tools over HTTP:
-
-```bash
-npx remnic-server --host 0.0.0.0 --port 4318 --auth-token "$REMNIC_AUTH_TOKEN"
-```
-
-For namespace-enabled deployments, configure `server.principal` in `remnic.config.json` so it matches a `writePrincipals` entry for your target namespace. Deployments with `namespacesEnabled: false` (the default) do not need a principal.
-
-## CLI Reference
-
-```bash
-# OpenClaw-hosted compatibility commands still use the `openclaw engram`
-# namespace during the v1.x rename window. Standalone commands use `remnic`.
-#
-# Setup & diagnostics
-openclaw engram setup              # Guided first-run setup
-openclaw engram doctor             # Health diagnostics with remediation hints
-openclaw engram config-review      # Config tuning recommendations
-openclaw engram stats              # Memory counts, search status
-openclaw engram inventory          # Full storage and namespace inventory
-
-# Search & recall
-openclaw engram search "query"     # Search memories from CLI
-openclaw engram harmonic-search "query"  # Preview harmonic retrieval matches
-
-# Governance
-openclaw engram governance-run --mode shadow  # Preview governance transitions
-openclaw engram governance-run --mode apply   # Apply reversible transitions
-openclaw engram review-disposition <id> --status rejected  # Operator review
-
-# Benchmarking
-openclaw engram benchmark recall   # Benchmark status and validation
-openclaw engram benchmark-ci-gate  # CI gate for regressions
-
-# Memory maintenance
-openclaw engram consolidate                  # Run standard consolidation
-openclaw engram semantic-consolidate         # Run semantic dedup consolidation
-openclaw engram semantic-consolidate --dry-run  # Preview without changes
-
-# Daily context briefing (#370)
-remnic briefing                                  # Yesterday's briefing (markdown)
-remnic briefing --since 3d --focus project:alpha # Focused 3-day lookback
-remnic briefing --format json --save             # JSON + dated file in $REMNIC_HOME/briefings
-
-# Page versioning
-remnic versions list <page-path>                  # List version history for a memory file
-remnic versions show <page-path> <version-id>     # Show a specific version snapshot
-remnic versions diff <page-path> <v1> <v2>        # Diff two versions of a memory file
-remnic versions revert <page-path> <version-id>   # Revert a file to a previous version
-
-# MECE taxonomy
-remnic taxonomy show                              # Show taxonomy categories and priorities
-remnic taxonomy resolver                          # Generate or display resolver decision tree
-remnic taxonomy add <id> <name>                   # Add a taxonomy category
-remnic taxonomy remove <id>                       # Remove a taxonomy category
-
-# Entity enrichment
-remnic enrich <entity-name|--all|audit|providers> [--dry-run]   # Run enrichment pipeline
-
-# Binary lifecycle
-remnic binary scan                                # Scan for binary files in memory directory
-remnic binary status                              # Show binary lifecycle status
-remnic binary run [--dry-run]                     # Run lifecycle (redirect/clean) for binaries
-remnic binary clean --force                       # Force-clean binaries past grace period
-
-# Access layer
-remnic daemon start                # Start HTTP API + managed daemon
-openclaw engram access mcp-serve   # Start OpenClaw-hosted stdio MCP server
-
-# Trust-zone demos
-openclaw engram trust-zone-demo-seed --dry-run       # Preview the opt-in buyer demo dataset
-openclaw engram trust-zone-demo-seed --scenario agentic-commerce-v1 --dry-run
-openclaw engram trust-zone-demo-seed                 # Explicitly seed the demo dataset
-openclaw engram trust-zone-promote --record-id <id> --target-zone working --reason "Operator review"
-```
-
-### Trust-zone demo workflow
-
-Trust zones now ship with a dedicated admin-console view plus an explicit demo seeding path for buyer-facing walkthroughs.
-
-- **Never automatic** — Remnic does not seed sample trust-zone records on install, startup, or feature enablement.
-- **Explicit only** — demo records appear only after you run `openclaw engram trust-zone-demo-seed` or trigger the matching admin-console action.
-- **Buyer-friendly story** — the trust-zone view surfaces provenance strength, promotion readiness, corroboration requirements, and operator promotion actions in one place.
-
-The default scenario is `enterprise-buyer-v1`, which creates a small, opinionated dataset covering:
-
-- quarantine records that are ready for review
-- working records that are blocked on missing provenance
-- working records that still need corroboration
-- working records with independent corroboration support
-- a trusted operator policy record
-
-The commerce scenario is `agentic-commerce-v1`. It models buyer-aware recommendations using synthetic catalog data plus:
-
-- brand, size, fit, budget, gift, and shipping preferences
-- excluded products and never-suggest rules
-- ask-before-checkout boundaries
-- a blocked unverified upsell claim
-- retrieval eval coverage for commerce personalization and checkout boundaries
-
-See [Agentic Commerce Demo](docs/agentic-commerce-demo.md) for the end-to-end walkthrough.
-
-See the [full CLI reference](docs/api.md#cli-commands) for all commands.
+- **Engine:** `@remnic/core` (the framework-agnostic memory engine), `@remnic/cli` (the standalone `remnic` binary), and `@remnic/server` (HTTP + MCP server).
+- **Plugins:** native adapters for OpenClaw, Claude Code, Codex, and Pi, plus Hermes shipped as `remnic-hermes` on PyPI.
+- **A la carte:** seven `@remnic/import-*` importers and three `@remnic/connector-*` wearable connectors, installed only when you need them.
+- **Benchmarks:** `@remnic/bench` provides the published suites and CI regression gates.
+
+The complete package map, dependency graph, and publish order are in [docs/architecture/monorepo-structure.md](docs/architecture/monorepo-structure.md).
 
 ## Configuration
 
-OpenClaw plugin settings live in `openclaw.json` under `plugins.entries.openclaw-remnic.config` (with a legacy `openclaw-engram` fallback during the rename window). Standalone settings live in `remnic.config.json` or `~/.config/remnic/config.json`. The table below shows the most commonly changed settings — Remnic has **60+ configuration options** covering search backends, capture modes, memory OS features, namespaces, governance, benchmarking, and more.
+Remnic is zero-config by default: `remnic init` writes a working `remnic.config.json` and every subsystem ships a sensible default. When you need control, there are hundreds of options grouped under four presets, selectable with a single `memoryOsPreset` key:
 
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `modelSource` | `gateway` for new OpenClaw installs; `plugin` otherwise | `gateway` routes LLM calls through OpenClaw agent model chains; `plugin` uses Remnic's own OpenAI/local LLM config |
-| `openaiApiKey` | `(env in plugin mode)` | Optional OpenAI API key. Not needed when `modelSource` is `gateway`; Remnic does not inherit `OPENAI_API_KEY` in gateway mode. |
-| `localLlmEnabled` | `false` | Enable Remnic's local LLM path when `modelSource` is `plugin` |
-| `localLlmUrl` | unset | Local LLM endpoint (e.g., `http://localhost:1234/v1`) |
-| `localLlmModel` | unset | Local model name (e.g., `qwen2.5-32b-instruct`) |
-| `model` | `gpt-5.5` | OpenAI model for extraction when `modelSource` is `plugin` and local LLM is disabled |
-| `searchBackend` | `"qmd"` | Search engine: `qmd`, `orama`, `lancedb`, `meilisearch`, `remote`, `noop` |
-| `captureMode` | `implicit` | Memory write policy: `implicit`, `explicit`, `hybrid` |
-| `recallBudgetChars` | `maxMemoryTokens * 4` | Recall budget (default ~8K chars; set 64K+ for large-context models) |
-| `memoryDir` | `~/.openclaw/workspace/memory/local` | Memory storage root |
-| `memoryOsPreset` | unset | Quick config: `conservative`, `balanced`, `research-max`, `local-llm-heavy` |
-| `lcmEnabled` | `false` | Enable Lossless Context Management (proactive session archive + summary DAG) |
-| `messagePartsEnabled` | `false` | Opt in to structured LCM message-part capture for tool calls, file paths, patches, and reasoning markers |
-| `messagePartsRecallMaxResults` | `6` | Max structured file/tool matches injected into recall when `messagePartsEnabled` is on |
-| `semanticConsolidationEnabled` | `false` | Enable periodic semantic dedup of similar memories |
-| `semanticConsolidationThreshold` | `0.8` | Token overlap threshold (0.8=conservative, 0.6=aggressive) |
-| `semanticConsolidationModel` | `"auto"` | LLM for synthesis: `"auto"`, `"fast"`, or specific model |
-| `extractionJudgeEnabled` | `false` | LLM-as-judge post-extraction durability filter |
-| `semanticChunkingEnabled` | `false` | Topic-boundary chunking via sentence embeddings |
-| `versioningEnabled` | `false` | Snapshot-based page versioning with history and revert |
-| `citationsEnabled` | `false` | Emit `oai-mem-citation` blocks in recall responses |
-| `taxonomyEnabled` | `false` | MECE knowledge directory with resolver decision tree |
-| `enrichmentEnabled` | `false` | External entity enrichment pipeline |
-| `binaryLifecycleEnabled` | `false` | Binary file lifecycle management (mirror/redirect/clean) |
-| `procedural.enabled` | `true` | **Procedural memory (issue #519):** master gate for procedure extraction, task-init recall injection, and trajectory mining. Default-on since issue #567 PR 4/5; set nested `procedural: { "enabled": false }` to opt out (see [Procedural memory](docs/procedural-memory.md)). |
-| `codingMode.projectScope` | `true` | **Coding agent mode (issue #569):** auto-scope memory to the git project (stable origin-URL hash, falls back to root path). Set to `false` to disable project-based namespace isolation. See [Coding agent mode](docs/coding-agent.md). |
-| `codingMode.branchScope` | `false` | **Coding agent mode (issue #569):** additionally scope writes to the current git branch; reads fall back to the project-level namespace so project memories stay visible from any branch while branch writes don't leak. Enable for per-branch experimentation. |
-| `codingMode.globalFallback` | `true` | **Recall global fallback (issue #703):** project-scoped sessions include the root/global namespace in recall read-fallbacks so that cross-project knowledge (framework bugs, library behavior, user preferences) surfaces everywhere. Set to `false` for strict project isolation. See [Coding agent mode](docs/coding-agent.md). |
-| `extractionScopeClassificationEnabled` | `true` | **Extraction scope classification (issue #704):** classify extracted facts as `"global"` or `"project"` scope. Global facts are promoted to the shared root namespace so they are visible across all projects. See [Coding agent mode](docs/coding-agent.md). |
-| `recallCrossNamespaceBudgetEnabled` | `false` | **Cross-namespace budget (issue #565):** per-principal sliding-window rate limiter. Throttles principals issuing bursts of cross-namespace recalls; soft limit emits a warning, hard limit denies the query. See [Threat model](docs/security/memory-extraction-threat-model.md). |
-| `recallAuditAnomalyDetectionEnabled` | `false` | **Recall audit anomaly detection (issue #565):** flag suspicious query patterns (repeat queries, namespace walks, high-cardinality entity probes, rapid-fire). Anomalies are surfaced in recall responses. See [Threat model](docs/security/memory-extraction-threat-model.md). |
-| `connectors.googleDrive.enabled` | `false` | **Google Drive live connector (issue #683 PR 2/N):** opt-in incremental import of Google Docs/Sheets/Slides + plain-text files. Requires `clientId`, `clientSecret`, `refreshToken` to be populated from a secret store (never commit values). Optional `pollIntervalMs` (default 300000) and `folderIds` (default `[]` = all accessible). The `googleapis` npm package is loaded lazily — install it only if you enable the connector. See [Connectors](docs/connectors.md). |
-| `connectors.notion.enabled` | `false` | **Notion live connector (issue #683 PR 3/N):** opt-in incremental import of Notion database pages. Requires `token` (Notion integration token) and `databaseIds` (list of database IDs to import). Optional `pollIntervalMs` (default 300000). See [Connectors](docs/connectors.md). |
-| `graphTraversalConfidenceFloor` | `0.2` | **Graph edge confidence floor (issue #681 PR 3/3):** minimum edge confidence required during graph spreading activation. Edges below this floor are pruned and contribute neither activation nor downstream neighbors. Legacy edges without a `confidence` field are treated as `1.0`. Range `[0, 1]`. See [Graph Reasoning](docs/architecture/graph-reasoning.md). |
-| `graphTraversalPageRankIterations` | `8` | **Graph PageRank refinement (issue #681 PR 3/3):** number of PageRank-style refinement iterations applied on top of the BFS spreading-activation scores. Each iteration redistributes a node's confidence-weighted activation along its outgoing edges. Set to `0` to disable refinement and use raw BFS scores. See [Graph Reasoning](docs/architecture/graph-reasoning.md). |
-| `patternReinforcementEnabled` | `false` | **Pattern reinforcement (issue #687):** master gate for the cross-session pattern-reinforcement maintenance job. Default `false` (opt-in). See [Pattern Reinforcement](docs/pattern-reinforcement.md). |
-| `patternReinforcementCadenceMs` | `604800000` | Minimum milliseconds between pattern-reinforcement runs (default 7 days). Set to `0` to disable cadence gating and run on every MCP/cron invocation. |
-| `patternReinforcementMinCount` | `3` | Minimum cluster size required before a canonical memory is reinforced. Clamped to `[2, 1000]`. |
-| `patternReinforcementCategories` | `["preference", "fact", "decision"]` | Memory categories the pattern-reinforcement job scans. Set to `[]` to process no categories. |
-| `recallDisclosureEscalation` | `"manual"` | **Recall disclosure auto-escalation (issue #677):** `"manual"` honors the caller's requested disclosure depth verbatim. `"auto"` escalates from `chunk` to `section` when top-K confidence falls below `recallDisclosureEscalationThreshold` — only on calls where the caller did not specify a depth. `raw` is never auto-selected. See [Recall Disclosure](docs/recall-disclosure.md). |
-| `recallDisclosureEscalationThreshold` | `0.5` | **Disclosure escalation threshold (issue #677):** confidence threshold in `[0, 1]` used by `recallDisclosureEscalation: "auto"`. Recalls whose top-result score is below this value are escalated from `chunk` to `section`. Has no effect in `manual` mode. See [Recall Disclosure](docs/recall-disclosure.md). |
-| `reinforcementRecallBoostEnabled` | `false` | **Reinforcement recall boost (issue #687 PR 3/4):** when `true`, memories whose `reinforcement_count` frontmatter field is set receive an additive score boost during recall. Default `false` (opt-in). |
-| `reinforcementRecallBoostWeight` | `0.05` | Score bonus per unit of `reinforcement_count`. Raw boost is `weight × count`, clipped at `reinforcementRecallBoostMax`. Range `[0, 1]`. |
-| `reinforcementRecallBoostMax` | `0.3` | Maximum additive reinforcement boost per result. Range `[0, 1]`. |
+- `conservative` — minimal footprint, extraction judge and heavier features off.
+- `balanced` — the general-purpose default.
+- `research-max` — every quality feature enabled, highest cost.
+- `local-llm-heavy` — tuned for local-model extraction and rerank.
 
-**[See the full config reference for all 60+ settings](docs/config-reference.md)** including search backend configuration, namespace policies, Memory OS features, governance, evaluation harness, trust zones, causal trajectories, and more.
+Extraction routing (`gateway`, OpenAI, or a local LLM), recall budget, search backend, lifecycle, namespaces, and encryption are all configurable. Every setting, its default, and operator guidance live in [docs/config-reference.md](docs/config-reference.md).
+
+## Self-hosting and operators
+
+Running Remnic for a team or across machines? `remnic daemon start` hands off to launchd or systemd when a service is installed, and `@remnic/server` exposes the same memory over HTTP + MCP for remote agents. Namespaces isolate tenants, and the standalone server supports multi-tenant, multi-harness setups.
+
+- [Standalone server guide](docs/guides/standalone-server.md) — multi-tenant setup and connecting multiple harnesses.
+- [Deployment topologies](docs/integration/deployment-topologies.md) — localhost, LAN, remote, and containerized layouts.
+- [Operations](docs/operations.md) — backups, exports, hourly summaries, and logs.
 
 ## Documentation
 
-- [Getting Started](docs/getting-started.md) — Installation, setup, first-run verification
-- [Config Reference](docs/config-reference.md) — Every setting with defaults
-- [Architecture Overview](docs/architecture/overview.md) — System design and storage layout
-- [Retrieval Pipeline](docs/architecture/retrieval-pipeline.md) — How recall works
-- [Memory Lifecycle](docs/architecture/memory-lifecycle.md) — Write, consolidation, expiry
-- [Search Backends](docs/search-backends.md) — Choosing and configuring search engines
-- [Writing a Search Backend](docs/writing-a-search-backend.md) — Build your own adapter
-- [API Reference](docs/api.md) — HTTP, MCP, and CLI documentation
-- [Codex CLI Integration](docs/guides/codex-cli.md) — Set up Remnic with OpenAI's Codex
-- [Standalone Server Guide](docs/guides/standalone-server.md) — Multi-tenant HTTP server for multiple agent harnesses
-- [Local LLM Guide](docs/guides/local-llm.md) — Local-first extraction and reranking
-- [Cost Control Guide](docs/guides/cost-control.md) — Budget mappings and presets
-- [Namespaces](docs/namespaces.md) — Multi-agent memory isolation
-- [Shared Context](docs/shared-context.md) — Cross-agent intelligence
-- [Identity Continuity](docs/identity-continuity.md) — Consistent agent personality
-- [Peer Registry](docs/peers.md) — Multi-peer identity schema, profile reasoner, `remnic peer` commands, and migration from legacy identity-anchor (issue #679)
-- [Graph Reasoning](docs/architecture/graph-reasoning.md) — Opt-in graph traversal
-- [Evaluation Harness](docs/evaluation-harness.md) — Benchmarks and CI delta gates
-- [Operations](docs/operations.md) — Backup, export, maintenance
-- [Lossless Context Management](docs/guides/lossless-context-management.md) — Never lose context to compaction
-- [Enable All Features](docs/enable-all-v8.md) — Full-feature config profile
-- [Migration Guide](docs/guides/migrations.md) — Upgrading from older versions
-- [Platform Migration Guide](docs/guides/platform-migration.md) — Migrating to the monorepo architecture (v9.1.36+)
-- [Hermes Setup](docs/integration/hermes-setup.md) — HTTP client for remote Remnic instances
-- [Deployment Topologies](docs/integration/deployment-topologies.md) — Localhost, LAN, remote, containerized, standalone
-- [Extraction Judge](docs/architecture/extraction-judge.md) — LLM-as-judge fact-worthiness gate
-- [Semantic Chunking](docs/architecture/semantic-chunking.md) — Topic-boundary detection
-- [Page Versioning](docs/architecture/page-versioning.md) — Snapshot-based history and revert
-- [Citations](docs/architecture/citations.md) — OAI-mem-citation block format
-- [Memory Extension Publishers](docs/architecture/memory-extension-publishers.md) — Pluggable publisher contract
-- [MECE Taxonomy](docs/architecture/mece-taxonomy.md) — Knowledge directory with resolver
-- [Enrichment Pipeline](docs/architecture/enrichment-pipeline.md) — Entity enrichment from external sources
-- [Binary Lifecycle](docs/architecture/binary-lifecycle.md) — Binary file management
-- [Memory Extensions](docs/architecture/memory-extensions.md) — Third-party extension discovery
-- [Codex Marketplace](docs/plugins/codex-marketplace.md) — Marketplace installation
-- [Procedural memory](docs/procedural-memory.md) — Procedure files, recall injection, mining; enable with `procedural.enabled` (issue #519)
-- [Pattern Reinforcement](docs/pattern-reinforcement.md) — Cross-session pattern detection, reinforced primitives, `remnic patterns list/explain` CLI, recall boost (issue #687)
-- [Coding agent mode](docs/coding-agent.md) — Auto-scope memory to git project / branch, review-context recall, `set_coding_context` MCP tool (issue #569)
-- [Recall X-ray](docs/xray.md) — `remnic xray` CLI, HTTP endpoint, MCP tool for per-result retrieval attribution (issue #570)
-- [Connectors](docs/connectors.md) — `remnic connectors list/status/run` CLI reference, OAuth setup, config keys, env vars, and troubleshooting for Google Drive and Notion (issue #683 PR 6/N)
-- [Live connectors framework](docs/live-connectors.md) — Connector framework contract, registry, state store API, and how to write a connector
-- [Memory importers](docs/importers.md) — Bring memory from ChatGPT, Claude, Gemini, mem0, and Supermemory (issue #568)
-- [Memory Extraction Threat Model](docs/security/memory-extraction-threat-model.md) — ADAM attack analysis, attacker tiers, and mitigation wiring (issue #565)
-- [ADAM Baseline 2026-04](docs/security/adam-baseline-2026-04.md) — Reproducible ASR measurements per attacker tier
+The complete, organized docs hub lives at **[docs/README.md](docs/README.md)**. Starting points by journey:
+
+- **Start here:** [Quickstart](docs/guides/quickstart.md) - [Getting started](docs/getting-started.md) - [CLI reference](docs/cli.md)
+- **Connect your tools:** [Connector setup](docs/integration/connector-setup.md) - [ChatGPT](docs/integration/chatgpt.md) - [Plugins index](docs/plugins/README.md) - [Deployment topologies](docs/integration/deployment-topologies.md)
+- **Configure:** [Config reference](docs/config-reference.md) - [Search backends](docs/search-backends.md) - [Local LLM](docs/guides/local-llm.md) - [Cost control](docs/guides/cost-control.md)
+- **Operate:** [Operations](docs/operations.md) - [Retention policy](docs/retention-policy.md) - [Import / export](docs/import-export.md) - [Standalone server](docs/guides/standalone-server.md)
+- **Internals:** [Architecture overview](docs/architecture/overview.md) - [Retrieval pipeline](docs/architecture/retrieval-pipeline.md) - [Memory lifecycle](docs/architecture/memory-lifecycle.md) - [HTTP + MCP API](docs/api.md)
+
+## FAQ
+
+**Do I need OpenClaw?** No. Remnic runs standalone through `@remnic/cli` and connects to any tool over MCP or HTTP. OpenClaw simply gets the deepest native integration.
+
+**Does it work offline or without an API key?** Retrieval works with no provider at all. Extraction needs a model, but you can route it to a [local LLM](docs/guides/local-llm.md) to keep everything on-device.
+
+**Where is my data?** In markdown files under your configured memory directory. Nothing leaves your machine except during extraction with a remote provider, or when a hosted client reads memories through Remnic's tools.
+
+**How much does it cost?** The software is MIT and free. Your only cost is your chosen extraction provider, which is zero when you use a local LLM.
+
+**Do I need QMD?** No, but it gives the best search. Without it, Remnic falls back to embedding search and then recency-ordered reads.
+
+**Can multiple agents share one memory?** Yes. Every connected tool reads and writes the same store, and [namespaces](docs/namespaces.md) isolate tenants when you want separation.
+
+**Is it production-ready?** Remnic is extensively tested with CI regression gates and a published benchmark suite. See [docs/benchmarks.md](docs/benchmarks.md) for the evidence.
+
+**I was using Engram.** Everything still works. See [Engram to Remnic](#engram-to-remnic) below for the migration path.
+
+## Engram to Remnic
+
+Engram is now Remnic. Canonical packages live under the `@remnic/*` scope, and OpenClaw installs use [`@remnic/plugin-openclaw`](https://www.npmjs.com/package/@remnic/plugin-openclaw). The legacy `engram` CLI name, the `openclaw engram` command namespace, and the `/engram/v1/...` HTTP paths remain available as a compatibility surface during the rename window. Migrating an existing install? Run `remnic openclaw migrate-engram --yes`, which backs up the legacy extension, installs the new plugin, preserves your `memoryDir`, and switches the memory slot. Full steps: [Engram to Remnic migration guide](docs/guides/openclaw-engram-to-remnic.md).
+
+## Community and roadmap
+
+- [Feature roadmap (GitHub Project)](https://github.com/users/joshuaswarren/projects/1) — current priority order, blockers, and next work.
+- [Issues](https://github.com/joshuaswarren/remnic/issues) — report a bug or request a feature.
+- [Contributing](CONTRIBUTING.md) — how to build Remnic and open a pull request.
+
+## Support
+
+Every bit of support helps keep Remnic alive and free. If you are able, [sponsor on GitHub](https://github.com/sponsors/joshuaswarren) or send a Lightning donation to `joshuaswarren@strike.me` to directly fund continued development and new integrations.
+
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?style=for-the-badge)](https://github.com/sponsors/joshuaswarren)
+
+If financial support is not an option, you can still make a big difference: [star the repo](https://github.com/joshuaswarren/remnic), share it, or recommend it to a colleague. Word of mouth is how most people find Remnic.
 
 ## Contributing
 
-Contributions are welcome! Please:
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feat/my-feature`)
-3. Write tests for new functionality
-4. Ensure `npm test` (672 tests) and `npm run check-types` pass
-5. Submit a pull request
+Contributions from humans and AI-assisted contributors are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md) for setup, the preflight gate, and PR expectations. Deeper references: [docs/development/contributing.md](docs/development/contributing.md) and [docs/CONVENTIONS.md](docs/CONVENTIONS.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The search index lives separately and is rebuildable from these files at any tim
 | Gemini | `@remnic/import-gemini` | `remnic import --adapter gemini` |
 | mem0 | `@remnic/import-mem0` | `remnic import --adapter mem0` |
 | Supermemory | `@remnic/import-supermemory` | `remnic import --adapter supermemory` |
-| WeClone | `@remnic/import-weclone` | `remnic import --adapter weclone` |
+| WeClone | `@remnic/import-weclone` | `openclaw engram bulk-import --source weclone` |
 | lossless-claw | `@remnic/import-lossless-claw` | `remnic import-lossless-claw` |
 
 See [docs/importers.md](docs/importers.md) for input formats, provenance metadata, and the full privacy breakdown.
@@ -210,7 +210,7 @@ Local-first is a trust feature, not a tagline.
 
 Remnic is a [pnpm](https://pnpm.io/) monorepo of **25+ published packages**. The engine is host-agnostic; every integration is a thin adapter over it, so standalone Remnic is always first-class and adapter work follows each host's upstream SDK rather than recreating host behavior inside Remnic.
 
-```
+```text
                         @remnic/core
              (extraction, storage, search,
               graph, trust, consolidation)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,27 @@
-# Security Policy
+# Security policy
+
+## Supported versions
+
+Remnic ships from a single rolling release line. Security fixes land on the
+latest published version; there are no long-term-support branches for older
+releases.
+
+| Version | Supported |
+|---------|-----------|
+| 9.6.x (latest) | Yes |
+| < 9.6 | Upgrade to the latest release |
+
+Always report against, and reproduce on, the latest published version.
 
 ## Reporting a vulnerability
 
 Please do not open public issues for suspected vulnerabilities.
 
 Use GitHub Security Advisories for private disclosure:
-- https://github.com/joshuaswarren/openclaw-engram/security/advisories/new
+- https://github.com/joshuaswarren/remnic/security/advisories/new
 
-If private advisory submission is unavailable, open an issue with minimal details and request secure follow-up.
+If private advisory submission is unavailable, open an issue with minimal
+details and request secure follow-up.
 
 ## Scope
 
@@ -19,10 +33,15 @@ Security-sensitive areas include:
 - Tool execution and external model/provider integration
 - CI/CD and release automation
 
+The adaptive-extraction threat model for the memory access surface is
+documented in
+[docs/security/memory-extraction-threat-model.md](docs/security/memory-extraction-threat-model.md).
+
 ## Responsible disclosure expectations
 
 - Provide a clear reproduction path and impact assessment.
-- Allow maintainers reasonable time to investigate and fix before public disclosure.
+- Allow maintainers reasonable time to investigate and fix before public
+  disclosure.
 - Avoid accessing or exposing any real user/private data.
 
 ## Hard requirements for contributors
@@ -31,16 +50,19 @@ Security-sensitive areas include:
 - Never include personal/private memory data in fixtures, tests, or docs.
 - Redact logs before sharing.
 
-## Network feature safety (v8.8)
+## Network feature safety
 
-Network sync and WebDAV surfaces are security-sensitive and must remain strict opt-in.
+Network sync and WebDAV surfaces are security-sensitive and must remain strict
+opt-in.
 
 - Default posture: disabled/not running unless explicitly invoked.
 - WebDAV exposure must be constrained to explicit allowlist roots only.
 - WebDAV should remain loopback-bound (`127.0.0.1`) by default.
-- If auth is used, require non-empty username + password together.
+- If auth is used, require a non-empty username + password together.
 - Reject traversal and symlink escape attempts outside allowlisted roots.
-- Do not add automatic public exposure behavior (for example, funnel/public listeners) as default behavior.
+- Do not add automatic public exposure behavior (for example, funnel/public
+  listeners) as default behavior.
 
 Operational recommendation:
-- Prefer private-network transport (for example, Tailscale) when syncing memory across hosts.
+- Prefer private-network transport (for example, Tailscale) when syncing
+  memory across hosts.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,36 +1,74 @@
 # Architecture
 
-Remnic is a local-first memory plugin for the [OpenClaw](https://github.com/openclaw/openclaw) gateway. For a detailed walkthrough, see the docs below.
+A one-page orientation to how Remnic is built. Remnic is a local-first memory and context layer for AI agents: one memory store on your machine, shared by every agent you connect. This page is the map; each section links into `docs/architecture/` for depth.
 
-## System Overview
+## The shape
 
-See **[docs/architecture/overview.md](architecture/overview.md)** for the full system design, component map, and data model.
+A host-agnostic engine (`@remnic/core`) owns all memory semantics. A standalone daemon (`@remnic/server`) exposes it over HTTP + MCP, and thin adapters connect each agent tool to that one store.
 
-## Key Design Decisions
+```
+        Claude Code   Codex CLI   Cursor   ChatGPT   Hermes   Replit   Pi/omp
+             │           │          │         │         │        │       │
+             └───────────┴──────────┴────┬────┴─────────┴────────┴───────┘
+                                         │ HTTP + MCP (127.0.0.1:4318)
+                                ┌────────▼─────────┐
+                                │  @remnic/server   │  standalone daemon
+                                ├───────────────────┤
+                                │   @remnic/core     │  memory engine
+                                │  orchestrator ·    │
+                                │  extraction ·      │
+                                │  search backends · │
+                                │  graph · lifecycle │
+                                └────────┬──────────┘
+                                         │
+                                ┌────────▼──────────┐
+                                │  markdown + YAML   │  plain files on disk
+                                │  ~/.remnic/memory  │  (no external database)
+                                └───────────────────┘
+```
 
-- **Local-first storage** — all memories live as plain markdown files on disk; no external database required.
-- **Three-phase flow** — *recall* (before each agent session), *buffer* (after each turn), *extract* (periodic LLM call).
+OpenClaw is one adapter (the deepest native integration), not the center. Standalone Remnic must remain correct without any single host.
+
+## The three-phase flow
+
+Every integration drives the same core loop:
+
+```
+Before an agent turn:   Recall   → inject relevant memories into the prompt
+After each turn:        Buffer   → accumulate turns until a trigger fires
+Periodically:           Extract  → one LLM call turns turns into stored memories
+```
+
+Recall runs a planner → candidate generation (artifacts, QMD hybrid search, embedding fallback) → policy filtering → optional rerank → cap → format. See [Retrieval pipeline](architecture/retrieval-pipeline.md). Extraction, consolidation, and expiry are covered in [Memory lifecycle](architecture/memory-lifecycle.md).
+
+## Key design decisions
+
+- **Local-first storage** — every memory is a plain markdown file with YAML frontmatter; no external database.
+- **Host-agnostic core** — `@remnic/core` has zero host imports; adapters translate, they don't own semantics.
 - **OpenAI Responses API** — extraction uses structured outputs via the Responses API, never Chat Completions.
-- **QMD for retrieval** — hybrid BM25 + vector + reranking via an external `qmd` process; degrades gracefully when unavailable.
-- **Plugin architecture** — integrates with OpenClaw via hooks (`gateway_start`, `before_agent_start`, `agent_end`) and registered tools/commands.
+- **Pluggable search** — QMD hybrid (BM25 + vector + rerank) is the default backend, with Orama, LanceDB, Meilisearch, remote, and no-op behind one interface; recall fails open when a backend is unavailable.
+- **À-la-carte packages** — install only the connectors/importers you use; optional peers keep the base install small.
 
-## Component Map
+## Where the code lives
 
-| Component | File | Role |
-|-----------|------|------|
-| Orchestrator | `src/orchestrator.ts` | Coordinates all phases |
-| Storage | `src/storage.ts` | Reads/writes markdown + YAML frontmatter |
-| Buffer | `src/buffer.ts` | Smart turn accumulation with signal-based triggers |
-| Extraction | `src/extraction.ts` | LLM extraction engine (OpenAI Responses API) |
-| QMD client | `src/qmd.ts` | Hybrid search (BM25 + vector + reranking) |
-| Retrieval | `src/retrieval.ts` | Recall pipeline: filter → rerank → cap → format |
-| HiMem | `src/himem.ts` | Episode/Note dual-store classification (v8.0) |
-| Boxes | `src/boxes.ts` | Memory Box builder + Trace Weaver (v8.0) |
-| Tools | `src/tools.ts` | Agent-callable memory tools |
+Remnic is a pnpm + Turborepo monorepo. Core is in `packages/remnic-core/src/`, the standalone runtime in `packages/remnic-server/` and `packages/remnic-cli/`, and each host/connector/importer is its own package. See [Monorepo structure](architecture/monorepo-structure.md) for the full 27-package map, dependency graph, and publish order.
 
-## Further Reading
+| Concern | Where |
+|---------|-------|
+| Orchestration (all phases) | `packages/remnic-core/src/orchestrator.ts` |
+| Storage (markdown + YAML) | `packages/remnic-core/src/storage.ts` |
+| Turn buffering | `packages/remnic-core/src/buffer.ts` |
+| Extraction (Responses API) | `packages/remnic-core/src/extraction.ts` |
+| Search interface + backends | `packages/remnic-core/src/search/` |
+| Standalone HTTP + MCP server | `packages/remnic-server/src/` |
+| OpenClaw adapter | `packages/plugin-openclaw/` + root `src/` wiring |
 
-- [Architecture Overview](architecture/overview.md) — full internals
-- [Retrieval Pipeline](architecture/retrieval-pipeline.md) — how recall works
-- [Procedural memory](procedural-memory.md) — optional `procedure` category, recall gate, miner
-- [Memory Lifecycle](architecture/memory-lifecycle.md) — write, consolidation, expiry
+## Further reading
+
+- [Architecture overview](architecture/overview.md) — full system design, storage layout, and data model
+- [Retrieval pipeline](architecture/retrieval-pipeline.md) — how recall works end to end
+- [Memory lifecycle](architecture/memory-lifecycle.md) — write, consolidation, expiry, and tiering
+- [Graph reasoning](architecture/graph-reasoning.md) — the opt-in graph layer
+- [Monorepo structure](architecture/monorepo-structure.md) — packages, dependencies, and releases
+- [Shared memory](architecture/shared-memory.md) — how one store serves many agents
+- [Config reference](config-reference.md) — every configuration flag

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,6 +1,6 @@
 # Development Conventions
 
-Conventions and patterns used throughout the openclaw-engram codebase.
+Conventions and patterns used throughout the Remnic codebase. The repo is a pnpm + Turborepo workspace; the memory engine lives in `packages/remnic-core/`.
 
 ## TypeScript
 
@@ -12,16 +12,16 @@ Conventions and patterns used throughout the openclaw-engram codebase.
 
 ## OpenAI Usage
 
-- **Always use the Responses API** — never Chat Completions. See `src/extraction.ts` for the pattern.
+- **Always use the Responses API** — never Chat Completions. See `packages/remnic-core/src/extraction.ts` for the pattern.
 - **Structured outputs** — use `zodTextFormat()` to get typed responses.
-- **Model references** — never hard-code model names; use `src/model-registry.ts`.
+- **Model references** — never hard-code model names; use `packages/remnic-core/src/model-registry.ts`.
 - **Token logging** — log total tokens and latency; never log user prompt content.
 
 ## File Organization
 
 - One logical unit per file where practical.
-- `src/types.ts` is the single source of truth for shared interfaces.
-- `src/config.ts` owns all config parsing and defaults.
+- `packages/remnic-core/src/types.ts` is the single source of truth for shared interfaces (`PluginConfig`).
+- `packages/remnic-core/src/config.ts` owns all config parsing and defaults.
 - New subsystems must register their config properties in `openclaw.plugin.json:configSchema`.
 
 ## Memory Storage
@@ -34,7 +34,7 @@ Conventions and patterns used throughout the openclaw-engram codebase.
 ## Testing
 
 - Tests live in `tests/` and use Node.js's built-in `node:test` runner.
-- Run with `npm test` (executes `tsx --test` against all `tests/*.test.ts` files).
+- Run with `npm test`, which builds `@remnic/core` and then runs the root `node:test` suite via `scripts/run-root-tests.mjs`. Individual packages carry their own tests too.
 - All tests must be deterministic — no network calls, no filesystem writes to real paths.
 - Use `tests/transfer-fixtures.ts` patterns for shared test data.
 - New subsystems require tests for: happy path, zero/empty input, and boundary conditions.
@@ -47,7 +47,7 @@ Conventions and patterns used throughout the openclaw-engram codebase.
 
 ## Adding a New Config Property
 
-1. Add to the interface in `src/config.ts` with a default.
+1. Add the property to `PluginConfig` in `packages/remnic-core/src/types.ts`, with its default in `packages/remnic-core/src/config.ts`.
 2. Add to `openclaw.plugin.json:configSchema` with type and description.
 3. Run `npm run check-config-contract` to verify alignment.
 4. Document in `docs/config-reference.md`.
@@ -56,9 +56,10 @@ Conventions and patterns used throughout the openclaw-engram codebase.
 
 | Script | Purpose |
 |--------|---------|
-| `npm run build` | Compile TypeScript to `dist/` |
-| `npm run lint` | Type-check without emitting (`tsc --noEmit`) |
-| `npm test` | Run full test suite |
-| `npm run preflight` | Full pre-PR gate (types + contract + tests + build) |
-| `npm run preflight:quick` | Fast gate (types + contract + key tests) |
-| `npm run check-config-contract` | Verify config types match plugin manifest |
+| `npm run build` | Build `@remnic/core`, sync the OpenClaw plugin manifest, then bundle the root plugin with `tsup` |
+| `npm run check-types` | Type-check with `tsc --noEmit` (plus each package's own `check-types`) |
+| `npm run lint` | Lint with Biome (`biome check`) |
+| `npm test` | Build core, then run the root test suite |
+| `npm run preflight` | Full pre-PR gate (`scripts/pr-preflight.sh full`) |
+| `npm run preflight:quick` | Fast pre-PR gate (`scripts/pr-preflight.sh quick`) |
+| `npm run check-config-contract` | Verify config types match the plugin manifest schema |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,75 +1,173 @@
-# Remnic Docs
+# Remnic documentation
 
-## Getting Started
+Remnic is an open-source, local-first memory and context layer for AI agents. One
+memory store, every agent: OpenClaw, Claude Code, Codex CLI, Cursor, ChatGPT
+(developer mode), Hermes, Replit, Pi, omp, and any MCP client. All data lives on
+your machine as plain markdown with YAML frontmatter. MIT licensed.
 
-- [Getting Started](getting-started.md) — Install, setup, first-run verification
-- [Search Backends](search-backends.md) — Choosing and configuring search engines (v9.0)
-- [Enable All Features](enable-all-v8.md) — Full-feature config profile
-- [Config Reference](config-reference.md) — Every setting with defaults, recommended values, and operator guidance
+This is the map of everything under `docs/`. New here? Read the
+[quickstart](guides/quickstart.md), then come back for the rest.
 
-## Architecture
+## Start here
 
-- [Overview](architecture/overview.md) — System design, components, storage layout
-- [Trace → Observation → Primitive](trace-to-primitive.md) — How Remnic compresses noisy session traces into durable memory primitives (issue #685)
-- [Retrieval Pipeline](architecture/retrieval-pipeline.md) — How recall works end-to-end
-- [Memory Lifecycle](architecture/memory-lifecycle.md) — Write, consolidation, expiry
-- [Dreams: phased consolidation](dreams.md) — Light sleep / REM / deep sleep phase mapping over the existing maintenance pipeline (issue #678)
-- [Graph Reasoning](architecture/graph-reasoning.md) — Opt-in graph traversal, assist, and explainability
-- [Graph Edge Decay](graph-edge-decay.md) — Confidence decay model, maintenance job, traversal pruning, and `--include-low-confidence` (issue #681)
-- [Writing a Search Backend](writing-a-search-backend.md) — Build your own search adapter (v9.0)
+- [Quickstart](guides/quickstart.md) — Install the CLI, start the daemon, connect one tool, and get your first recall in about five minutes.
+- [Getting started](getting-started.md) — The full install and first-run guide: every install option, minimal config, verification, and next steps.
+- [Enable all features](enable-all-v8.md) — A single config profile that turns on every major feature family at once.
+- [Search backends](search-backends.md) — Choose and configure a search engine (six backends behind one interface), plus upgrade and version-gate notes.
+- [All guides](guides/README.md) — Task-focused walkthroughs for installing, running, tuning, and migrating Remnic.
 
-## Guides
+## Connect your tools
 
-- [Local LLM Guide](guides/local-llm.md) — Setup and tune local-first extraction/rerank flows
-- [Cost Control Guide](guides/cost-control.md) — Budget mappings, presets, and rollout discipline
-- [Migration Guide](guides/migrations.md) — Move from manual tuning and historical roadmap docs to the current config surface
+Point any tool at a running Remnic server. See the [integration index](integration/README.md)
+for all wiring guides and the [plugins index](plugins/README.md) for what each
+packaged adapter is.
+
+- [Connector setup guide](integration/connector-setup.md) — Wire Claude Code, Codex, Cursor, Copilot, Cline, Roo Code, Windsurf, Amp, Replit, Hermes, and any MCP client to Remnic.
+- [ChatGPT (developer mode)](integration/chatgpt.md) — Give ChatGPT persistent, governed memory on your own infrastructure via MCP and OAuth 2.1.
+- [Pi coding agent](integration/pi.md) — Native Pi extension using Pi's hooks, slash commands, and compaction coordination.
+- [Oh My Pi (omp)](integration/omp.md) — omp rules, MCP server config, and the native omp extension.
+- [Hermes setup](integration/hermes-setup.md) — Hermes Agent via the `remnic-hermes` package or session-id auto-detection.
+- [Deployment topologies](integration/deployment-topologies.md) — Localhost, LAN, remote, containerized, and standalone layouts.
+- [Plugin ID and memory namespaces](integration/plugin-id-and-memory-namespaces.md) — The OpenClaw plugin id split, the memory-slot gate, and namespace isolation.
+- [Per-host plugins](plugins/README.md) — Adapter docs for OpenClaw, Claude Code, Codex, Hermes, Replit, and more.
+
+**Migrating from an earlier setup:**
+
+- [OpenClaw Engram to Remnic](guides/openclaw-engram-to-remnic.md) — Move from the legacy `openclaw-engram` package to `@remnic/plugin-openclaw`.
+- [Platform migration guide](guides/platform-migration.md) — Move from the single-package Engram plugin to the multi-package Remnic platform.
+- [Migrating from lossless-claw](lcm-to-remnic-migration.md) — Bring memory over from the lossless-claw context plugin.
+
+## Features
+
+### Recall and retrieval
+
+- [Advanced retrieval](advanced-retrieval.md) — Reranking, query expansion, and the relevance feedback loop.
+- [Retrieval explain](retrieval-explain.md) — Tier-annotated recall so you can see which retrieval tier produced each result.
+- [Recall disclosure depth](recall-disclosure.md) — Three-tier progressive disclosure (chunk / section / raw) and its cost/quality tradeoffs.
+- [Recall X-ray](xray.md) — Per-result attribution: provenance, safety, and why each memory surfaced.
+- [Temporal recall](temporal-recall.md) — `valid_at` / `invalid_at` fact lifecycle and the `as_of` recall filter.
+- [Contradiction review](contradiction-review.md) — Nightly scan that finds contradictory memory pairs and queues them for resolution.
+- [Tags](tags.md) — Free-form tag filters on recall and propose, and how tags differ from taxonomy.
+
+### Memory OS
+
+- [Dreams](dreams.md) — Named, phased consolidation (light sleep / REM / deep sleep) over the maintenance pipeline.
+- [Compounding engine](compounding.md) — Turns feedback into persistent institutional learning through weekly synthesis.
+- [Procedural memory](procedural-memory.md) — First-class `procedure` memories mined from recurring task trajectories.
+- [Pattern reinforcement](pattern-reinforcement.md) — Merges observations that recur across sessions into reinforced primitives.
+- [Graph edge decay](graph-edge-decay.md) — Confidence decay model, the maintenance job, and traversal pruning.
+- [Identity continuity](identity-continuity.md) — Recovery artifacts that let an assistant regain stable behavior after drift or incidents.
+- [Peers](peers.md) — A peer registry generalizing the singular identity anchor to many known parties.
+- [User-aware agents](user-aware-agents.md) — The typed user-model contract, context scopes, and boundary principles.
+- [Shared context](shared-context.md) — File-based coordination layer for cross-agent collaboration.
+- [Namespaces](namespaces.md) — Multi-agent memory isolation with a curated shared namespace.
+- [Inductive rule consolidation (IRC)](irc.md) — Synthesizes explicit preference state from signals in stored conversations.
+- [Context retention](context-retention.md) — Transcript indexing and richer hourly summaries for long-running systems.
+- [Local session summaries](local-session-summaries.md) — Privacy-first harvesting of local AI session transcripts into sanitized drafts.
+
+### Coding agents
+
+- [Coding agent mode](coding-agent.md) — Auto-scope memory by git project (and optionally branch) so coding context stays where it belongs.
+- [Coding knowledge (Track A)](coding-knowledge.md) — Durable, project-scoped coding knowledge inside `@remnic/core`, no extra dependencies.
+- [Coding graph (Track B)](coding-graph.md) — The optional `@remnic/coding-graph` package that indexes a native codebase graph.
+- [Developer workflow demo](developer-workflow-demo.md) — How user-aware memory helps coding agents plan, edit, check, and review.
+
+### Wearables and connectors
+
+- [Wearable transcripts](wearables.md) — Ingest Limitless, Bee, and Omi recordings into searchable day transcripts under strict trust gates.
+- [Live connectors](live-connectors.md) — The continuous, scheduled ingest path for external services.
+- [Connectors CLI](connectors.md) — Inspect and manually control the live connectors from the operator surface.
+
+### Import, export, and portability
+
+- [Import / export / backup](import-export.md) — Portable exports, imports, and safe backups of the plain-file store.
+- [Memory importers](importers.md) — Optional importer packages that pull memory out of external platforms.
+- [Capsules](capsules.md) — Portable, shareable memory capsules for moving a slice of memory between stores.
+
+### Dashboards and consoles
+
+- [Admin console](admin-console.md) — Local operator UI served by the access server for inspection and actions.
+- [Operator console](console.md) — Live `remnic console` engine introspection with trace recording and replay.
+- [Live graph dashboard](graph-dashboard.md) — Optional sidecar for graph observability and a live patch stream.
+
+### Demos
+
+- [Agentic commerce demo](agentic-commerce-demo.md) — Buyer-aware recommendations, checkout boundaries, and commerce eval coverage.
+- [ChatGPT Apps demo](chatgpt-apps-demo.md) — A local ChatGPT Apps-compatible memory inspector on the MCP runtime.
+- [Coding agent memory demo](../examples/coding-agent-memory-demo/) — No-key, cross-tool walkthrough for scoped coding-agent project memory.
 
 ## Operations
 
-- [Operations](operations.md) — Backup, export, hourly summaries, CLI, logs
-- [Published Benchmarks](benchmarks.md) — Full published benchmark suite, artifact expectations, and leaderboard safety
-- [Benchmark Readiness](benchmarks/sota-readiness.md) — #841-#850 cue-recall audit for published memory benchmarks
-- [Codex Credit Reconciliation](benchmarks/codex-credit-reconciliation.md) — Conservative recovery for blocked bounded-benchmark ledgers
-- [Retention Policy](retention-policy.md) — Hot/cold tier substrate, value-score model, `remnic forget`, `remnic tier list/explain` (issue #686)
-- [Import / Export](import-export.md) — Portable backups and migration
-- [Local AI Session Summary Drafts](local-session-summaries.md) — Privacy-first local transcript harvesting into sanitized summary drafts
-- [ops/pr-review-hardening-playbook.md](ops/pr-review-hardening-playbook.md) — Pre-push review checklist
-- [ops/plugin-engineering-patterns.md](ops/plugin-engineering-patterns.md) — Engineering patterns for retrieval/intent/cache
+- [Operations](operations.md) — Backups, exports, hourly summaries, logs, and day-to-day CLI.
+- [Retention policy](retention-policy.md) — Hot/cold tiers, the value-score model, `remnic forget`, and tier inspection.
+- [At-rest encryption](encryption.md) — AES-256-GCM transparent storage encryption, the secure-store CLI, and its threat model.
+- [Namespaces](namespaces.md) — Isolate memory across agents and tenants.
+- [Capsules](capsules.md) — Export, import, and share portable memory capsules.
+- [Import / export](import-export.md) — Portable backups and migration between stores.
+- [Model lab](model-lab.md) — Reproducible recipes to fine-tune the small local classification models the extraction pipeline can use.
+- [Codex credit reconciliation](benchmarks/codex-credit-reconciliation.md) — Conservative recovery for blocked bounded-benchmark ledgers.
 
-## Feature Guides
+### Benchmarking and evaluation
 
-- [At-Rest Encryption](encryption.md) — AES-256-GCM transparent storage encryption, secure-store CLI, threat model (issue #690)
-- [Advanced Retrieval](advanced-retrieval.md) — Reranking, query expansion, feedback loop
-- [Pattern Reinforcement](pattern-reinforcement.md) — Cross-session pattern detection: reinforced primitives, `remnic patterns list/explain` CLI, recall boost (issue #687)
-- [Recall X-ray](xray.md) — Per-result retrieval attribution, provenance, safety, and why each memory surfaced (issue #570)
-- [Recall Disclosure](recall-disclosure.md) — Three-tier progressive disclosure (chunk / section / raw): cost/quality tradeoffs, auto-escalation policy, and the disclosure-vs-retrieval-tier distinction (issue #677)
-- [User-Aware Agents](user-aware-agents.md) — User-model dimensions, context scopes, and boundary principles
-- [Agentic Commerce Demo](agentic-commerce-demo.md) — Buyer-aware recommendations, checkout boundaries, and commerce eval coverage
-- [Developer Workflow Demo](developer-workflow-demo.md) — Coding-agent memory for repo conventions, review behavior, checks, and ask-before rules
-- [Coding Agent Memory Demo](../examples/coding-agent-memory-demo/) — No-key cross-tool walkthrough for scoped coding-agent project memory
-- [Temporal Recall](temporal-recall.md) — `valid_at` / `invalid_at` fact lifecycle and `as_of` recall filter (issue #680)
-- [Tags](tags.md) — Free-form tag filter on recall and propose; tags vs taxonomy (issue #689)
-- [Live Connectors](live-connectors.md) — Continuous-sync framework for external sources (issue #683)
-- [Operator Console](console.md) — Live engine introspection: `remnic console` TUI, `--record-trace`, `--trace` replay (issue #688)
-- [Context Retention](context-retention.md) — Transcript indexing, hourly summaries
-- [Namespaces](namespaces.md) — Multi-agent memory isolation (v3.0)
-- [Shared Context](shared-context.md) — Cross-agent shared intelligence (v4.0)
-- [Compounding](compounding.md) — Weekly synthesis and mistake learning (v5.0)
-- [Identity Continuity](identity-continuity.md) — Continuity artifacts, templates, and rollout safety model (v8.4)
-- [Graph Dashboard](graph-dashboard.md) — Optional live graph observability server + patch stream (v8.8)
+- [Memory evals](memory-evals.md) — Why agent memory needs evals, and how Remnic's eval surface works.
+- [Evaluation harness](evaluation-harness.md) — The storage contract and status tooling for AMA-Bench-style evaluation.
+- [Published benchmarks](benchmarks.md) — The full published benchmark suite, artifact expectations, and leaderboard safety.
+- [Benchmark readiness](benchmarks/sota-readiness.md) — Audit checklist for running Remnic against published memory benchmarks.
+- [Benchmark runbook](benchmarks/runbook.md) — How to produce and publish full benchmark numbers.
+- [Benchmark integrity](bench/integrity.md) — Anti-gaming and integrity rules for the externally published suite.
+- [Assistant rubric](bench/assistant-rubric.md) — The sealed LLM-judge rubric and its rotation policy for the assistant tier.
+- [Single-flag ablations](benchmarks/ablations.md) — The LoCoMo single-flag ablation matrix.
+- [MemCorrect](benchmarks/memcorrect.md) — Open correction / steerability benchmark.
+- [Procedural recall benchmark](benchmarks/procedural-recall.md) — Scores how well stored procedures are injected into recall.
+- [Aged-dataset retention bench](benchmarks/retention-aged-dataset.md) — Retention behavior over an aged dataset.
+- [LoCoMo profile diagnosis](benchmarks/locomo-profile-diagnosis.md) — Runtime-profile regression diagnosis on the LoCoMo comparison.
 
-## Integrations
+## Reference
 
-- [ChatGPT (developer mode)](integration/chatgpt.md) — Give ChatGPT persistent, governed memory on your own infrastructure via MCP + OAuth 2.1. OpenAI no longer disables memory/tools for custom MCP servers, so Remnic works alongside native ChatGPT capabilities.
-- [Connector Setup Guide](integration/connector-setup.md) — Wire Remnic memory to Claude Code, Codex, Cursor, Copilot, Cline, Roo Code, Windsurf, Amp, Replit, Hermes, and any generic MCP client
-- [Pi Coding Agent](integration/pi.md) — Native Pi extension (`@remnic/plugin-pi`) for hooks, slash commands, and compaction coordination
-- [Oh My Pi (omp)](integration/omp.md) — omp rules, MCP server config, and the native omp extension
-- [Hermes Setup](integration/hermes-setup.md) — Hermes Agent via `remnic-hermes` Python package or `X-Hermes-Session-Id` auto-detection
-- [Deployment Topologies](integration/deployment-topologies.md) — Localhost, LAN, remote, containerized, standalone
-- [Plugin ID and Memory Namespaces](integration/plugin-id-and-memory-namespaces.md) — OpenClaw plugin id `openclaw-remnic`, memory namespace isolation
+- [CLI reference](cli.md) — Every standalone `remnic` command, plus the hosted `openclaw engram` surface.
+- [Config reference](config-reference.md) — Every setting with defaults, recommended values, and operator guidance.
+- [API reference](api.md) — HTTP and MCP surface, headers, and the standalone command contract.
+- [Setup, configuration, and tuning](setup-config-tuning.md) — The operational runbook for enabling and tuning features.
+- [Tags](tags.md) — Tag frontmatter and the recall/propose tag filter.
+- [Conventions](CONVENTIONS.md) — Conventions and patterns used throughout the codebase.
 
-## Plans / Roadmaps
+## Architecture and internals
 
-- [Remnic Feature Roadmap (GitHub Project)](https://github.com/users/joshuaswarren/projects/1) — Current priority order, blockers, and next work
-- [Plans Index](plans/README.md) — Historical design plans and archive layout
-- [Research Paper Mapping](research/paper-mapping.md) — How live features map to the papers and concepts that inspired them
+- [Architecture map](ARCHITECTURE.md) — The top-level walkthrough and pointers into every internals doc.
+- [Architecture index](architecture/README.md) — Core design, retrieval and extraction pipelines, the knowledge model, and decision records.
+- [Trace to Observation to Primitive](trace-to-primitive.md) — How noisy session traces become durable memory primitives.
+- [Tech stack](tech-stack.md) — Runtime, language, storage, and dependency choices at a glance.
+- [Writing a search backend](writing-a-search-backend.md) — Implement a custom `SearchBackend` adapter.
+- [Ingestion benchmark frontmatter schema](bench-ingestion-schema.md) — The canonical page frontmatter the schema-completeness rubric scores.
+
+## Contributing and development
+
+- [Contributing](development/contributing.md) — How to set up, build, and contribute to Remnic.
+- [Plugin development guide](development/plugin-development.md) — Build a Remnic plugin for a new AI agent platform.
+- [Release process](development/release-process.md) — Independent per-package versioning with Changesets.
+- [PR review hardening playbook](ops/pr-review-hardening-playbook.md) — Review checklist for PRs that touch behavior, performance, safety, or compatibility.
+- [Plugin engineering patterns](ops/plugin-engineering-patterns.md) — Engineering patterns for retrieval, intent, and cache work.
+- [Rule graduation ledger](ops/rule-graduations.md) — How prose rules graduate into machine-enforced checks.
+- [Memory-extraction threat model](security/memory-extraction-threat-model.md) — The threat Remnic's memory surface faces and the hardening approach.
+- [Entity isolation audit](security/entity-isolation-audit.md) — Audit of cross-entity memory isolation guarantees.
+- [Example memory extension](extensions/example-github-issues/README.md) — A worked example of publishing a third-party memory extension.
+
+## Project history and research
+
+Point-in-time records, kept for provenance. These are not current how-to docs.
+
+- [Plans index](plans/README.md) — Historical design and roadmap plans, plus the archive layout.
+- [Research paper](paper/README.md) — The Glass-Box Memory working-draft paper and appendices.
+- [Research paper mapping](research/paper-mapping.md) — How shipped feature families map to the papers that inspired them.
+- [Ideas backlog](ideas/README.md) — Exploratory ideas not yet on the roadmap.
+- [Requirements and product specs](requirements/README.md) — Historical requirements documents.
+- [Rename record](RENAME.md) — The Engram to Remnic rename plan and status (explains remaining `engram` identifiers).
+- [Superpowers specs and plans](superpowers/) — Benchmark-suite design specs and implementation plans (April 2026).
+- [Hackathon materials](hackathon/) — Build Week demo script and Devpost submission text.
+- [RCA: PR #11 review churn](ops/rca-pr11-review-churn-2026-02-21.md) — Root-cause analysis behind the plugin engineering patterns.
+- [ADAM baseline (April 2026)](security/adam-baseline-2026-04.md) — Point-in-time attack-success-rate measurements for the extraction attack harness.
+- [Bounded memory contracts experiment](experiments/bounded-memory-contracts.md) — Ablation of memory/context strategies under a controlled harness.
+- [Bug 001: agents hang after `before_agent_start`](bugs/001-agents-hang-after-before-agent-start-hook.md) — Historical bug report.
+- Dated benchmark runs: [Gemma LM Studio baseline](bench/2026-04-19-gemma-lmstudio-baseline.md) and [full-suite attempt](bench/2026-04-20-gemma-lmstudio-full-suite-attempt.md).
+
+For live priorities, see the [Remnic feature roadmap](https://github.com/users/joshuaswarren/projects/1).

--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -1,10 +1,26 @@
-# Remnic Admin Console
+# Admin console
 
-Local operator surface served by `remnic access http-serve` at
-`/remnic/ui` (and the legacy `/engram/ui` alias). All data fetches and
-operator actions go through the loopback bearer-token API; the page
-itself is a static `index.html` + `app.js` shell shipped under
-`admin-console/public/`.
+The admin console is a browser-based operator UI for a running Remnic instance:
+a memory browser, recall debugger, trust-zone and review-queue panes, and a live
+memory-graph view. All data fetches and operator actions go through the loopback
+bearer-token API; the page itself is a static `index.html` + `app.js` shell
+shipped under `admin-console/public/`. It is distinct from the terminal
+[operator console](./console.md), which inspects live engine internals.
+
+## Serving the console
+
+The console is mounted by the HTTP access server and reachable at `/remnic/ui/`
+(with the legacy `/engram/ui/` alias). Two ways to serve it:
+
+- **Standalone** — run `@remnic/server` (`remnic-server`) and set
+  `server.adminConsoleEnabled: true` (default `false`; env override
+  `REMNIC_ADMIN_CONSOLE_ENABLED`). The server binds `127.0.0.1:4318` by default,
+  so the console lives at `http://127.0.0.1:4318/remnic/ui/`.
+- **OpenClaw-hosted** — `openclaw engram access http-serve` (also
+  `127.0.0.1:4318` by default).
+
+All console calls require the same loopback bearer token as the rest of the
+`/engram/v1/*` operator API.
 
 ## Panes
 

--- a/docs/advanced-retrieval.md
+++ b/docs/advanced-retrieval.md
@@ -1,12 +1,12 @@
-# Advanced Retrieval (v2.2)
+# Advanced retrieval
 
-Engram’s retrieval pipeline can optionally do extra work at recall time to improve relevance.
+Remnic's retrieval pipeline can optionally do extra work at recall time to improve relevance.
 
 These features are **disabled by default** to keep latency low and avoid new failure modes.
 
 ## Features
 
-### Heuristic Query Expansion (No LLM)
+### Heuristic query expansion (no LLM)
 
 Config:
 - `queryExpansionEnabled` (default `false`)
@@ -17,7 +17,7 @@ Behavior:
 - Runs the original query plus a few deterministic expansions derived from salient tokens.
 - Merges and de-dupes results by memory path.
 
-### LLM Re-ranking (Optional)
+### LLM re-ranking (optional)
 
 Config:
 - `rerankEnabled` (default `false`)
@@ -31,9 +31,9 @@ Behavior:
 - Sends up to `rerankMaxCandidates` candidates (ID + snippet) to a short ranking prompt.
 - **Fail-open**: on timeout/error, keeps the original ordering.
 - Recommended: `rerankProvider: "local"` so this never forces cloud calls.
-- Note: `rerankProvider: "cloud"` is reserved/experimental in v2.2.0 and currently behaves as a no-op.
+- Note: `rerankProvider: "cloud"` is reserved/experimental and currently behaves as a no-op.
 
-### Feedback Loop (Thumbs Up/Down)
+### Feedback loop (thumbs up/down)
 
 Config:
 - `feedbackEnabled` (default `false`)
@@ -48,7 +48,7 @@ Storage:
 - Stored locally at `memoryDir/state/relevance.json`
 - Applied as a small score bias during retrieval (bounded; never a hard filter).
 
-### Negative Examples (Retrieved-but-Not-Useful)
+### Negative examples (retrieved-but-not-useful)
 
 Config:
 - `negativeExamplesEnabled` (default `false`)
@@ -83,12 +83,12 @@ Behavior: when **`recallDirectAnswerEnabled`** is true, Remnic runs a lightweigh
 What exists today:
 
 - `packages/remnic-core/src/direct-answer.ts` — pure eligibility function (`isDirectAnswerEligible`) exercised by unit tests.
-- `packages/remnic-core/src/direct-answer-wiring.ts` — `tryDirectAnswer(...)` source-agnostic binding, callable by tests but not yet invoked by the orchestrator.
+- `packages/remnic-core/src/direct-answer-wiring.ts` — `tryDirectAnswer(...)` source-agnostic binding, invoked by the recall orchestrator (`orchestration/recall-introspection.ts`) in observation mode: it annotates the tier decision when `recallDirectAnswerEnabled` is true and does not yet short-circuit the QMD path.
 - The five `recallDirectAnswer*` config keys below (parsed and validated; `recallDirectAnswerEnabled: false` disables observation-mode annotations).
 
 A dedicated `retrieval-direct-answer` bench fixture is planned but not yet in-tree.
 
-Planned eligibility ladder (in order, unchanged between observation and short-circuit modes):
+Eligibility ladder (in order, unchanged between observation and short-circuit modes):
 
 1. `config.recallDirectAnswerEnabled === false` → reason `disabled`
 2. Query normalizes to zero searchable tokens → reason `empty-query`
@@ -106,9 +106,9 @@ Config keys:
 - `recallDirectAnswerAmbiguityMargin` (default `0.15`)
 - `recallDirectAnswerEligibleTaxonomyBuckets` (default `["decisions","principles","conventions","runbooks","entities"]`)
 
-See [Retrieval explain](./retrieval-explain.md) for the planned shape of the tier annotation and the CLI / HTTP / MCP surfaces that will expose it.
+See [Retrieval explain](./retrieval-explain.md) for the shape of the tier annotation and the shipped CLI / HTTP / MCP surfaces that expose it.
 
-## Example: Enable Local-only Re-ranking
+## Example: enable local-only re-ranking
 
 In `openclaw.json`:
 
@@ -129,13 +129,13 @@ In `openclaw.json`:
 }
 ```
 
-## Debugging Slow Calls (Metadata-only)
+## Debugging slow calls (metadata-only)
 
 Config:
 - `slowLogEnabled` (default `false`)
 - `slowLogThresholdMs` (default `30000`)
 
-When enabled, Engram logs warnings like:
+When enabled, Remnic logs warnings like:
 - `SLOW local LLM: op=rerank durationMs=...`
 - `SLOW QMD query: durationMs=...`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,38 +1,12 @@
 # API Reference
 
+Remnic exposes one local service layer through HTTP and MCP adapters, a set of agent tools registered with the OpenClaw gateway, and an OpenClaw-hosted command surface. This page is the reference for all three. For the standalone `remnic` command-line tool, see the [CLI reference](cli.md).
+
 ## Standalone CLI Commands
 
-The canonical CLI is `remnic`. The legacy `engram` binary remains as a forwarder during the rename window, and the standalone commands below are still available through either name.
+The canonical CLI is `remnic`; the legacy `engram` binary remains as a forwarder during the rename window, and every command works under either name. The full standalone reference — all 35 top-level commands, their subcommands, and flags — lives in the [CLI reference](cli.md).
 
-| Command | Description |
-|---------|-------------|
-| `remnic init` | Create `remnic.config.json` in the current directory |
-| `remnic status [--json]` | Show server/daemon status and health |
-| `remnic query <text> [--json] [--explain]` | Query memories; `--explain` shows per-tier latency breakdown |
-| `remnic doctor` | Run diagnostics (Node version, config, API key, memory dir, daemon status) |
-| `remnic config` | Show current resolved configuration |
-| `remnic daemon <start\|stop\|restart>` | Manage the background HTTP server |
-| `remnic tree <generate\|watch\|validate>` | Workspace context tree operations |
-| `remnic onboard [dir] [--json]` | Analyze a project directory (language detection, doc discovery, ingestion plan) |
-| `remnic curate <path> [--json]` | Curate files into memory with duplicate/contradiction detection |
-| `remnic review <list\|approve\|dismiss\|flag> [id]` | Review inbox management |
-| `remnic sync <run\|watch> [--source <dir>]` | Diff-aware filesystem sync |
-| `remnic dedup [--json]` | Find duplicate memories |
-| `remnic connectors <list\|install\|remove\|doctor> [id]` | Manage host adapter connectors |
-| `remnic space <list\|switch\|create\|delete\|push\|pull\|share\|promote\|audit>` | Manage personal, project, and team memory spaces |
-| `remnic benchmark <run\|check\|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]` | Run benchmarks, check for regressions, generate reports |
-| `remnic versions <list\|show\|diff\|revert> <page-path> [version-id(s)]` | Page version history management |
-| `remnic taxonomy <show\|resolver\|add\|remove> [args]` | MECE taxonomy knowledge directory management |
-| `remnic enrich <entity-name\|--all\|audit\|providers> [--dry-run]` | External entity enrichment pipeline |
-| `remnic binary <scan\|status\|run\|clean> [--dry-run\|--force]` | Binary file lifecycle operations |
-
-All commands accept `--json` for machine-readable output. The CLI resolves configuration from:
-
-1. `REMNIC_CONFIG_PATH` environment variable (`ENGRAM_CONFIG_PATH` is still accepted in v1.x)
-2. `./remnic.config.json` in the current directory
-3. `~/.config/remnic/config.json` (default)
-
-See the [Platform Migration Guide](guides/platform-migration.md) for detailed setup and usage instructions.
+This page documents the shared access layer (HTTP + MCP), the agent tools, and the [`openclaw engram`](#cli-commands) hosted command surface.
 
 ---
 
@@ -42,31 +16,105 @@ Remnic exposes one shared local service layer through both HTTP and MCP adapters
 
 ### HTTP
 
-Core routes:
+Two infrastructure routes carry no request envelope and sit outside the op-gated catalog: `GET /engram/v1/health` (service health plus projection/search availability) and `POST /mcp` (the [MCP-over-HTTP](#mcp-over-http) JSON-RPC delegate). Every other route below is op-gated and shares the write envelope, rate limits, and validation described later on this page.
 
-- `GET /engram/v1/health` — service health plus projection/search availability
+**Recall and query**
+
 - `POST /engram/v1/recall` — shared recall entrypoint
 - `POST /engram/v1/recall/explain` — last recall snapshot plus intent/graph debug state
+- `GET /engram/v1/recall/tier-explain` — tier-explain document for a session
+- `GET /engram/v1/recall/xray` — recall with X-ray attribution capture (`q` required)
+- `GET /engram/v1/recall/timings` — recent recall timing samples
+- `POST /engram/v1/action-confidence` — read-only ask/draft/act/refuse/escalate decision
+
+**Memories and entities**
+
 - `POST /engram/v1/memories` — explicit memory write path
-- `POST /engram/v1/suggestions` — queue review-first memory suggestions
 - `GET /engram/v1/memories` — browse memories with query/status/category filters
 - `GET /engram/v1/memories/:id` — fetch one memory
-- `GET /engram/v1/memories/:id/timeline` — fetch one memory lifecycle timeline
+- `GET /engram/v1/memories/:id/timeline` — fetch one memory's lifecycle timeline
+- `POST /engram/v1/suggestions` — queue review-first memory suggestions
 - `GET /engram/v1/entities` — list entities
-- `GET /engram/v1/entities/:name` — fetch one entity
-- `GET /engram/v1/review-queue` — latest governance review bundle when present
-- `GET /engram/v1/maintenance` — health plus latest governance artifact summary
-- `GET /engram/v1/trust-zones/status` — trust-zone store status, counts, and latest record summary
-- `GET /engram/v1/trust-zones/records` — browse trust-zone records with zone/source/query filters
-- `POST /engram/v1/trust-zones/promote` — dry-run or apply a trust-zone promotion
-- `POST /engram/v1/trust-zones/demo-seed` — explicitly seed an opt-in buyer demo dataset
-- `POST /engram/v1/review-disposition` — operator review decision write path
-- `POST /engram/v1/observe` — feed conversation messages into LCM archive and extraction pipeline
+- `GET /engram/v1/entities/:id` — fetch one entity
+
+**Corrections**
+
+- `POST /engram/v1/correction/plan` — plan a natural-language memory correction
+- `POST /engram/v1/correction/apply` — apply a planned correction
+- `GET /engram/v1/correction/pending` — list pending corrections
+
+**Observe and LCM**
+
+- `POST /engram/v1/observe` — feed conversation messages into the LCM archive and extraction pipeline
 - `POST /engram/v1/lcm/search` — full-text search over LCM-archived conversations
 - `POST /engram/v1/lcm/compaction/flush` — drain pending LCM observations before a host compaction
 - `POST /engram/v1/lcm/compaction/record` — record a completed host compaction checkpoint
 - `GET /engram/v1/lcm/status` — LCM availability and stats
-- `POST /v1/citations/observed` — Record observed citation usage for attribution tracking
+
+**Trust zones**
+
+- `GET /engram/v1/trust-zones/status` — store status, counts, and latest record summary
+- `GET /engram/v1/trust-zones/records` — browse trust-zone records with zone/source/query filters
+- `POST /engram/v1/trust-zones/promote` — dry-run or apply a trust-zone promotion
+- `POST /engram/v1/trust-zones/demo-seed` — explicitly seed an opt-in demo dataset
+
+**Review, governance, and quality**
+
+- `GET /engram/v1/review-queue` — latest governance review bundle when present
+- `POST /engram/v1/review-disposition` — operator review-decision write path
+- `GET /engram/v1/review/contradictions` — list contradiction-review items
+- `GET /engram/v1/review/contradictions/:id` — one contradiction pair
+- `POST /engram/v1/review/resolve` — resolve a contradiction pair
+- `POST /engram/v1/contradiction-scan` — run an on-demand contradiction scan
+- `GET /engram/v1/maintenance` — health plus latest governance artifact summary
+- `GET /engram/v1/quality` — memory quality status
+
+**Coding agent**
+
+- `POST /engram/v1/coding-context` — attach or clear a session's coding context
+- `POST /engram/v1/coding/decisions` — record or list coding decision records
+- `POST /engram/v1/coding/architecture` — get or refresh the architecture card
+- `POST /engram/v1/coding/delta` — session delta since last seen
+
+**Capsules and offline sync**
+
+- `POST /engram/v1/capsules/export` — export a portable capsule archive
+- `POST /engram/v1/capsules/import` — import a capsule archive
+- `GET` or `POST /engram/v1/offline-sync/snapshot` — offline sync snapshot
+- `POST /engram/v1/offline-sync/files` — list files for offline sync
+- `POST /engram/v1/offline-sync/file-content` — read file content
+- `POST /engram/v1/offline-sync/apply-file-content` — apply file content
+- `POST /engram/v1/offline-sync/apply` — apply an offline sync batch
+- `GET /engram/v1/offline-sync/snapshot-stream` — snapshot stream (SSE)
+
+**Wearables**
+
+- `GET /engram/v1/wearables/status` — wearable source status
+- `POST /engram/v1/wearables/sync` — sync one source or all sources
+- `GET /engram/v1/wearables/transcript` — full transcript for a day
+- `GET /engram/v1/wearables/transcripts/search` — search stored transcripts
+- `GET /engram/v1/wearables/memories` — transcript-derived memories
+
+**Graph, peers, dreams, and console**
+
+- `GET /engram/v1/adapters` — host-adapter status
+- `GET /engram/v1/procedural/stats` — procedural-memory stats
+- `GET /engram/v1/graph/snapshot` — read-only graph snapshot
+- `GET /engram/v1/graph/events` — graph event stream (SSE)
+- `GET /engram/v1/peers` — list peers
+- `GET /engram/v1/peers/:id` — fetch one peer
+- `PUT /engram/v1/peers/:id` — create or update a peer
+- `DELETE /engram/v1/peers/:id` — delete a peer
+- `GET /engram/v1/peers/:id/profile` — fetch a peer's cognitive profile
+- `GET /engram/v1/dreams/status` — Dreams pipeline telemetry
+- `POST /engram/v1/dreams/run` — run one Dreams phase
+- `GET /engram/v1/console/state` — runtime console state snapshot
+- `POST /engram/v1/chat/message` — chat message (SSE)
+- `GET /engram/v1/chat/events/:id` — chat event stream (SSE)
+
+**Citations**
+
+- `POST /v1/citations/observed` — record observed citation usage for attribution tracking (note: no `/engram/v1` prefix)
 
 Recall request fields:
 
@@ -77,7 +125,7 @@ Recall request fields:
 - `mode` (`auto`, `no_recall`, `minimal`, `full`, `graph_mode`)
 - `includeDebug`
 - `cwd` (string, optional) — absolute path to the working directory. When provided and no coding context exists for the session, the server resolves git context automatically (see [Coding agent mode](coding-agent.md#project-detection)).
-- `projectTag` (string, optional) — project name (e.g. `"blend-supply"`). Creates a `tag:<name>` coding context. Takes precedence over `cwd` when both are provided.
+- `projectTag` (string, optional) — project name (e.g. `"acme-webshop"`). Creates a `tag:<name>` coding context. Takes precedence over `cwd` when both are provided.
 
 Recall response fields:
 
@@ -162,7 +210,7 @@ Request fields:
 - `namespace` (string, optional) — target namespace; defaults to the resolved namespace from the principal
 - `skipExtraction` (boolean, optional) — when `true`, messages are archived in LCM but not sent through extraction
 - `cwd` (string, optional) — absolute path to the working directory. When provided and no coding context exists for the session, the server resolves git context automatically (see [Coding agent mode](coding-agent.md#project-detection)).
-- `projectTag` (string, optional) — project name (e.g. `"blend-supply"`). Creates a `tag:<name>` coding context. Takes precedence over `cwd` when both are provided.
+- `projectTag` (string, optional) — project name (e.g. `"acme-webshop"`). Creates a `tag:<name>` coding context. Takes precedence over `cwd` when both are provided.
 
 Response (HTTP 202):
 
@@ -618,28 +666,30 @@ Update review metadata on an existing continuity loop entry.
 
 ## CLI Commands
 
-Run via `openclaw engram <command>`:
+Run via `openclaw engram <command>` when Remnic is hosted inside OpenClaw. This is a curated subset of the roughly 100 hosted subcommands; the [operations guide](operations.md) covers the operator workflows, and the standalone `remnic` binary is documented in the [CLI reference](cli.md).
 
 | Command | Description |
 |---------|-------------|
-| `flush` | Force-flush the buffer and run extraction now |
-| `search <query>` | Search memories from the terminal |
 | `stats` | Show memory counts, buffer state, and QMD status |
-| `export [--format json\|sqlite\|md]` | Export all memories to a portable file |
-| `import <file>` | Import memories from a portable file |
-| `purge` | Delete all memories (requires confirmation) |
-| `continuity incidents [--state open\|closed\|all] [--limit N]` | List continuity incidents |
-| `continuity incident-open --symptom <text> [--trigger-window <text>] [--suspected-cause <text>]` | Open a continuity incident |
-| `continuity incident-close --id <id> --fix-applied <text> --verification-result <text> [--preventive-rule <text>]` | Close a continuity incident |
+| `search <query>` | Search memories from the terminal |
+| `recall <query>` | Run a full recall |
+| `doctor` | Diagnose the hosted install |
+| `flush-access` | Flush pending access-tracking updates to disk |
+| `access-stats [--top N]` | Show the most-accessed memories |
+| `export [--format json\|md\|sqlite] [--out <path>]` | Export memories to a portable file |
+| `import [--from <path>] [--format auto\|json\|md\|sqlite]` | Import memories from a portable file |
+| `backup` | Snapshot the memory directory |
+| `purge` | Delete memories (requires confirmation) |
+| `bulk-import --source weclone` | Bulk-import from a registered hosted source (for example WeClone) |
+| `access <http-serve\|http-stop\|http-status\|mcp-serve>` | Manage the HTTP and MCP access surfaces |
+| `continuity <incidents\|incident-open\|incident-close>` | Manage continuity incidents |
 | `action-audit [--namespace <name>] [--limit N]` | Show namespace-aware memory action outcomes and policy decisions |
-| `action-confidence [--confidence N] [--risk low\|medium\|high\|irreversible\|restricted] [--context none\|partial\|sufficient]` | Evaluate ask/draft/act/refuse/escalate advisory policy |
+| `action-confidence [--confidence N] [--risk <level>] [--context <readiness>]` | Evaluate the ask/draft/act/refuse/escalate advisory policy |
 | `trust-zone-status` | Show trust-zone store status and aggregate counts |
 | `trust-zone-promote --record-id <id> --target-zone <zone> --reason <text> [--dry-run]` | Preview or apply a trust-zone promotion |
-| `trust-zone-demo-seed [--scenario enterprise-buyer-v1\|agentic-commerce-v1] [--recorded-at <iso>] [--dry-run]` | Explicitly preview or seed an opt-in trust-zone buyer demo dataset |
-| `versions <list\|show\|diff\|revert> <page-path> [version-id(s)]` | Page version history management |
-| `taxonomy <show\|resolver\|add\|remove> [args]` | MECE taxonomy knowledge directory management |
-| `enrich <entity-name\|--all\|audit\|providers> [--dry-run]` | External entity enrichment pipeline |
-| `binary <scan\|status\|run\|clean> [--dry-run\|--force]` | Binary file lifecycle operations |
+| `trust-zone-demo-seed [--scenario enterprise-buyer-v1\|agentic-commerce-v1] [--recorded-at <iso>] [--dry-run]` | Explicitly preview or seed an opt-in trust-zone demo dataset |
+
+`access` manages the HTTP and MCP access surfaces (`http-serve`, `http-stop`, `http-status`, `mcp-serve`); the separate `access-stats` command reports the most-accessed memories. The two are distinct commands — do not conflate them.
 
 ## Error Responses
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,45 @@
+# Architecture and internals
+
+How Remnic is built: the host-agnostic core, the pipelines that turn conversation
+into durable memory, and the extension points you hook into. Start with the
+[overview](overview.md), then dive into the subsystem you care about. For the
+top-level map, see [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md); to return to the
+docs hub, see [`docs/README.md`](../README.md).
+
+## Core
+
+- [Architecture overview](overview.md) — The whole system: local-first, host-agnostic `@remnic/core`, storage layout, and how components fit together.
+- [Monorepo structure](monorepo-structure.md) — How the 25+ packages are organized around the core, and what each layer owns.
+- [Memory lifecycle](memory-lifecycle.md) — A memory from conversation turn through consolidation to expiry.
+- [Shared memory architecture](shared-memory.md) — One memory owner on disk; how every agent reads and writes the same files.
+- [Embedded vs delegate mode](embedded-vs-delegate.md) — The two ways the OpenClaw bridge runs, and when to pick each.
+- [Binary lifecycle](binary-lifecycle.md) — Mirror, redirect, and clean stages for images, PDFs, audio, and video in the memory directory.
+
+## Retrieval and extraction pipelines
+
+- [Retrieval pipeline](retrieval-pipeline.md) — What happens on recall, end to end, before each agent session.
+- [Enrichment pipeline](enrichment-pipeline.md) — Importance-tiered external API spend for entity enrichment.
+- [Extraction judge](extraction-judge.md) — Optional LLM-as-judge gate that scores candidate facts against a durability rubric before write.
+- [Semantic chunking](semantic-chunking.md) — Smoothing-based topic-boundary detection for splitting memory into chunks.
+- [Graph reasoning](graph-reasoning.md) — The opt-in graph layer: explicit storage plus bounded traversal on top of normal recall.
+- [Citations](citations.md) — Codex-compatible `<oai-mem-citation>` blocks for memory attribution.
+- [Page-level versioning](page-versioning.md) — How memory pages are versioned over time.
+
+## Knowledge model and extensions
+
+- [MECE taxonomy](mece-taxonomy.md) — The knowledge directory and resolver decision tree.
+- [Memory extensions architecture](memory-extensions.md) — How third-party tools supply structured instructions that influence consolidation.
+- [Memory extension publishers](memory-extension-publishers.md) — The mechanism that installs host-specific instruction files into each agent host.
+- [Authentication model](auth-model.md) — Per-plugin/connector auth tokens and where they are stored.
+
+## Decision records
+
+- [QMD 2.0 integration decision](qmd-2-integration-decision.md) — Dated ADR for adopting the QMD 2.0 search substrate (issue #231).
+- [EMO/OEO architecture split](emo-oeo-split.md) — Decision record for the memory-orchestrator / observer split.
+
+## Related internals (top level)
+
+- [Trace to Observation to Primitive](../trace-to-primitive.md) — Canonical walkthrough of the observation pipeline (issue #685).
+- [Tech stack](../tech-stack.md) — Runtime, language, storage, and dependency choices at a glance.
+- [Writing a search backend](../writing-a-search-backend.md) — Implement a custom `SearchBackend` adapter.
+- [Ingestion benchmark frontmatter schema](../bench-ingestion-schema.md) — The canonical page frontmatter the schema-completeness rubric scores against.

--- a/docs/architecture/auth-model.md
+++ b/docs/architecture/auth-model.md
@@ -2,22 +2,22 @@
 
 ## Per-Plugin Tokens
 
-Each plugin/connector gets its own auth token. Tokens are stored at `~/.engram/tokens.json`:
+Each plugin/connector gets its own auth token. Tokens are stored at `~/.remnic/tokens.json` (a legacy `~/.engram/tokens.json` is read as a fallback):
 
 ```json
 {
-  "openclaw": "engram_oc_a1b2c3d4e5f6...",
-  "claude-code": "engram_cc_f6e5d4c3b2a1...",
-  "codex": "engram_cx_1a2b3c4d5e6f...",
-  "hermes": "engram_hm_6f5e4d3c2b1a...",
-  "replit": "engram_rl_b1c2d3e4f5a6..."
+  "openclaw": "remnic_oc_a1b2c3d4e5f6...",
+  "claude-code": "remnic_cc_f6e5d4c3b2a1...",
+  "codex": "remnic_cx_1a2b3c4d5e6f...",
+  "hermes": "remnic_hm_6f5e4d3c2b1a...",
+  "replit": "remnic_rl_b1c2d3e4f5a6..."
 }
 ```
 
 ### Token Format
 
 ```
-engram_<prefix>_<32-char-random-hex>
+remnic_<platform>_<48-char-random-hex>
 ```
 
 | Prefix | Platform |
@@ -26,25 +26,30 @@ engram_<prefix>_<32-char-random-hex>
 | `cc` | Claude Code |
 | `cx` | Codex CLI |
 | `hm` | Hermes Agent |
+| `pi` | Pi Coding Agent |
+| `op` | omp |
 | `rl` | Replit Agent |
-| `uk` | Unknown / generic |
+| `cu` | Cursor |
+| `cg` | ChatGPT |
+| `gm` | Generic MCP client |
+| `xx` | Unknown / fallback |
 
 ### Token Lifecycle
 
 ```bash
-engram token generate claude-code   # creates and stores token
-engram token list                   # shows all tokens (masked)
-engram token revoke claude-code     # removes token
+remnic token generate claude-code   # creates and stores token
+remnic token list                   # shows all tokens (masked)
+remnic token revoke claude-code     # removes token
 ```
 
-Tokens are generated automatically during `engram connectors install <platform>`.
+Tokens are generated automatically during `remnic connectors install <platform>`.
 
 ## How Tokens Are Used
 
 ### HTTP Requests
 
 ```
-Authorization: Bearer engram_cc_f6e5d4c3b2a1...
+Authorization: Bearer remnic_cc_f6e5d4c3b2a1...
 ```
 
 ### MCP Connections
@@ -84,9 +89,9 @@ The token model is designed to extend to multi-user scenarios:
 ```json
 {
   "tokens": {
-    "engram_cc_...": { "user": "joshua", "platform": "claude-code", "scopes": ["read", "write"] },
-    "engram_cx_...": { "user": "joshua", "platform": "codex", "scopes": ["read", "write"] },
-    "engram_cc_...": { "user": "teammate", "platform": "claude-code", "scopes": ["read"] }
+    "remnic_cc_...": { "user": "alice", "platform": "claude-code", "scopes": ["read", "write"] },
+    "remnic_cx_...": { "user": "alice", "platform": "codex", "scopes": ["read", "write"] },
+    "remnic_cc_...": { "user": "bob", "platform": "claude-code", "scopes": ["read"] }
   }
 }
 ```
@@ -95,7 +100,7 @@ Each user's memories would be stored in separate directories, with optional cros
 
 ## Security Considerations
 
-- Tokens are stored in `~/.engram/tokens.json` with `0600` permissions (owner-only read/write)
+- Tokens are stored in `~/.remnic/tokens.json` with `0600` permissions (owner-only read/write)
 - Tokens are never logged in full — only the prefix is shown in logs
 - The file is not committed to git (`.gitignore`)
 - EMO binds to `127.0.0.1` by default (localhost only) — external access requires explicit configuration

--- a/docs/architecture/embedded-vs-delegate.md
+++ b/docs/architecture/embedded-vs-delegate.md
@@ -19,7 +19,7 @@ OpenClaw Gateway (single process)
 
 ### When to use
 
-- You're an existing OpenClaw user upgrading to the new Engram
+- You're an existing OpenClaw user upgrading to the new Remnic
 - You want a single process managing everything
 - You don't need the EMO daemon running independently
 
@@ -54,19 +54,19 @@ EMO daemon (:4318)          ← standalone process
 ### Behavior
 
 - EMO daemon runs independently via launchd/systemd
-- Memory store path configured in EMO's config (defaults to `~/.engram/memory/`)
+- Memory store path configured in EMO's config (defaults to `~/.remnic/memory/`)
 - OpenClaw features still work (OEO proxies memory reads through EMO's HTTP API)
 - If OpenClaw stops, EMO keeps running — other agents unaffected
 
 ## Configuration
 
 ```json
-// In OpenClaw config or engram.config.json
+// In OpenClaw config or remnic.config.json
 {
-  "engram": {
+  "remnic": {
     "mode": "embedded",          // "embedded" or "delegate"
     "delegateUrl": "http://127.0.0.1:4318",  // only for delegate mode
-    "delegateToken": "engram_oc_..."          // only for delegate mode
+    "delegateToken": "remnic_oc_..."          // only for delegate mode
   }
 }
 ```
@@ -75,12 +75,12 @@ EMO daemon (:4318)          ← standalone process
 
 ```bash
 # Switch to delegate mode (requires running daemon)
-engram daemon install           # start daemon on boot
-engram config set mode delegate
+remnic daemon install           # start daemon on boot
+remnic config set mode delegate
 
 # Switch back to embedded mode
-engram config set mode embedded
-engram daemon stop              # optional: stop standalone daemon
+remnic config set mode embedded
+remnic daemon stop              # optional: stop standalone daemon
 ```
 
 ## Port Conflict Prevention

--- a/docs/architecture/embedded-vs-delegate.md
+++ b/docs/architecture/embedded-vs-delegate.md
@@ -60,27 +60,33 @@ EMO daemon (:4318)          ← standalone process
 
 ## Configuration
 
-```json
-// In OpenClaw config or remnic.config.json
-{
-  "remnic": {
-    "mode": "embedded",          // "embedded" or "delegate"
-    "delegateUrl": "http://127.0.0.1:4318",  // only for delegate mode
-    "delegateToken": "remnic_oc_..."          // only for delegate mode
-  }
-}
-```
+Bridge mode is not a config-file key. The OpenClaw plugin resolves it at gateway
+startup (`detectBridgeMode()` in `packages/plugin-openclaw/src/bridge.ts`):
 
-## Switching Modes
+1. If the `REMNIC_BRIDGE_MODE` environment variable is set (`embedded` or
+   `delegate`; legacy `ENGRAM_BRIDGE_MODE` also works), that wins.
+2. Otherwise, if a daemon is already listening on the configured port, the
+   bridge auto-detects **delegate** mode.
+3. Otherwise it runs **embedded**.
+
+In delegate mode the daemon endpoint comes from `REMNIC_HOST` (default
+`127.0.0.1`) and the daemon port env (legacy `ENGRAM_*` equivalents accepted).
+
+## Switching modes
 
 ```bash
-# Switch to delegate mode (requires running daemon)
-remnic daemon install           # start daemon on boot
-remnic config set mode delegate
+# Switch to delegate mode: start a daemon, then restart the gateway —
+# auto-detection picks delegate when the daemon is reachable.
+remnic daemon install
+launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
 
-# Switch back to embedded mode
-remnic config set mode embedded
-remnic daemon stop              # optional: stop standalone daemon
+# Or pin the mode explicitly in the gateway's environment:
+#   REMNIC_BRIDGE_MODE=delegate
+
+# Switch back to embedded: stop the daemon (or pin REMNIC_BRIDGE_MODE=embedded),
+# then restart the gateway.
+remnic daemon stop
+launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
 ```
 
 ## Port Conflict Prevention

--- a/docs/architecture/emo-oeo-split.md
+++ b/docs/architecture/emo-oeo-split.md
@@ -1,19 +1,21 @@
 # EMO/OEO Architecture Split
 
+> Decision record (historical) — 2026-04-05. The split that made the engine host-agnostic; the standalone-daemon architecture it describes is current. "EMO/OEO" and `openclaw-engram` are the decision-era component and package names.
+
 > **Status:** Accepted  
 > **Date:** 2026-04-05  
 > **Author:** Joshua Warren
 
 ## Summary
 
-Engram is restructured from a monolithic OpenClaw plugin into two components:
+Remnic is restructured from a monolithic OpenClaw plugin into two components:
 
 - **EMO (Engram Memory Orchestrator)** — standalone daemon process. The product.
 - **OEO (OpenClaw Engram Orchestrator)** — thin OpenClaw plugin that bridges to EMO.
 
 ## Problem
 
-Engram's value is universal memory for AI agents, but its architecture couples it to OpenClaw. Users of Claude Code, Codex CLI, Hermes Agent, and Replit Agent must run OpenClaw just to get Engram. This limits adoption and prevents the core value proposition: **all your agents sharing one memory**.
+Remnic's value is universal memory for AI agents, but its architecture couples it to OpenClaw. Users of Claude Code, Codex CLI, Hermes Agent, and Replit Agent must run OpenClaw just to get Remnic. This limits adoption and prevents the core value proposition: **all your agents sharing one memory**.
 
 ## Decision
 
@@ -58,7 +60,7 @@ When a user tells OpenClaw "I prefer TypeScript", Claude Code knows this on the 
 
 ### Positive
 
-- Engram becomes usable without OpenClaw
+- Remnic becomes usable without OpenClaw
 - Multi-agent memory sharing works out of the box
 - Clear separation of concerns (engine vs integration)
 - Each platform gets a native plugin, not just MCP
@@ -78,5 +80,5 @@ When a user tells OpenClaw "I prefer TypeScript", Claude Code knows this on the 
 ## Alternatives Considered
 
 1. **Keep monolithic plugin, add MCP-only connectors** — rejected because MCP alone can't provide automatic per-turn memory injection (no hooks)
-2. **Fork Engram for standalone** — rejected because it creates maintenance burden of two codebases
+2. **Fork Remnic for standalone** — rejected because it creates maintenance burden of two codebases
 3. **Make OpenClaw optional peer dep** — rejected because the split must be clean; the engine should have zero OpenClaw imports

--- a/docs/architecture/graph-reasoning.md
+++ b/docs/architecture/graph-reasoning.md
@@ -1,6 +1,6 @@
 # Graph Reasoning
 
-Engram's graph layer is opt-in. It adds explicit graph storage plus bounded traversal on top of the normal recall pipeline; it does not replace the standard retrieval contract.
+Remnic's graph layer is opt-in. It adds explicit graph storage plus bounded traversal on top of the normal recall pipeline; it does not replace the standard retrieval contract.
 
 ## Runtime Shape
 

--- a/docs/architecture/memory-lifecycle.md
+++ b/docs/architecture/memory-lifecycle.md
@@ -98,8 +98,8 @@ Parsing is strict for schema validation and fail-open in runtime helpers:
 
 Tier routing reuses lifecycle value inputs so demotion/promotion decisions stay consistent with lifecycle scoring:
 
-- `computeLifecycleValueInputs(...)` (in `src/lifecycle.ts`) provides normalized confidence/access/recency/importance/feedback signals plus disputed penalty.
-- `computeTierValueScore(...)` (in `src/tier-routing.ts`) derives a bounded value score from those inputs, adding correction/confirmation boosts and disputed penalties.
+- `computeLifecycleValueInputs(...)` (in `packages/remnic-core/src/lifecycle.ts`) provides normalized confidence/access/recency/importance/feedback signals plus disputed penalty.
+- `computeTierValueScore(...)` (in `packages/remnic-core/src/tier-routing.ts`) derives a bounded value score from those inputs, adding correction/confirmation boosts and disputed penalties.
 - `decideTierTransition(...)` applies deterministic threshold rules:
   - hot -> cold when age >= `qmdTierDemotionMinAgeDays` and value <= demotion threshold
   - cold -> hot when value >= promotion threshold
@@ -203,7 +203,7 @@ Classification priority:
 
 ## Content-Hash Deduplication (v6.0)
 
-Before every write, Engram normalizes the content (lowercase, strip punctuation, collapse whitespace) and checks a SHA-256 hash against `state/fact-hashes.txt`. Duplicates are skipped silently. The index is seeded from existing memories on first enable.
+Before every write, Remnic normalizes the content (lowercase, strip punctuation, collapse whitespace) and checks a SHA-256 hash against `state/fact-hashes.txt`. Duplicates are skipped silently. The index is seeded from existing memories on first enable.
 
 Config: `factDeduplicationEnabled` (default `true`).
 

--- a/docs/architecture/monorepo-structure.md
+++ b/docs/architecture/monorepo-structure.md
@@ -1,145 +1,212 @@
-# Monorepo Structure
+# Monorepo structure
 
-The monorepo is organized around a host-agnostic core. `@remnic/core`, `@remnic/server`, and `@remnic/cli` are the product center. OpenClaw, Hermes, Claude Code, Codex, and other integrations are adapters over that shared runtime and should not own core memory semantics.
+How the Remnic packages are organized, what depends on what, and how a release is published. The monorepo is a pnpm + Turborepo workspace built around a host-agnostic core: `@remnic/core` owns memory semantics, `@remnic/server` and `@remnic/cli` are the standalone runtime, and every host integration (OpenClaw, Hermes, Claude Code, Codex, Pi, Replit, and the importers/connectors) is an adapter over that shared engine. Adapters never own core memory semantics.
 
-## Package Map
+## Package map
+
+`packages/` holds 27 directories: 26 have an npm manifest, 25 are published to npm, one is private (`bench-ui`), and one ships to PyPI instead of npm (`plugin-hermes` → `remnic-hermes`). Several directory names differ from their published package names — those are called out below.
+
+### Core runtime
+
+| Directory | Published as | Role |
+|-----------|--------------|------|
+| `remnic-core` | `@remnic/core` | Memory engine: orchestrator, storage, extraction, all search backends, trust zones, namespaces, LCM, entity/causal graph, compounding, work layer. Zero host imports. |
+| `remnic-server` | `@remnic/server` | Standalone HTTP + MCP server that wraps core. |
+| `remnic-cli` | `@remnic/cli` | The `remnic` command (plus a legacy `engram` forwarder): init, daemon, connectors, tokens, query, doctor, and more. |
+
+### Host plugins
+
+| Directory | Published as | Role |
+|-----------|--------------|------|
+| `plugin-openclaw` | `@remnic/plugin-openclaw` | OpenClaw adapter with a bundled core runtime. |
+| `plugin-claude-code` | `@remnic/plugin-claude-code` | Claude Code plugin (hooks, skills, agents, `.mcp.json`). Files-only. |
+| `plugin-codex` | `@remnic/plugin-codex` | Codex CLI plugin (hooks, skills, MCP). |
+| `plugin-pi` | `@remnic/plugin-pi` | Memory extension for the Pi / omp coding agent. |
+| `plugin-hermes` | `remnic-hermes` (PyPI) | Hermes Agent `MemoryProvider` plugin, written in Python. |
+
+### Connectors (ingest live sources)
+
+| Directory | Published as | Role |
+|-----------|--------------|------|
+| `connector-bee` | `@remnic/connector-bee` | Bee wearable (bracelet) transcripts. |
+| `connector-limitless` | `@remnic/connector-limitless` | Limitless Pendant transcripts. |
+| `connector-omi` | `@remnic/connector-omi` | Omi necklace transcripts. |
+| `connector-replit` | `@remnic/replit` | Replit Agent MCP connector. |
+| `connector-weclone` | `@remnic/connector-weclone` | OpenAI-compatible proxy that adds memory to WeClone avatars; ships the `remnic-weclone-proxy` bin. |
+
+### Importers (one-time backfill from other tools)
+
+| Directory | Published as | Role |
+|-----------|--------------|------|
+| `import-chatgpt` | `@remnic/import-chatgpt` | ChatGPT data export. |
+| `import-claude` | `@remnic/import-claude` | Claude.ai data export. |
+| `import-gemini` | `@remnic/import-gemini` | Google Takeout Gemini Apps export. |
+| `import-lossless-claw` | `@remnic/import-lossless-claw` | lossless-claw (LCM) SQLite databases. |
+| `import-mem0` | `@remnic/import-mem0` | mem0.ai REST API. |
+| `import-supermemory` | `@remnic/import-supermemory` | Supermemory JSON export. |
+| `import-weclone` | `@remnic/import-weclone` | WeClone-preprocessed chat exports. |
+| `export-weclone` | `@remnic/export-weclone` | Exports memories as WeClone/Alpaca fine-tuning datasets. |
+
+### Libraries and tooling
+
+| Directory | Published as | Role |
+|-----------|--------------|------|
+| `belief-ledger` | `@remnic/belief-ledger` | Belief and prediction ledger built on the memory primitives. |
+| `coding-graph` | `@remnic/coding-graph` | web-tree-sitter symbol extraction + a SQLite code knowledge graph. Optional companion of core. |
+| `hermes-provider` | `@remnic/hermes-provider` | Typed TypeScript HTTP client for the memory API. |
+| `bench` | `@remnic/bench` | Retrieval-latency benchmark ladder and CI regression gates. |
+| `bench-ui` | `@remnic/bench-ui` (private) | Vite UI for browsing benchmark results. Not published. |
+| `shim-openclaw-engram` | `@joshuaswarren/openclaw-engram` | Deprecated compatibility shim that re-exports `@remnic/plugin-openclaw`. |
+
+## Dependency graph
+
+Dependencies are workspace ranges resolved from the manifests, not doc claims. Most adapters take core as a **required peer dependency**; core takes `@remnic/coding-graph` as an **optional peer**.
 
 ```
-remnic/
-├── packages/
-│   ├── remnic-core/          @remnic/core                  Memory engine (0 host deps)
-│   ├── remnic-server/        @remnic/server                HTTP + MCP server
-│   ├── remnic-cli/           @remnic/cli                   CLI binary (daemon, connectors, tokens)
-│   ├── plugin-openclaw/      @remnic/plugin-openclaw       OpenClaw adapter
-│   ├── plugin-claude-code/   @remnic/plugin-claude-code    Claude Code native plugin
-│   ├── plugin-codex/         @remnic/plugin-codex          Codex CLI native plugin
-│   ├── plugin-hermes/        remnic-hermes (PyPI)          Hermes MemoryProvider (Python)
-│   ├── connector-replit/     @remnic/replit                Replit MCP connector
-│   └── bench/                @remnic/bench                 Benchmarks
-├── src/                      OpenClaw runtime compatibility wiring and shims
-├── tests/                    Cross-package integration tests
-├── docs/                     All documentation
-└── evals/                    Evaluation harness
+@remnic/core            no internal deps; optional peer → @remnic/coding-graph
+├── @remnic/server      depends on core (+ express, express-rate-limit, MCP SDK)
+├── @remnic/cli         depends on core, @remnic/plugin-pi, @remnic/server
+│                        + 12 OPTIONAL peers (importers/connectors/bench, all
+│                          peerDependenciesMeta.optional)
+├── @remnic/coding-graph        required peer → core
+├── @remnic/belief-ledger       required peer → core
+├── @remnic/bench               depends on core AND @remnic/coding-graph
+├── @remnic/plugin-openclaw     depends on core (+ @sinclair/typebox, openai)
+├── @remnic/plugin-codex        depends on core
+├── @remnic/plugin-pi           depends on core
+├── @remnic/export-weclone      required peer → core
+├── @remnic/import-*            required peer → core (chatgpt, claude, gemini,
+│                                 lossless-claw, mem0, supermemory, weclone)
+├── @remnic/connector-bee       required peer → core
+├── @remnic/connector-limitless required peer → core
+├── @remnic/connector-omi       required peer → core
+└── @joshuaswarren/openclaw-engram  depends on core AND @remnic/plugin-openclaw
+
+Zero internal dependencies:
+  @remnic/plugin-claude-code   (files-only installer package)
+  @remnic/replit               (connector-replit; standalone MCP connector)
+  @remnic/connector-weclone    (standalone proxy)
+  @remnic/hermes-provider      (standalone HTTP client)
+  @remnic/bench-ui             (private Vite app)
+  remnic-hermes                (Python; talks to the daemon over HTTP)
 ```
 
-## Dependency Graph
+Note: `plugin-claude-code` and `@remnic/replit` have **zero** dependencies — they are installers/connectors that talk to a running daemon, not core consumers. Earlier docs incorrectly listed them as depending on core.
 
-```
-@remnic/core ← no internal deps, no OpenClaw imports
-│
-├── @remnic/server ← depends on core
-├── @remnic/cli ← depends on core, server
-├── @remnic/bench ← depends on core
-├── @remnic/plugin-openclaw ← depends on core
-├── @remnic/plugin-claude-code ← depends on core (installer only)
-├── @remnic/plugin-codex ← depends on core (installer only)
-└── @remnic/replit ← depends on core (installer only)
+## Publish order
 
-@remnic/hermes-provider ← standalone TS HTTP client (0 internal deps)
-remnic-hermes (Python) ← standalone, HTTP to Remnic server (0 internal deps)
-```
+Publish order is **not hardcoded**. It is generated per release by `scripts/publish-order.mjs` and written to `${RUNNER_TEMP}/remnic-publish-order.txt`, which the release workflow (`.github/workflows/release-and-publish.yml`) then consumes. That script is the single source of truth for release ordering.
 
-## Build Order
+The algorithm:
 
-Turborepo handles this automatically via `turbo.json`:
+- Considers **public** workspace packages only (private `bench-ui` and the PyPI-only `remnic-hermes` are excluded).
+- Builds a dependency DAG from `dependencies`, `optionalDependencies`, and **non-optional** `peerDependencies`. Optional peers (`peerDependenciesMeta.optional`) are deliberately excluded so they never constrain ordering (issue #1551) — that carve-out is why the mutual optional peer between core and `coding-graph` does not read as a cycle.
+- Runs a Kahn topological sort with a lexicographically sorted ready queue for deterministic output.
+- Errors if it finds a cycle or a public package that depends on a private one.
 
-1. `@remnic/core` (foundation — everything depends on this)
-2. `@remnic/server`, `@remnic/plugin-openclaw`, `@remnic/bench` (depend on core)
-3. `@remnic/cli` (depends on core + server)
-4. `@remnic/plugin-claude-code`, `@remnic/plugin-codex`, `@remnic/replit` (depend on core for installers)
-5. `remnic-hermes` (Python — separate build pipeline)
+The resulting order places dependency roots first (core and the zero-dep packages) and terminal consumers last (`remnic-cli`, then the `openclaw-engram` shim). During a release, packages whose trusted publishing is not yet provisioned return `E404` on first publish; those are collected and skipped rather than failing the run.
 
-## Package Details
+## À-la-carte packaging contract
+
+Remnic is designed so a user installs only what they use. Two mechanisms enforce this (see AGENTS.md §44 for the canonical statement):
+
+1. **Optional peer dependencies.** `remnic-cli` declares its importers, connectors, and `@remnic/bench` as optional peers (`peerDependenciesMeta.optional`). Installing `@remnic/cli` does not drag in every connector; a missing optional peer is a supported state, not an error.
+2. **Computed-specifier dynamic imports.** Code that reaches for an optional package imports it via a computed module specifier resolved at runtime, so bundlers and installers never treat it as a hard requirement. A feature whose optional package is absent degrades gracefully instead of failing to load.
+
+The invariant: adding or removing an optional connector/importer must never break a base install, and the publish-order generator must keep excluding optional peers so the release stays deterministic.
+
+## Build order
+
+Turborepo derives build order from the dependency graph via `turbo.json` — you do not maintain it by hand. Core builds first (everything depends on it); adapters and consumers follow; `@remnic/cli` builds after core, server, and `plugin-pi`. The Python `plugin-hermes` has its own separate build/publish pipeline.
+
+## Package details
 
 ### @remnic/core
 
-The memory engine. Contains the Orchestrator, StorageManager, ExtractionEngine, all search backends, trust zones, namespace isolation, LCM, entity graph, compounding, shared context, work layer, and all supporting modules.
-
-**Zero OpenClaw or Hermes imports.** Can be used by any host.
+The memory engine. Contains the orchestrator, storage manager, extraction engine, every search backend, trust zones, namespace isolation, LCM, the entity/causal graph, compounding, shared context, and the work layer. **Zero OpenClaw or Hermes imports** — usable by any host. Declares `@remnic/coding-graph` as an optional peer so code-graph features light up only when that package is present.
 
 ### @remnic/server
 
-Standalone HTTP + MCP server. Wraps `@remnic/core` with the shared access service and adapter registry for client identity resolution.
+Standalone HTTP + MCP server. Wraps `@remnic/core` with the shared access service and adapter registry for per-client identity resolution. Runs without OpenClaw.
 
 ### @remnic/cli
 
-CLI binary providing:
-- `remnic daemon install|uninstall|start|stop|status` — daemon lifecycle
-- `remnic connectors install|remove|doctor|list` — connector management
-- `remnic token generate|list|revoke` — auth token management
-- `remnic init|status|query|doctor|config` — setup and diagnostics
-- `remnic onboard|curate|review|sync|dedup` — memory operations
-- `remnic space|tree|bench` — workspace and benchmarking
+The `remnic` command (installs a legacy `engram` forwarder alongside it). Command groups include `init`, `daemon`, `connectors`, `token`, `query`, `doctor`, `config`, `space`, `tree`, `sync`, `dedup`, `curate`, `review`, `bench`, and more. See the [CLI reference](../cli.md) for the full surface. Depends on core, `@remnic/server`, and `@remnic/plugin-pi`, plus 12 optional peers.
 
 ### @remnic/plugin-openclaw
 
-OpenClaw adapter. Depends on `@remnic/core` and maps Remnic behavior onto OpenClaw's current plugin SDK and runtime surfaces. Keep host-specific logic here or in the root `src/` compatibility wiring when the OpenClaw loader still requires it.
+OpenClaw adapter that bundles a core runtime. Maps Remnic behavior onto OpenClaw's plugin SDK and runtime surfaces. Install with `openclaw plugins install clawhub:@remnic/plugin-openclaw`. Host-specific logic lives here or in the root `src/` compatibility wiring while the OpenClaw loader still requires it.
 
 ### @remnic/plugin-claude-code
 
-Native Claude Code plugin. Contains:
+Files-only Claude Code plugin (zero dependencies). Contains:
+
 - `.claude-plugin/plugin.json` — plugin manifest
 - `hooks/` — SessionStart, PostToolUse, UserPromptSubmit hooks
-- `skills/` — `/engram:remember`, `/engram:recall`, etc.
+- `skills/` — the `remnic-recall`, `remnic-remember`, `remnic-search`, `remnic-status`, `remnic-entities`, and `remnic-memory-workflow` skill directories
 - `agents/` — memory review agent
-- `.mcp.json` — MCP server pointing to the Remnic daemon
+- `.mcp.json` — MCP server pointing at the Remnic daemon
 
 ### @remnic/plugin-codex
 
-Native Codex CLI plugin. Contains:
-- `.codex-plugin/plugin.json` — plugin manifest
-- `hooks/` — SessionStart, PostToolUse, UserPromptSubmit, Stop hooks
-- `skills/` — memory workflow instructions
-- `.mcp.json` — MCP server pointing to the Remnic daemon
+Native Codex CLI plugin: `.codex-plugin/plugin.json`, hooks (SessionStart, PostToolUse, UserPromptSubmit, Stop), skills, and an `.mcp.json` pointing at the daemon. Depends on core.
 
-### remnic-hermes (Python)
+### @remnic/plugin-pi
 
-Hermes MemoryProvider plugin. Distributed via PyPI. Implements the Hermes v0.7.0+ MemoryProvider protocol:
-- `pre_llm_call` — inject recalled memories every turn
-- `sync_turn` — observe conversation every turn
-- `extract_memories` — structured extraction on session end
-- Also registers explicit tools (recall, store, search)
+Memory extension for the Pi / omp coding agent. Ships its own small `remnic.config.json` (daemon URL, namespace, connector token). Depends on core.
 
-### @remnic/replit
+### remnic-hermes (PyPI, Python)
 
-Replit MCP connector. Minimal package — setup instructions, config template, and installer that generates a token.
+Hermes Agent `MemoryProvider` plugin distributed on PyPI (Python ≥ 3.10). Implements the Hermes `MemoryProvider` protocol — `pre_llm_call` injects recalled memories, `sync_turn` observes each turn, `extract_memories` runs structured extraction on session end — and registers explicit recall/store/search tools. It has no npm manifest, so the npm publish-order generator skips it. Talks to the daemon over HTTP; no internal package deps.
 
-### @remnic/bench
+### Connectors and importers
 
-Retrieval latency benchmarks and CI regression gates.
+Connectors ingest live external sources (wearables, Replit, WeClone); importers do one-time backfills from other memory tools. Each is an independent optional peer of `@remnic/cli`, so you install only the ones you need.
 
-## Workspace Configuration
+### @remnic/coding-graph and @remnic/belief-ledger
+
+`coding-graph` builds a SQLite code knowledge graph from tree-sitter symbol extraction and is an optional companion of core. `belief-ledger` layers a belief/prediction ledger on the memory primitives. Both take core as a required peer.
+
+### @remnic/hermes-provider and @remnic/bench
+
+`hermes-provider` is a standalone typed HTTP client for the memory API (zero internal deps). `bench` runs the retrieval-latency ladder and CI regression gates; it depends on both core and `@remnic/coding-graph`.
+
+### @joshuaswarren/openclaw-engram (deprecated shim)
+
+A compatibility shim that re-exports `@remnic/plugin-openclaw` and forwards the legacy `engram-access` bin into core, so installs pinned to the old `openclaw-engram` package keep working. Depends on core and `@remnic/plugin-openclaw`.
+
+## Workspace configuration
 
 **pnpm-workspace.yaml:**
+
 ```yaml
 packages:
   - "packages/*"
 ```
 
 **turbo.json:**
+
 ```json
 {
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": { "dependsOn": ["^build"], "outputs": ["dist/**"] },
-    "test": { "dependsOn": ["build"] },
-    "check-types": {}
+    "check-types": { "dependsOn": ["^build"] },
+    "test": { "dependsOn": ["^build"] },
+    "dev": { "cache": false, "persistent": true }
   }
 }
 ```
 
-## Compatibility Shims
+## Compatibility shims
 
-Root `src/` currently exists for compatibility shims and OpenClaw runtime entrypoints that have not yet fully moved into `packages/plugin-openclaw`:
+The root `src/` directory still exists for OpenClaw runtime entrypoints and compatibility wiring that have not fully moved into `packages/plugin-openclaw`:
 
 ```typescript
 // src/orchestrator.ts
 export * from "@remnic/core/orchestrator";
 ```
 
-These ensure:
-- Existing tests in root `tests/` keep working during migration
-- The root `tsup.config.ts` build still produces a valid `dist/index.js`
-- Any external code importing from the root package isn't broken
+These keep root `tests/` working during migration, let the root `tsup` build produce a valid `dist/index.js` for the OpenClaw plugin, and avoid breaking external code that imports from the root package.
 
-Do not move new cross-platform semantics into root `src/`; put them in core and let adapters consume them.
+Do not put new cross-platform semantics in root `src/`. Add them to `@remnic/core` and let adapters consume them.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -182,9 +182,9 @@ api.registerTool()              // memory_search, memory_store, etc.
 api.registerCommand()           // CLI: openclaw engram <command>
 ```
 
-## v9.0 Search Backend Architecture
+## Search Backend Architecture
 
-Engram v9 introduces a port/adapter pattern for search. All backends implement the `SearchBackend` interface (`src/search/port.ts`), which the orchestrator calls for recall, update, and embedding operations.
+Remnic uses a port/adapter pattern for search. All backends implement the `SearchBackend` interface (`packages/remnic-core/src/search/port.ts`), which the orchestrator calls for recall, update, and embedding operations.
 
 ```
 Orchestrator → SearchBackend (interface)
@@ -196,7 +196,7 @@ Orchestrator → SearchBackend (interface)
                  └── NoopSearchBackend   (no-op)
 ```
 
-The factory (`src/search/factory.ts`) reads `searchBackend` from config and instantiates the correct adapter. Embedded backends (Orama, LanceDB) share two utilities:
+The factory (`packages/remnic-core/src/search/factory.ts`) reads `searchBackend` from config and instantiates the correct adapter. Embedded backends (Orama, LanceDB) share two utilities:
 - `document-scanner.ts` — scans the memory directory for indexable `.md` files
 - `embed-helper.ts` — computes vector embeddings via OpenAI or local LLM
 

--- a/docs/architecture/qmd-2-integration-decision.md
+++ b/docs/architecture/qmd-2-integration-decision.md
@@ -1,23 +1,25 @@
 # QMD 2.0 Integration Decision
 
+> Decision record (historical) — 2026-03-11. Describes the QMD adapter architecture still in use today.
+
 Issue: `#231`  
 Date: 2026-03-11
 
 ## Decision
 
-Engram will stay on the current QMD adapter architecture for now:
+Remnic will stay on the current QMD adapter architecture for now:
 
 - shared stdio MCP session as the warm primary path
 - CLI subprocess fallback for fail-open recovery
 - backend abstraction preserved so QMD is not the only long-term search option
 
-Engram will adopt the low-risk QMD 2.0 / late 1.1.x improvements that fit that architecture:
+Remnic will adopt the low-risk QMD 2.0 / late 1.1.x improvements that fit that architecture:
 
 - pass inferred recall intent into unified `query` when explicitly enabled
 - request QMD explain traces when explicitly enabled
 - persist a bounded `last_qmd_recall.json` snapshot plus a `memory_qmd_debug` operator tool
 
-Engram will not migrate to the QMD SDK in this issue.
+Remnic will not migrate to the QMD SDK in this issue.
 
 ## Comparison
 
@@ -27,11 +29,11 @@ Pros:
 
 - Direct access to `createStore`, unified `search()`, `getDocumentBody()`, and collection helpers
 - Cleaner typed boundary than shelling out
-- Easier long-term removal of custom glue if Engram ever becomes QMD-only
+- Easier long-term removal of custom glue if Remnic ever becomes QMD-only
 
 Cons:
 
-- Changes Engram's runtime contract substantially
+- Changes Remnic's runtime contract substantially
 - Increases coupling to QMD's in-process SQLite, model, and Node/runtime assumptions
 - Raises rollback risk for namespace-scoped routing, fail-open behavior, and multi-instance operator workflows
 - Requires a larger mocking/test harness shift than this issue needs
@@ -44,12 +46,12 @@ Pros:
 
 - Keeps models warm and is already integrated
 - Preserves process isolation around QMD internals
-- Gives a stable tool boundary without forcing Engram into QMD's SDK lifecycle
+- Gives a stable tool boundary without forcing Remnic into QMD's SDK lifecycle
 
 Cons:
 
 - Still needs adapter code for result normalization and recovery
-- Not every QMD capability is automatically surfaced unless Engram plumbs it through
+- Not every QMD capability is automatically surfaced unless Remnic plumbs it through
 
 Decision: keep as warm primary path.
 
@@ -72,8 +74,8 @@ Decision: keep as compatibility fallback.
 
 Pros:
 
-- Preserves Engram's current reliability model
-- Lets Engram adopt QMD 2.0 query features without a full architecture rewrite
+- Preserves Remnic's current reliability model
+- Lets Remnic adopt QMD 2.0 query features without a full architecture rewrite
 - Lowest migration risk for current roadmap needs
 
 Cons:
@@ -103,7 +105,7 @@ Useful, but not enough to justify the migration cost yet. Defer.
 
 ### Unified `search()`
 
-Adopt indirectly. Engram now forwards intent only through unified `query` and avoids its own hybrid top-up when that intent hint is active, so QMD's own query expansion/rerank path stays authoritative.
+Adopt indirectly. Remnic now forwards intent only through unified `query` and avoids its own hybrid top-up when that intent hint is active, so QMD's own query expansion/rerank path stays authoritative.
 
 ### `intent`
 
@@ -119,7 +121,7 @@ Reviewed, but deferred. Current recall still uses bounded snippets because that 
 
 ### Collection/default collection helpers
 
-Reviewed, but no change in this issue. Engram's namespace-derived collection naming stays in place.
+Reviewed, but no change in this issue. Remnic's namespace-derived collection naming stays in place.
 
 ### MCP server boundary changes
 
@@ -140,7 +142,7 @@ Both default to `false`.
 
 ### Rollback
 
-Disable the flags. Engram reverts to the previous behavior:
+Disable the flags. Remnic reverts to the previous behavior:
 
 - no QMD-native intent hinting
 - no QMD explain capture
@@ -150,4 +152,4 @@ No data migration is required. `state/last_qmd_recall.json` is debug-only and di
 
 ## Why not remove more glue now?
 
-Because this issue is about revisiting QMD 2.0 from first principles, not forcing a rewrite. The selected changes improve retrieval quality and observability now, while preserving Engram's broader backend abstraction and low-risk fallback model.
+Because this issue is about revisiting QMD 2.0 from first principles, not forcing a rewrite. The selected changes improve retrieval quality and observability now, while preserving Remnic's broader backend abstraction and low-risk fallback model.

--- a/docs/architecture/retrieval-pipeline.md
+++ b/docs/architecture/retrieval-pipeline.md
@@ -99,8 +99,8 @@ Recall uses `QmdClient.search()` first (shared stdio MCP session when healthy, s
 
 - `qmdCollection` specifies which QMD collection to search.
 - `qmdMaxResults` caps the number of candidates returned.
-- `qmdIntentHintsEnabled` passes Engram's inferred recall intent into QMD unified search when supported.
-- When an intent hint is active, Engram skips its own hybrid top-up so QMD's unified `query` path remains authoritative.
+- `qmdIntentHintsEnabled` passes Remnic's inferred recall intent into QMD unified search when supported.
+- When an intent hint is active, Remnic skips its own hybrid top-up so QMD's unified `query` path remains authoritative.
 - `qmdExplainEnabled` requests QMD explain traces and persists them to `state/last_qmd_recall.json` for operator inspection.
 - Optional `rerankEnabled` runs an additional LLM reranking pass over the merged candidates. This adds latency — enable only if QMD's built-in scoring is insufficient.
 
@@ -166,7 +166,7 @@ Retrieval debug artifacts (`state/last_graph_recall.json`, `state/last_intent.js
 - `memory_qmd_debug` reads `state/last_qmd_recall.json` when QMD recall snapshots are available
 - `last_intent.json` is the planner-side snapshot: query text, inferred intent, selected recall mode, and any classifier reasons the runtime records
 - `last_graph_recall.json` is the graph-side snapshot: mode, namespaces, seed paths, expanded paths, and graph provenance for each expansion
-- `last_qmd_recall.json` is the QMD-side snapshot: fetch limits, intent hint, explain capture state, top ranked results, and whether Engram used or skipped hybrid top-up
+- `last_qmd_recall.json` is the QMD-side snapshot: fetch limits, intent hint, explain capture state, top ranked results, and whether Remnic used or skipped hybrid top-up
 - richer graph snapshots may also include skip or fallback metadata and final ranked result summaries; explain tooling should tolerate those extra fields even when older builds only emit the core seed/expanded schema
 
 ## Namespace Routing (v3.0)

--- a/docs/architecture/shared-memory.md
+++ b/docs/architecture/shared-memory.md
@@ -27,14 +27,14 @@ All agents connect to a single EMO instance. EMO is the sole owner of the memory
 
 | Mode | Path | Why |
 |------|------|-----|
-| Standalone (no OpenClaw) | `~/.engram/memory/` | Clean default for new users |
+| Standalone (no OpenClaw) | `~/.remnic/memory/` | Clean default for new users (a legacy `~/.engram/memory/` is read if present) |
 | OpenClaw embedded/delegate | `~/.openclaw/workspace/memory/local/` | Backward compat; OpenClaw features (Ops Dashboard, Conductor, cron jobs) read from this path |
 
 The path is resolved at startup:
 1. Explicit `memoryDir` in config → use it
-2. `ENGRAM_MEMORY_DIR` env var → use it
+2. `REMNIC_MEMORY_DIR` env var (legacy `ENGRAM_MEMORY_DIR`) → use it
 3. OpenClaw detected (`~/.openclaw/` exists and plugin mode) → use OpenClaw path
-4. Fallback → `~/.engram/memory/`
+4. Fallback → `~/.remnic/memory/` (or an existing `~/.engram/memory/`)
 
 ## Identity Resolution
 

--- a/docs/bench-ingestion-schema.md
+++ b/docs/bench-ingestion-schema.md
@@ -1,10 +1,10 @@
-# Ingestion Benchmark: Canonical Page Frontmatter Schema
+# Ingestion benchmark: canonical page frontmatter schema
 
 This document defines the frontmatter schema that the **schema-completeness** rubric scores
 against during ingestion benchmarks. Every generated memory page is evaluated field by field;
 the aggregate score is `passing_field_checks / total_applicable_checks`.
 
-## Required Fields
+## Required fields
 
 All generated pages must include the following YAML frontmatter fields:
 
@@ -19,7 +19,7 @@ All generated pages must include the following YAML frontmatter fields:
 A page that omits any of these fields contributes a failing check for that field toward the
 completeness score.
 
-## Conditional Fields
+## Conditional fields
 
 These fields are required only for certain entity types. The benchmark gold graph records
 `expectExecSummary` and `expectTimeline` per gold page; the rubric only scores them when the
@@ -44,7 +44,7 @@ dedicated heading section (`## Timeline`) in the body.
 
 The scorer treats the field as present if `ExtractedPage.hasTimeline` is `true`.
 
-## Scoring Details
+## Scoring details
 
 The scorer is implemented in `packages/bench/src/ingestion-scorer.ts` under `schemaCompleteness`.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -432,7 +432,7 @@ pnpm install && pnpm --filter @remnic/core run build
 # Follow docs/benchmarks/runbook.md with the same --seed and --model.
 ```
 
-## Cue Recall And Leaderboard Safety
+## Cue recall and leaderboard safety
 
 Issues #841 through #850 added a shared rule for all published
 benchmarks: Remnic may use exact cues only when those cues are visible in

--- a/docs/benchmarks/ablations.md
+++ b/docs/benchmarks/ablations.md
@@ -143,6 +143,6 @@ remnic bench run --benchmark locomo \
 
 The ablation matrix runner is
 `scripts/bench/run-ablation-matrix.ts` (issue #1730). See the [two-tier
-benchmark protocol](./benchmarks.md#two-tier-benchmark-protocol) for why these
+benchmark protocol](../benchmarks.md#two-tier-benchmark-protocol) for why these
 Tier L numbers must never be conflated with Tier F (frontier) leaderboard
 claims.

--- a/docs/capsules.md
+++ b/docs/capsules.md
@@ -1,17 +1,35 @@
-# Memory Capsules — CLI Reference (issue #676 PR 6/6 + issue #690 PR 4/4)
+# Memory capsules
 
 Capsules are portable, versioned archives of a Remnic memory directory. They
-use the V2 bundle format (issue #676) which carries a `capsule` metadata block
-alongside the memory records. Unlike the older `export` / `import` commands,
-capsules are designed for:
+use the V2 bundle format which carries a `capsule` metadata block alongside the
+memory records. Unlike the older `export` / `import` commands (see
+[import-export.md](./import-export.md)), capsules are designed for:
 
 - **Sharing** — a capsule can be imported on a different machine or namespace.
 - **Reproducibility** — the capsule manifest records SHA-256 checksums for
   every file, so imports are tamper-evident.
 - **Encryption** — with the `--encrypt` flag, the archive payload is sealed
-  with AES-256-GCM using the secure-store master key (issue #690). Encrypted
-  capsules can be transferred across machines as long as the same passphrase is
-  available on the destination.
+  with AES-256-GCM using the secure-store master key. Encrypted capsules can be
+  transferred across machines as long as the same passphrase is available on
+  the destination.
+
+## Command surfaces
+
+Capsule tooling is split across the two Remnic CLI surfaces, and this matters
+for which binary you invoke:
+
+- **Standalone `remnic capsule`** dispatches exactly two subcommands: `fork`
+  and `lineage`. These operate directly on archive files and memory roots.
+- **Hosted `openclaw engram`** owns the full capsule lifecycle
+  (`capsule export`, `import`, `merge`, `list`, `inspect`) plus the
+  `secure-store` and `backup` commands that encryption depends on. These run
+  through the OpenClaw gateway / plugin runtime, not the standalone binary.
+
+The rest of this page uses `openclaw engram …` for the hosted commands and
+`remnic capsule …` only for `fork` / `lineage`.
+
+Provenance: capsule V2 bundle format and encryption land in issues #676 and
+#690.
 
 ---
 
@@ -20,21 +38,21 @@ capsules are designed for:
 ### 1. Initialize a secure store (once per memory directory)
 
 ```bash
-remnic secure-store init
+openclaw engram secure-store init
 # Prompts for a passphrase; writes .secure-store/header.json
 ```
 
 ### 2. Unlock the store before any encrypt / decrypt operation
 
 ```bash
-remnic secure-store unlock
+openclaw engram secure-store unlock
 # Prompts for the passphrase; registers the key in the daemon's keyring
 ```
 
 ### 3. Export an encrypted capsule
 
 ```bash
-remnic capsule export \
+openclaw engram capsule export \
   --name my-capsule \
   --encrypt
 # Writes: <memoryDir>/.capsules/my-capsule.capsule.json.gz.enc
@@ -44,7 +62,7 @@ remnic capsule export \
 ### 4. Import a capsule (auto-detects encryption)
 
 ```bash
-remnic capsule import /path/to/my-capsule.capsule.json.gz.enc
+openclaw engram capsule import /path/to/my-capsule.capsule.json.gz.enc
 ```
 
 The import command reads the REMNIC-ENC magic header and automatically
@@ -53,12 +71,12 @@ the destination machine.
 
 ---
 
-## Commands
+## Hosted capsule commands (`openclaw engram capsule`)
 
-### `remnic capsule export`
+### `openclaw engram capsule export`
 
 ```
-remnic capsule export [options]
+openclaw engram capsule export [options]
 
 Options:
   --name <id>             Capsule id (alphanumeric + dashes, max 64 chars). Required.
@@ -72,6 +90,7 @@ Options:
   --peer-ids <list>       Comma-separated peer id allow-list for the peers/ subtree.
   --encrypt               Seal the archive with the secure-store master key.
                           The store must be unlocked before running this command.
+  --namespace <ns>        Namespace (v3.0+, default: config defaultNamespace).
 ```
 
 **Output files:**
@@ -85,10 +104,10 @@ by the `.enc` file. A crash between the two steps leaves the plaintext `.gz`
 on disk (recoverable). The `.manifest.json` sidecar is always plaintext for
 cheap inspection.
 
-### `remnic capsule import`
+### `openclaw engram capsule import`
 
 ```
-remnic capsule import <archive> [options]
+openclaw engram capsule import <archive> [options]
 
 Arguments:
   archive                 Path to a .capsule.json.gz or .capsule.json.gz.enc archive.
@@ -112,7 +131,7 @@ The import command checks the first bytes of the archive file for the
 `REMNIC-ENC` magic header. When found, it decrypts in-memory before unpacking.
 The secure-store must be unlocked on the destination machine before importing.
 
-### `remnic capsule merge`
+### `openclaw engram capsule merge`
 
 Three-way merge a capsule archive into the current memory directory.
 
@@ -121,7 +140,7 @@ Three-way merge a capsule archive into the current memory directory.
 - Files that **differ** are conflicts, resolved by `--conflict-mode`.
 
 ```
-remnic capsule merge <archive> [options]
+openclaw engram capsule merge <archive> [options]
 
 Arguments:
   archive                   Path to a .capsule.json.gz (or .enc) archive.
@@ -142,20 +161,18 @@ Options:
 
 ```bash
 # Merge a peer's capsule, keeping your local changes on conflict
-remnic capsule merge shared.capsule.json.gz --conflict-mode prefer-local
+openclaw engram capsule merge shared.capsule.json.gz --conflict-mode prefer-local
 
 # Merge and take the incoming version on conflict (with local snapshot)
-remnic capsule merge update.capsule.json.gz --conflict-mode prefer-source
+openclaw engram capsule merge update.capsule.json.gz --conflict-mode prefer-source
 ```
 
----
-
-### `remnic capsule list`
+### `openclaw engram capsule list`
 
 List all capsule archives in the capsule store directory. Reads each sidecar `.manifest.json` for metadata — no decompression needed.
 
 ```
-remnic capsule list [options]
+openclaw engram capsule list [options]
 
 Options:
   --dir <path>     Override the capsule store directory. Default: <memoryDir>/.capsules
@@ -180,7 +197,7 @@ shared-bundle [2026-04-15] [83 files]
       "archivePath": "/path/to/.capsules/daily-backup.capsule.json.gz",
       "manifestPath": "/path/to/.capsules/daily-backup.manifest.json",
       "createdAt": "2026-04-26T00:00:00.000Z",
-      "pluginVersion": "9.3.68",
+      "pluginVersion": "9.6.22",
       "fileCount": 47,
       "description": "Daily backup capsule"
     }
@@ -188,9 +205,7 @@ shared-bundle [2026-04-15] [83 files]
 }
 ```
 
----
-
-### `remnic capsule inspect`
+### `openclaw engram capsule inspect`
 
 Show a capsule manifest without extracting the archive. Reads the sidecar `.manifest.json` when present (cheap, no decompression); decompresses the archive only if the sidecar is absent.
 
@@ -199,7 +214,7 @@ The `<archive>` argument accepts:
 - A capsule **id** — looked up as `<capsulesDir>/<id>.capsule.json.gz`.
 
 ```
-remnic capsule inspect <archive> [options]
+openclaw engram capsule inspect <archive> [options]
 
 Arguments:
   archive         Path to a .capsule.json.gz archive, or a capsule id.
@@ -212,18 +227,51 @@ Options:
 
 ```bash
 # By id (looks up <memoryDir>/.capsules/daily-backup.capsule.json.gz)
-remnic capsule inspect daily-backup
+openclaw engram capsule inspect daily-backup
 
 # By path
-remnic capsule inspect /path/to/daily-backup.capsule.json.gz --format json
+openclaw engram capsule inspect /path/to/daily-backup.capsule.json.gz --format json
 ```
 
 ---
 
-### `remnic backup --encrypt`
+## Standalone capsule commands (`remnic capsule`)
+
+The standalone binary handles capsule **forking** — deriving a new memory root
+from an existing capsule archive with a recorded lineage breadcrumb.
+
+### `remnic capsule fork`
+
+```
+remnic capsule fork <source-archive> --target <root> --fork-id <id>
+
+Arguments:
+  source-archive           Path to a .capsule.json.gz archive.
+
+Options:
+  --target <root>          Memory root to import into (required).
+  --fork-id <id>           Unique fork identifier (required).
+```
+
+Records are imported under `forks/<source-capsule-id>/` and a lineage
+breadcrumb (parent capsule id + version) is written to
+`forks/<fork-id>/lineage.json`, so a fork always knows where it came from.
+
+### `remnic capsule lineage`
+
+```
+remnic capsule lineage --root <dir> --fork-id <id>
+```
+
+Reads and prints the lineage breadcrumb for a fork — the parent capsule id,
+its version, and the fork root.
+
+---
+
+## Backup (`openclaw engram backup`)
 
 ```bash
-remnic backup --out-dir /path/to/backups --encrypt
+openclaw engram backup --out-dir /path/to/backups --encrypt
 ```
 
 The `--encrypt` flag produces a single encrypted `.backup.json.gz.enc` file
@@ -270,18 +318,18 @@ To restore an encrypted capsule on a different machine:
    the destination.
 2. Initialize the secure store on the destination with the **same passphrase**:
    ```bash
-   remnic secure-store init
+   openclaw engram secure-store init
    ```
    The recorded KDF is deterministic: the same passphrase plus the embedded
    KDF parameters and salt produces the same key, so you do not need to
    transfer any key material out-of-band.
 3. Unlock the store:
    ```bash
-   remnic secure-store unlock
+   openclaw engram secure-store unlock
    ```
 4. Import the capsule:
    ```bash
-   remnic capsule import /path/to/my-capsule.capsule.json.gz.enc
+   openclaw engram capsule import /path/to/my-capsule.capsule.json.gz.enc
    ```
 
 > **Important:** The passphrase must match. The key is derived from the
@@ -293,11 +341,11 @@ To restore an encrypted capsule on a different machine:
 
 ## Key requirements
 
-- The secure-store must be **initialized** (`remnic secure-store init`) before
-  any encrypt or decrypt operation.
-- The secure-store must be **unlocked** (`remnic secure-store unlock`) in the
-  currently running daemon before `capsule export --encrypt`, `capsule import`
-  (on encrypted archives), or `backup --encrypt`.
+- The secure-store must be **initialized** (`openclaw engram secure-store init`)
+  before any encrypt or decrypt operation.
+- The secure-store must be **unlocked** (`openclaw engram secure-store unlock`)
+  in the currently running daemon before `capsule export --encrypt`,
+  `capsule import` (on encrypted archives), or `backup --encrypt`.
 - The daemon's in-memory key is **cleared on restart**. Re-run `unlock` after
   any daemon restart.
 - If you lose the passphrase you cannot recover the encrypted archive. Store
@@ -309,7 +357,7 @@ To restore an encrypted capsule on a different machine:
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `Secure-store is locked or not initialized` | The daemon does not hold a key for this memory directory. | Run `remnic secure-store unlock` (or `init` if not yet set up). |
+| `Secure-store is locked or not initialized` | The daemon does not hold a key for this memory directory. | Run `openclaw engram secure-store unlock` (or `init` if not yet set up). |
 | `authentication failed — wrong passphrase, tampered archive` | Wrong passphrase on the destination, or the archive bytes were modified. | Verify the passphrase matches the one used during `init`. If the archive was transferred, check the hash. |
 | `unsupported encrypted-capsule format version N` | The archive was produced by a newer version of Remnic. | Upgrade Remnic on the destination machine. |
 | `'memoryDir' is required when 'encrypt' is true` | The export API was called programmatically without providing `memoryDir`. | Pass `memoryDir` to `exportCapsule()`. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,167 @@
+# CLI reference
+
+The complete reference for the standalone `remnic` command-line interface. Every command here is part of the `@remnic/cli` package and runs against your local memory store — no account, no cloud. For the OpenClaw-hosted `openclaw engram` surface, see [OpenClaw-hosted commands](#openclaw-hosted-commands) at the end.
+
+## Install
+
+```bash
+npm install -g @remnic/cli
+```
+
+This installs two binaries: `remnic` (canonical) and `engram` (a legacy forwarder kept during the rename window — every command below works under either name). You can pin the binary the auto-runner uses with `REMNIC_CLI_BIN` (or the legacy `ENGRAM_CLI_BIN`).
+
+New to Remnic? Start with the [quickstart](guides/quickstart.md), then come back here for the full command surface.
+
+## Conventions
+
+- Most commands accept `--json` for machine-readable output.
+- Configuration is resolved in this order:
+  1. `REMNIC_CONFIG_PATH` environment variable (`ENGRAM_CONFIG_PATH` is still honored during the compatibility window)
+  2. `./remnic.config.json` in the current directory
+  3. `~/.config/remnic/config.json` (default)
+- Placeholders use `<angle-brackets>`. Optional arguments use `[square-brackets]`.
+- Run any command with `--help` for its full option list.
+
+Remnic ships 35 top-level command names (`benchmark` is a compatibility alias of `bench`), grouped below by what you reach for them.
+
+## Setup & health
+
+| Command | What it does |
+|---------|--------------|
+| `remnic init` | Create `remnic.config.json` in the current directory |
+| `remnic migrate [--rollback] [--json]` | Run — or with `--rollback`, undo — the first-run Engram-to-Remnic migration |
+| `remnic status [--json]` | Show server/daemon status and health |
+| `remnic doctor` | Diagnose the install (Node version, config, API key, memory dir, daemon) |
+| `remnic config` | Print the resolved configuration |
+| `remnic daemon <start\|stop\|restart\|install\|uninstall\|status>` | Manage the background HTTP server. `install`/`uninstall` register or remove the OS service; `start`/`stop`/`restart`/`status` control a running one |
+| `remnic token <generate\|list\|revoke> [connector-id]` | Manage bearer tokens for the access server |
+| `remnic onboard [dir] [--json]` | Analyze a project directory (language detection, doc discovery, ingestion plan) |
+
+```bash
+remnic init
+remnic daemon start
+remnic status
+remnic doctor
+```
+
+## Daily use
+
+| Command | What it does |
+|---------|--------------|
+| `remnic query <text> [--json] [--explain]` | Query memories. `--explain` adds a per-tier latency and source breakdown |
+| `remnic xray <query> [--format text\|markdown\|json] [--budget <chars>] [--namespace <ns>] [--out <path>]` | Run a recall with X-ray capture and print the unified tier + audit + MMR + filter snapshot |
+| `remnic briefing [--since <window>] [--focus <filter>] [--save] [--format markdown\|json]` | Generate a daily context briefing |
+| `remnic review <list\|approve\|dismiss\|flag> [id]` | Manage the review inbox |
+| `remnic curate <path> [--json]` | Curate files into memory with duplicate and contradiction detection |
+| `remnic sync <run\|watch> [--source <dir>]` | Diff-aware filesystem sync into memory |
+| `remnic dedup [--json]` | Find duplicate memories |
+| `remnic tree <generate\|watch\|validate> [--output <path>] [--categories <list>] [--max-per-category <n>] [--no-entities] [--no-questions] [--json]` | Build and validate the workspace context tree |
+
+`remnic query` is the everyday entrypoint. Use `--explain` to see where a slow answer spends its time:
+
+```bash
+remnic query "what did we decide about the pricing model?" --explain
+```
+
+`remnic briefing` windows accept `yesterday`, `today`, `NNh`, `NNd`, or `NNw`; focus filters accept `person:<name>`, `project:<name>`, or `topic:<name>`:
+
+```bash
+remnic briefing --since 7d --focus project:acme-webshop --format markdown --save
+```
+
+## Connectors & integrations
+
+| Command | What it does |
+|---------|--------------|
+| `remnic connectors <list\|install\|remove\|doctor\|marketplace\|status\|run> [id]` | Manage host adapters and live connectors |
+| `remnic openclaw <install\|upgrade\|migrate-engram>` | Wire Remnic into OpenClaw, upgrade the plugin, or migrate a legacy `openclaw-engram` install |
+| `remnic oauth <pending\|approve\|deny> [--format <fmt>] [--yes]` | Manage pending OAuth authorizations (used by the ChatGPT MCP connector) |
+| `remnic wearables <status\|check\|sync\|transcript\|search\|memories\|speakers\|corrections\|fuse\|fused>` | Pull, clean, and store wearable transcripts (Limitless / Bee / Omi) |
+
+`connectors install <id>` writes the config a host tool needs to talk to Remnic. Built-in adapter ids include `claude-code`, `codex-cli`, `cursor`, `cline`, `github-copilot`, `roo-code`, `windsurf`, `amp`, `pi`, `omp`, `replit`, `generic-mcp`, `weclone`, and `hermes`. `connectors status` and `connectors run` operate on *live* connectors (background sync sources) rather than host adapters. `connectors marketplace <generate|validate|install>` manages Codex marketplace manifests.
+
+```bash
+remnic connectors list
+remnic connectors install claude-code
+remnic connectors status
+```
+
+`remnic openclaw` subcommands take the usual safety flags: `--yes`/`--force` to skip prompts, `--dry-run` to preview, plus `--memory-dir`, `--config`, `--version`, `--plugin-dir`, `--legacy-plugin-dir`, and `--no-restart`.
+
+`remnic wearables speakers` has its own `list|self|set|remove` actions and `corrections` has `list|add|remove`; `fuse`/`fused` merge and read cross-source fused transcripts for a day. Each source ships as an à la carte connector package (for example `npm install @remnic/connector-limitless`).
+
+## Memory management
+
+| Command | What it does |
+|---------|--------------|
+| `remnic space <list\|switch\|create\|delete\|push\|pull\|share\|promote\|audit>` | Manage personal, project, and team memory spaces. `create` accepts `--parent <id>` |
+| `remnic versions <list\|show\|diff\|revert> <page-path> [id] [--json]` | Page-level version history: list, show, diff, or revert snapshots |
+| `remnic taxonomy <show\|resolver\|add\|remove\|resolve>` | Manage the MECE knowledge-directory taxonomy. `add <id> <name>`, `remove <id>`, `resolve <text> [--category <cat>]` |
+| `remnic enrich <entity-name\|--all\|--dry-run\|audit\|providers>` | Run the external entity-enrichment pipeline |
+| `remnic procedural stats [--format json\|text] [--memory-dir <path>]` | Print procedural-memory stats (counts, recency, config) |
+| `remnic capsule <fork\|lineage>` | Fork a portable capsule archive into a memory root, or print a fork's lineage breadcrumb |
+| `remnic offline <prepare\|sync\|status\|watch>` | Remote/offline memory sync |
+| `remnic action-confidence [--action <text>] [--confidence <0-1>] [--risk <level>] [--context <readiness>]` | Evaluate the read-only ask/draft/act/refuse/escalate advisory policy |
+
+`remnic capsule` is the portability entrypoint:
+
+```bash
+remnic capsule fork <archive.capsule.json.gz> --target <memory-dir> --fork-id <id>
+remnic capsule lineage --fork-id <id> --root <memory-dir>
+```
+
+## Import & export
+
+| Command | What it does |
+|---------|--------------|
+| `remnic import --adapter <name> --file <path> [--dry-run] [--batch-size <n>]` | Import from a supported export file |
+| `remnic import-lossless-claw --src <path> [--dry-run] [--session-filter <id>]` | Migrate a lossless-claw LCM database into Remnic's LCM mode |
+| `remnic training:export --format <name> --output <path>` | Export memories as a fine-tuning dataset |
+
+`remnic import --adapter` supports exactly these adapters: `chatgpt`, `claude`, `gemini`, `mem0`, and `supermemory`. WeClone is not an import adapter — it is hosted-only via `openclaw engram bulk-import --source weclone`. Lossless-claw has its own dedicated `remnic import-lossless-claw` command above.
+
+```bash
+remnic import --adapter chatgpt --file ./conversations.json --dry-run
+```
+
+## Advanced & research
+
+| Command | What it does |
+|---------|--------------|
+| `remnic bench <action> [benchmark...]` | Run and manage benchmarks (alias: `remnic benchmark`) |
+| `remnic binary <scan\|status\|run\|clean>` | Binary-file lifecycle: `scan`, `status`, `run [--dry-run]`, `clean --force` |
+| `remnic extensions <list\|show\|validate\|reload>` | Manage memory extensions |
+
+`bench` actions: `list`, `run`, `datasets` (`download`/`status`), `runs` (`list`/`show`/`delete`), `compare`, `results`, `baseline` (`save`/`list`), `export`, `publish`, `published`, `judge-calibrate`, `ui`, `providers` (`discover`). The `check` and `report` actions run under the `benchmark` alias. `published` and `judge-calibrate` are maintainer tools for the published-benchmark harness.
+
+```bash
+remnic bench list
+remnic bench run --quick
+```
+
+`remnic extensions reload` is a reserved no-op (extension caching is not yet implemented); the other actions are live. See the [benchmarking guide](benchmarks.md) for the full `bench` workflow.
+
+## OpenClaw-hosted commands
+
+When Remnic runs inside OpenClaw, the gateway registers a single top-level `engram` command whose children are the deeper memory-operations surface — roughly 100 subcommands invoked as `openclaw engram <command>`. This surface is intentionally separate from the standalone `remnic` binary: it is the operator and maintenance toolkit that runs against the gateway's live orchestrator. There is no `openclaw remnic` namespace; inside a chat session the plugin exposes the `/remnic <on|off|status|clear|stats|flush>` session command instead.
+
+Most-used `openclaw engram` commands:
+
+```bash
+openclaw engram stats                 # memory counts, buffer state, QMD status
+openclaw engram search "<query>"      # search memories from the terminal
+openclaw engram recall "<query>"      # run a full recall
+openclaw engram doctor                # diagnose the hosted install
+openclaw engram export                # export memories to a portable file
+openclaw engram import                # import from a portable file
+openclaw engram backup                # snapshot the memory directory
+openclaw engram purge                 # delete memories (guarded)
+openclaw engram access http-serve     # start the HTTP access surface
+openclaw engram access mcp-serve      # start the MCP access surface
+openclaw engram access-stats          # most-accessed memories report
+openclaw engram bulk-import --source weclone
+```
+
+Note the distinction: `access` is the group that manages the HTTP and MCP access surfaces (`http-serve`, `http-stop`, `http-status`, `mcp-serve`), while `access-stats` is the separate most-accessed-memories report.
+
+Beyond these, the hosted surface covers namespaces, capsules, trust zones, dreams, peers, secure-store, governance, review, continuity, the work layer (`task`/`project`), and the research and creation-ledger command families. The [operations guide](operations.md) documents the operator workflows, and [API reference — CLI commands](api.md#cli-commands) is the full `openclaw engram` command table.

--- a/docs/coding-agent.md
+++ b/docs/coding-agent.md
@@ -112,7 +112,7 @@ to Remnic instead of running their own git detection and calling
 
 For sessions that are not inside a git repository (e.g., OpenClaw
 general conversations), the endpoints also accept an optional
-`projectTag` field (string, e.g. `"blend-supply"`). When provided,
+`projectTag` field (string, e.g. `"acme-webshop"`). When provided,
 Remnic creates a `tag:<name>` coding context that scopes the session
 to a project namespace without requiring a git repository on disk.
 This gives OpenClaw and other non-coding agents the same project
@@ -219,7 +219,7 @@ Input schema (option 2 — `projectTag` shorthand):
 ```json
 {
   "sessionKey": "string",
-  "projectTag": "blend-supply"
+  "projectTag": "acme-webshop"
 }
 ```
 
@@ -290,8 +290,8 @@ automatic project resolution as a fallback.
 
 ### Claude Code (ships today)
 
-[`packages/plugin-claude-code/hooks/bin/session-start.sh`](../packages/plugin-claude-code/hooks/bin/session-start.sh)
-(lines 54-150) reads `cwd` from the session-start payload, runs a
+[`packages/plugin-claude-code/hooks/bin/remnic-cc-hook.cjs`](../packages/plugin-claude-code/hooks/bin/remnic-cc-hook.cjs)
+(with `.sh` and `.ps1` variants for other shells) reads `cwd` from the session-start payload, runs a
 short local `git` sequence, and posts an
 `engram.set_coding_context` tool call to the Remnic daemon. The hook
 intentionally mirrors the pure logic of `resolveGitContext` in-shell
@@ -315,7 +315,7 @@ Claude Code, the shipped hooks do not yet send `cwd` on
 
 OpenClaw conversations are typically not inside a per-project git
 repository. The server accepts `projectTag` on `recall` and `observe`
-requests to scope memory to a named project (e.g., `"blend-supply"`),
+requests to scope memory to a named project (e.g., `"acme-webshop"`),
 creating a `tag:<name>` coding context without requiring git. However,
 the OpenClaw runtime does not yet forward `projectTag` automatically —
 operators must wire it into their integration or call

--- a/docs/compounding.md
+++ b/docs/compounding.md
@@ -1,12 +1,21 @@
-# Compounding Engine (v5.0)
+# Compounding engine
 
-The compounding engine turns feedback into persistent institutional learning.
+The compounding engine turns cross-agent feedback into persistent institutional learning: weekly synthesis reports, a stable mistake registry, and rubrics that can be injected into future prompts. Enable it when you want agents to accumulate lessons from approvals and rejections over time. Opt-in via `compoundingEnabled` (default `false`).
 
-Enable:
-- `compoundingEnabled: true`
+> Provenance: compounding engine landed in v5.0.
 
-Optional injection into every prompt:
-- `compoundingInjectEnabled` (default: true when compounding is enabled)
+## Enable it
+
+```json
+{
+  "compoundingEnabled": true,
+  "compoundingInjectEnabled": true,
+  "compoundingSemanticEnabled": false
+}
+```
+
+- `compoundingInjectEnabled` (default `true` when compounding is enabled) injects recurring mistake patterns and matching rubric snippets into recall.
+- `compoundingSemanticEnabled` (default `false`) adds an advisory `Promotion Candidates` section to weekly reports.
 
 ## Inputs
 
@@ -18,7 +27,7 @@ Write feedback via tool:
 
 ## Outputs
 
-On each weekly synthesis run, Engram writes:
+On each weekly synthesis run, Remnic writes:
 - `memoryDir/compounding/weekly/<YYYY-Www>.md`
 - `memoryDir/compounding/weekly/<YYYY-Www>.json`
 - `memoryDir/compounding/mistakes.json`
@@ -56,7 +65,7 @@ Promoted lessons are written as durable `principle` or `rule` memories with `sou
 
 When `compoundingInjectEnabled=true`, recall injection can include both recurring mistake patterns and rubric snippets that match the current query/workflow.
 
-## Running Weekly Synthesis
+## Running weekly synthesis
 
 Manual:
 
@@ -68,7 +77,7 @@ compounding_weekly_synthesize
 Recommended scheduling:
 - Use OpenClaw cron with an isolated agent turn that calls `compounding_weekly_synthesize`.
 
-## Continuity Audit Generation
+## Continuity audit generation
 
 When `identityContinuityEnabled=true`, `continuityAuditEnabled=true`, and `compoundingEnabled=true`, use:
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,8 +1,8 @@
 # Config Reference
 
-All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.config`.
+All settings live in `openclaw.json` under `plugins.entries.openclaw-remnic.config`. (Installs created before the rename may still use the legacy `openclaw-engram` entry key; Remnic reads either.)
 
-Use `openclaw engram config-review` for opinionated tuning recommendations and `openclaw engram doctor` for runtime or configuration problems. The narrative sections below explain the major feature groups; the schema-complete appendix at the bottom is the authoritative default-and-recommended matrix for every shipped config key.
+Use `openclaw engram config-review` for opinionated tuning recommendations and `openclaw engram doctor` for runtime or configuration problems. The narrative sections below explain the major feature groups; the schema-complete appendix at the bottom is the authoritative default-and-recommended matrix for every shipped config key. Remnic ships 699 schema-validated top-level options plus 4 tuning presets, so treat the appendix as the source of truth and reach for a preset before hand-tuning individual keys.
 
 ## Core
 
@@ -33,7 +33,7 @@ OpenClaw installs default new Remnic entries to `modelSource: "gateway"` so LLM 
 
 Preset intent:
 
-- `conservative` keeps recall budgets lower and leaves experimental learning/graph features off.
+- `conservative` keeps recall budgets lower and leaves experimental learning/graph features off. It also pins `procedural.enabled: false`, opting out of procedural memory even though the global default is `true` (issue #567). The `procedural` block is deep-merged, so a partial user override cannot silently re-enable it — set `procedural.enabled: true` explicitly if you want it back.
 - `balanced` enables the recommended indexing, artifact, and rerank defaults without turning on the higher-churn learning loops.
 - `research-max` enables the broadest shipped experimental surface, including graph recall and adaptive policy loops.
 - `local-llm-heavy` biases extraction/rerank/tooling toward local OpenAI-compatible endpoints and the fast local tier.
@@ -60,7 +60,7 @@ Access-layer safety notes:
 - Request bodies are capped by `agentAccessHttp.maxBodyBytes`.
 - Explicit write routes are rate-limited and support `schemaVersion`, `idempotencyKey`, and `dryRun` envelopes.
 - The stdio MCP server (`openclaw engram access mcp-serve`) uses the same internal access service as HTTP, so recall/read/write behavior stays aligned across both transports.
-- MCP is intentionally zero-config on the Engram side: launch `openclaw engram access mcp-serve` from the client and it will use the same local memory directory, namespace rules, and explicit-capture policy as the in-process plugin runtime.
+- MCP is intentionally zero-config on the Remnic side: launch `openclaw engram access mcp-serve` from the client and it will use the same local memory directory, namespace rules, and explicit-capture policy as the in-process plugin runtime.
 
 ## Buffer & Triggers
 
@@ -200,9 +200,9 @@ Supported keys:
 
 ### Recall Budget Tuning
 
-The recall budget controls how much context Engram injects into each agent prompt. Getting this right is critical — too small and memories are silently truncated; too large and you waste context window space.
+The recall budget controls how much context Remnic injects into each agent prompt. Getting this right is critical — too small and memories are silently truncated; too large and you waste context window space.
 
-**How it works (v9.0.66+):** Engram assembles recall context in pipeline section order (shared-context → profile → entity retrieval → knowledge index → ... → memories → transcripts → summaries). The budget-aware assembler reserves space for the `memories` section so earlier sections cannot fully exhaust the budget. However, the reservation is minimal (heading-sized). If the total budget is too small, earlier sections still crowd out memory content.
+**How it works (v9.0.66+):** Remnic assembles recall context in pipeline section order (shared-context → profile → entity retrieval → knowledge index → ... → memories → transcripts → summaries). The budget-aware assembler reserves space for the `memories` section so earlier sections cannot fully exhaust the budget. However, the reservation is minimal (heading-sized). If the total budget is too small, earlier sections still crowd out memory content.
 
 **Common pitfall:** The default budget is `maxMemoryTokens * 4` = **8,000 chars**. A typical profile is 4,000–8,000 chars and shared context adds another 4,000–6,000 chars. With these defaults, the `memories` section is still included (it is a protected section), but may be truncated to heading-only (~24 chars) with no actual memory content. The `lastRecall` state file will show successful memory retrieval (non-empty `memoryIds`) but the agent sees only the section heading because the content was truncated during context assembly.
 
@@ -361,7 +361,7 @@ Direct `includeFiles` sync plus the OpenClaw workspace adapter both persist incr
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `lifecyclePolicyEnabled` | `false` | Enable lifecycle scoring + transitions + retrieval weighting. |
+| `lifecyclePolicyEnabled` | `true` | Enable lifecycle scoring + transitions + retrieval weighting. Default-on since issue #686; set `false` to fully disable lifecycle behavior. |
 | `lifecycleFilterStaleEnabled` | `false` | Filter lifecycle `stale`/`archived` candidates from retrieval before final cap (only when policy is enabled). |
 | `lifecyclePromoteHeatThreshold` | `0.55` | Heat threshold for promotion toward `validated`/`active`. |
 | `lifecycleStaleDecayThreshold` | `0.65` | Decay threshold to move a memory to `stale`. |
@@ -484,11 +484,11 @@ The original v8 roadmap listed several operator knobs that are now split across 
 
 ## Gateway Model Source
 
-Route all Engram LLM calls through the OpenClaw gateway's agent model chain instead of Engram's own `openaiApiKey`/`localLlm*` configuration. This lets you define a single fallback chain per agent persona in `openclaw.json` and reuse the gateway's provider credentials.
+Route all Remnic LLM calls through the OpenClaw gateway's agent model chain instead of Remnic's own `openaiApiKey`/`localLlm*` configuration. This lets you define a single fallback chain per agent persona in `openclaw.json` and reuse the gateway's provider credentials.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `modelSource` | `gateway` for new OpenClaw installs; `plugin` otherwise | `gateway` delegates to a gateway agent's model chain; `plugin` uses Engram's own openai/localLlm config |
+| `modelSource` | `gateway` for new OpenClaw installs; `plugin` otherwise | `gateway` delegates to a gateway agent's model chain; `plugin` uses Remnic's own openai/localLlm config |
 | `gatewayAgentId` | `""` | Agent persona ID from `openclaw.json → agents.list[]` for primary LLM calls (extraction, consolidation, summarization). Falls back to `agents.defaults.model` if empty. |
 | `fastGatewayAgentId` | `""` | Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). Uses `gatewayAgentId` chain when empty. |
 | `taskModelChain` | _(unset)_ | Optional inline `{ "primary", "fallbacks": [] }` model chain for Remnic's background tasks (extraction, extraction judge, fact/profile/identity consolidation, summarization, semantic consolidation, calibration, causal consolidation). Resolves through gateway providers. When set, it overrides `gatewayAgentId`/`agents.defaults.model` for these tasks only. **Requires `modelSource: "gateway"`** — ignored (with a startup warning) in `plugin` mode. |
@@ -496,7 +496,7 @@ Route all Engram LLM calls through the OpenClaw gateway's agent model chain inst
 When `modelSource` is `gateway`:
 
 - `localLlmEnabled` and the direct OpenAI client are bypassed for primary LLM dispatch — all LLM calls flow through `FallbackLlmClient` with the configured agent chain
-- Extraction and consolidation start on the configured gateway chain directly; the historical "falling back to gateway" wording only applies when Engram is still in `plugin` mode
+- Extraction and consolidation start on the configured gateway chain directly; the historical "falling back to gateway" wording only applies when Remnic is still in `plugin` mode
 - The existing `openaiApiKey`, `model`, and `localLlm*` settings are ignored for LLM dispatch but retained as config for backward compatibility; `OPENAI_API_KEY` is not inherited in gateway mode
 - `localLlmFast*` settings are also bypassed when `fastGatewayAgentId` is set
 - **Reranking** uses the `fastGatewayAgentId` chain (or `gatewayAgentId` if fast is unset) instead of the local LLM — this can dramatically reduce rerank latency when the fast chain points at a cloud provider
@@ -527,7 +527,7 @@ Notes:
 
 ### Setup
 
-1. **Define providers** in `agents/main/agent/models.json` with the endpoints and credentials you want Engram to use (e.g., `fireworks`, `zai`, `anthropic`, `lmstudio`).
+1. **Define providers** in `agents/main/agent/models.json` with the endpoints and credentials you want Remnic to use (e.g., `fireworks`, `zai`, `anthropic`, `lmstudio`).
 
 2. **Create agent personas** in `openclaw.json → agents.list[]`:
 
@@ -535,7 +535,7 @@ Notes:
 {
   "id": "engram-llm",
   "default": false,
-  "name": "Engram LLM Chain",
+  "name": "Remnic LLM Chain",
   "model": {
     "primary": "fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
     "fallbacks": [
@@ -548,7 +548,7 @@ Notes:
 {
   "id": "engram-llm-fast",
   "default": false,
-  "name": "Engram Fast LLM Chain",
+  "name": "Remnic Fast LLM Chain",
   "model": {
     "primary": "fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
     "fallbacks": [
@@ -562,13 +562,13 @@ Notes:
 
 Model strings use the format `provider/model-id` where `provider` matches a key in the `providers` object of your agent's `models.json`. Built-in OpenClaw providers (e.g., `openai-codex`, `google-vertex`, `github-copilot`) work automatically — they don't need explicit entries in `models.json` since the gateway materializes them from its plugin catalogs.
 
-3. **Configure Engram** in `openclaw.json → plugins.entries.openclaw-engram.config`:
+3. **Configure Remnic** in `openclaw.json → plugins.entries.openclaw-remnic.config`:
 
 ```jsonc
 {
   "modelSource": "gateway",
-  "gatewayAgentId": "engram-llm",
-  "fastGatewayAgentId": "engram-llm-fast"
+  "gatewayAgentId": "remnic-llm",
+  "fastGatewayAgentId": "remnic-llm-fast"
 }
 ```
 
@@ -578,25 +578,25 @@ Model strings use the format `provider/model-id` where `provider` matches a key 
 
 When a primary model call fails (timeout, HTTP error, empty response), `FallbackLlmClient` tries each fallback in order. The chain stops at the first successful response.
 
-Provider lookup checks the explicit `models.providers` config first, then falls back to the gateway's materialized `models.json` (`~/.openclaw/agents/main/agent/models.json`), which contains all providers including built-in ones registered by gateway plugins (e.g., `openai-codex` with OAuth, `google-vertex`, `github-copilot`). This means any provider the gateway knows about — including OAuth-based providers — can be used in Engram's model chain without additional configuration.
+Provider lookup checks the explicit `models.providers` config first, then falls back to the gateway's materialized `models.json` (`~/.openclaw/agents/main/agent/models.json`), which contains all providers including built-in ones registered by gateway plugins (e.g., `openai-codex` with OAuth, `google-vertex`, `github-copilot`). This means any provider the gateway knows about — including OAuth-based providers — can be used in Remnic's model chain without additional configuration.
 
 ### API key resolution
 
-Provider auth is resolved using OpenClaw's native runtime. Engram first tries the gateway's `getRuntimeAuthForModel()` function, which handles all provider-specific transforms — OAuth token exchange (for `openai-codex`, `github-copilot`, etc.), base URL overrides, profile-based credentials, and secret reference formats — using the same codepath the gateway uses for its own agent sessions.
+Provider auth is resolved using OpenClaw's native runtime. Remnic first tries the gateway's `getRuntimeAuthForModel()` function, which handles all provider-specific transforms — OAuth token exchange (for `openai-codex`, `github-copilot`, etc.), base URL overrides, profile-based credentials, and secret reference formats — using the same codepath the gateway uses for its own agent sessions.
 
-If the gateway runtime isn't available (e.g., running outside the gateway process), Engram falls back to `resolveProviderApiKey()` for secret ref resolution, then checks the `PROVIDER_NAME_API_KEY` environment variable before skipping the provider.
+If the gateway runtime isn't available (e.g., running outside the gateway process), Remnic falls back to `resolveProviderApiKey()` for secret ref resolution, then checks the `PROVIDER_NAME_API_KEY` environment variable before skipping the provider.
 
-This means your existing auth setup works automatically — OAuth providers, API keys, 1Password, Vault, env vars, and plain-text keys all work without special Engram configuration.
+This means your existing auth setup works automatically — OAuth providers, API keys, 1Password, Vault, env vars, and plain-text keys all work without special Remnic configuration.
 
 ### Switching back
 
-Set `modelSource` to `plugin` (or remove it) to restore the original behavior where Engram uses its own `localLlm*` and `openaiApiKey` settings.
+Set `modelSource` to `plugin` (or remove it) to restore the original behavior where Remnic uses its own `localLlm*` and `openaiApiKey` settings.
 
 ## Local LLM / OpenAI-Compatible Endpoint
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `localLlmEnabled` | `false` | Enable Engram's local/compatible endpoint when `modelSource` remains `plugin` |
+| `localLlmEnabled` | `false` | Enable Remnic's local/compatible endpoint when `modelSource` remains `plugin` |
 | `localLlmUrl` | `http://localhost:1234/v1` | Base URL for endpoint |
 | `localLlmModel` | `local-model` | Model ID |
 | `localLlmApiKey` | `(unset)` | Optional API key |
@@ -652,7 +652,7 @@ Session integrity diagnostics/repair are CLI-driven and intentionally config-lig
 
 Safety contract:
 - Repair defaults to dry-run.
-- `--apply` only mutates Engram-managed transcript/checkpoint artifacts.
+- `--apply` only mutates Remnic-managed transcript/checkpoint artifacts.
 - OpenClaw session-file mutation requires explicit `--allow-session-file-repair` plus an explicit path and still does not perform automatic pointer rewiring.
 
 ### v8.8 Live Graph Dashboard
@@ -735,13 +735,13 @@ See [advanced-retrieval.md](advanced-retrieval.md) for guidance.
 FAISS notes:
 - `conversation_index_update` still writes chunk markdown under `memoryDir/conversation-index/chunks/...`; the FAISS backend additionally upserts those chunks into the local sidecar index.
 - The sidecar health check reports `degraded` when Python dependencies or local artifacts are missing. Recall stays fail-open and skips semantic transcript injection instead of breaking hook execution.
-- Sentence-transformers embeddings are opt-in via `ENGRAM_FAISS_ENABLE_ST=1`. Without that env var, the sidecar uses deterministic hash embeddings for low-friction local setups.
+- Sentence-transformers embeddings are opt-in via `REMNIC_FAISS_ENABLE_ST=1` (legacy `ENGRAM_FAISS_ENABLE_ST=1` still works). Without that env var, the sidecar uses deterministic hash embeddings for low-friction local setups.
 
 ## v9.1 Evaluation Harness Foundation
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `evalHarnessEnabled` | `false` | Enable Engram's benchmark/evaluation harness bookkeeping |
+| `evalHarnessEnabled` | `false` | Enable Remnic's benchmark/evaluation harness bookkeeping |
 | `evalShadowModeEnabled` | `false` | Record live recall decisions to the eval store without changing injected output |
 | `benchmarkBaselineSnapshotsEnabled` | `false` | Enable versioned baseline snapshot artifacts for the latest completed benchmark runs |
 | `benchmarkDeltaReporterEnabled` | `false` | Enable named-baseline delta reports against the current eval store |
@@ -780,7 +780,7 @@ FAISS notes:
 
 Current foundation slice:
 - `openclaw engram benchmark-status` scans `benchmarks/**.json` and `runs/**.json`, validates manifests/run summaries, and reports the latest completed run.
-- When `benchmarkBaselineSnapshotsEnabled` is on, Engram also tracks typed `baselines/*.json` artifacts under the eval store and surfaces the latest stored baseline snapshot in `openclaw engram benchmark-status`.
+- When `benchmarkBaselineSnapshotsEnabled` is on, Remnic also tracks typed `baselines/*.json` artifacts under the eval store and surfaces the latest stored baseline snapshot in `openclaw engram benchmark-status`.
 - When both eval flags are on, live recall also writes `shadow/YYYY-MM-DD/<trace-id>.json` records with hashes, counts, chosen source, and recalled memory IDs.
 - `openclaw engram benchmark-validate <path>` validates a manifest JSON file or a pack directory with a root `manifest.json`.
 - `openclaw engram benchmark-import <path> [--force]` validates first, then imports into `benchmarks/<benchmarkId>/`.
@@ -788,31 +788,31 @@ Current foundation slice:
 - `openclaw engram benchmark-baseline-report --snapshot-id <id>` compares the current eval store against a named stored baseline snapshot, emits both JSON and markdown summaries, and fails when pass rate, shared metrics, coverage, or eval artifact validity regress relative to that snapshot.
 - The required GitHub `eval-benchmark-gate` workflow uses the committed fixture baseline snapshot at `tests/fixtures/eval-ci/store/baselines/required-main.json` as its stable PR-gating reference.
 - `openclaw engram benchmark-ci-gate --base <dir> --candidate <dir>` compares two eval-store roots and fails when pass rate, shared metrics, or benchmark coverage regress.
-- When `objectiveStateRecallEnabled` is on, Engram can inject a separate `## Objective State` recall section sourced from the objective-state store.
-- When `causalTrajectoryMemoryEnabled` is on, Engram can persist typed causal chains into a separate store for later graph/retrieval slices.
-- When `causalTrajectoryRecallEnabled` is on, Engram can inject a separate `## Causal Trajectories` recall section sourced from the causal-trajectory store.
+- When `objectiveStateRecallEnabled` is on, Remnic can inject a separate `## Objective State` recall section sourced from the objective-state store.
+- When `causalTrajectoryMemoryEnabled` is on, Remnic can persist typed causal chains into a separate store for later graph/retrieval slices.
+- When `causalTrajectoryRecallEnabled` is on, Remnic can inject a separate `## Causal Trajectories` recall section sourced from the causal-trajectory store.
 - When `actionGraphRecallEnabled` is also on, each newly recorded causal trajectory emits deterministic `goal -> action -> observation -> outcome -> follow_up` edges into the causal graph without changing retrieval behavior yet.
-- When `trustZonesEnabled` is on, Engram can persist provenance-bearing records into separate `quarantine`, `working`, and `trusted` storage tiers.
-- When `quarantinePromotionEnabled` is also on, Engram exposes an explicit promotion path that blocks direct `quarantine -> trusted` jumps and requires anchored provenance before promoting risky working records into `trusted`.
-- When `trustZoneRecallEnabled` is also on, Engram injects a separate `## Trust Zones` recall section sourced from `working` and `trusted` trust-zone records while keeping `quarantine` records out of recall by default.
+- When `trustZonesEnabled` is on, Remnic can persist provenance-bearing records into separate `quarantine`, `working`, and `trusted` storage tiers.
+- When `quarantinePromotionEnabled` is also on, Remnic exposes an explicit promotion path that blocks direct `quarantine -> trusted` jumps and requires anchored provenance before promoting risky working records into `trusted`.
+- When `trustZoneRecallEnabled` is also on, Remnic injects a separate `## Trust Zones` recall section sourced from `working` and `trusted` trust-zone records while keeping `quarantine` records out of recall by default.
 - When `memoryPoisoningDefenseEnabled` is also on, `openclaw engram trust-zone-status` reports deterministic provenance trust scores derived from source class plus `sourceId` / `evidenceHash` / `sessionKey` anchors so later poisoning defenses can build on explicit signals instead of hidden heuristics.
 - With both `memoryPoisoningDefenseEnabled` and `quarantinePromotionEnabled` enabled, risky `working -> trusted` promotions now require at least one independent non-`quarantine` corroborating record with anchored provenance and overlapping `entityRefs` or `tags`.
 - When `memoryRedTeamBenchEnabled` is on, benchmark manifests can also declare `benchmarkType: "memory-red-team"` plus `attackClass` and `targetSurface`, and `openclaw engram benchmark-status` reports red-team pack counts and unique attack metadata.
-- When `harmonicRetrievalEnabled` is on, Engram can persist typed abstraction nodes into a separate abstraction-node store for later harmonic retrieval slices.
-- When `abstractionAnchorsEnabled` is also on, Engram can persist cue-anchor index entries under `{abstractionNodeStoreDir}/anchors` for entities, files, tools, outcomes, constraints, and dates.
-- When the harmonic retrieval section is enabled in the recall pipeline, Engram can inject a dedicated `## Harmonic Retrieval` section that explains which abstraction nodes matched and which cue anchors contributed.
+- When `harmonicRetrievalEnabled` is on, Remnic can persist typed abstraction nodes into a separate abstraction-node store for later harmonic retrieval slices.
+- When `abstractionAnchorsEnabled` is also on, Remnic can persist cue-anchor index entries under `{abstractionNodeStoreDir}/anchors` for entities, files, tools, outcomes, constraints, and dates.
+- When the harmonic retrieval section is enabled in the recall pipeline, Remnic can inject a dedicated `## Harmonic Retrieval` section that explains which abstraction nodes matched and which cue anchors contributed.
 - Use `openclaw engram abstraction-node-status` to inspect node storage, `openclaw engram cue-anchor-status` to inspect anchor counts and invalid index records, and `openclaw engram harmonic-search <query>` to preview blended harmonic retrieval matches.
-- When `verifiedRecallEnabled` is on, Engram can inject a separate `## Verified Episodes` recall section sourced from recent memory boxes, but only when each surfaced box still cites at least one non-archived source memory whose `memoryKind` remains `episode`.
+- When `verifiedRecallEnabled` is on, Remnic can inject a separate `## Verified Episodes` recall section sourced from recent memory boxes, but only when each surfaced box still cites at least one non-archived source memory whose `memoryKind` remains `episode`.
 - Use `openclaw engram verified-recall-search <query>` to preview verified episodic recall matches, including verified memory counts, matched fields, and cited episodic memory IDs.
 - When `semanticRulePromotionEnabled` is on, `openclaw engram semantic-rule-promote --memory-id <id>` can promote an explicit `IF ... THEN ...` rule from a non-archived episodic memory into a durable `rule` memory with lineage, `sourceMemoryId`, and duplicate suppression.
-- When `semanticRuleVerificationEnabled` is on, Engram can inject a separate `## Verified Rules` recall section sourced from promoted `rule` memories, but only when each surfaced rule still clears a provenance-aware effective-confidence threshold after re-checking its `sourceMemoryId`.
-- When both `creationMemoryEnabled` and `commitmentLedgerEnabled` are on, Engram can persist explicit commitment ledger entries and expose them through `openclaw engram commitment-status` and `openclaw engram commitment-record`.
-- When `commitmentLifecycleEnabled` is also on, Engram can transition commitment states with `openclaw engram commitment-set-state`, report overdue/stale/decay-eligible counts in `openclaw engram commitment-status`, and apply overdue-expiry plus resolved-entry cleanup through `openclaw engram commitment-lifecycle-run`.
-- When both `creationMemoryEnabled` and `resumeBundlesEnabled` are on, Engram can persist explicit typed resume bundles, inspect them with `openclaw engram resume-bundle-status`, write manual shells with `openclaw engram resume-bundle-record`, and assemble bounded bundles from transcript recovery plus recent objective state, work products, and open commitments with `openclaw engram resume-bundle-build`.
-- When `creationMemoryEnabled` is on, Engram can persist explicit work-product ledger entries and expose them through `openclaw engram work-product-status` and `openclaw engram work-product-record`.
-- When both `creationMemoryEnabled` and `workProductRecallEnabled` are on, Engram can inject a separate `## Work Products` recall section sourced from the typed work-product ledger and expose `openclaw engram work-product-recall-search <query>` for reuse previews.
-- When `memoryUtilityLearningEnabled` is on, Engram can persist typed downstream utility telemetry for promotion and ranking decisions, inspect the resulting event ledger with `openclaw engram utility-status`, record explicit benchmark/operator utility observations through `openclaw engram utility-record`, and learn bounded offline promotion/ranking weights through `openclaw engram utility-learn` with the persisted learner snapshot visible in `openclaw engram utility-learning-status`.
-- When `promotionByOutcomeEnabled` is also on and a learner snapshot exists, Engram applies bounded learned utility multipliers to ranking heuristic deltas and bounded promotion/demotion threshold nudges to tier migration without re-reading raw utility telemetry on the hot path.
+- When `semanticRuleVerificationEnabled` is on, Remnic can inject a separate `## Verified Rules` recall section sourced from promoted `rule` memories, but only when each surfaced rule still clears a provenance-aware effective-confidence threshold after re-checking its `sourceMemoryId`.
+- When both `creationMemoryEnabled` and `commitmentLedgerEnabled` are on, Remnic can persist explicit commitment ledger entries and expose them through `openclaw engram commitment-status` and `openclaw engram commitment-record`.
+- When `commitmentLifecycleEnabled` is also on, Remnic can transition commitment states with `openclaw engram commitment-set-state`, report overdue/stale/decay-eligible counts in `openclaw engram commitment-status`, and apply overdue-expiry plus resolved-entry cleanup through `openclaw engram commitment-lifecycle-run`.
+- When both `creationMemoryEnabled` and `resumeBundlesEnabled` are on, Remnic can persist explicit typed resume bundles, inspect them with `openclaw engram resume-bundle-status`, write manual shells with `openclaw engram resume-bundle-record`, and assemble bounded bundles from transcript recovery plus recent objective state, work products, and open commitments with `openclaw engram resume-bundle-build`.
+- When `creationMemoryEnabled` is on, Remnic can persist explicit work-product ledger entries and expose them through `openclaw engram work-product-status` and `openclaw engram work-product-record`.
+- When both `creationMemoryEnabled` and `workProductRecallEnabled` are on, Remnic can inject a separate `## Work Products` recall section sourced from the typed work-product ledger and expose `openclaw engram work-product-recall-search <query>` for reuse previews.
+- When `memoryUtilityLearningEnabled` is on, Remnic can persist typed downstream utility telemetry for promotion and ranking decisions, inspect the resulting event ledger with `openclaw engram utility-status`, record explicit benchmark/operator utility observations through `openclaw engram utility-record`, and learn bounded offline promotion/ranking weights through `openclaw engram utility-learn` with the persisted learner snapshot visible in `openclaw engram utility-learning-status`.
+- When `promotionByOutcomeEnabled` is also on and a learner snapshot exists, Remnic applies bounded learned utility multipliers to ranking heuristic deltas and bounded promotion/demotion threshold nudges to tier migration without re-reading raw utility telemetry on the hot path.
 - Use `openclaw engram semantic-rule-verify <query>` to preview verified semantic-rule matches, including verification status, effective confidence, and the cited source memory id.
 - Future slices will add automated benchmark runners on top of this store and gate format.
 
@@ -988,7 +988,7 @@ of truth for similarity logic across read-time and write-time code paths.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `emitLegacyTools` | `true` | Advertise legacy `engram_*`/`engram.*` MCP tool aliases alongside canonical `remnic_*` names. Set `false` to halve the advertised `tools/list` surface (only `remnic_*`); tools stay callable under both names. Also settable via `REMNIC_EMIT_LEGACY_TOOLS`. (issue #1427) |
+| `emitLegacyTools` | conditional (see below) | Advertise legacy `engram_*`/`engram.*` MCP tool aliases alongside canonical `remnic_*` names. On a fresh install the schema default is `false`, so only `remnic_*` is advertised; the value is sticky-`true` when legacy connector entries already exist on disk (so upgrades keep working). Set explicitly to override, or use `REMNIC_EMIT_LEGACY_TOOLS`. Tools stay callable under both names regardless. (issue #1427) |
 | `citationsEnabled` | `false` | Emit oai-mem-citation blocks in recall responses |
 | `citationsAutoDetect` | `true` | Auto-detect Codex citation context |
 
@@ -1529,7 +1529,7 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `factArchivalMaxImportance` | `0.3` | `0.3` |
 | `factArchivalMaxAccessCount` | `2` | `2` |
 | `factArchivalProtectedCategories` | `["commitment","preference","decision","principle","procedure"]` | `["commitment","preference","decision","principle","procedure"]` |
-| `lifecyclePolicyEnabled` | `false` | `false` until you are ready to measure lifecycle outcomes |
+| `lifecyclePolicyEnabled` | `true` | `true` (default-on since issue #686; set `false` to disable lifecycle scoring entirely) |
 | `lifecycleFilterStaleEnabled` | `false` | `false` for the initial lifecycle rollout |
 | `lifecyclePromoteHeatThreshold` | `0.55` | `0.55` |
 | `lifecycleStaleDecayThreshold` | `0.65` | `0.65` |
@@ -1632,7 +1632,7 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `versioningEnabled` | `false` | `false` |
 | `versioningMaxPerPage` | `50` | `50` |
 | `versioningSidecarDir` | `".versions"` | `".versions"` |
-| `emitLegacyTools` | `true` | `true` |
+| `emitLegacyTools` | `false` (fresh install; sticky-`true` when legacy entries exist) | `false` for `remnic_*`-only clients; leave sticky-`true` on upgraded installs |
 | `citationsEnabled` | `false` | `false` |
 | `citationsAutoDetect` | `true` | `true` |
 | `taxonomyEnabled` | `false` | `false` |

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -1,46 +1,108 @@
-# Connectors CLI Reference
+# Connectors
 
-`remnic connectors` is the operator surface for inspecting and manually
-controlling the [live connectors](./live-connectors.md) that continuously ingest
-content from external services (Google Drive, Notion, Gmail, GitHub, …) into your memory
-directory.
+Remnic has two distinct connector families, both driven by the `remnic
+connectors` command group. They do opposite things — read the table before
+reaching for a subcommand.
 
-This page documents configuration keys, environment variables, OAuth setup
-notes per connector, the full CLI reference, and troubleshooting.  For the
-framework contract (how to write a connector) see
+- **Live connectors** continuously ingest content *from* an external service
+  (Google Drive, Notion, Gmail, GitHub) into your memory directory on a poll
+  schedule. This is inbound content ingestion.
+- **Agent-tool connectors** publish a Remnic memory extension *into* an AI
+  coding tool (Claude Code, Codex CLI, Cursor, and 11 more) so that tool shares
+  your memory store. This is outbound tool wiring, not ingestion.
+
+For the live-connector framework contract (how to write one) see
 [live-connectors.md](./live-connectors.md).
 
 ---
 
-## Quick reference
+## Command families at a glance
 
-```bash
-# List all configured connectors (human-readable table)
-remnic connectors list
+| Command | Family | What it does |
+|---|---|---|
+| `remnic connectors list` | Agent-tool | List the 14 marketplace agent-tool connectors and their install state |
+| `remnic connectors install <id>` | Agent-tool | Install a connector and publish its memory extension |
+| `remnic connectors remove <id>` | Agent-tool | Remove a connector and unpublish its extension |
+| `remnic connectors doctor <id>` | Agent-tool | Health-check one connector and its publisher |
+| `remnic connectors marketplace <sub>` | Agent-tool | Browse / install third-party connectors from a marketplace source |
+| `remnic connectors status` | Live | Live-connector poll status (Google Drive + Notion), JSON by default |
+| `remnic connectors run <name>` | Live | Manually trigger one incremental sync (Google Drive + Notion) |
 
-# Machine-readable JSON status (useful in scripts / CI)
-remnic connectors status
-
-# Manually run one incremental sync (operator debug)
-remnic connectors run google-drive
-remnic connectors run notion
-```
+The standalone `remnic` binary wires the live-connector debug path for **Google
+Drive and Notion only**. Gmail and GitHub are live connectors too, but they run
+under the hosted maintenance scheduler; inspect all four with the hosted
+surface `openclaw engram connectors list` / `status` / `run`.
 
 ---
 
-## Subcommand: `remnic connectors list`
+## Agent-tool connectors
 
-Lists every configured live connector with its enabled state, last poll time,
-cumulative docs imported, and last error (if any).
+`remnic connectors list` shows the built-in marketplace of agent-tool
+connectors. Each publishes a Remnic memory extension (skill, MCP wiring, or
+plugin) into the target tool so it shares your memory store.
 
 ```
-Usage: remnic connectors list [options]
+Available connectors:
+  ✓ claude-code            Claude Code v9.6.22 — Anthropic's Claude Code CLI — direct memory access via MCP
+  ○ codex-cli              Codex CLI v9.6.22 — OpenAI Codex CLI — memory via MCP tool
+  ○ cursor                 Cursor IDE v9.6.22 — Cursor IDE — memory via config file + tool calls
+  ...
+```
+
+`✓` marks an installed connector, `○` an available one. The 14 built-ins are
+`claude-code`, `codex-cli`, `cursor`, `cline`, `github-copilot`, `roo-code`,
+`windsurf`, `amp`, `pi`, `omp`, `replit`, `generic-mcp`, `weclone`, and
+`hermes`. Add `--json` for machine-readable `{ installed, available }`.
+
+### Install, remove, doctor
+
+```bash
+remnic connectors install claude-code            # publish the memory extension
+remnic connectors install cursor --config key=value
+remnic connectors remove cursor                  # unpublish + remove
+remnic connectors doctor codex-cli               # health-check connector + publisher
+```
+
+`install` writes the connector config, then (unless `installExtension=false`)
+publishes the memory extension into the tool when that tool is present on the
+host. `doctor` reports both the connector's own checks and the publisher's
+extension status.
+
+### Marketplace
+
+```bash
+remnic connectors marketplace list               # browse marketplace sources
+remnic connectors marketplace install <source>   # install from a source
+```
+
+`marketplace` takes `--config <path>` for a config *file* (not `key=value`
+pairs) when installing.
+
+---
+
+## Live connectors
+
+Live connectors poll an external service and import changed documents into your
+memory directory. The maintenance scheduler runs them automatically once
+configured: the `engram-live-connectors-sync` cron calls the
+`engram.live_connectors_run` MCP tool every minute and honors each connector's
+`pollIntervalMs`. The subcommands below are the operator/debug surface.
+
+### `remnic connectors status`
+
+Live-connector poll status. Defaults to **JSON** so scripts can `jq` it without
+passing `--format json` every time. The standalone binary reports **Google
+Drive and Notion**; use the hosted `openclaw engram connectors list` to see
+Gmail and GitHub as well.
+
+```
+Usage: remnic connectors status [options]
 
 Options:
-  --format <fmt>   Output format: text (default), markdown, or json
+  --format <fmt>   Output format: json (default), text, or markdown
 ```
 
-**Example — text output (default):**
+**Example — `--format text`:**
 
 ```
 Live connectors (2):
@@ -57,7 +119,7 @@ Live connectors (2):
     last_error:    invalid_token: The token you provided is invalid.
 ```
 
-**Example — `--format json`:**
+**Example — JSON (default):**
 
 ```json
 [
@@ -74,29 +136,12 @@ Live connectors (2):
 ]
 ```
 
----
+### `remnic connectors run <name>`
 
-## Subcommand: `remnic connectors status`
+Manually triggers one incremental `syncIncremental()` pass for the named live
+connector. Useful when:
 
-Identical data to `list` but defaults to **JSON output** so shell scripts can
-reliably `jq`-parse the result without requiring `--format json` every time.
-
-```
-Usage: remnic connectors status [options]
-
-Options:
-  --format <fmt>   Output format: json (default), text, or markdown
-```
-
----
-
-## Subcommand: `remnic connectors run <name>`
-
-Manually triggers one incremental `syncIncremental()` pass for the named
-connector.  Useful when:
-
-- You want to verify credentials work without waiting for the next scheduler
-  tick.
+- You want to verify credentials without waiting for the next scheduler tick.
 - A sync failed and you want to retry immediately.
 - You are debugging cursor advancement.
 
@@ -104,22 +149,15 @@ connector.  Useful when:
 Usage: remnic connectors run <name> [options]
 
 Arguments:
-  name             Connector id (e.g. google-drive, notion)
+  name             Live connector id: google-drive or notion
 
 Options:
   --format <fmt>   Output format: text (default), markdown, or json
 ```
 
-On success, exits `0` and prints the number of new documents imported.  On
+On success, exits `0` and prints the number of new documents imported. On
 failure, exits `1`, writes the error to stderr, and records the failure in the
-connector's state file so `connectors list` reflects it.
-
-The maintenance scheduler calls the MCP tool `engram.live_connectors_run` every
-minute once connectors are configured through the `engram-live-connectors-sync`
-cron. That runner honors each connector's `pollIntervalMs` and covers every
-enabled built-in connector.
-`remnic connectors run <name>` currently supports Google Drive and Notion as the
-single-connector debug path.
+connector's state file so `connectors status` reflects it.
 
 **Example — success:**
 
@@ -287,6 +325,18 @@ The database ID is the 32-character hex string between the last `/` and `?`.
 
 ---
 
+## Connectors: Gmail and GitHub
+
+Gmail and GitHub run on the same live-connector framework as Google Drive and
+Notion, but the standalone `remnic connectors status` / `run` debug path covers
+Drive and Notion only. Manage and inspect Gmail and GitHub through the hosted
+maintenance scheduler and the `openclaw engram connectors list` / `status` /
+`run` surface. Their config lives under `connectors.gmail` and
+`connectors.github`; see [live-connectors.md](./live-connectors.md) for keys
+and OAuth setup.
+
+---
+
 ## State files
 
 Per-connector state (cursor + sync metadata) lives at:
@@ -307,7 +357,7 @@ atomic (temp + rename) but a manual edit during an active sync could race.
 
 ## Troubleshooting
 
-### `connectors list` shows all connectors as disabled
+### `connectors status` shows a live connector as disabled
 
 Connectors are opt-in.  Set `connectors.<name>.enabled: true` in your config
 and ensure credentials are populated.

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -57,16 +57,19 @@ Available connectors:
 ### Install, remove, doctor
 
 ```bash
-remnic connectors install claude-code            # publish the memory extension
+remnic connectors install codex-cli              # token + config + memory extension
 remnic connectors install cursor --config key=value
 remnic connectors remove cursor                  # unpublish + remove
 remnic connectors doctor codex-cli               # health-check connector + publisher
 ```
 
-`install` writes the connector config, then (unless `installExtension=false`)
-publishes the memory extension into the tool when that tool is present on the
-host. `doctor` reports both the connector's own checks and the publisher's
-extension status.
+`install` mints the host token and writes the connector config, then (unless
+`installExtension=false`) publishes the memory extension into the tool when that
+tool is present on the host *and has a real publisher* — Codex CLI does, while
+the Claude Code and Hermes publishers are intentional no-op stubs: their host
+wiring is manual, per [docs/plugins/claude-code.md](plugins/claude-code.md) and
+[docs/plugins/hermes.md](plugins/hermes.md). `doctor` reports both the
+connector's own checks and the publisher's extension status.
 
 ### Marketplace
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -24,7 +24,7 @@ For the live-connector framework contract (how to write one) see
 | `remnic connectors install <id>` | Agent-tool | Install a connector and publish its memory extension |
 | `remnic connectors remove <id>` | Agent-tool | Remove a connector and unpublish its extension |
 | `remnic connectors doctor <id>` | Agent-tool | Health-check one connector and its publisher |
-| `remnic connectors marketplace <sub>` | Agent-tool | Browse / install third-party connectors from a marketplace source |
+| `remnic connectors marketplace <generate\|validate\|install>` | Agent-tool | Generate, validate, or install marketplace manifests |
 | `remnic connectors status` | Live | Live-connector poll status (Google Drive + Notion), JSON by default |
 | `remnic connectors run <name>` | Live | Manually trigger one incremental sync (Google Drive + Notion) |
 
@@ -74,12 +74,13 @@ connector's own checks and the publisher's extension status.
 ### Marketplace
 
 ```bash
-remnic connectors marketplace list               # browse marketplace sources
-remnic connectors marketplace install <source>   # install from a source
+remnic connectors marketplace generate            # generate marketplace.json
+remnic connectors marketplace validate [path]     # validate a marketplace.json file
+remnic connectors marketplace install <source>    # install from a source
 ```
 
-`marketplace` takes `--config <path>` for a config *file* (not `key=value`
-pairs) when installing.
+`marketplace install` takes `--config <path>` for a config *file* (not
+`key=value` pairs).
 
 ---
 

--- a/docs/console.md
+++ b/docs/console.md
@@ -1,38 +1,41 @@
-# Operator Console
+# Operator console (TUI)
 
-The operator console (`remnic console`) is a live engine-introspection
-surface for Remnic. It shows the current state of the engine's
-pipelines — buffer, extraction queue, dedup decisions, maintenance
-ledger tail, QMD probe, and daemon health — as they happen. Distinct
-from [Recall X-ray](xray.md) (which inspects retrieval), the console
-inspects the engine itself.
+The operator console is a live engine-introspection surface for Remnic. It shows
+the current state of the engine's pipelines — buffer, extraction queue, dedup
+decisions, maintenance ledger tail, QMD probe, and daemon health — as they
+happen. It is a **terminal UI**, distinct from the browser-based
+[admin console](./admin-console.md); and distinct from [Recall X-ray](./xray.md)
+(which inspects *retrieval*) — the operator console inspects the *engine itself*.
+
+The console ships on the OpenClaw-hosted CLI as `openclaw engram console`. There
+is no standalone `remnic console` command; standalone deployments read the same
+data over the [HTTP endpoint](#http-api) or the [MCP tool](#mcp-tool).
 
 Tracking issue: [#688](https://github.com/joshuaswarren/remnic/issues/688).
 
 ## Modes
 
-| Mode | Flag | What it does |
-|------|------|--------------|
-| **Live TUI** (default) | `remnic console` | Interactive five-panel terminal UI that polls the engine every 2 seconds. Press `Ctrl-C` to exit. |
-| **One-shot snapshot** | `remnic console --state-only` | Prints a single `ConsoleStateSnapshot` as pretty-printed JSON and exits. Useful for piping into `jq` or external monitoring. |
-| **Record trace** | `remnic console --record-trace <path>` | Runs the live TUI **and** appends every refresh-cycle snapshot to `<path>` as JSONL (one frame per line). |
-| **Replay trace** | `remnic console --trace <path> [--speed N]` | Replays a previously-recorded JSONL trace at the original cadence. `--speed 2` halves the inter-frame delay; `--speed 0.5` doubles it. EOF exits cleanly. |
+| Mode | Invocation | What it does |
+|------|------------|--------------|
+| **Live TUI** (default) | `openclaw engram console` | Interactive five-panel terminal UI that polls the engine every 2 seconds. Press `Ctrl-C` to exit. |
+| **One-shot snapshot** | `openclaw engram console --state-only` | Prints a single `ConsoleStateSnapshot` as pretty-printed JSON and exits. Useful for piping into `jq` or external monitoring. |
+| **Record trace** | `openclaw engram console --record-trace <path>` | Runs the live TUI **and** appends every refresh-cycle snapshot to `<path>` as JSONL (one frame per line). |
+| **Replay trace** | `openclaw engram console --trace <path> [--speed N]` | Replays a previously-recorded JSONL trace at the original cadence. `--speed 2` halves the inter-frame delay; `--speed 0.5` doubles it. EOF exits cleanly. |
 
 ## Trace recording
 
-`--record-trace <path>` opens the file in append mode (parent
-directory is created with `mkdir -p`) and writes one
-`ConsoleStateSnapshot` per line, separated by `\n`. Each line is a
-self-contained JSON object — you can `jq -c` over the file or stream
-it into another tool.
+`--record-trace <path>` opens the file in append mode (parent directory is
+created with `mkdir -p`) and writes one `ConsoleStateSnapshot` per line,
+separated by `\n`. Each line is a self-contained JSON object — you can `jq -c`
+over the file or stream it into another tool.
 
-A trace recorder failure (disk full, permission denied) **never**
-crashes the live TUI. Errors are captured internally and surfaced via
-the recorder's `getLastError()` accessor; the loop keeps painting.
+A trace recorder failure (disk full, permission denied) **never** crashes the
+live TUI. Errors are captured internally and surfaced via the recorder's
+`getLastError()` accessor; the loop keeps painting.
 
 ```bash
 # Record a trace while you reproduce a problem.
-remnic console --record-trace ~/.remnic/traces/2026-04-26.jsonl
+openclaw engram console --record-trace ~/.remnic/traces/2026-04-26.jsonl
 
 # Inspect a few frames manually.
 head -3 ~/.remnic/traces/2026-04-26.jsonl | jq .
@@ -42,74 +45,73 @@ head -3 ~/.remnic/traces/2026-04-26.jsonl | jq .
 
 ## Trace replay
 
-`--trace <path>` reads the JSONL file frame-by-frame and feeds each
-snapshot into the same `renderFrame` function the live TUI uses.
-Replay is fully sandboxed: no orchestrator instance is required, no
-filesystem reads beyond the trace file itself.
+`--trace <path>` reads the JSONL file frame-by-frame and feeds each snapshot into
+the same `renderFrame` function the live TUI uses. Replay is fully sandboxed: no
+orchestrator instance is required, no filesystem reads beyond the trace file
+itself.
 
-The inter-frame delay is computed from the captured `capturedAt`
-timestamps (so a trace originally captured at 2 Hz replays at 2 Hz),
-divided by the `--speed` multiplier:
+The inter-frame delay is computed from the captured `capturedAt` timestamps (so a
+trace originally captured at 2 Hz replays at 2 Hz), divided by the `--speed`
+multiplier:
 
 ```bash
 # Replay at original cadence.
-remnic console --trace trace.jsonl
+openclaw engram console --trace trace.jsonl
 
-# Replay 4× faster.
-remnic console --trace trace.jsonl --speed 4
+# Replay 4x faster.
+openclaw engram console --trace trace.jsonl --speed 4
 
 # Replay slowly enough to step through visually.
-remnic console --trace trace.jsonl --speed 0.25
+openclaw engram console --trace trace.jsonl --speed 0.25
 ```
 
 Edge cases:
 
-- **Malformed lines** (invalid JSON, `null` literal, array literal)
-  are skipped. The replay summary reports `framesSkipped`.
-- **Negative deltas** (timestamps that go backward) are clamped to
-  zero — the next frame paints immediately.
-- **Pathologically long gaps** (hour-long pauses in the captured
-  trace) are capped at 60 seconds so a tester always sees forward
-  progress.
-- **`--speed Infinity`** is permitted and means "no delay" — frames
-  paint back-to-back.
+- **Malformed lines** (invalid JSON, `null` literal, array literal) are skipped.
+  The replay summary reports `framesSkipped`.
+- **Negative deltas** (timestamps that go backward) are clamped to zero — the
+  next frame paints immediately.
+- **Pathologically long gaps** (hour-long pauses in the captured trace) are
+  capped at 60 seconds so a tester always sees forward progress.
+- **`--speed Infinity`** is permitted and means "no delay" — frames paint
+  back-to-back.
 
 ## On-disk trace format
 
-Each line of a trace file is the full JSON-serialized
-`ConsoleStateSnapshot` produced by
-[`gatherConsoleState`](../packages/remnic-core/src/console/state.ts):
+Each line of a trace file is the full JSON-serialized `ConsoleStateSnapshot`
+produced by `gatherConsoleState`
+(`packages/remnic-core/src/console/state.ts`):
 
 ```json
 {
   "capturedAt": "2026-04-26T15:23:01.512Z",
   "bufferState": { "turnsCount": 4, "byteCount": 312 },
-  "extractionQueue": { "depth": 0, "recentVerdicts": [...] },
-  "dedupRecent": [...],
-  "maintenanceLedgerTail": [...],
+  "extractionQueue": { "depth": 0, "recentVerdicts": [] },
+  "dedupRecent": [],
+  "maintenanceLedgerTail": [],
   "qmdProbe": { "available": true, "daemonMode": true, "debug": "..." },
-  "daemon": { "uptimeMs": 9421000, "version": "9.3.205" },
+  "daemon": { "uptimeMs": 9421000, "version": "9.6.22" },
   "errors": []
 }
 ```
 
-The schema is intentionally identical to the `--state-only` and
-`/console/state` HTTP responses, so the same trace file can be
-post-processed with the same tooling.
+The schema is intentionally identical to the `--state-only`, HTTP, and MCP
+responses, so the same trace file can be post-processed with the same tooling.
 
 ## HTTP API
 
-`GET /engram/v1/console/state`
+```
+GET /engram/v1/console/state[?namespace=<ns>]
+```
 
-Returns a single `ConsoleStateSnapshot` as JSON. Same schema as
-`--state-only` and the MCP tool below. Requires a valid bearer token.
+Returns a single `ConsoleStateSnapshot` as JSON. Same schema as `--state-only`
+and the MCP tool below. Requires a valid bearer token. The standalone server
+binds `127.0.0.1:4318` by default.
 
 ```bash
 curl -H "Authorization: Bearer $REMNIC_TOKEN" \
-  http://localhost:4000/engram/v1/console/state | jq .
+  http://127.0.0.1:4318/engram/v1/console/state | jq .
 ```
-
-Query parameters:
 
 | Parameter | Description |
 |-----------|-------------|
@@ -120,24 +122,33 @@ Response shape is identical to the snapshot format shown in
 
 ## MCP tool
 
-`engram.console_state` (also aliased as `remnic.console_state`)
+`remnic.console_state` (canonical) / `engram.console_state` (legacy alias).
 
 ```json
 {
-  "name": "engram.console_state",
+  "name": "remnic.console_state",
   "arguments": {
     "namespace": "optional-namespace"
   }
 }
 ```
 
-Returns the same `ConsoleStateSnapshot` JSON. Useful for operator agents
-that want to query engine health without shelling out to the CLI.
+Returns the same `ConsoleStateSnapshot` JSON. Useful for operator agents that
+want to query engine health without shelling out to the CLI.
+
+## Console vs admin console
+
+| | Operator console (this page) | [Admin console](./admin-console.md) |
+| --- | --- | --- |
+| **Kind** | Terminal UI (TUI) | Browser UI (static HTML/JS shell) |
+| **Focus** | Live engine internals: buffer, extraction queue, dedup, maintenance, QMD probe, daemon | Memory browser, recall debugger, trust zones, review queue, entity/graph explorers |
+| **Launch** | `openclaw engram console` | HTTP access server at `/remnic/ui/` |
+| **Data endpoint** | `GET /engram/v1/console/state` | the full `/engram/v1/*` operator API |
 
 ## Source
 
 | File | Role |
 |------|------|
-| `packages/remnic-core/src/console/state.ts` | Engine-state aggregator (PR 1/3, [#721](https://github.com/joshuaswarren/remnic/pull/721)). |
-| `packages/remnic-core/src/console/tui.ts` | Live TUI render loop (PR 2/3, [#728](https://github.com/joshuaswarren/remnic/pull/728)). |
-| `packages/remnic-core/src/console/trace.ts` | Trace record + replay (PR 3/3). |
+| `packages/remnic-core/src/console/state.ts` | Engine-state aggregator (issue #688 / [#721](https://github.com/joshuaswarren/remnic/pull/721)). |
+| `packages/remnic-core/src/console/tui.ts` | Live TUI render loop ([#728](https://github.com/joshuaswarren/remnic/pull/728)). |
+| `packages/remnic-core/src/console/trace.ts` | Trace record + replay. |

--- a/docs/context-retention.md
+++ b/docs/context-retention.md
@@ -1,8 +1,8 @@
-# Context Retention (v2.4)
+# Context retention
 
-v2.4 hardens long-running systems by making summaries richer and enabling optional "semantic recall" over past transcripts.
+Remnic hardens long-running sessions by making hourly summaries richer and enabling optional semantic recall over past transcripts.
 
-## Extended Hourly Summaries
+## Extended hourly summaries
 
 Config (all default off):
 - `hourlySummariesExtendedEnabled`
@@ -14,16 +14,16 @@ Output:
 - Each hour is stored as a section with structured subsections.
 
 Tool stats:
-- Engram captures tool names during `agent_end` and stores a per-session JSONL under `memoryDir/state/tool-usage/...`.
+- Remnic captures tool names during `agent_end` and stores a per-session JSONL under `memoryDir/state/tool-usage/...`.
 - Extended summaries can aggregate those counts per hour.
 
-## Scheduling Hourly Summaries
+## Scheduling hourly summaries
 
-Engram exposes tool `memory_summarize_hourly`. The recommended scheduling approach is an OpenClaw cron job that runs an **isolated agent turn** and calls the tool.
+Remnic exposes tool `memory_summarize_hourly`. The recommended scheduling approach is an OpenClaw cron job that runs an **isolated agent turn** and calls the tool.
 
-Engram intentionally does not silently modify `~/.openclaw/cron/jobs.json` unless `hourlySummaryCronAutoRegister: true`.
+Remnic intentionally does not silently modify `~/.openclaw/cron/jobs.json` unless `hourlySummaryCronAutoRegister: true`.
 
-## Conversation Semantic Recall (Optional)
+## Conversation semantic recall (optional)
 
 Config (default off):
 - `conversationIndexEnabled`
@@ -40,8 +40,8 @@ Config (default off):
 How it works:
 1. `conversation_index_update` chunks transcript history into markdown docs under:
    - `memoryDir/conversation-index/chunks/<sessionKey>/<YYYY-MM-DD>/*.md`
-2. When `conversationIndexBackend` is `qmd`, Engram updates and searches the configured QMD collection.
-3. When `conversationIndexBackend` is `faiss`, Engram shells out to the bundled Python sidecar and stores local artifacts under:
+2. When `conversationIndexBackend` is `qmd`, Remnic updates and searches the configured QMD collection.
+3. When `conversationIndexBackend` is `faiss`, Remnic shells out to the bundled Python sidecar and stores local artifacts under:
    - `memoryDir/state/conversation-index/faiss/index.faiss`
    - `memoryDir/state/conversation-index/faiss/metadata.jsonl`
    - `memoryDir/state/conversation-index/faiss/manifest.json`

--- a/docs/contradiction-review.md
+++ b/docs/contradiction-review.md
@@ -39,22 +39,26 @@ The contradiction scan closes this gap by:
 
 ## Surfaces
 
-### CLI
+### CLI (hosted)
+
+Contradiction review ships on the OpenClaw-hosted CLI. (Do not confuse it with
+the standalone `remnic review` command, which drives the separate memory
+*suggestion* queue with `list|approve|dismiss|flag`.)
 
 ```bash
 # List unresolved contradictions
-engram review list
-engram review list --filter contradicts --namespace work
+openclaw engram review list
+openclaw engram review list --filter contradicts --namespace work
 
 # Show a specific pair
-engram review show <pairId>
+openclaw engram review show <pairId>
 
 # Resolve a pair
-engram review resolve <pairId> --verb keep-a
-engram review resolve <pairId> --verb both-valid
+openclaw engram review resolve <pairId> --verb keep-a
+openclaw engram review resolve <pairId> --verb both-valid
 
 # Run an on-demand scan
-engram review scan
+openclaw engram review scan
 ```
 
 Valid verbs:
@@ -73,11 +77,11 @@ POST /engram/v1/review/resolve  { pairId, verb }
 POST /engram/v1/contradiction-scan  { namespace? }
 ```
 
-### MCP Tools
+### MCP tools
 
-- `engram.review_list` — List review items
-- `engram.review_resolve` — Resolve a pair
-- `engram.contradiction_scan_run` — Run on-demand scan
+- `remnic.review_list` / `engram.review_list` — List review items
+- `remnic.review_resolve` / `engram.review_resolve` — Resolve a pair
+- `remnic.contradiction_scan_run` / `engram.contradiction_scan_run` — Run an on-demand scan
 
 ## Cron
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -5,8 +5,8 @@
 ### Prerequisites
 
 - Node.js >= 22.12.0
-- pnpm >= 9.0
-- Python 3.11+ (for `plugin-hermes` only)
+- pnpm 10.x (the repo pins `pnpm@10.32.1` via `packageManager`)
+- Python 3.10+ (for `plugin-hermes` only)
 
 ### Setup
 
@@ -22,13 +22,13 @@ pnpm test
 
 ```bash
 # Build one package
-pnpm run build --filter=@remnic/core
+pnpm --filter @remnic/core build
 
 # Test one package
-pnpm test --filter=@remnic/server
+pnpm --filter @remnic/cli test
 
 # Type-check one package
-pnpm run check-types --filter=@remnic/cli
+pnpm --filter @remnic/cli check-types
 ```
 
 ### Running Everything
@@ -99,7 +99,7 @@ import os from "node:os";
 import path from "node:path";
 
 test("description of behavior", async () => {
-  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-test-"));
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-test-"));
   try {
     // test logic using temp directory
     assert.equal(actual, expected);
@@ -125,7 +125,9 @@ npx tsx --test tests/specific.test.ts  # one file
 4. Write documentation first (if adding new features)
 5. Write tests second
 6. Write implementation third
-7. Run `pnpm run preflight:quick`
+7. Run `pnpm run preflight:quick` (lint, type-check, targeted tests, and the
+   `check:docs-parity` gate — every fenced `remnic <cmd>` block in `docs/**.md`,
+   `README.md`, and `packages/*/README.md` must resolve to a real CLI command)
 8. If you touched `orchestrator.ts`, `storage.ts`, `intent.ts`, `memory-cache.ts`,
    `entity-retrieval.ts`, `config.ts`, or any file under `storage/` or `orchestration/`
    in `src/` or `packages/remnic-core/src/`, run `pnpm run test:entity-hardening`
@@ -141,6 +143,7 @@ npx tsx --test tests/specific.test.ts  # one file
 - [ ] Documentation updated (if behavior changed)
 - [ ] No secrets or credentials committed
 - [ ] PR diff <= 400 LOC (or justified)
+- [ ] `remnic` commands in docs pass `pnpm run check:docs-parity`
 - [ ] Review fixes will be batched by subsystem, not pushed as micro-fixes
 
 ## Release Process

--- a/docs/development/plugin-development.md
+++ b/docs/development/plugin-development.md
@@ -6,11 +6,21 @@ How to create a Remnic plugin for a new AI agent platform.
 
 Every Remnic plugin follows the same pattern:
 
-1. **Connect to EMO** — via HTTP API or MCP protocol on `:4318`
+1. **Connect to Remnic** — via the daemon's HTTP API or MCP protocol on `:4318`
 2. **Auto-recall** — inject memory context before the agent processes a prompt
 3. **Auto-observe** — capture conversation turns and file changes for memory extraction
 4. **Explicit tools** — provide the agent with direct recall/store/search capabilities
 5. **Authenticate** — use a per-plugin token from `~/.remnic/tokens.json` with `~/.engram/tokens.json` as a migration fallback
+
+## Architecture boundary
+
+`@remnic/core` never imports a host package. Core owns memory behavior and
+exposes host-agnostic contracts; each plugin depends on core and maps those
+contracts onto its platform's plugin SDK, hooks, and manifest. Keep
+host-specific types, commands, and lifecycle glue in the plugin package. When
+the host already provides a native command surface, tool-registration path, or
+memory lifecycle hook, consume that upstream primitive instead of inventing a
+parallel abstraction in core.
 
 ## Integration Depth Tiers
 
@@ -21,7 +31,7 @@ The platform supports MCP but has no plugin/hook system. The agent must explicit
 ```json
 {
   "mcpServers": {
-    "engram": {
+    "remnic": {
       "url": "http://localhost:4318/mcp",
       "headers": { "Authorization": "Bearer ${REMNIC_AUTH_TOKEN}" }
     }
@@ -38,7 +48,7 @@ The platform has a plugin format AND lifecycle hooks. Hooks enable automatic mem
 - `UserPromptSubmit` → recall memories relevant to the prompt, inject as `additionalContext`
 - `PostToolUse` → observe file changes in background
 
-**Required MCP:** Full 44-tool MCP server for explicit operations.
+**Required MCP:** the full Remnic MCP tool surface (100+ tools) for explicit operations.
 
 ### Tier 3: MemoryProvider (Hermes)
 
@@ -86,7 +96,7 @@ Follow the target platform's plugin documentation. At minimum:
 
 ### Step 4: Add an Installer
 
-Create `src/installer.ts` that `engram connectors install myplatform` calls:
+Create `src/installer.ts` that `remnic connectors install myplatform` calls:
 
 ```typescript
 export async function install(options: { tokenStore: TokenStore; configDir: string }) {
@@ -148,7 +158,7 @@ REMNIC_TOKEN="$(node -e "
 ")"
 
 INPUT="$(cat)"
-# Parse input, call EMO API, return hook response
+# Parse input, call the Remnic API, return hook response
 ```
 
 ## Testing Your Plugin

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -1,97 +1,122 @@
-# Release Process
+# Release process
 
-## Versioning Strategy
+How Remnic versions and publishes its packages. Releases are automated by
+`.github/workflows/release-and-publish.yml` and driven by merged pull-request
+labels, not by a manual version-bump file. There is no Changesets step.
 
-Each package is versioned independently using [Changesets](https://github.com/changesets/changesets).
+## How a release happens
 
-### Adding a Changeset
+Every push to `main` runs the release workflow. It is idempotent: the release
+commit's source SHA is embedded in the git tag, so re-running against the same
+`main` SHA reuses the existing tag instead of cutting a duplicate release.
 
-When your PR changes a package's public API or behavior:
+1. **Quality gates.** The workflow runs `pnpm run check-types`, `pnpm test`,
+   `pnpm run build`, and `node scripts/check-release-artifacts.mjs`. A failure
+   here stops the release before anything is tagged or published.
+2. **Resolve the bump type from the merged PR's labels.** The workflow finds
+   the PR that introduced the head commit and reads its labels:
+   - `major` or `breaking-change` -> **major** bump
+   - `feature` or `enhancement` -> **minor** bump
+   - anything else -> **patch** bump
+3. **Compute the next version.** The next version is derived from the latest
+   `vX.Y.Z` tag plus the resolved bump. If the root `package.json` version is
+   *higher* than that auto-bump, `package.json` wins — this lets a PR set an
+   intentional version (for example jumping to a new minor) and have it stick.
+4. **Set versions across the workspace.** `scripts/set-release-version.mjs`
+   writes the release version into the root and every workspace
+   `package.json`, plus the OpenClaw and Claude Code plugin manifests. Changed
+   workspace packages are bumped relative to the previous release tag by
+   `scripts/bump-changed-packages.mjs`.
+5. **Commit and tag.** The release commit (`chore(release): vX.Y.Z [skip ci]`)
+   is pushed to `main` via a deploy key, and an annotated `vX.Y.Z` tag is
+   created on it. The tag message records `source-main-sha:` for the
+   idempotency check above.
+6. **Generate the publish order.** `scripts/publish-order.mjs` topologically
+   sorts the public workspace packages over their dependencies,
+   optionalDependencies, and required peerDependencies (optional peers are
+   excluded). The order is written to a temp file the publish step reads.
+7. **Publish to npm.** Packages publish in that order with `pnpm publish`
+   (see below). npm 11.x is pinned so provenance / trusted-publishing behavior
+   only changes through review; all publishes carry provenance attestations.
+8. **Rescan ClawHub.** After npm publishing, the workflow triggers a ClawHub
+   package rescan for `@remnic/plugin-openclaw`.
 
-```bash
-pnpm changeset
-```
+### Manual override
 
-This prompts you to select which packages changed and whether the change is a patch, minor, or major bump. It creates a markdown file in `.changeset/` describing the change.
+Trigger the workflow via `workflow_dispatch` with a `version_override` input
+(for example `10.0.0`) to publish an exact version and skip the label-based
+auto-bump. The workflow refuses an override whose tag already exists.
 
-### Version Bumping
+### Bootstrap releases
 
-On merge to `main`, the release workflow:
+When `@remnic/core` is not yet on npm (a brand-new package name), the workflow
+treats the root `package.json` version as authoritative instead of inheriting
+the previous tag line. This prevents a first public publish from starting at
+the wrong version.
 
-1. Collects all changesets since last release
-2. Bumps versions in each affected `package.json`
-3. Updates `CHANGELOG.md` per package
-4. Creates a "Version Packages" PR
-5. Merging that PR triggers publishing
+## Why pnpm, and the E404 carve-out
 
-## Publishing
+Packages publish with **`pnpm publish`, not `npm publish`**, because pnpm
+rewrites `workspace:^` / `workspace:*` specifiers to real version numbers at
+pack time. `npm publish` does not, which would leak `workspace:^` verbatim into
+published metadata (issue #403).
 
-### npm Packages
+The publish loop is à-la-carte: optional surfaces (bench, weclone, importers,
+plugins) all ship so users can install only what they need. A package that npm
+rejects with **E404 on its very first publish** — trusted publishing not yet
+provisioned for that name — is collected, surfaced loudly, and skipped so it
+does not strand every package after it in the topological order. Any other
+publish failure is fatal.
 
-Published automatically by `.github/workflows/release-and-publish.yml`:
+## Published packages
 
-| Package | npm Name | Registry |
-|---------|----------|----------|
+25 packages publish to npm; one dashboard is private; the Hermes plugin
+publishes to PyPI on its own workflow. See
+[monorepo-structure.md](../architecture/monorepo-structure.md) for the full
+package map. Directory names differ from published names for several packages:
+
+| Directory | Published name | Registry |
+|---|---|---|
 | `packages/remnic-core` | `@remnic/core` | npm |
-| `packages/remnic-server` | `@remnic/server` | npm |
 | `packages/remnic-cli` | `@remnic/cli` | npm |
-| `packages/plugin-openclaw` | `@remnic/plugin-openclaw` | npm |
-| `packages/shim-openclaw-engram` | `@joshuaswarren/openclaw-engram` | npm |
-| `packages/plugin-claude-code` | `@remnic/plugin-claude-code` | npm |
-| `packages/plugin-codex` | `@remnic/plugin-codex` | npm |
+| `packages/remnic-server` | `@remnic/server` | npm |
 | `packages/connector-replit` | `@remnic/replit` | npm |
-| `packages/bench` | `@remnic/bench` | npm |
-| `packages/export-weclone` | `@remnic/export-weclone` | npm |
-| `packages/import-weclone` | `@remnic/import-weclone` | npm |
-| `packages/connector-weclone` | `@remnic/connector-weclone` | npm |
-| `packages/hermes-provider` | `@remnic/hermes-provider` | npm |
+| `packages/shim-openclaw-engram` | `@joshuaswarren/openclaw-engram` | npm |
+| `packages/plugin-hermes` | `remnic-hermes` | PyPI |
+| `packages/bench-ui` | (private, not published) | — |
 
-All npm publishes include provenance attestations.
+Every other `packages/<name>` publishes as `@remnic/<name>`.
 
-For the first public Remnic publish, the workflow treats the workspace root
-`package.json` version as authoritative while `@remnic/core` is still absent
-from npm. That bootstrap rule prevents the release job from inheriting the old
-Engram `v9.x` tag line before the `1.0.0` Remnic packages exist on the
-registry.
+## PyPI package
 
-### PyPI Package
-
-`packages/plugin-hermes` is published separately by `.github/workflows/hermes-python.yml`:
+`packages/plugin-hermes` (`remnic-hermes`) publishes separately via
+`.github/workflows/hermes-python.yml`. To publish manually (maintainers only):
 
 ```bash
-# Manual publish (maintainers only)
 cd packages/plugin-hermes
 python -m build
 twine upload dist/*
 ```
 
-### Marketplace Publishing
+## Marketplace publishing
 
-- **Claude Code plugin** → Anthropic marketplace (manual submission)
-- **Codex plugin** → OpenAI Codex marketplace (manual submission)
+- **Claude Code plugin** -> Anthropic marketplace (manual submission).
+- **Codex plugin** -> OpenAI Codex marketplace (manual submission).
+- **OpenClaw plugin** -> ClawHub. The workflow rescans automatically after a
+  release; manual publish steps are in
+  [../plugins/openclaw.md](../plugins/openclaw.md).
 
-## Backward Compatibility
+## Changelog
 
-### The `@remnic/plugin-openclaw` Package
+`CHANGELOG.md` is maintained by hand. Each PR adds its entry under
+`[Unreleased]`; the `changelog-guard` workflow enforces this on pull requests.
+The release workflow does not generate per-package changelogs.
 
-The `packages/plugin-openclaw/` directory publishes as `@remnic/plugin-openclaw` on npm. OpenClaw installs should now target that package directly.
+## Backward-compatibility notes
 
-### The Root Package
-
-The root `package.json` is a workspace root and is NOT published. It exists only for workspace management.
-
-### Deprecation Notice
-
-The old `@joshuaswarren/openclaw-engram` scope package now lives at `packages/shim-openclaw-engram/` as a frozen compatibility shim. It re-exports the OpenClaw bridge plugin, forwards `engram-access`, prints a postinstall rename banner, and carries the npm deprecation notice pointing users to the new `@remnic/*` packages.
-
-## Emergency Hotfix
-
-For critical fixes that can't wait for the normal changeset flow:
-
-```bash
-git checkout -b hotfix/critical-fix main
-# make fix
-pnpm changeset   # create changeset with patch bump
-git push
-# merge PR → auto-publishes
-```
+The root `package.json` is the private workspace root and is never published.
+The old `@joshuaswarren/openclaw-engram` scope now lives at
+`packages/shim-openclaw-engram/` as a frozen compatibility shim: it re-exports
+the OpenClaw bridge plugin, forwards `engram-access`, prints a rename banner on
+install, and carries an npm deprecation notice pointing at the `@remnic/*`
+packages.

--- a/docs/dreams.md
+++ b/docs/dreams.md
@@ -1,167 +1,161 @@
 # Dreams: named, phased consolidation
 
-> **Status:** documentation only (PR 1/4 of [issue
-> #678](https://github.com/joshuaswarren/remnic/issues/678)). This page
-> describes the conceptual model and maps the existing implementation.
-> No new code, config, CLI, or telemetry surface ships in this PR.
-> Subsequent PRs add the `dreams.phases.*` config block (PR 2), the
-> per-phase telemetry surface (PR 3), and the `remnic dreams run` CLI
-> (PR 4).
+**Dreams** is Remnic's name for the background consolidation pipeline that runs
+between user-facing turns: scoring recent activity, synthesising and de-duplicating
+across sessions, promoting durable findings, and migrating cold material out of the
+hot working set. The pipeline is split into three named phases that mirror the
+biological metaphor so operators have one mental model and one vocabulary.
 
-## What "dreams" means here
+**Default posture:** the three phases mirror existing lifecycle gates. **Light
+sleep** runs by default (it mirrors `lifecyclePolicyEnabled`, default `true`); **REM**
+is off by default (mirrors `semanticConsolidationEnabled`, default `false`); **deep
+sleep** is off by default (it turns on only when nightly governance, tier migration,
+or page-versioning is enabled). The separate `dreaming` **diary** surface is a
+different feature and is off by default (`dreaming.enabled`, default `false`).
 
-In Remnic, **dreams** is the umbrella name for the background
-consolidation pipeline that runs between user-facing turns: scoring
-recent activity, synthesising and de-duplicating across sessions,
-promoting durable findings, and migrating cold material out of the hot
-working set.
+## The three phases
 
-The pipeline is split into three named phases that mirror the
-biological metaphor:
+1. **Light sleep** — recent activity scoring and clustering.
+2. **REM** — cross-session synthesis, supersession resolution, and semantic
+   consolidation.
+3. **Deep sleep** — promotion to durable memory, hot→cold tier migration,
+   page-version snapshots, and archive.
 
-1. **Light sleep** — recent activity scoring + clustering.
-2. **REM** — cross-session synthesis, supersession resolution, and
-   semantic consolidation.
-3. **Deep sleep** — promotion to durable memory, hot→cold tier
-   migration, page-version snapshots, and archive.
+Every phase is implemented by code that ships today. The phase boundaries are a
+descriptive grouping over existing primitives, not new behavior.
 
-Every phase is implemented today by code that already ships on `main`.
-This PR only renames and groups the existing primitives so operators
-have one mental model and one vocabulary; the phase boundaries are
-descriptive, not new behaviour.
+## Enable it
+
+Each phase reads its own gates. The unified `dreams.phases.*` block groups them and
+wins over the legacy top-level keys when set:
+
+```json
+{
+  "dreams": {
+    "phases": {
+      "lightSleep": { "enabled": true },
+      "rem": { "enabled": true },
+      "deepSleep": { "enabled": true }
+    }
+  }
+}
+```
+
+**Precedence (highest to lowest):**
+
+- `dreams.phases.lightSleep.enabled` > `lifecyclePolicyEnabled`
+- `dreams.phases.rem.enabled` > `semanticConsolidationEnabled`
+- `dreams.phases.deepSleep.enabled` > (no legacy top-level equivalent)
+
+`dreams` (the consolidation pipeline) is a **different config namespace** from
+`dreaming` (the diary surface). Setting `dreaming.enabled` does not turn on
+consolidation, and enabling a dreams phase does not write a diary. When a value is
+set under `dreams.phases.*` it wins; the legacy top-level keys still parse so
+existing configs keep working.
 
 ## Naming note: three "dreams" concepts in the codebase
 
-Remnic already uses the word "dreams" for two adjacent things. To
-avoid confusion, this section catalogues all three usages explicitly.
-The unqualified name **"dreams"** in this document — and in the future
-`dreams.phases.*` config block, `remnic dreams` CLI, and
-`engram.dreams_status` MCP tool — refers exclusively to the
-consolidation pipeline.
+Remnic uses the word "dreams" for three adjacent things. The unqualified name
+**"dreams"** — in this document, in the `dreams.phases.*` config block, the
+`openclaw engram dreams` CLI, and the `engram.dreams_status` MCP tool — refers
+exclusively to the consolidation pipeline.
 
-| Concept | Where it lives today | What it is |
+| Concept | Where it lives | What it is |
 |---|---|---|
 | **Dreams (this document)** — consolidation pipeline | `packages/remnic-core/src/maintenance/`, `semantic-consolidation.ts`, `tier-routing.ts`, `tier-migration.ts`, `temporal-supersession.ts`, `summarizer.ts`, `summary-snapshot.ts`, `page-versioning.ts`, `hygiene.ts`, `lifecycle.ts` | The phased background process described here. |
-| **Dreams diary surface** | `packages/remnic-core/src/surfaces/dreams.ts` | Markdown-fragment surface that parses `<!-- openclaw:dreaming:diary:start -->` / `<!-- openclaw:dreaming:diary:end -->` markers in MEMORY-style files. Exposes `read` / `append` / `watch`. Unrelated to consolidation phases. |
+| **Dreams diary surface** | `packages/remnic-core/src/surfaces/dreams.ts` | Markdown-fragment surface that parses `<!-- openclaw:dreaming:diary:start -->` / `<!-- openclaw:dreaming:diary:end -->` markers in MEMORY-style files. Exposes `read` / `append` / `watch`. Gated by `dreaming.enabled`. Unrelated to consolidation phases. |
 | **`memoryKind: "dream"` frontmatter** | YAML frontmatter on memory files; recognised in `orchestrator.ts` and storage paths | A memory category. A single-fact tag, not a process. |
 
-### Decision recorded by this PR
-
-The pipeline gets the unqualified name **dreams**. The diary surface
-and `memoryKind: "dream"` are pre-existing usages and stay as they
-are for now. A follow-up may rename the diary surface to
-`dream-diary` and revisit the `memoryKind` value to remove the
-overlap, but that rename is explicitly out of scope for issues #678
-PR 1–4. Until then, when reading code, treat the directory
-`packages/remnic-core/src/surfaces/dreams.ts` as the diary, and
-treat anything under `maintenance/` plus the consolidation modules
-listed above as the pipeline.
+When reading code, treat `packages/remnic-core/src/surfaces/dreams.ts` as the
+diary, and treat anything under `maintenance/` plus the consolidation modules above
+as the pipeline.
 
 ## Phase mapping
 
-The following table maps each named phase to the existing modules
-that implement it today. Operators can already tune most of this
-behaviour through the per-module config keys listed in the next
-section; PR 2/4 will introduce the unified `dreams.phases.*` block
-that reads those existing keys and lets the new keys win when set.
+Each named phase maps to the existing modules that implement it.
 
 | Phase | What runs | Existing modules |
 |---|---|---|
 | **light sleep** | Recent activity scoring and clustering — assigns a value score to each candidate memory based on hits, recency, and lifecycle signals; emits an observation-ledger entry; updates the recent buffer state. | `tier-routing.ts` (`computeTierValueScore`, `decideTierTransition`), `lifecycle.ts` (heat / decay thresholds), `maintenance/observation-ledger-utils.ts`, `maintenance/rebuild-observations.ts`, buffer state in `buffer.ts`. |
 | **REM** | Cross-session synthesis: cluster similar facts, resolve supersessions where a newer fact replaces an older one, and run semantic consolidation (SPLIT / MERGE / UPDATE) over the clusters. Emits summary snapshots. | `semantic-consolidation.ts` (`findSimilarClusters`, `buildConsolidationPrompt`, `chooseConsolidationOperator`, `parseOperatorAwareConsolidationResponse`), `temporal-supersession.ts` (`computeSupersessionKey`, `shouldSupersedeExisting`), `summarizer.ts`, `summary-snapshot.ts`, `consolidation-operator.ts`, `consolidation-provenance-check.ts`. |
-| **deep sleep** | Promotion to durable memory, hot→cold tier migration, page-version snapshotting on every overwrite, and archive of stale or low-value entries. | `tier-migration.ts` (`migrateMemory`, hot↔cold journal), `page-versioning.ts` (snapshot/prune by `maxVersionsPerPage`), `hygiene.ts` (file size / archive triggers), `maintenance/archive-observations.ts`, `maintenance/memory-governance.ts`, `maintenance/memory-governance-cron.ts` (the `engram-nightly-governance` cron that orchestrates the deep-sleep run today). |
+| **deep sleep** | Promotion to durable memory, hot→cold tier migration, page-version snapshotting on every overwrite, and archive of stale or low-value entries. | `tier-migration.ts` (`migrateMemory`, hot↔cold journal), `page-versioning.ts` (snapshot/prune by `maxVersionsPerPage`), `hygiene.ts` (file size / archive triggers), `maintenance/archive-observations.ts`, `maintenance/memory-governance.ts`, `maintenance/memory-governance-cron.ts` (the `engram-nightly-governance` cron that orchestrates the deep-sleep run). |
 
-## Existing config gates per phase
+## Config gates per phase
 
-These are the config keys that already exist in `config.ts` and
-gate behaviour for each phase. PR 2/4 will group these under
-`dreams.phases.{lightSleep,rem,deepSleep}.*` while keeping the
-existing top-level keys readable for backward compatibility.
+The `dreams.phases.*` block groups these existing keys; the legacy top-level keys
+remain readable for backward compatibility.
 
-### Light sleep gates (today)
+### Light sleep gates
 
-- `lifecyclePolicyEnabled` — master switch for value-score driven
-  routing. Default `true`.
-- `lifecycleFilterStaleEnabled` — filter stale entries out of recall.
-  Default `false`.
-- `lifecyclePromoteHeatThreshold` — value score above which a memory
-  is treated as hot.
-- `lifecycleStaleDecayThreshold` — value score below which a memory
-  starts to decay.
-- `lifecycleArchiveDecayThreshold` — value score below which a memory
-  is eligible for archive.
-- `lifecycleProtectedCategories` — categories that bypass decay /
-  archive even when their score drops.
-
-### REM gates (today)
-
-- `temporalSupersessionEnabled` — supersession resolution at write /
-  consolidation time. Default `true`.
-- `temporalSupersessionIncludeInRecall` — whether superseded memories
-  surface in recall. Default `false`.
-- `semanticConsolidationEnabled` — turn on the cluster→merge /
-  split / update LLM consolidator.
-- `semanticConsolidationModel` — model used for the consolidation
-  call. Falls back to the platform default.
-- `semanticConsolidationThreshold` — cosine-similarity threshold for
-  cluster membership. Default `0.8`.
-- `semanticConsolidationMinClusterSize` — minimum cluster size before
-  consolidation runs. Default `2` (clamped lower bound).
-- `semanticConsolidationExcludeCategories` — categories that REM
-  skips entirely.
-- `semanticConsolidationIntervalHours` — how often the REM pass
-  runs.
-- `semanticConsolidationMaxPerRun` — cap on cluster operations per
-  run, to bound cost.
-- `consolidationMinIntervalMs` — global minimum gap between
-  consolidation passes (default ~10 minutes).
-- `consolidationRequireNonZeroExtraction` — only consolidate when
-  the recent extraction has produced at least one fact. Default
+- `lifecyclePolicyEnabled` — master switch for value-score driven routing. Default
   `true`.
+- `lifecycleFilterStaleEnabled` — filter stale entries out of recall. Default
+  `false`.
+- `lifecyclePromoteHeatThreshold` — value score above which a memory is treated as
+  hot.
+- `lifecycleStaleDecayThreshold` — value score below which a memory starts to decay.
+- `lifecycleArchiveDecayThreshold` — value score below which a memory is eligible
+  for archive.
+- `lifecycleProtectedCategories` — categories that bypass decay / archive even when
+  their score drops.
 
-(Note: `summaryRecallHours` and `summaryModel` are *not* REM-phase
-gates — they configure the recall summaries path in
-`orchestrator.ts`, not `runSemanticConsolidation`. Summary
-snapshots themselves are written from a separate flow:
-`HourlySummarizer.saveSummary` / `runHourly` in `summarizer.ts`
-calls `summary-snapshot.ts`. That flow is *not* gated by the
-`semanticConsolidation*` keys; do not expect tuning REM settings
-to change snapshot behaviour.)
+### REM gates
 
-### Deep sleep gates (today)
+- `temporalSupersessionEnabled` — supersession resolution at write / consolidation
+  time. Default `true`.
+- `temporalSupersessionIncludeInRecall` — whether superseded memories surface in
+  recall. Default `false`.
+- `semanticConsolidationEnabled` — turn on the cluster→merge / split / update LLM
+  consolidator. Default `false`.
+- `semanticConsolidationModel` — model used for the consolidation call. Falls back
+  to the platform default.
+- `semanticConsolidationThreshold` — cosine-similarity threshold for cluster
+  membership. Default `0.8`.
+- `semanticConsolidationMinClusterSize` — minimum cluster size before consolidation
+  runs. Default `2` (clamped lower bound).
+- `semanticConsolidationExcludeCategories` — categories REM skips entirely.
+- `semanticConsolidationIntervalHours` — how often the REM pass runs.
+- `semanticConsolidationMaxPerRun` — cap on cluster operations per run, to bound
+  cost.
+- `consolidationMinIntervalMs` — global minimum gap between consolidation passes
+  (default ~10 minutes).
+- `consolidationRequireNonZeroExtraction` — only consolidate when the recent
+  extraction has produced at least one fact. Default `true`.
 
-- The `fileHygiene` block (`fileHygiene.enabled`,
-  `fileHygiene.archiveDir`, `fileHygiene.lintBudgetBytes`,
-  `fileHygiene.rotateEnabled`, `fileHygiene.rotateMaxBytes`,
-  `fileHygiene.warningsLogPath`, etc.) — drives archive and warning
-  emission for files that exceed size thresholds.
-- `versioningEnabled` (default `false`) — master switch for
-  page-version snapshots. `StorageManager.snapshotBeforeWrite`
-  exits early when this flag is not set, so deep-sleep
-  snapshotting is a no-op without it. Operators must enable this
-  *before* tuning the retention key below.
-- `versioningMaxPerPage` (top-level config key, consumed by
-  `page-versioning.ts` as `maxVersionsPerPage`) — retention for the
-  snapshot history that every memory file overwrite produces once
-  `versioningEnabled` is `true`. `0` disables pruning.
-- The `engram-nightly-governance` cron registered in
-  `maintenance/memory-governance-cron.ts` — orchestrates the deep
-  sleep pass on a schedule. The same module registers exactly four
-  crons today: `engram-day-summary`, `engram-nightly-governance`,
-  `engram-procedural-mining`, and `engram-contradiction-scan`.
-  Light sleep and REM are *not* cron-scheduled — they run inside the
-  orchestrator maintenance pass via `runLifecyclePolicyPass` (light
-  sleep) and `runSemanticConsolidation` (REM) in `orchestrator.ts`.
-  PR 3/4 (this PR) wires per-phase telemetry through both code paths
-  (cron and orchestrator pass) so the named-phase view stays
-  consistent regardless of which trigger ran the work.
+`summaryRecallHours` and `summaryModel` are *not* REM-phase gates — they configure
+the recall-summaries path in `orchestrator.ts`, not `runSemanticConsolidation`.
+Summary snapshots are written from a separate flow
+(`HourlySummarizer.saveSummary` / `runHourly` in `summarizer.ts`) that is not gated
+by the `semanticConsolidation*` keys; tuning REM settings does not change snapshot
+behavior.
 
-## Per-phase telemetry (PR 3/4)
+### Deep sleep gates
 
-Every phase run — whether triggered by a cron, the orchestrator
-maintenance pass, or the `remnic dreams run` CLI — appends one JSONL
-entry to `<memoryDir>/state/dreams-ledger.jsonl`. The entry has this
-shape:
+- The `fileHygiene` block (`fileHygiene.enabled`, `fileHygiene.archiveDir`,
+  `fileHygiene.lintBudgetBytes`, `fileHygiene.rotateEnabled`,
+  `fileHygiene.rotateMaxBytes`, `fileHygiene.warningsLogPath`, …) — drives archive
+  and warning emission for files that exceed size thresholds.
+- `versioningEnabled` (default `false`) — master switch for page-version snapshots.
+  `StorageManager.snapshotBeforeWrite` exits early when this flag is not set, so
+  deep-sleep snapshotting is a no-op without it. Enable this *before* tuning the
+  retention key below.
+- `versioningMaxPerPage` (consumed by `page-versioning.ts` as `maxVersionsPerPage`)
+  — retention for the snapshot history that every memory file overwrite produces
+  once `versioningEnabled` is `true`. `0` disables pruning.
+- The `engram-nightly-governance` cron (`maintenance/memory-governance-cron.ts`) —
+  orchestrates the deep-sleep pass on a schedule. That module registers exactly four
+  crons: `engram-day-summary`, `engram-nightly-governance`,
+  `engram-procedural-mining`, and `engram-contradiction-scan`. Light sleep and REM
+  are *not* cron-scheduled — they run inside the orchestrator maintenance pass via
+  `runLifecyclePolicyPass` (light sleep) and `runSemanticConsolidation` (REM).
+  Per-phase telemetry is wired through both code paths (cron and orchestrator pass)
+  so the named-phase view stays consistent regardless of which trigger ran the work.
+
+## Per-phase telemetry
+
+Every phase run — whether triggered by a cron, the orchestrator maintenance pass,
+or the `openclaw engram dreams run` CLI — appends one JSONL entry to
+`<memoryDir>/state/dreams-ledger.jsonl`:
 
 ```jsonc
 {
@@ -177,20 +171,24 @@ shape:
 }
 ```
 
-Older ledger entries that predate this PR simply won't have this
-field. No backfill is required — the aggregator treats missing entries
-as having zero runs.
+Older ledger entries that predate this schema simply lack the field; the aggregator
+treats missing entries as zero runs, so no backfill is required.
 
-### `remnic dreams status`
+## CLI, HTTP, and MCP surfaces
 
+Dreams inspection and manual invocation are hosted by the OpenClaw plugin runtime
+under the `engram` command group.
+
+### `openclaw engram dreams status`
+
+```bash
+openclaw engram dreams status [--window-hours <n>] [--format text|json|markdown]
 ```
-remnic dreams status [--window-hours <n>] [--format text|json|markdown]
-```
 
-Reads the dreams ledger and prints a per-phase summary for the last N
-hours (default 24). Example text output:
+Reads the dreams ledger and prints a per-phase summary for the last N hours
+(default 24). Example text output:
 
-```
+```text
 Dreams status (last 24h):
   Window: 2026-04-26T12:00:00.000Z → 2026-04-27T12:00:00.000Z
 
@@ -213,13 +211,36 @@ Dreams status (last 24h):
     Last run:        2026-04-27T02:23:00.000Z
 ```
 
-### `GET /engram/v1/dreams/status`
+### `openclaw engram dreams run`
 
-```
-GET /engram/v1/dreams/status?windowHours=24
+`dreams run` triggers a single phase without waiting for the cron — useful for
+debugging a phase or verifying that a config change had the expected effect.
+
+```bash
+openclaw engram dreams run --phase <phase> [--dry-run] [--format text|json]
 ```
 
-Returns the same shape as a JSON body:
+`--phase` accepts kebab-case (`light-sleep`, `rem`, `deep-sleep`) or camelCase
+(`lightSleep`, `rem`, `deepSleep`). `--dry-run` reports what would happen without
+committing writes, and does not write a ledger entry so the status surface stays
+clean.
+
+```text
+$ openclaw engram dreams run --phase light-sleep --dry-run
+Dreams run: Light Sleep (dry-run)
+  Duration:   12ms
+  Items:      84
+  Notes:      dry-run: would score 84 observation entries
+```
+
+### HTTP
+
+```text
+GET  /engram/v1/dreams/status?windowHours=24
+POST /engram/v1/dreams/run          { "phase": "lightSleep", "dryRun": true }
+```
+
+The status response returns per-phase aggregates:
 
 ```jsonc
 {
@@ -234,98 +255,38 @@ Returns the same shape as a JSON body:
       "lastRunAt": "2026-04-27T09:15:00.000Z",
       "lastDurationMs": 1200
     },
-    "rem": { ... },
-    "deepSleep": { ... }
+    "rem": { },
+    "deepSleep": { }
   }
 }
 ```
 
-### MCP tool `engram.dreams_status` / `remnic.dreams_status`
+### MCP tools
 
-```jsonc
-// call
-{ "name": "engram.dreams_status", "arguments": { "windowHours": 24 } }
+`engram.dreams_status` / `remnic.dreams_status` and `engram.dreams_run` /
+`remnic.dreams_run` return the same shapes as the HTTP endpoints. `dreams_run`
+accepts `{ "phase": "...", "dryRun": true }`; valid phases are `lightSleep`, `rem`,
+`deepSleep`.
 
-// result — same shape as the HTTP response body
-{ "windowStart": "...", "windowEnd": "...", "phases": { ... } }
-```
+## Caveats
 
-## Manual phase invocation (PR 4/4)
-
-`remnic dreams run` lets operators trigger a single phase without
-waiting for the cron. This is useful for debugging a misbehaving
-phase or for verifying that a configuration change has the expected
-effect.
-
-### `remnic dreams run`
-
-```
-remnic dreams run --phase <phase> [--dry-run] [--format text|json]
-```
-
-`--phase` accepts kebab-case (`light-sleep`, `rem`, `deep-sleep`) or
-camelCase (`lightSleep`, `rem`, `deepSleep`).
-
-`--dry-run` reports what would happen without committing any writes.
-The ledger entry is not written in dry-run mode so the status surface
-stays clean.
-
-Example:
-
-```
-$ remnic dreams run --phase light-sleep --dry-run
-Dreams run: Light Sleep (dry-run)
-  Duration:   12ms
-  Items:      84
-  Notes:      dry-run: would score 84 observation entries
-```
-
-### `POST /engram/v1/dreams/run`
-
-```jsonc
-// request
-POST /engram/v1/dreams/run
-{ "phase": "lightSleep", "dryRun": true }
-
-// response — same shape as a scheduled-run telemetry record
-{
-  "phase": "lightSleep",
-  "dryRun": true,
-  "durationMs": 12,
-  "itemsProcessed": 84,
-  "notes": "dry-run: would score 84 observation entries"
-}
-```
-
-### MCP tool `engram.dreams_run` / `remnic.dreams_run`
-
-```jsonc
-// call
-{ "name": "engram.dreams_run", "arguments": { "phase": "deepSleep", "dryRun": false } }
-
-// result
-{ "phase": "deepSleep", "dryRun": false, "durationMs": 31200, "itemsProcessed": 500 }
-```
-
-## What's next
-
-PRs 3/4 and 4/4 are now shipped (combined in a single PR). The
-remaining item from the original plan:
-
-- **PR 2/4** (not yet shipped) — Group the existing per-cron /
-  per-module thresholds into a `dreams.phases.{lightSleep,rem,deepSleep}.*`
-  config block. Backward-compatible: the existing top-level keys still
-  parse; any new key under `dreams.phases.*` wins when set. `remnic
-  doctor` gains a section that lists current per-phase threshold values
-  and the last-run timestamp for each phase.
+- The named phases are a grouping over existing lifecycle primitives, not a new
+  scheduler. Turning on a phase enables the underlying gates it maps to.
+- Deep sleep has no single top-level legacy toggle; it activates through nightly
+  governance, tier migration, or page-versioning being enabled.
+- `dreams` (consolidation) and `dreaming` (diary) are distinct config namespaces;
+  do not conflate them.
 
 ## See also
 
-- [Memory Lifecycle](architecture/memory-lifecycle.md) — the canonical
-  write → consolidation → expiry walkthrough that dreams sits inside.
-- [Retention Policy](retention-policy.md) — value-score model, hot /
-  cold tier substrate, and the `remnic forget` / `remnic tier list /
-  explain` surfaces that share infrastructure with deep sleep.
-- [Operations](operations.md) — backup, export, and CLI surfaces that
-  consume the same observation ledger as dreams.
-- Source-of-truth issue: [#678](https://github.com/joshuaswarren/remnic/issues/678).
+- [Retention policy](retention-policy.md) — value-score model, hot/cold tier
+  substrate, and the forget/tier surfaces that deep sleep shares infrastructure
+  with.
+- [Operations](operations.md) — backup, export, and CLI surfaces that consume the
+  same observation ledger as dreams.
+
+## Provenance
+
+The named-phase model and the `dreams.phases.*` config block, telemetry ledger,
+CLI, HTTP, and MCP surfaces track issue
+[#678](https://github.com/joshuaswarren/remnic/issues/678).

--- a/docs/enable-all-v8.md
+++ b/docs/enable-all-v8.md
@@ -1,13 +1,13 @@
-# Enable All v8 Features
+# Enable all features (full-feature profile)
 
-This guide provides a single config profile that explicitly enables all major v8 feature families in `openclaw-engram`.
+This is the full-feature profile: a single config block that explicitly turns on every major Remnic feature family at once, so you can validate the whole surface in one pass and then trim back to what you need. The `v8` in the file name is a historical label; these features shipped across many releases through v9.6.22, so treat this as the current maximal profile, not a version-specific one.
 
-Apply under:
+Apply it under the OpenClaw plugin entry. The current plugin id is `openclaw-remnic`; installs created before the rename may still use the legacy `openclaw-engram` id, which Remnic continues to read.
 
-- `plugins.entries.openclaw-engram.enabled = true`
-- `plugins.entries.openclaw-engram.config = { ... }`
+- `plugins.entries.openclaw-remnic.enabled = true`
+- `plugins.entries.openclaw-remnic.config = { ... }`
 
-## Full v8 Config Profile
+## Full config profile
 
 ```jsonc
 {
@@ -75,9 +75,9 @@ Apply under:
 - Keep secrets in environment variables (`${OPENAI_API_KEY}`), not hardcoded keys.
 - If you run many features at once, expect higher extraction/consolidation activity.
 - `debug: true` is recommended while validating; disable later for quieter logs.
-- If you use `conversationIndexBackend: "faiss"`, install `scripts/faiss_requirements.txt` first and optionally set `ENGRAM_FAISS_ENABLE_ST=1` for sentence-transformers embeddings.
+- If you use `conversationIndexBackend: "faiss"`, install `scripts/faiss_requirements.txt` first and optionally set `REMNIC_FAISS_ENABLE_ST=1` (legacy `ENGRAM_FAISS_ENABLE_ST=1` still works) for sentence-transformers embeddings.
 - If you prefer QMD for transcript recall, swap the FAISS fields for `conversationIndexBackend: "qmd"` plus `conversationIndexQmdCollection`.
-- **`procedural.enabled`** turns on issue #519 procedural memory (writes under `procedures/`, recall injection, mining). The sample block above enables it; remove the `procedural` object or set `"enabled": false` if you want this profile without procedural behavior. See [procedural-memory.md](procedural-memory.md).
+- **`procedural.enabled`** controls procedural memory (writes under `procedures/`, recall injection, mining). It is default-on since issue #567, so setting `"enabled": true` here is explicit rather than required; remove the `procedural` object or set `"enabled": false` to run this profile without procedural behavior. See [procedural-memory.md](procedural-memory.md).
 
 ## Required Restart
 

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,159 +1,15 @@
-# At-Rest Encryption (Secure Store)
+# At-rest encryption (secure store)
 
-Issue #690 — AES-256-GCM transparent storage encryption.
+The secure store gives Remnic transparent AES-256-GCM encryption for memory files
+on disk. Enable it when the machine holding your memory store is not fully trusted —
+a laptop that can be lost or stolen, a device whose backups leave your control, or a
+shared host where a `cat` of a memory file must not reveal its contents.
 
-## Threat Model
+**Opt-in via `secureStoreEnabled` (default `false`).** A second key,
+`secureStoreEncryptOnWrite` (default `true`), controls whether new writes are
+encrypted once the store is enabled.
 
-### What at-rest encryption protects against
-
-- **Physical disk compromise** — if the device's storage is read by an attacker (stolen laptop, forensic image, decommissioned SSD) the memory files are unreadable without the passphrase.
-- **Cloud backup exfiltration** — if memory files are included in a cloud backup and that backup is accessed by a third party, the ciphertext is opaque.
-- **Accidental exposure** — a `cat` of a memory file or a leaked backup tarball reveals only ciphertext.
-
-### What it does NOT protect against
-
-- **A running, unlocked daemon** — once `remnic secure-store unlock` is called, the decryption key is held in memory. Any process that can communicate with the daemon (localhost MCP, HTTP, CLI) can retrieve plaintext memories.
-- **Memory dumps** — the kernel or a privileged process can read the key from process memory. This is a fundamental limitation of software-only encryption.
-- **Passphrase at rest** — the passphrase is never stored by Remnic, but if your passphrase manager is compromised, so is your memory store.
-- **QMD search index** — the search backend indexes content in its own data store (BM25, vector embeddings). Index files are NOT currently encrypted by this module. Disable QMD or use `secureStoreEnabled: true` with awareness of this gap.
-
-### Scope
-
-Only memory files in `facts/`, `corrections/`, `procedures/`, `reasoning-traces/`, `artifacts/`, `archive/`, and `profile.md` are encrypted by this module. Entity files, state files, JSON indexes, and continuity records are not yet covered.
-
----
-
-## Recovery
-
-**Passphrase loss equals data loss.**
-
-Remnic does not store your passphrase anywhere. There is no "forgot my passphrase" recovery path. If you lose your passphrase:
-
-- Your encrypted memory files cannot be decrypted.
-- The only recovery path is restoring a **non-encrypted backup** taken before `migrateMemoryDirToEncrypted` was run.
-
-**Recommendation:** Before enabling encryption, take a full backup of your memory directory:
-
-```bash
-cp -r ~/.openclaw/memories ~/.openclaw/memories-backup-plaintext
-```
-
-Store the backup somewhere safe and non-encrypted (e.g. an encrypted external drive with a separately remembered passphrase).
-
----
-
-## Naming Disambiguation
-
-Remnic uses the term **"secure-store"** for its at-rest encryption module. This is intentional — it avoids collision with:
-
-- **Obsidian Vault** — an Obsidian workspace directory (`vaultId`, `obsidianVaults` config)
-- **Key Vault** (Azure/AWS/GCP) — cloud secret stores
-- **macOS Keychain** — system credential storage
-
-When reading docs or config, `secure-store` always means Remnic's at-rest encryption layer.
-
----
-
-## CLI Reference
-
-All `secure-store` commands take the `--memory-dir` flag (defaults to configured memory directory).
-
-### Initialize
-
-```bash
-remnic secure-store init
-```
-
-Creates a `.secure-store/header.json` metadata file in your memory directory. You will be prompted for a passphrase (twice for confirmation).
-
-New stores use Argon2id by default. Use `--kdf scrypt` only when you need to
-create a compatibility store that avoids the native Argon2id dependency:
-
-```bash
-remnic secure-store init --kdf scrypt
-```
-
-**Minimum passphrase length:** 8 characters.
-
-This command does NOT encrypt existing memory files. Run `remnic secure-store migrate` after init to encrypt existing files.
-
-### Unlock
-
-```bash
-remnic secure-store unlock
-```
-
-Derives the AES-256 key from your passphrase and stores it in the in-memory keyring. The daemon can then read and write encrypted memory files.
-
-**The key is never persisted to disk.** You must run `unlock` after every daemon restart.
-
-### Migrate Existing Files
-
-```bash
-remnic secure-store migrate
-```
-
-Encrypts existing plaintext storage-managed memory files using the currently
-unlocked secure-store key. Already encrypted files are skipped, so the command
-is safe to rerun.
-
-This command requires the store to be initialized and unlocked:
-
-```bash
-remnic secure-store unlock
-remnic secure-store migrate
-```
-
-`migrate` covers the storage roots already routed through Remnic's secure-fs
-layer. Remaining sidecar coverage is tracked separately so the migration command
-does not encrypt files that older code paths would still read as plaintext.
-
-### Disable Encryption
-
-```bash
-remnic secure-store disable
-```
-
-Decrypts encrypted storage-managed files back to plaintext using the currently
-unlocked secure-store key. Plaintext files are skipped, so the command is safe
-to rerun.
-
-This command requires the store to be initialized and unlocked:
-
-```bash
-remnic secure-store unlock
-remnic secure-store disable
-```
-
-The `.secure-store/header.json` metadata is kept in place. Use the `decrypt`
-subcommand as an alias when you want the command name to describe the file
-operation:
-
-```bash
-remnic secure-store decrypt
-```
-
-### Lock
-
-```bash
-remnic secure-store lock
-```
-
-Zeros the in-memory key and removes it from the keyring. The daemon can no longer read or write encrypted files until `unlock` is run again.
-
-### Status
-
-```bash
-remnic secure-store status
-```
-
-Shows whether the store is initialized, locked, or unlocked. Prints no secret material.
-
----
-
-## Enabling Encryption in Config
-
-Set these keys in your config (via `--config` or `openclaw.plugin.json`):
+## Enable it
 
 ```json
 {
@@ -167,21 +23,187 @@ Set these keys in your config (via `--config` or `openclaw.plugin.json`):
 | `secureStoreEnabled` | `false` | Enable the secure-fs layer for reads and writes. |
 | `secureStoreEncryptOnWrite` | `true` | Encrypt new writes when `secureStoreEnabled` is true. Set to `false` to pause new encryptions while still decrypting existing files (useful during incremental migration). |
 
-When `secureStoreEnabled` is `true` and the store is locked, `recall` returns a clear error message:
+Enabling the config is only half the setup: you must also initialize a passphrase
+and migrate existing files. See the CLI reference below.
 
+## Threat model
+
+### What at-rest encryption protects against
+
+- **Physical disk compromise** — if the device's storage is read by an attacker
+  (stolen laptop, forensic image, decommissioned SSD) the memory files are
+  unreadable without the passphrase.
+- **Cloud backup exfiltration** — if memory files are included in a cloud backup
+  and that backup is accessed by a third party, the ciphertext is opaque.
+- **Accidental exposure** — a `cat` of a memory file or a leaked backup tarball
+  reveals only ciphertext.
+
+### What it does NOT protect against
+
+- **A running, unlocked daemon** — once the store is unlocked, the decryption key
+  is held in memory. Any process that can communicate with the daemon (localhost
+  MCP, HTTP, CLI) can retrieve plaintext memories.
+- **Memory dumps** — the kernel or a privileged process can read the key from
+  process memory. This is a fundamental limitation of software-only encryption.
+- **Passphrase at rest** — the passphrase is never stored by Remnic, but if your
+  passphrase manager is compromised, so is your memory store.
+- **QMD search index** — the search backend indexes content in its own data store
+  (BM25, vector embeddings). Index files are NOT currently encrypted by this
+  module. Disable QMD, or enable the secure store with awareness of this gap.
+
+### Scope
+
+Only memory files in `facts/`, `corrections/`, `procedures/`,
+`reasoning-traces/`, `artifacts/`, `archive/`, and `profile.md` are encrypted by
+this module. Entity files, state files, JSON indexes, and continuity records are
+not yet covered.
+
+## CLI reference
+
+Secure-store commands are hosted by the OpenClaw plugin runtime under the `engram`
+command group. All of them take the `--memory-dir` flag (defaults to the configured
+memory directory).
+
+> Some Remnic error strings still reference the shorter `remnic secure-store`
+> spelling for a standalone dispatch that is not yet wired (tracked by
+> [#1532](https://github.com/joshuaswarren/remnic/issues/1532)); today the
+> commands run as `openclaw engram secure-store <cmd>`.
+
+### Initialize
+
+```bash
+openclaw engram secure-store init
 ```
-[secure-store locked] Memory store is encrypted and locked.
-Run `remnic secure-store unlock` then restart the daemon to decrypt.
+
+Creates a `.secure-store/header.json` metadata file in your memory directory. You
+will be prompted for a passphrase (twice for confirmation).
+
+New stores use Argon2id by default. Use `--kdf scrypt` only when you need to create
+a compatibility store that avoids the native Argon2id dependency:
+
+```bash
+openclaw engram secure-store init --kdf scrypt
 ```
 
----
+**Minimum passphrase length:** 8 characters.
 
-## Encryption Format
+This command does NOT encrypt existing memory files. Run
+`openclaw engram secure-store migrate` after init to encrypt existing files.
+
+### Unlock
+
+```bash
+openclaw engram secure-store unlock
+```
+
+Derives the AES-256 key from your passphrase and stores it in the in-memory
+keyring. The daemon can then read and write encrypted memory files.
+
+**The key is never persisted to disk.** You must run `unlock` after every daemon
+restart.
+
+### Migrate existing files
+
+```bash
+openclaw engram secure-store unlock
+openclaw engram secure-store migrate
+```
+
+Encrypts existing plaintext storage-managed memory files using the currently
+unlocked secure-store key. Already-encrypted files are skipped, so the command is
+safe to rerun. It requires the store to be initialized and unlocked.
+
+`migrate` covers the storage roots already routed through Remnic's secure-fs layer.
+Remaining sidecar coverage is tracked separately so the migration command does not
+encrypt files that older code paths would still read as plaintext.
+
+### Disable encryption
+
+```bash
+openclaw engram secure-store unlock
+openclaw engram secure-store disable
+```
+
+Decrypts encrypted storage-managed files back to plaintext using the currently
+unlocked key. Plaintext files are skipped, so the command is safe to rerun. It
+requires the store to be initialized and unlocked.
+
+The `.secure-store/header.json` metadata is kept in place. Use the `decrypt`
+subcommand as an alias when you want the command name to describe the file
+operation:
+
+```bash
+openclaw engram secure-store decrypt
+```
+
+### Lock
+
+```bash
+openclaw engram secure-store lock
+```
+
+Zeros the in-memory key and removes it from the keyring. The daemon can no longer
+read or write encrypted files until `unlock` is run again.
+
+### Status
+
+```bash
+openclaw engram secure-store status
+```
+
+Shows whether the store is initialized, locked, or unlocked. Prints no secret
+material.
+
+## Behavior when locked
+
+When `secureStoreEnabled` is `true` and the store is locked, `recall` returns a
+clear error instead of plaintext:
+
+```text
+[secure-store locked] Memory store is encrypted and locked. Unlock the
+secure-store inside this daemon process, or restart the daemon through a
+secure-store aware launcher that installs the key.
+```
+
+## Recovery
+
+**Passphrase loss equals data loss.**
+
+Remnic does not store your passphrase anywhere. There is no "forgot my passphrase"
+recovery path. If you lose your passphrase:
+
+- Your encrypted memory files cannot be decrypted.
+- The only recovery path is restoring a **non-encrypted backup** taken before you
+  migrated the memory directory to encrypted.
+
+**Recommendation:** before enabling encryption, take a full backup of your memory
+directory:
+
+```bash
+cp -r <memoryDir> <memoryDir>-backup-plaintext
+```
+
+Store the backup somewhere safe and non-encrypted (for example, an encrypted
+external drive with a separately remembered passphrase).
+
+## Naming disambiguation
+
+Remnic uses the term **"secure-store"** for its at-rest encryption module. This is
+intentional — it avoids collision with:
+
+- **Obsidian vault** — an Obsidian workspace directory (`vaultId`, `obsidianVaults`
+  config)
+- **Key Vault** (Azure/AWS/GCP) — cloud secret stores
+- **macOS Keychain** — system credential storage
+
+When reading docs or config, `secure-store` always means Remnic's at-rest
+encryption layer.
+
+## Encryption format
 
 **Algorithm:** AES-256-GCM (NIST SP 800-38D).
 
-**KDF:** Argon2id by default, with scrypt retained for legacy/compatibility
-stores.
+**KDF:** Argon2id by default, with scrypt retained for legacy/compatibility stores.
 
 Argon2id defaults:
 
@@ -204,7 +226,7 @@ Legacy scrypt params:
 
 **On-disk format per file:**
 
-```
+```text
 [MAGIC:10][VER:1][FLAGS:1] — 12-byte file header
 [CIPHER_VER:1][SALT:16][IV:12][AUTHTAG:16][CIPHERTEXT:...] — AES-GCM envelope
 ```
@@ -215,23 +237,36 @@ Legacy scrypt params:
 - `SALT` — per-file KDF salt (matches the metadata salt in normal operation).
 - `IV` — random 96-bit GCM nonce, unique per write.
 - `AUTHTAG` — 128-bit GCM authentication tag.
-- `CIPHERTEXT` — AES-CTR encrypted content.
+- `CIPHERTEXT` — AES-GCM encrypted content.
 
-**Path-bound AAD:** The file path relative to the memory root is bound as GCM associated authenticated data. Moving or renaming an encrypted file without re-encrypting it will cause an auth failure on next read.
-
----
+**Path-bound AAD:** the file path relative to the memory root is bound as GCM
+associated authenticated data. Moving or renaming an encrypted file without
+re-encrypting it will cause an auth failure on next read.
 
 ## Performance
 
 Key derivation is paid once per `unlock` call, not per file read. Argon2id uses
 64 MiB, 3 iterations, and 4 lanes by default; legacy scrypt stores use N=2^17.
+Per-file encrypt/decrypt overhead is negligible (~microseconds) compared to disk
+I/O.
 
-Per-file encrypt/decrypt overhead is negligible (~microseconds) compared to disk I/O.
+## Caveats
 
----
+- The search index (QMD) is not encrypted by this module — content is recoverable
+  from the index even when memory files are ciphertext.
+- Only the storage roots listed under **Scope** are covered; sidecar state and
+  index files remain plaintext.
+- You must `unlock` after every daemon restart; the key is never persisted.
 
-## Cross-Links
+## Cross-links
 
-- [Capsule Export Encryption](capsules.md) — `remnic capsule export --encrypt` uses the same `seal()`/`open()` primitives from `secure-store/cipher.ts`.
-- [Config Reference](config-reference.md) — `secureStoreEnabled`, `secureStoreEncryptOnWrite`.
+- [Capsules](capsules.md) — `remnic capsule export --encrypt` uses the same
+  `seal()`/`open()` primitives from `secure-store/cipher.ts`.
+- [Config reference](config-reference.md) — `secureStoreEnabled`,
+  `secureStoreEncryptOnWrite`.
 - [Operations](operations.md) — backup recommendations when using encryption.
+
+## Provenance
+
+The secure store shipped in issue
+[#690](https://github.com/joshuaswarren/remnic/issues/690).

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -1,17 +1,19 @@
-# Evaluation Harness
+# Evaluation harness
 
-Engram is moving to a benchmark-first development model. This first slice adds the storage contract and status tooling for an AMA-Bench-style evaluation harness without changing live recall behavior.
+Remnic is moving to a benchmark-first development model. This first slice adds the storage contract and status tooling for an AMA-Bench-style evaluation harness without changing live recall behavior.
 
-## Why This Exists
+For the memory-outcome dimensions and quick-benchmark coverage this harness measures, see [Memory evals](memory-evals.md).
 
-Recent agent-memory work is clear: memory should be evaluated on real agent trajectories, not chat QA. Engram's evaluation harness is meant to answer one operational question for every memory PR:
+## Why this exists
+
+Recent agent-memory work is clear: memory should be evaluated on real agent trajectories, not chat QA. Remnic's evaluation harness is meant to answer one operational question for every memory PR:
 
 `Did this make agent outcomes better, worse, or just different?`
 
 Primary source:
 - AMA-Bench / AMA-Agent: https://arxiv.org/abs/2602.22769
 
-## Current Scope
+## Current scope
 
 This slice ships:
 
@@ -41,9 +43,9 @@ This slice does **not** yet ship:
 
 Those land in follow-on PR slices documented in the roadmap.
 
-## Directory Layout
+## Directory layout
 
-By default, Engram looks under:
+By default, Remnic looks under:
 
 ```text
 {memoryDir}/state/evals/
@@ -61,7 +63,7 @@ By default, Engram looks under:
 
 You can override the root with `evalStoreDir`.
 
-## Benchmark Manifest Format
+## Benchmark manifest format
 
 ```json
 {
@@ -115,7 +117,7 @@ Example red-team benchmark manifest:
 }
 ```
 
-## Run Summary Format
+## Run summary format
 
 ```json
 {
@@ -142,9 +144,9 @@ Supported statuses:
 - `failed`
 - `partial`
 
-## Shadow Recall Record Format
+## Shadow recall record format
 
-When both `evalHarnessEnabled` and `evalShadowModeEnabled` are on, Engram records a best-effort shadow snapshot for each live recall decision without changing the injected context:
+When both `evalHarnessEnabled` and `evalShadowModeEnabled` are on, Remnic records a best-effort shadow snapshot for each live recall decision without changing the injected context:
 
 ```json
 {
@@ -246,18 +248,18 @@ The CI gate:
 - fails when pass rate or shared metrics regress
 - currently treats `trustViolationRate` as lower-is-better and other shared metrics as higher-is-better
 
-## Rollout Guidance
+## Rollout guidance
 
 - Keep `evalHarnessEnabled: false` by default in production until you want benchmark bookkeeping on disk.
 - Turn on `evalShadowModeEnabled` when you want to start recording live recall decisions for measurement without changing recall output.
 - Treat benchmark packs as versioned operator assets. PRs that change them should explain why the benchmark changed.
 - Use `memory-red-team` packs for poisoning-defense suites so attack intent stays explicit in status output instead of relying on tags alone.
 
-## Next Steps
+## Next steps
 
 See:
 
-- [Engram Feature Roadmap (GitHub Project)](https://github.com/users/joshuaswarren/projects/1)
+- [Feature roadmap (GitHub Project)](https://github.com/users/joshuaswarren/projects/1)
 - [Historical Plans Index](plans/README.md)
 - [PR1 Eval Harness Foundation Plan](plans/2026-03-06-engram-pr1-eval-harness-foundation.md)
 - [PR2 Benchmark Pack Validator And Import Tools](plans/2026-03-06-engram-pr2-benchmark-tools.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,102 +1,182 @@
-# Getting Started
+# Getting started
+
+The complete install and first-run guide. Pick an install path, drop in a minimal
+config, and verify that memory is flowing. If you only want the fastest happy path,
+read the [Quickstart](guides/quickstart.md) first and come back here for the details.
+
+Remnic runs two ways: **standalone**, where a local daemon serves every MCP-capable
+tool, and as a **native OpenClaw plugin**, where OpenClaw hosts Remnic in-process.
+Most tools use the standalone path; OpenClaw gets the deepest integration.
 
 ## Prerequisites
 
-- [OpenClaw](https://github.com/openclaw/openclaw) gateway running
-- OpenAI API key (for extraction; retrieval-only mode works without one)
-- [QMD](https://github.com/tobi/qmd) installed (recommended)
+- **Node.js 22.12 or newer** ([nodejs.org](https://nodejs.org/)).
+- **An OpenAI API key** for memory extraction. Retrieval-only mode works without one —
+  you just won't get new memories extracted from conversations.
+- **QMD (optional, recommended)** for the highest-quality search. Remnic falls back to
+  embedding search and recency-ordered reads without it. See [Set up QMD](#set-up-qmd-optional-recommended).
 
-## Installation
+## Install
 
-### Option A: npm (recommended)
+### Option A: Standalone (npm)
+
+The universal path. Works with Claude Code, Codex CLI, Cursor, and any other MCP
+client through the local daemon.
 
 ```bash
-openclaw plugins install clawhub:@remnic/plugin-openclaw
+npm install -g @remnic/cli
 ```
 
-### Option B: Developer install (from Git)
+This installs the `remnic` command and the bundled `@remnic/server` the daemon runs.
+A legacy `engram` binary is installed alongside as a forwarder during the v1.x rename
+window.
+
+Create the daemon's config, set your secrets, then install the background service:
 
 ```bash
-git clone https://github.com/joshuaswarren/remnic.git \
-  ~/.openclaw/extensions/remnic
-cd ~/.openclaw/extensions/remnic
-pnpm install && pnpm run build
-```
-
-### Option C: Standalone (no OpenClaw)
-
-Use Remnic as a standalone memory system without OpenClaw. Requires [Node.js](https://nodejs.org/) 22.12+ and [tsx](https://github.com/privatenumber/tsx) (`npm install -g tsx`).
-
-Build from source and use the standalone CLI:
-
-```bash
-npm install -g tsx               # Required — CLI entry point is TypeScript
-git clone https://github.com/joshuaswarren/remnic.git
-cd remnic && pnpm install && pnpm run build
-cd packages/remnic-cli && npm link # Makes `remnic` available on PATH
-cd ../..
-remnic init                      # Create config in current directory
+mkdir -p ~/.config/remnic
+remnic init                                  # scaffold a config to copy from
+cp remnic.config.json ~/.config/remnic/config.json
 export OPENAI_API_KEY=sk-...
 export REMNIC_AUTH_TOKEN=$(openssl rand -hex 32)
-remnic daemon start              # Start background server (requires source build)
-remnic status                    # Verify it's running
-remnic query "hello" --explain   # Test with tier breakdown
+remnic daemon install                        # write service file, enable, start
+remnic status                                # confirm it is running
 ```
 
-> **Note:** The canonical CLI is `remnic`. The legacy `engram` binary remains as a forwarder during the rename window. Running `npm link` from `packages/remnic-cli/` (not the repo root) makes the CLI globally available — the root package only exposes `engram-access`. Alternatively, invoke directly: `npx tsx packages/remnic-cli/src/index.ts <command>`.
+`remnic init` writes a starter `remnic.config.json` in the current directory. The
+managed daemon looks for config at `~/.config/remnic/config.json` (it runs outside your
+shell's working directory), so copy it there — or point the service at any path with
+`REMNIC_CONFIG_PATH`. See [Configure](#configure) for the file shape.
 
-Standalone mode provides 15+ CLI commands for querying, onboarding projects, curating files, managing spaces, running benchmarks, and more. See the [Platform Migration Guide](guides/platform-migration.md) for standalone adoption details.
+### Option B: OpenClaw plugin
 
-OpenClaw remains the recommended installation path for most users.
+If you run the [OpenClaw](https://github.com/openclaw/openclaw) gateway, install Remnic
+as its memory plugin. One command configures everything:
 
-## Minimal Config
+```bash
+remnic openclaw install
+```
 
-Add to `openclaw.json` under `plugins.entries.openclaw-engram.config`:
+This sets both `plugins.entries."openclaw-remnic"` and `plugins.slots.memory` in
+`~/.openclaw/openclaw.json` (or `$OPENCLAW_CONFIG_PATH`), then restarts the gateway.
+Use `--dry-run` first to preview the config diff, or `--yes` to skip prompts.
+
+Migrating from the old `@joshuaswarren/openclaw-engram` plugin? Run
+`remnic openclaw migrate-engram`, which backs up the legacy extension before switching
+you to `@remnic/plugin-openclaw`. To pull a newer published package and re-apply the
+config, run `remnic openclaw upgrade`.
+
+### Option C: From source
+
+For contributors and adapter authors. Remnic is a pnpm monorepo.
+
+```bash
+git clone https://github.com/joshuaswarren/remnic.git
+cd remnic
+pnpm install && pnpm run build
+cd packages/remnic-cli && npm link          # put `remnic` on your PATH
+cd ../..
+remnic init
+remnic daemon start                          # manual foreground-style start
+remnic status
+remnic query "hello" --explain               # test recall with a tier breakdown
+```
+
+Run `npm link` from `packages/remnic-cli/`, not the repo root — the root package only
+exposes the `engram-access` bin. You can also invoke the CLI directly without linking:
+`npx tsx packages/remnic-cli/src/index.ts <command>`.
+
+## Configure
+
+Remnic's two run modes use two different config shapes. Both accept the same underlying
+plugin settings.
+
+### Standalone: `remnic.config.json`
+
+A top-level file with `remnic` (plugin settings) and `server` (bind + auth) blocks.
+This is what `remnic init` scaffolds:
 
 ```jsonc
 {
-  "openaiApiKey": "${OPENAI_API_KEY}",
-  "recallBudgetChars": 64000
+  "remnic": {
+    "openaiApiKey": "${OPENAI_API_KEY}",
+    "memoryDir": "~/.remnic/memory",
+    "memoryOsPreset": "balanced",
+    "recallBudgetChars": 64000
+  },
+  "server": {
+    "host": "127.0.0.1",
+    "port": 4318,
+    "authToken": "${REMNIC_AUTH_TOKEN}"
+  }
 }
 ```
 
-**Important:** The `recallBudgetChars` setting controls how much memory context is injected into agent prompts. The default (8,000 chars) is too small for most deployments — profile and shared context alone can exhaust it, leaving no room for actual memories. Set it to 64,000 for large-context models (Claude, GPT-5) or 32,000 for smaller models. See [Recall Budget Tuning](config-reference.md#recall-budget-tuning).
+Discovery order: `--config <path>` → `REMNIC_CONFIG_PATH` (or `ENGRAM_CONFIG_PATH`) →
+`./remnic.config.json` → `./engram.config.json` → `~/.config/remnic/config.json` →
+`~/.config/engram/config.json`. The managed daemon defaults to
+`~/.config/remnic/config.json`.
 
-All other settings have sensible defaults. Config changes require a full gateway restart (hot reload via `SIGUSR1` does not fire `gateway_start`):
+### OpenClaw: `openclaw.json`
+
+Plugin settings live inline in the gateway config under
+`plugins.entries."openclaw-remnic".config` (installs upgraded from the old plugin id
+keep working under the legacy `openclaw-engram` fallback):
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "openclaw-remnic": {
+        "config": {
+          "openaiApiKey": "${OPENAI_API_KEY}",
+          "recallBudgetChars": 64000
+        }
+      }
+    },
+    "slots": {
+      "memory": "openclaw-remnic"
+    }
+  }
+}
+```
+
+Both `entries."openclaw-remnic"` and `slots.memory = "openclaw-remnic"` are required —
+OpenClaw only loads the plugin bound to the `memory` slot. Config changes need a full
+gateway restart (`SIGUSR1` hot reload does not re-fire `gateway_start`):
 
 ```bash
 launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
 ```
 
-Verify startup:
+Override the config path with `OPENCLAW_ENGRAM_CONFIG_PATH` (falling back to
+`OPENCLAW_CONFIG_PATH`) for service environments.
 
-```bash
-grep '\[engram\]' ~/.openclaw/logs/gateway.log | tail -5
-# Should see the memory service start line (the log prefix remains [engram] during v1.x)
-```
+### Tune `recallBudgetChars`
 
-## Set Up QMD (Recommended)
+`recallBudgetChars` caps how much memory context is injected into each prompt. The
+default (8,000 chars) is small — your profile and shared context alone can exhaust it,
+leaving no room for actual memories. Set it to **64,000** for large-context models
+(Claude, GPT-5) or **32,000** for smaller ones. This is the single highest-impact
+setting for recall quality. See
+[Recall budget tuning](config-reference.md#recall-budget-tuning).
 
-[QMD](https://github.com/tobi/qmd) provides hybrid BM25 + vector + reranking search. Without it, Remnic falls back to semantic embedding search (using your OpenAI key when available) and then recency-ordered file reads.
+Everything else has sensible defaults. For a curated starting point, set
+`memoryOsPreset` to `conservative`, `balanced`, `research-max`, or `local-llm-heavy`.
 
-**QMD 2.5.3 is the current supported target.** QMD 1.x still works, but 2.0+
-resolves several known issues natively (session ID crash, model override env
-vars, join performance), 2.5.0 adds runtime diagnostics, structured MCP
-searches, safer indexing, model/GPU env controls, and absolute snippet line
-numbers, and 2.5.3 adds the preferred `--format` selector plus line-range,
-docid-header, full-path, launcher, and Metal-teardown fixes. Remnic detects the
-installed QMD version and only uses newer flags when available. Install via npm
-or bun:
+## Set up QMD (optional, recommended)
+
+[QMD](https://github.com/tobi/qmd) gives Remnic hybrid BM25 + vector + reranking
+search — the highest-quality backend. Remnic supports QMD **2.5.3** and detects the
+installed version at runtime, enabling newer capabilities only when the binary has them.
 
 ```bash
 npm install -g @tobilu/qmd@2.5.3
 # or: bun install -g @tobilu/qmd@2.5.3
-
-# Verify
-qmd --version  # should show 2.5.3
+qmd --version                                 # confirm 2.5.3
 ```
 
-Add to `~/.config/qmd/index.yml`:
+Register your memory directory in `~/.config/qmd/index.yml`:
 
 ```yaml
 openclaw-engram:
@@ -104,13 +184,14 @@ openclaw-engram:
   extensions: [.md]
 ```
 
-Index the collection:
+The `openclaw-engram` collection name is a stable compatibility identifier — keep it as
+is. Then index and embed:
 
 ```bash
 qmd update && qmd embed
 ```
 
-Enable in your plugin config:
+Enable it in your Remnic config:
 
 ```jsonc
 {
@@ -119,136 +200,66 @@ Enable in your plugin config:
 }
 ```
 
-### Upgrading QMD
+For version gates, the upgrade procedure, alternative backends (Orama, LanceDB,
+Meilisearch, remote, noop), and CPU-latency tuning, see
+[Search backends](search-backends.md).
 
-QMD 2.5.3 is a drop-in upgrade from older 2.x installs. Existing collections,
-indexes, and config files work without changes. Remnic detects the installed
-version at startup and enables newer features only when the installed binary
-supports them.
+## Verify it works
 
-**What changed:**
-- QMD `2.5.3`: `qmd query`/`qmd search` prefer `--format json`; Remnic uses that
-  form only for 2.5.3+ and keeps legacy `--json` for older QMD installs.
-- QMD `2.5.3`: `qmd get`/`qmd multi-get` output is line-numbered by default,
-  includes `#docid` headers, accepts `:from:count` line ranges, and supports
-  `--full-path` for direct filesystem paths. These are useful for humans and
-  agents reading QMD directly; Remnic's search path keeps JSON output with
-  docids for provenance and dedupe.
-- QMD `2.5.2`/`2.5.3`: global launcher fixes improve Windows, pnpm-global,
-  Node/Bun source-mode selection, and macOS Metal teardown behavior.
-- Unified `search()` replaces the old query/search/structuredSearch split internally
-- MCP server rewritten as a clean SDK consumer (same external contract)
-- Source reorganized into `src/cli/` and `src/mcp/` subdirectories
-- New programmatic SDK: `import { createStore } from '@tobilu/qmd'`
-- `better-sqlite3` bumped to ^12.4.5 (Node 25 support)
-
-**Patches no longer needed:** The following QMD 1.x patches are resolved natively in 2.0:
-- PR #166 (MCP session ID crash) — built-in `sessionIdGenerator`
-- PR #112 (model override env vars) — `QMD_EMBED_MODEL`, `QMD_GENERATE_MODEL`, `QMD_RERANK_MODEL` supported
-- PR #117 (CROSS JOIN fix) — vector search uses two-step query pattern
-
-**Upgrade steps:**
+**Standalone.** Confirm the daemon is healthy and recall responds:
 
 ```bash
-# 1. Install the supported QMD target
-npm install -g @tobilu/qmd@2.5.3
-# or: bun install -g @tobilu/qmd@2.5.3
-
-# 2. If native bindings need repair, rebuild better-sqlite3 manually
-cd ~/.bun/install/global/node_modules/better-sqlite3
-npm rebuild better-sqlite3
-
-# 3. Verify
-qmd --version       # 2.5.3
-qmd doctor          # available on QMD 2.5+
-qmd status           # should show existing collections
-
-# 4. Restart the gateway
-launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
-
-# 5. Verify Remnic picked up the new QMD version
-grep "cliVersion" ~/.openclaw/logs/gateway.log | tail -1
-# Should show: cliVersion=qmd 2.5.3
+remnic status
+remnic doctor
+remnic query "your query" --explain
 ```
 
-To let Remnic perform this upgrade for PATH/fallback installs, set
-`qmdAutoUpgradeEnabled: true`. Remnic will install
-`@tobilu/qmd@qmdSupportedVersion` at most once per
-`qmdAutoUpgradeCheckIntervalMs`. Explicit `qmdPath` installs are never
-auto-upgraded.
-
-**Note:** If you used the OpenClaw patcher for QMD patches, those patches target QMD 1.x source paths that no longer exist in 2.0. The patcher will harmlessly skip them. You can remove old QMD patch entries from the patcher config.
-
-## Five-Minute Config
-
-Enable the most impactful features incrementally:
-
-```jsonc
-{
-  "openaiApiKey": "${OPENAI_API_KEY}",
-  "recallBudgetChars": 64000,
-  "qmdEnabled": true,
-  "qmdCollection": "openclaw-engram",
-
-  // v8.0: Recall Planner (enabled by default)
-  "recallPlannerEnabled": true,
-
-  // v8.0: Episode/Note dual store (opt-in)
-  "episodeNoteModeEnabled": true,
-
-  // v8.0: Memory Boxes (opt-in)
-  "memoryBoxesEnabled": true,
-  "traceWeaverEnabled": true
-}
-```
-
-## Verify It Works
-
-Start a conversation with OpenClaw. After a few turns, check:
+**OpenClaw.** Start a conversation, then after a few turns check the setup and
+extracted memories:
 
 ```bash
-openclaw engram setup --json
-openclaw engram config-review --json
 openclaw engram doctor --json
 openclaw engram inventory --json
-
-# See extracted memories
-ls ~/.openclaw/workspace/memory/local/facts/
-
-# Search memories from CLI
+ls ~/.openclaw/workspace/memory/local/facts/   # extracted facts land here
 openclaw engram search "your query"
 ```
 
-## Config Override (Service Environments)
+## Troubleshooting: hooks aren't firing (OpenClaw)
 
-Override the config file path via environment variable:
+**Symptom:** Remnic looks installed, but no memories are created and the gateway log
+shows no `[engram]`/`[remnic]` lines after conversations.
+
+**Cause:** OpenClaw gates memory plugins on `plugins.slots.memory`. If that slot does
+not name the plugin id, OpenClaw never calls `register(api)` — no hooks fire, nothing is
+stored or recalled.
+
+**Fix:** run the installer, which sets the slot for you, then restart the gateway:
 
 ```bash
-OPENCLAW_ENGRAM_CONFIG_PATH=/absolute/path/to/openclaw.json
+remnic openclaw install
+launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
 ```
 
-Fallback: `OPENCLAW_CONFIG_PATH`.
+**Verify the hooks fired.** After restart, look for the activation line in the gateway
+log (`~/.openclaw/logs/gateway.log`), whose prefix stays `[engram]` during the v1.x
+window:
 
-## Alternative Search Backends (v9.0)
-
-QMD provides the highest quality retrieval, but Engram v9 supports five other backends. To use an alternative, set `searchBackend` in your config:
-
-```jsonc
-{
-  "searchBackend": "orama"   // or "lancedb", "meilisearch", "remote", "noop"
-}
+```bash
+grep "gateway_start fired" ~/.openclaw/logs/gateway.log
 ```
 
-Orama requires zero setup — no external server, no native dependencies. Just set the config and restart.
+If it is absent, `remnic doctor` reports which check failed — config file validity,
+`plugins.entries`, the plugin entry, `plugins.slots.memory`, and the memory directory —
+each with a remediation hint. To wire it by hand, ensure both
+`entries."openclaw-remnic"` and `slots.memory = "openclaw-remnic"` exist; the full
+design note is in
+[Plugin id and memory namespaces](integration/plugin-id-and-memory-namespaces.md).
 
-See [Search Backends](search-backends.md) for a full comparison and configuration guide.
+## Next steps
 
-## Next Steps
-
-- [Search Backends](search-backends.md) — choose and configure your search engine
-- [Procedural memory](procedural-memory.md) — how-to / runbook memories (issue #519); **default-on** since issue #567 PR 4/5 — set `procedural.enabled` to `false` under the Remnic plugin config to opt out of extraction, mining, and recall-time procedure injection
-- [Enable All Features](enable-all-v8.md) — explicit full-profile config for all feature families
-- [Config Reference](config-reference.md) — full settings list with defaults and recommended values
-- [Operations](operations.md) — backups, exports, hourly summaries
-- [Architecture Overview](architecture/overview.md) — how it all fits together
-- [Writing a Search Backend](writing-a-search-backend.md) — implement your own adapter
+- [Connect your tools](guides/quickstart.md#step-3-connect-your-tool) — per-platform connectors
+- [Search backends](search-backends.md) — choose, tune, and upgrade your search engine
+- [Config reference](config-reference.md) — every setting with defaults and presets
+- [Procedural memory](procedural-memory.md) — how-to/runbook memories, default-on; set `procedural.enabled` to `false` to opt out
+- [Operations](operations.md) — backups, exports, summaries
+- [Architecture overview](architecture/overview.md) — how it all fits together

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,35 +31,49 @@ This installs the `remnic` command and the bundled `@remnic/server` the daemon r
 A legacy `engram` binary is installed alongside as a forwarder during the v1.x rename
 window.
 
-Create the daemon's config, set your secrets, then install the background service:
+Create the daemon's config, put your secrets in it, then install the background
+service:
 
 ```bash
 mkdir -p ~/.config/remnic
 remnic init                                  # scaffold a config to copy from
 cp remnic.config.json ~/.config/remnic/config.json
-export OPENAI_API_KEY=sk-...
-export REMNIC_AUTH_TOKEN=$(openssl rand -hex 32)
+# Edit ~/.config/remnic/config.json and replace the ${OPENAI_API_KEY} and
+# ${REMNIC_AUTH_TOKEN} placeholders with real values (e.g. a fresh
+# `openssl rand -hex 32` for the token).
 remnic daemon install                        # write service file, enable, start
 remnic status                                # confirm it is running
 ```
 
-`remnic init` writes a starter `remnic.config.json` in the current directory. The
-managed daemon looks for config at `~/.config/remnic/config.json` (it runs outside your
-shell's working directory), so copy it there — or point the service at any path with
-`REMNIC_CONFIG_PATH`. See [Configure](#configure) for the file shape.
+`remnic init` writes a starter `remnic.config.json` in the current directory with
+`${OPENAI_API_KEY}` and `${REMNIC_AUTH_TOKEN}` placeholders. **The managed service
+does not inherit your shell environment** — launchd/systemd only pass `PATH` and
+`REMNIC_CONFIG_PATH` to the daemon, and placeholders are not expanded — so put the
+real values in the config file (or add them to the service environment yourself).
+Shell `export`s work only for a foreground `remnic daemon start` in the same
+session. The managed daemon looks for config at `~/.config/remnic/config.json`
+(it runs outside your shell's working directory), so copy it there — or point the
+service at any path with `REMNIC_CONFIG_PATH`. See [Configure](#configure) for the
+file shape.
 
 ### Option B: OpenClaw plugin
 
-If you run the [OpenClaw](https://github.com/openclaw/openclaw) gateway, install Remnic
-as its memory plugin. One command configures everything:
+If you run the [OpenClaw](https://github.com/openclaw/openclaw) gateway, install
+Remnic as its memory plugin:
 
 ```bash
-remnic openclaw install
+openclaw plugins install clawhub:@remnic/plugin-openclaw   # 1. install the plugin package
+remnic openclaw install                                    # 2. wire the memory slot
+launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway    # 3. restart the gateway (macOS)
+remnic doctor                                              # 4. verify every check passes
 ```
 
-This sets both `plugins.entries."openclaw-remnic"` and `plugins.slots.memory` in
-`~/.openclaw/openclaw.json` (or `$OPENCLAW_CONFIG_PATH`), then restarts the gateway.
-Use `--dry-run` first to preview the config diff, or `--yes` to skip prompts.
+`remnic openclaw install` sets both `plugins.entries."openclaw-remnic"` and
+`plugins.slots.memory` in `~/.openclaw/openclaw.json` (or `$OPENCLAW_CONFIG_PATH`) —
+it does not download the plugin package itself, so run the `openclaw plugins install`
+step first. Config changes only take effect after a full gateway restart (on Linux,
+restart your gateway service, e.g. `systemctl restart openclaw-gateway`). Use
+`--dry-run` to preview the config diff, or `--yes` to skip prompts.
 
 Migrating from the old `@joshuaswarren/openclaw-engram` plugin? Run
 `remnic openclaw migrate-engram`, which backs up the legacy extension before switching

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -190,7 +190,16 @@ npm install -g @tobilu/qmd@2.5.3
 qmd --version                                 # confirm 2.5.3
 ```
 
-Register your memory directory in `~/.config/qmd/index.yml`:
+Register your memory directory in `~/.config/qmd/index.yml`. **The `path` must match
+your configured `memoryDir`** — for a standalone install using the config shown above:
+
+```yaml
+openclaw-engram:
+  path: ~/.remnic/memory
+  extensions: [.md]
+```
+
+For an OpenClaw plugin install, point it at the plugin's memory directory instead:
 
 ```yaml
 openclaw-engram:
@@ -199,7 +208,7 @@ openclaw-engram:
 ```
 
 The `openclaw-engram` collection name is a stable compatibility identifier — keep it as
-is. Then index and embed:
+is in both modes. Then index and embed:
 
 ```bash
 qmd update && qmd embed

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,20 +108,22 @@ plugin settings.
 ### Standalone: `remnic.config.json`
 
 A top-level file with `remnic` (plugin settings) and `server` (bind + auth) blocks.
-This is what `remnic init` scaffolds:
+`remnic init` scaffolds the skeleton — note it writes `memoryDir` relative to the
+directory you ran it in (`<cwd>/.remnic/memory`) and leaves `${...}` placeholders
+for secrets. A recommended config after editing:
 
 ```jsonc
 {
   "remnic": {
-    "openaiApiKey": "${OPENAI_API_KEY}",
-    "memoryDir": "~/.remnic/memory",
+    "openaiApiKey": "sk-...",              // real value — placeholders are not expanded
+    "memoryDir": "~/.remnic/memory",       // pick a stable absolute path
     "memoryOsPreset": "balanced",
-    "recallBudgetChars": 64000
+    "recallBudgetChars": 64000             // recommended; init does not set this
   },
   "server": {
     "host": "127.0.0.1",
     "port": 4318,
-    "authToken": "${REMNIC_AUTH_TOKEN}"
+    "authToken": "<paste openssl rand -hex 32>"
   }
 }
 ```
@@ -163,8 +165,8 @@ gateway restart (`SIGUSR1` hot reload does not re-fire `gateway_start`):
 launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
 ```
 
-Override the config path with `OPENCLAW_ENGRAM_CONFIG_PATH` (falling back to
-`OPENCLAW_CONFIG_PATH`) for service environments.
+Override the config path with `OPENCLAW_CONFIG_PATH` for service environments
+(the legacy `OPENCLAW_ENGRAM_CONFIG_PATH` is still honored as a fallback).
 
 ### Tune `recallBudgetChars`
 

--- a/docs/graph-dashboard.md
+++ b/docs/graph-dashboard.md
@@ -1,13 +1,15 @@
-# Live Graph Dashboard (v8.8)
+# Live graph dashboard
 
-The live graph dashboard is an optional sidecar process for graph observability.
+The live graph dashboard is an optional sidecar process that serves a read-only view of the memory graph: a snapshot endpoint, a health endpoint, and a WebSocket stream that pushes patches when the graph files change. It has no config flag — you start it on demand with the CLI — and it only surfaces data once the graph subsystem is enabled (`multiGraphMemoryEnabled` / `graphRecallEnabled`, both default `false`).
+
+> Provenance: the live graph dashboard landed in v8.8.
 
 It serves:
 - `GET /api/graph` — current parsed graph snapshot
 - `GET /api/health` — runtime health/status payload
 - WebSocket stream (same host/port) — patch updates after graph file changes
 
-## Start / Stop / Status
+## Start, stop, status
 
 ```bash
 openclaw engram dashboard start --host 127.0.0.1 --port 4319
@@ -20,7 +22,7 @@ Default behavior:
 - Loopback bind by default (`127.0.0.1`).
 - Graceful degradation when graph files are missing/corrupt (health endpoint remains available).
 
-## Safety Notes
+## Safety notes
 
 - Keep loopback bind unless you explicitly need remote access.
 - WebSocket upgrades require an explicit `Origin` header that is loopback (`127.0.0.1`, `localhost`, or `::1`) and uses the dashboard's bound HTTP port (`http:` only).

--- a/docs/graph-edge-decay.md
+++ b/docs/graph-edge-decay.md
@@ -1,17 +1,36 @@
-# Graph Edge Confidence Decay
+# Graph edge confidence decay
 
-> Shipped in issue #681 (three PRs). PR 1/3 added the `confidence` schema
-> field to `GraphEdge`. PR 2/3 wired the maintenance job that decays edges
-> over time. PR 3/3 integrated confidence into the recall traversal path and
-> added `--include-low-confidence` for diagnostic queries.
+Graph edge decay keeps Remnic's memory graph focused on connections that still
+matter: every edge carries a `confidence` value that erodes over time unless the
+edge is reinforced, and low-confidence edges drop out of recall traversal. Enable it
+on long-lived graphs where stale associations accumulate and dilute spreading
+activation.
+
+**Opt-in via `graphEdgeDecayEnabled` (default `false`).** Decay only has edges to
+work on when the memory graph is enabled — `multiGraphMemoryEnabled` and
+`graphRecallEnabled` are both `false` by default, so turn the graph on first (or use
+the `research-max` preset).
+
+## Enable it
+
+```json
+{
+  "multiGraphMemoryEnabled": true,
+  "graphRecallEnabled": true,
+  "graphEdgeDecayEnabled": true
+}
+```
+
+With decay off (the default), all edges stay at their initial confidence for the
+lifetime of the graph.
 
 ## Overview
 
-Every edge in Remnic's graph stores carries an optional `confidence ∈ [0, 1]`
-value. Newly written edges start at `1.0`. The maintenance job periodically
-reduces confidence for edges that have not been reinforced recently. Edges that
-remain below the configured floor are pruned from traversal, which focuses
-recall on high-quality, actively reinforced connections.
+Every edge in Remnic's graph stores an optional `confidence ∈ [0, 1]` value. Newly
+written edges start at `1.0`. The maintenance job periodically reduces confidence
+for edges that have not been reinforced recently. Edges that remain below the
+configured floor are pruned from traversal, which focuses recall on high-quality,
+actively reinforced connections.
 
 ## Model
 
@@ -23,25 +42,24 @@ Each edge stores two fields:
 | `lastReinforcedAt` | `string \| undefined` | ISO timestamp of the most recent reinforcement event. Missing means "never reinforced since write". |
 
 Confidence decreases at a fixed fractional rate per **decay window** that has
-elapsed since `lastReinforcedAt`. Edges that span multiple windows are charged
-for all elapsed windows in a single pass, so the job is idempotent — running it
-twice with the same timestamp is a no-op.
+elapsed since `lastReinforcedAt`. Edges that span multiple windows are charged for
+all elapsed windows in a single pass, so the job is idempotent — running it twice
+with the same timestamp is a no-op.
 
 When an edge is observed during extraction (e.g., two memories share a named
-entity), the reinforcement primitive resets `lastReinforcedAt` to `now` and
-bumps `confidence` by the default reinforcement delta (`0.05`), capped at
-`1.0`. Repeated co-occurrence can recover confidence that previously decayed,
-but it cannot push an edge above the confidence ceiling.
+entity), the reinforcement primitive resets `lastReinforcedAt` to `now` and bumps
+`confidence` by the default reinforcement delta (`0.05`), capped at `1.0`. Repeated
+co-occurrence can recover confidence that previously decayed, but it cannot push an
+edge above the ceiling.
 
 **Confidence floor** — edges whose confidence drops to or below the configured
-`graphEdgeDecayFloor` are never decayed further. They remain in the graph but
-will be pruned during recall traversal unless `--include-low-confidence` is
-specified.
+`graphEdgeDecayFloor` are never decayed further. They remain in the graph but will
+be pruned during recall traversal unless `--include-low-confidence` is specified.
 
-## Maintenance Job
+## Maintenance job
 
-The decay job runs on a configurable cadence and processes all three graph
-stores (`entity.jsonl`, `time.jsonl`, `causal.jsonl`).
+The decay job runs on a configurable cadence and processes all three graph stores
+(`entity.jsonl`, `time.jsonl`, `causal.jsonl`).
 
 ### Configuration
 
@@ -53,30 +71,25 @@ stores (`entity.jsonl`, `time.jsonl`, `causal.jsonl`).
 | `graphEdgeDecayPerWindow` | `0.1` | Fraction of confidence lost per elapsed window. Range `[0, 1]`. |
 | `graphEdgeDecayFloor` | `0.1` | Minimum confidence an edge can decay to; decay stops here. Range `[0, 1]`. |
 
-### Tuning Guidance
+### Tuning guidance
 
-- **Aggressive decay** (high-churn environments): lower `graphEdgeDecayWindowMs`
-  to `30d` and raise `graphEdgeDecayPerWindow` to `0.2`–`0.3`. Edges that are
-  not reinforced within a month will lose confidence quickly, keeping the graph
-  lean.
-
+- **Aggressive decay** (high-churn environments): lower `graphEdgeDecayWindowMs` to
+  `30d` and raise `graphEdgeDecayPerWindow` to `0.2`–`0.3`. Edges that are not
+  reinforced within a month lose confidence quickly, keeping the graph lean.
 - **Conservative decay** (stable long-term knowledge): raise
-  `graphEdgeDecayWindowMs` to `180d` and lower `graphEdgeDecayPerWindow` to
-  `0.05`. Edges survive six months of inactivity before losing significant
-  confidence.
-
-- **Disable decay**: set `graphEdgeDecayEnabled` to `false` (the default). All
-  edges remain at their initial confidence for the lifetime of the graph.
-
+  `graphEdgeDecayWindowMs` to `180d` and lower `graphEdgeDecayPerWindow` to `0.05`.
+  Edges survive six months of inactivity before losing significant confidence.
+- **Disable decay**: set `graphEdgeDecayEnabled` to `false` (the default). All edges
+  remain at their initial confidence for the lifetime of the graph.
 - **Raise the floor**: increasing `graphEdgeDecayFloor` keeps old edges visible
-  during traversal even without reinforcement. Lowering it to `0.0` allows edges
-  to decay to zero and be effectively invisible unless `--include-low-confidence`
-  is passed.
+  during traversal even without reinforcement. Lowering it to `0.0` allows edges to
+  decay to zero and be effectively invisible unless `--include-low-confidence` is
+  passed.
 
 ### Telemetry
 
 Each run writes a JSON status file to
-`<memoryDir>/state/graph-edge-decay-status.json` with the following fields:
+`<memoryDir>/state/graph-edge-decay-status.json`:
 
 ```json
 {
@@ -100,60 +113,60 @@ Each run writes a JSON status file to
 }
 ```
 
-`remnic doctor` reads this file and surfaces the last run time and summary
-stats in its health report.
+`remnic doctor` reads this file and surfaces the last run time and summary stats in
+its health report.
 
-## Recall Integration
+## Recall integration
 
-### Confidence-Weighted Spreading Activation
+### Confidence-weighted spreading activation
 
 During graph traversal, each edge's contribution to spreading activation is
 multiplied by its `confidence`:
 
-```
+```text
 score += edge.weight × edge.confidence × decay^hop
 ```
 
-Legacy edges without a `confidence` field are treated as `1.0`, so old graphs
-work unchanged.
+Legacy edges without a `confidence` field are treated as `1.0`, so old graphs work
+unchanged.
 
-### Traversal Pruning
+### Traversal pruning
 
 Edges with `confidence < graphTraversalConfidenceFloor` are excluded from the
-adjacency index before BFS begins. Pruned edges contribute no activation and
-cannot serve as intermediate hops to deeper neighbors.
+adjacency index before BFS begins. Pruned edges contribute no activation and cannot
+serve as intermediate hops to deeper neighbors.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `graphTraversalConfidenceFloor` | `0.2` | Minimum confidence required for traversal. Range `[0, 1]`. Legacy edges (no `confidence` field) are always `1.0`. |
 | `graphTraversalPageRankIterations` | `8` | PageRank refinement iterations on top of BFS. Set `0` to use raw BFS scores. |
 
-### The `--include-low-confidence` Flag
+### The `--include-low-confidence` flag
 
-By default, recall traversal respects `graphTraversalConfidenceFloor` and
-ignores decayed edges. Pass `--include-low-confidence` to a `remnic recall`
-command to override this and include all edges regardless of confidence:
+By default, recall traversal respects `graphTraversalConfidenceFloor` and ignores
+decayed edges. Pass `--include-low-confidence` to a recall command to override this
+and include all edges regardless of confidence:
 
 ```bash
 # Standard recall — low-confidence edges pruned
-remnic recall "what do I know about authentication?"
+openclaw engram recall "what do I know about authentication?"
 
 # Diagnostic recall — all edges included even if heavily decayed
-remnic recall "what do I know about authentication?" --include-low-confidence
+openclaw engram recall "what do I know about authentication?" --include-low-confidence
 ```
 
 This is an **operator / debug tool**, not a tuning knob. Use it when:
 
 - You want to understand what edges exist before decay has cleared them.
-- You suspect a recall is missing results because edges have decayed below
-  the floor.
+- You suspect a recall is missing results because edges have decayed below the
+  floor.
 - You are auditing graph state before or after a decay maintenance run.
 
-The flag threads through the full recall pipeline — both the
-`expandResultsViaGraph` hot path and the `applyColdFallbackPipeline` cold path
-respect it. It is also available via the HTTP API as a query parameter:
+The flag threads through the full recall pipeline — both the `expandResultsViaGraph`
+hot path and the `applyColdFallbackPipeline` cold path respect it. It is also
+available via the HTTP API:
 
-```
+```text
 POST /engram/v1/recall
 { "query": "...", "includeLowConfidence": true }
 
@@ -162,22 +175,38 @@ POST /engram/v1/recall?include_low_confidence=true
 { "query": "..." }
 ```
 
-## X-ray Surfacing
+## X-ray surfacing
 
 When recall X-ray capture is enabled (`remnic xray <query>`), each graph result
 carries an `edgeConfidence` field in the per-result provenance. This is the
-confidence of the highest-confidence edge along the BFS path that landed the
-result. The `graphEdgeConfidences` array in the X-ray snapshot lists one entry
-per edge in the recall path, aligned with `graphPath`.
+confidence of the highest-confidence edge along the BFS path that landed the result.
+The `graphEdgeConfidences` array in the X-ray snapshot lists one entry per edge in
+the recall path, aligned with `graphPath`.
 
-Low-confidence results returned via `--include-low-confidence` will show
-reduced `edgeConfidence` values in the X-ray, making it easy to distinguish
-them from normally-admitted results.
+Low-confidence results returned via `--include-low-confidence` show reduced
+`edgeConfidence` values in the X-ray, making it easy to distinguish them from
+normally-admitted results.
 
-## Cross-References
+## Caveats
 
-- [Graph Reasoning](architecture/graph-reasoning.md) — overall graph architecture,
-  spreading activation model, PageRank refinement, lateral inhibition
-- [Graph Dashboard](graph-dashboard.md) — live graph observability server
-- [Config Reference](config-reference.md) — all `graphEdgeDecay*` and
-  `graphTraversalConfidenceFloor` settings
+- Decay needs a populated graph. With `multiGraphMemoryEnabled` /
+  `graphRecallEnabled` off (the defaults), there are no edges to decay.
+- `--include-low-confidence` is a diagnostic override, not a recall-quality tuning
+  knob — leaving it on defeats the point of pruning.
+- Confidence recovery is bounded: repeated co-occurrence can raise a decayed edge
+  but never above `1.0`.
+
+## Cross-references
+
+- [Graph reasoning](architecture/graph-reasoning.md) — overall graph architecture,
+  spreading activation model, PageRank refinement, lateral inhibition.
+- [Graph dashboard](graph-dashboard.md) — live graph observability server.
+- [Config reference](config-reference.md) — all `graphEdgeDecay*` and
+  `graphTraversalConfidenceFloor` settings.
+
+## Provenance
+
+Graph edge confidence decay shipped in issue
+[#681](https://github.com/joshuaswarren/remnic/issues/681) across three PRs: the
+`confidence` schema field on `GraphEdge`, the decay maintenance job, and confidence
+integration into recall traversal plus `--include-low-confidence`.

--- a/docs/graph-edge-decay.md
+++ b/docs/graph-edge-decay.md
@@ -47,10 +47,10 @@ all elapsed windows in a single pass, so the job is idempotent — running it tw
 with the same timestamp is a no-op.
 
 When an edge is observed during extraction (e.g., two memories share a named
-entity), the reinforcement primitive resets `lastReinforcedAt` to `now` and bumps
-`confidence` by the default reinforcement delta (`0.05`), capped at `1.0`. Repeated
-co-occurrence can recover confidence that previously decayed, but it cannot push an
-edge above the ceiling.
+entity), the reinforcement primitive resets `lastReinforcedAt` to `now` and
+bumps `confidence` by the default reinforcement delta (`0.05`), capped at
+`1.0`. Repeated co-occurrence can recover confidence that previously decayed,
+but it cannot push an edge above the ceiling.
 
 **Confidence floor** — edges whose confidence drops to or below the configured
 `graphEdgeDecayFloor` are never decayed further. They remain in the graph but will

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,31 @@
+# Guides
+
+Task-focused walkthroughs for installing, running, tuning, and migrating Remnic.
+New here? Start with the [quickstart](quickstart.md). To return to the docs hub,
+see [`docs/README.md`](../README.md).
+
+## Getting started
+
+- [Quickstart: install Remnic in 5 minutes](quickstart.md) — Install the CLI, start the daemon, connect one tool, and confirm your first recall.
+- [Standalone multi-tenant server](standalone-server.md) — Run Remnic as an HTTP server that serves persistent memory to many agent harnesses at once.
+
+## Running and tuning
+
+- [Daemon management](daemon-management.md) — Start, stop, and supervise the background daemon that owns the memory store.
+- [Cost control](cost-control.md) — Budget presets, latency/churn tradeoffs, and disciplined rollout.
+- [Local LLM guide](local-llm.md) — Keep extraction, reranking, and helper flows on an OpenAI-compatible endpoint you control.
+- [Offline mode](offline-mode.md) — Keep working when the home daemon is unreachable, then sync changes back.
+- [Daily context briefing](daily-briefing.md) — Produce a focused "what matters right now" view across your memory store.
+- [Lossless context management (LCM)](lossless-context-management.md) — How Remnic preserves context that runtime compaction would otherwise discard.
+
+## Tool-specific setup
+
+- [Using Remnic with Codex CLI](codex-cli.md) — Wire Remnic memory into OpenAI's terminal coding agent.
+
+## Migrating
+
+- [OpenClaw Engram to Remnic](openclaw-engram-to-remnic.md) — Move from the legacy `@joshuaswarren/openclaw-engram` package to `@remnic/plugin-openclaw`.
+- [Platform migration guide](platform-migration.md) — Migrate from the single-package Engram plugin to the multi-package Remnic platform.
+- [Migrations guide](migrations.md) — Move from manual tuning and historical roadmap docs to the current config surface.
+
+For migrating off lossless-claw specifically, see [`docs/lcm-to-remnic-migration.md`](../lcm-to-remnic-migration.md).

--- a/docs/guides/codex-cli.md
+++ b/docs/guides/codex-cli.md
@@ -368,20 +368,10 @@ After setup, start a new Codex session and check:
 
 Codex's phase-2 consolidation reads canonical files under `<codex_home>/memories/`
 (`memory_summary.md`, `MEMORY.md`, `raw_memories.md`, `rollout_summaries/*.md`).
-Remnic can mirror hot memories into this exact layout so the always-loaded
-`memory_summary.md` is populated with Remnic content — giving Codex a quick
-cross-session pass without any MCP roundtrips.
+Remnic can mirror its hot memories into that exact layout so the always-loaded
+`memory_summary.md` carries Remnic content with no MCP roundtrips. It is opt-in
+via a `.remnic-managed` sentinel file, writes atomically, and no-ops when the
+content is unchanged — `remnic connectors install codex-cli` sets this up for you.
 
-Materialization is **opt-in via a sentinel file** (`<codex_home>/memories/.remnic-managed`):
-if the sentinel is missing, Remnic will skip the directory and log a warning,
-so hand-edited layouts are never clobbered. Writes are atomic (temp dir +
-rename), and idempotent no-ops happen whenever the content hash is unchanged.
-
-Triggers (all configurable):
-
-- After semantic or causal consolidation completes (`codexMaterializeOnConsolidation`)
-- At Codex session end via the bundled Stop hook (`codexMaterializeOnSessionEnd`)
-- Manually: `tsx scripts/codex-materialize.ts --reason manual`
-
-See [plugins/codex.md — Native memory materialization](../plugins/codex.md#native-memory-materialization)
-for the full list of config knobs and the opt-out procedure.
+For the trigger flags, token budget, and full opt-out procedure, see
+[plugins/codex.md — Native memory materialization](../plugins/codex.md#native-memory-materialization).

--- a/docs/guides/cost-control.md
+++ b/docs/guides/cost-control.md
@@ -1,4 +1,4 @@
-# Cost Control Guide
+# Cost control guide
 
 Start with the preset that matches your appetite for latency and churn:
 
@@ -7,7 +7,7 @@ Start with the preset that matches your appetite for latency and churn:
 - `research-max`: broadest shipped experimental surface
 - `local-llm-heavy`: biases expensive helper/extraction paths toward local inference
 
-## Budget Mapping
+## Budget mapping
 
 The original roadmap named budgets at a higher level than the current runtime surface. Use this mapping when tuning a live install:
 
@@ -23,7 +23,7 @@ The original roadmap named budgets at a higher level than the current runtime su
 | `maxProactiveExtractionTokens` | `proactiveExtractionMaxTokens` |
 | `indexRefreshBudgetMs` | Use `qmdUpdateMinIntervalMs`, `qmdUpdateTimeoutMs`, and `conversationIndexMinUpdateIntervalMs` |
 
-## Lowest-Risk Rollout
+## Lowest-risk rollout
 
 1. Start with `memoryOsPreset: "conservative"` or `memoryOsPreset: "balanced"`.
 2. Keep `maxCompressionTokensPerHour` and `maxProactiveQuestionsPerExtraction` at their defaults until baseline recall is stable.
@@ -31,7 +31,7 @@ The original roadmap named budgets at a higher level than the current runtime su
 4. Raise `maxMemoryTokens` only after you know which sections are providing real value.
 5. Enable graph traversal only after checking that standard recall already finds the right seeds.
 
-## Practical Levers
+## Practical levers
 
 - If recall payloads are too large, lower `maxMemoryTokens` before changing per-section budgets.
 - If ranking is too slow, lower `rerankTimeoutMs` and keep rerank fail-open.
@@ -40,11 +40,11 @@ The original roadmap named budgets at a higher level than the current runtime su
 - If proactive extraction is noisy, set `maxProactiveQuestionsPerExtraction: 0`.
 - If proactive extraction is slow, lower `proactiveExtractionTimeoutMs` or `proactiveExtractionMaxTokens`, or set either to `0` to hard-disable the second pass.
 
-## What Engram Does Not Currently Expose
+## What Remnic does not currently expose
 
 Two roadmap knobs remain intentionally unshipped as first-class fields:
 
 - a single global `maxRecallMs`
 - a dedicated `maxArtifactsPerSession`
 
-Engram uses stage-specific timeouts and artifact gating instead. That keeps the live runtime aligned with the actual retrieval paths rather than pretending everything can be bounded by one coarse timer.
+Remnic uses stage-specific timeouts and artifact gating instead. That keeps the live runtime aligned with the actual retrieval paths rather than pretending everything can be bounded by one coarse timer.

--- a/docs/guides/daemon-management.md
+++ b/docs/guides/daemon-management.md
@@ -43,7 +43,7 @@ remnic daemon uninstall   # disable + remove service file
 remnic daemon start       # start now (without installing service)
 remnic daemon stop        # stop now
 remnic daemon restart     # restart
-remnic daemon status      # show running state, port, memory path
+remnic daemon status      # running state + pid, port, service, memory extensions
 ```
 
 ## Configuration

--- a/docs/guides/daily-briefing.md
+++ b/docs/guides/daily-briefing.md
@@ -1,4 +1,4 @@
-# Daily Context Briefing
+# Daily context briefing
 
 The daily briefing produces a focused "here is what matters right now" view of your memory store by cross-referencing:
 
@@ -51,7 +51,7 @@ The response includes both `markdown` and `json` representations along with the 
 {
   "plugins": {
     "entries": {
-      "openclaw-engram": {
+      "openclaw-remnic": {
         "config": {
           "briefing": {
             "enabled": true,

--- a/docs/guides/local-llm.md
+++ b/docs/guides/local-llm.md
@@ -1,10 +1,10 @@
-# Local LLM Guide
+# Local LLM guide
 
-Use Engram's local LLM path when you want extraction, reranking, and selected helper flows to stay on an OpenAI-compatible endpoint you control.
+Use Remnic's local LLM path when you want extraction, reranking, and selected helper flows to stay on an OpenAI-compatible endpoint you control.
 
-This guide applies when `modelSource` is `plugin` (the default). If you switch to `modelSource: "gateway"`, Engram sends extraction/consolidation/rerank calls to the configured gateway agent chain instead, and `localLlm*` settings no longer control the primary extraction path.
+This guide applies when `modelSource` is `plugin` (the parser default when the key is unset; new installs may be seeded with `gateway`). With `modelSource: "gateway"`, Remnic sends extraction/consolidation/rerank calls to the configured gateway agent chain instead, and `localLlm*` settings no longer control the primary extraction path.
 
-## Fast Start
+## Fast start
 
 If you want the preset first:
 
@@ -21,7 +21,7 @@ If you want the preset first:
 
 The preset seeds the broader advanced surface, but your explicit `localLlm*` values still win.
 
-## Recommended Split
+## Recommended split
 
 Use the primary local model for slower tasks:
 
@@ -36,11 +36,11 @@ Use the fast local tier for short-turn helpers:
 - temporal-memory summaries
 - compression-guideline refinement
 
-## Key Settings
+## Key settings
 
 | Setting | Why it matters |
 |---------|----------------|
-| `localLlmEnabled` | Master switch for Engram's local inference path while `modelSource=plugin` |
+| `localLlmEnabled` | Master switch for Remnic's local inference path while `modelSource=plugin` |
 | `localLlmUrl` | Base URL for the OpenAI-compatible endpoint |
 | `localLlmModel` | Main local model ID |
 | `localLlmFastEnabled` | Enables the smaller/faster local tier |
@@ -50,14 +50,14 @@ Use the fast local tier for short-turn helpers:
 | `localLlmFastTimeoutMs` | Lower bound for fast helper requests |
 | `embeddingFallbackProvider` | Use `local` if you also want embedding fallback to stay local |
 
-## Operational Notes
+## Operational notes
 
 - Keep `localLlmFallback=true` during bring-up unless you explicitly want hard failures.
 - If the local server reports a smaller context window than the model supports, set `localLlmMaxContext`.
 - If reranking feels slow, lower `rerankTimeoutMs` before changing the main extraction timeout.
-- The local path is fail-open by default. If the endpoint disappears, Engram should degrade rather than block the gateway.
+- The local path is fail-open by default. If the endpoint disappears, Remnic should degrade rather than block the gateway.
 
-## Custom OpenAI-Compatible Endpoint (Self-Hosted)
+## Custom OpenAI-compatible endpoint (self-hosted)
 
 If you run a single OpenAI-compatible server (vLLM, Ollama, LM Studio, etc.) that serves both chat completions and embeddings, you can point everything at it with just `openaiBaseUrl`:
 
@@ -70,9 +70,9 @@ If you run a single OpenAI-compatible server (vLLM, Ollama, LM Studio, etc.) tha
 }
 ```
 
-Engram routes extraction, consolidation, and embedding requests to your endpoint. The embedding path appends `/embeddings` to `openaiBaseUrl` automatically.
+Remnic routes extraction, consolidation, and embedding requests to your endpoint. The embedding path appends `/embeddings` to `openaiBaseUrl` automatically.
 
-### Separate Chat and Embedding Models
+### Separate chat and embedding models
 
 If your chat model and embedding model live on different servers, use `openaiBaseUrl` for chat and the `localLlm*` settings for embeddings:
 
@@ -89,7 +89,7 @@ If your chat model and embedding model live on different servers, use `openaiBas
 }
 ```
 
-### Docker Networking
+### Docker networking
 
 When running OpenClaw in Docker and the LLM server on the host, use `host.docker.internal` instead of `localhost`:
 
@@ -100,7 +100,7 @@ When running OpenClaw in Docker and the LLM server on the host, use `host.docker
 }
 ```
 
-## When Not To Use It
+## When not to use it
 
 - If you do not have a stable local endpoint yet, start with `memoryOsPreset: "balanced"`.
 - If you want the lowest moving-part count, start with `conservative` and leave local inference disabled until the rest of the install is stable.

--- a/docs/guides/lossless-context-management.md
+++ b/docs/guides/lossless-context-management.md
@@ -1,8 +1,8 @@
-# Lossless Context Management (LCM)
+# Lossless context management (LCM)
 
 When AI agents hit their context window limit, the runtime compresses older messages to make room. This is called **compaction**, and it permanently discards the original content. LCM prevents information loss by proactively archiving every message and building a hierarchical summary structure that can be injected back into recall.
 
-## How It Works
+## How it works
 
 LCM operates as a complement to native compaction — it does not replace it. Instead, it observes, archives, summarizes, and provides expansion tools.
 
@@ -41,7 +41,7 @@ Summaries are organized in a hierarchical directed acyclic graph:
 
 The **fresh tail** (most recent N turns, default 16) always uses leaf-level summaries for maximum detail. Older portions use the deepest available nodes for maximum compression.
 
-### Three-Level Summarization
+### Three-level summarization
 
 When creating summaries, LCM uses a three-level escalation strategy:
 
@@ -59,7 +59,7 @@ Add to your `openclaw.json`:
 {
   "plugins": {
     "entries": {
-      "openclaw-engram": {
+      "openclaw-remnic": {
         "config": {
           "lcmEnabled": true
         }
@@ -77,7 +77,7 @@ All LCM settings have sensible defaults. Override only what you need:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `lcmEnabled` | `false` | Enable LCM |
+| `lcmEnabled` | `false` | Enable LCM (the `research-max` preset turns this on) |
 | `lcmLeafBatchSize` | `8` | Number of turns per leaf summary node |
 | `lcmRollupFanIn` | `4` | Number of child nodes merged into one parent |
 | `lcmFreshTailTurns` | `16` | Recent turns that always use leaf-level (most detailed) summaries |
@@ -86,11 +86,11 @@ All LCM settings have sensible defaults. Override only what you need:
 | `lcmDeterministicMaxTokens` | `512` | Token limit for the deterministic (no-LLM) fallback summarizer |
 | `lcmArchiveRetentionDays` | `90` | Days to retain raw archived messages before pruning |
 
-## MCP Tools
+## MCP tools
 
-LCM registers three tools that agents can use to explore conversation history:
+LCM registers three tools that agents can use to explore conversation history. Each is registered remnic-first with a legacy `engram_context_*` alias retained during the compatibility window:
 
-### `engram_context_search`
+### `remnic_context_search`
 
 Full-text search across all archived conversation messages.
 
@@ -102,7 +102,7 @@ SessionId: (optional) filter to a specific session
 
 Returns matching messages with turn index, role, snippet, and session ID.
 
-### `engram_context_describe`
+### `remnic_context_describe`
 
 Get a compressed summary of a turn range. Uses the best available summary node from the DAG.
 
@@ -114,7 +114,7 @@ ToTurn: 50
 
 Returns the summary text, turn count, and depth of the covering node.
 
-### `engram_context_expand`
+### `remnic_context_expand`
 
 Retrieve raw lossless messages for a turn range. This is the "zoom in" tool — when a summary isn't detailed enough, the agent can expand to the original messages.
 
@@ -127,7 +127,7 @@ MaxTokens: 2000
 
 Returns the original messages with role and content, truncated to fit the token budget (preserving first and last messages).
 
-## How It Complements Native Compaction
+## How it complements native compaction
 
 LCM sits in the **memory plugin slot**, not the context engine slot. It cannot prevent or replace compaction — the runtime controls that. Instead:
 

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -1,39 +1,47 @@
-# Migrations Guide
+# Migrations
 
-## Platform Migration (v9.1.36+)
+Remnic covers several distinct migration paths. This page is the index; each
+path has its own detailed guide. It also covers two housekeeping migrations that
+have no separate guide: consolidating a hand-tuned config onto a preset, and
+finding the current roadmap.
 
-The v9.1.36 release reorganizes the project into a Remnic monorepo with five packages (`@remnic/core`, `@remnic/cli`, `@remnic/server`, `@remnic/bench`, `@remnic/hermes-provider`) and adds a standalone CLI, spaces, benchmarks, onboarding, curation, diff-aware sync, connector management, and a retrieval tier system.
+## Which migration do you need?
 
-**For most OpenClaw users, the upgrade is transparent** -- the npm entry point, config format, plugin manifest, memory storage, and all 60+ config options are unchanged.
+| You are moving from | Guide |
+|---|---|
+| The legacy `@joshuaswarren/openclaw-engram` plugin to `@remnic/plugin-openclaw` | [OpenClaw Engram to Remnic](openclaw-engram-to-remnic.md) |
+| The single-package plugin to the standalone `@remnic/cli` and server | [Platform migration](platform-migration.md) |
+| lossless-claw (LCM) to Remnic's built-in LCM mode | [LCM to Remnic](../lcm-to-remnic-migration.md) |
+| mem0, Supermemory, ChatGPT, Claude, or Gemini exports | Run `remnic import --adapter <name> --file <path>` |
 
-**Full guide:** [Platform Migration Guide](platform-migration.md)
+## Upgrading in place
 
-**Quick verification:**
+For existing OpenClaw users the plugin update path is transparent: the npm entry
+point, config format, plugin manifest, memory storage, and config schema are
+unchanged. Verify after upgrading:
 
 ```bash
-openclaw engram doctor --json   # OpenClaw users
-remnic doctor                    # standalone users
-npm test                         # 672 tests pass
+openclaw engram doctor --json   # OpenClaw plugin users
+remnic doctor                   # standalone users
 ```
 
-**Rollback:** `openclaw plugins install npm:@remnic/plugin-openclaw@<previous-version>`
+Roll back by pinning the previous plugin version:
 
----
+```bash
+openclaw plugins install npm:@remnic/plugin-openclaw@<previous-version>
+```
 
-This guide also covers:
+Memory storage is never modified by an upgrade, so rollback never loses data.
 
-1. moving from hand-tuned advanced flags to `memoryOsPreset`
-2. moving from historical local plan files to the GitHub Project for roadmap sequencing
+## Consolidating config onto a preset
 
-## Config Migration
+If your config grew by copying old advanced-flag examples, collapse it onto a
+preset first:
 
-If your config grew by copying old v8 examples, collapse it first:
-
-1. Choose the nearest preset: `conservative`, `balanced`, `research-max`, or `local-llm-heavy`.
+1. Choose the nearest preset: `conservative`, `balanced`, `research-max`, or
+   `local-llm-heavy`.
 2. Delete advanced flags that now match the preset.
 3. Re-add only the values you intentionally want to override.
-
-Example:
 
 ```jsonc
 {
@@ -43,131 +51,29 @@ Example:
 }
 ```
 
-That is easier to review than carrying a large copied block of defaults.
+That is far easier to review than carrying a large copied block of defaults.
 
-## Backward-Compatible Alias
+Older docs sometimes used `research` as a preset label. The config parser still
+accepts it as an alias, but the canonical name is `research-max`.
 
-Older docs sometimes used `research` as a preset label. The config parser still accepts it, but the canonical name is `research-max`.
+## Where the roadmap lives
 
-## Documentation Migration
-
-The roadmap source of truth is now the GitHub Project:
+The roadmap source of truth is the GitHub Project:
 
 - [Remnic Feature Roadmap](https://github.com/users/joshuaswarren/projects/1)
 
-Use `docs/plans/` only for architecture context after you already know the active project item.
+Use `docs/plans/` only for architecture context after you already know the
+active project item. Good workflow:
 
-Good workflow:
+1. Check the GitHub Project for order, blockers, and coordination.
+2. Read the relevant issue.
+3. Open the matching historical plan only if you need deeper design rationale.
 
-1. check the GitHub Project for order, blockers, and coordination
-2. read the relevant issue
-3. open the matching historical plan only if you need deeper design rationale
-
-## Platform Migration (v9.1.36+)
-
-The v9.1.36 release introduced a monorepo architecture with five packages, a standalone CLI, and several new capabilities. All existing OpenClaw installations continue to work without modification.
-
-### What Changed
-
-The repository was reorganized from a single package into a monorepo:
-
-```
-packages/
-  core/              — Framework-agnostic engine (no OpenClaw imports)
-  cli/               — Standalone CLI binary (15+ commands)
-  server/            — Standalone HTTP/MCP server
-  bench/             — Benchmarks + CI regression gates
-  hermes-provider/   — HTTP client for remote Remnic instances
-```
-
-New capabilities added across milestones M0-M7:
-
-| Area | What's New |
-|------|-----------|
-| Schema validation | Zod-validated request/response schemas on all endpoints |
-| Structured errors | Consistent JSON errors with correlation IDs |
-| Hermes provider | Standalone HTTP client for remote Remnic instances |
-| Standalone CLI | 15+ commands for init, status, query, doctor, daemon, onboard, curate, review, sync, dedup, connectors, space, benchmark |
-| Onboarding | Language detection, doc discovery, ingestion planning |
-| Curation | Deliberate ingestion with dedup/contradiction detection |
-| Review inbox | Low-confidence item governance |
-| Diff-aware sync | Source change detection with incremental ingestion |
-| Dedup | Duplicate memory detection |
-| Connectors | Host adapter registry with lifecycle management |
-| Spaces | Personal, project, and team memory spaces |
-| Benchmarks | Latency ladder with tier breakdowns and CI regression gates |
-| Retrieval tiers | Tier 0 (exact) through Tier 4 (full scan) |
-
-### What Stayed the Same
-
-These integration points are unchanged -- auto-update is safe:
-
-- **npm entry point**: `dist/index.js` -- identical behavior and exports
-- **Config format**: `openclaw.json` under `plugins.entries.openclaw-engram.config` -- same schema
-- **Plugin manifest**: `openclaw.plugin.json` -- still loaded by OpenClaw gateway
-- **Memory storage**: `~/.openclaw/workspace/memory/local/` -- same file layout
-- **All 60+ config options**: Unchanged with same defaults
-- **Extraction/recall pipeline**: Identical behavior
-
-### New Standalone Packages
-
-| Package | Description |
-|---------|-------------|
-| `@remnic/core` | Framework-agnostic engine with zero OpenClaw imports |
-| `@remnic/cli` | Standalone CLI binary with 15+ commands |
-| `@remnic/server` | Standalone HTTP/MCP server |
-| `@remnic/bench` | Benchmarks + CI regression gates |
-| `@remnic/hermes-provider` | HTTP client for remote Remnic instances |
-
-### New CLI Commands
-
-The standalone `remnic` CLI provides these commands:
-
-| Command | Description |
-|---------|-------------|
-| `engram init` | Create `engram.config.json` in the current directory |
-| `engram status [--json]` | Show server/daemon status |
-| `engram query <text> [--explain]` | Query memories with optional tier breakdown |
-| `engram doctor` | Run diagnostics (Node version, config, API key, memory dir, daemon) |
-| `engram config` | Show current configuration |
-| `engram daemon start\|stop\|restart` | Manage background server |
-| `engram tree generate\|watch\|validate` | Context tree generation *(stub — not yet implemented)* |
-| `engram onboard [dir]` | Onboard project directory |
-| `engram curate <path>` | Curate files into memory |
-| `engram review list\|approve\|dismiss\|flag` | Review inbox management |
-| `engram sync run\|watch` | Diff-aware filesystem sync |
-| `engram dedup` | Find duplicate memories |
-| `engram connectors list\|install\|remove\|doctor` | Host adapter management |
-| `engram space list\|switch\|create\|delete\|push\|pull\|share\|promote\|audit` | Memory space management |
-| `engram benchmark run\|check\|report` | Latency benchmarks and regression gates |
-
-### Verification Steps
-
-**OpenClaw users:**
-
-```bash
-openclaw engram doctor --json    # Health diagnostics
-npm test                         # 672 tests should pass
-openclaw engram config-review    # Config tuning check
-```
-
-**Standalone users:**
-
-```bash
-engram doctor                    # Run diagnostics
-engram status                    # Server status
-engram query "test" --explain    # Verify query with tier breakdown
-```
-
-### Full Migration Guide
-
-For comprehensive details, including adoption paths for each standalone feature and rollback instructions, see the [Platform Migration Guide](platform-migration.md).
-
----
-
-## Operator Migration Checklist
+## Operator checklist
 
 - Replace copied preset JSON blocks with `memoryOsPreset` where possible.
-- Update any docs that still point contributors at a specific plan file as if it were the live roadmap.
-- Re-run config contract checks after adding or removing advanced fields.
-- For v9.1.36+ platform migration: see the [Platform Migration Guide](platform-migration.md) for full details.
+- Update any internal docs that still point contributors at a specific plan file
+  as if it were the live roadmap.
+- Re-run the config contract check after adding or removing advanced fields.
+- Moving to the standalone CLI or server? See the
+  [Platform migration guide](platform-migration.md).

--- a/docs/guides/offline-mode.md
+++ b/docs/guides/offline-mode.md
@@ -1,4 +1,4 @@
-# Offline Mode
+# Offline mode
 
 Offline mode lets a laptop keep using Remnic when the home Remnic daemon is
 unreachable, then sync local changes back when the network returns.
@@ -16,7 +16,7 @@ cruise cabin without reconfiguring agents. If the home daemon is reachable, the
 watcher pushes and pulls. If it is not reachable, Remnic stays local and the
 watcher retries until the connection comes back.
 
-## Before Travel
+## Before travel
 
 Start or verify the home daemon:
 
@@ -37,7 +37,7 @@ remnic daemon start
 Seed the laptop from the home daemon:
 
 ```bash
-export REMNIC_OFFLINE_REMOTE_URL="http://home-remnic.tailnet-name.ts.net:4317"
+export REMNIC_OFFLINE_REMOTE_URL="http://home-remnic.tailnet-name.ts.net:4318"
 export REMNIC_OFFLINE_TOKEN="$REMNIC_AUTH_TOKEN"
 remnic offline prepare --namespace default
 ```
@@ -45,7 +45,7 @@ remnic offline prepare --namespace default
 `prepare` downloads a full snapshot from the remote namespace and writes the
 offline sync state under `<memoryDir>/.offline-sync/state/`.
 
-## Stay Synced
+## Stay synced
 
 Keep this running on the laptop before you leave:
 
@@ -64,7 +64,7 @@ The watcher performs the same work as `remnic offline sync`:
 Network failures do not clear local state or block local Remnic use. The next
 watch iteration tries again.
 
-## Manual Sync
+## Manual sync
 
 Use `sync` when you want a one-shot transfer:
 
@@ -80,7 +80,7 @@ remnic offline status --namespace default
 remnic offline status --namespace default --json
 ```
 
-## Multiple Namespaces
+## Multiple namespaces
 
 Sync each namespace independently:
 
@@ -94,7 +94,7 @@ remnic offline watch --namespace work --interval-ms 120000
 The state file key includes the remote identity and namespace, so separate
 namespaces do not overwrite each other's sync base.
 
-## Conflict Handling
+## Conflict handling
 
 Offline mode uses a shared-base merge protocol. A file is applied only when the
 target side is still at the base version the sender last saw.
@@ -109,7 +109,7 @@ and writes the incoming version under:
 The sync result reports the conflict path so you can inspect or merge it later.
 Remote-side conflicts behave the same way on the home daemon.
 
-## What Syncs
+## What syncs
 
 Offline sync operates at the Remnic storage directory layer. That means it works
 for core memories, retrieval indices, governance metadata, review queues,
@@ -174,18 +174,18 @@ watcher logs one warning and permanently skips that file for the lifetime of
 the watcher process, so the rest of the namespace keeps syncing. Add the path
 to `offlineSyncExcludes` (or `--exclude`) to silence it across restarts.
 
-## Environment Variables
+## Environment variables
 
 The CLI reads these values when flags are omitted:
 
 ```bash
-export REMNIC_OFFLINE_REMOTE_URL="http://home-remnic.tailnet-name.ts.net:4317"
+export REMNIC_OFFLINE_REMOTE_URL="http://home-remnic.tailnet-name.ts.net:4318"
 export REMNIC_OFFLINE_TOKEN="..."
 ```
 
 Legacy fallbacks are also accepted:
 
 ```bash
-export ENGRAM_OFFLINE_REMOTE_URL="http://home-remnic.tailnet-name.ts.net:4317"
+export ENGRAM_OFFLINE_REMOTE_URL="http://home-remnic.tailnet-name.ts.net:4318"
 export ENGRAM_AUTH_TOKEN="..."
 ```

--- a/docs/guides/openclaw-engram-to-remnic.md
+++ b/docs/guides/openclaw-engram-to-remnic.md
@@ -1,4 +1,4 @@
-# OpenClaw Engram to Remnic Migration
+# OpenClaw Engram to Remnic migration
 
 This guide is for OpenClaw users moving from the legacy
 `@joshuaswarren/openclaw-engram` package to the canonical
@@ -8,7 +8,7 @@ Use it when an OpenClaw upgrade reports `0 plugins updated, 1 unchanged,
 1 skipped`, or when `engram-http` starts but `/engram/v1/health` never
 responds after moving to a newer OpenClaw bundle.
 
-## Short Answer
+## Short answer
 
 Run the Remnic migration command:
 
@@ -24,7 +24,7 @@ launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
 remnic doctor
 ```
 
-## What the Command Changes
+## What the command changes
 
 `remnic openclaw migrate-engram` is a focused wrapper around the safe OpenClaw
 upgrade path. It:
@@ -42,7 +42,7 @@ The legacy `plugins.entries["openclaw-engram"]` entry is intentionally retained
 during migration. Keep it until the gateway log shows Remnic starting under the
 canonical id and `remnic doctor` passes. After that, it can be removed manually.
 
-## Config Key
+## Config key
 
 Use this key after migration:
 
@@ -70,7 +70,7 @@ Do not rename the package to `remnic-workspace` in `plugins.entries`. The npm
 workspace root is named `remnic-workspace`, but the OpenClaw plugin id is
 `openclaw-remnic`.
 
-## Preserving Local Patches
+## Preserving local patches
 
 If your legacy `@joshuaswarren/openclaw-engram` tree contains local edits, the
 migration command leaves that tree in place and also copies it into the timestamped
@@ -85,12 +85,11 @@ Recommended flow:
 4. Restart the OpenClaw gateway.
 5. Run `remnic doctor`.
 
-For GPT-5-family OpenAI chat-completions models, Remnic now sends
-`max_completion_tokens` instead of `max_tokens` and omits `temperature` for
-native OpenAI `gpt-5*` models. Local compatibility patches for that behavior
-should not be needed after this release.
+For native OpenAI `gpt-5*` chat-completions models, Remnic sends
+`max_completion_tokens` instead of `max_tokens` and omits `temperature`. Local
+compatibility patches for that behavior are no longer needed.
 
-## Useful Flags
+## Useful flags
 
 ```bash
 remnic openclaw migrate-engram --dry-run
@@ -116,7 +115,7 @@ Look for:
 
 - `plugins.slots.memory = "openclaw-remnic"`;
 - `plugins.entries["openclaw-remnic"]`;
-- `[remnic] gateway_start fired` in the gateway log;
+- `gateway_start fired — Remnic memory plugin is active` in the gateway log;
 - a successful health response from the loopback Remnic HTTP server.
 
 If the gateway does not start, restore `openclaw.json` or the extension

--- a/docs/guides/platform-migration.md
+++ b/docs/guides/platform-migration.md
@@ -1,271 +1,189 @@
-# Platform Migration Guide (v9.1.36+)
+# Platform migration
 
-This guide covers the migration from the old single-package Engram plugin to the Remnic platform architecture introduced in v9.1.36. If you are an existing OpenClaw user upgrading through the normal plugin update path, most changes are transparent.
+Remnic began as a single OpenClaw plugin package and is now a monorepo with a
+framework-agnostic core, a standalone CLI, and a standalone HTTP/MCP server.
+This guide is for operators moving beyond the plugin-only setup: running Remnic
+without OpenClaw, scripting memory operations, or connecting to a remote
+instance. Existing OpenClaw users do not need any of this — the plugin update
+path is transparent.
 
-If you are moving from the legacy `@joshuaswarren/openclaw-engram` package to
-the canonical `@remnic/plugin-openclaw` package, start with
-[OpenClaw Engram to Remnic migration](openclaw-engram-to-remnic.md). That guide
-covers `plugins.entries.openclaw-engram` vs `plugins.entries.openclaw-remnic`,
+If you are moving from the legacy `@joshuaswarren/openclaw-engram` package to the
+canonical `@remnic/plugin-openclaw` package, start with
+[OpenClaw Engram to Remnic](openclaw-engram-to-remnic.md). That guide covers the
+`plugins.entries.openclaw-engram` to `plugins.entries.openclaw-remnic` rename,
 the `remnic openclaw migrate-engram` tooling, and local patch preservation.
 
----
+## What the platform looks like now
 
-## What Changed (M0-M7)
+The monorepo publishes 25+ packages. The ones you interact with directly:
 
-The repository has been reorganized into a monorepo with five packages. The public API surface has expanded significantly, but all existing integration points remain backward compatible.
-
-### Monorepo Structure
-
-```
-packages/
-  core/              — Framework-agnostic engine (no OpenClaw imports)
-  cli/               — Standalone CLI binary (15+ commands)
-  server/            — Standalone HTTP/MCP server
-  bench/             — Benchmarks + CI regression gates
-  hermes-provider/   — HTTP client for remote Remnic instances
-```
-
-### New Capabilities
-
-| Milestone | Capability | Description |
-|-----------|------------|-------------|
-| M0 | Monorepo packages | `@remnic/core`, `@remnic/cli`, `@remnic/server`, `@remnic/bench`, `@remnic/hermes-provider` |
-| M0 | Schema validation | `access-schema.ts` with Zod validates all request bodies before processing |
-| M0 | Structured error responses | Consistent JSON error envelopes with `error`, `code`, `details` fields and `X-Request-Id` correlation IDs |
-| M1 | Hermes provider | `@remnic/hermes-provider` — lightweight HTTP client for connecting to remote Remnic instances |
-| M1 | Standalone CLI | 15+ commands: `init`, `status`, `query`, `doctor`, `config`, `daemon`, `tree`, `onboard`, `curate`, `review`, `sync`, `dedup`, `connectors`, `space`, `benchmark` |
-| M2 | Workspace tree projection | Context tree generation + validation + live watch mode (`remnic tree generate\|watch\|validate`) |
-| M3 | Onboarding + Curation | Project ingestion with language detection, doc discovery, and ingestion planning; file curation with duplicate/contradiction detection |
-| M3 | Diff-aware sync | Filesystem sync that detects added/modified/deleted files and ingests changes incrementally |
-| M4 | Connector manager | Host adapter lifecycle management (list, install, remove, doctor) |
-| M5 | Spaces | Personal, project, and team memory spaces with push/pull/share/promote/audit workflows |
-| M6 | Benchmarks | Latency ladder with tier breakdowns, saved baselines, CI regression gates, and `--explain` mode |
-| M7 | Retrieval tier system | Tier 0 (exact) through Tier 4 (full scan) with documented latency expectations per tier |
-
-### Package Architecture
-
-```
-@remnic/core            — Framework-agnostic engine (re-exports orchestrator, config, storage, search, extraction, graph, trust zones)
-@remnic/cli             — Standalone CLI binary (15+ commands)
-@remnic/server          — Standalone HTTP/MCP server
-@remnic/bench           — Benchmarks + CI regression gates
-@remnic/hermes-provider — HTTP client for remote Remnic instances
-```
-
-The `@remnic/core` package has zero OpenClaw imports and can be consumed by any host adapter (CLI, HTTP server, MCP server, custom integrations).
-
----
-
-## What Stayed the Same
-
-The following integration points are unchanged. If you only used Engram through OpenClaw, your setup continues to work without modification.
-
-| Integration Point | Status |
+| Package | Role |
 |---|---|
-| npm entry point (`dist/index.js`) | Identical — same module exports |
-| Config format (`openclaw.json` -> `plugins.entries.openclaw-engram.config`) | Same schema |
-| Plugin manifest (`openclaw.plugin.json`) | Still loaded by OpenClaw gateway |
-| Memory storage (`~/.openclaw/workspace/memory/local/`) | Same file layout, frontmatter schema, and directory structure |
-| Install hooks | Only `prepack` — no `postinstall` or `prepare` hooks |
-| Config options | All 60+ options unchanged |
-| Extraction pipeline | Identical behavior |
-| Recall pipeline | Identical behavior |
-| MCP tools | Same 10+ tools with same signatures |
-| HTTP API | Same routes, same request/response shapes |
-| SDK capability detection | Runtime feature detection (no version checks) |
+| `@remnic/core` | Framework-agnostic engine — orchestrator, config, storage, search, extraction, graph. Zero OpenClaw imports. |
+| `@remnic/cli` | Standalone `remnic` CLI (36 top-level commands). |
+| `@remnic/server` | Standalone HTTP + stdio-MCP server. |
+| `@remnic/plugin-openclaw` | The OpenClaw plugin (deepest native integration). |
+| `@remnic/hermes-provider` | HTTP client for connecting to a remote Remnic instance. |
 
----
+The remaining packages are host adapters (Claude Code, Codex, Cursor, Pi),
+connectors (Limitless, Bee, Omi, WeClone), and importers (mem0, Supermemory,
+ChatGPT, Claude, Gemini, lossless-claw). See
+[monorepo structure](../architecture/monorepo-structure.md) for the full map.
 
-## How to Verify the Upgrade
+Because `@remnic/core` has zero OpenClaw imports, any host — CLI, HTTP server,
+MCP server, or a custom integration — can consume it.
 
-### OpenClaw Users
+## What stays the same for OpenClaw users
+
+If you only use Remnic through OpenClaw, your setup keeps working without
+modification:
+
+| Integration point | Status |
+|---|---|
+| npm entry point (`dist/index.js`) | Identical exports |
+| Config location (`openclaw.json` → `plugins.entries.openclaw-remnic.config`) | Same schema (legacy `openclaw-engram` entry still honored) |
+| Plugin manifest (`openclaw.plugin.json`) | Still loaded by the OpenClaw gateway |
+| Memory storage (`~/.openclaw/workspace/memory/local/`) | Same file layout and frontmatter schema |
+| Config schema | Same keys and defaults |
+| Extraction and recall pipelines | Identical behavior |
+| MCP tools | Same tool names and signatures |
+| HTTP API | Same routes and request/response shapes |
+
+## Verify an upgrade
+
+OpenClaw plugin users:
 
 ```bash
-# 1. Diagnostics
-openclaw engram doctor --json
-
-# 2. Verify test suite
-npm test   # 672 tests should pass
-
-# 3. Check config
+openclaw engram doctor --json      # runtime diagnostics
 openclaw engram config-review --json
-
-# 4. Verify memory store is intact
-openclaw engram inventory --json
+openclaw engram inventory --json   # confirm the memory store is intact
 ```
 
-### Standalone Users
+Standalone users:
 
 ```bash
-# 1. Diagnostics
 remnic doctor
-
-# 2. Server status
 remnic status
-
-# 3. Verify query works
 remnic query "test query" --json
 ```
 
----
+## Adopt the standalone tools
 
-## Adopting Standalone Features
+All standalone features are optional. They are useful for running Remnic without
+OpenClaw, CI benchmark regression gates, scripted memory operations, and
+connecting to a remote instance via Hermes.
 
-All standalone features are optional. OpenClaw users can continue using the plugin path indefinitely. The standalone tools are useful for:
+### Install the CLI from source
 
-- Running Engram without OpenClaw
-- CI/CD benchmark regression gates
-- Scripted memory operations
-- Connecting to remote Remnic instances via Hermes
-
-### Install Standalone CLI
+Building from source is required for daemon mode:
 
 ```bash
-# Build from source (required for daemon mode)
 git clone https://github.com/joshuaswarren/remnic.git
 cd remnic && pnpm install && pnpm run build
-cd packages/remnic-cli && npm link    # Makes `remnic` available on PATH
+cd packages/remnic-cli && npm link    # puts `remnic` on your PATH
 cd ../..
 ```
 
-### Initialize Configuration
+### Initialize configuration
 
 ```bash
 remnic init
-# Creates remnic.config.json in the current directory
+# Writes remnic.config.json in the current directory
 ```
 
-Set required environment variables:
+Set the environment it needs:
 
 ```bash
 export OPENAI_API_KEY=sk-...
 export REMNIC_AUTH_TOKEN=$(openssl rand -hex 32)
-# Optional: override memory location (default: ~/.remnic/memory for standalone, ~/.openclaw/workspace/memory/local for OpenClaw users)
+# Optional: override the memory directory (legacy ENGRAM_MEMORY_DIR also accepted)
 # export REMNIC_MEMORY_DIR=/path/to/custom/memory
 ```
 
-### Start Standalone Server
+`REMNIC_AUTH_TOKEN` gates every server request; the daemon merges the env token
+over `server.authToken` in the config file. The legacy `ENGRAM_AUTH_TOKEN` is
+still accepted during the v1.x compatibility window.
+
+### Start the server
 
 ```bash
 remnic daemon start
-remnic status          # verify it is running
+remnic status          # confirm it is running
 remnic daemon stop     # when done
 ```
 
-### Query with Tier Breakdown
+The server binds `127.0.0.1:4318` by default.
+
+### Query with a tier breakdown
 
 ```bash
 remnic query "what did I decide about the API?" --explain
 ```
 
-Output shows which retrieval tiers were used and their latencies:
+The output shows which retrieval tiers ran and their latencies.
 
-```
-Query: what did I decide about the API?
-Tiers used: tier0 -> tier1 -> tier2
-Total duration: 142ms
-  tier0: 3ms (0 results)
-  tier1: 45ms (2 results)
-  tier2: 94ms (5 results)
-```
-
-### Run Benchmarks
+### Run benchmarks
 
 ```bash
-# First run — establishes baseline
-remnic benchmark run
-
-# Subsequent runs — checks for regressions
-remnic benchmark check
-
-# Detailed tier breakdown
-remnic benchmark run --explain
-
-# Generate report
+remnic benchmark run                 # first run establishes a baseline
+remnic benchmark check               # later runs check for regressions
+remnic benchmark check --explain     # detailed tier breakdown
 remnic benchmark report --report=benchmarks/report.json
 ```
 
-### Manage Spaces
+### Manage spaces
 
 ```bash
-# List spaces
 remnic space list
-
-# Create a project space
-remnic space create my-project project
-
-# Switch active space
+remnic space create my-project project   # <name> [personal|project|team]
 remnic space switch <space-id>
-
-# Push memories between spaces
 remnic space push <source-id> <target-id>
-
-# Audit trail
 remnic space audit
 ```
 
-### Onboard a Project
+### Onboard a project
 
 ```bash
-# Analyze a project directory
 remnic onboard ~/src/my-project --json
-
-# Curate specific files into memory
 remnic curate ~/src/my-project/docs/ --json
-
-# Review ingested content
 remnic review list
 remnic review approve <id>
 ```
 
-### Diff-Aware Sync
+### Diff-aware sync
 
 ```bash
-# One-time sync
-remnic sync run --source ~/src/my-project
-
-# Continuous watch
-remnic sync watch --source ~/src/my-project
+remnic sync run --source ~/src/my-project    # one-time
+remnic sync watch --source ~/src/my-project  # continuous
 ```
 
-### Find Duplicates
+### Find duplicates and manage connectors
 
 ```bash
 remnic dedup --json
-```
-
-### Manage Connectors
-
-```bash
-# List available and installed connectors
 remnic connectors list
-
-# Install a connector
 remnic connectors install <connector-id>
-
-# Diagnose connector health
 remnic connectors doctor <connector-id>
 ```
 
----
-
 ## Rollback
 
-If the upgrade causes issues:
-
-**OpenClaw plugin users** — pin to the previous version:
+OpenClaw plugin users — pin the previous version:
 
 ```bash
 openclaw plugins install npm:@remnic/plugin-openclaw@<previous-version>
 ```
 
-**Standalone CLI users** — the legacy shim package (`@joshuaswarren/openclaw-engram`) only exposes `engram-access`, not the full CLI. Full CLI rollback requires building from source at the desired version tag:
+Standalone CLI users — the legacy shim package
+(`@joshuaswarren/openclaw-engram`) only exposes `engram-access`, not the full
+CLI. Full CLI rollback means building from source at the desired tag:
 
 ```bash
 cd remnic
 git fetch --all && git checkout <previous-version-tag>
 pnpm install && pnpm run build
-cd packages/remnic-cli && npm link    # re-links the CLI binary to this version
+cd packages/remnic-cli && npm link
 ```
 
-Memory storage is never modified by an upgrade, so rollback is safe and does not lose data.
+Memory storage is never modified by an upgrade, so rollback is safe and does not
+lose data.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -1,140 +1,120 @@
-# Quickstart: Install Remnic in 5 Minutes
+# Quickstart
 
-Remnic is a universal memory system for AI agents. Install it once, connect your tools, and all your agents share the same memory.
+Get memory working for your AI agent in about five minutes. Install Remnic once,
+connect your tool, and every agent — Claude Code, Codex, Cursor, OpenClaw, and more —
+shares the same local, plain-markdown memory store.
 
-## Step 1: Install Remnic
+## Step 1: Install
+
+Remnic ships as a single npm package and needs Node.js 22.12 or newer.
 
 ```bash
 npm install -g @remnic/cli
 ```
 
-## Step 2: Start the Daemon
+This installs the `remnic` command (plus a legacy `engram` alias for the v1.x compatibility window) and pulls in the local server the daemon runs.
+
+## Step 2: Start the daemon
+
+The daemon is the local memory server every tool connects to. Install it once and it
+auto-starts on boot:
 
 ```bash
 remnic daemon install
 ```
 
-This starts the Remnic daemon (historically called EMO) and configures it to auto-start on boot.
+Check it:
 
-To check the daemon, run `remnic daemon status`. The command prints whether the daemon is currently running (and its pid if so), the port it is listening on, and whether the system service is installed. None of those fields require the daemon to be reachable — the command only inspects the system service definition and the port binding, so it works even when the daemon process is down.
+```bash
+remnic daemon status
+```
 
-## Step 3: Connect Your Tools
+`status` reports whether the daemon is running (with its pid), the port it listens on
+(`4318` by default), whether the system service is installed, and the memory-extension
+state. It reads the service definition and port directly, so it works even when the
+daemon process is down. For auto-start, logs, and port changes, see
+[Daemon management](./daemon-management.md).
 
-Install the plugin for your AI tool. Each plugin has its own install path — read its README before running anything:
+## Step 3: Connect your tool
 
-- Claude Code: <https://github.com/joshuaswarren/remnic/blob/main/packages/plugin-claude-code/README.md> (three manual steps; the Remnic-side connector install does not configure Claude Code)
-- Codex CLI: <https://github.com/joshuaswarren/remnic/blob/main/packages/plugin-codex/README.md>
-- Hermes Agent: <https://github.com/joshuaswarren/remnic/blob/main/packages/plugin-hermes/README.md>
-- Replit Agent: <https://github.com/joshuaswarren/remnic/blob/main/packages/connector-replit/README.md>
+Register a connector for each AI tool you use:
 
-See [Plugin docs](../plugins/) for the platform-by-platform overview, and the [Connector setup](https://github.com/joshuaswarren/remnic/blob/main/docs/integration/connector-setup.md) guide for how `remnic connectors` tracks per-host state.
+```bash
+remnic connectors install <id>
+```
 
-Each `remnic connectors install <host>` command mints a host-specific auth token and writes Remnic-side connector state. Whether it also configures the host itself varies — read the plugin README for the host you picked before assuming anything is wired up.
+Built-in connector ids: `claude-code`, `codex-cli`, `cursor`, `cline`,
+`github-copilot`, `roo-code`, `windsurf`, `amp`, `pi`, `omp`, `replit`, `weclone`,
+`hermes`, and `generic-mcp` for any other MCP client. Run `remnic connectors list` to
+see them all.
 
-Want to see cross-tool memory before installing connectors? Run the no-key
-[Coding Agent Memory Demo](../../examples/coding-agent-memory-demo/) from a
-source checkout. It uses real Remnic storage and recall paths to carry scoped
-project context from one coding-agent session identity to another with
-retrieval reasons.
+`remnic connectors install <id>` mints a host-specific auth token and writes the
+Remnic-side connector state. Some hosts also need a manual step or two on their own
+side, so read the plugin guide before assuming a tool is fully wired up:
+
+- [Claude Code](../plugins/claude-code.md)
+- [Codex CLI](../plugins/codex.md)
+- [OpenClaw](../plugins/openclaw.md)
+- [Hermes](../plugins/hermes.md)
+- [Replit](../plugins/replit.md)
+- Every platform: [Plugin guides index](../plugins/README.md)
+
+Want to see cross-tool memory before wiring up a real tool? Run the no-key
+[coding-agent memory demo](../../examples/coding-agent-memory-demo/) from a source
+checkout — it carries scoped project context from one agent-session identity to another
+using the real storage and recall paths.
 
 ## Step 4: Verify
 
-`remnic connectors doctor <id>` requires a connector id — it doctor-checks one connector at a time (see `Usage: remnic connectors doctor <id>` in the CLI). Run it per connector you installed.
+Run `remnic doctor` for an overall health check, then `remnic connectors doctor <id>`
+for each connector you installed (it checks one connector at a time). A green result
+means the Remnic side is configured correctly; if a tool still is not recalling
+memories, its plugin guide has the host-side checklist.
 
-The command prints a row per `DoctorCheck` in the format `<check.name>: <check.detail>` (see `cmdConnectors` at `packages/remnic-cli/src/index.ts:8425-8427`), followed by `Connector healthy` or `Connector has issues`. Three sources contribute rows:
+## Step 5: Use it
 
-- `Config file` (path under `getConnectorsDir()`) and `Config valid` — from `doctorConnector` at `packages/remnic-core/src/connectors/index.ts:2569`. Optionally `MCP server` (if the install persisted an `mcpServerUrl`) and `Memory directory` (if it persisted a `memoryDir`).
-- `Publisher: <host>` — from the publisher block at `cmdConnectors:8384-8417`. The block runs only when `PUBLISHERS[targetHostId]` is defined. `@remnic/cli` registers publishers at module load (`packages/remnic-cli/src/index.ts:356-360`) for `codex`, `claude-code`, `hermes`, `pi`, and `omp`. `hostIdForConnector("codex-cli") = "codex"` (per `CONNECTOR_TO_HOST` at `packages/remnic-core/src/memory-extension/index.ts:67-69`); every other connector id maps to itself, so `codex-cli` produces a publisher row for the `codex` host, and `claude-code`, `hermes`, `pi`, `omp` produce publisher rows for their own host ids. `replit` and every other connector id not in the registration table prints NO publisher row.
+Now just use your tools normally. Remnic works in the background:
 
-None of the checks probe whether the host plugin is loaded, the host MCP server is wired up, or the host-side MemoryProvider is active. The publisher row only checks Remnic-side publisher state (publisher's `isHostAvailable()` and whether the host's memory-extension directory exists on disk for publishers that resolve one).
+- **Start a session** → it recalls your preferences and project context
+- **Type a prompt** → it injects the relevant memories
+- **Edit files** → it observes and learns your patterns
+- **Switch tools** → your memory carries over instantly
 
-For `codex-cli`, a representative green run after `remnic connectors install codex-cli` (when Codex is installed at `~/.codex` and the install persisted the extension) looks like:
+Try it in Claude Code:
 
-```bash
-remnic connectors doctor codex-cli
-  ✓ Config file: /home/<you>/.config/engram/.engram-connectors/connectors/codex-cli.json
-  ✓ Config valid: OK
-  ✓ Publisher: codex: extension at /home/<you>/.codex/memories_extensions/remnic
-
-Connector healthy
 ```
-
-For `claude-code` and `hermes`, the publishers are intentional all-no-op stubs (`isHostAvailable()` returns `false`, per `claude-code-publisher.ts:31-33` and `hermes-publisher.ts:31-33`), so the publisher row prints `host not installed (skip)` with `ok = !available || extensionExists = true` (the `!available` branch). The verdict is still `Connector healthy`:
-
-```bash
-remnic connectors doctor claude-code
-  ✓ Config file: /home/<you>/.config/engram/.engram-connectors/connectors/claude-code.json
-  ✓ Config valid: OK
-  ✓ Publisher: claude-code: host not installed (skip)
-
-Connector healthy
-
-remnic connectors doctor hermes
-  ✓ Config file: /home/<you>/.config/engram/.engram-connectors/connectors/hermes.json
-  ✓ Config valid: OK
-  ✓ Publisher: hermes: host not installed (skip)
-
-Connector healthy
-```
-
-For `replit`, the install only mints a bearer token. There is no `@remnic/cli` `registerPublisher("replit", ...)` call and no `replit` entry in `CONNECTOR_TO_HOST`, so `hostIdForConnector("replit")` returns `"replit"`, `PUBLISHERS["replit"]` is `undefined`, the `if (factory)` block at `cmdConnectors:8384` is skipped, and the doctor prints only the two config rows:
-
-```bash
-remnic connectors doctor replit
-  ✓ Config file: /home/<you>/.config/engram/.engram-connectors/connectors/replit.json
-  ✓ Config valid: OK
-
-Connector healthy
-```
-
-For `claude-code`, `remnic connectors doctor claude-code` returns `Connector healthy` after step 1 of the install (the two config rows pass and the publisher row reports `host not installed (skip)` because the stub returns false) — but the host itself is not actually wired up until steps 2 and 3 from the plugin README are also done. See [`docs/plugins/claude-code.md`](../plugins/claude-code.md#troubleshooting) for what to check when auto-recall/auto-observe do not fire despite a green doctor output.
-
-## Step 5: Use It
-
-Just use your AI tools normally. Remnic works automatically:
-
-- **Start a session** → Remnic recalls your preferences and project context
-- **Type a prompt** → Remnic injects relevant memories
-- **Edit files** → Remnic observes and learns patterns
-- **Switch tools** → memories carry over instantly
-
-### Try it
-
-In Claude Code:
-```
-> /engram:remember I prefer functional programming patterns over OOP
+> /engram:remember I prefer functional programming over OOP
 > /engram:recall programming preferences
 ```
 
-The slash commands still use the legacy `/engram:*` names during the v1.x compatibility window. The product and CLI are now `remnic`.
+Slash commands keep the `/engram:*` names during the v1.x compatibility window; the
+product and CLI are `remnic`. Now open another tool — say Codex CLI — and it already
+knows your preference.
 
-Then open Codex CLI and start a new session — it already knows your preference.
-
-### Get a daily briefing
-
-Once you have memories flowing in, generate a focused summary of what changed recently:
+Once memories are flowing, get a focused summary of what changed recently:
 
 ```bash
-remnic briefing                          # yesterday, markdown, no save
-remnic briefing --since 3d               # last 72 hours
-remnic briefing --focus project:alpha    # scoped to one project
-remnic briefing --format json --save     # save a dated JSON file
+remnic briefing --since 3d
 ```
 
-The briefing cross-references active entities, recent facts, and open commitments. If `OPENAI_API_KEY` is set, it also appends a short list of suggested follow-ups via the Responses API. See [Daily Briefing](./daily-briefing.md) for the full guide.
+See [Daily briefing](./daily-briefing.md) for scopes, JSON output, and saved reports.
 
-## Already Using OpenClaw?
+## Already using OpenClaw?
 
-If you're an existing OpenClaw user:
+OpenClaw has the deepest native integration. One command configures it end to end —
+the plugin entry plus the `plugins.slots.memory` slot — without touching your existing
+memories:
 
 ```bash
-remnic connectors install openclaw
+remnic openclaw install
 ```
 
-This upgrades OEO to expose `:4318` so other agents can share the same memory store OpenClaw uses. Your existing memories are untouched.
+Restart the gateway afterward. Full walkthrough and config live in
+[Getting started](../getting-started.md).
 
-## Next Steps
+## Next steps
 
-- [Daemon management](./daemon-management.md) — configure auto-start, logs, ports
-- [Plugin docs](../plugins/) — detailed guides per platform
-- [Architecture](../architecture/emo-oeo-split.md) — how it works under the hood
+- [Getting started](../getting-started.md) — every install option, config, and first-run detail
+- [Daemon management](./daemon-management.md) — auto-start, logs, ports
+- [Plugin guides](../plugins/README.md) — per-platform setup
+- [Architecture overview](../architecture/overview.md) — how it works under the hood

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -106,16 +106,18 @@ See [Daily briefing](./daily-briefing.md) for scopes, JSON output, and saved rep
 
 ## Already using OpenClaw?
 
-OpenClaw has the deepest native integration. One command configures it end to end —
-the plugin entry plus the `plugins.slots.memory` slot — without touching your existing
-memories:
+OpenClaw has the deepest native integration. Install the plugin package, then wire
+the memory slot — your existing memories are untouched:
 
 ```bash
+openclaw plugins install clawhub:@remnic/plugin-openclaw
 remnic openclaw install
 ```
 
-Restart the gateway afterward. Full walkthrough and config live in
-[Getting started](../getting-started.md).
+`remnic openclaw install` writes the plugin entry plus `plugins.slots.memory` in
+`openclaw.json`; it does not download the package, so run the `openclaw plugins
+install` step first. Restart the gateway afterward. Full walkthrough and config live
+in [Getting started](../getting-started.md).
 
 ## Next steps
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -36,9 +36,10 @@ daemon process is down. For auto-start, logs, and port changes, see
 [Daemon management](./daemon-management.md).
 
 To let Remnic *extract* new memories (not just recall), give it a model provider:
-put your OpenAI API key — or local-LLM settings — in `~/.config/remnic/config.json`.
-The managed service reads secrets from that file, not from your shell environment.
-See [Getting started](../getting-started.md#configure) for the config shape.
+put your OpenAI API key — or local-LLM settings — in `~/.config/remnic/config.json`,
+then run `remnic daemon restart` (the server reads config only at startup). The
+managed service reads secrets from that file, not from your shell environment. See
+[Getting started](../getting-started.md#configure) for the config shape.
 
 ## Step 3: Connect your tool
 
@@ -85,16 +86,14 @@ Now just use your tools normally. Remnic works in the background:
 - **Edit files** → it observes and learns your patterns
 - **Switch tools** → your memory carries over instantly
 
-Try it in Claude Code:
+Try it in Claude Code (with the [Claude Code plugin](../plugins/claude-code.md) loaded):
 
 ```
-> /engram:remember I prefer functional programming over OOP
-> /engram:recall programming preferences
+> /remnic-remember I prefer functional programming over OOP
+> /remnic-recall programming preferences
 ```
 
-Slash commands keep the `/engram:*` names during the v1.x compatibility window; the
-product and CLI are `remnic`. Now open another tool — say Codex CLI — and it already
-knows your preference.
+Now open another tool — say Codex CLI — and it already knows your preference.
 
 Once memories are flowing, get a focused summary of what changed recently:
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -35,6 +35,11 @@ state. It reads the service definition and port directly, so it works even when 
 daemon process is down. For auto-start, logs, and port changes, see
 [Daemon management](./daemon-management.md).
 
+To let Remnic *extract* new memories (not just recall), give it a model provider:
+put your OpenAI API key — or local-LLM settings — in `~/.config/remnic/config.json`.
+The managed service reads secrets from that file, not from your shell environment.
+See [Getting started](../getting-started.md#configure) for the config shape.
+
 ## Step 3: Connect your tool
 
 Register a connector for each AI tool you use:

--- a/docs/guides/standalone-server.md
+++ b/docs/guides/standalone-server.md
@@ -1,4 +1,4 @@
-# Standalone Multi-Tenant Server
+# Standalone multi-tenant server
 
 ## Introduction
 
@@ -47,7 +47,7 @@ Use plugin mode when:
 
 All clients connect to the same Remnic process. Each tenant's memories are isolated in their own namespace, with a shared namespace for cross-tenant knowledge. The server authenticates every request with a bearer token and resolves the caller's principal to enforce namespace read/write policies.
 
-## Quick Start
+## Quick start
 
 Generate a secure token and start the server:
 
@@ -76,7 +76,7 @@ binary, unsupported version, or collection probe problem. The API path remains
 
 To bind to all interfaces (e.g., for LAN access from other machines), use `--host 0.0.0.0`. Only do this on trusted networks or behind a reverse proxy.
 
-## Connecting Agent Harnesses
+## Connecting agent harnesses
 
 ### OpenClaw (plugin mode)
 
@@ -131,7 +131,7 @@ Add Remnic to your `~/.claude.json`:
 
 Claude Code will discover Remnic's tools automatically. Canonical tool names use the `remnic.*` prefix; legacy `engram.*` aliases remain available through v1.x.
 
-### Custom HTTP Agents
+### Custom HTTP agents
 
 Any HTTP client can use the REST API directly. Here are examples in Python and JavaScript.
 
@@ -191,15 +191,15 @@ const data = await resp.json();
 console.log(data.results);
 ```
 
-## Multi-Tenant Namespace Configuration
+## Multi-tenant namespace configuration
 
-Namespaces isolate memory per tenant while allowing controlled sharing. Enable them in your `openclaw.json`:
+Namespaces isolate memory per tenant while allowing controlled sharing. They are opt-in — `namespacesEnabled` defaults to `false`. Enable them in your `openclaw.json`:
 
 ```json
 {
   "plugins": {
     "entries": {
-      "openclaw-engram": {
+      "openclaw-remnic": {
         "config": {
           "namespacesEnabled": true,
           "sharedNamespace": "shared",
@@ -260,7 +260,7 @@ available through `remnic-server` (see [Per-Request Principal Override](#per-req
 
 See the [Namespaces documentation](../namespaces.md) for full details on namespace storage layout, QMD collection configuration, and CLI tooling.
 
-## The Observe Endpoint
+## The observe endpoint
 
 `POST /engram/v1/observe` feeds conversation messages into Remnic's memory pipeline. This is the primary integration point for custom agents that are not using MCP.
 
@@ -315,7 +315,7 @@ See the [Namespaces documentation](../namespaces.md) for full details on namespa
 
 The observe endpoint is rate-limited to **30 requests per minute** per server instance. Dry runs and idempotency replays do not count toward the limit. If the limit is exceeded, the server returns HTTP 429.
 
-## LCM Search
+## LCM search
 
 `POST /engram/v1/lcm/search` performs full-text search over the LCM conversation archive. This searches raw archived messages, not extracted memories.
 
@@ -364,7 +364,7 @@ The observe endpoint is rate-limited to **30 requests per minute** per server in
 
 If `lcmEnabled` is `false`, the response will have an empty `results` array and `lcmEnabled: false`.
 
-### LCM Status
+### LCM status
 
 `GET /engram/v1/lcm/status` returns LCM availability and stats:
 
@@ -378,7 +378,7 @@ If `lcmEnabled` is `false`, the response will have an empty `results` array and 
 }
 ```
 
-## Per-Request Principal Override
+## Per-request principal override
 
 Standalone `remnic-server` does not currently expose a CLI flag to enable
 trusted per-request principal override. In standalone mode, principal resolution
@@ -415,14 +415,14 @@ curl -X POST http://localhost:4318/engram/v1/observe \
 
 The `X-Engram-Principal` header value becomes the authenticated principal for that request, determining namespace read/write access.
 
-### Security Considerations
+### Security considerations
 
 - **Only enable `--trust-principal-header` when the bearer token provides sufficient trust.** Anyone with the token can impersonate any principal.
 - If you run the server behind a reverse proxy, ensure the proxy strips or validates the `X-Engram-Principal` header from untrusted clients.
 - Without `--trust-principal-header`, the header is silently ignored — principal resolution falls back to configured principal or session key rules.
 - For production multi-tenant standalone setups, consider running separate server instances per tenant with different tokens and fixed configured principals, rather than trusting a single token with header-based principal resolution.
 
-## Shared Knowledge Layer
+## Shared knowledge layer
 
 The shared namespace provides cross-tenant knowledge sharing. All tenants can read from it during recall, but only authorized principals can write to it.
 

--- a/docs/identity-continuity.md
+++ b/docs/identity-continuity.md
@@ -1,8 +1,25 @@
-# Identity Continuity
+# Identity continuity
 
-Identity continuity adds recovery-oriented memory artifacts so the assistant can regain stable behavior after drift, context loss, or tool/runtime incidents.
+Identity continuity adds recovery-oriented memory artifacts — an identity anchor, incident records, continuity audits, and improvement loops — so the assistant can regain stable behavior after drift, context loss, or a tool/runtime incident. It is fail-open: disabling the flags returns runtime behavior to baseline retrieval/extraction. Opt-in via `identityContinuityEnabled` (default `false`).
 
-This feature set is controlled by the v8.4 config surface and is designed to be fail-open: disabling continuity flags should return runtime behavior to baseline retrieval/extraction paths.
+> Provenance: the identity-continuity config surface landed in v8.4.
+
+## Enable it
+
+```json
+{
+  "identityContinuityEnabled": true,
+  "identityInjectionMode": "recovery_only",
+  "identityMaxInjectChars": 1200,
+  "continuityIncidentLoggingEnabled": true,
+  "continuityAuditEnabled": false
+}
+```
+
+- `identityInjectionMode` (default `recovery_only`; also `minimal`, `full`) controls how the identity anchor is injected.
+- `identityMaxInjectChars` (default `1200`) caps injected anchor size.
+- `continuityIncidentLoggingEnabled` (defaults to `identityContinuityEnabled`) toggles incident logging.
+- `continuityAuditEnabled` (default `false`) toggles audit generation.
 
 ## Artifacts
 
@@ -19,7 +36,7 @@ Primary artifacts:
 - `audits/weekly/*.md` and `audits/monthly/*.md`: generated continuity audits by period.
 - `improvement-loops.md`: recurring loop register and review metadata.
 
-## Safety Boundaries
+## Safety boundaries
 
 Continuity features must keep these invariants:
 
@@ -32,7 +49,7 @@ Continuity features must keep these invariants:
    - `continuityAuditEnabled=false` disables audit generation paths.
 5. Fail-open behavior on parse/storage errors (log and continue).
 
-## Template: Identity Anchor
+## Template: identity anchor
 
 Use this structure for safe merges via `identity_anchor_update`:
 
@@ -59,7 +76,7 @@ Use this structure for safe merges via `identity_anchor_update`:
 - Recovery guidance:
 ```
 
-## Template: Continuity Incident
+## Template: continuity incident
 
 Incident files are markdown with frontmatter; open/close tools maintain lifecycle fields.
 
@@ -85,7 +102,7 @@ identity anchor omitted in recovery response
 Observed during weekly continuity audit.
 ```
 
-## Template: Continuity Audit
+## Template: continuity audit
 
 ```markdown
 ---
@@ -114,7 +131,20 @@ signalSummary:
 - Run `continuity_loop_review` for stale loops.
 ```
 
-## Rollout by Risk Tier
+## CLI and tools
+
+The continuity surface runs on the hosted `openclaw engram` CLI plus MCP tools; the standalone `remnic` binary does not include these commands. All commands no-op when `identityContinuityEnabled` is false.
+
+```bash
+openclaw engram continuity incidents --state open --limit 25
+openclaw engram continuity incident-open --symptom "<symptom>"
+openclaw engram continuity incident-close --id <id> --fix-applied "<fix>" --verification-result "<result>"
+openclaw engram identity
+```
+
+Tools: `identity_anchor_get`, `identity_anchor_update`, `continuity_incident_open`, `continuity_incident_close`, `continuity_incident_list`, `continuity_loop_add_or_update`, `continuity_loop_review`, `continuity_audit_generate`, `memory_identity`.
+
+## Rollout by risk tier
 
 1. Low risk:
    - Enable `identityContinuityEnabled`.

--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -1,6 +1,11 @@
-# Import / Export / Backup (v2.3)
+# Import, export, and backup
 
-Engram stores memory as plain files. v2.3 adds portable export/import and safe backups via the `openclaw engram` CLI.
+Remnic stores memory as plain markdown + YAML files. This guide covers portable
+export/import and safe backups through the `openclaw engram` gateway CLI, plus
+the bulk-import and training-export pipelines.
+
+> Importing memory *from another platform* (ChatGPT, Claude, Gemini, mem0,
+> Supermemory, lossless-claw, WeClone)? See [Memory importers](importers.md).
 
 ## Export
 
@@ -195,7 +200,7 @@ for the adapter-specific docs and programmatic API.
 
 ## Migration Helpers (v8.16 Task 1)
 
-Engram includes bounded migration helpers under `openclaw engram migrate`:
+Remnic includes bounded migration helpers under `openclaw engram migrate`:
 
 ```bash
 openclaw engram migrate normalize-frontmatter

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -2,17 +2,30 @@
 
 Issue [#568](https://github.com/joshuaswarren/remnic/issues/568) ships a
 family of optional importer packages that pull personal memory out of
-external platforms and land it in Remnic as first-class memories.
+external platforms and land it in Remnic as first-class memories. Seven
+import packages ship today across three CLI surfaces.
 
-Five sources are supported today:
+**Five plug into the shared `remnic import --adapter <source>` command:**
 
-| Source  | Package                   | Source label | Input                                     |
-|---------|---------------------------|--------------|-------------------------------------------|
-| ChatGPT | `@remnic/import-chatgpt`  | `chatgpt`    | Data-export JSON (memories + conversations) |
-| Claude  | `@remnic/import-claude`   | `claude`     | Data-export JSON (projects + conversations) |
-| Gemini  | `@remnic/import-gemini`   | `gemini`     | Google Takeout `My Activity.json`            |
-| mem0    | `@remnic/import-mem0`     | `mem0`       | REST API (paginated) or offline JSON dump    |
-| Supermemory | `@remnic/import-supermemory` | `supermemory` | JSON export from Supermemory Memories API |
+| Source      | Package                      | Adapter id    | Input                                        |
+|-------------|------------------------------|---------------|----------------------------------------------|
+| ChatGPT     | `@remnic/import-chatgpt`     | `chatgpt`     | Data-export JSON (memories + conversations)  |
+| Claude      | `@remnic/import-claude`      | `claude`      | Data-export JSON (projects + conversations)  |
+| Gemini      | `@remnic/import-gemini`      | `gemini`      | Google Takeout `My Activity.json`            |
+| mem0        | `@remnic/import-mem0`        | `mem0`        | REST API (paginated) or offline JSON dump    |
+| Supermemory | `@remnic/import-supermemory` | `supermemory` | JSON export from Supermemory Memories API    |
+
+**Two ship as their own commands, because their data models differ:**
+
+| Source        | Package                       | Command                                   | Input                                |
+|---------------|-------------------------------|-------------------------------------------|--------------------------------------|
+| lossless-claw | `@remnic/import-lossless-claw`| `remnic import-lossless-claw`             | lossless-claw LCM SQLite database    |
+| WeClone       | `@remnic/import-weclone`      | `openclaw engram bulk-import --source weclone` | WeClone-preprocessed chat export JSON |
+
+`remnic import --adapter` covers only the first five. lossless-claw is a
+SQLite-to-SQLite LCM migration ([details below](#lossless-claw)); WeClone chat
+history flows through the bulk-import pipeline documented in
+[Import / Export / Backup](import-export.md#bulk-import-issue-460).
 
 Each importer is an **à-la-carte optional runtime companion** of the
 `@remnic/cli` package. They are never bundled into the base CLI install,
@@ -124,7 +137,7 @@ instantly even on machines where the memory directory isn't set up.
 Every imported memory carries provenance metadata that flows through the
 orchestrator into recall and attribution:
 
-- `sourceLabel` — the platform name (`chatgpt`, `claude`, `gemini`, `mem0`)
+- `sourceLabel` — the platform name (`chatgpt`, `claude`, `gemini`, `mem0`, `supermemory`)
 - `sourceId` — stable source-side id for idempotent re-imports
 - `sourceTimestamp` — the export's original timestamp (ISO 8601)
 - `importedFromPath` — the file path or API endpoint URL
@@ -193,3 +206,40 @@ remnic import --adapter supermemory --file ./supermemory-memories.json
 ```
 
 If your export spans multiple pages, concatenate them into one object `{ "memories": [...] }` (or one flat array) before import.
+
+## lossless-claw
+
+`@remnic/import-lossless-claw` migrates a lossless-claw LCM database into
+Remnic's own LCM store. It is **not** a `remnic import --adapter` source — its
+data model is turns plus a summary DAG, not facts — so it ships as a dedicated
+top-level command:
+
+```bash
+npm install -g @remnic/import-lossless-claw
+remnic import-lossless-claw --src ~/.openclaw/lcm.db --dry-run
+remnic import-lossless-claw --src ~/.openclaw/lcm.db
+```
+
+Flags:
+
+| Flag | Description |
+|------|-------------|
+| `--src <path>` | Required. Path to a lossless-claw SQLite database (typically `~/.openclaw/lcm.db`). |
+| `--memory-dir <path>` | Remnic memory directory. Defaults to the resolved `REMNIC_MEMORY_DIR` / config value. |
+| `--dry-run` | Count what would be imported without writing. |
+| `--session-filter <id>` | Restrict to a single resolved session id. Repeatable. |
+
+lossless-claw occupies OpenClaw's `contextEngine` slot while Remnic occupies
+the `memory` slot, so the two run side-by-side; use this importer only when you
+want session history migrated into Remnic's LCM store. Remnic's LCM is
+single-parent, so multi-parent summary nodes collapse to the lowest-ordinal
+parent and the collapse count is reported in the run summary.
+
+## WeClone
+
+`@remnic/import-weclone` bulk-imports WeClone-preprocessed chat exports
+(Telegram, WhatsApp, Discord, Slack). It runs through the bulk-import pipeline
+rather than `remnic import --adapter`, so it is invoked as `openclaw engram
+bulk-import --source weclone`. See
+[Import / Export / Backup](import-export.md#bulk-import-issue-460) for the full
+command, flags, and prerequisites.

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -1,0 +1,23 @@
+# Integration
+
+Wiring guides for connecting Remnic memory to specific tools, hosts, and network
+topologies. Each Remnic HTTP/MCP server speaks the same protocol, so most tools
+connect the same way, you just point them at the server. To return to the docs
+hub, see [`docs/README.md`](../README.md).
+
+For per-host plugin adapters (the packaged extensions themselves), see the
+[plugins index](../plugins/README.md). This directory is the *how to wire it up*
+layer; `docs/plugins/` is the *what each adapter is* layer.
+
+## Connect a tool
+
+- [Connector setup guide](connector-setup.md) — Point Claude Code, Codex, Cursor, Copilot, Cline, Roo Code, Windsurf, Amp, Replit, Hermes, or any generic MCP client at Remnic.
+- [ChatGPT (developer mode)](chatgpt.md) — Give ChatGPT persistent, governed memory on your own infrastructure via MCP and OAuth 2.1.
+- [Pi coding agent](pi.md) — Native Pi extension (`@remnic/plugin-pi`) using Pi's hooks, slash commands, and compaction coordination.
+- [Oh My Pi (omp)](omp.md) — omp rules, MCP server config, and the native omp extension.
+- [Hermes setup](hermes-setup.md) — Hermes Agent via the `remnic-hermes` Python package or `X-Hermes-Session-Id` auto-detection.
+
+## Deploy and scope
+
+- [Deployment topologies](deployment-topologies.md) — Localhost, LAN, remote, containerized, and standalone server layouts.
+- [Plugin ID and memory namespaces](plugin-id-and-memory-namespaces.md) — The OpenClaw plugin id split (`openclaw-remnic`), the `plugins.slots.memory` gate, and namespace isolation.

--- a/docs/integration/connector-setup.md
+++ b/docs/integration/connector-setup.md
@@ -266,7 +266,7 @@ const response = await fetch(`${REMNIC_API_URL}/recall`, {
 
 ## Hermes Agent
 
-Hermes supports MCP servers via `config.yaml`. For deeper integration, Hermes v0.7.0+ also supports a dedicated **MemoryProvider plugin protocol** — see [Hermes setup guide](../guides/hermes-setup.md).
+Hermes supports MCP servers via `config.yaml`. For deeper integration, Hermes v0.7.0+ also supports a dedicated **MemoryProvider plugin protocol** — see [Hermes setup guide](hermes-setup.md).
 
 ### Option A: MCP (quick start)
 

--- a/docs/integration/deployment-topologies.md
+++ b/docs/integration/deployment-topologies.md
@@ -31,10 +31,10 @@ Run Remnic on a remote server or VPS. Use a reverse proxy (nginx, Caddy) with TL
 ```nginx
 server {
     listen 443 ssl;
-    server_name engram.example.com;
+    server_name remnic.example.com;
 
-    ssl_certificate /etc/ssl/certs/engram.pem;
-    ssl_certificate_key /etc/ssl/private/engram.key;
+    ssl_certificate /etc/ssl/certs/remnic.pem;
+    ssl_certificate_key /etc/ssl/private/remnic.key;
 
     location / {
         proxy_pass http://127.0.0.1:4318;
@@ -201,7 +201,7 @@ Returns:
     "active": true,
     "degraded": false,
     "mode": "cli",
-    "collection": "remnic-memory",
+    "collection": "openclaw-engram",
     "collectionState": "present",
     "installedVersion": "qmd 2.5.3",
     "supportedVersion": "2.5.3",

--- a/docs/integration/hermes-setup.md
+++ b/docs/integration/hermes-setup.md
@@ -19,7 +19,7 @@ remnic connectors install hermes
 
 Then restart Hermes to pick up the new plugin.
 
-`remnic-hermes` v1.0.2 includes the full Remnic parity surface in Hermes: automatic MemoryProvider recall/observation, daemon-side LCM recall enrichment, session reset scoping, and explicit `remnic_*` tools for recall debugging, LCM search, memory CRUD, continuity, identity, governance, work boards, shared context, compounding, day summaries, briefings, context checkpoints, and profiling. Legacy `engram_*` aliases are still registered during the compatibility window.
+`remnic-hermes` v1.0.4 includes the full Remnic parity surface in Hermes: automatic MemoryProvider recall/observation, daemon-side LCM recall enrichment, session reset scoping, and explicit `remnic_*` tools for recall debugging, LCM search, memory CRUD, continuity, identity, governance, work boards, shared context, compounding, day summaries, briefings, context checkpoints, and profiling. Legacy `engram_*` aliases are still registered during the compatibility window.
 
 ## Which Hermes plugin slot Remnic uses
 

--- a/docs/integration/plugin-id-and-memory-namespaces.md
+++ b/docs/integration/plugin-id-and-memory-namespaces.md
@@ -68,8 +68,8 @@ launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
 # Step 3: Start a conversation — check the gateway log
 grep "gateway_start" ~/.openclaw/logs/gateway.log
 
-# Expected output:
-# [remnic] gateway_start fired — Remnic memory plugin is active (id=openclaw-engram, memoryDir=~/.openclaw/workspace/memory/local)
+# Expected output (the id matches the configured entry; installs via the legacy shim show id=openclaw-engram):
+# gateway_start fired — Remnic memory plugin is active (id=openclaw-remnic, memoryDir=~/.openclaw/workspace/memory/local)
 
 # Step 4: Verify the full health picture
 remnic doctor

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -1,18 +1,18 @@
-# Inductive Rule Consolidation (IRC)
+# Inductive rule consolidation (IRC)
 
-IRC is a preference synthesis layer in Engram's recall pipeline. It detects preference signals in stored conversations and synthesizes explicit preference statements that are injected into recall context.
+IRC is a preference synthesis layer in Remnic's recall pipeline. It detects preference signals in stored conversations and synthesizes explicit preference statements that are injected into recall context.
 
 ## Problem
 
-Engram stores conversations as factual content: *"I enjoy Adobe Premiere Pro for video editing."* But when a user later asks *"Can you recommend video editing resources?"*, the recall context needs to clearly signal that this user prefers Adobe Premiere Pro. Without IRC, the raw text is returned but preference intent isn't surfaced explicitly.
+Remnic stores conversations as factual content: *"I enjoy Adobe Premiere Pro for video editing."* But when a user later asks *"Can you recommend video editing resources?"*, the recall context needs to clearly signal that this user prefers Adobe Premiere Pro. Without IRC, the raw text is returned but preference intent isn't surfaced explicitly.
 
-## How It Works
+## How it works
 
 IRC runs as a parallel recall section in the orchestrator, using a dual-strategy approach:
 
 ### Strategy 1: Extracted Memory Files (Production)
 
-When LLM-powered extraction is available, Engram extracts structured facts, entities, and preferences from conversations. IRC reads these extracted memories and consolidates them into preference statements using pattern matching and the `consolidatePreferences()` function.
+When LLM-powered extraction is available, Remnic extracts structured facts, entities, and preferences from conversations. IRC reads these extracted memories and consolidates them into preference statements using pattern matching and the `consolidatePreferences()` function.
 
 ### Strategy 2: LCM FTS Fallback (No LLM)
 
@@ -42,7 +42,7 @@ To disable IRC:
 }
 ```
 
-## Detected Patterns
+## Detected patterns
 
 Strategy 2 recognizes these preference signal patterns (with optional adverbs):
 
@@ -66,7 +66,7 @@ recallInternal()
 
 IRC is non-fatal: errors are caught and logged, never blocking recall.
 
-## Key Files
+## Key files
 
 - `src/compounding/preference-consolidator.ts` — Core IRC logic (both strategies)
 - `src/orchestrator.ts` — IRC integration in recall pipeline

--- a/docs/lcm-to-remnic-migration.md
+++ b/docs/lcm-to-remnic-migration.md
@@ -55,7 +55,7 @@ In your `openclaw.json` (or whatever config file the Remnic plugin reads):
 {
   "plugins": {
     "entries": {
-      "openclaw-engram": {
+      "openclaw-remnic": {
         "config": {
           "lcmEnabled": true
         }
@@ -64,6 +64,9 @@ In your `openclaw.json` (or whatever config file the Remnic plugin reads):
   }
 }
 ```
+
+The plugin entry is `openclaw-remnic`; the legacy id `openclaw-engram` is
+still honored as a fallback for existing installs.
 
 See [`docs/guides/lossless-context-management.md`](guides/lossless-context-management.md)
 for the full LCM configuration reference.

--- a/docs/live-connectors.md
+++ b/docs/live-connectors.md
@@ -1,4 +1,4 @@
-# Live Connectors
+# Live connectors
 
 Live connectors are the **continuous** ingest path: they run on a schedule,
 remember where they left off, and pull *new* documents from external services
@@ -268,7 +268,7 @@ maintenance cron job:
 
 | Job id | Schedule | Tool |
 |--------|----------|------|
-| `engram-live-connectors-sync` | `* * * * *` when configured; `*/5 * * * *` before connector config loads | `engram.live_connectors_run` |
+| `engram-live-connectors-sync` | `* * * * *` when configured; `*/5 * * * *` before connector config loads | `remnic.live_connectors_run` (legacy alias `engram.live_connectors_run`) |
 
 The cron wakes every minute once connectors are configured and runs only
 connectors whose own `pollIntervalMs` says they are due. Operators can call the

--- a/docs/memory-evals.md
+++ b/docs/memory-evals.md
@@ -1,4 +1,4 @@
-# Memory Evals
+# Memory evals
 
 Agent memory without evals is vibes with a database.
 
@@ -6,6 +6,11 @@ Remnic memory evals measure whether user-aware memory improves agent outcomes
 without crossing boundaries. The first-class contract lives in `@remnic/bench`
 as `MEMORY_EVAL_DIMENSIONS`; each dimension maps to quick-capable benchmark
 surfaces so CI can catch regressions without a second eval harness.
+
+This is the concept doc: what memory quality means and how each dimension maps
+to quick benchmarks. For the eval-store, shadow-recording, and CI-gate machinery
+that runs and records these benchmarks, see the
+[Evaluation harness](evaluation-harness.md).
 
 ## Questions
 
@@ -37,7 +42,7 @@ Lower is better for the rate metrics that describe harm, violations, or
 unnecessary interruptions. Higher is better for recall, precision, lift, and
 turns saved.
 
-## Running Quick Coverage
+## Running quick coverage
 
 Use the exported list when building CI or release checks:
 

--- a/docs/model-lab.md
+++ b/docs/model-lab.md
@@ -6,33 +6,33 @@ classification models Remnic's extraction pipeline can consume locally:
 - **faithfulness-gate** (`remnic-faithfulness-gate-v1`) — (factText, quote, context)
   → {entailed, contradicted, unsupported}. Backs the extraction faithfulness
   gate (#1576 / #1585).
-- **correction-intent** (`remnic-correction-intent-v1`) — turn text + a small
-  prior-turn window → the #1581 `corrections[]` block (or none). Backs passive-
-  correction detection (#1581 / #1585).
+- **correction-intent** (`remnic-correction-intent-v1`) — a turn window →
+  {correction, none} detection classifier. Backs passive-correction detection
+  (#1581 / #1585 / #1738). Emitting the full #1581 `corrections[]` block
+  (targetHint, correctedAssertion, polarity) is the v2 causal-LM follow-up.
 
 Everything reproduces from manifests; **no datasets or weights are ever
 committed to this repo** (git carries recipes and hashes, never blobs).
 
-## Status: software landed, eval numbers GPU-gated
+## Status: both v1 models trained; downstream numbers GPU-gated
 
 This document describes the reproducible software shipped for #1585:
 
 | Piece | Status |
 |---|---|
-| Manifest schema + version-pin (`common/manifest_schema.py`, `common/training_stack.py`) | ✅ landed (both manifests committed as `pending-training` schema examples) |
-| Seeded data generators (faithfulness perturbations + correction-intent morphology) | ✅ landed (CI-tested: determinism + selfcheck, pure CPU) |
-| Train recipes (`train.py`, lazy-imported GPU stack) | ✅ landed (recipe + reproducibility contract) |
-| Eval harness (held-out p95 latency + F1) | ✅ landed (`common/latency.py`, `common/eval_runner.py`) |
-| Remnic config pointers | ✅ landed (`extractionFaithfulnessBaseUrl`, `correctionIntent*`) |
-| **Actual training runs + eval-number manifests** | ✅ **faithfulness-gate trained** (v1, this PR — held-out macro-F1 1.0, p95 9.93 ms; see Results below); ⏳ correction-intent pending (train loop is a scaffold + its `trl`/`bitsandbytes` pins don't resolve on PyPI — follow-up issue filed) |
-| **Downstream bench artifacts (gate quality vs prompted LLM; MemCorrect false_apply)** | ⏳ **GPU-gated** — produced by the #1574 bench protocol, not the model-lab recipes; the manifest's `eval.downstream` points there |
-| **HF weight publish (`common/hf_push.py`)** | ⏳ **pending** — `hf_push.py` is a stub (`NotImplementedError`) and no HF credentials exist on the lab box; the trained weights are content-pinned locally via `manifest.artifact.localArtifactSha256` (see that block) |
+| Manifest schema + version-pin (`common/manifest_schema.py`, `common/training_stack.py`) | landed (both manifests committed as `trained` with real eval numbers) |
+| Seeded data generators (faithfulness perturbations + correction-intent morphology) | landed (CI-tested: determinism + selfcheck, pure CPU) |
+| Train recipes (`train.py`, lazy-imported GPU stack) | landed (recipe + reproducibility contract) |
+| Eval harness (held-out p95 latency + F1) | landed (`common/latency.py`, `common/eval_runner.py`) |
+| Remnic config pointers | landed (`extractionFaithfulnessBaseUrl`, `correctionIntent*`) |
+| **Actual training runs + eval-number manifests** | **both v1 models trained** on the lab RTX 3090 (#1737 faithfulness-gate, #1738 correction-intent) — held-out macro-F1 1.0 each; see Results below |
+| **Downstream bench artifacts (gate quality vs prompted LLM; MemCorrect false_apply)** | GPU-gated — produced by the #1574 / #1584 bench protocols, not the model-lab recipes; each manifest's `eval.downstream` points there |
+| **HF weight publish (`common/hf_push.py`)** | pending — `hf_push.py` is a stub (`NotImplementedError`) and no HF credentials exist on the lab box; the trained weights are content-pinned locally via `manifest.artifact.localArtifactSha256` (see that block) |
 
 Per rule 55 (#1520): **no accuracy/latency number appears here without an
-artifact from a real run.** The faithfulness-gate manifest is `trained` and
-carries real held-out numbers; correction-intent stays `pending-training`
-until its train loop lands. Every number below traces to a manifest `eval`
-block.
+artifact from a real run.** Both v1 manifests are `status: trained` and carry
+real held-out numbers; the downstream (production-signal) numbers are still
+GPU-gated. Every number below traces to a manifest `eval` block.
 
 ## Results — faithfulness-gate v1 (real run, RTX 3090)
 
@@ -63,6 +63,35 @@ the backward pass) and is unstable under bf16 on small data. `roberta-large-mnli
 is the documented ≤4B fallback — fp32-stable and already NLI-pretrained — and
 converged cleanly (held-out macro-F1 climbed 0.22→0.48→0.65→0.96→1.0 over
 epochs 1–5). See `manifest.baseModel.$comment`.
+
+## Results — correction-intent v1 (real run, RTX 3090)
+
+Trained from the manifest at `model-lab/correction-intent/manifest.json`
+(`status: trained`). v1 is the **detection** slice of #1581: a turn window in,
+`{correction, none}` out. It shares the faithfulness-gate encoder stack and the
+same reproducible venv (identical `trainingStack.pipFreezeSha256`).
+
+| Metric | Value | Source |
+|---|---|---|
+| Held-out macro-F1 | **1.000** | `manifest.eval.heldOut.macroF1` (25 held-out examples, 10% split) |
+| Per-class F1 (correction / none) | 1.00 / 1.00 | `manifest.eval.heldOut.detection` |
+| Held-out p95 latency | **11.75 ms** | `manifest.eval.heldOut.latencyMs.p95` (single-example GPU forward, fp32) |
+| Base model | `roberta-large-mnli` (0.355 B) | `manifest.baseModel` — 3-way NLI head reinitialized to a 2-way detection head |
+| Dataset | 250 records (120 correction / 130 none), sha256 `c0238a2b…` | `manifest.dataRecipe` |
+
+The original #1585 plan used a <=4B instruct causal LM (TRL/LoRA) emitting the
+`corrections[]` JSON block, but `trl==0.16.6` / `bitsandbytes==0.44.1` do not
+exist on PyPI and the only resolvable `trl` breaks the shared venv's `datasets`
+pin (#1738). v1 therefore reuses the fp32-stable `roberta-large-mnli` encoder;
+it converged cleanly (held-out macro-F1 0.92 → 0.87 → 1.0 over epochs 1–3, held
+through epoch 12). Span extraction (`correctedAssertion` + polarity) is
+`not-applicable-v1` and is the v2 causal-LM follow-up.
+
+Same held-out caveat as the gate: the split is drawn from the same morphology
+generator as the train set, so macro-F1 1.0 reflects perfect pattern separation,
+not real-world robustness. The production number is the **downstream** one
+(detection quality vs the prompted-LLM classifier on real conversations),
+produced by the #1584 MemCorrect bench protocol — out of scope for `eval.py`.
 
 ## Hardware envelope (sets the model-size policy)
 
@@ -96,16 +125,17 @@ python model-lab/faithfulness-gate/train.py --version-tag v1 \
     --base-model roberta-large-mnli --mixed-precision fp32 --epochs 12 --learning-rate 1e-5
 python model-lab/faithfulness-gate/eval.py --version-tag v1            # → manifest eval.heldOut block (F1 + p95 latency)
 
-# 3. Correction-intent (≤4B instruct LM, LoRA) — PENDING:
-#    train.py is a scaffold (exits recipe-ready-not-run) and its trl/bitsandbytes
-#    pins don't resolve on PyPI yet; see the follow-up issue. generate-data is CPU-only
-#    and runnable; eval (offline scoring of pre-computed predictions) is too.
-python model-lab/correction-intent/generate-data.py --seed 1337 --yes   # → correction-intent/data/
+# 3. Correction-intent (encoder detection classifier — roberta-large-mnli; v1 is #1738):
+python model-lab/correction-intent/generate-data.py --seed 1337 --yes   # → correction-intent/data/ (sha256 in the manifest)
+python model-lab/correction-intent/train.py --version-tag v1 \
+    --base-model roberta-large-mnli --mixed-precision fp32 --epochs 12 --learning-rate 1e-5
+python model-lab/correction-intent/eval.py --version-tag v1            # → manifest eval.heldOut block (detection F1 + p95 latency)
 ```
 
 `train.py`/`eval.py` lazy-import the GPU stack so `--help` works on a bare
 machine; each exits with code 2 + an install hint if `torch`/`transformers`
-(and `trl`/`peft` for correction-intent) are missing. **They never run in CI.**
+are missing (both v1 models share the encoder stack — no `trl`/`peft`).
+**They never run in CI.**
 
 After a real run, `train.py` captures the exact interpreter + lib versions into
 the manifest's `trainingStack` block (`common/training_stack.capture_training_stack`),

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -1,11 +1,13 @@
-# Namespaces (v3.0)
+# Namespaces
 
-Namespaces allow multiple agents to share one Engram installation while keeping most memories isolated per agent, with a curated shared namespace.
+Namespaces let multiple agents share one Remnic installation while keeping most memories isolated per agent, plus a curated shared namespace for cross-agent context. Opt-in via `namespacesEnabled` (default `false`).
 
-## Key Config
+> Provenance: namespaces landed in v3.0; shared-namespace promotion and the `fact` promotion category in v9.0.66/v9.0.67; the namespace catalog is issue #1499 and namespace-aware maintenance fanout is issue #1500.
+
+## Key config
 
 - `namespacesEnabled` (default: false)
-- `namespaceCatalogEnabled` (default: true; inert unless `namespacesEnabled` — see [Namespace Catalog](#namespace-catalog-issue-1499))
+- `namespaceCatalogEnabled` (default: true; inert unless `namespacesEnabled` — see [Namespace catalog](#namespace-catalog))
 - `defaultNamespace` (default: `default`)
 - `sharedNamespace` (default: `shared`)
 - `namespacePolicies`: list of namespaces and read/write principals
@@ -14,11 +16,11 @@ Namespaces allow multiple agents to share one Engram installation while keeping 
 - `scopeProfiles` + `defaultScopeProfile`: optional hosted-team layered scope profiles
 - `teams`: trusted team membership and team-project namespace templates used by scope profiles
 
-## Cross-Agent Memory Access
+## Cross-agent memory access
 
 Non-generalist agents (any agent besides the one matching the `defaultNamespace`) recall from both their own **self namespace** and the **shared namespace** (as configured via `defaultRecallNamespaces`). Each agent's extracted memories are stored in its `self` namespace, so agents always have access to their own memories. The shared namespace provides cross-agent context — if it is empty, these agents still receive their own memories but miss context extracted by other agents.
 
-**Shared namespace promotion (v9.0.66+):** When `autoPromoteToSharedEnabled: true`, extracted memories are automatically promoted to the shared namespace. This is the primary mechanism for cross-agent memory sharing. Verify promotion is working:
+**Shared namespace promotion:** When `autoPromoteToSharedEnabled: true`, extracted memories are automatically promoted to the shared namespace. This is the primary mechanism for cross-agent memory sharing. Verify promotion is working:
 
 ```bash
 ls ~/.openclaw/workspace/memory/local/namespaces/shared/facts/
@@ -28,11 +30,11 @@ If this directory is empty or missing, non-generalist agents may have limited cr
 
 **Note:** Shared namespace promotion is not the only source of cross-agent recall. Namespaces configured with `includeInRecallByDefault: true` in `namespacePolicies` are also included in recall for all agents. Check your namespace policies if agents need access to specific namespaces beyond `self` and `shared`.
 
-**Categories eligible for promotion:** The `autoPromoteToSharedCategories` setting controls which memory categories are promoted. The default is `["fact", "correction", "decision", "preference"]`. The `"fact"` category was added in v9.0.67 — prior versions defaulted to `["correction", "decision", "preference"]` only.
+**Categories eligible for promotion:** The `autoPromoteToSharedCategories` setting controls which memory categories are promoted. The default is `["fact", "correction", "decision", "preference"]`; earlier releases defaulted to `["correction", "decision", "preference"]` only.
 
 **Cross-agent recall:** The primary mechanism for cross-agent memory sharing is shared namespace promotion. When promotion is configured, memories extracted by any agent are copied to the shared namespace and become available to all agents during recall.
 
-## Scope Profiles
+## Scope profiles
 
 `scopeProfiles` are optional. When absent, Remnic keeps the existing `defaultRecallNamespaces` behavior. When `defaultScopeProfile` points to a profile, implicit recall and write-producing access paths resolve the profile through the same core scope planner used for observe diagnostics.
 
@@ -84,9 +86,9 @@ Security rules:
 - Automatic profile promotion remains off unless `autoPromote.enabled` is true. The initial core contract exposes authorized promotion targets for surfaces; it does not make automatic cross-user sharing the default.
 - If project context is missing, Remnic skips project layers and falls back to the next authorized configured layer instead of inventing a project namespace.
 
-## QMD Collections for Namespaces
+## QMD collections for namespaces
 
-When namespaces are enabled, QMD needs entries for namespace-specific collections in `~/.config/qmd/index.yml`. The collection names follow the pattern `<qmdCollection>--ns--<namespace>`, where `<qmdCollection>` is the base collection name from your Engram config (default: `openclaw-engram`). This matches the runtime logic in `namespaceCollectionName()` (`src/namespaces/search.ts`). Check the gateway log for the exact names — Engram logs `QMD collection "..." not found` with the expected name when entries are missing.
+When namespaces are enabled, QMD needs entries for namespace-specific collections in `~/.config/qmd/index.yml`. The collection names follow the pattern `<qmdCollection>--ns--<namespace>`, where `<qmdCollection>` is the base collection name from your Remnic config (default: `openclaw-engram`, an intentional compatibility name). This matches the runtime logic in `namespaceCollectionName()` (`src/namespaces/search.ts`). Check the gateway log for the exact names — Remnic logs `QMD collection "..." not found` with the expected name when entries are missing.
 
 ```yaml
 # Base collection (default namespace root)
@@ -113,7 +115,7 @@ After adding entries, rebuild the indexes:
 qmd update && qmd embed
 ```
 
-## Storage Layout
+## Storage layout
 
 Compatibility behavior:
 - The default namespace continues to use the legacy `memoryDir` root unless `memoryDir/namespaces/<defaultNamespace>` exists.
@@ -133,9 +135,9 @@ This prevents "lost memories" when an install enables namespaces before migratin
   - default namespace: `workspace/IDENTITY.md`
   - non-default namespaces: `workspace/IDENTITY.<namespace>.md`
 
-## Multi-Tenant Example
+## Multi-tenant example
 
-Namespaces work well for multi-tenant deployments where different projects or clients share one Engram installation. Here is a generic configuration isolating two tenants with a shared knowledge layer:
+Namespaces work well for multi-tenant deployments where different projects or clients share one Remnic installation. Here is a generic configuration isolating two tenants with a shared knowledge layer:
 
 ```json
 {
@@ -158,7 +160,7 @@ Namespaces work well for multi-tenant deployments where different projects or cl
 
 Each tenant's agents use a session key prefix (e.g., `project-alpha:session-123`) which maps to a principal (`alpha-agent`) via the prefix rules. The principal determines namespace access: `alpha-agent` can read and write `project-alpha`, read `shared`, but cannot access `project-beta`.
 
-## Shared Knowledge Layer
+## Shared knowledge layer
 
 The shared namespace provides cross-tenant or cross-agent knowledge sharing. Typical configuration:
 
@@ -172,7 +174,7 @@ Memories reach the shared namespace in two ways:
 
 2. **Manual promotion** — Use the `memory_promote` tool or `memory_store` with `namespace: "shared"` when the authenticated principal has write access.
 
-## Principal Resolution for HTTP Callers
+## Principal resolution for HTTP callers
 
 When connecting via the HTTP API or MCP-over-HTTP, the principal is resolved in this order:
 
@@ -226,7 +228,7 @@ curl -X POST http://localhost:4318/engram/v1/observe \
 
 See the [Standalone Server Guide](guides/standalone-server.md) for full multi-tenant setup instructions.
 
-## Namespace Catalog (issue #1499)
+## Namespace catalog
 
 The **namespace catalog** is a rebuildable metadata index that lets Remnic
 *enumerate* the configured and dynamically-created namespaces that exist or
@@ -270,7 +272,7 @@ Rebuild preserves known metadata (timestamps, principal hints) where safe,
 preserves the legacy/default-root compatibility case, and reports ambiguous
 roots instead of silently misclassifying them.
 
-## Namespace-Aware Maintenance Fanout (issue #1500)
+## Namespace-aware maintenance fanout
 
 When `namespacesEnabled: true`, background maintenance can use the namespace
 catalog to process dynamic project and team-project namespaces that were created

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,7 +2,7 @@
 
 ## Backup, Export, and Import
 
-Engram supports portable exports and safe backups via CLI.
+Remnic supports portable exports and safe backups via CLI.
 
 ### Export
 
@@ -29,7 +29,7 @@ openclaw engram import --from /tmp/engram-export --format auto
 openclaw engram backup --out-dir /tmp/engram-backups --retention-days 14
 ```
 
-With namespaces (v3.0):
+With namespaces enabled (default off):
 
 ```bash
 openclaw engram export --namespace shared --format json --out /tmp/shared-export
@@ -48,7 +48,7 @@ openclaw engram doctor             # Aggregated runtime diagnostics + remediatio
 openclaw engram inventory          # Memory/entity/storage footprint, review queue, and native-knowledge sync counts
 openclaw engram topics              # View extracted topic list
 openclaw engram threads             # View conversation threads
-openclaw engram access              # Most-accessed memories
+openclaw engram access-stats         # Most-accessed memories
 openclaw engram route list          # List routing rules
 openclaw engram route add ...       # Add/update a routing rule
 openclaw engram route remove ...    # Remove routing rules by pattern
@@ -91,7 +91,7 @@ Compatibility diagnostics:
 - Use `openclaw engram compat --strict` to fail with non-zero exit code on warnings or errors.
 
 Operator toolkit:
-- `openclaw engram setup` validates the loaded OpenClaw config, creates missing Engram-owned directories, checks QMD reachability/collection presence, and can scaffold `MEMORY.md` when explicit capture is enabled.
+- `openclaw engram setup` validates the loaded OpenClaw config, creates missing Remnic-owned directories, checks QMD reachability/collection presence, and can scaffold `MEMORY.md` when explicit capture is enabled.
 - `openclaw engram setup --preview-capture-instructions` prints the managed explicit-capture snippet without writing files.
 - `openclaw engram setup --install-capture-instructions` writes or updates only the managed explicit-capture block inside `MEMORY.md`.
 - `openclaw engram setup --remove-capture-instructions` removes the managed explicit-capture block and deletes `MEMORY.md` if that block was the file's only content.
@@ -113,7 +113,7 @@ Graph diagnostics:
 Session integrity diagnostics:
 - `openclaw engram session-check` reports transcript chain anomalies (malformed lines, invalid entries, duplicate turn IDs, broken role chains, incomplete tail turns) and checkpoint integrity state.
 - `openclaw engram session-repair` is dry-run by default and outputs both plan + apply summary payloads.
-- `session-repair --apply` mutates only Engram-managed files (transcripts/checkpoint) and never rewires OpenClaw pointers/session references.
+- `session-repair --apply` mutates only Remnic-managed files (transcripts/checkpoint) and never rewires OpenClaw pointers/session references.
 - `--allow-session-file-repair` only unlocks an explicit guarded workflow for external session-file paths and still performs no automatic rewiring.
 
 Memory action diagnostics:
@@ -157,7 +157,7 @@ Access layer notes:
 - `openclaw engram access mcp-serve` exposes the same recall/read/write service layer over stdio for MCP clients such as Codex and Claude Code.
 - Use `GET /engram/v1/health`, `GET /engram/v1/quality`, or `GET /engram/v1/maintenance` as startup probes when local scripts need projection/governance readiness signals before issuing recall or review requests.
 
-## Compression Guideline Optimizer Tool (v8.11)
+## Compression Guideline Optimizer Tool
 
 Agent tool names:
 - `compression_guidelines_optimize`
@@ -180,7 +180,7 @@ Cron-safe usage pattern:
 - Call the tool in an isolated cron session to avoid blocking interactive turns.
 - Prefer `dryRun=true` for first-pass checks, then run with `dryRun=false` when stable.
 
-## Network Sync and WebDAV (v8.8)
+## Network Sync and WebDAV
 
 Network features are opt-in and not started by default.
 
@@ -243,7 +243,7 @@ Operational safety notes:
 
 ## Hourly Summaries (Cron)
 
-Engram can generate hourly summaries of conversation activity.
+Remnic can generate hourly summaries of conversation activity.
 
 Recommended cron setup (via OpenClaw agent turn — avoids `main` session restrictions):
 
@@ -271,7 +271,7 @@ Enable extended summaries:
 
 ## Cron Recall Policy
 
-Engram supports cron-specific recall policy so you can keep high-frequency automation jobs cheap while still enabling memory context for selected cron sessions.
+Remnic supports cron-specific recall policy so you can keep high-frequency automation jobs cheap while still enabling memory context for selected cron sessions.
 
 ```jsonc
 {
@@ -303,7 +303,7 @@ Pattern tip:
 
 ## File Hygiene
 
-Engram can optionally lint and rotate large workspace files that are bootstrapped into the prompt (e.g. `IDENTITY.md`). Without rotation, an oversized file can be silently truncated by the gateway.
+Remnic can optionally lint and rotate large workspace files that are bootstrapped into the prompt (e.g. `IDENTITY.md`). Without rotation, an oversized file can be silently truncated by the gateway.
 
 ```jsonc
 {
@@ -356,7 +356,7 @@ wc -l ~/.openclaw/workspace/memory/local/state/fact-hashes.txt
 
 ## Observation Ledger Maintenance
 
-Engram exposes explicit maintenance commands for observation artifacts.
+Remnic exposes explicit maintenance commands for observation artifacts.
 
 ```bash
 # Archive dated transcript/tool/hourly artifacts older than retention window
@@ -385,7 +385,7 @@ Operational guarantees:
 
 ## Memory Projection Maintenance
 
-Engram can also rebuild a derived SQLite projection for current-state inspection and per-memory timelines.
+Remnic can also rebuild a derived SQLite projection for current-state inspection and per-memory timelines.
 
 ```bash
 # Rebuild the derived projection from markdown memory files plus lifecycle events
@@ -421,7 +421,7 @@ Operational guarantees:
 
 ## Memory Governance Maintenance
 
-Engram can run a deterministic memory-governance sweep that builds a review queue, applies reversible status/archive transitions, and writes durable audit artifacts for each run.
+Remnic can run a deterministic memory-governance sweep that builds a review queue, applies reversible status/archive transitions, and writes durable audit artifacts for each run.
 
 ```bash
 # Simulate a governance run and write review artifacts only

--- a/docs/pattern-reinforcement.md
+++ b/docs/pattern-reinforcement.md
@@ -1,48 +1,88 @@
-# Pattern Reinforcement
+# Pattern reinforcement
 
-Pattern reinforcement (issue #687) generalizes the **procedural memory miner** into a universal mechanism: any observation that recurs across sessions is merged into a single *reinforced primitive* with a confidence boost, regardless of whether it is a procedure, a fact, or a preference.
+Pattern reinforcement generalizes Remnic's procedural-memory miner into a universal
+mechanism: any observation that recurs across sessions is merged into a single
+*reinforced primitive* with a confidence boost, whether it is a procedure, a fact,
+or a preference. Enable it when you want repeated preferences, facts, and decisions
+to consolidate and outrank one-off mentions instead of accumulating as duplicates.
 
-This feature tracks [issue #687](https://github.com/joshuaswarren/remnic/issues/687).
+**Opt-in via `patternReinforcementEnabled` (default `false`).** The recall boost for
+reinforced primitives is a second, independent opt-in
+(`reinforcementRecallBoostEnabled`, default `false`).
 
-Also see: [Procedural memory](procedural-memory.md) (the procedure-specific miner that ships alongside), [Recall X-ray](xray.md) (surfacing `reinforcementBoost` in score decomposition), [Config reference](config-reference.md#pattern-reinforcement-issue-687).
+## Enable it
+
+```json
+{
+  "patternReinforcementEnabled": true
+}
+```
+
+That turns on the maintenance job with a weekly cadence and the default categories.
+To also weight reinforced primitives higher in recall, add
+`reinforcementRecallBoostEnabled: true` (see [Recall boost](#recall-boost)).
 
 ## Concept
 
-The procedural miner already detects recurring multi-step runbooks. Pattern reinforcement extends that principle to all configurable memory categories:
+The procedural miner already detects recurring multi-step runbooks. Pattern
+reinforcement extends that principle to all configurable memory categories:
 
-- A user expressing the same preference across 30 sessions → reinforced preference primitive.
-- A debugging pattern recurring across 20 sessions in different repos → reinforced engineering practice.
+- A user expressing the same preference across 30 sessions → reinforced preference
+  primitive.
+- A debugging pattern recurring across 20 sessions in different repos → reinforced
+  engineering practice.
 - The same project context referenced repeatedly → reinforced project anchor.
 
-The procedural miner is unchanged. Pattern reinforcement runs as a **separate maintenance job** on a configurable cadence and considers only the categories you configure (default: `preference`, `fact`, `decision`).
+The procedural miner is unchanged. Pattern reinforcement runs as a **separate
+maintenance job** on a configurable cadence and considers only the categories you
+configure (default: `preference`, `fact`, `decision`).
 
 ## Reinforcement model
 
-The job runs `runPatternReinforcement()` from `packages/remnic-core/src/maintenance/pattern-reinforcement.ts` using a storage interface that accepts any `StorageManager`-compatible implementation.
+The job runs `runPatternReinforcement()` from
+`packages/remnic-core/src/maintenance/pattern-reinforcement.ts` using a storage
+interface that accepts any `StorageManager`-compatible implementation.
 
 ### Cluster key
 
 Each memory is keyed by `category::normalizedContent`:
 
-```
+```text
 normalizedContent = content.trim().toLowerCase().replace(/\s+/g, " ").slice(0, 200)
 key               = `${category}::${normalizedContent}`
 ```
 
-Truncating to 200 characters means long-form content with a stable opening still clusters together even when the tail differs slightly. The category prefix ensures that identical text in different categories (e.g., a `fact` and a `decision` with the same wording) is never cross-superseded.
+Truncating to 200 characters means long-form content with a stable opening still
+clusters together even when the tail differs slightly. The category prefix ensures
+that identical text in different categories (e.g., a `fact` and a `decision` with
+the same wording) is never cross-superseded.
 
 ### What gets reinforced
 
 The job:
 
-1. **Clusters** all active and superseded memories in the configured categories by cluster key. Forgotten, archived, quarantined, pending_review, and rejected memories are excluded.
-2. **Picks the most-recent active member** of each cluster with `cluster.size >= minCount` as the **canonical**.
-3. **Stamps the canonical** with `reinforcement_count` (total cluster size) and `last_reinforced_at` (ISO 8601). Provenance fields `derived_from` (source IDs) and `derived_via: "pattern-reinforcement"` are also written.
-4. **Marks older duplicates** `status: "superseded"` with a `supersededBy` pointer to the canonical's ID.
+1. **Clusters** all active and superseded memories in the configured categories by
+   cluster key. Forgotten, archived, quarantined, pending_review, and rejected
+   memories are excluded.
+2. **Picks the most-recent active member** of each cluster with
+   `cluster.size >= minCount` as the **canonical**.
+3. **Stamps the canonical** with `reinforcement_count` (total cluster size) and
+   `last_reinforced_at` (ISO 8601). Provenance fields `derived_from` (source IDs)
+   and `derived_via: "pattern-reinforcement"` are also written.
+4. **Marks older duplicates** `status: "superseded"` with a `supersededBy` pointer
+   to the canonical's ID.
 
-The job is idempotent for the **counter**: re-running on the same corpus does not double-bump `reinforcement_count`. The bump-only-on-change guard compares cluster size to the canonical's previous counter and bumps only when it grew.
+The job is idempotent for the **counter**: re-running on the same corpus does not
+double-bump `reinforcement_count`. The bump-only-on-change guard compares cluster
+size to the canonical's previous counter and bumps only when it grew.
 
-Note that the canonical's frontmatter can still be rewritten on a re-run when the **cluster membership** changes (new sources joined or older sources rotated out, even at the same total count) or when **`derived_via`** needs to be set to `"pattern-reinforcement"` for the first time. In those cases the maintenance job updates `derived_from` and `updated` to keep provenance accurate, while leaving `reinforcement_count` unchanged. Operators tuning write churn should treat these refresh writes as the steady-state cost of accurate provenance, not as counter drift.
+The canonical's frontmatter can still be rewritten on a re-run when the **cluster
+membership** changes (new sources joined or older sources rotated out, even at the
+same total count) or when **`derived_via`** needs to be set to
+`"pattern-reinforcement"` for the first time. In those cases the job updates
+`derived_from` and `updated` to keep provenance accurate while leaving
+`reinforcement_count` unchanged. Treat these refresh writes as the steady-state
+cost of accurate provenance, not as counter drift.
 
 ### YAML frontmatter fields
 
@@ -65,9 +105,7 @@ status: superseded
 supersededBy: mem_jkl012
 ```
 
-## Knobs
-
-Enable the job in plugin config:
+## Configuration
 
 ```json
 {
@@ -83,15 +121,27 @@ Enable the job in plugin config:
 | `patternReinforcementEnabled` | `false` | Master gate. Set to `true` to enable the maintenance job. |
 | `patternReinforcementCadenceMs` | `604800000` (7 days) | Minimum milliseconds between runs. Set to `0` to disable cadence gating (run on every invocation of the MCP/cron trigger). |
 | `patternReinforcementMinCount` | `3` | Minimum cluster size before a canonical is promoted. Clamped to `[2, 1000]`; clusters of 1 are degenerate. |
-| `patternReinforcementCategories` | `["preference", "fact", "decision"]` | Categories the job scans. Empty array means no categories are processed. |
+| `patternReinforcementCategories` | `["preference", "fact", "decision"]` | Categories the job scans. An empty array means no categories are processed. |
 
-The cadence guard is **entirely in-memory** and is NOT derived from the `last_reinforced_at` field written to memory frontmatter. The orchestrator keeps a `lastPatternReinforcementAtByNs` Map (keyed by namespace) that records the epoch-ms timestamp when each run completes. If `Date.now() - lastRunAt < patternReinforcementCadenceMs`, the job returns early with `skippedReason: "cadence"`.
+The cadence guard is **entirely in-memory** and is NOT derived from the
+`last_reinforced_at` field written to memory frontmatter. The orchestrator keeps a
+`lastPatternReinforcementAtByNs` map (keyed by namespace) that records the
+epoch-ms timestamp when each run completes. If
+`Date.now() - lastRunAt < patternReinforcementCadenceMs`, the job returns early
+with `skippedReason: "cadence"`.
 
-Because the map is in-process, it resets on every process restart. A freshly restarted gateway will always run the job on the first invocation that follows, regardless of when the previous process last ran it. Operators who need cross-restart cadence control should rely on external scheduling — for example a system cron job that calls the `remnic.pattern_reinforcement_run` MCP tool on a fixed interval — rather than the in-process gate alone. Set `patternReinforcementCadenceMs: 0` to disable cadence gating entirely and run on every invocation.
+Because the map is in-process, it resets on every process restart. A freshly
+restarted gateway always runs the job on the first invocation that follows,
+regardless of when the previous process last ran it. Operators who need
+cross-restart cadence control should rely on external scheduling — for example a
+system cron job that calls the `remnic.pattern_reinforcement_run` MCP tool on a
+fixed interval — rather than the in-process gate alone. Set
+`patternReinforcementCadenceMs: 0` to disable cadence gating entirely.
 
 ## Recall boost
 
-Reinforced primitives can be weighted higher in recall. This is **opt-in** (`reinforcementRecallBoostEnabled: false` by default):
+Reinforced primitives can be weighted higher in recall. This is **opt-in**
+(`reinforcementRecallBoostEnabled`, default `false`):
 
 ```json
 {
@@ -103,32 +153,40 @@ Reinforced primitives can be weighted higher in recall. This is **opt-in** (`rei
 | Key | Default | Notes |
 | --- | ------- | ----- |
 | `reinforcementRecallBoostEnabled` | `false` | When `true`, memories with `reinforcement_count > 0` receive an additive score boost. |
-| `reinforcementRecallBoostMax` | `0.3` | Maximum additive reinforcement boost per result. Range `[0, 1]`. The raw boost is `reinforcementRecallBoostWeight × reinforcement_count`, clipped to this cap. |
+| `reinforcementRecallBoostMax` | `0.3` | Maximum additive reinforcement boost per result. Range `[0, 1]`. |
+| `reinforcementRecallBoostWeight` | `0.05` | Per-unit boost multiplier. |
 
-A third key `reinforcementRecallBoostWeight` (default `0.05`) controls the per-unit boost. The formula:
+The formula:
 
-```
+```text
 boost = min(reinforcementRecallBoostMax, reinforcementRecallBoostWeight × reinforcement_count)
 ```
 
-A memory reinforced 12 times with default weight and max would receive `min(0.3, 0.05 × 12) = min(0.3, 0.6) = 0.3` — the cap.
+A memory reinforced 12 times with the default weight and max receives
+`min(0.3, 0.05 × 12) = min(0.3, 0.6) = 0.3` — the cap.
 
-## X-ray surfacing
+### X-ray surfacing
 
-When `reinforcementRecallBoostEnabled` is on and a result actually received a non-zero boost (`reinforcementBoost > 0`), Recall X-ray attaches the value to the per-result `explain` object. The shared X-ray renderer formats it inline as `reinforcement_boost=<value>` alongside the other score components (`importance`, `mmr_penalty`, `tier_prior`, etc.). Results that did not receive a boost simply omit the field.
+When `reinforcementRecallBoostEnabled` is on and a result actually received a
+non-zero boost (`reinforcementBoost > 0`), Recall X-ray attaches the value to the
+per-result `explain` object, formatted inline as `reinforcement_boost=<value>`
+alongside the other score components (`importance`, `mmr_penalty`, `tier_prior`,
+etc.). Results that did not receive a boost omit the field. This makes it easy to
+audit which results were boosted by pattern reinforcement vs. which won on raw
+relevance. See [Recall X-ray](xray.md) for the full per-result explain schema.
 
-This makes it easy to audit which results were boosted by pattern reinforcement vs. which won on raw relevance. See [Recall X-ray](xray.md) for the full per-result explain schema.
+## Inspecting reinforced patterns
 
-## CLI surface
+The `patterns` command group is hosted by the OpenClaw plugin runtime under the
+`engram` group. Both subcommands read from the active `memoryDir` and require no
+extra config.
 
-The `remnic patterns` command group exposes pattern-reinforcement output. Both subcommands read from the active `memoryDir` and require no extra config.
-
-### `remnic patterns list`
+### `openclaw engram patterns list`
 
 Lists memories whose `reinforcement_count > 0`, sorted by count descending.
 
 ```bash
-remnic patterns list [--limit N] [--category cat1,cat2] [--since ISO] [--format text|markdown|json]
+openclaw engram patterns list [--limit N] [--category cat1,cat2] [--since ISO] [--format text|markdown|json]
 ```
 
 | Flag | Default | Description |
@@ -140,7 +198,7 @@ remnic patterns list [--limit N] [--category cat1,cat2] [--since ISO] [--format 
 
 Example output (`--format text`):
 
-```
+```text
 Pattern memories (3):
 
   [12x] mem_jkl012  (preference, last_reinforced=2026-04-27T08:00:00.000Z, status=active)
@@ -149,32 +207,27 @@ Pattern memories (3):
   [8x] mem_abc456  (fact, last_reinforced=2026-04-20T10:00:00.000Z, status=active)
         the project uses pnpm workspaces...
         path: memories/facts/mem_abc456.md
-  [5x] mem_def789  (decision, last_reinforced=2026-04-15T14:30:00.000Z, status=active)
-        decided to use the port/adapter pattern...
-        path: memories/decisions/mem_def789.md
 ```
 
-### `remnic patterns explain <memoryId>`
+### `openclaw engram patterns explain <memoryId>`
 
 Shows the full reinforcement picture for a single canonical:
 
 - `reinforcement_count` and `last_reinforced_at`
-- `derived_from` source memory IDs (each cluster member's `frontmatter.id`) stamped by the maintenance job
+- `derived_from` source memory IDs stamped by the maintenance job
 - Canonical body
 - Cluster members — memories whose `supersededBy` points at this canonical
 
 ```bash
-remnic patterns explain <memoryId> [--format text|markdown|json]
+openclaw engram patterns explain <memoryId> [--format text|markdown|json]
 ```
 
-Exits with code `1` and a descriptive error if `<memoryId>` is not found or has no `reinforcement_count > 0`.
+Exits with code `1` and a descriptive error if `<memoryId>` is not found or has no
+`reinforcement_count > 0`. Invalid flag values (`--format xml`, `--limit 0`,
+`--since not-a-date`) throw a listed-options error rather than silently defaulting.
 
-Invalid flag values (`--format xml`, `--limit 0`, `--since not-a-date`) throw a listed-options error rather than silently defaulting (see CLAUDE.md rule 51).
-
-Example:
-
-```bash
-$ remnic patterns explain mem_jkl012
+```text
+$ openclaw engram patterns explain mem_jkl012
 Pattern: mem_jkl012
   reinforcement_count: 12
   last_reinforced_at: 2026-04-27T08:00:00.000Z
@@ -195,26 +248,27 @@ Cluster members (2):
       prefer terse implementation comments.
   - mem_def456 (status=superseded, supersededAt=2026-04-27T08:00:00.000Z)
       avoid block comments unless they explain a larger invariant.
-
-Run `remnic patterns explain mem_jkl012 --format json` for machine-readable output.
 ```
 
 ## Triggering the job
 
-Pattern reinforcement is **not** triggered automatically by the Dreams REM phase. The runtime call site is `EngramAccessService.patternReinforcementRun`, which is exposed through:
+Pattern reinforcement is **not** triggered automatically by the Dreams REM phase.
+The runtime call site is `EngramAccessService.patternReinforcementRun`, exposed
+through:
 
-- **MCP tool:** `remnic.pattern_reinforcement_run` (canonical) / `engram.pattern_reinforcement_run` (legacy alias)
-- **Maintenance scheduler / cron:** the job can be registered as a standalone maintenance cron entry
+- **MCP tool:** `remnic.pattern_reinforcement_run` (canonical) /
+  `engram.pattern_reinforcement_run` (legacy alias)
+- **Maintenance scheduler / cron:** the job can be registered as a standalone
+  maintenance cron entry
 
-To trigger an ad-hoc run, call the MCP tool directly:
+To trigger an ad-hoc run, call the MCP tool:
 
 ```json
 { "name": "remnic.pattern_reinforcement_run", "arguments": {} }
 ```
 
-Pass `"force": true` to bypass the in-process cadence gate for an immediate run regardless of when the last run completed.
-
-See [Dreams: phased consolidation](dreams.md) for the Dreams pipeline; pattern reinforcement scheduling is independent of it.
+Pass `"force": true` to bypass the in-process cadence gate for an immediate run.
+For the separate procedural miner, use `remnic.procedure_mining_run`.
 
 ## Relationship to procedural memory
 
@@ -229,55 +283,34 @@ Pattern reinforcement and the procedural miner are **siblings**, not replacement
 | Config gate | `procedural.enabled` (default `true`) | `patternReinforcementEnabled` (default `false`) |
 | Recall injection | Task-initiation procedure block | Score boost via `reinforcementRecallBoostEnabled` |
 
-Procedure memories themselves are not in the default `patternReinforcementCategories` list, so the two pipelines do not interfere.
+Procedure memories are not in the default `patternReinforcementCategories` list, so
+the two pipelines do not interfere.
 
-## Examples
+## Caveats
 
-### Enabling pattern reinforcement
+- The job merges duplicates by normalized content; it does not do semantic
+  clustering. Reworded-but-equivalent memories with different opening text will not
+  cluster.
+- The recall boost is off by default. Enabling reinforcement alone stamps counters
+  but does not change ranking until `reinforcementRecallBoostEnabled` is on.
+- The cadence gate is in-process only; use external scheduling for cross-restart
+  cadence control.
 
-Minimal config to turn on the job with weekly cadence:
+## Cross-references
 
-```json
-{
-  "patternReinforcementEnabled": true
-}
-```
+- [Procedural memory](procedural-memory.md) — the procedure-specific miner that
+  ships alongside.
+- [Recall X-ray](xray.md) — surfacing `reinforcementBoost` in the score
+  decomposition.
+- [Dreams: phased consolidation](dreams.md) — pattern-reinforcement scheduling is
+  independent of the Dreams pipeline.
 
-### Enabling recall boost
+## Provenance
 
-```json
-{
-  "patternReinforcementEnabled": true,
-  "reinforcementRecallBoostEnabled": true,
-  "reinforcementRecallBoostMax": 0.25
-}
-```
-
-### Restricting to preferences only
-
-```json
-{
-  "patternReinforcementEnabled": true,
-  "patternReinforcementCategories": ["preference"],
-  "patternReinforcementMinCount": 5
-}
-```
-
-### Running the job manually via MCP
-
-Pattern reinforcement has its own MCP tool:
-
-```json
-{ "name": "remnic.pattern_reinforcement_run", "arguments": {} }
-```
-
-Pass `"force": true` to bypass the in-process cadence gate. The legacy alias `engram.pattern_reinforcement_run` also works.
-
-For the separate procedural miner, use `remnic.procedure_mining_run`.
-
-## Acceptance criteria (from issue #687)
-
-- Bench fixture: 30 sessions repeating the same preference; reinforcement merges them into one primitive within one maintenance cycle.
-- Reinforced primitives outrank one-shot equivalents in recall on a controlled fixture (requires `reinforcementRecallBoostEnabled: true`).
-- `remnic patterns explain <id>` traces a reinforced primitive back to its sources.
-- Procedural-miner behavior unchanged.
+Pattern reinforcement tracks issue
+[#687](https://github.com/joshuaswarren/remnic/issues/687): a bench fixture repeats
+one preference across 30 sessions and reinforcement merges them into a single
+primitive within one maintenance cycle, reinforced primitives outrank one-shot
+equivalents in recall (with the boost enabled),
+`openclaw engram patterns explain <id>` traces a primitive back to its sources, and
+the procedural miner is unchanged.

--- a/docs/peers.md
+++ b/docs/peers.md
@@ -1,13 +1,19 @@
 # Peers
 
-Issue [#679](https://github.com/joshuaswarren/remnic/issues/679) introduces a
-**peer registry**: a generalization of Remnic's singular
+Remnic has a **peer registry**: a generalization of Remnic's singular
 identity-anchor model into a multi-peer schema. Every party that interacts
 with a Remnic store — the operator themself, other humans, other agents,
 and non-conversational integrations — can be represented as a `Peer` with
 an evolving cognitive profile.
 
-All five PRs are now merged. This page covers the complete feature.
+Provenance: the peer registry lands across five PRs under issue
+[#679](https://github.com/joshuaswarren/remnic/issues/679); this page covers
+the complete feature.
+
+> **Command surface.** The `peer` command group runs on the hosted
+> `openclaw engram` surface (the OpenClaw gateway / plugin runtime). The
+> standalone `remnic` binary does not expose `peer`; use `openclaw engram peer …`
+> or the HTTP/MCP surfaces below.
 
 ## Concepts
 
@@ -25,7 +31,7 @@ kernel files under `peers/{peer-id}/`:
 `Peer.kind` is one of:
 
 - `self` — the current Remnic operator. Supersedes the legacy
-  identity-anchor model; `remnic peer migrate` seeds
+  identity-anchor model; `openclaw engram peer migrate` seeds
   `peers/self/identity.md` from existing legacy data.
 - `human` — another human collaborator distinct from `self`.
 - `agent` — another AI agent (e.g. Claude Code, Codex, Hermes).
@@ -82,9 +88,9 @@ markdown.
 
 ## Profile reasoner
 
-The async profile reasoner (shipped in PR 2/5) runs inside the Dreams REM
-phase. It reads recent `interactions.log.md` entries and derives structured
-`profile.md` fields with provenance. Each field records:
+The async profile reasoner runs inside the Dreams REM phase. It reads recent
+`interactions.log.md` entries and derives structured `profile.md` fields with
+provenance. Each field records:
 
 - `observedAt` — ISO-8601 timestamp of the observation.
 - `signal` — the log entry text that drove the inference.
@@ -96,10 +102,10 @@ The reasoner is **disabled by default** and must be opted in via
 
 ## Recall integration
 
-PR 3/5 wires the peer registry into the recall pipeline. When a peer is
-registered for the active session (`orchestrator.setPeerIdForSession`),
-Remnic injects a brief excerpt from that peer's `profile.md` into the
-prompt context as a `## Peer Profile` section.
+The peer registry wires into the recall pipeline. When a peer is registered
+for the active session (`orchestrator.setPeerIdForSession`), Remnic injects a
+brief excerpt from that peer's `profile.md` into the prompt context as a
+`## Peer Profile` section.
 
 ### Recall X-ray annotation
 
@@ -127,48 +133,48 @@ injection in the X-ray trace.
 
 ## CLI commands
 
-All peer commands live under `remnic peer`:
+All peer commands run on the hosted `openclaw engram peer` surface:
 
 ```
-remnic peer list [--json]
-remnic peer show <id> [--json]
-remnic peer set <id> [--kind <kind>] [--display-name <name>] [--notes <text>] [--json]
-remnic peer delete <id> [--json]
-remnic peer forget <id> --confirm yes [--json]
-remnic peer profile <id> [--json]
-remnic peer migrate [--dry-run] [--display-name <name>] [--json]
+openclaw engram peer list [--json]
+openclaw engram peer show <id> [--json]
+openclaw engram peer set <id> [--kind <kind>] [--display-name <name>] [--notes <text>] [--json]
+openclaw engram peer delete <id> [--json]
+openclaw engram peer forget <id> --confirm yes [--json]
+openclaw engram peer profile <id> [--json]
+openclaw engram peer migrate [--dry-run] [--display-name <name>] [--json]
 ```
 
-### `remnic peer list`
+### `openclaw engram peer list`
 
 Lists all registered peers. `--json` emits `{ "peers": [...] }`.
 
-### `remnic peer show <id>`
+### `openclaw engram peer show <id>`
 
 Shows the identity record for a single peer. Exits non-zero when the
 peer is not found.
 
-### `remnic peer set <id>`
+### `openclaw engram peer set <id>`
 
 Creates or updates a peer. On first write, `--kind` sets the peer kind
 (default `"human"` when omitted at service layer). On subsequent writes,
 `kind` is immutable — pass `--display-name` or `--notes` to update those
 fields instead.
 
-### `remnic peer delete <id>`
+### `openclaw engram peer delete <id>`
 
 Removes `peers/{id}/identity.md`. The peer directory and companion files
 (`profile.md`, `interactions.log.md`) are left in place. Idempotent:
 returns a no-op result when the peer does not exist.
 
-### `remnic peer forget <id> --confirm yes`
+### `openclaw engram peer forget <id> --confirm yes`
 
 **DESTRUCTIVE.** Purges the entire peer directory — `identity.md`,
 `profile.md`, `interactions.log.md`, and any other companion files under
 `peers/{id}/`. All data is permanently removed.
 
 ```
-remnic peer forget <id> --confirm yes [--json]
+openclaw engram peer forget <id> --confirm yes [--json]
 ```
 
 Requires `--confirm yes` exactly. Any other value (or omitting the flag)
@@ -223,17 +229,17 @@ Returns `400 { "error": "confirm_required" }` when the body omits
 Returns `{ "ok": true, "purged": true|false }`. Throws when `confirm` is
 absent or not `"yes"`.
 
-### `remnic peer profile <id>`
+### `openclaw engram peer profile <id>`
 
 Prints the evolving cognitive profile for a peer. The profile is written
 by the async reasoner; exits non-zero when no profile exists yet.
 
-### `remnic peer migrate`
+### `openclaw engram peer migrate`
 
 Migrates legacy identity-anchor data into `peers/self/identity.md`.
 
 ```
-remnic peer migrate [--dry-run] [--display-name <name>] [--json]
+openclaw engram peer migrate [--dry-run] [--display-name <name>] [--json]
 ```
 
 **What it reads:**
@@ -253,7 +259,7 @@ with no notes. Symlinked source files are silently skipped.
 - **Idempotent** — if `peers/self/identity.md` already exists the command
   returns immediately without overwriting.
 - **Non-destructive** — legacy files are never deleted. Verify the result
-  with `remnic peer show self` before archiving legacy data.
+  with `openclaw engram peer show self` before archiving legacy data.
 - **`--dry-run`** — computes and prints the proposed peer record without
   writing anything to disk.
 
@@ -262,14 +268,14 @@ with no notes. Symlinked source files are silently skipped.
 ```
 Migrated identity-anchor data to peers/self/identity.md.
   Read anchor:  /path/to/memory/identity/identity-anchor.md
+```
 
 Legacy identity-anchor files are untouched. Verify the migration result
-with `remnic peer show self` before archiving legacy files.
-```
+with `openclaw engram peer show self` before archiving legacy files.
 
 ## HTTP and MCP surfaces
 
-PR 4/5 shipped the following HTTP endpoints and MCP tools:
+The peer registry ships the following HTTP endpoints and MCP tools:
 
 | Surface | HTTP | MCP tool |
 |---------|------|----------|
@@ -286,12 +292,12 @@ The legacy `engram_identity_anchor_get` and `engram_identity_anchor_update`
 MCP tools continue to work unchanged. `identityAnchorUpdate` is now
 **deprecated** — the method is preserved for backward compatibility but
 will be removed in a future major version. Use `peerSet({ id: "self", ... })`
-or `remnic peer set self` to update the self peer going forward.
+or `openclaw engram peer set self` to update the self peer going forward.
 
-After running `remnic peer migrate` you can verify with:
+After running `openclaw engram peer migrate` you can verify with:
 
 ```
-remnic peer show self
+openclaw engram peer show self
 ```
 
 And then optionally archive the legacy files:
@@ -312,9 +318,9 @@ mv ~/.remnic/identity/identity-anchor.md ~/.remnic/identity/identity-anchor.md.b
 - **Provenance everywhere.** Every profile field carries a list of
   `PeerProfileFieldProvenance` entries pointing back to the originating
   session/signal. You can audit exactly why a profile claim exists.
-- **Forget is destructive.** Use `remnic peer forget <id> --confirm yes`
+- **Forget is destructive.** Use `openclaw engram peer forget <id> --confirm yes`
   to permanently purge the full peer directory (identity, profile, and
-  interaction log). Use `remnic peer delete <id>` to remove only the
+  interaction log). Use `openclaw engram peer delete <id>` to remove only the
   identity kernel while preserving companion files.
-- **Capsule export gating.** Capsule export (issue #676) does not
-  include peer profiles unless explicitly opted in.
+- **Capsule export gating.** Capsule export does not include peer profiles
+  unless explicitly opted in.

--- a/docs/plans/2026-07-04-ci-speedup-plan.md
+++ b/docs/plans/2026-07-04-ci-speedup-plan.md
@@ -67,7 +67,7 @@ the Proxmox cluster with nightly-prune/weekly-restart/telemetry automation
 (`scripts/ci-runner-*`), currently serving Deckard CI. Findings:
 
 - proxmox2/3/4/5/z1 are documented as I/O- or capacity-saturated ("do not add
-  workers"); proxmox (192.168.2.3) has modest headroom.
+  workers"); the primary proxmox node has modest headroom.
 - **jarvis** (EPYC 7443P 24C/48T, 256 GB ECC, 3.5 TiB free local-lvm, dual
   10 GbE) is the only node with real capacity; the ML VM leaves ~60 GB +
   spare cores on the host.

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,0 +1,30 @@
+# Plugins
+
+Per-host adapter docs: what each packaged Remnic plugin is, what it does, and how
+it hooks into its agent platform. To return to the docs hub, see
+[`docs/README.md`](../README.md).
+
+**Plugins vs integration.** This directory (`docs/plugins/`) documents the
+per-host *adapters* — the shipped packages (`@remnic/plugin-*`) that embed Remnic
+in a specific agent runtime. The [`docs/integration/`](../integration/README.md)
+directory holds the *wiring guides* for connecting any tool to a running Remnic
+server. Reach for a plugin doc to understand an adapter; reach for an integration
+guide to set one up. For MCP-only tools without a plugin system, the connector
+lives here too (see Replit) but is wired via the connector setup guide.
+
+Each adapter also ships a package `README.md` under `packages/plugin-*/`, which is
+the single source of truth for install and options; these pages summarize and
+point to it.
+
+## Adapters
+
+- [OpenClaw plugin](openclaw.md) — `@remnic/plugin-openclaw`, the OpenClaw memory-slot bridge (canonical id `openclaw-remnic`, legacy `openclaw-engram`). The deepest native integration.
+- [Claude Code plugin](claude-code.md) — `@remnic/plugin-claude-code`: recall and observation hooks for Claude Code.
+- [Codex CLI plugin](codex.md) — `@remnic/plugin-codex`: automatic recall, observation, and session-end learning for OpenAI Codex CLI.
+- [Codex marketplace integration](codex-marketplace.md) — Discover and install the Remnic plugin through `codex marketplace`.
+- [Hermes agent plugin](hermes.md) — Remnic MemoryProvider for Hermes Agent: recall on every LLM turn plus automatic capture.
+- [Replit agent connector](replit.md) — MCP-based connector for Replit Agent (no plugin system, so MCP-only).
+
+## Research and spikes
+
+- [OpenClaw native memory registrars](openclaw-native-memory-registrars.md) — Spike checking OpenClaw's native memory-registrar surface against Remnic's model.

--- a/docs/plugins/codex.md
+++ b/docs/plugins/codex.md
@@ -4,18 +4,36 @@ Native Remnic plugin for OpenAI Codex CLI. Provides automatic memory recall, obs
 
 ## Installation
 
+Codex integration takes three discrete steps. None is automated end-to-end today; each writes to a different place.
+
+### 1. Mint a token and install the phase-2 guide
+
 ```bash
 remnic connectors install codex-cli
 ```
 
-This:
-1. Starts the Remnic daemon if not running
-2. Generates a dedicated auth token
-3. Installs the plugin to `~/.codex/plugins/`
-4. Enables hooks (`[features] codex_hooks = true` in `~/.codex/config.toml`)
-5. Configures MCP server pointing to Remnic
-6. Drops the Codex memory extension at `~/.codex/memories_extensions/remnic/instructions.md`
-7. Runs a health check
+This writes `~/.remnic/connectors/codex-cli.json` (Remnic connector state), stores a per-connector bearer token in `~/.remnic/tokens.json`, and materializes `~/.codex/memories_extensions/remnic/instructions.md` (the local-only phase-2 consolidation guide). It runs a daemon health check but does **not** start the daemon, and it does **not** write `~/.codex/config.toml` or deploy `.codex-plugin/`, `hooks/`, or `skills/`.
+
+### 2. Add Remnic as an MCP server
+
+Paste this block into `~/.codex/config.toml`, then set `REMNIC_AUTH_TOKEN` in Codex's environment to the token from step 1:
+
+```toml
+[mcp_servers.remnic]
+url = "http://127.0.0.1:4318/mcp"
+bearer_token_env_var = "REMNIC_AUTH_TOKEN"
+http_headers = { "X-Engram-Client-Id" = "codex" }
+```
+
+Without this step Codex cannot reach the Remnic daemon.
+
+### 3. Install and load the plugin
+
+```bash
+npm install -g @remnic/plugin-codex
+```
+
+Then load it through Codex's own plugin loader (symlink into `~/.codex/plugins/`, marketplace install, or whatever your Codex build supports — consult Codex's plugin docs). Until this step runs, the session hooks and skills are inactive, so auto-recall and auto-observe do not fire.
 
 ## What It Does
 
@@ -26,7 +44,8 @@ This:
 | `SessionStart` | Session begins | Recalls project context + user preferences |
 | `UserPromptSubmit` | Every user message | Recalls memories relevant to the prompt |
 | `PostToolUse` | After Bash execution | Observes command results and file changes |
-| `Stop` | Session ends | Flushes session learnings to EMO |
+| `Stop` | Session ends | Flushes buffered observations to the daemon for extraction |
+| `PreCompact` | Before Codex compacts the conversation | Flushes the observe buffer to long-term memory so nothing is lost before summarization |
 
 ### Explicit Skills
 
@@ -45,7 +64,7 @@ materializer.
 
 ### MCP Tools
 
-All 44 Remnic MCP tools are available via the `.mcp.json` configuration. The legacy `engram.*` aliases remain available during v1.x.
+The full Remnic MCP tool surface is available via the `.mcp.json` configuration. The legacy `engram.*` aliases remain available during the v1.x compatibility window.
 
 ## Memory Extension
 
@@ -101,13 +120,13 @@ via the `codex.installExtension` config flag:
 ```
 
 When `installExtension` is `false`, `remnic connectors install codex-cli`
-still installs MCP and hooks but does not touch `memories_extensions/`.
+still writes Remnic connector state and the bearer token but does not materialize `memories_extensions/`. Adding the MCP block and loading the plugin (steps 2 and 3 above) remain manual either way.
 
 ## How It Differs from Claude Code Plugin
 
 - **Stop hook:** Codex has a `Stop` event that fires when the agent completes its turn. The plugin uses this to flush any remaining observations and store session learnings — ensuring nothing is lost even if the session ends abruptly.
 - **PostToolUse matcher:** Matches `Bash` (Codex's primary tool) instead of `Write|Edit|MultiEdit`.
-- **Hooks feature flag:** Codex hooks require `[features] codex_hooks = true` — the installer sets this automatically.
+- **Hook trust:** Codex does not run non-managed hooks until a human approves them via `/hooks` on first use; the installer never bypasses that review.
 - **Config format:** TOML (`~/.codex/config.toml`) instead of JSON.
 
 ## Configuration
@@ -122,12 +141,7 @@ Additional Codex-specific issue:
 
 ### Hooks not firing
 
-Verify hooks are enabled:
-
-```bash
-grep codex_hooks ~/.codex/config.toml
-# Should show: codex_hooks = true
-```
+Codex does not run non-managed hooks until you review and trust them. The first time the hooks are enabled, run `/hooks` in the Codex CLI and approve the four Remnic entries (`SessionStart`, `UserPromptSubmit`, `Stop`, `PreCompact`). Codex records trust against the hook hash, so editing `hooks.json` re-triggers the review. For fleet or headless rollouts, ship the hooks under a `managed_dir` declared in `requirements.toml` so Codex trusts them by policy.
 
 ## Native memory materialization
 

--- a/docs/plugins/replit.md
+++ b/docs/plugins/replit.md
@@ -45,11 +45,11 @@ Unlike Claude Code, Codex, and Hermes, Replit has no hook system. This means:
 | Session start recall | No | Agent can call recall at conversation start |
 | Per-prompt memory | No | Agent decides when to check memory |
 
-The agent has full access to all 44 MCP tools but must choose to use them.
+The agent has full access to the entire Remnic MCP tool surface but must choose to use the tools.
 
 ## Available MCP Tools
 
-All Remnic MCP tools are available — recall, observe, store, search, entities, governance, work tracking, etc. See [MCP tools reference](../api/mcp-tools.md).
+All Remnic MCP tools are available — recall, observe, store, search, entities, governance, work tracking, and more. See the [MCP tools reference](../api.md).
 
 ## Troubleshooting
 

--- a/docs/procedural-memory.md
+++ b/docs/procedural-memory.md
@@ -14,7 +14,7 @@ Everything behavioral is gated by plugin config **`procedural.enabled`** (defaul
 - Intent-gated recall does not inject a procedure section.
 - The nightly miner MCP entry returns without writing files.
 
-Operators who want to stay opt-out must set `procedural.enabled: false` explicitly. Mirror the same keys under `openclaw.plugin.json` / host config as for other Engram-style toggles.
+Operators who want to stay opt-out must set `procedural.enabled: false` explicitly, or select the **conservative** memory-OS preset, which pins `procedural.enabled: false` against the default-on flip. Mirror the same keys under `openclaw.plugin.json` / host config as for other Remnic toggles.
 
 ### Migration from default-off
 
@@ -58,7 +58,7 @@ Operators who need to override any of these should do so explicitly; all fields 
 
 A dedicated miner clusters **causal trajectory** records (bounded lookback by `recordedAt` / `lookbackDays`) and can write **`status: pending_review`** procedure candidates. Promotion to **`active`** respects optional auto-promote rules and avoids clobbering user-edited bodies.
 
-Automation is **not** part of `runMemoryGovernance`. Use the MCP tool **`engram.procedure_mining_run`** (and optional cron registration mirroring other nightly jobs) so procedural mining stays isolated from shadow/apply governance.
+Automation is **not** part of `runMemoryGovernance`. Use the MCP tool **`remnic.procedure_mining_run`** (legacy alias **`engram.procedure_mining_run`**), with optional cron registration mirroring other nightly jobs, so procedural mining stays isolated from shadow/apply governance.
 
 ## Stats surface (issue #567 PR 5/5)
 
@@ -78,14 +78,14 @@ All three surfaces are read-only and namespace-scoped (CLAUDE.md rule 42). The H
 
 ## Pattern reinforcement CLI (issue #687 PR 4/4)
 
-The `remnic patterns` command group exposes the pattern-reinforcement output written by the maintenance job (PR 2/4).  Both subcommands read from the active `memoryDir` and require no extra config.
+The pattern-reinforcement CLI ships on the OpenClaw-hosted surface as `openclaw engram patterns`; there is no standalone `remnic patterns` command. The command group exposes the pattern-reinforcement output written by the maintenance job (PR 2/4). Both subcommands read from the active `memoryDir` and require no extra config.
 
-### `remnic patterns list`
+### `openclaw engram patterns list`
 
 Lists memories whose `reinforcement_count > 0`, sorted by count descending.
 
 ```bash
-remnic patterns list [--limit N] [--category cat1,cat2] [--since ISO] [--format text|markdown|json]
+openclaw engram patterns list [--limit N] [--category cat1,cat2] [--since ISO] [--format text|markdown|json]
 ```
 
 | Flag | Description | Default |
@@ -95,12 +95,12 @@ remnic patterns list [--limit N] [--category cat1,cat2] [--since ISO] [--format 
 | `--since ISO` | Only include memories reinforced on or after this ISO 8601 timestamp | all time |
 | `--format fmt` | Output format: `text`, `markdown`, or `json` | `text` |
 
-### `remnic patterns explain <memoryId>`
+### `openclaw engram patterns explain <memoryId>`
 
 Shows the full reinforcement picture for a single canonical: reinforcement count, `last_reinforced_at`, `derived_from` provenance chain (page-version refs stamped by PR 2/4), canonical body, and cluster members (memories whose `supersededBy` points at this canonical).
 
 ```bash
-remnic patterns explain <memoryId> [--format text|markdown|json]
+openclaw engram patterns explain <memoryId> [--format text|markdown|json]
 ```
 
 Exits with code `1` and a descriptive error if `<memoryId>` is not found or has no `reinforcement_count > 0`.

--- a/docs/retention-policy.md
+++ b/docs/retention-policy.md
@@ -1,48 +1,73 @@
 # Retention policy
 
-> Issue: [#686 — Year-2 retention: scaling decay, index pruning, and forgetting at scale](https://github.com/joshuaswarren/remnic/issues/686).
->
-> This document is the operator's reference for Remnic's retention substrate.
-> It describes the tier model, what the lifecycle policy does, what stays
-> opt-in vs default-on, and how to inspect or intervene when a memory ends up
-> in the wrong place.
+Remnic's retention substrate keeps a long-running memory store fast and small: it
+value-scores every memory, migrates cold material out of the hot search path, and
+gives operators explicit forget and purge surfaces. Enable it when your corpus has
+grown to the point where stale facts crowd out recent ones or the index has become
+slow to search.
+
+**Default posture:** lifecycle scoring is **on by default** (`lifecyclePolicyEnabled`,
+default `true` since [#686](https://github.com/joshuaswarren/remnic/issues/686)),
+but the behaviors that actually move or hide data are **opt-in**: hot/cold tier
+migration (`qmdTierMigrationEnabled`, default `false`), cold-tier search
+(`qmdColdTierEnabled`, default `false`), and the recall-time stale filter
+(`lifecycleFilterStaleEnabled`, default `false`). A fresh install scores memories
+but does not migrate, hide, or delete anything until you turn those gates on.
+
+## Enable it
+
+Lifecycle scoring already runs. To add value-aware hot/cold migration and cold-tier
+search, set:
+
+```json
+{
+  "lifecyclePolicyEnabled": true,
+  "qmdTierMigrationEnabled": true,
+  "qmdColdTierEnabled": true
+}
+```
+
+For the OpenClaw plugin these keys live under
+`plugins.entries.openclaw-remnic.config`; for the standalone server they go in the
+`remnic` block of `remnic.config.json`. See
+[Config reference](config-reference.md) for the full schema.
 
 ## Why retention matters
 
-Every long-running memory store hits the same wall: the index keeps growing
-even though most of the value is in a small, recently-touched subset. Without
-retention, the BM25 index, the graph, and the cold-scan fallback all compound
-indefinitely; recall@K erodes because relevant recent facts compete with stale
-chatter; cold-start probes get slower; backups balloon.
+Every long-running memory store hits the same wall: the index keeps growing even
+though most of the value is in a small, recently-touched subset. Without retention,
+the BM25 index, the graph, and the cold-scan fallback all compound indefinitely;
+recall@K erodes because relevant recent facts compete with stale chatter;
+cold-start probes get slower; backups balloon.
 
 [agentmemory](https://github.com/rohitg00/agentmemory) explicitly calls year-2
-retention an unsolved problem. Remnic's answer is a value-scored two-tier
-substrate plus an explicit forget surface — described below.
+retention an unsolved problem. Remnic's answer is a value-scored two-tier substrate
+plus an explicit forget surface, described below.
 
 ## The tier model
 
 Remnic stores memories in two **physical tiers** plus an archival escape hatch:
 
-- **Hot tier** — `<memoryDir>/{facts,procedures,reasoning-traces,corrections}/`
-  on disk; indexed in the QMD collection named by `qmdCollection` (default
-  `openclaw-engram`). This is the default search path.
+- **Hot tier** — `<memoryDir>/{facts,procedures,reasoning-traces,corrections}/` on
+  disk; indexed in the QMD collection named by `qmdCollection` (default
+  `openclaw-engram`, an intentional compatibility name). This is the default search
+  path.
 - **Cold tier** — `<memoryDir>/cold/...` on disk; indexed in the separate QMD
-  collection named by `qmdColdCollection` (default `openclaw-engram-cold`).
-  Searched only when `qmdColdTierEnabled === true` and the recall path opts
-  into the cold-fallback pipeline.
-- **Archive** — `<memoryDir>/archive/...`. Not part of either active tier;
-  scanned only as a last-ditch fallback when both hot and cold yield no
-  results.
+  collection named by `qmdColdCollection` (default `openclaw-engram-cold`). Searched
+  only when `qmdColdTierEnabled` is `true` and the recall path opts into the
+  cold-fallback pipeline.
+- **Archive** — `<memoryDir>/archive/...`. Not part of either active tier; scanned
+  only as a last-ditch fallback when both hot and cold yield no results.
 
 `tier-routing.ts` and `tier-migration.ts` implement the migration logic, the
-value-score model, and the journaling. The cold collection is a real,
-separate QMD index — not a virtual partition — so demoting a memory removes
-it from the live index size accounting.
+value-score model, and the journaling. The cold collection is a real, separate QMD
+index — not a virtual partition — so demoting a memory removes it from the live
+index size accounting.
 
 ### How a memory's tier is decided
 
-`computeTierValueScore(memory, now, signals)` aggregates several signals into
-a single `[0, 1]` value:
+`computeTierValueScore(memory, now, signals)` aggregates several signals into a
+single `[0, 1]` value:
 
 | Signal              | Weight | Meaning                                              |
 |---------------------|-------:|------------------------------------------------------|
@@ -55,8 +80,8 @@ a single `[0, 1]` value:
 | user-confirmed      | +0.05  | Bonus when `verificationState === "user_confirmed"`. |
 | disputed-fact       | −0.50  | Heavy penalty for disputed memories.                 |
 
-`decideTierTransition(memory, currentTier, policy, now, signals)` then
-applies the policy:
+`decideTierTransition(memory, currentTier, policy, now, signals)` then applies the
+policy:
 
 - **Hot → Cold (demotion)** when `ageDays >= demotionMinAgeDays` AND
   `valueScore <= demotionValueThreshold`.
@@ -65,72 +90,70 @@ applies the policy:
 
 ## What ships on by default vs opt-in
 
-| Behavior                                              | Status on current branch |
-|-------------------------------------------------------|--------------------------|
-| Lifecycle policy engine (`lifecyclePolicyEnabled`)    | default `false` (opt-in) |
-| Lifecycle metrics (`lifecycleMetricsEnabled`)         | explicit value, otherwise mirrors policy |
-| Tier migration (`qmdTierMigrationEnabled`)            | default `false` (opt-in) |
-| Recall queries hot tier only                          | always (PR 1/6 audit) |
-| Cold-tier fallback (`qmdColdTierEnabled`)             | default `false` (opt-in) |
-| Recall-time stale filter (`lifecycleFilterStaleEnabled`) | default `false` (opt-in) |
+| Behavior                                                  | Status on current release |
+|-----------------------------------------------------------|---------------------------|
+| Lifecycle policy engine (`lifecyclePolicyEnabled`)        | default `true` (#686 PR 3/6) |
+| Lifecycle metrics (`lifecycleMetricsEnabled`)             | explicit value, otherwise mirrors policy |
+| Tier migration (`qmdTierMigrationEnabled`)                | default `false` (opt-in) |
+| Recall queries hot tier only                              | always (PR 1/6 audit) |
+| Cold-tier fallback (`qmdColdTierEnabled`)                 | default `false` (opt-in) |
+| Recall-time stale filter (`lifecycleFilterStaleEnabled`)  | default `false` (opt-in) |
 
-Automatic hot/cold migration is gated by `qmdTierMigrationEnabled: true`.
-`lifecyclePolicyEnabled` controls the separate lifecycle scoring and metadata
-pass. Both default off, so fresh installs keep pre-#686 behavior until an
-operator explicitly enables the relevant path.
+Lifecycle scoring and metadata run by default, but automatic hot/cold migration is
+gated by `qmdTierMigrationEnabled: true`. Cold-tier search and recall-time stale
+filtering are also opt-in. So a fresh install scores memories yet keeps every
+memory in the hot tier and visible to recall until an operator enables migration or
+filtering.
 
 ## Default-recall behavior (audit, #686 PR 1/6)
 
-The recall path on `main` was audited and pinned with regression tests in
+The recall path was audited and pinned with regression tests in
 [#693](https://github.com/joshuaswarren/remnic/pull/693):
 
-1. **Default recall queries the hot QMD collection only.** Every primary
-   call to `fetchQmdMemoryResultsWithArtifactTopUp` outside of
-   `applyColdFallbackPipeline` omits the `collection` option, so the QMD
-   client falls through to the hot collection. The namespace-aware
-   `searchAcrossNamespaces` path does the same.
+1. **Default recall queries the hot QMD collection only.** Every primary call to
+   `fetchQmdMemoryResultsWithArtifactTopUp` outside of `applyColdFallbackPipeline`
+   omits the `collection` option, so the QMD client falls through to the hot
+   collection. The namespace-aware `searchAcrossNamespaces` path does the same.
 2. **The cold QMD collection is opt-in.** Queried only inside
-   `applyColdFallbackPipeline` and only when `qmdColdTierEnabled === true`.
-   Default `false` — a fresh install never reaches the cold-QMD branch.
+   `applyColdFallbackPipeline` and only when `qmdColdTierEnabled` is `true`. Default
+   `false` — a fresh install never reaches the cold-QMD branch.
 3. **The cold *directory* is not read on recall.**
    `StorageManager.collectActiveMemoryPaths` scans only the hot subtrees.
 4. **Archive is read only as a last-ditch fallback.**
 
-Regression tests in `tests/retrieval-cold-tier-default-excluded.test.ts`
-keep this contract enforced via runtime tripwires that hook
-`qmd.search` / `qmd.hybridSearch`,
-`fetchQmdMemoryResultsWithArtifactTopUp`, and
-`searchLongTermArchiveFallback`. Static AST audits were intentionally
-dropped because their completeness is unbounded (computed property names,
-shadowed identifiers, etc.); the runtime boundary check is strictly stronger.
+Regression tests in `tests/retrieval-cold-tier-default-excluded.test.ts` keep this
+contract enforced via runtime tripwires that hook `qmd.search` /
+`qmd.hybridSearch`, `fetchQmdMemoryResultsWithArtifactTopUp`, and
+`searchLongTermArchiveFallback`. Static AST audits were intentionally dropped
+because their completeness is unbounded (computed property names, shadowed
+identifiers, etc.); the runtime boundary check is strictly stronger.
 
 ## Bench: aged-dataset retention harness (#686 PR 2/6)
 
-[#698](https://github.com/joshuaswarren/remnic/pull/698) shipped
-`@remnic/bench`'s `retention-aged-dataset` benchmark — a hermetic synthetic
-corpus generator with Pareto-distributed query frequencies, configurable
-age skew, and deterministic seeds. The harness measures `recall@K`, latency
-proxy, and hot/cold tier shares for both the full-corpus baseline and the
-hot-only configuration.
+[#698](https://github.com/joshuaswarren/remnic/pull/698) shipped `@remnic/bench`'s
+`retention-aged-dataset` benchmark — a hermetic synthetic corpus generator with
+Pareto-distributed query frequencies, configurable age skew, and deterministic
+seeds. The harness measures `recall@K`, a latency proxy, and hot/cold tier shares
+for both the full-corpus baseline and the hot-only configuration.
 
-When the optional `@remnic/bench` runtime is available to `@remnic/cli`,
-run it via:
+When the optional `@remnic/bench` runtime is available to `@remnic/cli`, run it via
+the standalone CLI:
 
 ```bash
 remnic bench run --quick retention-aged-dataset
 ```
 
 Base CLI installs that cannot load `@remnic/bench` will report
-`retention-aged-dataset` as an unknown benchmark; use `remnic bench list`
-to confirm availability. The bench produces a structured report including
+`retention-aged-dataset` as an unknown benchmark; use `remnic bench list` to
+confirm availability. The bench produces a structured report including
 `recall_at_5_delta` so default-tuning iterations have an objective signal.
 
-## The forgotten tier (#686 PR 4/6)
+## The forgotten tier
 
-`remnic forget <id> [--reason <text>]` soft-deletes a memory: it sets
+`openclaw engram forget <id> [--reason <text>]` soft-deletes a memory: it sets
 `status: "forgotten"`, stamps `forgottenAt`, and writes an optional
-`forgottenReason` into the YAML frontmatter. The file stays on disk so the act
-is reversible. Forgotten memories are excluded from recall, browse, and entity
+`forgottenReason` into the YAML frontmatter. The file stays on disk so the act is
+reversible. Forgotten memories are excluded from recall, browse, and entity
 attribution by the status-allow-list filters that serve active context.
 
 ```yaml
@@ -139,13 +162,15 @@ forgottenAt: 2026-04-25T18:30:00.000Z
 forgottenReason: stale preference, user retracted
 ```
 
-Shipped in `packages/remnic-core/src/maintenance/forget.ts`; wired as
-`remnic forget` in `cli.ts`.
+Implemented in `packages/remnic-core/src/maintenance/forget.ts`; registered as the
+`forget` command in the `engram` command tree (`cli.ts`).
 
-## Operator visibility (#686 PR 5/6)
+## Operator visibility
 
-Current OpenClaw plugin CLI surfaces give operators a window into the tier
-substrate without manually walking the filesystem:
+The OpenClaw plugin CLI surfaces give operators a window into the tier substrate
+without manually walking the filesystem. Tier inspection and migration control run
+through the OpenClaw-hosted `engram` command group; `doctor` is available on the
+standalone `remnic` binary too.
 
 ```bash
 # Migration telemetry and last-cycle summary
@@ -154,18 +179,21 @@ openclaw engram tier-status
 # One bounded migration pass; dry-run by default
 openclaw engram tier-migrate --dry-run --limit 50
 
+# Tier distribution summary (hot/cold counts, status breakdown, recent migrations)
+openclaw engram tier list
+
+# Per-memory tier explain
+openclaw engram tier explain <id>
+
 # Explain the most recent recall snapshot
 openclaw engram recall-explain --format json
 
-# Tier distribution summary (hot/cold counts, status breakdown, recent migrations)
-remnic tier list
-
-# Per-memory tier explain
-remnic tier explain <id>
+# Standalone health check including tier distribution
+remnic doctor
 ```
 
-`tier-status` reports cumulative migration counters plus the latest cycle
-summary (`cycles`, `scanned`, `migrated`, `promoted`, `demoted`, `errors`).
+`tier-status` reports cumulative migration counters plus the latest cycle summary
+(`cycles`, `scanned`, `migrated`, `promoted`, `demoted`, `errors`).
 
 `tier-migrate` runs one bounded maintenance pass. It defaults to dry-run; pass
 `--write` to apply mutations after reviewing the reported plan.
@@ -173,39 +201,39 @@ summary (`cycles`, `scanned`, `migrated`, `promoted`, `demoted`, `errors`).
 `recall-explain` reports the most recent recall snapshot (or a session selected
 with `--session`) and can emit either text or JSON.
 
-`remnic doctor` now includes a `tier_distribution` check that shows hot/cold
-counts, forgotten-memory count, top status breakdown, recent migrations (last
-7 days from the migration journal), and top demotion reasons — all without any
-mutations.
+`remnic doctor` includes a `tier_distribution` check that shows hot/cold counts,
+forgotten-memory count, top status breakdown, recent migrations (last 7 days from
+the migration journal), and top demotion reasons — all without any mutations.
 
 ## Purge command
 
-`remnic purge` is the operator-facing hard-delete surface for Year-2 retention:
+`openclaw engram purge` is the operator-facing hard-delete surface for year-2
+retention:
 
 ```bash
 # Preview what would be deleted (dry-run; no --confirm needed)
-remnic purge --older-than P1Y --tier cold --dry-run
+openclaw engram purge --older-than P1Y --tier cold --dry-run
 
 # Execute: hard-delete cold memories older than 1 year
-remnic purge --older-than P1Y --tier cold --confirm yes
+openclaw engram purge --older-than P1Y --tier cold --confirm yes
 
 # Hard-delete only forgotten memories across all tiers older than 90 days
-remnic purge --older-than P90D --tier all --forgotten-only --confirm yes
+openclaw engram purge --older-than P90D --tier all --forgotten-only --confirm yes
 ```
 
-`--older-than` accepts ISO 8601 durations (`P1Y`, `P90D`, `P6M`) or plain
-days (`365`, `90`).
+`--older-than` accepts ISO 8601 durations (`P1Y`, `P90D`, `P6M`) or plain days
+(`365`, `90`).
 
-`--tier` defaults to `cold`. Use `--tier all` to target hot, cold, and
-archived memories.
+`--tier` defaults to `cold`. Use `--tier all` to target hot, cold, and archived
+memories.
 
-`--confirm yes` is required to execute mutations; any other value (or omitting
-the flag) forces dry-run. The literal string `"yes"` is the only accepted
-value — no substitutes.
+`--confirm yes` is required to execute mutations; any other value (or omitting the
+flag) forces dry-run. The literal string `"yes"` is the only accepted value — no
+substitutes.
 
 All purges are logged to `<memoryDir>/state/observation-ledger/purge-audit.jsonl`
-before the function returns. The QMD index is updated after each deletion so
-the search index stays consistent.
+before the function returns. The QMD index is updated after each deletion so the
+search index stays consistent.
 
 Implemented in `packages/remnic-core/src/maintenance/purge.ts`.
 
@@ -224,19 +252,19 @@ The check is always `ok` — it is informational, never a gate.
 
 ## First-start migration
 
-When `lifecyclePolicyEnabled: true` and `qmdTierMigrationEnabled: true` are
-set for the first time on a memoryDir that has never been touched by the
-lifecycle policy, a one-time rate-limited demotion sweep runs automatically
-during orchestrator deferred initialization.
+When `lifecyclePolicyEnabled: true` and `qmdTierMigrationEnabled: true` are set for
+the first time on a memoryDir that has never been touched by the lifecycle policy,
+a one-time rate-limited demotion sweep runs automatically during orchestrator
+deferred initialization.
 
-The sweep is capped at 50 demotions per run (`FIRST_START_DEMOTION_CAP = 50`)
-so a large pre-existing corpus does not stall startup. It is resumable: a
-state marker file `<memoryDir>/state/.lifecycle-init-done` is written after
-all mutations succeed. Subsequent starts see the marker and skip the sweep.
+The sweep is capped at 50 demotions per run (`FIRST_START_DEMOTION_CAP = 50`) so a
+large pre-existing corpus does not stall startup. It is resumable: a state marker
+file `<memoryDir>/state/.lifecycle-init-done` is written after all mutations
+succeed. Subsequent starts see the marker and skip the sweep.
 
-The sweep is idempotent and safe to run multiple times (as long as the marker
-is absent): it only demotes hot memories that already score below the
-configured demotion threshold and meet the minimum age requirement.
+The sweep is idempotent and safe to run multiple times (as long as the marker is
+absent): it only demotes hot memories that already score below the configured
+demotion threshold and meet the minimum age requirement.
 
 Implemented in `packages/remnic-core/src/maintenance/first-start-migration.ts`;
 hooked into `orchestrator.ts:deferredInitialize()`.
@@ -245,24 +273,25 @@ hooked into `orchestrator.ts:deferredInitialize()`.
 
 To search the cold QMD collection before archive fallback on hot misses:
 
-```yaml
-# openclaw.json plugin config
-qmdColdTierEnabled: true
+```json
+{
+  "qmdColdTierEnabled": true
+}
 ```
 
 When enabled, `applyColdFallbackPipeline` queries the cold QMD collection only
-after the hot-tier search returns no results. If cold QMD is disabled or returns
-no hits, archive scan fallback can still run. Default off because the long-tail
-rarely contributes to a recall worth the latency.
+after the hot-tier search returns no results. If cold QMD is disabled or returns no
+hits, archive scan fallback can still run. Default off because the long-tail rarely
+contributes a recall worth the latency.
 
 ## Configuration knobs
 
 | Key                                       | Default                | Purpose                                       |
 |-------------------------------------------|-----------------------:|-----------------------------------------------|
-| `lifecyclePolicyEnabled`                  | `false`                | Enable lifecycle scoring.                     |
-| `lifecyclePromoteHeatThreshold`           | `0.55`                 | Lifecycle heat threshold for validated/active transitions. |
-| `lifecycleStaleDecayThreshold`            | `0.65`                 | Lifecycle decay threshold for stale state.    |
-| `lifecycleArchiveDecayThreshold`          | `0.85`                 | Lifecycle decay threshold for archived state. |
+| `lifecyclePolicyEnabled`                  | `true`                 | Enable lifecycle scoring (on since #686).     |
+| `lifecyclePromoteHeatThreshold`           | `0.55`                 | Heat threshold for validated/active transitions. |
+| `lifecycleStaleDecayThreshold`            | `0.65`                 | Decay threshold for the stale state.          |
+| `lifecycleArchiveDecayThreshold`          | `0.85`                 | Decay threshold for the archived state.       |
 | `lifecycleProtectedCategories`            | (5 categories)         | Categories never demoted automatically.       |
 | `lifecycleMetricsEnabled`                 | mirrors policy         | Emit lifecycle metrics for inspection.        |
 | `lifecycleFilterStaleEnabled`             | `false`                | Filter stale lifecycle memories from recall.  |
@@ -271,42 +300,42 @@ rarely contributes to a recall worth the latency.
 | `qmdTierDemotionValueThreshold`           | `0.35`                 | Value score threshold for hot→cold demotion.  |
 | `qmdTierPromotionValueThreshold`          | `0.7`                  | Value score threshold for cold→hot promotion. |
 | `qmdColdTierEnabled`                      | `false`                | Query cold QMD before archive fallback.       |
-| `qmdColdCollection`                       | `openclaw-engram-cold` | QMD collection name for cold tier.            |
+| `qmdColdCollection`                       | `openclaw-engram-cold` | QMD collection name for the cold tier.        |
 
-See `docs/config-reference.md` for the full schema.
+See [Config reference](config-reference.md) for the full schema.
 
 ## Auditing the substrate
 
-Three signals together let an operator confirm the policy is doing the
-right thing:
+Three signals together let an operator confirm the policy is doing the right thing:
 
-1. `openclaw engram tier-status` — are migration cycles running and moving the expected counts?
-2. `openclaw engram tier-migrate --dry-run --limit 50` — what would the next bounded migration pass move?
-3. `openclaw engram recall-explain --format json` — for a surprising recall,
-   which snapshot and tier signals were recorded?
+1. `openclaw engram tier-status` — are migration cycles running and moving the
+   expected counts?
+2. `openclaw engram tier-migrate --dry-run --limit 50` — what would the next
+   bounded migration pass move?
+3. `openclaw engram recall-explain --format json` — for a surprising recall, which
+   snapshot and tier signals were recorded?
 
 When the answer is "the policy is right but the threshold is wrong," tune the
 `lifecycle*` and `qmdTier*` config knobs and re-run the aged-dataset bench to
-verify. A dedicated forget/restore surface remains future work on this branch.
+verify.
 
-## PR roll-up
+## Caveats
 
-Issue #686's six PRs:
+- Migration only runs when you opt in. Turning on `lifecyclePolicyEnabled` alone
+  scores memories but never demotes them; you also need `qmdTierMigrationEnabled`.
+- Cold-tier search adds latency on hot misses. Leave `qmdColdTierEnabled` off
+  unless recall is genuinely missing long-tail facts.
+- `purge` is a hard delete. Always run with `--dry-run` first; only
+  `--confirm yes` executes.
+- A dedicated soft-delete restore surface (to reverse `openclaw engram forget`
+  within the retention window) remains future work on this branch.
 
-| PR  | Title                                                          | Status              |
-|-----|----------------------------------------------------------------|---------------------|
-| 1/6 | Recall-path audit + cold-tier exclusion test                   | Merged ([#693](https://github.com/joshuaswarren/remnic/pull/693)) |
-| 2/6 | Aged-dataset retention bench harness                           | Merged ([#698](https://github.com/joshuaswarren/remnic/pull/698)) |
-| 3/6 | Lifecycle policy default and migration gate follow-up          | [#707](https://github.com/joshuaswarren/remnic/pull/707) |
-| 4/6 | Forgotten-tier soft-delete surface                             | [#708](https://github.com/joshuaswarren/remnic/pull/708) |
-| 5/6 | Operator visibility CLI follow-up                              | [#709](https://github.com/joshuaswarren/remnic/pull/709) |
-| 6/6 | This document                                                  | Merged              |
-| +   | Purge CLI, doctor tier section, first-start migration          | This PR             |
+## Provenance
 
-## What's next
-
-| Future PR | Scope |
-|-----------|-------|
-| HTTP / MCP surfaces for tier telemetry and migration control | Recall explanation already has HTTP endpoints; tier telemetry remains CLI-only. |
-| Default-tuning study | Ship a tunable threshold profile based on aged-dataset bench results across multiple corpus shapes. |
-| Soft-delete restore surface | `remnic restore <id>` to reverse a `remnic forget` while still within the retention window. |
+This document tracks issue
+[#686 — Year-2 retention: scaling decay, index pruning, and forgetting at scale](https://github.com/joshuaswarren/remnic/issues/686),
+delivered across six PRs: recall-path audit + cold-tier exclusion test (#693,
+merged), the aged-dataset bench harness (#698, merged), the lifecycle-default and
+migration-gate follow-up (#707), the forgotten-tier soft-delete surface (#708), the
+operator-visibility CLI (#709), plus the purge CLI, doctor tier section, and
+first-start migration.

--- a/docs/retrieval-explain.md
+++ b/docs/retrieval-explain.md
@@ -1,17 +1,51 @@
-# Retrieval Explain
+# Retrieval explain (tier explain)
 
-> Issue #518. **Status: design spec.** The tier-annotation shape, CLI / HTTP / MCP surfaces, and `LastRecallSnapshot.tierExplain` field described below are **not yet shipped** in the current release. This document defines the contract that downstream slices will land against, so operators and plugin authors can review the surface before it arrives. See [advanced-retrieval.md](./advanced-retrieval.md#direct-answer-retrieval-tier-issue-518) for what ships today (pure eligibility function + config keys).
->
-> Orthogonal to the graph-path `POST /engram/v1/recall/explain` operation, which already exists and returns a graph explanation document — this design adds a **per-result tier annotation**, not a new graph explainer.
+After a recall, Remnic can tell you **which retrieval tier would have served
+the query** — `direct-answer`, `hybrid`, and so on — plus the filters that
+narrowed the candidate set. This annotation is called *tier explain*, and it
+rides on the caller's last-recall snapshot.
 
-## What it will surface
+> **Not to be confused with the graph-path `recall/explain` surface.** Two
+> adjacent surfaces have similar names. This page documents the **tier
+> annotation** (issue #518). The separately-shipped graph-path explainer
+> answers "why did the graph subsystem return these memories?" and lives at
+> `POST /engram/v1/recall/explain` / the `remnic.recall_explain` MCP tool. The
+> [distinction table](#two-surfaces-with-similar-names) below spells out which
+> is which. Tier explain is also the block carried inside a
+> [Recall X-ray](./xray.md) snapshot.
 
-After a recall, Remnic records a `LastRecallSnapshot` for the calling session (see `packages/remnic-core/src/recall-state.ts`). A planned slice will extend the snapshot with an optional `tierExplain` field populated when the **direct-answer retrieval tier** is enabled (`recallDirectAnswerEnabled: true`):
+## Enable it
+
+Tier explain is gated behind the direct-answer retrieval tier, which is
+**off by default**. Opt in with a single flag:
+
+```jsonc
+// plugins.entries.openclaw-remnic.config (or the top-level `remnic` block of a
+// standalone remnic.config.json). Legacy plugin key: openclaw-engram.
+{
+  "recallDirectAnswerEnabled": true
+}
+```
+
+`recallDirectAnswerEnabled` defaults to `false` (verified in
+`packages/remnic-core/src/config.ts`). When it is `false`, `tierExplain` is
+never populated and all three surfaces below report "not populated".
+
+## How it works
+
+When `recallDirectAnswerEnabled` is `true`, the orchestrator runs a lightweight
+direct-answer eligibility gate **in observation mode** alongside the normal QMD
+retrieval path (`packages/remnic-core/src/orchestration/recall-introspection.ts`).
+It records *which tier would have served the query* onto the calling session's
+`LastRecallSnapshot.tierExplain` field
+(`packages/remnic-core/src/recall-state.ts`) — it does **not** short-circuit
+QMD or change which memories are returned. A future slice will flip the
+short-circuit bit so the direct-answer winner can be returned before QMD runs;
+until then this is a pure observability annotation.
+
+The recorded shape is `RecallTierExplain` (`packages/remnic-core/src/types.ts`):
 
 ```ts
-// Planned shape — already defined as `RecallTierExplain` in
-// packages/remnic-core/src/types.ts, but not yet attached to
-// LastRecallSnapshot or populated at runtime.
 interface RecallTierExplain {
   tier: "exact-cache" | "fuzzy-cache" | "direct-answer" | "hybrid" | "rerank-graph" | "agentic";
   tierReason: string;        // human-readable summary
@@ -22,22 +56,31 @@ interface RecallTierExplain {
 }
 ```
 
-The first slice that ships runtime behavior will populate `tier: "direct-answer"` only (observation mode). Later slices will populate it for the other tiers.
+The current release populates `tier: "direct-answer"` (the observation-mode
+verdict). Other tiers are reserved for later slices.
 
-## Planned surfaces
+## Surfaces
 
-All three surfaces below are **not yet implemented**. They are documented here as the target contract for the wiring slice. Do not rely on any of them until a subsequent PR lands their implementation; existing `recall/explain` (graph explanation) is unaffected.
+All three surfaces read the same `LastRecallSnapshot.tierExplain` field and are
+shipped in the current release.
 
-### CLI (planned)
+### CLI (hosted)
 
 ```sh
-remnic recall-explain [--session <key>] [--format text|json]
+openclaw engram recall-explain [--session <key>] [--format text|json]
 ```
 
-- **`--session`**: look up a specific session. Omit to read the most recent snapshot across sessions.
-- **`--format`**: `text` (default) for human output, `json` for a stable machine-readable payload. Any other value will be rejected — no silent default.
+- **`--session`** — look up a specific session. Omit to read the most recent
+  snapshot across sessions.
+- **`--format`** — `text` (default) or `json`. Any other value is rejected with
+  a listed-options error rather than silently defaulting.
 
-Planned text output for a direct-answer hit:
+There is no standalone `remnic recall-explain` command; tier explain is exposed
+through the OpenClaw-hosted CLI, the HTTP endpoint, and the MCP tool. Standalone
+callers read the same data over HTTP/MCP, or inline via a
+[Recall X-ray](./xray.md) capture (`remnic xray`).
+
+Text output for a direct-answer hit:
 
 ```
 === Recall Explain ===
@@ -59,15 +102,17 @@ source-anchors:
   - /memory/pm.md:10-14
 ```
 
-When no direct-answer verdict has been recorded the output will still show the snapshot metadata followed by `tier-explain: (not populated — direct-answer tier disabled or did not fire)`.
+When no direct-answer verdict has been recorded, the output shows the snapshot
+metadata followed by
+`tier-explain: (not populated — direct-answer tier disabled or did not fire)`.
 
-### HTTP (planned)
+### HTTP
 
 ```
-GET /engram/v1/recall/tier-explain[?session=<key>]
+GET /engram/v1/recall/tier-explain[?session=<key>][&namespace=<ns>]
 ```
 
-Bearer auth (same as other `/engram/v1/*` routes). Will return JSON matching `toRecallExplainJson()`:
+Bearer auth, same as every other `/engram/v1/*` route. Returns JSON:
 
 ```json
 {
@@ -91,41 +136,68 @@ Bearer auth (same as other `/engram/v1/*` routes). Will return JSON matching `to
 }
 ```
 
-When no snapshot exists yet, `snapshotFound: false`, `hasExplain: false`, and `tierExplain: null`.
+When no snapshot exists yet, `snapshotFound: false`, `hasExplain: false`, and
+`tierExplain: null`.
 
-This endpoint is **orthogonal** to the already-shipped `POST /engram/v1/recall/explain`, which returns a graph-path explanation document (the pre-existing `recallExplain` operation). The two paths will coexist under different verbs and URLs.
+### MCP
 
-### MCP (planned)
+- `remnic.recall_tier_explain` (canonical) / `engram.recall_tier_explain`
+  (legacy alias).
+- Optional `sessionKey` and `namespace` arguments. Omit `sessionKey` to read the
+  most recent snapshot.
+- Returns the same payload as the HTTP endpoint.
 
-Planned new tool:
+## Two surfaces with similar names
 
-- `remnic.recall_tier_explain` (canonical) / `engram.recall_tier_explain` (legacy alias)
-- Optional `sessionKey` argument. Omit to read the most recent snapshot.
-- Will return the same JSON payload as the HTTP endpoint.
+| | Tier explain (this page, #518) | Graph-path recall/explain (#570-era) |
+| --- | --- | --- |
+| **Answers** | "Which retrieval tier would have served this query, and what filtered candidates out?" | "Why did the graph subsystem return these memories?" (graph-path explanation document) |
+| **CLI** | `openclaw engram recall-explain` | (no dedicated CLI) |
+| **HTTP** | `GET /engram/v1/recall/tier-explain` | `POST /engram/v1/recall/explain` |
+| **MCP** | `remnic.recall_tier_explain` / `engram.recall_tier_explain` | `remnic.recall_explain` / `engram.recall_explain` |
+| **Data source** | `LastRecallSnapshot.tierExplain` | `EngramAccessService.recallExplain()` graph traversal |
 
-The existing `engram.recall_explain` MCP tool (graph-path explainer) is unrelated and unchanged.
+The confusing overlap is deliberate history, not a bug: the CLI verb is
+`recall-explain` but it renders **tier** explain, while the `recall_explain`
+MCP tool renders the **graph-path** explanation. When in doubt, match on the
+route/tool name in the table above, not the word "explain".
 
 ## Reading the `filteredBy` list
 
-When populated, labels will identify which gate eliminated at least one candidate on the way to the final verdict. They will be emitted regardless of eligibility so downstream consumers can see the narrowing steps.
+Each label identifies a gate that eliminated at least one candidate on the way
+to the verdict. They are emitted regardless of the final eligibility so
+consumers can see the narrowing steps:
 
-- `non-active-status` — a candidate was filtered because its status wasn't `active`
-- `not-trusted-zone` — candidate's trust zone wasn't `trusted`
-- `ineligible-taxonomy-bucket` — candidate's taxonomy bucket wasn't in the allowlist
-- `below-importance-floor` — candidate's importance was below the floor AND it wasn't `user_confirmed`
-- `entity-ref-mismatch` — caller supplied `queryEntityRefs` and the candidate's `entityRef` wasn't in the set
-- `below-token-overlap-floor` — candidate's query↔memory token overlap was below the floor
+- `non-active-status` — a candidate's status wasn't `active`
+- `not-trusted-zone` — a candidate's trust zone wasn't `trusted`
+- `ineligible-taxonomy-bucket` — a candidate's taxonomy bucket wasn't in the allowlist
+- `below-importance-floor` — a candidate's importance was below the floor AND it wasn't `user_confirmed`
+- `entity-ref-mismatch` — the caller supplied `queryEntityRefs` and the candidate's `entityRef` wasn't in the set
+- `below-token-overlap-floor` — a candidate's query-to-memory token overlap was below the floor
 
 ## Caveats
 
-- Once wired, `tierExplain` will populate only when `recallDirectAnswerEnabled: true` and direct-answer returns a concrete verdict. Disabled-by-default is intentional — see [advanced-retrieval.md](./advanced-retrieval.md) for the rationale.
-- The first runtime slice will run direct-answer in **observation mode** (post-recall, no short-circuit). Recall latency will be the sum of the full retrieval path *plus* the eligibility gate (bounded: small corpus ≈ under 10ms, larger corpora scale linearly with memory count).
-- The payload's `tierExplain` is designed to be deep-copied defensively by the shared renderer so clients can mutate their local copy without tearing the store.
+- `tierExplain` populates only when `recallDirectAnswerEnabled: true` and the
+  direct-answer gate returns a concrete verdict. Off-by-default is intentional
+  (least-privileged recall) — see [Advanced retrieval](./advanced-retrieval.md)
+  for the eligibility ladder and the full `recallDirectAnswer*` config keys.
+- The current release runs direct-answer in **observation mode**: recall
+  latency is the full retrieval path *plus* the eligibility gate (bounded — a
+  small corpus adds under ~10ms; larger corpora scale with memory count). The
+  short-circuit that returns the direct-answer winner before QMD is not yet
+  shipped.
+- The `tierExplain` payload is deep-copied by the shared renderer, so clients
+  can mutate their local copy without tearing the store.
 
 ## Related reading
 
-- [Advanced Retrieval](./advanced-retrieval.md) — sibling tiers (query expansion, re-ranking, feedback loop, procedural recall) and current status of the direct-answer slice.
-- Module: `packages/remnic-core/src/direct-answer.ts` — pure eligibility gate `isDirectAnswerEligible(...)` (shipped).
-- Module: `packages/remnic-core/src/direct-answer-wiring.ts` — source-agnostic wiring function `tryDirectAnswer(...)` (shipped; not yet invoked by the orchestrator).
-- Type: `packages/remnic-core/src/types.ts` → `RecallTierExplain` (shipped as a type; not yet attached to `LastRecallSnapshot`).
-- Bench: a dedicated `retrieval-direct-answer` fixture under `packages/bench/src/benchmarks/remnic/` is planned but **not yet in-tree**. Today's in-tree retrieval benchmarks are `retrieval-personalization` and `retrieval-temporal`.
+- [Recall X-ray](./xray.md) — per-result attribution snapshot that carries this
+  same `tierExplain` block inline (plus filters, score decomposition, and audit
+  correlation).
+- [Advanced retrieval](./advanced-retrieval.md) — the direct-answer tier's
+  eligibility gate, sibling tiers, and current ship status.
+- `packages/remnic-core/src/direct-answer.ts` — pure eligibility gate
+  `isDirectAnswerEligible(...)`.
+- `packages/remnic-core/src/direct-answer-wiring.ts` — source-agnostic
+  `tryDirectAnswer(...)` binding invoked by the orchestrator in observation mode.
+- `packages/remnic-core/src/types.ts` — `RecallTierExplain` interface.

--- a/docs/search-backends.md
+++ b/docs/search-backends.md
@@ -1,6 +1,6 @@
 # Search Backends
 
-Engram v9 supports six search backends through a pluggable port/adapter architecture. Each backend implements the same `SearchBackend` interface, so switching engines requires only a config change — no code modifications.
+Remnic supports six search backends through a pluggable port/adapter architecture. Each backend implements the same `SearchBackend` interface, so switching engines requires only a config change — no code modifications.
 
 ## Choosing a Backend
 
@@ -102,11 +102,47 @@ QMD version coverage:
 | `2.5.0` | Enables doctor/status diagnostics, version-matched skills, structured MCP `lex`/`vec`/`hyde` searches, absolute snippet lines, scoped embed behavior, and QMD model/GPU env controls. |
 | `2.5.3` | Uses QMD's preferred `--format json` selector for `query`/`search` subprocess calls and inherits QMD's line-range, docid-header, full-path, launcher, and Metal-teardown fixes. Remnic keeps legacy `--json` for older QMD versions. |
 
+### Upgrading QMD
+
+QMD `2.5.3` is a drop-in upgrade from any 2.x install — existing collections, indexes,
+and config files work unchanged. Remnic detects the installed version at startup and
+enables newer features only when the binary supports them, so upgrading is low-risk.
+
+```bash
+# 1. Install the supported target
+npm install -g @tobilu/qmd@2.5.3
+# or: bun install -g @tobilu/qmd@2.5.3
+
+# 2. Verify
+qmd --version        # 2.5.3
+qmd doctor           # available on QMD 2.5+
+qmd status           # existing collections should still list
+
+# 3. Restart your host so Remnic re-detects the version.
+#    Standalone:  remnic daemon restart
+#    OpenClaw:    launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
+```
+
+If native bindings misbehave after the upgrade, rebuild them with
+`npm rebuild better-sqlite3`.
+
+Moving up from QMD 1.x also resolves three issues that previously required manual
+patches, all fixed natively in 2.0+:
+
+- MCP session-ID crash — built-in `sessionIdGenerator`.
+- Model override env vars — `QMD_EMBED_MODEL`, `QMD_GENERATE_MODEL`, `QMD_RERANK_MODEL`.
+- Vector-search join performance — two-step query pattern.
+
+If you used the OpenClaw patcher for those 1.x patches, it targets source paths that no
+longer exist in 2.x and will harmlessly skip them; remove the stale QMD patch entries.
+To upgrade PATH/fallback installs automatically, set `qmdAutoUpgradeEnabled` (see the
+QMD config table above).
+
 ### QMD Daemon Mode
 
-For lower latency, Engram prefers a shared stdio `qmd mcp` session when QMD is healthy. It does not currently talk to the HTTP daemon endpoint directly, even though the legacy `qmdDaemonUrl` setting is still retained for compatibility.
+For lower latency, Remnic prefers a shared stdio `qmd mcp` session when QMD is healthy. It does not currently talk to the HTTP daemon endpoint directly, even though the legacy `qmdDaemonUrl` setting is still retained for compatibility.
 
-Engram automatically prefers the shared MCP session when available and falls back to subprocess calls on empty results, timeouts, or transport failure.
+Remnic automatically prefers the shared MCP session when available and falls back to subprocess calls on empty results, timeouts, or transport failure.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
@@ -192,7 +228,7 @@ Orama is an embedded, pure JavaScript search engine with hybrid FTS + vector sup
 }
 ```
 
-That's all you need. Engram handles database creation, document indexing, and persistence automatically.
+That's all you need. Remnic handles database creation, document indexing, and persistence automatically.
 
 ### How It Works
 
@@ -336,7 +372,7 @@ The Remote backend sends search requests to an HTTP REST endpoint. Use it to int
 
 ## Noop
 
-The Noop backend disables search entirely. Engram still extracts and stores memories, but recall returns no search results. Useful for extraction-only setups or testing.
+The Noop backend disables search entirely. Remnic still extracts and stores memories, but recall returns no search results. Useful for extraction-only setups or testing.
 
 ```jsonc
 {
@@ -350,14 +386,14 @@ Switching backends is a config-only change. Your memory files are always plain m
 
 1. Update `searchBackend` in your config
 2. Add any backend-specific settings
-3. Restart the gateway: `launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway`
-4. Run `openclaw engram stats` to verify the new backend is active
+3. Restart your host — standalone: `remnic daemon restart`; OpenClaw: `launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway`
+4. Verify the active backend — standalone: `remnic doctor`; OpenClaw: `openclaw engram stats`
 
 Embedded backends (Orama, LanceDB) will automatically index your existing memory files on the next update cycle.
 
 ## Global Search
 
-All backends support `searchGlobal()`, which searches across all collections (not just the default one). This is used by Engram's cross-collection recall when hot/cold tiering or conversation indexing is enabled.
+All backends support `searchGlobal()`, which searches across all collections (not just the default one). This is used by Remnic's cross-collection recall when hot/cold tiering or conversation indexing is enabled.
 
 - **QMD**: Searches all configured QMD collections
 - **Orama**: Scans all `.msp` files in the database directory

--- a/docs/security/memory-extraction-threat-model.md
+++ b/docs/security/memory-extraction-threat-model.md
@@ -107,9 +107,9 @@ intentional given the out-of-scope statement in the issue.
 ## 4. Attack surfaces
 
 ### 4.1 MCP tools
-Enumerated in `access-mcp.ts:98-817`. Every read-path tool that touches memory
+Enumerated in `access-mcp.ts`. Every read-path tool that touches memory
 is reachable by any client that successfully completes the MCP `initialize`
-handshake and passes `tools/call`. The surface is broad — **47 tool names**
+handshake and passes `tools/call`. The surface is broad — dozens of tool names
 including legacy-alias pairs — so attackers have many phrasings to try.
 
 Read-path tools that return memory content:
@@ -152,8 +152,9 @@ including `/engram/v1/recall`, `GET /engram/v1/memories` (list/browse),
 exposed via the MCP tool surface (`access-mcp.ts`).
 
 ### 4.3 CLI access
-`remnic recall`, `remnic memory search`, `remnic memory get`, and related
-commands run in-process with the same permissions as the invoking user. Out
+`remnic query` (standalone recall) and the hosted `openclaw engram recall` /
+`openclaw engram search` commands run in-process with the same permissions as
+the invoking user. Out
 of the MCP threat model but in scope for the harness because the same
 orchestrator code paths are exercised — PR 2's in-process fixture will drive
 the orchestrator directly rather than going through transports.

--- a/docs/setup-config-tuning.md
+++ b/docs/setup-config-tuning.md
@@ -50,7 +50,8 @@ In `openclaw.json` (the current plugin id is `openclaw-remnic`; installs created
 ```
 
 Service env override (optional):
-- `OPENCLAW_ENGRAM_CONFIG_PATH=/absolute/path/to/openclaw.json`
+- `OPENCLAW_CONFIG_PATH=/absolute/path/to/openclaw.json` (legacy
+  `OPENCLAW_ENGRAM_CONFIG_PATH` is honored as a fallback)
 
 Third-party OpenAI-compatible extraction endpoints:
 - Set `localLlmEnabled: true` and point `localLlmUrl` at the provider base URL.

--- a/docs/setup-config-tuning.md
+++ b/docs/setup-config-tuning.md
@@ -1,23 +1,23 @@
-# Setup, Configuration, and Tuning
+# Setup, configuration, and tuning
 
-This guide is the operational runbook for enabling and tuning Engram features across the current Engram config surface.
+This is the operator runbook for tuning Remnic beyond its shipped defaults. Remnic works well out of the box, so reach for this guide when you are self-hosting, running multi-agent or namespaced deployments, or trading off recall budget, retention, cost, and latency. Every example targets the OpenClaw plugin surface (`openclaw.json`); standalone operators can set the same keys in `remnic.config.json` and use `remnic doctor` / `remnic config` in place of the `openclaw engram` commands shown here.
 
-Operator loop:
+Start every tuning pass with the built-in diagnostics:
 - Run `openclaw engram setup --json` after first install or after moving memory/workspace paths.
 - Run `openclaw engram config-review --json` to compare your active config with shipped defaults and recommended settings.
 - Run `openclaw engram doctor --json` to catch misconfigurations, missing dependencies, and runtime health problems before blaming recall quality on the model.
 
 ## 1) Enable Plugin + Core Config
 
-In `openclaw.json`:
+In `openclaw.json` (the current plugin id is `openclaw-remnic`; installs created before the rename may still use the legacy `openclaw-engram` id, which Remnic continues to read):
 
 ```jsonc
 {
   "plugins": {
-    "allow": ["openclaw-engram"],
-    "slots": { "memory": "openclaw-engram" },
+    "allow": ["openclaw-remnic"],
+    "slots": { "memory": "openclaw-remnic" },
     "entries": {
-      "openclaw-engram": {
+      "openclaw-remnic": {
         "enabled": true,
         "config": {
           "openaiApiKey": "${OPENAI_API_KEY}",
@@ -60,7 +60,7 @@ Third-party OpenAI-compatible extraction endpoints:
 ## 1b) File Hygiene (Avoid Silent Truncation)
 
 If your workspace bootstrap files (commonly `USER.md`, `MEMORY.md`, `IDENTITY.md`) get large, OpenClaw can silently truncate them during prompt bootstrap.
-Enable Engram's optional file hygiene to warn early and (optionally) rotate oversized files into an archive directory:
+Enable Remnic's optional file hygiene to warn early and (optionally) rotate oversized files into an archive directory:
 
 ```jsonc
 {
@@ -133,12 +133,12 @@ FAISS alternative:
 
 FAISS setup notes:
 - Install the sidecar dependencies with `pip install -r scripts/faiss_requirements.txt`.
-- Set `ENGRAM_FAISS_ENABLE_ST=1` if you want sentence-transformers embeddings. Without it, the sidecar uses deterministic hash embeddings.
+- Set `REMNIC_FAISS_ENABLE_ST=1` (legacy `ENGRAM_FAISS_ENABLE_ST=1` still works) if you want sentence-transformers embeddings. Without it, the sidecar uses deterministic hash embeddings.
 - Expect local FAISS artifacts under `memoryDir/state/conversation-index/faiss/` (`index.faiss`, `metadata.jsonl`, `manifest.json`).
 - Use `openclaw engram conversation-index-health` to confirm the backend is `faiss` and not degraded.
 - Use `openclaw engram conversation-index-inspect` to diagnose missing artifacts, stale manifests, or empty indexes.
 - Use `openclaw engram conversation-index-rebuild --hours 24` to force a deterministic rebuild from transcript history.
-- If the sidecar is unavailable or the local artifacts are missing, Engram fails open and simply skips semantic transcript recall.
+- If the sidecar is unavailable or the local artifacts are missing, Remnic fails open and simply skips semantic transcript recall.
 
 ## 2b) v8.0 Phase 1 (Experimental, Cost-Aware)
 
@@ -166,7 +166,7 @@ Recommended rollout:
 
 ## 2c) v8.3 Lifecycle Policy Rollout
 
-Start in shadow mode, then phase in retrieval behavior:
+`lifecyclePolicyEnabled` is default-on since issue #686, so scoring and transitions already run on a fresh install. The config below makes the rollout explicit and keeps retrieval filtering off until you have measured outcomes; set `lifecyclePolicyEnabled: false` to opt out entirely.
 
 ```jsonc
 {
@@ -345,7 +345,7 @@ Use this when cron prompts are large/instruction-heavy and cause QMD query insta
 ```
 
 Behavior:
-- For instruction-heavy cron prompts, Engram builds a compact retrieval query and applies minimal recall budget.
+- For instruction-heavy cron prompts, Remnic builds a compact retrieval query and applies minimal recall budget.
 - In `cronConversationRecallMode: "auto"`, conversation semantic recall is skipped only for instruction-heavy cron prompts.
 - Set `cronConversationRecallMode: "always"` to force conversation semantic recall for cron jobs that need it.
 - Set `cronConversationRecallMode: "never"` to disable conversation semantic recall for all cron jobs.

--- a/docs/shared-context.md
+++ b/docs/shared-context.md
@@ -1,17 +1,21 @@
-# Shared Context (v4.0)
+# Shared context
 
-Shared-context is a file-based coordination layer that multiple agents can read/write, enabling cross-agent collaboration without direct agent-to-agent messaging.
+Shared context is a file-based coordination layer that multiple agents read and write, enabling cross-agent collaboration without direct agent-to-agent messaging. Enable it when you run several agents that should pool priorities, work products, and feedback in one place. Opt-in via `sharedContextEnabled` (default `false`).
 
-Default location:
-- `~/.openclaw/workspace/shared-context/`
+> Provenance: shared context landed in v4.0.
 
-Override:
-- `sharedContextDir`
+## Enable it
 
-Enable:
-- `sharedContextEnabled: true`
+```json
+{
+  "sharedContextEnabled": true,
+  "sharedContextDir": "~/.openclaw/workspace/shared-context"
+}
+```
 
-## Directory Structure
+`sharedContextDir` is optional and defaults to `~/.openclaw/workspace/shared-context/`.
+
+## Directory structure
 
 - `priorities.md`: curated living priority stack (agents read before acting)
 - `priorities.inbox.md`: append-only inbox for new priority notes
@@ -62,12 +66,12 @@ Compatibility aliases remain supported:
 - `crossSignalsSemanticTimeoutMs`
 
 Injection:
-- When enabled, Engram injects `priorities.md`, the latest `roundtable/*.md`, and the latest `cross-signals/*.md` into the system prompt (timeboxed and capped by `sharedContextMaxInjectChars`).
+- When enabled, Remnic injects `priorities.md`, the latest `roundtable/*.md`, and the latest `cross-signals/*.md` into the system prompt (timeboxed and capped by `sharedContextMaxInjectChars`, default 4,000).
 - Shared context is assembled at **position 1** in the recall pipeline — before profile and memories. It consumes recall budget first.
 
 ### Budget interaction
 
-With the default `recallBudgetChars` of 8,000 and `sharedContextMaxInjectChars` of 6,000, shared context plus profile (~7,500 chars) can exhaust the entire budget, leaving zero room for actual memories. If you enable shared context, set `recallBudgetChars` to at least 32,000 (or 64,000+ for large-context models). See [Recall Budget Tuning](config-reference.md#recall-budget-tuning).
+With the default `recallBudgetChars` of 8,000 and `sharedContextMaxInjectChars` of 4,000, shared context plus profile can consume most of the budget, leaving little room for actual memories. If you enable shared context, raise `recallBudgetChars` to at least 32,000 (or 64,000+ for large-context models). See [Recall budget tuning](config-reference.md#recall-budget-tuning).
 
 ## Scheduling
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,10 +1,19 @@
 # Tags
 
-Tags are free-form labels stored on each memory's frontmatter. They give callers a lightweight way to slice recall results without committing to the rigid structure of the MECE taxonomy. Issue #689 wires tag filtering end-to-end across the CLI, HTTP, and MCP surfaces.
+Tags are free-form labels stored on each memory's frontmatter. They give callers a
+lightweight way to slice recall results — `#weekly-review`, `#draft`, `#client-acme`
+— without committing to the rigid structure of the MECE taxonomy. Reach for tags
+when you want ad-hoc filtering; reach for the taxonomy when you need consistent,
+planner-friendly retrieval against a fixed shape.
+
+**Always available, no gating flag.** Tag filtering is wired end-to-end across the
+CLI, HTTP, and MCP recall surfaces. There is no config key to turn on; pass `tags`
+on any recall call.
 
 ## Tags vs taxonomy
 
-Remnic has two adjacent classification systems. Knowing which is which keeps reviews short.
+Remnic has two adjacent classification systems. Knowing which is which keeps reviews
+short.
 
 | Aspect | Tags | Taxonomy (`packages/remnic-core/src/taxonomy/`) |
 | --- | --- | --- |
@@ -15,25 +24,31 @@ Remnic has two adjacent classification systems. Knowing which is which keeps rev
 | Filter semantics | `any` (default) or `all` match against caller-supplied tag set | Single-bucket lookup |
 | Storage | Inline in frontmatter (`storage.ts`) | Path under `<memoryDir>/...` per resolved category |
 
-If you need consistent, planner-friendly retrieval against a fixed shape, use the taxonomy. If you need ad-hoc slicing — `#weekly-review`, `#draft`, `#client-acme` — use tags.
+The taxonomy resolver itself is opt-in (`taxonomyEnabled`, default `false`); tags
+are always on. If you need consistent, planner-friendly retrieval against a fixed
+shape, enable and use the taxonomy. If you need ad-hoc slicing, use tags.
 
-## Recall surface (issue #689)
+## Recall surface
 
 All three access surfaces accept the same two inputs:
 
 - `tags`: a string array (max 50 entries, each 1–256 chars after trim).
-- `tagMatch`: `"any"` (default when `tags` is provided and `tagMatch` is omitted) or `"all"`. Ignored when `tags` is absent or empty.
+- `tagMatch`: `"any"` (default when `tags` is provided and `tagMatch` is omitted)
+  or `"all"`. Ignored when `tags` is absent or empty.
 
-Comparison is case-sensitive exact match against tags stored on each memory's frontmatter. Empty / whitespace-only tag strings are dropped before matching. Duplicates are deduplicated.
+Comparison is case-sensitive exact match against tags stored on each memory's
+frontmatter. Empty/whitespace-only tag strings are dropped before matching.
+Duplicates are deduplicated.
 
 ### CLI
 
 ```bash
-remnic recall "what did I plan?" --tag draft --tag weekly-review
-remnic recall "decisions" --tag client-acme --tag-match all
+openclaw engram recall "what did I plan?" --tag draft --tag weekly-review
+openclaw engram recall "decisions" --tag client-acme --tag-match all
 ```
 
-`--tag` is repeatable. `--tag-match` accepts only `any` or `all`; any other value throws and lists valid options (CLAUDE.md rule 51 — never silently default).
+`--tag` is repeatable. `--tag-match` accepts only `any` or `all`; any other value
+throws and lists the valid options (never silently defaults).
 
 ### HTTP
 
@@ -47,29 +62,47 @@ remnic recall "decisions" --tag client-acme --tag-match all
 }
 ```
 
-For curl-friendly invocations the surface also accepts query-string parameters: `?tag=draft&tag=weekly-review&tag_match=all`. Body fields take precedence over query-string fallbacks.
+For curl-friendly invocations the surface also accepts query-string parameters:
+`?tag=draft&tag=weekly-review&tag_match=all`. Body fields take precedence over
+query-string fallbacks.
 
 ### MCP
 
-The `engram.recall` (and aliased `remnic.recall`) tool accepts `tags: string[]` and `tagMatch: "any" | "all"` in its input schema. Malformed values throw structured input errors.
+The `engram.recall` (aliased `remnic.recall`) tool accepts `tags: string[]` and
+`tagMatch: "any" | "all"` in its input schema. Malformed values throw structured
+input errors.
 
 ## Where the filter runs
 
 The filter is post-search and in-memory:
 
-1. The orchestrator runs the usual recall pipeline (QMD search → MMR → rerank → assembly).
-2. The access service hydrates each result's frontmatter via `serializeRecallResults`, so each candidate already carries its `tags` array.
-3. `applyTagFilter` (in `recall-tag-filter.ts`) drops candidates whose tags don't satisfy the filter according to the requested mode.
+1. The orchestrator runs the usual recall pipeline (QMD search → MMR → rerank →
+   assembly).
+2. The access service hydrates each result's frontmatter via
+   `serializeRecallResults`, so each candidate already carries its `tags` array.
+3. `applyTagFilter` (in `recall-tag-filter.ts`) drops candidates whose tags don't
+   satisfy the filter according to the requested mode.
 4. Filtered `count`, `memoryIds`, and `results` are returned to the caller.
 
-For X-ray (`/engram/v1/recall/xray`, `engram.recall_xray`, `remnic xray`) the filter additionally records a `tag-filter` entry in `snapshot.filters` with `considered → admitted` counts so operators can see how aggressive the filter was.
+For X-ray (`/engram/v1/recall/xray`, `engram.recall_xray`, `remnic xray`) the
+filter additionally records a `tag-filter` entry in `snapshot.filters` with
+`considered → admitted` counts so operators can see how aggressive the filter was.
 
-## Out of scope (explicitly deferred)
+## Caveats (explicitly deferred)
 
-The v1 ships intentionally narrow:
+The v1 surface ships intentionally narrow:
 
-- No QMD sidecar tag index. The filter is in-memory; deep result sets pay frontmatter I/O for every candidate.
-- No LLM auto-tagging. Tags are caller-supplied at write time or via existing extraction.
+- No QMD sidecar tag index. The filter is in-memory; deep result sets pay
+  frontmatter I/O for every candidate.
+- No LLM auto-tagging. Tags are caller-supplied at write time or via existing
+  extraction.
 - No tag hierarchies. Tags are flat strings with no nesting semantics.
 
-These are deliberate carve-outs and may ship in follow-ups. The current implementation aims for a tight, predictable surface that callers can rely on without waiting for the structural work.
+These are deliberate carve-outs and may ship in follow-ups. The current
+implementation aims for a tight, predictable surface callers can rely on without
+waiting for the structural work.
+
+## Provenance
+
+Tag filtering across the CLI, HTTP, and MCP surfaces tracks issue
+[#689](https://github.com/joshuaswarren/remnic/issues/689).

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -1,43 +1,53 @@
-# Tech Stack
+# Tech stack
 
-## Runtime
+What Remnic is built on. Versions below are the ranges declared in the workspace manifests; the memory engine and its dependencies live in `packages/remnic-core/`.
+
+## Runtime and tooling
 
 | Layer | Technology | Notes |
 |-------|-----------|-------|
-| Runtime | Node.js ≥ 22.12.0 | ESM modules (`"type": "module"`) |
-| Language | TypeScript 5.x | Strict mode; compiled with `tsup` |
-| Build | [tsup](https://tsup.egoist.dev/) | Bundles to `dist/` for distribution |
+| Runtime | Node.js ≥ 22.12.0 | ESM only (`"type": "module"`) |
+| Package manager | pnpm 10.32.1 | Declared via `packageManager`; workspace globs `packages/*` |
+| Monorepo | Turborepo 2.9.x | Task graph + caching via `turbo.json` |
+| Language | TypeScript 5.9 | Strict mode; `tsc --noEmit` for type checks |
+| Build | [tsup](https://tsup.egoist.dev/) 8.x | Bundles packages to `dist/` |
+| Lint / format | [Biome](https://biomejs.dev/) 1.9.4 | `biome.json`; an `eslint.config.js` is also present in the repo |
 
-## Core Dependencies
+## Core dependencies
 
 | Package | Purpose |
 |---------|---------|
-| `openai ^6` | LLM extraction/consolidation via OpenAI Responses API |
+| `openai ^6` | LLM extraction/consolidation via the OpenAI Responses API |
 | `zod ^3` | Runtime schema validation for structured LLM outputs |
-| `@sinclair/typebox ^0.34` | JSON Schema generation for plugin config contract |
+| `@sinclair/typebox ^0.34` | JSON Schema generation for the plugin config contract |
 | `better-sqlite3 ^12` | Embedded SQLite for artifact cache and indexes |
+| `@lancedb/lancedb ^0.26` | LanceDB embedded vector search backend |
+| `@orama/orama ^3` | Orama embedded (pure-JS) search backend |
+| `meilisearch ^0.46` | Meilisearch search backend client |
+| `@node-rs/argon2 ^2` | Argon2 hashing for the secure store |
 | `@honcho-ai/sdk ^2` | Optional Honcho-AI integration for shared context |
 
-## Dev Dependencies
+## Dev dependencies
 
 | Package | Purpose |
 |---------|---------|
 | `tsx ^4` | Run TypeScript files directly (tests, scripts) |
 | `tsup ^8` | Build and bundle TypeScript |
-| `typescript ^5.9` | Type checking; `tsc --noEmit` for lint |
+| `typescript ^5.9` | Type checking (`tsc --noEmit`) |
+| `@biomejs/biome 1.9.4` | Linting and formatting |
+| `turbo 2.9.x` | Monorepo task runner |
 
-## External Tools (not npm packages)
+## External tools (not npm packages)
 
 | Tool | Purpose | Required? |
 |------|---------|-----------|
-| [QMD](https://github.com/tobi/qmd) | Hybrid BM25 + vector search | Recommended; graceful fallback |
-| OpenAI API | LLM extraction and consolidation | Required for extraction |
+| [QMD](https://github.com/tobi/qmd) | Hybrid BM25 + vector search (default backend); supported version 2.5.3 | Recommended; recall falls back gracefully when unavailable |
+| OpenAI API | LLM extraction and consolidation | Required for extraction (unless using a local-LLM configuration) |
 
-## Test Infrastructure
+## Test infrastructure
 
-Tests use Node.js's built-in test runner (`node:test`) executed via `tsx --test`.
-No additional test framework is needed — import `node:test` and `node:assert` directly.
+Tests use Node.js's built-in test runner (`node:test`) executed via `tsx --test` — no additional test framework. Import `node:test` and `node:assert` directly. The root suite runs through `scripts/run-root-tests.mjs`; each package also carries its own tests.
 
 ## CI
 
-GitHub Actions (`.github/workflows/`) runs `npm run check-types`, `npm run test`, and `npm run build` on every push and pull request.
+GitHub Actions (`.github/workflows/`) runs the type checks, the test suite, the build, and the config/docs parity gates (`check-config-contract`, `check-docs-parity`) on every push and pull request.

--- a/docs/temporal-recall.md
+++ b/docs/temporal-recall.md
@@ -1,54 +1,58 @@
 # Temporal recall: `valid_at`, `invalid_at`, and `as_of`
 
-> Issue [#680](https://github.com/joshuaswarren/remnic/issues/680).
-> Promote temporal supersession to a first-class fact lifecycle that
-> callers can query historically.
+Temporal recall lets Remnic answer "what was true *then*", not just "what is true
+now". It records when each fact was authoritative and lets any recall be pinned to a
+past instant, so a superseded fact still surfaces when you ask about the window in
+which it held.
 
-Remnic now persists when a fact is "true" with two explicit ISO 8601
-frontmatter fields:
+**Always on, no gating flag.** Temporal supersession runs by default
+(`temporalSupersessionEnabled`, default `true`), and the `as_of` query parameter is
+available on every recall surface with no configuration. Superseded predecessors are
+excluded from normal recall (`temporalSupersessionIncludeInRecall`, default
+`false`) but remain queryable historically via `as_of`.
+
+## The lifecycle fields
+
+Remnic persists when a fact is "true" with two explicit ISO 8601 frontmatter
+fields:
 
 | Field        | Meaning                                               |
 | ------------ | ----------------------------------------------------- |
 | `validAt`    | When the fact begins being authoritative.             |
 | `invalidAt`  | When the fact stops being authoritative (exclusive).  |
 
-A fact is considered authoritative for the half-open interval
-`[validAt, invalidAt)`. Both fields are optional. When `validAt` is
-absent, the fact's `created` timestamp is used as a read-time fallback
-so legacy memories written before #680 participate in `as_of` filtering
-without a backfill migration. When `invalidAt` is absent, the fact is
-considered authoritative through "now".
+A fact is authoritative for the half-open interval `[validAt, invalidAt)`. Both
+fields are optional. When `validAt` is absent, the fact's `created` timestamp is
+used as a read-time fallback, so legacy memories written before this schema
+participate in `as_of` filtering without a backfill migration. When `invalidAt` is
+absent, the fact is authoritative through "now".
 
 ### Legacy supersession boundaries (approximate)
 
-For memories with `status: "superseded"` written before #680 — which
-have `supersededAt` populated but no `invalidAt` — the read-time
-filter falls back to `supersededAt` as `effectiveInvalidAt`. This
-keeps legacy predecessors out of historical recall once they were
-clearly retired, without requiring a backfill.
+For memories with `status: "superseded"` written before this schema — which have
+`supersededAt` populated but no `invalidAt` — the read-time filter falls back to
+`supersededAt` as `effectiveInvalidAt`. This keeps legacy predecessors out of
+historical recall once they were clearly retired, without requiring a backfill.
 
-The fallback is approximate: `supersededAt` reflects when the
-supersession *write* fired, which can post-date the successor's true
-`validAt` if consolidation ran on a delayed cadence. So a legacy
-predecessor may appear in `as_of` recall slightly longer than its
-successor's actual replacement instant. New data (post-#680) writes
-`invalidAt` directly from the successor's `validAt`, so this
-imprecision applies only to data written before the temporal-lifecycle
-schema landed.
+The fallback is approximate: `supersededAt` reflects when the supersession *write*
+fired, which can post-date the successor's true `validAt` if consolidation ran on a
+delayed cadence. So a legacy predecessor may appear in `as_of` recall slightly
+longer than its successor's actual replacement instant. New data writes `invalidAt`
+directly from the successor's `validAt`, so this imprecision applies only to data
+written before the temporal-lifecycle schema landed.
 
 ## How `invalid_at` gets populated
 
-The temporal supersession pipeline (`temporal-supersession.ts`) already
-detects when a newer fact replaces an older one on the same
-`(entityRef, attribute)` pair. As of #680 it now also stamps the
-predecessor's `invalidAt`:
+The temporal supersession pipeline (`temporal-supersession.ts`) detects when a
+newer fact replaces an older one on the same `(entityRef, attribute)` pair and
+stamps the predecessor's `invalidAt`:
 
-- The successor's `validAt` is copied verbatim onto the predecessor's
-  `invalidAt` so the two facts dovetail at exactly the same instant.
-- When the successor has no explicit `validAt`, the predecessor's
-  `invalidAt` is set to the successor's persisted `created` timestamp.
-- An existing `invalidAt` on the predecessor is preserved (idempotent),
-  so manual or earlier supersession events are not overwritten.
+- The successor's `validAt` is copied verbatim onto the predecessor's `invalidAt`
+  so the two facts dovetail at exactly the same instant.
+- When the successor has no explicit `validAt`, the predecessor's `invalidAt` is
+  set to the successor's persisted `created` timestamp.
+- An existing `invalidAt` on the predecessor is preserved (idempotent), so manual
+  or earlier supersession events are not overwritten.
 
 ## Recall as it existed at a point in time
 
@@ -56,21 +60,17 @@ Every recall surface accepts an `as_of` ISO 8601 timestamp:
 
 | Surface | How to pass `as_of`                          |
 | ------- | -------------------------------------------- |
-| CLI     | `remnic recall "<query>" --as-of <iso>`      |
+| CLI     | `openclaw engram recall "<query>" --as-of <iso>` |
 | HTTP    | `?as_of=<iso>` on `POST /engram/v1/recall`, or `asOf` in the JSON body |
-| MCP     | `asOf` field on the `engram.recall` tool     |
+| MCP     | `asOf` field on the `engram.recall` tool (aliased `remnic.recall`) |
 
-Each surface validates the timestamp at the input boundary
-(`Date.parse`) and rejects malformed values with a structured error.
-There is no silent fallback (CLAUDE.md rule 51).
+Each surface validates the timestamp at the input boundary (`Date.parse`) and
+rejects malformed values with a structured error. There is no silent fallback.
 
-When `as_of` is set, recall drops candidates that were not
-authoritative at that instant — i.e. those where
-`effectiveValidAt(fm) > asOf` OR
-`effectiveInvalidAt(fm) !== undefined && effectiveInvalidAt(fm) <= asOf`.
-The upper bound is exclusive so a fact's exact end-of-life timestamp
-hides it (CLAUDE.md gotcha #35: time-range filters use exclusive
-upper bounds).
+When `as_of` is set, recall drops candidates that were not authoritative at that
+instant — i.e. those where `effectiveValidAt(fm) > asOf` OR
+`effectiveInvalidAt(fm) !== undefined && effectiveInvalidAt(fm) <= asOf`. The upper
+bound is exclusive so a fact's exact end-of-life timestamp hides it.
 
 ## Worked example
 
@@ -105,35 +105,40 @@ structuredAttributes:
 project X relocated to NYC
 ```
 
-A normal `remnic recall "where is project X based?"` returns the NYC
-fact (the Austin fact is filtered as `superseded`).
+A normal `openclaw engram recall "where is project X based?"` returns the NYC fact
+(the Austin fact is filtered as `superseded`).
 
-A historical recall pinned to the day before the move returns the
-Austin fact:
+A historical recall pinned to the day before the move returns the Austin fact:
 
 ```bash
-remnic recall "where is project X based?" --as-of 2026-03-31T00:00:00Z
+openclaw engram recall "where is project X based?" --as-of 2026-03-31T00:00:00Z
 # → "project X is based in Austin" (validAt <= asOf < invalidAt)
 ```
 
-A recall pinned exactly at the supersession instant returns the NYC
-fact (because `invalidAt` is exclusive):
+A recall pinned exactly at the supersession instant returns the NYC fact (because
+`invalidAt` is exclusive):
 
 ```bash
-remnic recall "where is project X based?" --as-of 2026-04-01T00:00:00Z
+openclaw engram recall "where is project X based?" --as-of 2026-04-01T00:00:00Z
 # → "project X relocated to NYC"
 ```
 
-## What is intentionally out of scope
+## Caveats and out of scope
 
-This slice does NOT include:
+- Legacy supersession boundaries are approximate (see above); only data written
+  after the temporal schema landed dovetails at the exact replacement instant.
+- The upper bound is exclusive: a fact's exact `invalidAt` timestamp hides it.
+- Not included: mass migration/backfill of `validAt` onto existing files (the
+  read-time fallback to `created` covers legacy data); vector clocks, branching
+  timelines, or cross-fact causality; and any new supersession policy — the
+  existing pipeline is unchanged apart from emitting `invalidAt` on the
+  predecessor.
 
-- Mass migration / backfill of `validAt` onto existing files. The
-  read-time fallback to `created` covers legacy data.
-- Vector clocks, branching timelines, or cross-fact causality.
-- A new `temporal-supersession` policy. The existing pipeline is
-  unchanged apart from emitting `invalidAt` on the predecessor.
+See the test suite at `packages/remnic-core/src/temporal-validity.test.ts` for the
+canonical boundary cases.
 
-See the test suite at
-`packages/remnic-core/src/temporal-validity.test.ts` for the canonical
-boundary cases.
+## Provenance
+
+Temporal recall tracks issue
+[#680](https://github.com/joshuaswarren/remnic/issues/680), which promotes temporal
+supersession to a first-class fact lifecycle that callers can query historically.

--- a/docs/trace-to-primitive.md
+++ b/docs/trace-to-primitive.md
@@ -46,7 +46,7 @@ The trace is the noise. We are not going to keep it.
 
 ### Extraction — distill the trace into observation candidates
 
-When the buffer flushes (smart-flush signals: topic shift, time elapsed, explicit `before_reset`), `extraction.ts` calls the extractor (GPT-5.2 via the OpenAI Responses API). The extractor reads the trace and emits zero or more `ExtractedFact` records, each with a category (decision, preference, fact, principle, …), content, confidence, and tags. A separate pass (`importance.ts` / `calibration.ts`) then assigns an importance score in `[0, 1]` — importance is computed *after* extraction, not part of the `ExtractedFact` payload itself.
+When the buffer flushes (smart-flush signals: topic shift, time elapsed, explicit `before_reset`), `extraction.ts` calls the extractor (the configured extraction model via the OpenAI Responses API). The extractor reads the trace and emits zero or more `ExtractedFact` records, each with a category (decision, preference, fact, principle, …), content, confidence, and tags. A separate pass (`importance.ts` / `calibration.ts`) then assigns an importance score in `[0, 1]` — importance is computed *after* extraction, not part of the `ExtractedFact` payload itself.
 
 For our session, the pipeline might emit (extractor output → after importance scoring):
 
@@ -54,7 +54,7 @@ For our session, the pipeline might emit (extractor output → after importance 
 2. `{ category: "fact", content: "Postgres replica lag alarm fires when GC pauses cross 200ms", confidence: 0.9 }` → `importance: 0.78`
 3. `{ category: "principle", content: "Caching layer should be per-tenant, not global", confidence: 0.85 }` → `importance: 0.7`
 
-The extraction judge (`extraction-judge.ts`) then post-filters: it asks an LLM whether each candidate is genuinely durable or just transient task chatter. The flaky-test debugging turns produce no observations — they were noise.
+The extraction judge (`extraction-judge.ts`) — opt-in via `extractionJudgeEnabled` (default `false`) — then post-filters when enabled: it asks an LLM whether each candidate is genuinely durable or just transient task chatter. In this walkthrough the flaky-test debugging turns produce no observations — they were noise.
 
 Each surviving candidate becomes a `MemoryObservation` (the public type in `@remnic/core`):
 
@@ -113,7 +113,7 @@ That `MemoryFile` is the **primitive**. Three primitives now exist where four ho
 
 ### Reinforcement — primitives compound over time
 
-`compounding/engine.ts` runs weekly, surfacing primitives that recurred or were referenced and bumping their access counters / heat scores. Stale, never-recalled primitives drift toward the cold tier under the lifecycle policy (issue #686). The retention substrate decides when a primitive is durable enough to keep, when it's cold enough to demote, and — via `remnic forget` — when an operator wants it gone entirely.
+`compounding/engine.ts` runs weekly, surfacing primitives that recurred or were referenced and bumping their access counters / heat scores. Stale, never-recalled primitives drift toward the cold tier under the lifecycle policy (issue #686). The retention substrate decides when a primitive is durable enough to keep, when it's cold enough to demote, and — via `openclaw engram forget` — when an operator wants it gone entirely.
 
 ## Why this framing matters
 
@@ -124,7 +124,7 @@ Remnic's pipeline produces primitives that are:
 - **Searchable** — primitives are first-class records, not buried inside transcripts.
 - **Citable** — every recall response includes `<oai-mem-citation>` blocks pointing back to the source primitive.
 - **Reinforceable** — compounding raises the value of primitives that keep mattering.
-- **Forgettable** — `remnic forget <id>` is the explicit escape hatch.
+- **Forgettable** — `openclaw engram forget <id>` is the explicit escape hatch.
 
 The trace is noise. The primitive is the product.
 
@@ -135,7 +135,7 @@ The trace is noise. The primitive is the product.
 | `@remnic/core` types | The `MemoryObservation` interface ships in the public types so callers can read post-extraction state without reaching into `extraction.ts`. |
 | `remnic doctor` | Reports observation throughput, judge accept/reject/defer breakdown, and the most recent `observedAt` via the `observations` check (issue #685). Reads from `state/observation-ledger/extraction-judge-verdicts.jsonl`. |
 | `recall` responses | `<oai-mem-citation>` blocks point at the primitive ids that came out the other end of the pipeline. |
-| `remnic tier list` / `tier explain` | Inspect what happened to primitives after they were written (issue #686). |
+| `openclaw engram tier list` / `tier explain` | Inspect what happened to primitives after they were written (issue #686). |
 | `observation-ledger` | A separate concept: a JSONL telemetry directory (`state/observation-ledger/`) capturing turn-count aggregates (`maintenance/rebuild-observations.ts`) and judge verdict events (`extraction-judge-telemetry.ts`). Operator-observability data, distinct from the lifecycle-event ledger and from the `MemoryObservation` type — see the naming note below. |
 
 ## Naming note: observation vs observation-ledger

--- a/docs/user-aware-agents.md
+++ b/docs/user-aware-agents.md
@@ -99,7 +99,7 @@ Public line:
 The helper is exposed as:
 
 - core: `evaluateActionConfidence(input)`
-- HTTP: `POST /remnic/v1/action-confidence`
+- HTTP: `POST /engram/v1/action-confidence`
 - MCP: `remnic.action_confidence` and legacy `engram.action_confidence`
 - CLI: `remnic action-confidence`
 

--- a/docs/wearables.md
+++ b/docs/wearables.md
@@ -245,7 +245,16 @@ remnic wearables speakers set bee 0 "Alex" --self
 remnic wearables speakers set limitless "Speaker 2" "Jane Doe"
 remnic wearables corrections add "remnick" "Remnic"
 remnic wearables corrections list
+remnic wearables fuse 2026-06-10           # merge same-day transcripts across sources
+remnic wearables fused 2026-06-10          # print the fused day artifact
 ```
+
+**Cross-source fusion** (`fuse` / `fused`) merges the same calendar day's
+transcripts from multiple wearables into one deduplicated day artifact. Fusion
+is opt-in (`wearables.fusion.enabled`, default `false`): `fuse <date>` builds or
+refreshes the fused artifact for that day, and `fused <date>` prints it. A day
+whose sources disagree on timezone is skipped rather than merged incorrectly,
+and any stale fused artifact for that day is cleared.
 
 Continuous syncing is built in: long-lived hosts (the gateway, the
 HTTP daemon) start an in-process **auto-sync** scheduler by default

--- a/docs/xray.md
+++ b/docs/xray.md
@@ -1,55 +1,57 @@
 # Recall X-ray
 
-Issue [#570](https://github.com/joshuaswarren/remnic/issues/570) adds a
-unified per-result attribution snapshot for recalls. After any recall,
-an X-ray capture tells you **exactly why each memory surfaced** — which
-retrieval tier served it, how its score decomposed, every filter it
-passed (and the first filter that would have rejected it), any graph
-path traversed, the audit-log entry id, memory provenance and safety
-context, and the character budget the final payload consumed.
+A recall X-ray is a unified per-result attribution snapshot. After any recall,
+it tells you **exactly why each memory surfaced** — which retrieval tier served
+it, how its score decomposed, every filter it passed (and the first filter that
+would have rejected it), any graph path traversed, the audit-log entry id,
+memory provenance and safety context, and the character budget the final payload
+consumed.
 
-Most competitors treat retrieval as a black box. Remnic X-ray makes the
-whole ladder legible in one snapshot that is rendered identically by
-the CLI, HTTP, and MCP surfaces — so what an operator reads in a
-terminal matches byte-for-byte what an agent reads over MCP.
+Most memory systems treat retrieval as a black box. X-ray makes the whole ladder
+legible in one snapshot that is rendered identically by the CLI, HTTP, and MCP
+surfaces — so what an operator reads in a terminal matches byte-for-byte what an
+agent reads over MCP.
+
+> **Not to be confused with [Retrieval explain](./retrieval-explain.md).** That
+> page documents the standalone *tier explain* surface (`recall_tier_explain`),
+> which annotates only the last-recall snapshot with the direct-answer tier
+> verdict. X-ray is the richer capture: it runs a fresh recall against an
+> arbitrary query and returns per-result filters, score decomposition, and audit
+> correlation — and carries the tier-explain block inside its snapshot. See
+> [Tier explain vs X-ray](#tier-explain-vs-x-ray) below.
 
 ## How to run
+
+X-ray ships as a first-class **standalone** command:
 
 ```sh
 remnic xray "<query>" [--format json|text|markdown] [--budget N] [--namespace ns] [--out file]
 ```
 
-CLI surface defined in
-[`packages/remnic-core/src/cli.ts`](../packages/remnic-core/src/cli.ts)
-(lines 4015-4076). The handler delegates to a shared
-`EngramAccessService.recallXray(...)` so the CLI, HTTP, and MCP
-surfaces share the same `xrayQueue` mutex and cannot race each other
-(rules 40 and 47).
+The OpenClaw-hosted equivalent is `openclaw engram xray "<query>"`, which adds a
+`--disclosure chunk|section|raw` flag for the per-disclosure token-spend summary.
+Both handlers delegate to a shared `EngramAccessService.recallXray(...)` so the
+CLI, HTTP, and MCP surfaces share the same `xrayQueue` mutex and cannot race each
+other.
 
-Flags:
+Flags (standalone), validated by `parseXrayCliOptions` in
+`packages/remnic-core/src/recall-xray-cli.ts` — an empty or missing query throws
+a listed-options error rather than silently defaulting:
 
-- `<query>` (required, non-empty). Validated by `parseXrayCliOptions`
-  in
-  [`packages/remnic-core/src/recall-xray-cli.ts`](../packages/remnic-core/src/recall-xray-cli.ts)
-  (lines 52-77) — an empty or missing query throws a listed-options
-  error rather than silently defaulting.
-- `--format` — `text` (default), `markdown`, or `json`. Unknown
-  values raise an error that lists the valid options
-  (`parseXrayFormat`, `recall-xray-renderer.ts` lines 40-52).
-- `--budget <chars>` — positive integer override for the recall
-  character budget on this single call. Not a positive integer →
-  rejected at the CLI boundary (rules 14 and 51).
-- `--namespace <ns>` — override the namespace to scope this recall
-  against.
-- `--out <path>` — write the rendered snapshot to a file instead of
-  stdout. The path is tilde-expanded (rule 17).
+- `<query>` (required, non-empty).
+- `--format` — `text` (default), `markdown`, or `json`. Unknown values raise an
+  error that lists the valid options.
+- `--budget <chars>` — positive integer override for the recall character budget
+  on this single call. Not a positive integer is rejected at the CLI boundary.
+- `--namespace <ns>` — override the namespace to scope this recall against.
+- `--out <path>` — write the rendered snapshot to a file instead of stdout. The
+  path is tilde-expanded.
 
 ### Sample output
 
 The following is a synthetic example of a text-format X-ray for a
-review-context-augmented recall. Exact field ordering and spacing are
-stable under the renderer's golden tests (lines 93-139 of
-`recall-xray-renderer.ts`).
+review-context-augmented recall. Field ordering and spacing are stable under the
+renderer's golden tests.
 
 ```
 === Recall X-ray ===
@@ -110,17 +112,15 @@ source-anchors:
   - decisions/recall-cache-ttl.md:10-14
 ```
 
-The markdown format is structurally identical but rendered as GitHub
-tables + H2/H3 sections; the JSON format is the raw
-`RecallXraySnapshot` serialized under a `{ snapshotFound: true, ... }`
-envelope.
+The markdown format is structurally identical but rendered as GitHub tables +
+H2/H3 sections; the JSON format is the raw `RecallXraySnapshot` serialized under
+a `{ snapshotFound: true, ... }` envelope.
 
 ## JSON schema
 
-The canonical v1 shape lives in
-[`packages/remnic-core/src/recall-xray.ts`](../packages/remnic-core/src/recall-xray.ts).
-A stable `schemaVersion: "1"` tag on every snapshot lets downstream
-consumers version-gate their parsers.
+The canonical v1 shape lives in `packages/remnic-core/src/recall-xray.ts`. A
+stable `schemaVersion: "1"` tag on every snapshot lets downstream consumers
+version-gate their parsers.
 
 ### `RecallXraySnapshot`
 
@@ -155,7 +155,7 @@ interface RecallXrayResult {
     | "review-context";
   scoreDecomposition: RecallXrayScoreDecomposition;
   graphPath?: string[];
-  graphEdgeConfidences?: number[]; // issue #681 PR 3/3 — aligned with graphPath
+  graphEdgeConfidences?: number[]; // aligned with graphPath
   auditEntryId?: string;
   admittedBy: string[];      // filters the candidate passed
   rejectedBy?: string;       // first filter that would have rejected
@@ -194,14 +194,14 @@ still remains the always-present retrieval scope.
 
 When the graph subsystem (`servedBy: "graph"`) produced a result, the X-ray
 optionally surfaces a `graphEdgeConfidences` array aligned with `graphPath`:
-each entry is the confidence of the edge between consecutive nodes, so the
-array length is always `graphPath.length - 1`. Operators use this to
-attribute floor-pruning and PageRank ranking decisions back to specific
-edges. See [`graph-reasoning.md`](architecture/graph-reasoning.md) for the
-underlying floor and iteration controls (`graphTraversalConfidenceFloor`,
+each entry is the confidence of the edge between consecutive nodes, so the array
+length is always `graphPath.length - 1`. Operators use this to attribute
+floor-pruning and PageRank ranking decisions back to specific edges. See
+[graph-reasoning.md](architecture/graph-reasoning.md) for the underlying floor
+and iteration controls (`graphTraversalConfidenceFloor`,
 `graphTraversalPageRankIterations`).
 
-### `RecallXrayScoreDecomposition` (lines 68-75)
+### `RecallXrayScoreDecomposition`
 
 ```ts
 interface RecallXrayScoreDecomposition {
@@ -210,19 +210,18 @@ interface RecallXrayScoreDecomposition {
   importance?: number;
   mmrPenalty?: number;
   tierPrior?: number;
-  reinforcementBoost?: number;  // additive boost from reinforcement_count (issue #687 PR 3/4)
+  reinforcementBoost?: number;  // additive boost from reinforcement_count
   final: number;             // the only guaranteed field
 }
 ```
 
-Different tiers populate different terms. `hybrid` typically reports
-`vector` + `bm25` + `mmrPenalty`; `direct-answer` reports `importance`
-+ `tierPrior`. When `reinforcementRecallBoostEnabled` is `true`, memories
-with `reinforcement_count` frontmatter also carry `reinforcementBoost`.
-The renderer formats each known field with four decimal places and keeps
-the line stable across missing fields.
+Different tiers populate different terms. `hybrid` typically reports `vector` +
+`bm25` + `mmrPenalty`; `direct-answer` reports `importance` + `tierPrior`. When
+`reinforcementRecallBoostEnabled` is `true`, memories with `reinforcement_count`
+frontmatter also carry `reinforcementBoost`. The renderer formats each known
+field with four decimal places and keeps the line stable across missing fields.
 
-### `RecallFilterTrace` (lines 104-110)
+### `RecallFilterTrace`
 
 ```ts
 interface RecallFilterTrace {
@@ -233,11 +232,20 @@ interface RecallFilterTrace {
 }
 ```
 
-The `servedBy` union is orthogonal to the `RetrievalTier` enum used by
-issue #518's tier-explain surface. The two sets stay separate on
-purpose so the observability contracts can evolve independently;
-`tierExplain` is carried verbatim inside the X-ray snapshot when the
-direct-answer tier ran.
+## Tier explain vs X-ray
+
+The `servedBy` union above is orthogonal to the `RetrievalTier` enum used by the
+[tier-explain surface](./retrieval-explain.md) (issue #518). The two sets stay
+separate on purpose so the observability contracts can evolve independently.
+
+The `tierExplain` field inside a snapshot is populated **only when
+`recallDirectAnswerEnabled: true`** (default `false`, verified in
+`packages/remnic-core/src/config.ts`) and the direct-answer gate returns a
+verdict for the recall. When the flag is off, `tierExplain` is `null` — every
+other part of the X-ray snapshot (filters, results, score decomposition, audit
+ids) is unaffected and still populated. In short: X-ray always attributes *which
+tier served each result* via `servedBy`; the embedded `tierExplain` block is the
+extra direct-answer observation that only appears when you opt in.
 
 ## HTTP surface
 
@@ -245,36 +253,30 @@ direct-answer tier ran.
 GET /engram/v1/recall/xray?q=<query>[&session=<key>][&namespace=<ns>][&budget=<chars>]
 ```
 
-Defined in
-[`packages/remnic-core/src/access-http.ts`](../packages/remnic-core/src/access-http.ts)
-(lines 403-477). The route is `GET` so proxies can cache the response
-by full URL; all recall parameters are query-string fields. Bearer
-auth is enforced identically to the rest of `/engram/v1/*`, and the
-namespace is resolved through `resolveNamespace(...)` before the
-orchestrator runs — the same scope layer the write path uses, so there
-is no cross-namespace read leak (rule 42).
+Defined in `packages/remnic-core/src/access-http.ts`. The route is `GET` so
+proxies can cache the response by full URL; all recall parameters are
+query-string fields. Bearer auth is enforced identically to the rest of
+`/engram/v1/*`, and the namespace is resolved through `resolveNamespace(...)`
+before the orchestrator runs — the same scope layer the write path uses, so
+there is no cross-namespace read leak.
 
-Content negotiation: the endpoint currently returns JSON
-(`respondJson`). CLI and operator callers who want the markdown or
-text rendering compute it locally via `renderXray(snapshot, format)`
-from the shared renderer.
+Content negotiation: the endpoint returns JSON (`respondJson`). CLI and operator
+callers who want the markdown or text rendering compute it locally via
+`renderXray(snapshot, format)` from the shared renderer.
 
-Validation errors surface as `400`s with an `error`/`code`/`message`
-triple (missing query, invalid budget). Backend faults bubble to the
-global `handle()` catch so they return `500` with a logged trace id.
+Validation errors surface as `400`s with an `error`/`code`/`message` triple
+(missing query, invalid budget). Backend faults bubble to the global `handle()`
+catch so they return `500` with a logged trace id.
 
 ## MCP tool
 
-Registered as `engram.recall_xray` in
-[`packages/remnic-core/src/access-mcp.ts`](../packages/remnic-core/src/access-mcp.ts)
-(lines 180-207, handler at 1228-1280). `withToolAliases` emits
-`remnic.recall_xray` as the canonical alias automatically — the
-dual-name invariant that every new MCP tool ships with.
+Registered as `remnic.recall_xray` (canonical) with `engram.recall_xray` as the
+legacy alias, in `packages/remnic-core/src/access-mcp.ts`. `withToolAliases`
+emits the dual name automatically — the invariant that every MCP tool ships with.
 
-Input schema accepts `query` (required), `sessionKey`, `namespace`,
-and `budget`. Validation errors are surfaced as MCP tool-call errors
-listing the valid options instead of silently returning
-`snapshotFound: false`.
+Input schema accepts `query` (required), `sessionKey`, `namespace`, and
+`budget`. Validation errors are surfaced as MCP tool-call errors listing the
+valid options instead of silently returning `snapshotFound: false`.
 
 Response shape matches the HTTP surface exactly:
 
@@ -285,67 +287,55 @@ Response shape matches the HTTP surface exactly:
 }
 ```
 
-When the orchestrator does not produce a snapshot (capture disabled,
-session scope mismatch), the response is `{ "snapshotFound": false }`.
+When the orchestrator does not produce a snapshot (capture disabled, session
+scope mismatch), the response is `{ "snapshotFound": false }`.
 
-## Legacy `/recall/explain` markdown delegation
+## Shared markdown renderer
 
-Issue #518 introduced `recall/explain` with `text` and `json` formats
-that surface a single-session tier snapshot. Issue #570 PR 7 adds a
-`markdown` format to that same surface — and rather than duplicate the
-rendering logic, the explain renderer delegates to the shared X-ray
-markdown renderer when `format === "markdown"`. See
-[`packages/remnic-core/src/recall-explain-renderer.ts`](../packages/remnic-core/src/recall-explain-renderer.ts)
-(lines 29-35, 239-340).
-
-This is backwards-compatible. Existing `text` and `json` callers see
-no change — the markdown branch is additive. The adapter at
-`toRecallXraySnapshotFromLegacy(...)` maps the
-`LastRecallSnapshot` shape into the X-ray snapshot shape so the
-renderer's single code path handles both surfaces (CLAUDE.md rule 22:
-one renderer, not three).
-
-The orthogonality from #518 is preserved: `recall/explain` still
-returns a single-session snapshot; `recall/xray` captures a fresh
-snapshot against an arbitrary query. They answer different questions
-and live at different URLs.
+The graph-path `recall/explain` surface and the tier-explain surface both gained
+a `markdown` format that delegates to the shared X-ray markdown renderer rather
+than duplicating rendering logic (`packages/remnic-core/src/recall-explain-renderer.ts`).
+This is backwards-compatible: existing `text` and `json` callers see no change;
+the markdown branch is additive. The adapter
+`toRecallXraySnapshotFromLegacy(...)` maps the `LastRecallSnapshot` shape into
+the X-ray snapshot shape so a single renderer code path handles both surfaces.
 
 ## Observability positioning
 
-Most memory / retrieval systems treat recall as a black box. You see
-what the system returned; you do not see why, which filters it applied,
-or how close a rejected candidate came to being admitted. X-ray makes
-the retrieval ladder legible:
+X-ray makes the retrieval ladder legible:
 
-- **Per-result attribution** — every returned memory carries its
-  `servedBy` tier, score decomposition, and the ordered list of
-  filters it passed, with the first rejecting filter tracked even for
-  admitted results (when one exists).
-- **Filter ladder** — the snapshot records every gate the orchestrator
-  ran with `considered` and `admitted` counts, so you can see exactly
-  where candidates are being dropped.
-- **Budget accounting** — `budget.used` / `budget.chars` shows what
-  fraction of the recall budget the final payload consumed, so
-  over-long or too-sparse recalls are diagnosable without log diving.
+- **Per-result attribution** — every returned memory carries its `servedBy`
+  tier, score decomposition, and the ordered list of filters it passed, with the
+  first rejecting filter tracked even for admitted results (when one exists).
+- **Filter ladder** — the snapshot records every gate the orchestrator ran with
+  `considered` and `admitted` counts, so you can see exactly where candidates are
+  being dropped.
+- **Budget accounting** — `budget.used` / `budget.chars` shows what fraction of
+  the recall budget the final payload consumed, so over-long or too-sparse
+  recalls are diagnosable without log diving.
 - **Audit correlation** — each result carries an `auditEntryId` that
-  cross-references the standard audit log; you can follow a recall
-  from X-ray to the recall-audit trail to the storage operation.
-- **Tier-explain inline** — when the direct-answer tier ran, its
-  `RecallTierExplain` block is carried verbatim inside the snapshot
-  so the filter ladder and the tier verdict live side by side.
+  cross-references the standard audit log; you can follow a recall from X-ray to
+  the recall-audit trail to the storage operation.
+- **Tier-explain inline** — when the direct-answer tier is enabled and fired,
+  its `RecallTierExplain` block is carried verbatim inside the snapshot so the
+  filter ladder and the tier verdict live side by side.
 
-For one-off investigations operators run `remnic xray "<query>"`. For
-systemic observability they consume the MCP tool or HTTP endpoint and
-stream snapshots into their own analytics pipeline — the JSON shape is
-stable under `schemaVersion: "1"`.
+For one-off investigations, operators run `remnic xray "<query>"`. For systemic
+observability they consume the MCP tool or HTTP endpoint and stream snapshots
+into their own analytics pipeline — the JSON shape is stable under
+`schemaVersion: "1"`.
 
 ## Related reading
 
-- [Retrieval Explain](./retrieval-explain.md) — issue #518's
-  single-session tier-explain surface. The `markdown` format there now
-  delegates to the X-ray renderer.
-- [Advanced Retrieval](./advanced-retrieval.md) — the tiers whose
-  output X-ray attributes.
-- [`packages/remnic-core/src/recall-xray.ts`](../packages/remnic-core/src/recall-xray.ts) — schema, builder, and pure factories.
-- [`packages/remnic-core/src/recall-xray-renderer.ts`](../packages/remnic-core/src/recall-xray-renderer.ts) — shared text / markdown / JSON renderer used by CLI, HTTP, and MCP.
-- [`packages/remnic-core/src/recall-xray-cli.ts`](../packages/remnic-core/src/recall-xray-cli.ts) — `--format` / `--budget` / `--namespace` / `--out` validation.
+- [Retrieval explain](./retrieval-explain.md) — the standalone tier-explain
+  surface (`recall_tier_explain`) whose block X-ray embeds, and its distinction
+  from the graph-path `recall/explain` explainer.
+- [Recall disclosure depth](./recall-disclosure.md) — the `chunk`/`section`/`raw`
+  payload depth that X-ray reports as a per-result token-spend summary.
+- [Advanced retrieval](./advanced-retrieval.md) — the tiers whose output X-ray
+  attributes.
+- `packages/remnic-core/src/recall-xray.ts` — schema, builder, and pure factories.
+- `packages/remnic-core/src/recall-xray-renderer.ts` — shared text / markdown /
+  JSON renderer used by CLI, HTTP, and MCP.
+- `packages/remnic-core/src/recall-xray-cli.ts` — `--format` / `--budget` /
+  `--namespace` / `--out` validation.

--- a/llms.txt
+++ b/llms.txt
@@ -1,221 +1,223 @@
 Remnic (formerly Engram)
-Persistent, private, local-first memory for AI agents.
-Open source, MIT licensed. https://github.com/joshuaswarren/remnic
+Open-source, local-first memory and context layer for AI agents.
+MIT licensed. https://github.com/joshuaswarren/remnic
+
+One memory store, every agent. Tell one tool a preference and every other
+tool remembers it: OpenClaw, Claude Code, Codex CLI, Cursor, ChatGPT
+(developer mode), Hermes, Replit, Pi, omp, and any MCP client.
 
 All data stays on the user's machine as plain markdown files with YAML
-frontmatter. No cloud services, no external databases, no subscriptions.
+frontmatter. No cloud service, no external database, no subscription. The
+canonical store is a directory you own and can read, grep, and back up.
 
-Works with OpenClaw, Claude Code, Codex CLI, Hermes Agent, Replit, Cursor,
-and any MCP-compatible client. Tell one agent a preference — every agent
-remembers it.
+Remnic is universal/standalone-first (`npm install -g @remnic/cli`), with
+OpenClaw as the deepest native integration. "Engram" survives only as an
+intentional compatibility surface (HTTP `/engram/v1/...`, the `openclaw
+engram` command namespace, the `openclaw-engram` legacy plugin id, `engram`
+bin aliases, `ENGRAM_*` env fallbacks, `X-Engram-*` headers). Prefer the
+`remnic` equivalent wherever one exists.
+
 
 ARCHITECTURE
 
-TypeScript ESM monorepo. pnpm workspaces. Node 22+.
+TypeScript ESM monorepo. pnpm workspaces (pnpm 10.x). Node >= 22.12.
+27 package directories: 25 published to npm, one private dashboard, one
+PyPI-only Python plugin.
 
-Packages:
-  @remnic/core            Engine (orchestrator, storage, search, extraction,
-                          graph, trust zones, LCM). Framework-agnostic.
-  @remnic/cli             Standalone CLI binary, 20+ commands.
-  @remnic/server          HTTP + MCP server with multi-token auth, daemon mode.
-  @remnic/bench           Latency benchmarks with CI regression gates.
-  @remnic/plugin-openclaw OpenClaw adapter (embedded or delegate mode).
-  @remnic/plugin-codex    Codex CLI adapter (hooks + MCP + memory extension).
-  @remnic/hermes-provider TypeScript HTTP client for remote Remnic instances.
-  @remnic/import-supermemory Optional Supermemory JSON importer for
-                          `remnic import --adapter supermemory`.
-  remnic-hermes           Python PyPI package, MemoryProvider for Hermes Agent.
+Published npm packages:
+  @remnic/core             Memory engine: orchestrator, storage, extraction,
+                           search, entity graph, trust zones, LCM.
+                           Framework-agnostic; every adapter builds on it.
+  @remnic/cli              Standalone `remnic` CLI (36 top-level commands).
+                           Ships `remnic` and legacy `engram` bins.
+  @remnic/server           Standalone HTTP + MCP server. Multi-token auth,
+                           daemon mode, OAuth facade. Ships `remnic-server`
+                           and legacy `engram-server` bins.
+  @remnic/coding-graph     web-tree-sitter symbol extraction + SQLite code
+                           knowledge graph. Optional companion of core.
+  @remnic/belief-ledger    Belief and prediction ledger on Remnic primitives.
+  @remnic/bench            Published memory-benchmark harness + CI regression
+                           gates.
+  @remnic/plugin-openclaw  OpenClaw memory-slot adapter with bundled core
+                           runtime. Deepest integration.
+  @remnic/plugin-codex     Codex CLI plugin (hooks + MCP + memory extension).
+  @remnic/plugin-claude-code  Claude Code plugin (hooks, skills, agents, MCP).
+                           Files-only, zero dependencies.
+  @remnic/plugin-pi        Remnic memory extension for the Pi Coding Agent.
+  @remnic/replit           Replit Agent MCP connector.
+  @remnic/connector-limitless  Limitless Pendant wearable connector.
+  @remnic/connector-bee    Bee wearable connector.
+  @remnic/connector-omi    Omi necklace connector.
+  @remnic/connector-weclone  OpenAI-compatible proxy adding Remnic memory to
+                           WeClone avatars. Ships `remnic-weclone-proxy`.
+  @remnic/export-weclone   Export memories as WeClone/Alpaca fine-tuning sets.
+  @remnic/hermes-provider  Typed TypeScript HTTP client for the memory API.
+  @remnic/import-chatgpt   ChatGPT data-export importer.
+  @remnic/import-claude    Claude.ai data-export importer.
+  @remnic/import-gemini    Google Takeout Gemini Apps importer.
+  @remnic/import-mem0      mem0.ai REST importer.
+  @remnic/import-supermemory  Supermemory JSON export importer.
+  @remnic/import-weclone   WeClone-preprocessed chat export importer.
+  @remnic/import-lossless-claw  lossless-claw (LCM) SQLite importer.
+  @joshuaswarren/openclaw-engram  Deprecated compatibility shim; re-exports
+                           @remnic/plugin-openclaw and forwards `engram-access`.
 
-OpenClaw adapter note:
-  The OpenClaw plugin registers `before_prompt_build` with Remnic's
-  `initGateTimeoutMs` as the per-hook timeout on SDKs that support hook
-  options. The same config bounds Remnic's internal cold-start init gate for
-  recall and day summaries. Default: 30000ms; accepted range: 1000-120000ms.
-  Current OpenClaw compatibility target: reviewed npm build 2026.6.11-beta.1,
-  with 2026.6.5-beta.3, 2026.6.5-beta.5, 2026.6.5-beta.6, 2026.6.7-beta.1,
-  2026.6.8-beta.1, 2026.6.8-beta.2, 2026.6.9-beta.1, 2026.6.10-beta.1,
-  2026.6.10-beta.2, and 2026.6.11-beta.1 retained in the explicit prerelease
-  peer range and package metadata floor >=2026.4.1. As of June 26, 2026 the
-  active 60-day floor is April 27, 2026; keep the
-  more-permissive 2026.4.1 floor unless an upstream breaking change makes it
-  impossible. Keep openclaw.install.minHostVersion AND openclaw.compat.pluginApi
-  as a single >=x.y.z comparator (never a || list): OpenClaw's installer
-  AND-evaluates whitespace tokens and normalizes the host prerelease suffix, so
-  the floor already admits stable and prerelease hosts (issue #1450). Put
-  explicit reviewed prerelease versions ONLY in peerDependencies.openclaw,
-  which is resolved by npm/node-semver (supports ||, but excludes prereleases
-  from a bare >= range). Keep the manifest on current native
-  fields: kind="memory", contracts.tools, commandAliases, activation,
-  setup.requiresRuntime=false, setup.providers[].envVars for optional
-  OPENAI_API_KEY, and providerAuthChoices. Also keep providerAuthEnvVars and
-  supports mirrored for older OpenClaw hosts. Do not restore unsupported
-  top-level securityDisclosure; document privacy/provider behavior in docs
-  instead.
+Also published:
+  remnic-hermes            Python (PyPI) MemoryProvider plugin for Hermes
+                           Agent. Talks to the daemon over HTTP.
+Not published:
+  @remnic/bench-ui         Private Vite dashboard for benchmark summaries.
 
-Three-phase flow:
-  1. Recall   Before each agent turn, inject relevant memories into context.
-  2. Buffer   After each turn, accumulate content until a trigger fires.
-  3. Extract  Periodically, extract structured memories via an LLM call.
+Adapters never leak host-specific contracts back into `@remnic/core`. Core
+owns memory behavior; each adapter maps that behavior onto its host's plugin
+SDK, hooks, and manifest. Core never imports a host package.
 
-Storage: plain markdown + YAML frontmatter. Categories include fact,
-decision, preference, correction, relationship, principle, commitment,
-moment, skill, rule, entity, and more.
 
-Search: hybrid BM25 + vector + reranking via QMD. Six backend options:
-QMD (default), Orama (embedded JS), LanceDB (embedded native Arrow),
-Meilisearch (server), Remote (HTTP REST), Noop (extraction only).
-Current QMD target: @tobilu/qmd 2.5.3. Remnic probes qmd --version and gates
-newer flags; QMD 2.5.3+ uses --format json for query/search subprocess output,
-while older supported QMD installs keep legacy --json.
+THREE-PHASE FLOW
+
+  1. Recall   Before an agent turn, inject relevant memories into context.
+  2. Buffer   After a turn, accumulate content until a trigger fires.
+  3. Extract  Periodically, distill structured memories via an LLM call.
+
+Importance gating keeps trivial content off disk. Recall runs three
+specialized retrievers in parallel (latency = max, not sum), with graceful
+per-retriever degradation and zero extra LLM cost:
+  DirectFact   Entity-filename keyword overlap (single-digit ms).
+  Contextual   Hybrid BM25 + vector search.
+  Temporal     Date index with recency-decay scoring.
+
+
+STORAGE FORMAT
+
+Plain markdown + YAML frontmatter, one file per memory. Categories include
+fact, decision, preference, correction, relationship, principle, commitment,
+moment, skill, rule, and entity. Lifecycle: active -> validated -> stale ->
+archived. Episode/note model separates time-specific events from stable
+beliefs. Inline provenance tags carry source attribution in the fact body.
+
+
+SEARCH BACKENDS
+
+Six backends, selected by `searchBackend`:
+  qmd          Default. Hybrid BM25 + vector + reranking via QMD.
+  orama        Embedded JavaScript index.
+  lancedb      Embedded native Arrow index.
+  meilisearch  External Meilisearch server.
+  remote       HTTP REST backend.
+  noop         Extraction only, no search.
+
+QMD target: @tobilu/qmd 2.5.3. Remnic probes `qmd --version` and gates newer
+flags: 2.5.3+ uses `--format json` for query/search subprocess output; older
+supported QMD installs keep legacy `--json`. Default query strategy is
+`hybrid` and the default subprocess strategy is `query` (both BY DESIGN; do
+not present BM25-only as the recommended default). Daemon timeout 8000 ms;
+query-time rerank on.
+
 
 KEY FEATURES
 
-Core (enabled by default):
-  - Automatic extraction and recall injection
-  - Entity tracking and relationship graph
-  - Memory lifecycle (active -> validated -> stale -> archived)
-  - Episode/note model (time-specific events vs stable beliefs)
-  - Importance-gated extraction (trivial content never hits disk)
-  - Inline source attribution (provenance tags in fact body)
+Core (on by default):
+  - Automatic extraction and recall injection.
+  - Entity tracking (basic relationship links).
+  - Memory lifecycle policy (retention/tiering light-sleep phase).
+  - Importance-gated extraction.
+  - Inline source attribution.
+  - Procedural memory mining (default-on; conservative preset pins it off).
+  - Trust zones: quarantine -> working -> trusted provenance tiers with
+    promotion rules and poisoning defense.
 
-Lossless Context Management (LCM):
-  Proactive session archive into local SQLite + hierarchical summary DAG.
-  When context gets compacted, LCM injects compressed history back into
-  recall. Three-level summarization with guaranteed convergence. Full-text
-  search over archived messages. Zero data loss.
+Opt-in (default off unless noted):
+  - Lossless Context Management (LCM): proactive SQLite session archive +
+    hierarchical summary DAG re-injected on compaction. On in research-max.
+  - Extraction judge: LLM-as-judge durability filter, shadow mode available.
+  - Semantic chunking: topic-boundary detection via sentence embeddings.
+  - Semantic consolidation: cluster + synthesize canonical memories.
+  - Page versioning: numbered snapshots per overwrite; list/diff/revert.
+  - MECE taxonomy: deterministic categorization decision tree.
+  - Enrichment pipeline: importance-tiered external entity enrichment.
+  - Binary lifecycle: mirror/redirect/clean stages for binary files.
+  - Namespaces: per-principal isolation with read/write ACLs.
+  - Secure store: at-rest encryption (encrypt-on-write; unlock to read).
+  - Wearables: Limitless / Bee / Omi transcript capture and fusion.
+  - Graph recall / multi-graph memory + graph edge decay.
+  - Recall direct-answer: observation-only tier annotation (never
+    short-circuits QMD).
+  - Dreams pipeline: lightSleep on; rem and deepSleep off by default.
+  - Coding graph: code-symbol knowledge graph for coding agents.
 
-Parallel Specialized Retrieval:
-  Three agents run in parallel (latency = max, not sum):
-    DirectFact  Scans entity filenames for keyword overlap (<5ms).
-    Contextual  Existing hybrid BM25+vector search.
-    Temporal    Reads date index with recency decay scoring (<10ms).
-  Zero additional LLM cost. Graceful per-agent degradation.
+Verify any default in packages/remnic-core/src/config.ts or the
+openclaw.plugin.json configSchema before relying on it.
 
-Semantic Consolidation:
-  Finds clusters of similar memories via token overlap, synthesizes a
-  canonical version via LLM, archives originals. Conservative threshold
-  (80%+), corrections and commitments excluded by default.
-
-Trust Zones:
-  Quarantine -> working -> trusted tiers with promotion rules and
-  poisoning defense. Provenance tracking and corroboration scoring.
-
-Extraction Judge (issue #376):
-  LLM-as-judge post-extraction durability filter. Shadow mode available
-  for calibration before enabling gating.
-
-Semantic Chunking (issue #368):
-  Topic-boundary detection via sentence embeddings and cosine similarity
-  with smoothing. Alternative to recursive chunking.
-
-Page Versioning (issue #371):
-  Snapshot-based history for memory files. Every overwrite saves a
-  numbered snapshot. List, inspect, diff, and revert via CLI or API.
-
-OAI-mem-citation Blocks (issue #379):
-  Recall responses emit <oai-mem-citation> blocks matching the Codex
-  citation format for memory attribution and usage tracking.
-
-Memory Extension Publisher Contract (issue #381):
-  Pluggable contract for installing host-specific instruction files into
-  any AI agent host's extension directory. Generalizes Codex extension
-  pattern.
-
-Memory Extension Discovery (issue #382):
-  Third-party memory extensions provide structured instructions that
-  influence consolidation, auto-discovered from extension directories.
-
-MECE Taxonomy (issue #366):
-  Mutually Exclusive, Collectively Exhaustive knowledge directory with
-  resolver decision tree for deterministic memory categorization.
-
-Enrichment Pipeline (issue #365):
-  Importance-tiered API spend for entity enrichment from external sources
-  with a provider registry.
-
-Binary Lifecycle (issue #367):
-  Three-stage pipeline (mirror, redirect, clean) for binary files in the
-  memory directory with configurable storage backends.
-
-Codex Marketplace (issue #418):
-  Install via: codex marketplace add joshuaswarren/remnic
-
-Memory OS (progressive opt-in):
-  Memory boxes, graph recall, compounding (weekly synthesis), shared
-  context (cross-agent), identity continuity, hot/cold tiering, native
-  knowledge search, behavior loop tuning.
-
-Advanced (opt-in):
-  Objective-state recall, causal trajectories, harmonic retrieval,
-  verified recall, semantic rule promotion, creation memory, commitment
-  lifecycle.
-
-BUILD / TEST / DEVELOP
-
-  Build:        pnpm run build
-  Test:         npm run test        (node:test with tsx, 672+ tests)
-  Typecheck:    pnpm run check-types
-  Quality gate: npm run preflight:quick
-  Eval suite:   npm run eval:run
 
 ACCESS LAYER
 
-HTTP API:
-  Most routes under /engram/v1/... (v1.x compatibility window).
-  Bearer-token auth, binds to loopback by default.
-  Routes: health, recall, recall/explain, memories (CRUD), entities,
-  observe, lcm/search, lcm/status, trust-zones/status, trust-zones/records,
-  trust-zones/promote, review-queue, maintenance, suggestions,
-  review-disposition.
-  Exception: POST /v1/citations/observed (no /engram prefix).
+HTTP API (@remnic/server, or embedded in the OpenClaw host):
+  Bearer-token auth (constant-time compare), binds to loopback by default.
+  REST routes under /engram/v1/... (compatibility prefix): health, recall,
+  recall/explain, memories (CRUD), entities, observe, lcm/search, lcm/status,
+  trust-zones/status, trust-zones/records, trust-zones/promote, review-queue,
+  maintenance, suggestions, review-disposition. Single MCP transport at
+  POST /mcp. Exception route: POST /v1/citations/observed (no /engram prefix).
 
 MCP tools:
-  Exposed via stdio and HTTP transports. 14+ tools covering recall, store,
-  entity lookup, memory search, LCM expansion, trust zone inspection, and
-  observation.
+  Over 100 tools, exposed over stdio and HTTP. Each canonical `remnic.*` name
+  is paired with an `engram.*` legacy alias. Covers recall (with X-ray and
+  tier-explain), store, memory search, entity lookup, LCM search, trust-zone
+  inspection, observation, correction planning, peers, wearables, and
+  maintenance. Every MCP tool ships an outputSchema.
 
-Standalone CLI (20+ commands):
-  init, status, query, doctor, config, daemon, tree, onboard, curate,
-  review, sync, dedup, connectors, space, benchmark, versions, taxonomy,
-  enrich, binary.
+Standalone CLI (`remnic`, 36 top-level commands):
+  init, migrate, status, query, action-confidence, xray, doctor, config,
+  daemon, token, tree, onboard, curate, review, sync, offline, oauth, dedup,
+  connectors, space, bench (alias benchmark), briefing, versions, binary,
+  taxonomy, enrich, procedural, openclaw, extensions, training:export, import,
+  import-lossless-claw, wearables, capsule.
+  Full reference: docs/cli.md.
 
-Operator UI:
-  http://127.0.0.1:4318/engram/ui/
+OpenClaw-hosted surface (`openclaw engram <command>`):
+  Roughly 100 subcommands registered by core inside the OpenClaw host for
+  operators (tier, forget/purge, namespaces, capsule, secure-store, peer,
+  dreams, governance, benchmark, and more). There is no `openclaw remnic`
+  shell namespace; the in-chat session command is `/remnic <on|off|status|
+  clear|stats|flush>`. See docs/api.md.
 
-DOCUMENTATION
+Operator UI: http://127.0.0.1:4318/engram/ui/
 
-  README.md                    Full installation guide, feature list, architecture
-  CLAUDE.md                    Project instructions and privacy policy
-  AGENTS.md                    Agent guide with 43 review prevention patterns
-  docs/config-reference.md     90+ configuration properties
-  docs/api.md                  HTTP, MCP, and CLI reference
-  docs/architecture/           Per-feature architecture docs
-  docs/guides/                 Standalone, Codex, Claude Code, local LLM, etc.
-  docs/guides/openclaw-engram-to-remnic.md
-                               Legacy OpenClaw Engram -> Remnic migration:
-                               package rename, config keys, backups, patches
-  docs/getting-started.md      Quick start
-  docs/operations.md           Operations guide
-  docs/search-backends.md      Search backend comparison
-  docs/namespaces.md           Namespace isolation
-  docs/import-export.md        Data portability
 
 CONFIGURATION
 
-Config resolved from: REMNIC_CONFIG_PATH env var -> ./remnic.config.json ->
-~/.config/remnic/config.json. Presets: conservative, balanced, research-max,
-local-llm-heavy. 90+ properties. LLM routing: OpenAI API, local LLM (Ollama,
-LM Studio), or gateway model chain with multi-provider fallback.
+Standalone resolution order: `--config` > REMNIC_CONFIG_PATH (legacy
+ENGRAM_CONFIG_PATH) > ./remnic.config.json > ./engram.config.json >
+~/.config/remnic/config.json > ~/.config/engram/config.json. The standalone
+file has a top-level `remnic` block plus a separate `server` block
+(host/port/authToken/principal). Under OpenClaw, config lives at
+plugins.entries.openclaw-remnic.config (legacy openclaw-engram fallback),
+schema-validated with additionalProperties:false.
+
+Hundreds of options across the schema, four presets (`memoryOsPreset`):
+  conservative     Minimal footprint; pins procedural memory off.
+  balanced         Query-aware indexing, verbatim artifacts, local rerank.
+  research-max     Graph recall, proactive extraction, compression, LCM on.
+  local-llm-heavy  Local LLM + fast local path, local embedding fallback.
+(`research` is an alias for `research-max`.) User keys win over the preset;
+the `procedural` block is deep-merged so a partial override cannot discard a
+preset's pinned value.
+
+LLM routing: OpenAI API, local LLM (Ollama, LM Studio), or a gateway model
+chain with multi-provider fallback. For the exact option count run
+`npm run check-config-contract`; full reference in docs/config-reference.md.
+
 
 QUICK START (STANDALONE)
 
   npm install -g @remnic/cli
   remnic init
-  export OPENAI_API_KEY=sk-...
+  export OPENAI_API_KEY=<your-key>
   export REMNIC_AUTH_TOKEN=$(openssl rand -hex 32)
   remnic daemon start
   remnic status
   remnic query "hello" --explain
+
 
 QUICK START (OPENCLAW)
 
@@ -224,84 +226,9 @@ QUICK START (OPENCLAW)
   launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
   remnic doctor
 
-  OpenClaw 2026.5.30-beta.1 may resolve bare plugin package names through npm
-  first during the launch cutover. Remnic is published on ClawHub as
-  @remnic/plugin-openclaw; use explicit clawhub:@remnic/plugin-openclaw for
-  deterministic installs, and explicit npm:@remnic/plugin-openclaw@<version>
-  for npm-only fallback or rollback versions.
+Use the explicit `clawhub:` source for deterministic installs;
+`npm:@remnic/plugin-openclaw@<version>` for npm-only fallback or rollback.
 
-  ClawHub publish note: publish @remnic/plugin-openclaw from the built
-  ClawPack/npm tarball, not from the raw GitHub source folder. Run
-  pnpm --filter @remnic/plugin-openclaw build, pnpm run verify:openclaw-clawpack,
-  clawhub package pack packages/plugin-openclaw, then clawhub package publish
-  the generated remnic-plugin-openclaw-<version>.tgz with source metadata.
-
-OPENCLAW PLUGIN COMPATIBILITY
-
-  Policy: Remnic supports OpenClaw releases from at least the previous 60 days.
-  Recalculate the floor from the current date before changing package metadata.
-  As of June 3, 2026, the active floor is April 4, 2026. Remnic intentionally
-  keeps OpenClaw 2026.4.1 as a more-permissive package metadata floor.
-
-  Current manifest shape for OpenClaw 2026.5.31+:
-  kind: "memory" selects the exclusive memory slot.
-  setup.providers[].envVars advertises optional plugin-mode OPENAI_API_KEY
-  discovery. providerAuthChoices keeps the custom onboarding/CLI metadata.
-  providerAuthEnvVars must remain mirrored for older pre-runtime auth probes.
-
-  June 2, 2026 sweep: issues #1258, #1259, #1266, and #1271 were reviewed
-  against OpenClaw tags through v2026.6.2-alpha.2. The manifest, SDK overview,
-  and SDK entrypoint docs remained compatible; Remnic's SDK snapshot still
-  matched every reviewed tag. New additive OpenClaw surfaces are consumed only
-  through gates: host embedding providers via
-  hostEmbeddingProviderEnabled, inbound transcript capture via
-  openclawMessageReceivedCaptureEnabled, bounded reply/thread metadata via
-  openclawReplyMetadataCaptureEnabled, opt-in quoted-reply extraction context
-  via openclawReplyMetadataExtractionHintsEnabled, and canonical channel
-  envelope prefixes via openclawChannelEnvelopeCleaningEnabled. Never make
-  these static imports or required paths; older OpenClaw hosts must keep using
-  Remnic's existing embedding, agent_end, and legacy envelope-cleaning paths.
-  v2026.6.2-alpha.1 and v2026.6.2-alpha.2 are source tags but were not GitHub
-  release pages or npm packages during that sweep.
-
-  June 3, 2026 sweep: issue #1312 was reviewed against OpenClaw source tags
-  v2026.6.1-beta.3 and v2026.6.3-alpha.1. v2026.6.3-alpha.1 exists upstream,
-  but it was not a GitHub release page at review time. The diff from
-  v2026.6.2-alpha.2 touched OpenClaw policy/workboard docs and
-  provider/exec/runtime internals; the v2026.6.1-beta.3 diff from
-  v2026.6.1-beta.2 did not touch plugin docs or src/plugins. Optional surfaces
-  confirmed in this window are resolve_exec_env, CLI backend
-  ownsNativeCompaction, and ProviderNormalizeTransportContext.modelId. Remnic
-  does not register an exec-environment hook, does not provide a CLI backend,
-  and does not implement provider transport normalization, so no runtime
-  behavior change is needed. Keep these surfaces optional and gated if a future
-  feature uses them.
-  supports must remain for OpenClaw 2026.4 / early 2026.5 slot and lifecycle
-  routing. Top-level securityDisclosure is not a current native manifest field
-  and must stay omitted.
-  contracts.tools: required by OpenClaw 2026.5+ plugin descriptor planning and
-  tool ownership validation. Add every Remnic-owned registerTool name here when
-  adding OpenClaw tools, including conditional LCM aliases.
-
-  Source of truth: packages/plugin-openclaw/openclaw.plugin.json.
-  Synced copies: openclaw.plugin.json and
-  packages/shim-openclaw-engram/openclaw.plugin.json.
-  Guard test: tests/openclaw-plugin-runtime-surfaces.test.ts.
-
-LEGACY OPENCLAW ENGRAM MIGRATION
-
-  Use this for @joshuaswarren/openclaw-engram 9.2.x -> @remnic/plugin-openclaw.
-  Canonical OpenClaw plugin id: openclaw-remnic.
-  Legacy plugin id: openclaw-engram.
-  Do not use remnic-workspace as an OpenClaw plugin id; it is the npm workspace
-  root package name, not the OpenClaw runtime id.
-
-  remnic openclaw migrate-engram --yes
-
-  This backs up openclaw.json, backs up the legacy openclaw-engram extension
-  directory, installs @remnic/plugin-openclaw into openclaw-remnic, writes
-  plugins.entries["openclaw-remnic"], sets plugins.slots.memory to
-  "openclaw-remnic", and preserves the memoryDir.
 
 CONNECTING OTHER AGENTS
 
@@ -310,26 +237,93 @@ CONNECTING OTHER AGENTS
   remnic connectors install replit
   pip install remnic-hermes
 
-CHATGPT DEVELOPER MODE (headline integration):
-  ChatGPT can now persist memories across conversations using YOUR
-  infrastructure as the source of truth. OpenAI no longer disables built-in
-  memory/tools when you connect a custom MCP server. Remnic plugs into
-  that gap as an MCP + OAuth 2.1 integration, giving ChatGPT a persistent,
-  governed, local-first memory store. The canonical store stays on your
-  disk; when ChatGPT calls Remnic's tools, those tool inputs/outputs are
-  processed by OpenAI. Remnic is available only in chats where the
-  app/tools are enabled. Native ChatGPT memory is OFF by default for
-  apps and must be enabled per app; Remnic's own store/recall work
-  regardless (https://developers.openai.com/apps-sdk/build/mcp-server#memory-and-tool-calls).
+Built-in connector ids: claude-code, codex-cli, cursor, cline,
+github-copilot, roo-code, windsurf, amp, pi, omp, replit, generic-mcp,
+weclone, hermes.
 
-  docs/integration/chatgpt.md     Full setup guide with Quick Start,
-                                  Overview, Requirements, step-by-step OAuth
-                                  flow, troubleshooting, and security notes.
-                                  chatgpt.com developer mode -> Remnic via
-                                  Tailscale Funnel or Cloudflare Tunnel, with
-                                  server.oauth config and local operator
-                                  approval (`remnic oauth pending|approve|deny`).
-                                  The OAuth facade in @remnic/server is the
-                                  authorization server; the connector id is
-                                  `chatgpt` (token prefix remnic_cg_).
-                                  Every MCP tool ships an outputSchema (PR #1844).
+
+CHATGPT DEVELOPER MODE
+
+ChatGPT can persist memory across conversations using your own infrastructure
+as the source of truth. OpenAI no longer disables built-in memory when you
+connect a custom MCP server, so Remnic plugs in as an MCP + OAuth 2.1
+integration. The canonical store stays on your disk; when ChatGPT calls
+Remnic's tools, those tool inputs/outputs are processed by OpenAI. The OAuth
+authorization server is the facade in @remnic/server; the connector id is
+`chatgpt` (token prefix remnic_cg_). Reach it via Tailscale Funnel or
+Cloudflare Tunnel with local operator approval (`remnic oauth
+pending|approve|deny`). Setup guide: docs/integration/chatgpt.md.
+
+
+OPENCLAW PLUGIN COMPATIBILITY
+
+Policy: Remnic supports OpenClaw releases from at least the previous 60 days.
+Recalculate the floor from the current date before changing package metadata;
+only raise it when an upstream breaking change makes an older host impossible
+to support.
+
+`openclaw.compat.pluginApi` and `openclaw.install.minHostVersion` use one
+`>=2026.4.1` comparator, never a `||` list: OpenClaw's installer splits the
+range on whitespace and AND-evaluates every token (a `||` fails entirely) and
+normalizes away the host prerelease suffix, so a single floor admits both
+stable and prerelease hosts (issue #1450). Reviewed prereleases are listed
+ONLY in `peerDependencies.openclaw` (a `||` list), because npm/node-semver
+resolves that field and drops prereleases from a bare `>=` range.
+
+Manifest stays on current native fields: kind="memory", contracts.tools
+(every Remnic-owned tool name, including conditional LCM aliases),
+commandAliases, activation, setup.requiresRuntime=false, and
+setup.providers[].envVars for optional OPENAI_API_KEY. Keep providerAuthChoices
+and mirror providerAuthEnvVars/supports for older hosts. Do not add top-level
+securityDisclosure. Source of truth:
+packages/plugin-openclaw/openclaw.plugin.json. Compatibility sweeps and
+ClawHub publish mechanics live in docs/plugins/openclaw.md.
+
+
+LEGACY ENGRAM MIGRATION
+
+For @joshuaswarren/openclaw-engram 9.2.x -> @remnic/plugin-openclaw:
+
+  remnic openclaw migrate-engram --yes
+
+Canonical OpenClaw plugin id is openclaw-remnic; the legacy id is
+openclaw-engram. `remnic-workspace` is the npm workspace root, never an
+OpenClaw plugin id. The migration backs up openclaw.json and the legacy
+extension dir, installs the new plugin, rewrites plugins.entries and
+plugins.slots.memory, and preserves memoryDir. Guide:
+docs/guides/openclaw-engram-to-remnic.md.
+
+
+DOCUMENTATION
+
+  README.md                     Overview, install, feature list, architecture.
+  docs/README.md                Docs hub, organized by journey.
+  docs/guides/quickstart.md     Five-minute universal path.
+  docs/getting-started.md       Comprehensive install and first-run guide.
+  docs/cli.md                   Full standalone `remnic` CLI reference.
+  docs/config-reference.md      Every configuration option.
+  docs/api.md                   HTTP, MCP, and `openclaw engram` reference.
+  docs/search-backends.md       Backend comparison + QMD version gating.
+  docs/namespaces.md            Namespace isolation and principals.
+  docs/import-export.md         Data portability.
+  docs/operations.md            Day-two operations.
+  docs/architecture/            Per-subsystem architecture docs.
+  docs/plugins/openclaw.md      OpenClaw adapter, compat policy, publishing.
+  docs/integration/             Per-host connector setup guides.
+  docs/security/                Threat models and security notes.
+  SECURITY.md                   Vulnerability reporting and disclosure.
+  AGENTS.md / CLAUDE.md         Agent operating rules and privacy policy.
+
+
+BUILD / TEST / DEVELOP
+
+  Install:      pnpm install
+  Build:        pnpm run build
+  Test:         pnpm test
+  Typecheck:    pnpm run check-types
+  Quality gate: pnpm run preflight:quick
+  Config check: npm run check-config-contract
+  Docs parity:  npm run check:docs-parity
+  Eval suite:   npm run eval:run
+
+Contributor guide: docs/development/contributing.md.

--- a/llms.txt
+++ b/llms.txt
@@ -28,7 +28,7 @@ Published npm packages:
   @remnic/core             Memory engine: orchestrator, storage, extraction,
                            search, entity graph, trust zones, LCM.
                            Framework-agnostic; every adapter builds on it.
-  @remnic/cli              Standalone `remnic` CLI (36 top-level commands).
+  @remnic/cli              Standalone `remnic` CLI (35 top-level commands).
                            Ships `remnic` and legacy `engram` bins.
   @remnic/server           Standalone HTTP + MCP server. Multi-token auth,
                            daemon mode, OAuth facade. Ships `remnic-server`
@@ -166,7 +166,8 @@ MCP tools:
   inspection, observation, correction planning, peers, wearables, and
   maintenance. Every MCP tool ships an outputSchema.
 
-Standalone CLI (`remnic`, 36 top-level commands):
+Standalone CLI (`remnic`, 35 top-level commands, plus a
+`benchmark` alias of `bench`):
   init, migrate, status, query, action-confidence, xray, doctor, config,
   daemon, token, tree, onboard, curate, review, sync, offline, oauth, dedup,
   connectors, space, bench (alias benchmark), briefing, versions, binary,

--- a/packages/belief-ledger/README.md
+++ b/packages/belief-ledger/README.md
@@ -5,6 +5,15 @@ predictions, and opinions as structured Remnic facts, retrieves prior claims tha
 may conflict, asks a host LLM to classify the relationship, and tracks prediction
 calibration over time.
 
+Part of [Remnic](https://github.com/joshuaswarren/remnic), the open-source,
+local-first memory and context layer for AI agents.
+
+## Install
+
+```bash
+npm install @remnic/belief-ledger
+```
+
 This package is intentionally host-neutral:
 
 - It depends on `@remnic/core` public APIs.
@@ -68,3 +77,7 @@ path. For OpenClaw-backed Remnic runtimes, pass the existing gateway-backed
   verdict source or return a user-verdict prompt.
 - `reflect`: compute calibration summaries, Brier score, flipped claims, and
   dormant topics.
+
+## License
+
+MIT

--- a/packages/bench-ui/README.md
+++ b/packages/bench-ui/README.md
@@ -1,0 +1,10 @@
+# @remnic/bench-ui
+
+Private Vite UI shell for browsing [`@remnic/bench`](../bench) result summaries.
+Not published to npm; internal tooling for the Remnic monorepo.
+
+```bash
+pnpm --filter @remnic/bench-ui dev
+```
+
+Part of [Remnic](https://github.com/joshuaswarren/remnic).

--- a/packages/coding-graph/README.md
+++ b/packages/coding-graph/README.md
@@ -4,8 +4,7 @@
 engine: web-tree-sitter grammars, per-language symbol extractors, and the
 neutral `FileIR` intermediate representation that the graph store consumes.
 
-> Part of #1548 (Track B, Phase 1). Package and core wiring for PR1 (#1551
-> step 1 + step 2). The real backend lands in PR2 (#1551 step 3+).
+> Part of Remnic's coding-knowledge layer (issue #1548).
 
 ## Install
 
@@ -15,23 +14,21 @@ npm install @remnic/coding-graph
 pnpm add @remnic/coding-graph
 ```
 
-## Status (PR1)
+## What it provides
 
-This package's public surface is **scaffolded only**:
+- `createCodingGraphEngine()` — returns a working engine backed by a
+  WASM tree-sitter parser. It parses source files into the neutral `FileIR`
+  (symbols plus import edges) for the 15 tier-1 languages.
+- `TIER_1_LANGUAGES` — the supported tier-1 language list.
+- `ENGINE_VERSION` / `CODING_GRAPH_ENGINE_VERSION` — the engine version
+  string. The single source of truth lives in `@remnic/core`; this package
+  re-exports it so every consumer stays in lockstep.
+- `CodingGraphEngine` interface and the `CodingGraphError` tagged error class.
 
-- `ENGINE_VERSION = "0.1.0-pr1"` constant
-- `TIER_1_LANGUAGES` (15 languages)
-- `CodingGraphError` tagged error class (`code: "not_implemented" | "module_load_failed"`)
-- `CodingGraphEngine` interface — the full PR2 contract, no implementation
-- `createCodingGraphEngine()` — throws `CodingGraphError("not_implemented", …)`
-
-Calling `createCodingGraphEngine()` *always* throws a tagged error. There
-is no silent stub and there is no half-working fallback. The runtime
-contract is observable today; PR2 fills the implementation.
-
-`web-tree-sitter` is declared as the parser engine; grammar `.wasm` assets
-will ship in PR2 via the `grammars/` directory listed in the package's
-`files` manifest.
+A per-file parse failure surfaces as a tagged `{ ok: false, code: "parse_failed" }`
+result rather than a thrown exception, so one unparseable file never bricks a
+whole index run. Grammar `.wasm` assets ship in the `grammars/` directory listed
+in the package's `files` manifest.
 
 ## How `@remnic/core` loads this
 

--- a/packages/connector-weclone/README.md
+++ b/packages/connector-weclone/README.md
@@ -24,8 +24,15 @@ avatar remembers what happened yesterday and sounds like you while doing it.
 
 ## Install
 
-The proxy ships as part of the Remnic monorepo and is wired into the `remnic`
-CLI. The recommended install path is:
+`@remnic/connector-weclone` is an **optional companion** package, installed
+separately from the base Remnic install. It provides the `remnic-weclone-proxy`
+binary:
+
+```bash
+npm install -g @remnic/connector-weclone
+```
+
+Then register the connector and write its config through the `remnic` CLI:
 
 ```bash
 remnic connectors install weclone \
@@ -35,8 +42,10 @@ remnic connectors install weclone \
 
 This writes two files:
 
-- `~/.config/engram/.engram-connectors/connectors/weclone.json` — connector
+- `~/.config/remnic/.remnic-connectors/connectors/weclone.json` — connector
   registry entry (tracked by `remnic connectors list / remove / doctor`).
+  Pre-rename installs keep reading the legacy
+  `~/.config/engram/.engram-connectors/` layout until they migrate.
 - `~/.remnic/connectors/weclone.json` — proxy config read by
   `remnic-weclone-proxy` at startup.
 
@@ -145,6 +154,11 @@ Callers wiring up a Discord bot should pass the Discord user ID as
   upstream or downstream.
 - Multimodal content (image parts, etc.) is preserved verbatim; only the text
   parts of the last user message are used for recall.
+
+## Further reading
+
+- Connector guide: [docs/integration/connector-setup.md](https://github.com/joshuaswarren/remnic/blob/main/docs/integration/connector-setup.md)
+- Monorepo: [github.com/joshuaswarren/remnic](https://github.com/joshuaswarren/remnic)
 
 ## License
 

--- a/packages/export-weclone/README.md
+++ b/packages/export-weclone/README.md
@@ -19,8 +19,11 @@ pnpm add @remnic/export-weclone
 # or: npm i @remnic/export-weclone
 ```
 
-`@remnic/export-weclone` depends on `@remnic/core` and is intended to be
-used alongside an existing Remnic memory store.
+`@remnic/export-weclone` is an **optional companion** of
+[`@remnic/cli`](https://www.npmjs.com/package/@remnic/cli), installed separately —
+the base install never pulls it in. It depends on `@remnic/core` and is meant to
+run alongside an existing Remnic memory store. `remnic training:export --format
+weclone` loads it lazily and prints an install hint if it is missing.
 
 ## Quick start
 

--- a/packages/hermes-provider/README.md
+++ b/packages/hermes-provider/README.md
@@ -1,0 +1,92 @@
+# @remnic/hermes-provider
+
+Typed TypeScript HTTP client for a remote [Remnic](https://github.com/joshuaswarren/remnic)
+memory daemon. Wraps the Remnic HTTP API (`/engram/v1/*`) with a small, fully
+typed `HermesClient` — recall, observe, store, entity/memory browse, and LCM
+search — plus built-in retries, timeouts, and structured errors.
+
+Use this when you are building a service or agent in TypeScript/JavaScript that
+talks to a Remnic daemon over HTTP and you want types and retry handling instead
+of hand-rolled `fetch` calls.
+
+## Install
+
+```bash
+npm install @remnic/hermes-provider
+```
+
+## Usage
+
+```ts
+import { HermesClient } from "@remnic/hermes-provider";
+
+const client = new HermesClient({
+  baseUrl: "http://127.0.0.1:4318",
+  authToken: "${REMNIC_AUTH_TOKEN}",
+});
+
+// Verify the daemon is reachable.
+await client.health();
+
+// Recall memories for a query.
+const { context } = await client.recall("what did I decide about the schema?");
+
+// Buffer a conversation turn for extraction.
+await client.observe("session-1", [
+  { role: "user", content: "We are switching the store to markdown files." },
+  { role: "assistant", content: "Understood — local-first it is." },
+]);
+
+// Store an explicit memory.
+await client.store({ content: "Team prefers short release notes." });
+```
+
+## Client options
+
+`new HermesClient(options)` accepts:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `baseUrl` | required | Base URL of the Remnic daemon, e.g. `http://127.0.0.1:4318`. |
+| `authToken` | required | Bearer token for the daemon. |
+| `namespace` | unset | Default namespace applied to requests. |
+| `sessionKey` | unset | Default session key applied to requests. |
+| `maxRetries` | `3` | Retry budget for retryable failures (5xx, 429, read POSTs). |
+| `retryBaseDelayMs` | `100` | Base delay for exponential backoff. |
+| `timeoutMs` | `5000` | Per-request timeout (via `AbortController`). |
+
+## Methods
+
+- `health()` — daemon health probe.
+- `recall(query, options?)` — semantic recall; `options` covers `topK`, `mode`,
+  `namespace`, `sessionKey`, `includeDebug`, `idempotencyKey`.
+- `observe(sessionKey, messages, options?)` — buffer conversation turns for
+  extraction.
+- `store(request)` / `submitSuggestion(request)` — write a memory directly, or
+  queue one for review.
+- `getEntities(options?)` / `getEntity(name, options?)` — browse tracked entities.
+- `getMemories(options?)` / `getMemory(id, options?)` — browse stored memories.
+- `lcmSearch(query, options?)` — search the Lossless Context Management archive.
+
+All response and option types are exported from the package.
+
+## Behavior
+
+- **Retries** use exponential backoff on 5xx and read-only POSTs. 429 responses
+  honor a numeric `Retry-After` header. State-mutating writes are not retried
+  unless you pass an `idempotencyKey`, so a lost response never duplicates a write.
+- **Errors** throw a typed `HermesError` carrying `status`, `code`, `message`, and
+  optional field-level `details`. A 404 on `getEntity`/`getMemory` resolves to
+  `{ found: false }` rather than throwing.
+
+The `/engram/v1/*` request paths are Remnic's stable HTTP API surface, kept under
+the `engram` prefix for compatibility.
+
+## Links
+
+- HTTP API reference: [docs/api.md](https://github.com/joshuaswarren/remnic/blob/main/docs/api.md)
+- Monorepo: [github.com/joshuaswarren/remnic](https://github.com/joshuaswarren/remnic)
+
+## License
+
+MIT

--- a/packages/import-weclone/README.md
+++ b/packages/import-weclone/README.md
@@ -1,12 +1,13 @@
 # @remnic/import-weclone
 
-Import [WeClone](https://github.com/xming521/weclone)-preprocessed chat exports
-(Telegram, WhatsApp, Discord, Slack) into Remnic to bootstrap a memory store
-instantly, rather than waiting for organic memory accumulation through daily AI
-tool usage.
+Bootstrap a [Remnic](https://github.com/joshuaswarren/remnic) memory store from
+[WeClone](https://github.com/xming521/weclone)-preprocessed chat exports
+(Telegram, WhatsApp, Discord, Slack) instead of waiting for memory to accumulate
+through daily AI-tool usage.
 
-Part of [Remnic](https://github.com/joshuaswarren/remnic), the universal memory
-layer for AI agents.
+This is an **optional companion** package, installed separately. Importing it
+registers the WeClone adapter with Remnic's core bulk-import registry as a side
+effect — no explicit setup needed.
 
 ## Install
 
@@ -14,143 +15,42 @@ layer for AI agents.
 npm install @remnic/import-weclone
 ```
 
-Importing this package registers the WeClone adapter with the core
-bulk-import registry as a side effect, so `openclaw engram bulk-import
---source weclone ...` works without any explicit setup. Tests that call
-`clearBulkImportSources()` can re-register via
-`ensureWecloneImportAdapterRegistered()`.
-
-## Why WeClone?
-
-WeClone already handles the hard parts of chat ingestion:
-
-- Platform-specific export parsing (Telegram JSON, WhatsApp, Discord, Slack)
-- PII detection and redaction (Microsoft Presidio)
-- Message deduplication and basic cleanup
-
-Rather than duplicate that pipeline, this package consumes WeClone's
-preprocessed JSON directly and maps it into the bulk-import contract defined by
-`@remnic/core`.
-
-## Pipeline
-
-```
-WeClone preprocessed JSON
-         |
-         v
-+---------------------------------+
-|  parseWeCloneExport             |  parser.ts
-|  - platform resolution          |
-|  - role inference (self/bot)    |
-|  - schema validation            |
-+---------------+-----------------+
-                | BulkImportSource
-                v
-+---------------------------------+
-|  groupIntoThreads               |  threader.ts
-|  - sort by timestamp            |
-|  - split on >30 min time gaps   |
-|  - merge via reply chains       |
-+---------------+-----------------+
-                | ThreadGroup[]
-                v
-+---------------------------------+
-|  mapParticipants                |  participant.ts
-|  - count messages per sender    |
-|  - classify self/frequent/      |
-|    occasional                   |
-+---------------+-----------------+
-                | ParticipantEntity[]
-                v
-+---------------------------------+
-|  chunkThreads                   |  chunker.ts
-|  - split long threads with      |
-|    overlap for context          |
-+---------------+-----------------+
-                | ImportTurn[][]
-                v
-+---------------------------------+
-|  runBulkImportPipeline          |  @remnic/core
-|  - batch extraction             |
-|  - dedup against existing       |
-|  - store with trustLevel=import |
-+---------------------------------+
-```
+WeClone already handles the hard parts of chat ingestion — platform-specific
+export parsing, PII detection and redaction, and deduplication. Rather than
+duplicate that, this package consumes WeClone's preprocessed JSON and maps it
+into the bulk-import contract defined by `@remnic/core`.
 
 ## CLI usage
 
-The importer is exposed via the `engram bulk-import` subcommand in
-`@remnic/core`:
+WeClone import runs through the orchestrator-backed `bulk-import` command in
+`@remnic/core`, exposed under the `openclaw engram` command namespace (Remnic's
+hosted CLI surface):
 
 ```bash
-# Dry-run: parse, validate, and report counts without persisting
+# Dry-run: parse, validate, and report counts without persisting.
 openclaw engram bulk-import \
   --source weclone \
   --file ./preprocessed_telegram.json \
   --platform telegram \
   --dry-run
 
-# Persist: run extraction over the export and write memories to disk
+# Persist: run extraction over the export and write memories to disk.
 openclaw engram bulk-import \
   --source weclone \
   --file ./preprocessed_telegram.json \
   --platform telegram
-
-# Strict mode: fail on any invalid message instead of skipping
-openclaw engram bulk-import \
-  --source weclone \
-  --file ./preprocessed_telegram.json \
-  --platform telegram \
-  --strict
 ```
 
-Persistence is wired through the Remnic orchestrator's extraction pipeline.
-Each batch is buffered and extracted the same way an organic conversation
-would be; memories land under the orchestrator's default-namespace root
-(`memoryDir/facts/` by default). Use `--dry-run` to validate an export
-before committing to the extraction cost. Per-invocation namespace
-override for bulk-import writes is not yet wired — see the note in
-[`docs/import-export.md`](../../docs/import-export.md).
+Persistence flows through the Remnic orchestrator's extraction pipeline, so each
+batch is extracted the same way an organic conversation would be. Memories land
+under the orchestrator's default-namespace root (`memoryDir/facts/` by default)
+tagged `trustLevel: "import"`. Use `--dry-run` to validate an export before
+committing to the extraction cost.
 
-## Programmatic usage
-
-```ts
-import { readFileSync } from "node:fs";
-import {
-  parseWeCloneExport,
-  groupIntoThreads,
-  mapParticipants,
-  chunkThreads,
-  // Side-effect import also registers the bulk-import adapter; see `index.ts`.
-  wecloneImportAdapter,
-} from "@remnic/import-weclone";
-import {
-  getBulkImportSource,
-  runBulkImportPipeline,
-} from "@remnic/core";
-
-// The adapter is registered automatically on import. Look it up:
-const adapter = getBulkImportSource("weclone");
-
-// 1) Parse a WeClone-preprocessed export.
-const raw = JSON.parse(readFileSync("./export.json", "utf8"));
-const source = parseWeCloneExport(raw, { platform: "telegram" });
-
-// 2) Pre-process into threads, participants, chunks.
-const threads = groupIntoThreads(source.turns);
-const participants = mapParticipants(source.turns);
-const chunks = chunkThreads(threads, { maxTurnsPerChunk: 20 });
-
-// 3) Run the bulk-import pipeline. In dryRun mode `processBatch` is never
-//    called; for real persistence the host CLI supplies an `ingestBatch`
-//    callback that wraps `orchestrator.ingestBulkImportBatch` (see
-//    `openclaw engram bulk-import`).
-const result = await runBulkImportPipeline(
-  source,
-  { batchSize: 20, dryRun: true, dedup: true, trustLevel: "import" },
-  async () => ({ memoriesCreated: 0, duplicatesSkipped: 0 }),
-);
-```
+> The generic `remnic import --adapter <name>` command covers the ChatGPT,
+> Claude, Gemini, Mem0, and Supermemory importers. WeClone uses the core
+> bulk-import source registry instead, which is why it runs through
+> `bulk-import` rather than `remnic import`.
 
 ## Supported platforms
 
@@ -161,67 +61,57 @@ const result = await runBulkImportPipeline(
 | Discord   | `discord`          |
 | Slack     | `slack`            |
 
-The parser defaults to `telegram` when neither `options.platform` nor an
-export-level `platform` field is provided. Unknown platforms are rejected.
+The parser defaults to `telegram` when no platform is given. Unknown platforms
+are rejected.
 
 ## Input schema
 
-The parser accepts either:
+The parser accepts either a wrapper object with a `messages` array or a raw array
+of messages. Required per-message fields: `sender`, `text`, `timestamp`
+(ISO-8601); optional: `message_id`, `reply_to_id`.
 
-1. A wrapper object:
+```json
+{
+  "platform": "telegram",
+  "messages": [
+    { "sender": "Alice", "text": "hello", "timestamp": "2025-01-10T08:00:00.000Z" }
+  ]
+}
+```
 
-   ```json
-   {
-     "platform": "telegram",
-     "export_date": "2025-01-10T00:00:00.000Z",
-     "messages": [
-       {
-         "sender": "Alice",
-         "text": "hello",
-         "timestamp": "2025-01-10T08:00:00.000Z",
-         "message_id": "m-001",
-         "reply_to_id": "m-000"
-       }
-     ]
-   }
-   ```
+## Programmatic use
 
-2. A raw array of messages (platform defaults to `telegram`).
+The adapter registers automatically on import; look it up from the core registry,
+or drive the pipeline stages directly:
 
-Required per-message fields: `sender`, `text`, `timestamp` (ISO-8601). Optional:
-`message_id`, `reply_to_id`.
+```ts
+import { readFileSync } from "node:fs";
+import { parseWeCloneExport } from "@remnic/import-weclone";
+import { getBulkImportSource, runBulkImportPipeline } from "@remnic/core";
 
-## Role inference
+const adapter = getBulkImportSource("weclone");
+const source = parseWeCloneExport(
+  JSON.parse(readFileSync("./export.json", "utf8")),
+  { platform: "telegram" },
+);
 
-Each `sender` is mapped to one of the `ImportTurn` roles:
+// dryRun never calls the batch callback; real persistence supplies an
+// ingest callback wired to the orchestrator (see `openclaw engram bulk-import`).
+const result = await runBulkImportPipeline(
+  source,
+  { batchSize: 20, dryRun: true, dedup: true, trustLevel: "import" },
+  async () => ({ memoriesCreated: 0, duplicatesSkipped: 0 }),
+);
+```
 
-- `user` - the "self" sender (first non-bot sender encountered, or override
-  via `selfSender`).
-- `assistant` - any sender matching a bot heuristic (`bot`, `assistant`, `ai`,
-  `chatgpt`, `gpt`, `claude`, `copilot`, `llama`) or listed in
-  `assistantSenders`.
-- `other` - everyone else.
+Tests that call `clearBulkImportSources()` can re-register the adapter via
+`ensureWecloneImportAdapterRegistered()`.
 
-The heuristic uses word-boundary matching so human names that happen to contain
-substrings like `ai` (e.g. `Aidan`, `Caitlin`) are not mis-classified.
+## Further reading
 
-## Design notes
-
-- **Imported memories are tagged with `trustLevel: "import"`** in the
-  pipeline options so downstream ranking/dedup can reason about their
-  provenance. The confidence-weighted ranking discount described in the
-  original issue is tracked as a follow-up — today the flag is plumbed but
-  not consumed by the recall ranker.
-- **Threads are conversation boundaries, not days.** The default 30-minute
-  gap with reply-chain merging produces coherent extraction batches without
-  relying on calendar boundaries.
-- **Entity bootstrapping is best-effort.** `mapParticipants` emits
-  lightweight `ParticipantEntity` records; the core entity graph is populated
-  as the pipeline processes chunks.
-- **Idempotent re-imports.** The pipeline's dedup pass (when wired)
-  fingerprint-matches against existing memories, so re-running the importer
-  after appending new messages is safe.
+- Import/export guide: [docs/import-export.md](https://github.com/joshuaswarren/remnic/blob/main/docs/import-export.md)
+- Monorepo: [github.com/joshuaswarren/remnic](https://github.com/joshuaswarren/remnic)
 
 ## License
 
-MIT. See [LICENSE](https://github.com/joshuaswarren/remnic/blob/main/LICENSE).
+MIT

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -2,7 +2,7 @@
 
 Remnic MemoryProvider plugin for [Hermes Agent](https://github.com/NousResearch/hermes-agent). Automatically injects memories into every LLM call and observes every conversation turn — no agent code changes required.
 
-Current PyPI package: `remnic-hermes` v1.0.2. This release includes automatic MemoryProvider recall/observation, daemon-side LCM recall enrichment, session reset scoping, the full explicit Remnic tool parity surface, and legacy `engram_*` aliases for existing configs.
+The `remnic-hermes` PyPI package provides automatic MemoryProvider recall/observation, daemon-side LCM recall enrichment, session reset scoping, the full explicit Remnic tool parity surface, and legacy `engram_*` aliases for existing configs.
 
 ## Why MemoryProvider
 


### PR DESCRIPTION
## What this is

A ground-up overhaul of all living Remnic documentation: root README, docs hub, every guide/feature/architecture/integration doc, llms.txt, CONTRIBUTING, and all 27 package READMEs. Every command, config default, package fact, and link was verified against source before being documented.

## Method

1. **Ground-truth audits first.** Four source-level audits established reality before any writing: the package inventory (27 packages, publish order, dependency claims), the real CLI surface (35 standalone `remnic` commands + ~100 `openclaw engram` hosted subcommands), config truth (699 schema keys, 4 presets, per-flag defaults with file evidence), and a staleness/integrity sweep (broken links, orphans, stale claims).
2. **A designed information architecture.** Universal/standalone-first framing with OpenClaw as the deepest native integration; a journey-organized docs hub; no file moves or renames, so no inbound link breaks.
3. **Every doc rebuilt or verified against the audits**, with a shared conventions contract (sentence-case headings, verified defaults stated per feature, intentional Engram compat surfaces preserved and labeled, no line-number references in user docs).

## Highlights

- **README.md**: 1,227 lines → 308. One narrative, two quick starts, tool matrix, honest feature groups, FAQ. All stale claims gone ("672 tests", "60+ options", "five importers", hermes v1.0.2).
- **NEW `docs/cli.md`**: the full standalone CLI reference — previously no complete reference existed anywhere.
- **`docs/README.md` hub + 4 new directory indexes**: every living doc now reachable (previously ~60 orphans); historical material (plans/, paper/, RENAME.md, hackathon) clearly labeled.
- **Surface attribution fixed everywhere**: docs no longer claim standalone `remnic` commands that only exist as `openclaw engram <cmd>` (forget, tier, patterns, peer, secure-store, capsule export/import, console, dreams, …), and no longer document nonexistent commands (`remnic connectors install openclaw`, `remnic import --adapter weclone`).
- **Wrong documented defaults corrected**: `lifecyclePolicyEnabled` (actually `true` since #686), `emitLegacyTools` (conditional, not `true`), `sharedContextMaxInjectChars` (4,000 not 6,000), plus stale "not yet shipped" banners removed from shipped features (tier explain, direct-answer observation mode, dreams, correction-intent model).
- **llms.txt rewritten** as a dense, current LLM-facing summary (all 25 published packages, real command counts, both quick starts, OpenClaw compat floor preserved per AGENTS.md).
- **Privacy**: real client name removed from all doc examples; private IP redacted from a plans doc.
- **quickstart/getting-started** rebuilt: 5-minute universal path + comprehensive install guide covering both config shapes; QMD upgrade content relocated to search-backends.md.

## Verification

- `node scripts/check-docs-parity.mjs` — OK (33 commands resolve, stub publishers honest, Build Week dataset commands pinned)
- `npm run check-config-contract` — OK (PluginConfig=701, parseConfig=699, schema=699)
- Custom sweep: **0 broken relative links** across docs/, README, CONTRIBUTING, llms.txt, package READMEs; **0 orphaned living docs**; 0 remaining stale-claim pattern hits
- Rebased onto latest main (includes the expanded parity checker from #1892)

## Explicitly out of scope (follow-ups)

- `blend-supply` / `worthington-direct` (real client names) also appear in **shipped code**: MCP tool description strings in `packages/remnic-core/src/access-mcp.ts` and multiple test fixtures. That is a code change and should be its own small PR.
- `AGENTS.md`, `CHANGELOG.md`, and historical records (`docs/plans/`, `docs/paper/`, `RENAME.md`, hackathon docs, dated bench results) intentionally untouched, except a single private-IP redaction in one plans doc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime behavior in the shown diff; main risk is readers following outdated commands if any audit misses remain.
> 
> **Overview**
> **Reframes and reorganizes user-facing documentation** around standalone Remnic (`@remnic/cli` / daemon) with OpenClaw as one deep integration, replacing scattered Engram-era narratives and overstuffed root README content.
> 
> The **root `README.md` is heavily condensed** into a shorter product story: universal quick start, OpenClaw plugin path, tool matrix, feature highlights grouped by theme, FAQ, and pointers into `docs/` instead of inline encyclopedic sections (MemCorrect hackathon, wearables/importers detail, giant config tables, etc.).
> 
> **Contributor and policy docs are updated for Remnic**: `CONTRIBUTING.md` (pnpm workflow, quality gates including `check:docs-parity`, narrower PR scope), `SECURITY.md` (supported versions, `remnic` advisory URL, threat-model link), and `docs/CONVENTIONS.md` (paths under `packages/remnic-core`, current npm scripts).
> 
> **The docs hub and architecture layer are rebuilt for navigation**: `docs/README.md` becomes journey-organized (start → connect → features → operate → reference → internals); new `docs/architecture/README.md`; `docs/ARCHITECTURE.md` and `docs/architecture/monorepo-structure.md` refresh the package map (~27 packages), dependency/publish-order story, and core-vs-adapter framing.
> 
> **Reference pages align with verified surfaces**: `docs/api.md` expands the HTTP route catalog and **splits standalone `remnic` vs `openclaw engram`** (with `docs/cli.md` called out as the full CLI reference in README/llms per PR scope); integration/architecture pages rename Engram→Remnic, update default paths (`~/.remnic`, `remnic_*` tokens), and correct stale “planned” wording (e.g. direct-answer observation mode, monorepo dep claims for zero-dep plugins).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a57dab31f4d00807d556934c696e9e3683498301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->