### PR TITLE
docs(build-week): refresh submission evidence ledger

### DIFF
--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -89,36 +89,56 @@ and Codex session evidence at submission time.
   below), so judges can run the tool without rebuilding anything.
 
 Delivered implementation commit:
-[`fb295ff8`](https://github.com/joshuaswarren/remnic/commit/fb295ff8fb9cb66c7f4bcde793d4ce63aa095ae1)
+[`2c2f63be`](https://github.com/joshuaswarren/remnic/commit/2c2f63be98ad3d8b40bca96567de067e11d4e56d)
 (MCP adapter, Responses judge provider, and report card).
 
 Additional in-window receipts:
 
-- [`43bf0b8d`](https://github.com/joshuaswarren/remnic/commit/43bf0b8d)
+- [`e758e275`](https://github.com/joshuaswarren/remnic/commit/e758e27552c531e428ad5997cafb3c8870200005)
   pins the judge data. It also adds a repeatable bootstrap confidence range.
-- [`c8e5837f`](https://github.com/joshuaswarren/remnic/commit/c8e5837f)
+- [`e698b144`](https://github.com/joshuaswarren/remnic/commit/e698b14409f8022f42b08097fe6834cace47a99b)
   adds the judge instructions, honest Devpost draft, and demo script.
-- [`f2496bdc`](https://github.com/joshuaswarren/remnic/commit/f2496bdc)
+- [`b12307c5`](https://github.com/joshuaswarren/remnic/commit/b12307c51a8a9b1bff4f314a2f1ae93daa09e991)
   adds the cold packed-tarball test. It passed on Linux x64 with Node 22.23.1
   on 2026-07-14. The run ended in `PACKAGED_SANDBOX_OK`. It used
   `adapterMode=mcp`, saved one task with `uptake_at_next=1`, and made a
   15,144-byte report. Run it with
   `node scripts/verify-build-week-sandbox.mjs`.
-- [`3777d3ac`](https://github.com/joshuaswarren/remnic/commit/3777d3ac)
+- [`366b6143`](https://github.com/joshuaswarren/remnic/commit/366b61436e5b5e960f59c0480a387ebce70a9629)
   makes provider failures fail closed. A rejected GPT-5.6 smoke can no longer
   produce a complete-looking artifact or exit successfully; 47 focused tests
   cover partial status, legitimate negative scores, empty results, and
   promotion refusal.
-- [`4a6a8192`](https://github.com/joshuaswarren/remnic/commit/4a6a8192),
-  [`6aa5d22f`](https://github.com/joshuaswarren/remnic/commit/6aa5d22f), and
-  [`2e692843`](https://github.com/joshuaswarren/remnic/commit/2e692843)
+- [`7ea9657a`](https://github.com/joshuaswarren/remnic/commit/7ea9657a61599cde1ee3b18e145324652049e5de),
+  [`3b301c41`](https://github.com/joshuaswarren/remnic/commit/3b301c417ffe42d878f76e14a46315ee1aafdfad), and
+  [`3d42b455`](https://github.com/joshuaswarren/remnic/commit/3d42b455ec0b7e2762c44aa760991e976e3f7342)
   are in-window research hardening beyond the submission core: bounded
   cross-session temporal recall, an evidence-bounded LoCoMo category
   diagnosis, and a default-off empty-recall abstention foundation. They are
   not presented as benchmark lifts because the required acceptance artifacts
   are still operator-gated.
-- [`4b17970e`](https://github.com/joshuaswarren/remnic/commit/4b17970e)
+- [`e3ffce20`](https://github.com/joshuaswarren/remnic/commit/e3ffce20096e51916c33e82562d9f5c194fc495f)
   adds the narrowly tested manifest-only Dependabot review-gate exception.
+- [`53db4aeb`](https://github.com/joshuaswarren/remnic/commit/53db4aebd885947b953e0d35ee73e26f6405b010),
+  [`6483f2da`](https://github.com/joshuaswarren/remnic/commit/6483f2da407af6531c2b3a90fc86a1e7d4689e93), and
+  [`1db7d86f`](https://github.com/joshuaswarren/remnic/commit/1db7d86f27f230e282b32d7c4d7e83c96117d8bd)
+  add the one-shot Codex CLI path, enforce its credit cap, and add safety checks
+  for bounded frontier runs.
+- [`164f925d`](https://github.com/joshuaswarren/remnic/commit/164f925d559f360fe9c9cb85f3f102fa7959b7a9),
+  [`bcc11197`](https://github.com/joshuaswarren/remnic/commit/bcc1119734d7c281975478268c1fc51292ea404f),
+  [`50fa56b0`](https://github.com/joshuaswarren/remnic/commit/50fa56b01711c6df8b7e138f17e97e94c31a2ab0), and
+  [`ab849733`](https://github.com/joshuaswarren/remnic/commit/ab84973365935418f938fd0ed9510d3b4a95e1c7)
+  add the LoCoMo diagnosis tool, pin staged dataset paths, add safe credit
+  recovery, and let judge calibration resume after a stop.
+
+On July 15, merged head `ab849733` passed the cold package test:
+`node scripts/verify-build-week-sandbox.mjs --keep`. The test put version 9.6.24
+in a clean global prefix. The host was Linux x86_64 with Node 22.23.1. The test
+ended in `PACKAGED_SANDBOX_OK`. This was a keyless, one-task MCP run. No judge
+or provider ran. It scored `uptake_at_next=1` and `non_resurrection=0`. It also
+wrote a 15,144-byte offline HTML report. The focused results-store test passed
+20 of 20 tests. This receipt proves the packaged keyless path and report
+export. It is not a paid-model result.
 
 Codex `/feedback` session ID for the core functionality:
 **PENDING OPERATOR INPUT.** Run `/feedback` in the primary Codex session and
@@ -131,12 +151,12 @@ full-run claim.
 
 ## How Codex and GPT-5.6 were used
 
-Codex built the adapter, provider, report card, and sandbox work above.
-Exploration of the existing adapter seam, implementation, tests, and
-iteration all ran inside Codex sessions during the window. The README and
-the `/feedback` session ID document where Codex sped up the work. They also
-record the key design calls: the adapter contract shape, the scoring
-rubric, and the report layout.
+Codex built the new adapter, provider, report card, and sandbox. Codex also
+reviewed that work. It explored the old adapter seam, wrote the code and tests,
+and handled each revision during the event. The README records
+where Codex sped up the work. The `/feedback` session ID remains operator input
+and will be added before submission. Those receipts show three key choices: the
+adapter shape, the scoring rubric, and the report layout.
 
 GPT-5.6 is part of the product. It can act as an opt-in judge with strict
 structured output. There are two provider paths. The optional Responses API
@@ -237,7 +257,7 @@ queued internal work can finish after the last scored task.
 After the npm packages are installed, no datasets, API keys, or network:
 
 ```bash
-npm install -g @remnic/cli @remnic/bench
+npm install -g @remnic/cli@9.6.24 @remnic/bench@9.6.24
 remnic bench run --quick memcorrect-v1 --adapter mcp --mcp-demo
 remnic bench runs list
 remnic bench export <run-id> --format html --output ./memcorrect-report.html
@@ -248,7 +268,7 @@ no dataset, API key, or network. It exercises the real MCP transport and
 correction contract. It is a product smoke test, not a publishable backend or
 model result.
 
-Until the Build Week revision is published to npm, use the source checkout:
+To test a development checkout instead of the published packages:
 
 ```bash
 pnpm install --frozen-lockfile
@@ -276,21 +296,22 @@ in `docs/paper/repro-appendix.md`.
 | Environment | Build Week support statement |
 |---|---|
 | Node.js | 22.12 or newer |
-| Linux | Source-checkout and packed-tarball global-prefix paths verified on Linux x64 |
+| Linux | Source-checkout and version 9.6.24 packed-tarball global-prefix paths verified on Linux x64 |
 | macOS | Supported by the Node CLI; final global-install receipt pending |
 | Windows | Use WSL2 for the claimed path; native Windows is not claimed as verified |
 | MCP transport | stdio and Streamable HTTP |
 
-The packed-tarball cold-install receipt is complete. Public npm version `9.6.17`
-predates this work. A release with the commits above must ship before the
-deadline. After that release, rerun the same test and record the version here.
+The version 9.6.24 packed-tarball cold-install receipt is complete on Linux.
+Both `@remnic/cli` and `@remnic/bench` are published at 9.6.24. This receipt
+does not claim a macOS or native Windows verification.
 
 ## Honest framing of the novelty claim
 
 MemCorrect's contribution is a composition and protocol claim. It is a
-one-command harness that scores any memory backend on correction acceptance
-and stale-memory harm, with provenance-locked artifacts. It is not a claim
-to be first to measure memory correction. StateBench, STALE, MemSyco-Bench,
+one-command harness that scores Remnic or another backend implementing its
+supported adapter contract on correction acceptance and stale-memory harm,
+with provenance-locked artifacts. It is not a claim to be first to measure
+memory correction. StateBench, STALE, MemSyco-Bench,
 MemStrata, and MemoryAgentBench are prior art. We engage them in
 `docs/paper/related-work.md`.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,33 @@ There is a useful split in AI memory between **memory backends** (extract facts,
 | Built-in agent memory that does not scale | Hybrid search, lifecycle management, namespaces, and governance |
 | Third-party memory services that cost money and hold your data | Everything stays local: your filesystem, your rules |
 
+## MemCorrect, our OpenAI Build Week entry
+
+Remnic's Developer Tools entry is **MemCorrect**. It tests Remnic or another
+memory backend that uses the same adapter contract. The test asks three
+questions: Did recall find the right fact? Did the memory accept a correction?
+Did the stale fact stay gone?
+
+```bash
+npm install -g @remnic/cli@9.6.24 @remnic/bench@9.6.24
+remnic bench run --quick memcorrect-v1 --adapter mcp --mcp-demo
+remnic bench runs list
+remnic bench export <run-id> --format html --output ./memcorrect-report.html
+```
+
+After installation, this quick path needs no dataset, API key, or network. It
+starts the packaged stdio MCP demo and tests the generic MCP adapter. It also
+writes an offline HTML report. We tested the 9.6.24 packed tarballs from a clean
+global prefix on Linux x86_64 with Node 22.23.1.
+
+During Build Week, we added the MCP adapter, an optional GPT-5.6 judge through
+the OpenAI Responses API, and the report card. Codex helped us study the old
+adapter seam, write and test the new path, and review it. Remnic and the first
+benchmark harness predate the event. The
+[submission evidence ledger](HACKATHON.md) draws that line commit by commit. It
+also leaves the Codex `/feedback`, paid frontier artifact, video, and final
+submission marked as pending.
+
 ## Quick start
 
 ### Prerequisites

--- a/docs/hackathon/demo-script.md
+++ b/docs/hackathon/demo-script.md
@@ -3,10 +3,10 @@
 Target duration: 2 minutes 40 seconds. Hard limit: 3 minutes.
 
 Operator gate before recording: replace every bracketed placeholder used in the
-video with real evidence. Do not record until the npm cold-install path and
-Codex `/feedback` session ID exist. If the GPT-5.6 frontier artifact does not
-land, omit that result and its URL rather than substituting another model or
-turning a bounded trial into a full-run claim.
+video with real evidence. The version 9.6.24 packed-tarball path is verified on
+Linux x86_64. The Codex `/feedback` session ID is still required. If the GPT-5.6
+frontier artifact does not land, omit that result and its URL. Do not substitute
+another model or turn a bounded trial into a full-run claim.
 
 ## 0:00-0:20: the stale-memory problem
 
@@ -41,9 +41,9 @@ HTML report.
 
 Voiceover: "These are separate checks. Uptake asks whether the next answer
 uses the correction. Non-resurrection asks whether the old fact returns later.
-The packaged demo currently accepts the correction immediately but later serves
-the stale fact again. MemCorrect catches both behaviors instead of collapsing
-them into one flattering score."
+In the verified version 9.6.24 packaged run, uptake was 1. Non-resurrection was
+0: the correction appeared at once, but the stale fact returned later.
+MemCorrect catches both behaviors instead of hiding them in one score."
 
 If the packaged demo behavior changes before recording, update this beat to the
 actual output. Never narrate a metric that is not visible in the recorded run.
@@ -71,9 +71,8 @@ run and recorded.
 
 Voiceover: "Replace the demo with a stdio command or Streamable HTTP URL.
 For a non-canonical MCP surface, map the store, recall, correct, and reset tools
-and their argument semantics explicitly. Preflight rejects an unsafe or
-unscoped server; a backend failure never gets scored as an innocent empty
-recall."
+and their arguments. Preflight rejects an unsafe or unscoped server. It also
+keeps a backend failure separate from an empty recall."
 
 ## 2:10-2:35: Codex and GPT-5.6 roles
 
@@ -90,20 +89,20 @@ remnic bench run --quick memcorrect-v1 --adapter mcp --mcp-demo \
 
 Voiceover: "Codex built and adversarially reviewed the new MCP adapter,
 Responses provider, and report card during Build Week. GPT-5.6 is the optional
-structured-output judge inside the harness. Our bounded CLI measurement uses
-Luna for bulk work and Terra for quality-critical judging, with every completed
-turn charged to the harness ledger. The account stays exclusive to that run,
-and missing usage blocks further dispatch. Remnic itself and the original
+structured-output judge inside the harness. Our bounded CLI protocol assigns
+Luna to bulk work and Terra to quality-critical judging. It charges each
+completed turn to the harness ledger and requires exclusive account use during
+the run. Missing usage blocks further dispatch. Remnic itself and the original
 benchmark package are prior work; our public evidence ledger draws that line
 commit by commit."
 
-The exact API model id above is `gpt-5.6`. It is distinct from the
-ChatGPT-backed Codex CLI slugs `gpt-5.6-luna` and `gpt-5.6-terra`. If the CLI
-artifact is shown, its run must use one-shot isolated `codex exec` calls, normal
-service rather than fast mode, a 2,473-credit budget, a 473-credit reserve, and
-the real model labels. `gpt-5.6-sol` is opt-in only and is outside the bounded
-plan. Confirm ChatGPT authentication with `codex login status` and the catalog
-with `codex debug models` immediately before recording.
+The API model id above is `gpt-5.6`. The Codex CLI uses the separate slugs
+`gpt-5.6-luna` and `gpt-5.6-terra`. If the CLI artifact is shown, its run must
+use isolated one-shot `codex exec` calls and normal service, not fast mode. It
+must show the 2,473-credit budget, 473-credit reserve, and real model labels.
+`gpt-5.6-sol` is opt-in only and is outside the bounded plan. Right before
+recording, check the login with `codex login status` and the model list with
+`codex debug models`.
 
 Do not say GPT-5.6 was benchmarked as the system under test unless the real,
 hash-locked artifact is on screen.
@@ -121,6 +120,8 @@ database."
 - [ ] Runtime is under 3 minutes and audio is present.
 - [ ] Audio explicitly explains both Codex and GPT-5.6 usage.
 - [ ] Commands shown match the released packages or the disclosed source path.
+- [ ] The keyless package receipt identifies version 9.6.24 and does not imply
+  a paid-model run.
 - [ ] No API key, token, personal data, or private terminal history is visible.
 - [ ] Every narrated score appears in the recorded artifact.
 - [ ] Any CLI artifact identifies Luna/Terra separately from API `gpt-5.6`.

--- a/docs/hackathon/devpost-description.md
+++ b/docs/hackathon/devpost-description.md
@@ -1,17 +1,17 @@
 # Devpost submission text (OpenAI Build Week 2026)
 
-Status: DRAFT. This copy describes the finished submission and the
-deliverables that will land through #1869 to #1873. It is NOT paste-ready
-until the final verification pass (#1873) confirms every claim against
-shipped code and strikes anything that did not land. HACKATHON.md
-tracks that line. Gated with voice-lint (article mode) before each
-revision ships.
+Status: DRAFT. Do not paste this copy into Devpost yet. First, check every
+claim against shipped code. Add the Codex `/feedback` session ID and video URL.
+Any paid GPT-5.6 result named here also needs a committed artifact and manifest.
+`HACKATHON.md` tracks those gates. This file must pass voice-lint in article
+mode before each revision ships.
 
-Project name: MemCorrect: benchmark any AI agent's memory.
+Project name: MemCorrect: benchmark an AI agent's memory.
 
 Tagline: Agent memory without evals is vibes with a database. MemCorrect
-scores any agent memory backend with one command. It checks recall quality,
-correction handling, and stale-memory harm. GPT-5.6 does the grading.
+scores Remnic or another conforming memory backend with one command. It checks
+recall quality, correction handling, and stale-memory harm. GPT-5.6 can grade
+answers when selected.
 
 Built with: typescript, node.js, gpt-5.6, codex, openai-responses-api, mcp,
 sqlite.
@@ -54,24 +54,28 @@ a scored claim anyone can re-run.
 ## How we built it
 
 The new work for Build Week was built in Codex sessions. GPT-5.6 was integrated
-as the opt-in judge through the OpenAI Responses API. The session ID is in the
-form. The line between prior work and hackathon work is drawn commit-by-commit in
+as the opt-in judge through the OpenAI Responses API. The Codex `/feedback`
+session ID remains operator input and must be added to the form before
+submission. The line between prior work and hackathon work is drawn commit by
+commit in
 [HACKATHON.md](https://github.com/joshuaswarren/remnic/blob/main/HACKATHON.md).
 
 Codex studied our adapter seam first. Then it built the generic MCP memory
 adapter, its tests, and the checks that decide if a backend can be scored
-at all. It wired GPT-5.6 in as the judge and iterated on the rubric with
-us. Codex then polished the HTML export into one scored report card you can
+at all. It wired GPT-5.6 in as the judge and implemented the versioned rubric.
+Codex then polished the HTML export into one scored report card you can
 hand to your team.
 
 GPT-5.6 is the opt-in judge inside the tool through the OpenAI Responses API.
 That exact API model id is `gpt-5.6`. Our separate ChatGPT-backed Codex CLI
-measurement plan uses `gpt-5.6-luna` for bulk responder and internal work and
-`gpt-5.6-terra` for quality-critical judging. Each completion is a fresh,
-isolated `codex exec`; no fast mode is used. The 2,473-credit grant is used
-exclusively by that run and keeps a 473-credit reserve, so the bounded harness
-can spend at most 2,000 credits. Bounded mode verifies ChatGPT authentication. Actual
-input, cached-input, and output usage is reconciled after every completed turn.
+measurement protocol assigns `gpt-5.6-luna` to bulk responder and internal
+work, and `gpt-5.6-terra` to quality-critical judging. Each completion is a
+fresh, isolated `codex exec`; the protocol forbids fast mode. During a
+benchmark window, it requires exclusive account use and keeps 473 of the
+2,473-credit grant in reserve, so planned spend cannot exceed 2,000 credits.
+Bounded mode verifies ChatGPT authentication. The harness records actual
+input, cached-input, and output usage after every completed turn and blocks
+further dispatch if exact usage is missing.
 `gpt-5.6-sol` is opt-in only and outside that bounded plan. We do not claim a
 published GPT-5.6 model result until a committed artifact and manifest exist,
 and a bounded artifact is labeled as partial coverage.
@@ -87,9 +91,9 @@ contracts in the code.
 
 ## Accomplishments we're proud of
 
-A memory benchmark you can run in about a minute after installation. One
-command exercises MCP correction uptake and stale-memory harm together. And
-the discipline behind it: no number ships in our docs without a committed
+A keyless quick benchmark you can run after installation. One command
+exercises MCP correction uptake and stale-memory harm together. And the
+discipline behind it: every public submission number requires a committed
 artifact behind it.
 
 ## What we learned
@@ -109,16 +113,19 @@ honestly. This is a protocol claim, not a "first to think of it" claim.
 
 ## Try it (judges)
 
-After package installation, the smoke path needs no dataset, API key, or network:
+Version 9.6.24 of both packages is published. After installation, the smoke
+path needs no dataset, API key, or network:
 
 ```bash
-npm install -g @remnic/cli @remnic/bench
+npm install -g @remnic/cli@9.6.24 @remnic/bench@9.6.24
 remnic bench run --quick memcorrect-v1 --adapter mcp --mcp-demo
 remnic bench runs list
 remnic bench export <run-id> --format html --output ./memcorrect-report.html
 ```
 
-The quick run uses a packaged stdio MCP server. After installation it needs no
+The quick run uses a packaged stdio MCP server. The corresponding 9.6.24
+packed-tarball path passed in a clean Linux x86_64 global prefix with Node
+22.23.1 and produced a 15,144-byte offline report. The run itself needs no
 dataset, key, or network, and it exercises the real adapter. To add GPT-5.6
 judging, export `OPENAI_API_KEY` and append `--judge-provider openai
 --judge-model gpt-5.6`. Reproduction paths live in


### PR DESCRIPTION
## Summary
- replace unreachable evidence links with commits reachable from main
- document the verified 9.6.24 Linux packed-tarball receipt without presenting it as paid-model evidence
- refresh README, demo, and Devpost copy while preserving operator and frontier-result placeholders

## Verification
- npm run preflight:quick
- node scripts/check-docs-parity.mjs
- scoped voice checks
- npm view @remnic/cli version and npm view @remnic/bench version both returned 9.6.24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to hackathon/README copy; no runtime, auth, or benchmark code paths change.
> 
> **Overview**
> **Refreshes OpenAI Build Week submission docs** so public copy matches shipped **9.6.24** packages and reachable commit evidence on `main`.
> 
> **`HACKATHON.md`** updates the delivered implementation commit, expands in-window receipt links (sandbox, fail-closed provider, Codex CLI credit path, LoCoMo/judge tooling), and adds a **July 15** Linux cold-install receipt for merged head `ab849733`—explicitly **keyless**, not a paid-model result. Judge install commands pin `@remnic/cli@9.6.24` / `@remnic/bench@9.6.24`; novelty framing narrows claims to Remnic or other backends on the supported adapter contract.
> 
> **`README.md`** adds a **MemCorrect** section with the same pinned quick-start and ledger link while keeping `/feedback`, frontier artifact, video, and final submission as pending.
> 
> **`docs/hackathon/demo-script.md`** and **`devpost-description.md`** align voiceover/checklists and judge copy with the verified tarball metrics (`uptake_at_next=1`, `non_resurrection=0`), credit protocol wording, and gates before pasting to Devpost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d16f01ed768b1a9a5c5ae084a6c08603a42b6c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->