### PR TITLE
docs(bench): quarantine stale benchmark claims

### DIFF
--- a/docs/benchmarks/memcorrect.md
+++ b/docs/benchmarks/memcorrect.md
@@ -178,6 +178,24 @@ The prompt-only baseline must score near-zero on
 must not. If a Remnic run fails that floor, **file the bugs against
 #1580/#1579 — do not tune the benchmark**.
 
+### Old failed runs
+
+Two full runs from 2026-07-13 stay in the repo. They are failed test records.
+They are not lab wins. They are not proof for OpenAI Build Week.
+
+- [`2026-07-13-memcorrect-v1-prompt-only-baseline-9485f44.json`](results/2026-07-13-memcorrect-v1-prompt-only-baseline-9485f44.json)
+  is the expected prompt-only floor. It scored `uptake_at_next=0`,
+  `non_resurrection=0`, and `false_apply=1`.
+- [`2026-07-13-memcorrect-v1-remnic-native-9485f44.json`](results/2026-07-13-memcorrect-v1-remnic-native-9485f44.json)
+  got the same bad correction scores. Its `non_resurrection=0` result breaks
+  the rule above.
+
+The Remnic file shows a bug at commit `9485f4482`. It does not show a pass.
+Keep both files so we can trace and fix the bug. Do not post them as new
+leaderboard results. Do not use them for a contest claim. A new run can replace
+this status only when it passes the stated gates, including the
+non-resurrection floor.
+
 ## Submitting third-party results
 
 1. Implement `MemCorrectSystemAdapter` for your system (see the contract
@@ -194,9 +212,8 @@ must not. If a Remnic run fails that floor, **file the bugs against
 
 - PR 1 (generator + schema) — landed.
 - PR 2 (runner + metrics) — landed.
-- PR 3 (adapters) — baseline + Remnic-native wrapper landed. **Lab
-  artifacts are not committed in this PR**: the local-lab Tier-L run
-  requires the lab GPU (Jarvis), which is intentionally out of scope for
-  the harness PR. Run it on the lab box and commit both artifacts per the
-  issue's PR 3 acceptance.
+- PR 3 (adapters): baseline + Remnic-native wrapper landed. Both saved runs are
+  old failure evidence. The prompt-only run fails as expected. The Remnic run
+  also fails the required `non_resurrection` test. A fresh passing run is still
+  due. The old files do not meet PR 3 acceptance.
 - PR 4 (this doc + leaderboard-export wiring) — landed.

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -1,5 +1,12 @@
 # Engram Eval Suite — Benchmark Results
 
+> **Old results: not current or Build Week proof.** This page keeps a March
+> 2026 Engram v9.0 test snapshot and its first notes. It is not a current
+> Remnic report. It is not a valid leaderboard. It is not proof for OpenAI
+> Build Week. MemoryArena used a bad score method that let F1 exceed 1.0. Do
+> not quote its `0.704` headline or the broad win claims as valid. Use new,
+> provenance-locked runs for current claims.
+
 **Engram version:** 9.0.89+
 **Git SHA:** 56a50a9
 **Date:** 2026-03-15


### PR DESCRIPTION
## Summary
- label the July 13 MemCorrect artifacts as historical failure evidence
- prevent the invalid March MemoryArena scorer and stale headline from being used as current or Build Week claims
- preserve the records for traceability while requiring fresh passing evidence

## Verification
- npm run preflight:quick
- docs parity and scoped voice checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only policy and provenance clarifications; no runtime, scoring, or benchmark harness changes.
> 
> **Overview**
> Documentation now **blocks stale benchmark artifacts from being treated as current wins** or OpenAI Build Week proof, while keeping them in-repo for traceability.
> 
> **MemCorrect** (`docs/benchmarks/memcorrect.md`): Adds an **Old failed runs** section for the two 2026-07-13 JSON artifacts—prompt-only baseline (expected floor) and Remnic-native (`non_resurrection=0` violates the sanity contract). States they are failure records at commit `9485f4482`, not leaderboard or contest material, and that PR 3 acceptance still needs a **fresh passing run**.
> 
> **Engram evals** (`evals/RESULTS.md`): Adds a top **callout** that the March 2026 snapshot is not a current Remnic report or valid leaderboard; **MemoryArena’s `0.704` headline and broad win claims must not be quoted** because the scorer allowed F1 &gt; 1.0—current claims require new provenance-locked runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24db7bc53e43978a5b70f3643023eecacc7fbd98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->