### PR TITLE
test(bench): harden packaged sandbox receipt

### DIFF
--- a/scripts/verify-build-week-sandbox.mjs
+++ b/scripts/verify-build-week-sandbox.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   existsSync,
   mkdtempSync,
@@ -55,6 +56,68 @@ const coldEnv = {
   npm_config_update_notifier: "false",
   REMNIC_BENCH_GIT_SHA: process.env.REMNIC_BENCH_GIT_SHA ?? "packaged-sandbox",
 };
+
+for (const key of Object.keys(coldEnv)) {
+  if (
+    /(?:^|_)(?:API_KEY|AUTH_TOKEN|BEARER_TOKEN)$/i.test(key) ||
+    /^(?:CLAUDE_CODE_OAUTH_TOKEN|OPENAI_ACCESS_TOKEN|CODEX_API_KEY)$/i.test(key)
+  ) {
+    delete coldEnv[key];
+  }
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "undefined";
+}
+
+function manifestArtifactIdentity(manifest) {
+  return {
+    schemaVersion: manifest.schemaVersion,
+    run: {
+      id: manifest.run.id,
+      ...(manifest.run.mode ? { mode: manifest.run.mode } : {}),
+      selectedBenchmarks: manifest.run.selectedBenchmarks,
+      runtimeProfiles: manifest.run.runtimeProfiles,
+      selectedWorkItems: manifest.run.selectedWorkItems,
+      ...(manifest.run.limit !== undefined ? { limit: manifest.run.limit } : {}),
+      ...(manifest.run.seed !== undefined ? { seed: manifest.run.seed } : {}),
+    },
+    git: {
+      commit: manifest.git.commit,
+      shortCommit: manifest.git.shortCommit,
+    },
+    command: {
+      argv: manifest.command.argv,
+      envKeys: manifest.command.envKeys,
+    },
+    environment: {
+      platform: manifest.environment.platform,
+      arch: manifest.environment.arch,
+      nodeVersion: manifest.environment.nodeVersion,
+      ...(manifest.environment.packageManager
+        ? { packageManager: manifest.environment.packageManager }
+        : {}),
+    },
+    ...(manifest.qmd ? { qmd: manifest.qmd } : {}),
+    configFiles: manifest.configFiles,
+    datasets: manifest.datasets,
+    results: manifest.results,
+    ...(manifest.codexCredit ? { codexCredit: manifest.codexCredit } : {}),
+  };
+}
 
 function shellQuote(value) {
   return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value)
@@ -218,7 +281,43 @@ try {
   if (mcpArtifact.result?.results?.aggregates?.uptake_at_next?.mean !== 1) {
     throw new Error("MemCorrect packaged demo did not accept the correction at the next turn");
   }
-  assertNonEmptyFile(path.join(mcpResultsDir, "MANIFEST.json"), "MemCorrect manifest");
+  if (mcpArtifact.result?.results?.aggregates?.non_resurrection?.mean !== 0) {
+    throw new Error("MemCorrect packaged demo did not reproduce the expected stale-memory resurrection");
+  }
+  const manifestPath = path.join(mcpResultsDir, "MANIFEST.json");
+  assertNonEmptyFile(manifestPath, "MemCorrect manifest");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const manifestResult = manifest?.results?.find(
+    (entry) => entry?.resultId === mcpArtifact.result.meta.id,
+  );
+  if (!manifestResult || manifestResult.judge !== null) {
+    throw new Error("MemCorrect packaged smoke did not prove a keyless, no-judge run");
+  }
+  const expectedResultPath = path.relative(mcpResultsDir, mcpArtifact.path).split(path.sep).join("/");
+  const resultBytes = readFileSync(mcpArtifact.path);
+  if (
+    manifestResult.path !== expectedResultPath ||
+    manifestResult.benchmark !== "memcorrect-v1" ||
+    manifestResult.mode !== mcpArtifact.result.meta.mode ||
+    manifestResult.sizeBytes !== resultBytes.length ||
+    manifestResult.sha256 !== sha256(resultBytes)
+  ) {
+    throw new Error("MemCorrect manifest is not bound to the packaged result artifact");
+  }
+  const expectedArtifactHash = sha256(stableStringify(manifestArtifactIdentity(manifest)));
+  if (manifest.artifactHash !== expectedArtifactHash) {
+    throw new Error("MemCorrect manifest artifactHash does not match its canonical contents");
+  }
+  const manifestDataset = manifest?.datasets?.find(
+    (entry) => entry?.benchmark === "memcorrect-v1",
+  );
+  if (
+    !manifestDataset ||
+    manifestDataset.status !== "not-provided" ||
+    manifestDataset.fileCount !== 0
+  ) {
+    throw new Error("MemCorrect packaged smoke unexpectedly depended on dataset files");
+  }
 
   const listed = remnic(["bench", "runs", "list", "--results-dir", mcpResultsDir, "--json"], {
     capture: true,
@@ -245,6 +344,16 @@ try {
   const report = readFileSync(reportPath, "utf8");
   if (!report.includes("Correction ledger") || !report.includes("Provenance")) {
     throw new Error("HTML export is not the Build Week memory report card");
+  }
+  if (
+    /\b(?:src|href|data)\s*=\s*["']?\s*(?:https?:)?\/\//i.test(report) ||
+    /@import\s+(?:url\()?\s*["']?\s*(?:https?:)?\/\//i.test(report) ||
+    /url\(\s*["']?\s*(?:https?:)?\/\//i.test(report)
+  ) {
+    throw new Error("HTML report card is not self-contained");
+  }
+  if (!report.includes(manifest.artifactHash)) {
+    throw new Error("HTML report card does not identify the verified manifest artifact hash");
   }
 
   const installed = run("npm", ["ls", "-g", "--prefix", prefixDir, "--depth=0"], {

--- a/scripts/verify-build-week-sandbox.mjs
+++ b/scripts/verify-build-week-sandbox.mjs
@@ -47,24 +47,19 @@ for (const dir of [packDir, prefixDir, homeDir, workDir, npmCacheDir]) {
   mkdirSync(dir, { recursive: true });
 }
 
-const coldEnv = {
-  ...process.env,
+const coldEnv = Object.fromEntries(
+  ["PATH", "PATHEXT", "SystemRoot", "ComSpec", "WINDIR", "TMPDIR", "TMP", "TEMP", "LANG", "LC_ALL", "CI"]
+    .filter((key) => process.env[key] !== undefined)
+    .map((key) => [key, process.env[key]]),
+);
+Object.assign(coldEnv, {
   HOME: homeDir,
   npm_config_cache: npmCacheDir,
   npm_config_audit: "false",
   npm_config_fund: "false",
   npm_config_update_notifier: "false",
   REMNIC_BENCH_GIT_SHA: process.env.REMNIC_BENCH_GIT_SHA ?? "packaged-sandbox",
-};
-
-for (const key of Object.keys(coldEnv)) {
-  if (
-    /(?:^|_)(?:API_KEY|AUTH_TOKEN|BEARER_TOKEN)$/i.test(key) ||
-    /^(?:CLAUDE_CODE_OAUTH_TOKEN|OPENAI_ACCESS_TOKEN|CODEX_API_KEY)$/i.test(key)
-  ) {
-    delete coldEnv[key];
-  }
-}
+});
 
 function sha256(value) {
   return createHash("sha256").update(value).digest("hex");
@@ -117,6 +112,32 @@ function manifestArtifactIdentity(manifest) {
     results: manifest.results,
     ...(manifest.codexCredit ? { codexCredit: manifest.codexCredit } : {}),
   };
+}
+
+function assertSelfContainedReport(report) {
+  const attributePattern = /\b(?:src|href|data|poster|srcset)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/gi;
+  for (const match of report.matchAll(attributePattern)) {
+    const reference = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+    if (reference && !reference.startsWith("#") && !reference.startsWith("data:")) {
+      throw new Error(`HTML report card references an external asset: ${reference}`);
+    }
+  }
+
+  const cssUrlPattern = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^\s"')]+))\s*\)/gi;
+  for (const match of report.matchAll(cssUrlPattern)) {
+    const reference = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+    if (reference && !reference.startsWith("#") && !reference.startsWith("data:")) {
+      throw new Error(`HTML report card CSS references an external asset: ${reference}`);
+    }
+  }
+
+  const cssImportPattern = /@import\s+(?:url\()?\s*(?:"([^"]*)"|'([^']*)'|([^\s"');]+))/gi;
+  for (const match of report.matchAll(cssImportPattern)) {
+    const reference = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+    if (reference && !reference.startsWith("data:")) {
+      throw new Error(`HTML report card imports an external asset: ${reference}`);
+    }
+  }
 }
 
 function shellQuote(value) {
@@ -345,13 +366,7 @@ try {
   if (!report.includes("Correction ledger") || !report.includes("Provenance")) {
     throw new Error("HTML export is not the Build Week memory report card");
   }
-  if (
-    /\b(?:src|href|data)\s*=\s*["']?\s*(?:https?:)?\/\//i.test(report) ||
-    /@import\s+(?:url\()?\s*["']?\s*(?:https?:)?\/\//i.test(report) ||
-    /url\(\s*["']?\s*(?:https?:)?\/\//i.test(report)
-  ) {
-    throw new Error("HTML report card is not self-contained");
-  }
+  assertSelfContainedReport(report);
   if (!report.includes(manifest.artifactHash)) {
     throw new Error("HTML report card does not identify the verified manifest artifact hash");
   }


### PR DESCRIPTION
## Summary
- strip provider credentials from the cold packaged sandbox
- bind the MemCorrect manifest to the result bytes and verify its canonical artifact hash
- require the offline report to embed provenance without external assets

## Verification
- node scripts/verify-build-week-sandbox.mjs --skip-build --keep
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the packaged sandbox verification script and test assertions; no production runtime or auth paths are modified.
> 
> **Overview**
> **Hardens the Build Week packaged sandbox verifier** so cold installs exercise a credential-stripped environment and stronger receipts for MemCorrect runs.
> 
> The sandbox **`coldEnv`** no longer spreads all of `process.env`; it whitelists OS/npm essentials plus bench-specific npm flags, reducing the chance provider secrets leak into the packaged smoke.
> 
> After the MemCorrect MCP quick run, assertions now cover **`non_resurrection`** (expected stale-memory resurrection), a **keyless no-judge** manifest (`judge === null`), **manifest ↔ result binding** (relative path, size, per-file `sha256`), **canonical `artifactHash`** via `stableStringify(manifestArtifactIdentity(...))`, and **zero dataset files** (`not-provided`).
> 
> HTML export checks add **`assertSelfContainedReport`** (no external `src`/`href`/CSS `url()`/`@import` assets) and require the report to embed the verified **`manifest.artifactHash`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b33dca0191a71cfe773c3ec53c6873fcaa96b7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->