### PR TITLE
feat(coding-graph): LSP edge reconciliation (#1895)

### DIFF
--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -925,6 +925,99 @@ export class GraphStore {
     return this.queue.schedule(() => this.runUpsertEdges(edges));
   }
 
+  /**
+   * Retire stale LSP-provenance edges for a file (issue #1895).
+   *
+   * The LSP resolution pass re-derives edges from the CURRENT source on each
+   * run. After writing the new `lsp` edges for a file, this method deletes
+   * prior `lsp`-provenance edges owned by that file's nodes whose
+   * `(src, dst, type)` key is NOT in the asserted set. This is the LSP
+   * layer's side of the provenance-lifecycle contract: each layer owns its
+   * own stale-edge retirement (#1894 established that reindex's heuristic
+   * scope never touches `lsp` rows).
+   *
+   * Heuristic, trace, and semantic edges are never touched.
+   *
+   * @returns the number of retired edges.
+   */
+  reconcileLspEdges(
+    filePath: string,
+    assertedEdges: ReadonlyArray<{
+      srcQualifiedName: string;
+      dstQualifiedName: string;
+      type: string;
+    }>,
+  ): number {
+    if (this.closed) return 0;
+    try {
+      // Resolve the file and its nodes.
+      const fileRow = expectRow<{ id: number }>(
+        this.db.prepare("SELECT id FROM files WHERE path = ?").get(filePath),
+        ["id"],
+      );
+      if (!fileRow) return 0;
+      const nodes = expectRows<{ id: string; qualified_name: string }>(
+        this.db
+          .prepare("SELECT id, qualified_name FROM nodes WHERE file_id = ?")
+          .all(fileRow.id),
+        ["id", "qualified_name"],
+      );
+      if (nodes.length === 0) return 0;
+
+      // Build srcQualifiedName → nodeId for this file's nodes.
+      const srcMap = new Map<string, string>();
+      for (const n of nodes) srcMap.set(n.qualified_name, n.id);
+      const nodeIds = nodes.map((n) => n.id);
+
+      // Build the asserted key set (resolved to node IDs).
+      const assertedKeys = new Set<string>();
+      for (const e of assertedEdges) {
+        const srcId = srcMap.get(e.srcQualifiedName);
+        if (!srcId) continue;
+        const dstId = resolveNodeId(e.dstQualifiedName, new Map(), this.db);
+        if (!dstId) continue;
+        assertedKeys.add(`${srcId}\u0000${dstId}\u0000${e.type}`);
+      }
+
+      // Find prior lsp edges owned by this file's nodes.
+      const placeholders = nodeIds.map(() => "?").join(", ");
+      const priorEdges = expectRows<{ src: string; dst: string; type: string }>(
+        this.db
+          .prepare(
+            `SELECT src, dst, type FROM edges
+              WHERE src IN (${placeholders}) AND provenance = 'lsp'`,
+          )
+          .all(...nodeIds),
+        ["src", "dst", "type"],
+      );
+
+      // Delete those NOT in the asserted set.
+      let deleted = 0;
+      const toDelete: Array<[string, string, string]> = [];
+      for (const e of priorEdges) {
+        const key = `${e.src}\u0000${e.dst}\u0000${e.type}`;
+        if (!assertedKeys.has(key)) toDelete.push([e.src, e.dst, e.type]);
+      }
+      if (toDelete.length > 0) {
+        const SQLITE_VARIABLE_LIMIT = 32_766;
+        const PARAMS_PER_TUPLE = 3;
+        const MAX_TUPLES = Math.floor(SQLITE_VARIABLE_LIMIT / PARAMS_PER_TUPLE);
+        for (let i = 0; i < toDelete.length; i += MAX_TUPLES) {
+          const chunk = toDelete.slice(i, i + MAX_TUPLES);
+          const ph = chunk.map(() => "(?, ?, ?)").join(", ");
+          const r = this.db
+            .prepare(`DELETE FROM edges WHERE (src, dst, type) IN (${ph})`)
+            .run(...chunk.flat());
+          deleted += r.changes;
+        }
+      }
+      return deleted;
+    } catch (error) {
+      logWriteFailure(error);
+      return 0;
+    }
+  }
+
   /** Wait for pending writes to drain — test seam. */
   async drain(): Promise<void> {
     await this.queue.drain();

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -964,9 +964,15 @@ export class GraphStore {
       );
       if (nodes.length === 0) return 0;
 
-      // Build srcQualifiedName → nodeId for this file's nodes.
+      // Build srcQualifiedName → nodeId for this file's nodes. Only
+      // include names that appear exactly once (same conservative
+      // ambiguity policy as upsertFileEdges — cursor review on #1914).
+      const nameCount = new Map<string, number>();
+      for (const n of nodes) nameCount.set(n.qualified_name, (nameCount.get(n.qualified_name) ?? 0) + 1);
       const srcMap = new Map<string, string>();
-      for (const n of nodes) srcMap.set(n.qualified_name, n.id);
+      for (const n of nodes) {
+        if (nameCount.get(n.qualified_name) === 1) srcMap.set(n.qualified_name, n.id);
+      }
       const nodeIds = nodes.map((n) => n.id);
 
       // Build the asserted key set (resolved to node IDs).

--- a/packages/coding-graph/src/lsp-reconciliation.test.ts
+++ b/packages/coding-graph/src/lsp-reconciliation.test.ts
@@ -1,0 +1,145 @@
+/**
+ * LSP edge reconciliation tests (issue #1895).
+ *
+ * When the LSP resolution pass re-derives edges from the CURRENT source,
+ * it must retire prior lsp-provenance edges whose (src, dst, type) key it
+ * no longer derives. The store's reconcileLspEdges method does this;
+ * the LSP executor wires it after each file batch's upgrades are applied.
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { GraphStore, type FileIR } from "./graph-store.js";
+
+const span = (startByte: number, endByte: number) => ({ startByte, endByte });
+
+function fileIR(overrides: Partial<FileIR> & { path: string }): FileIR {
+  return {
+    language: "typescript",
+    contentHash: `h-${overrides.path}`,
+    symbols: [],
+    imports: [],
+    exports: [],
+    callSites: [],
+    routes: [],
+    ...overrides,
+  } as FileIR;
+}
+
+async function openTempStore(): Promise<{ store: GraphStore; dir: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "cg-lsp-recon-"));
+  const store = await GraphStore.open({ dbPath: path.join(dir, "graph.sqlite") });
+  return { store, dir };
+}
+
+const HEUR = { confidence: 0.9, provenance: "heuristic" as const };
+const LSP = { confidence: 1, provenance: "lsp" as const };
+
+test("reconcile retires lsp edges no longer derived; keeps re-derived ones", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    // Seed: greet calls format (heuristic) + helper (lsp-upgraded).
+    await store.upsertFileBatch([
+      {
+        ...fileIR({
+          path: "main.ts",
+          symbols: [
+            { kind: "function", name: "greet", qualifiedName: "greet", span: span(0, 70) },
+            { kind: "function", name: "format", qualifiedName: "format", span: span(71, 132) },
+            { kind: "function", name: "helper", qualifiedName: "helper", span: span(133, 190) },
+          ],
+        }),
+        edges: [
+          { srcQualifiedName: "greet", dstQualifiedName: "format", type: "CALLS", ...HEUR },
+          { srcQualifiedName: "greet", dstQualifiedName: "helper", type: "CALLS", ...HEUR },
+        ],
+      },
+    ]);
+    // LSP upgraded both.
+    await store.upsertEdges([
+      { srcQualifiedName: "greet", dstQualifiedName: "format", type: "CALLS", ...LSP },
+      { srcQualifiedName: "greet", dstQualifiedName: "helper", type: "CALLS", ...LSP },
+    ]);
+
+    let stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.equal(stats.stats.edges, 2, "seed: 2 lsp-upgraded CALLS edges");
+
+    // LSP re-run derives ONLY greet->format (helper call was removed).
+    // Reconcile: retire lsp edges for main.ts NOT in the new set.
+    const deleted = store.reconcileLspEdges("main.ts", [
+      { srcQualifiedName: "greet", dstQualifiedName: "format", type: "CALLS" },
+    ]);
+    assert.equal(deleted, 1, "retired the stale greet->helper lsp edge");
+
+    stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.equal(stats.stats.edges, 1, "only the re-derived edge remains");
+    assert.deepEqual(stats.stats.edgesByType, { CALLS: 1 });
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("reconcile preserves heuristic edges and trace edges untouched", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    await store.upsertFileBatch([
+      {
+        ...fileIR({
+          path: "main.ts",
+          symbols: [
+            { kind: "function", name: "greet", qualifiedName: "greet", span: span(0, 70) },
+            { kind: "function", name: "format", qualifiedName: "format", span: span(71, 132) },
+          ],
+        }),
+        edges: [
+          { srcQualifiedName: "greet", dstQualifiedName: "format", type: "CALLS", ...HEUR },
+        ],
+      },
+    ]);
+    await store.upsertEdges([
+      { srcQualifiedName: "greet", dstQualifiedName: "format", type: "CALLS", ...LSP },
+      { srcQualifiedName: "greet", dstQualifiedName: "format", type: "HTTP_CALLS", confidence: 1, provenance: "trace" },
+    ]);
+
+    // LSP re-run found nothing for main.ts → reconcile with empty asserted set.
+    const deleted = store.reconcileLspEdges("main.ts", []);
+    assert.equal(deleted, 1, "retired the lsp CALLS edge");
+
+    const stats = await store.schemaStats();
+    assert.ok(stats.ok);
+    assert.deepEqual(stats.stats.edgesByType, { HTTP_CALLS: 1 }, "trace edge untouched");
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("reconcile with no prior lsp edges is a no-op", async () => {
+  const { store, dir } = await openTempStore();
+  try {
+    await store.upsertFileBatch([
+      {
+        ...fileIR({
+          path: "main.ts",
+          symbols: [
+            { kind: "function", name: "greet", qualifiedName: "greet", span: span(0, 70) },
+          ],
+        }),
+        edges: [],
+      },
+    ]);
+    const deleted = store.reconcileLspEdges("main.ts", [
+      { srcQualifiedName: "greet", dstQualifiedName: "missing", type: "CALLS" },
+    ]);
+    assert.equal(deleted, 0);
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/coding-graph/src/lsp/resolution.ts
+++ b/packages/coding-graph/src/lsp/resolution.ts
@@ -301,6 +301,13 @@ export async function executeLspResolution(
     // Send all definition requests for this file, collecting upgrades.
     const upgrades: EdgeUpgrade[] = [];
     let batchFailed = false;
+    // Track whether EVERY request in this file batch was processed to a
+    // definitive result (resolved or definitively-not-found). A timeout,
+    // request_error, or server-crash mid-batch makes the batch
+    // non-exhaustive: reconciliation must NOT run because the asserted
+    // set would be incomplete, deleting valid lsp edges for call sites
+    // that were never queried (cursor High + codex P1 on #1914).
+    let batchExhaustive = true;
 
     // Open the document with full text before querying definitions (LSP 3.17).
     // The server needs the content to answer definition requests accurately.
@@ -343,6 +350,10 @@ export async function executeLspResolution(
           break;
         }
         // request_timeout / request_error — count as unresolved, continue.
+        // request_timeout / request_error — count as unresolved.
+        // The batch is non-exhaustive: this call site's LSP result is
+        // indeterminate, so reconciliation for this file is suppressed.
+        batchExhaustive = false;
         unresolved++;
         continue;
       }
@@ -386,10 +397,11 @@ export async function executeLspResolution(
         await applyUpgrades(upgrades);
         upgraded += upgrades.length;
       }
-      // Reconcile regardless of upgrade count: an empty upgrade list
-      // still asserts "no lsp edges for this file's current call sites",
-      // so prior lsp rows for removed calls retire.
-      if (options.reconcileLspEdges) {
+      // Reconcile ONLY when the batch was exhaustive (every call site
+      // processed to a definitive result). A partial batch's asserted
+      // set would be incomplete and retire valid edges for unprocessed
+      // call sites (cursor High + codex P1 on #1914).
+      if (batchExhaustive && options.reconcileLspEdges) {
         options.reconcileLspEdges(
           filePath,
           upgrades.map((u) => ({

--- a/packages/coding-graph/src/lsp/resolution.ts
+++ b/packages/coding-graph/src/lsp/resolution.ts
@@ -219,6 +219,21 @@ export interface ResolveOptions {
     upgrades: readonly EdgeUpgrade[],
   ) => Promise<void>;
   /**
+   * Optional stale-edge reconciliation (issue #1895): after applying a
+   * file batch's upgrades, the caller retires prior `lsp`-provenance
+   * edges owned by that file whose `(src, dst, type)` keys the current
+   * batch does NOT assert. When absent, stale lsp edges persist until
+   * node pruning — the soft-fail path documented in #1894.
+   */
+  readonly reconcileLspEdges?: (
+    filePath: string,
+    assertedEdges: ReadonlyArray<{
+      srcQualifiedName: string;
+      dstQualifiedName: string;
+      type: string;
+    }>,
+  ) => void;
+  /**
    * Workspace root for resolving repo-relative file paths to absolute LSP
    * URIs and normalizing returned URIs back to repo-relative paths.
    */
@@ -362,21 +377,35 @@ export async function executeLspResolution(
       break;
     }
 
-    // Apply upgrades transactionally per file batch. If the apply throws,
-    // zero upgrades from this batch persist (rule 25 — the applyUpgrades
+    // Apply upgrades transactionally per file batch, then reconcile stale
+    // lsp edges for this file (issue #1895). If the apply throws, zero
+    // upgrades from this batch persist (rule 25 — the applyUpgrades
     // callback MUST be transactional).
-    if (upgrades.length > 0) {
-      try {
+    try {
+      if (upgrades.length > 0) {
         await applyUpgrades(upgrades);
         upgraded += upgrades.length;
-      } catch {
-        // The apply failed — degrade but don't crash. Upgrades from this
-        // batch are lost (the callback's transaction rolled back). Edges
-        // from already-applied batches survive (they were in separate
-        // transactions — this is the documented per-batch isolation).
-        // Count the lost upgrades as unresolved for reporting.
-        unresolved += upgrades.length;
       }
+      // Reconcile regardless of upgrade count: an empty upgrade list
+      // still asserts "no lsp edges for this file's current call sites",
+      // so prior lsp rows for removed calls retire.
+      if (options.reconcileLspEdges) {
+        options.reconcileLspEdges(
+          filePath,
+          upgrades.map((u) => ({
+            srcQualifiedName: u.srcQualifiedName,
+            dstQualifiedName: u.dstQualifiedName,
+            type: u.type,
+          })),
+        );
+      }
+    } catch {
+      // The apply failed — degrade but don't crash. Upgrades from this
+      // batch are lost (the callback's transaction rolled back). Edges
+      // from already-applied batches survive (they were in separate
+      // transactions — this is the documented per-batch isolation).
+      // Count the lost upgrades as unresolved for reporting.
+      unresolved += upgrades.length;
     }
   }
 


### PR DESCRIPTION
Closes #1895. Each provenance layer owns its lifecycle: reindex owns heuristic edges only (#1894); this PR gives the LSP pass its own stale-edge retirement so vanished-call lsp rows don't linger.

**GraphStore.reconcileLspEdges(filePath, assertedEdges)**: deletes prior lsp-provenance edges owned by a file's nodes whose (src, dst, type) key is NOT in the asserted set. Heuristic/trace/semantic edges are never touched.

**LSP executor wiring**: `executeLspResolution` calls the new optional `ResolveOptions.reconcileLspEdges` callback after each file batch's upgrades are applied — including when the upgrade list is empty (a file whose calls all disappeared still asserts 'no lsp edges here', retiring stale rows).

3 new tests covering retire-stale-keep-rederived, preserve-heuristic-and-trace, and no-op-when-no-prior-lsp. 476/476 package tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes graph edge lifecycle on the LSP path; incorrect reconciliation could drop valid `lsp` edges, though exhaustive-batch gating and provenance scoping limit blast radius.
> 
> **Overview**
> Adds **LSP-owned stale-edge retirement** so removed call sites do not leave old `lsp` rows in the graph after each resolution pass (complementing reindex’s heuristic-only scope from #1894).
> 
> **`GraphStore.reconcileLspEdges`** deletes prior `provenance = 'lsp'` edges whose source nodes belong to the given file and whose `(src, dst, type)` key is not in the asserted set; heuristic, trace, and semantic edges are unchanged. Deletes are chunked for SQLite bind limits; ambiguous local qualified names are skipped like the file-batch edge path.
> 
> **`executeLspResolution`** gains an optional `reconcileLspEdges` callback, invoked after each file batch’s upgrades (including when the upgrade list is empty). Reconciliation runs only when the batch is **exhaustive**—timeouts/request errors mark the batch non-exhaustive so partial runs cannot delete valid edges for unqueried call sites.
> 
> Three tests cover retire-stale/keep-rederived, non-`lsp` edges preserved, and no-op when no prior LSP edges exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72638c39b2a45e05cb51fcf1d13b28dded57bc33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->