### PR TITLE
feat(core): preserve LCM expanded row identity

### DIFF
--- a/packages/remnic-core/src/lcm-engine.test.ts
+++ b/packages/remnic-core/src/lcm-engine.test.ts
@@ -4,7 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { extractLcmConfig, LcmEngine } from "./lcm/engine.js";
+import { LcmArchive } from "./lcm/archive.js";
+import { LcmEngine, extractLcmConfig } from "./lcm/engine.js";
 import { openLcmDatabase } from "./lcm/schema.js";
 import type { PluginConfig } from "./types.js";
 
@@ -541,6 +542,135 @@ test("LCM normalizes session IDs across observe, stats, and clear", async () => 
     ]);
     await engine.waitForObserveQueueIdle();
     assert.equal((await engine.getStats()).totalMessages, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("expandContext preserves distinct archive-row identity for duplicate turns", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-lcm-expand-identity-"),
+  );
+
+  try {
+    const engine = new LcmEngine(
+      createPluginConfig(memoryDir),
+      async () => "summary",
+    );
+    await engine.ensureInitialized();
+
+    const db = openLcmDatabase(memoryDir);
+    let expected: ReturnType<LcmArchive["getMessages"]>;
+    try {
+      const archive = new LcmArchive(db);
+      archive.appendMessages("session-expanded", [
+        { turnIndex: 7, role: "user", content: "duplicate turn user" },
+        {
+          turnIndex: 7,
+          role: "assistant",
+          content: "duplicate turn assistant",
+        },
+      ]);
+      expected = archive.getMessages("session-expanded", 7, 7);
+    } finally {
+      db.close();
+    }
+
+    assert.equal(expected.length, 2);
+    const [firstDuplicate, secondDuplicate] = expected;
+    assert.ok(firstDuplicate);
+    assert.ok(secondDuplicate);
+    assert.notEqual(firstDuplicate.id, secondDuplicate.id);
+
+    const expanded = await engine.expandContext(
+      "  session-expanded  ",
+      7,
+      7,
+      100,
+    );
+
+    assert.deepEqual(
+      expanded,
+      expected.map(({ id, session_id, turn_index, role, content }) => ({
+        id,
+        session_id,
+        turn_index,
+        role,
+        content,
+      })),
+    );
+    assert.deepEqual(
+      expanded.map(({ session_id }) => session_id),
+      ["session-expanded", "session-expanded"],
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("expandContext preserves first, middle, and last row identity when truncated", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-lcm-expand-truncated-identity-"),
+  );
+
+  try {
+    const engine = new LcmEngine(
+      createPluginConfig(memoryDir),
+      async () => "summary",
+    );
+    await engine.ensureInitialized();
+
+    const db = openLcmDatabase(memoryDir);
+    let archived: ReturnType<LcmArchive["getMessages"]>;
+    try {
+      const archive = new LcmArchive(db);
+      archive.appendMessages("session-truncated", [
+        { turnIndex: 1, role: "user", content: "AAAAAAAA" },
+        { turnIndex: 2, role: "assistant", content: "BBBBBBBB" },
+        { turnIndex: 3, role: "user", content: "CCCCCCCC" },
+        { turnIndex: 4, role: "assistant", content: "DDDDDDDD" },
+      ]);
+      archived = archive.getMessages("session-truncated", 1, 4);
+    } finally {
+      db.close();
+    }
+
+    assert.equal(archived.length, 4);
+    const [first, middle, , last] = archived;
+    assert.ok(first);
+    assert.ok(middle);
+    assert.ok(last);
+
+    const expanded = await engine.expandContext(
+      "  session-truncated  ",
+      1,
+      4,
+      5,
+    );
+
+    assert.deepEqual(expanded, [
+      {
+        id: first.id,
+        session_id: "session-truncated",
+        turn_index: 1,
+        role: "user",
+        content: "AAAAAAAA",
+      },
+      {
+        id: middle.id,
+        session_id: "session-truncated",
+        turn_index: 2,
+        role: "assistant",
+        content: "BBBBBB",
+      },
+      {
+        id: last.id,
+        session_id: "session-truncated",
+        turn_index: 4,
+        role: "assistant",
+        content: "DDDDDD",
+      },
+    ]);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/lcm/engine.ts
+++ b/packages/remnic-core/src/lcm/engine.ts
@@ -23,6 +23,15 @@ export interface LcmEngineConfig {
   messagePartsRecallMaxResults: number;
 }
 
+/** An expanded archive row with stable lineage identity; content may be budget-truncated. */
+export interface LcmExpandedMessage {
+  id: number;
+  session_id: string;
+  turn_index: number;
+  role: string;
+  content: string;
+}
+
 function positiveInteger(value: unknown, fallback: number, min = 1): number {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
   return Math.max(min, Math.floor(value));
@@ -526,7 +535,7 @@ export class LcmEngine {
     fromTurn: number,
     toTurn: number,
     maxTokens: number,
-  ): Promise<Array<{ turn_index: number; role: string; content: string }>> {
+  ): Promise<LcmExpandedMessage[]> {
     if (!this.config.enabled) return [];
     const normalizedSessionId = normalizeLcmSessionId(sessionId);
     if (!normalizedSessionId) return [];
@@ -542,6 +551,8 @@ export class LcmEngine {
 
     if (totalChars <= maxChars) {
       return messages.map((m) => ({
+        id: m.id,
+        session_id: m.session_id,
         turn_index: m.turn_index,
         role: m.role,
         content: m.content,
@@ -549,8 +560,7 @@ export class LcmEngine {
     }
 
     // Keep first and last messages, truncate from middle
-    const result: Array<{ turn_index: number; role: string; content: string }> =
-      [];
+    const result: LcmExpandedMessage[] = [];
     let budget = maxChars;
 
     // Reserve space for the last message
@@ -567,6 +577,8 @@ export class LcmEngine {
       const m = messages[i];
       const truncated = m.content.slice(0, budget);
       result.push({
+        id: m.id,
+        session_id: m.session_id,
         turn_index: m.turn_index,
         role: m.role,
         content: truncated,
@@ -576,6 +588,8 @@ export class LcmEngine {
 
     // Always append the last message
     result.push({
+      id: lastMsg.id,
+      session_id: lastMsg.session_id,
       turn_index: lastMsg.turn_index,
       role: lastMsg.role,
       content: lastMsg.content.slice(0, lastMsgChars + Math.max(0, budget)),

--- a/packages/remnic-core/src/lcm/index.ts
+++ b/packages/remnic-core/src/lcm/index.ts
@@ -1,4 +1,9 @@
-export { LcmEngine, extractLcmConfig, type LcmEngineConfig } from "./engine.js";
+export {
+  LcmEngine,
+  extractLcmConfig,
+  type LcmEngineConfig,
+  type LcmExpandedMessage,
+} from "./engine.js";
 export { LcmArchive, estimateTokens } from "./archive.js";
 export { LcmDag, type SummaryNode } from "./dag.js";
 export { LcmSummarizer, type SummarizeFn } from "./summarizer.js";


### PR DESCRIPTION
## Summary
- preserve stable archive row IDs and normalized session IDs in `expandContext`
- retain row identity through full-budget and truncated expansion paths
- add duplicate-turn and truncation regressions without changing selection or budgeting

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/lcm-engine.test.ts` (16/16)
- `pnpm --filter @remnic/core check-types`
- `npm run test:entity-hardening` (246/246)
- `npm run preflight:quick`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is additive on the expand API shape; budgeting logic is unchanged aside from passing through identity fields.
> 
> **Overview**
> **`expandContext`** now returns **`LcmExpandedMessage`** rows that carry stable archive **`id`** and normalized **`session_id`**, not only `turn_index`, `role`, and `content`. That applies on the full-budget path and when token budgeting truncates middle content while keeping first/last messages.
> 
> The new type is re-exported from the LCM package entrypoint. Regression tests cover duplicate messages on the same turn (distinct IDs) and truncated expansion (first/middle/last rows keep the correct archive IDs and shortened content).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5b38826fdfbb0f21980f2c2ea6e8ed708fae3f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->