### PR TITLE
fix: remove real client names from MCP tool descriptions and test fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Replaced real client names used as example project tags in MCP tool
+  descriptions (`access-mcp.ts`) and test fixtures with generic placeholders
+  (`acme-webshop`, `globex-storefront`). The shipped MCP schema no longer
+  references any real project name.
 - coding-graph indexing now derives CALLS edges from parsed call sites
   (Phase A heuristic resolution, issue #1891). Previously `codegraph_index`
   produced nodes but zero edges, leaving `trace_path`, blast radius, and

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -268,11 +268,11 @@ test("HTTP coding-context endpoint accepts projectTag shorthand", async () => {
       },
       body: JSON.stringify({
         sessionKey: "s1",
-        projectTag: "Blend/Supply",
+        projectTag: "Acme/Webshop",
       }),
     });
 
-    const projectId = projectTagProjectId("Blend/Supply");
+    const projectId = projectTagProjectId("Acme/Webshop");
     assert.equal(response.status, 200);
     assert.deepEqual(await response.json(), { ok: true });
     assert.deepEqual(calls, [

--- a/packages/remnic-core/src/access-mcp.test.ts
+++ b/packages/remnic-core/src/access-mcp.test.ts
@@ -301,7 +301,7 @@ test("MCP write tools accept and forward client-injected cwd/projectTag (#1434)"
         category: "fact",
         dryRun: true,
         cwd: "/home/dev/project-x",
-        projectTag: "Blend/Supply",
+        projectTag: "Acme/Webshop",
       }),
     );
     const result = (response as Record<string, unknown> & {
@@ -310,7 +310,7 @@ test("MCP write tools accept and forward client-injected cwd/projectTag (#1434)"
 
     assert.equal(result?.isError, false, `${toolName} should accept cwd/projectTag`);
     assert.equal(received?.cwd, "/home/dev/project-x", `${toolName} must forward cwd`);
-    assert.equal(received?.projectTag, "Blend/Supply", `${toolName} must forward projectTag`);
+    assert.equal(received?.projectTag, "Acme/Webshop", `${toolName} must forward projectTag`);
   }
 });
 

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -542,7 +542,7 @@ export class EngramMcpServer {
             cwd: { type: "string", description: "Working directory for auto git-context resolution." },
             projectTag: {
               type: "string",
-              description: "Project tag for non-git project scoping (e.g. 'blend-supply').",
+              description: "Project tag for non-git project scoping (e.g. 'acme-webshop').",
             },
             asOf: {
               type: "string",
@@ -611,7 +611,7 @@ export class EngramMcpServer {
             projectTag: {
               type: "string",
               description:
-                "Arbitrary project tag for non-git project scoping (e.g. 'blend-supply'). " +
+                "Arbitrary project tag for non-git project scoping (e.g. 'acme-webshop'). " +
                 "Creates a coding context with projectId 'tag:<projectTag>'. " +
                 "Use instead of codingContext when the session isn't tied to a specific git repo.",
             },
@@ -1274,7 +1274,7 @@ export class EngramMcpServer {
             cwd: { type: "string", description: "Working directory for auto git-context resolution." },
             projectTag: {
               type: "string",
-              description: "Project tag for non-git project scoping (e.g. 'blend-supply').",
+              description: "Project tag for non-git project scoping (e.g. 'acme-webshop').",
             },
           },
           required: ["sessionKey", "messages"],

--- a/packages/remnic-core/src/access-service-coding-write.test.ts
+++ b/packages/remnic-core/src/access-service-coding-write.test.ts
@@ -76,11 +76,11 @@ test("#1434 projectTag scopes the write to the project namespace, read-only", as
   const resolved = await resolver(service)({
     sessionKey: "sess-1",
     authenticatedPrincipal: "alice",
-    projectTag: "Blend/Supply",
+    projectTag: "Acme/Webshop",
     content: "x",
   });
 
-  assert.equal(resolved, projectNamespaceFor("Blend/Supply"));
+  assert.equal(resolved, projectNamespaceFor("Acme/Webshop"));
   assert.notEqual(resolved, "default", "project context must change the namespace");
   // Read-only: resolving must NOT persist coding context on the session.
   assert.equal(
@@ -100,7 +100,7 @@ test("#1434 a sessionless write with projectTag stays on the base namespace (rec
   const service = new EngramAccessService(orch);
   const resolved = await resolver(service)({
     authenticatedPrincipal: "alice",
-    projectTag: "Blend/Supply",
+    projectTag: "Acme/Webshop",
     content: "x",
   });
   assert.equal(resolved, "default");
@@ -109,9 +109,9 @@ test("#1434 a sessionless write with projectTag stays on the base namespace (rec
 test("#1434 an existing session coding context scopes the write (recall-then-store flow)", async () => {
   const orch = makeOrchestratorStub();
   orch.setCodingContextForSession("sess-ctx", {
-    projectId: projectTagProjectId("Blend/Supply"),
+    projectId: projectTagProjectId("Acme/Webshop"),
     branch: null,
-    rootPath: projectTagProjectId("Blend/Supply"),
+    rootPath: projectTagProjectId("Acme/Webshop"),
     defaultBranch: null,
   });
   const service = new EngramAccessService(orch);
@@ -121,7 +121,7 @@ test("#1434 an existing session coding context scopes the write (recall-then-sto
     authenticatedPrincipal: "alice",
     content: "x",
   });
-  assert.equal(resolved, projectNamespaceFor("Blend/Supply"));
+  assert.equal(resolved, projectNamespaceFor("Acme/Webshop"));
 });
 
 test("#1434 an existing session binding wins over per-call projectTag (recall symmetry)", async () => {
@@ -155,7 +155,7 @@ test("#1434 explicit namespace wins and bypasses coding overlay", async () => {
     sessionKey: "sess-2",
     authenticatedPrincipal: "alice",
     namespace: "default",
-    projectTag: "Blend/Supply",
+    projectTag: "Acme/Webshop",
     content: "x",
   });
   assert.equal(resolved, "default");
@@ -208,12 +208,12 @@ test("#1434 project write overlays onto the principal self base (recall symmetry
   const resolved = await resolver(service)({
     sessionKey: "sess-3c",
     authenticatedPrincipal: "alice",
-    projectTag: "Blend/Supply",
+    projectTag: "Acme/Webshop",
     content: "x",
   });
   assert.equal(
     resolved,
-    combineNamespaces("alice", projectNamespaceName(projectTagProjectId("Blend/Supply"))),
+    combineNamespaces("alice", projectNamespaceName(projectTagProjectId("Acme/Webshop"))),
   );
 });
 
@@ -228,7 +228,7 @@ test("#1434 an explicit coding-overlay namespace string is NOT a writable target
     resolver(service)({
       sessionKey: "sess-explicit-overlay",
       authenticatedPrincipal: "alice",
-      namespace: projectNamespaceFor("Blend/Supply"), // "default-project-…"
+      namespace: projectNamespaceFor("Acme/Webshop"), // "default-project-…"
       content: "x",
     }),
     /not writable/,
@@ -308,7 +308,7 @@ test("#1434 namespaces disabled: cwd/projectTag are a no-op (common single-tenan
   const service = new EngramAccessService(orch);
   const resolved = await resolver(service)({
     sessionKey: "sess-4",
-    projectTag: "Blend/Supply",
+    projectTag: "Acme/Webshop",
     content: "x",
   });
   assert.equal(resolved, "default");
@@ -368,18 +368,18 @@ test("#1434 a real memory_store attaches coding context so a later bare recall o
   const service = new EngramAccessService(orch);
 
   const res = await service.memoryStore(
-    storeRequest({ sessionKey: "sess-attach", projectTag: "Blend/Supply" }),
+    storeRequest({ sessionKey: "sess-attach", projectTag: "Acme/Webshop" }),
   );
 
   assert.equal(res.status, "stored");
-  assert.equal(res.namespace, projectNamespaceFor("Blend/Supply"));
+  assert.equal(res.namespace, projectNamespaceFor("Acme/Webshop"));
   // The store attached the coding context the recall path reads.
   assert.equal(
     contexts.get("sess-attach")?.projectId,
-    projectTagProjectId("Blend/Supply"),
+    projectTagProjectId("Acme/Webshop"),
   );
   assert.ok(
-    getStorageCalls.every((ns) => ns === projectNamespaceFor("Blend/Supply")),
+    getStorageCalls.every((ns) => ns === projectNamespaceFor("Acme/Webshop")),
     `expected all getStorage calls on the project namespace, got ${JSON.stringify(getStorageCalls)}`,
   );
   // A later BARE resolve (no per-call context) on the same session — what a
@@ -389,7 +389,7 @@ test("#1434 a real memory_store attaches coding context so a later bare recall o
     authenticatedPrincipal: "alice",
     content: "y",
   });
-  assert.equal(bare, projectNamespaceFor("Blend/Supply"));
+  assert.equal(bare, projectNamespaceFor("Acme/Webshop"));
 });
 
 test("#1434 an explicit-namespace store does NOT bind the session to a project (Codex review)", async () => {
@@ -399,7 +399,7 @@ test("#1434 an explicit-namespace store does NOT bind the session to a project (
   const { orch, contexts } = makeAttachOrchestrator();
   const service = new EngramAccessService(orch);
   const res = await service.memoryStore(
-    storeRequest({ sessionKey: "sess-explicit", namespace: "default", projectTag: "Blend/Supply" }),
+    storeRequest({ sessionKey: "sess-explicit", namespace: "default", projectTag: "Acme/Webshop" }),
   );
   assert.equal(res.status, "stored");
   assert.equal(res.namespace, "default");
@@ -411,7 +411,7 @@ test("#1434 a dryRun store does NOT bind the session to a project (Codex review)
   const { orch, contexts } = makeAttachOrchestrator();
   const service = new EngramAccessService(orch);
   const res = await service.memoryStore(
-    storeRequest({ sessionKey: "sess-dry", projectTag: "Blend/Supply", dryRun: true }),
+    storeRequest({ sessionKey: "sess-dry", projectTag: "Acme/Webshop", dryRun: true }),
   );
   assert.equal(res.status, "validated");
   assert.equal(contexts.get("sess-dry"), undefined, "dryRun must not bind the session");

--- a/packages/remnic-core/src/access-service-lcm-forgery.test.ts
+++ b/packages/remnic-core/src/access-service-lcm-forgery.test.ts
@@ -193,7 +193,7 @@ test("#1495 P1 FORGERY BLOCKED: a default-only caller cannot read another tenant
   const victimRes = await service.observe(
     observeRequest({
       sessionKey: "alice:s1",
-      projectTag: "Blend/Supply",
+      projectTag: "Acme/Webshop",
     }),
   );
   const victimWriteKey = probe.rows[0]!.session_id;
@@ -235,7 +235,7 @@ test("#1495 P1 FORGERY BLOCKED: a default-only caller cannot read another tenant
   const service = new EngramAccessService(probe.orch);
 
   const victimRes = await service.observe(
-    observeRequest({ sessionKey: "alice:s1", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "alice:s1", projectTag: "Acme/Webshop" }),
   );
   const victimOverlayNs = victimRes.effectiveNamespace!;
   assert.ok(victimOverlayNs.startsWith("alice-"));
@@ -268,7 +268,7 @@ test("#1495 P1 LEGITIMATE ACCESS PRESERVED: the victim still reads its OWN overl
 
   // alice archives under her overlay AND binds the coding context to her session.
   await service.observe(
-    observeRequest({ sessionKey: "alice:s1", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "alice:s1", projectTag: "Acme/Webshop" }),
   );
 
   // A same-session lcmSearch by alice (no explicit namespace) must reach her rows:
@@ -330,7 +330,7 @@ test("#1505 codex P1 r2 FORGERY BLOCKED: explicit-namespace + sessionless lcmSea
 
   // VICTIM archives overlay rows.
   const victimRes = await service.observe(
-    observeRequest({ sessionKey: "alice:s1", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "alice:s1", projectTag: "Acme/Webshop" }),
   );
   assert.ok(victimRes.effectiveNamespace!.startsWith("alice-"));
 
@@ -361,7 +361,7 @@ test("#1505 codex P1 r2 FORGERY BLOCKED: default-readable implicit + sessionless
   const service = new EngramAccessService(probe.orch);
 
   const victimRes = await service.observe(
-    observeRequest({ sessionKey: "alice:s1", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "alice:s1", projectTag: "Acme/Webshop" }),
   );
   assert.ok(victimRes.effectiveNamespace!.startsWith("alice-"));
 

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -305,12 +305,12 @@ test("#1505 thread 2 (c) projectTag: observe LCM write key == recall reader key 
   const service = new EngramAccessService(probe.orch);
 
   const res = await service.observe(
-    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
   );
 
   const expectedNs = combineNamespaces(
     "pi-geek",
-    projectNamespaceName(projectTagProjectId("Blend/Supply")),
+    projectNamespaceName(projectTagProjectId("Acme/Webshop")),
   );
   const expectedKey = encodeNs(expectedNs, "pi-geek:abc123");
   assert.equal(res.effectiveNamespace, expectedNs);
@@ -442,7 +442,7 @@ test("#1505 thread 2 (d) projectScope:false ⇒ raw sessionKey everywhere (singl
   const service = new EngramAccessService(probe.orch);
 
   const res = await service.observe(
-    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
   );
   // No overlay ⇒ effective namespace is the default store ⇒ raw key.
   assert.equal(res.effectiveNamespace, "default");
@@ -470,7 +470,7 @@ test("#1505 thread 2 (d) namespacesEnabled:false ⇒ raw sessionKey everywhere",
   const service = new EngramAccessService(probe.orch);
 
   const res = await service.observe(
-    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
   );
   assert.equal(res.effectiveNamespace, "default");
   assert.equal(probe.lcmWriteKeys[0], "pi-geek:abc123", "raw LCM write key");
@@ -501,14 +501,14 @@ test("#1505 thread 1: extraction provenance principal is the resolved principal 
   await service.observe(
     observeRequest({
       sessionKey: "pi-geek:abc123",
-      projectTag: "Blend/Supply",
+      projectTag: "Acme/Webshop",
       skipExtraction: false, // exercise the extraction path
     }),
   );
 
   const expectedNs = combineNamespaces(
     "pi-geek",
-    projectNamespaceName(projectTagProjectId("Blend/Supply")),
+    projectNamespaceName(projectTagProjectId("Acme/Webshop")),
   );
   assert.equal(probe.extractionCalls.length, 1);
   // Provenance identity: the resolved principal, never a default parsed from the
@@ -590,7 +590,7 @@ test("#1505 thread 2: LCM read namespace honors authenticatedPrincipal (write-un
     observeRequest({
       sessionKey: "sess-1",
       authenticatedPrincipal: "alice",
-      projectTag: "Blend/Supply",
+      projectTag: "Acme/Webshop",
     }),
   );
   const writeKey = probe.lcmWriteKeys[0];
@@ -639,7 +639,7 @@ test("#1505 thread 2 compaction regression: flush/record overlay-derived key mat
   const service = new EngramAccessService(probe.orch);
 
   await service.observe(
-    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
   );
   await service.lcmCompactionFlush({ sessionKey: "pi-geek:abc123" });
 
@@ -748,7 +748,7 @@ test("#1505 round 3: access lcmSearch routes the session_id through the SCOPED (
   const service = new EngramAccessService(probe.orch);
 
   await service.observe(
-    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
   );
   const writeKey = probe.lcmWriteKeys[0];
   // New #1495 P1 encoding: `\x1f<overlayNs>\x1f<sessionKey>`. Parse the overlay
@@ -872,8 +872,8 @@ test("#1505 round 3 thread 1: orchestrator LCM read key falls back to default wh
 
   // Bind a coding context to sess-1 so the overlay would apply on alice's base.
   probe.contexts.set("sess-1", {
-    projectId: "blend-supply",
-    projectName: "Blend/Supply",
+    projectId: "acme-webshop",
+    projectName: "Acme/Webshop",
   } as unknown as CodingContext);
 
   const lcmReadNamespaceForSession = Orchestrator.prototype[
@@ -914,8 +914,8 @@ test("#1505 round 3 thread 1: orchestrator LCM read key falls back to default wh
   } as Partial<PluginConfig>);
 
   probe.contexts.set("sess-1", {
-    projectId: "blend-supply",
-    projectName: "Blend/Supply",
+    projectId: "acme-webshop",
+    projectName: "Acme/Webshop",
   } as unknown as CodingContext);
 
   const lcmReadNamespaceForSession = Orchestrator.prototype[
@@ -944,8 +944,8 @@ test("#1505 round 3 thread 1: orchestrator LCM read key still uses the overlay w
   } as Partial<PluginConfig>);
 
   probe.contexts.set("pi-geek:abc123", {
-    projectId: "blend-supply",
-    projectName: "Blend/Supply",
+    projectId: "acme-webshop",
+    projectName: "Acme/Webshop",
   } as unknown as CodingContext);
 
   const lcmReadNamespaceForSession = Orchestrator.prototype[
@@ -977,8 +977,8 @@ test("#1505 round 3 thread 2: lcmSearch returns NO overlay rows when the princip
   const service = new EngramAccessService(probe.orch);
 
   probe.contexts.set("sess-1", {
-    projectId: "blend-supply",
-    projectName: "Blend/Supply",
+    projectId: "acme-webshop",
+    projectName: "Acme/Webshop",
   } as unknown as CodingContext);
 
   await service.lcmSearch({
@@ -1036,7 +1036,7 @@ test("#1505 round 4 thread (codex P2): compaction flush/record target the OVERLA
     observeRequest({
       sessionKey: "sess-1",
       authenticatedPrincipal: "alice",
-      projectTag: "Blend/Supply",
+      projectTag: "Acme/Webshop",
     }),
   );
   const writeKey = probe.lcmWriteKeys[0];
@@ -1080,8 +1080,8 @@ test("#1505 round 4 thread (codex P2): a read-only lcmSearch by the SAME write-o
   const service = new EngramAccessService(probe.orch);
 
   probe.contexts.set("sess-1", {
-    projectId: "blend-supply",
-    projectName: "Blend/Supply",
+    projectId: "acme-webshop",
+    projectName: "Acme/Webshop",
   } as unknown as CodingContext);
 
   await service.lcmSearch({
@@ -1115,7 +1115,7 @@ test("#1505 round 3 thread 2: lcmSearch still routes through the overlay key whe
     observeRequest({
       sessionKey: "sess-1",
       authenticatedPrincipal: "alice",
-      projectTag: "Blend/Supply",
+      projectTag: "Acme/Webshop",
     }),
   );
   const writeKey = probe.lcmWriteKeys[0];
@@ -1172,7 +1172,7 @@ test("#1505 thread NBHWs (codex P2): restrictive `default` WRITE policy + writab
     observeRequest({
       sessionKey: "sess-1",
       authenticatedPrincipal: "alice",
-      projectTag: "Blend/Supply",
+      projectTag: "Acme/Webshop",
     }),
   );
   const writeKey = probe.lcmWriteKeys[0];
@@ -1230,7 +1230,7 @@ test("#1505 thread NBHWz (sweep): restrictive `default` READ policy + readable s
 
   // observe archives under pi-geek's readable+writable project overlay.
   await service.observe(
-    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
   );
   const writeKey = probe.lcmWriteKeys[0];
   assertOverlayWriteKey(writeKey, "pi-geek-"); // observe must archive under pi-geek's overlay key, got ${writeKey}
@@ -1277,8 +1277,8 @@ test("#1505 codex P1 'Don't treat any readable namespace as default LCM access':
 
   // Bind a coding context so the overlay WOULD apply on alice's base.
   probe.contexts.set("sess-1", {
-    projectId: "blend-supply",
-    projectName: "Blend/Supply",
+    projectId: "acme-webshop",
+    projectName: "Acme/Webshop",
   } as unknown as CodingContext);
 
   const res = await service.lcmSearch({

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -162,14 +162,14 @@ test("#1495 projectTag: LCM, extraction, objective-state, and response all agree
   const service = new EngramAccessService(probe.orch);
 
   const res = await service.observe(
-    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
   );
 
   // Effective write namespace == principal self base overlaid with the project,
   // EXACTLY what a same-session project-scoped recall/store resolves.
   const expected = combineNamespaces(
     "pi-geek",
-    projectNamespaceName(projectTagProjectId("Blend/Supply")),
+    projectNamespaceName(projectTagProjectId("Acme/Webshop")),
   );
 
   assert.equal(res.effectiveNamespace, expected, "response effectiveNamespace");
@@ -334,7 +334,7 @@ test("#1495 explicit namespace wins and project context does NOT silently overri
     observeRequest({
       sessionKey: "pi-geek:abc123",
       namespace: "team",
-      projectTag: "Blend/Supply",
+      projectTag: "Acme/Webshop",
     }),
   );
 
@@ -364,7 +364,7 @@ test("#1495 projectScope:false ⇒ no overlay (unqualified write stays on config
   const service = new EngramAccessService(probe.orch);
 
   const res = await service.observe(
-    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
   );
 
   assert.equal(res.effectiveNamespace, "default");
@@ -385,7 +385,7 @@ test("#1495 namespacesEnabled:false ⇒ single-store behavior preserved", async 
   const service = new EngramAccessService(probe.orch);
 
   const res = await service.observe(
-    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
   );
 
   assert.equal(res.effectiveNamespace, "default");
@@ -409,7 +409,7 @@ test("#1495 unauthorized explicit namespace throws BEFORE session context is att
       observeRequest({
         sessionKey: "pi-geek:abc123",
         namespace: "victim-secret",
-        projectTag: "Blend/Supply",
+        projectTag: "Acme/Webshop",
       }),
     ),
     /not writable/,
@@ -445,7 +445,7 @@ test("#1505 thread 1/3: unauthorized OVERLAY self-base throws BEFORE coding cont
 
   await assert.rejects(
     service.observe(
-      observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+      observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
     ),
     /not writable/,
   );
@@ -491,13 +491,13 @@ test("#1505 thread jvO: restrictive default-namespace write policy does NOT reje
 
   const expectedOverlay = combineNamespaces(
     "pi-geek",
-    projectNamespaceName(projectTagProjectId("Blend/Supply")),
+    projectNamespaceName(projectTagProjectId("Acme/Webshop")),
   );
 
   // FAIL-BEFORE: this threw `namespace is not writable: default`. PASS-AFTER:
   // the observe is accepted exactly like memory_store/suggestion_submit would.
   const res = await service.observe(
-    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
   );
 
   // Every side effect uses the authorized overlay write target.
@@ -533,7 +533,7 @@ test("#1505 thread jvO: a genuine reject (unwritable self base) under a restrict
 
   await assert.rejects(
     service.observe(
-      observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+      observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
     ),
     /not writable/,
   );
@@ -553,12 +553,12 @@ test("#1495 scopeDebug exposes the resolved plan for callers/tests", async () =>
   const service = new EngramAccessService(probe.orch);
 
   const res = await service.observe(
-    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Acme/Webshop" }),
   );
 
   const expected = combineNamespaces(
     "pi-geek",
-    projectNamespaceName(projectTagProjectId("Blend/Supply")),
+    projectNamespaceName(projectTagProjectId("Acme/Webshop")),
   );
   assert.ok(res.scopeDebug, "scopeDebug must be present");
   assert.equal(res.scopeDebug!.principal, "pi-geek");
@@ -611,9 +611,9 @@ test("#1495 the scope plan's writeNamespace matches resolveCodingScopedWriteName
   const probe = makeObserveProbe(withSelfPolicyPrefix("pi-geek"));
   // Bind a session coding context so both resolvers see the same project.
   probe.contexts.set("pi-geek:abc123", {
-    projectId: projectTagProjectId("Blend/Supply"),
+    projectId: projectTagProjectId("Acme/Webshop"),
     branch: null,
-    rootPath: projectTagProjectId("Blend/Supply"),
+    rootPath: projectTagProjectId("Acme/Webshop"),
     defaultBranch: null,
   });
   const service = new EngramAccessService(probe.orch);
@@ -765,14 +765,14 @@ test("#1495 skipExtraction does not enqueue extraction but still archives LCM un
   const res = await service.observe(
     observeRequest({
       sessionKey: "pi-geek:abc123",
-      projectTag: "Blend/Supply",
+      projectTag: "Acme/Webshop",
       skipExtraction: true,
     }),
   );
 
   const expected = combineNamespaces(
     "pi-geek",
-    projectNamespaceName(projectTagProjectId("Blend/Supply")),
+    projectNamespaceName(projectTagProjectId("Acme/Webshop")),
   );
   assert.equal(res.extractionQueued, false);
   assert.equal(probe.extractionCalls.length, 0);

--- a/packages/remnic-core/src/access-service-project-tag.test.ts
+++ b/packages/remnic-core/src/access-service-project-tag.test.ts
@@ -24,10 +24,10 @@ test("projectTag auto-resolution uses the shared project tag canonicalizer", asy
   } as any);
 
   await (service as any).maybeAttachCodingContext("session-a", {
-    projectTag: "Blend/Supply",
+    projectTag: "Acme/Webshop",
   });
 
-  const projectId = projectTagProjectId("Blend/Supply");
+  const projectId = projectTagProjectId("Acme/Webshop");
   assert.deepEqual(contexts.get("session-a"), {
     projectId,
     branch: null,

--- a/packages/remnic-core/src/access-service-raw-excerpt-read-gate.test.ts
+++ b/packages/remnic-core/src/access-service-raw-excerpt-read-gate.test.ts
@@ -173,7 +173,7 @@ type RawExcerptInternals = {
 };
 
 const SESSION_KEY = "pi-geek:abc123";
-const PROJECT_TAG = "Blend/Supply";
+const PROJECT_TAG = "Acme/Webshop";
 
 function overlayNamespace(): string {
   return combineNamespaces(

--- a/packages/remnic-core/src/coding/coding-namespace.test.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.test.ts
@@ -58,9 +58,9 @@ test("projectNamespaceName: empty input falls back to 'unknown'", () => {
 });
 
 test("projectTagProjectId: lossy tags get hash disambiguators", () => {
-  assert.equal(projectTagProjectId("blend-supply"), "tag:blend-supply");
-  assert.notEqual(projectTagProjectId("blend/supply"), projectTagProjectId("blend-supply"));
-  assert.match(projectTagProjectId("blend/supply"), /^tag:blend-supply-[0-9a-f]{8}$/);
+  assert.equal(projectTagProjectId("acme-webshop"), "tag:acme-webshop");
+  assert.notEqual(projectTagProjectId("acme/webshop"), projectTagProjectId("acme-webshop"));
+  assert.match(projectTagProjectId("acme/webshop"), /^tag:acme-webshop-[0-9a-f]{8}$/);
 });
 
 test("projectNamespaceName: length-capped to 64 chars, no trailing dash", () => {

--- a/packages/remnic-core/src/coding/wire-coding-context.test.ts
+++ b/packages/remnic-core/src/coding/wire-coding-context.test.ts
@@ -39,11 +39,11 @@ test("recall schema accepts projectTag field", () => {
   const result = validateRequest<RecallRequest>("recall", {
     query: "test query",
     sessionKey: "sess-1",
-    projectTag: "blend-supply",
+    projectTag: "acme-webshop",
   });
   assert.equal(result.success, true);
   if (result.success) {
-    assert.equal(result.data.projectTag, "blend-supply");
+    assert.equal(result.data.projectTag, "acme-webshop");
   }
 });
 
@@ -52,7 +52,7 @@ test("recall schema accepts both cwd and projectTag", () => {
     query: "test query",
     sessionKey: "sess-1",
     cwd: "/home/user/project",
-    projectTag: "blend-supply",
+    projectTag: "acme-webshop",
   });
   assert.equal(result.success, true);
 });
@@ -89,11 +89,11 @@ test("observe schema accepts projectTag field", () => {
   const result = validateRequest<ObserveRequest>("observe", {
     sessionKey: "sess-1",
     messages: [{ role: "user", content: "hello" }],
-    projectTag: "worthington-direct",
+    projectTag: "globex-storefront",
   });
   assert.equal(result.success, true);
   if (result.success) {
-    assert.equal(result.data.projectTag, "worthington-direct");
+    assert.equal(result.data.projectTag, "globex-storefront");
   }
 });
 
@@ -185,13 +185,13 @@ test("set_coding_context with projectTag creates tag-based context", async () =>
   const { mcp, calls } = makeMcp();
   const result = await call(mcp, "engram.set_coding_context", {
     sessionKey: "session-A",
-    projectTag: "blend-supply",
+    projectTag: "acme-webshop",
   });
   assert.deepEqual(result, { ok: true });
   assert.equal(calls.length, 1);
-  assert.equal(calls[0]!.ctx?.projectId, "tag:blend-supply");
+  assert.equal(calls[0]!.ctx?.projectId, "tag:acme-webshop");
   assert.equal(calls[0]!.ctx?.branch, null);
-  assert.equal(calls[0]!.ctx?.rootPath, "tag:blend-supply");
+  assert.equal(calls[0]!.ctx?.rootPath, "tag:acme-webshop");
   assert.equal(calls[0]!.ctx?.defaultBranch, null);
 });
 
@@ -199,16 +199,16 @@ test("set_coding_context with projectTag disambiguates lossy tags", async () => 
   const { mcp, calls } = makeMcp();
   await call(mcp, "engram.set_coding_context", {
     sessionKey: "session-A",
-    projectTag: "blend/supply",
+    projectTag: "acme/webshop",
   });
   await call(mcp, "engram.set_coding_context", {
     sessionKey: "session-B",
-    projectTag: "blend-supply",
+    projectTag: "acme-webshop",
   });
 
   assert.notEqual(calls[0]!.ctx?.projectId, calls[1]!.ctx?.projectId);
-  assert.match(calls[0]!.ctx?.projectId ?? "", /^tag:blend-supply-[0-9a-f]{8}$/);
-  assert.equal(calls[1]!.ctx?.projectId, "tag:blend-supply");
+  assert.match(calls[0]!.ctx?.projectId ?? "", /^tag:acme-webshop-[0-9a-f]{8}$/);
+  assert.equal(calls[1]!.ctx?.projectId, "tag:acme-webshop");
 });
 
 test("set_coding_context with codingContext takes precedence over projectTag", async () => {
@@ -221,7 +221,7 @@ test("set_coding_context with codingContext takes precedence over projectTag", a
       rootPath: "/work/proj",
       defaultBranch: "main",
     },
-    projectTag: "blend-supply",
+    projectTag: "acme-webshop",
   });
   assert.equal(calls.length, 1);
   assert.equal(calls[0]!.ctx?.projectId, "origin:abcd1234");
@@ -242,7 +242,7 @@ test("set_coding_context with codingContext=null clears (even with projectTag pr
   await call(mcp, "engram.set_coding_context", {
     sessionKey: "session-A",
     codingContext: null,
-    projectTag: "blend-supply",
+    projectTag: "acme-webshop",
   });
   assert.equal(calls.length, 1);
   assert.equal(calls[0]!.ctx, null);
@@ -252,11 +252,11 @@ test("set_coding_context projectTag via canonical alias remnic.*", async () => {
   const { mcp, calls } = makeMcp();
   const result = await call(mcp, "remnic.set_coding_context", {
     sessionKey: "session-B",
-    projectTag: "worthington-direct",
+    projectTag: "globex-storefront",
   });
   assert.deepEqual(result, { ok: true });
   assert.equal(calls.length, 1);
-  assert.equal(calls[0]!.ctx?.projectId, "tag:worthington-direct");
+  assert.equal(calls[0]!.ctx?.projectId, "tag:globex-storefront");
 });
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -321,10 +321,10 @@ test("maybeAttachCodingContext: projectTag attaches tag-based context", async ()
     ): Promise<void>;
   }).maybeAttachCodingContext.bind(service);
 
-  await maybeAttach("session-X", { projectTag: "blend-supply" });
+  await maybeAttach("session-X", { projectTag: "acme-webshop" });
   assert.equal(calls.length, 1);
-  assert.equal(calls[0]!.ctx?.projectId, "tag:blend-supply");
-  assert.equal(calls[0]!.ctx?.rootPath, "tag:blend-supply");
+  assert.equal(calls[0]!.ctx?.projectId, "tag:acme-webshop");
+  assert.equal(calls[0]!.ctx?.rootPath, "tag:acme-webshop");
 });
 
 test("maybeAttachCodingContext: skips when session already has context", async () => {
@@ -351,7 +351,7 @@ test("maybeAttachCodingContext: skips when session already has context", async (
     ): Promise<void>;
   }).maybeAttachCodingContext.bind(service);
 
-  await maybeAttach("session-X", { projectTag: "blend-supply" });
+  await maybeAttach("session-X", { projectTag: "acme-webshop" });
   assert.equal(calls.length, 0, "should not overwrite existing context");
 });
 
@@ -379,7 +379,7 @@ test("maybeAttachCodingContext: skips when projectScope disabled", async () => {
     ): Promise<void>;
   }).maybeAttachCodingContext.bind(service);
 
-  await maybeAttach("session-X", { projectTag: "blend-supply" });
+  await maybeAttach("session-X", { projectTag: "acme-webshop" });
   assert.equal(calls.length, 0, "should not attach when projectScope is disabled");
 });
 
@@ -407,7 +407,7 @@ test("maybeAttachCodingContext: skips when no sessionKey", async () => {
     ): Promise<void>;
   }).maybeAttachCodingContext.bind(service);
 
-  await maybeAttach(undefined, { projectTag: "blend-supply" });
+  await maybeAttach(undefined, { projectTag: "acme-webshop" });
   assert.equal(calls.length, 0, "should not attach without sessionKey");
 });
 

--- a/packages/remnic-core/src/issue-1492-coding-mode-consistency.test.ts
+++ b/packages/remnic-core/src/issue-1492-coding-mode-consistency.test.ts
@@ -90,13 +90,13 @@ async function walkCollectDirs(root: string, out: Set<string>): Promise<void> {
 // ─── Symptom A: coding-namespace derivation is stable across write/read ────
 
 test("#1492 Symptom A: a project-scoped session derives ONE stable overlay namespace — the write/read convergence point", () => {
-  // The reporter's scenario: user "pi-geek" in project "Blend/Supply". Both the
+  // The reporter's scenario: user "pi-geek" in project "Acme/Webshop". Both the
   // observe write path and the recall read path must resolve the SAME scoped
   // namespace. They do so by combining the principal base with the project
   // overlay through exactly ONE helper (combineNamespaces); a second ad-hoc
   // combination is what caused the original drift.
   const principal = "pi-geek";
-  const projectId = projectTagProjectId("Blend/Supply");
+  const projectId = projectTagProjectId("Acme/Webshop");
   const codingContext = {
     projectId,
     branch: null,

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -761,7 +761,7 @@ test("MCP day_summary tolerates injected git context keys", async () => {
         namespace: "global",
         timeZone: "America/Chicago",
         cwd: "/tmp/project",
-        projectTag: "blend-supply",
+        projectTag: "acme-webshop",
       },
     },
   });


### PR DESCRIPTION
## Problem

This is a public repository, but the shipped MCP tool schema (`packages/remnic-core/src/access-mcp.ts`) used a real client project name as the example `projectTag` in three tool descriptions — meaning every MCP client that lists Remnic's tools sees a real client name. Twelve test files additionally used two real client names as fixture project tags. Flagged as a follow-up in #1901.

## Change

String-only, no behavior change:

- `access-mcp.ts`: all three tool-description examples now use `acme-webshop`.
- Test fixtures: `acme-webshop` / `Acme/Webshop` / `acme/webshop` replace the dash/slash/display variants — chosen to preserve the lossy-tag hash-disambiguation semantics exercised by `coding-namespace.test.ts` (`tag:acme-webshop` vs `tag:acme-webshop-<hash>`); `globex-storefront` replaces the second name.
- CHANGELOG entry under `[Unreleased] > Fixed`.

Docs examples were already fixed in #1901; together the two PRs remove every occurrence from the repo (verified via case-insensitive grep — remaining `blend` matches are the English word in scoring/rerank code).

## Verification

- All 12 changed test files: 250/250 pass (`tsx --test`)
- `npm run preflight:quick` — OK
- Repo-wide grep for both names outside docs: zero matches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test fixture text only; no production logic, auth, or data paths are modified.
> 
> **Overview**
> Replaces real client project names in the **shipped MCP tool schema** (`access-mcp.ts`) with generic example tags (`acme-webshop`) so MCP clients listing tools no longer see a real customer name in `projectTag` descriptions (recall, set_coding_context, observe).
> 
> **Test and fixture sweep:** a dozen test files now use fictional tags—`Acme/Webshop`, `acme-webshop`, `acme/webshop` (keeping lossy-tag / hash-disambiguation cases) and `globex-storefront` for the second former name—without changing assertions or runtime logic.
> 
> Documents the change under `[Unreleased] > Fixed` in **CHANGELOG.md**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d818d0c72337082d0032cf66f13c0f4981d3faa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->