### PR TITLE
perf(extraction): per-fingerprint backoff + circuit breaker + retry budget (#1908)

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -72,6 +72,8 @@ Access-layer safety notes:
 | `highSignalPatterns` | `[]` | Additional regex patterns for immediate extraction |
 | `consolidateEveryN` | `3` | Run consolidation every N extractions |
 
+> **Overflow policy (provider outage).** While the extraction circuit breaker is open during a prolonged provider outage, buffered turns are retained (not dropped) so no extractable turn is lost — they are re-extracted once the provider recovers. Buffered *session entries* are bounded to `MAX_BUFFER_ENTRY_COUNT` (200); once exceeded, the oldest empty session entries are pruned oldest-first and the pruning is logged loudly (a `warn`) so overflow degrades observably rather than silently. See the `extractionBreaker*` / `extractionRetry*` settings under **Local LLM**.
+
 ## Extraction Guardrails
 
 | Setting | Default | Description |
@@ -608,6 +610,14 @@ Set `modelSource` to `plugin` (or remove it) to restore the original behavior wh
 | `localLlmRetryBackoffMs` | `400` | Base backoff in milliseconds for local endpoint retries |
 | `localLlm400TripThreshold` | `5` | Consecutive 4xx responses before the local endpoint is temporarily tripped |
 | `localLlm400CooldownMs` | `120000` | Cooldown window before retrying a tripped local endpoint |
+| `extractionRetryEnabled` | `true` | Master gate for extraction retry backoff + circuit breaker. When `false`, restores pre-change behavior exactly: the extractor is called on every triggered observe with no gate (config-only rollback, no redeploy). |
+| `extractionRetryScheduleMs` | `[60000, 300000, 1800000, 7200000]` | Per-fingerprint exponential backoff schedule (1m, 5m, 30m, 2h), indexed by attempt. After a failed extraction, that fingerprint is not re-attempted until its backoff elapses. |
+| `extractionRetryMaxBackoffMs` | `21600000` | Upper bound (6h) on any single backoff interval, and the long-park interval once `parse_empty` exhausts its attempt cap. |
+| `extractionRetryJitterRatio` | `0.2` | Multiplicative jitter (±ratio) applied to each backoff interval to avoid synchronized retries. |
+| `extractionParseEmptyMaxAttempts` | `3` | Attempts for a `parse_empty` fingerprint (provider responded but produced no parseable output) before it is long-parked for `extractionRetryMaxBackoffMs`. Still never marked processed. |
+| `extractionBreakerFailureThreshold` | `5` | Consecutive provider failures before the process-level circuit breaker opens and short-circuits extraction for all fingerprints. |
+| `extractionBreakerCooldownMs` | `300000` | Breaker open cooldown (5m) for transient provider failures (429/5xx/network). A half-open probe after cooldown closes the breaker on one success. |
+| `extractionBreakerAuthCooldownMs` | `1800000` | Breaker open cooldown (30m) for auth/config failures (401/403 or "no models configured"), which open the breaker immediately instead of hot-looping. |
 | `localLlmMaxContext` | `(unset)` | Override context window size |
 | `localLlmFastEnabled` | `false` | Enable a separate fast local tier for short planner/rerank/helper calls |
 | `localLlmFastModel` | `""` | Optional model id for the fast local tier |
@@ -1404,6 +1414,14 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `localLlmRetryBackoffMs` | `400` | `400` |
 | `localLlm400TripThreshold` | `5` | `5` |
 | `localLlm400CooldownMs` | `120000` | `120000` |
+| `extractionRetryEnabled` | `true` | `true` (set `false` to fully restore pre-change extraction behavior — the config-only rollback) |
+| `extractionRetryScheduleMs` | `[60000, 300000, 1800000, 7200000]` | `[60000, 300000, 1800000, 7200000]` |
+| `extractionRetryMaxBackoffMs` | `21600000` | `21600000` |
+| `extractionRetryJitterRatio` | `0.2` | `0.2` |
+| `extractionParseEmptyMaxAttempts` | `3` | `3` |
+| `extractionBreakerFailureThreshold` | `5` | `5` |
+| `extractionBreakerCooldownMs` | `300000` | `300000` |
+| `extractionBreakerAuthCooldownMs` | `1800000` | `1800000` |
 | `localLlmMaxContext` | (unset) | (unset) |
 | `localLlmFastEnabled` | `false` | `false` unless you have a separate fast local tier |
 | `localLlmFastModel` | `""` | `""` |

--- a/docs/setup-config-tuning.md
+++ b/docs/setup-config-tuning.md
@@ -447,6 +447,14 @@ Reliability / load:
   - `localLlmRetryBackoffMs: 400`
   - `localLlm400TripThreshold: 5`
   - `localLlm400CooldownMs: 120000`
+- Extraction failure damping (retry backoff + circuit breaker):
+  - `extractionRetryEnabled: true` — master gate. Set `false` to fully restore pre-change behavior (extractor called on every triggered observe, no gate); this is the config-only rollback.
+  - `extractionRetryScheduleMs: [60000, 300000, 1800000, 7200000]` — per-fingerprint exponential backoff (1m, 5m, 30m, 2h). A single transient 429 parks that fingerprint for only 1 minute.
+  - `extractionRetryMaxBackoffMs: 21600000` — 6h cap on any backoff interval.
+  - `extractionRetryJitterRatio: 0.2` — ±20% jitter so retries don't synchronize.
+  - `extractionParseEmptyMaxAttempts: 3` — after 3 unparseable responses a fingerprint is long-parked (never marked processed).
+  - `extractionBreakerFailureThreshold: 5` — consecutive provider failures before the process-level breaker opens and short-circuits extraction for all sessions. A 401/403/"no models configured" opens it immediately.
+  - `extractionBreakerCooldownMs: 300000` / `extractionBreakerAuthCooldownMs: 1800000` — breaker open cooldown for transient (5m) vs auth/config (30m) failures. After cooldown a half-open probe closes the breaker on one success and clears retry state. Watch `openclaw remnic doctor` (the `extraction-resilience` check) for a breaker stuck `open` or `auth_config` errors.
 
 Latency:
 - Increase `conversationRecallTimeoutMs` only if your QMD host is consistently fast.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2927,6 +2927,47 @@
         "default": 5,
         "description": "Consecutive 400 responses before local LLM enters temporary cooldown."
       },
+      "extractionRetryEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Master gate for extraction retry backoff + circuit breaker. When false, restores pre-change behavior (extractor called on every triggered observe, no gate)."
+      },
+      "extractionRetryScheduleMs": {
+        "type": "array",
+        "items": { "type": "number" },
+        "default": [60000, 300000, 1800000, 7200000],
+        "description": "Per-fingerprint exponential extraction backoff schedule (ms), indexed by attempt."
+      },
+      "extractionRetryMaxBackoffMs": {
+        "type": "number",
+        "default": 21600000,
+        "description": "Upper bound (ms) on any single extraction backoff interval and the long-park interval for exhausted parse_empty fingerprints."
+      },
+      "extractionRetryJitterRatio": {
+        "type": "number",
+        "default": 0.2,
+        "description": "Multiplicative jitter ratio (+/-) applied to each extraction backoff interval."
+      },
+      "extractionParseEmptyMaxAttempts": {
+        "type": "number",
+        "default": 3,
+        "description": "Attempts for a parse_empty extraction fingerprint before it is long-parked (still never marked processed)."
+      },
+      "extractionBreakerFailureThreshold": {
+        "type": "number",
+        "default": 5,
+        "description": "Consecutive provider failures before the extraction circuit breaker opens and short-circuits extraction."
+      },
+      "extractionBreakerCooldownMs": {
+        "type": "number",
+        "default": 300000,
+        "description": "Extraction circuit-breaker open cooldown (ms) for transient provider failures (429/5xx/network)."
+      },
+      "extractionBreakerAuthCooldownMs": {
+        "type": "number",
+        "default": 1800000,
+        "description": "Extraction circuit-breaker open cooldown (ms) for auth/config failures (401/403 or no models configured)."
+      },
       "localLlmApiKey": {
         "type": "string",
         "description": "Optional API key for authenticated OpenAI-compatible local endpoints"

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2927,47 +2927,6 @@
         "default": 5,
         "description": "Consecutive 400 responses before local LLM enters temporary cooldown."
       },
-      "extractionRetryEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Master gate for extraction retry backoff + circuit breaker. When false, restores pre-change behavior (extractor called on every triggered observe, no gate)."
-      },
-      "extractionRetryScheduleMs": {
-        "type": "array",
-        "items": { "type": "number" },
-        "default": [60000, 300000, 1800000, 7200000],
-        "description": "Per-fingerprint exponential extraction backoff schedule (ms), indexed by attempt."
-      },
-      "extractionRetryMaxBackoffMs": {
-        "type": "number",
-        "default": 21600000,
-        "description": "Upper bound (ms) on any single extraction backoff interval and the long-park interval for exhausted parse_empty fingerprints."
-      },
-      "extractionRetryJitterRatio": {
-        "type": "number",
-        "default": 0.2,
-        "description": "Multiplicative jitter ratio (+/-) applied to each extraction backoff interval."
-      },
-      "extractionParseEmptyMaxAttempts": {
-        "type": "number",
-        "default": 3,
-        "description": "Attempts for a parse_empty extraction fingerprint before it is long-parked (still never marked processed)."
-      },
-      "extractionBreakerFailureThreshold": {
-        "type": "number",
-        "default": 5,
-        "description": "Consecutive provider failures before the extraction circuit breaker opens and short-circuits extraction."
-      },
-      "extractionBreakerCooldownMs": {
-        "type": "number",
-        "default": 300000,
-        "description": "Extraction circuit-breaker open cooldown (ms) for transient provider failures (429/5xx/network)."
-      },
-      "extractionBreakerAuthCooldownMs": {
-        "type": "number",
-        "default": 1800000,
-        "description": "Extraction circuit-breaker open cooldown (ms) for auth/config failures (401/403 or no models configured)."
-      },
       "localLlmApiKey": {
         "type": "string",
         "description": "Optional API key for authenticated OpenAI-compatible local endpoints"
@@ -5747,6 +5706,54 @@
       "workspaceDir": {
         "type": "string",
         "description": "Override workspace directory path"
+      },
+      "extractionBreakerAuthCooldownMs": {
+        "type": "number",
+        "default": 1800000,
+        "description": "Extraction circuit-breaker open cooldown (ms) for auth/config failures (401/403 or no models configured)."
+      },
+      "extractionBreakerCooldownMs": {
+        "type": "number",
+        "default": 300000,
+        "description": "Extraction circuit-breaker open cooldown (ms) for transient provider failures (429/5xx/network)."
+      },
+      "extractionBreakerFailureThreshold": {
+        "type": "number",
+        "default": 5,
+        "description": "Consecutive provider failures before the extraction circuit breaker opens and short-circuits extraction."
+      },
+      "extractionParseEmptyMaxAttempts": {
+        "type": "number",
+        "default": 3,
+        "description": "Attempts for a parse_empty extraction fingerprint before it is long-parked (still never marked processed)."
+      },
+      "extractionRetryEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Master gate for extraction retry backoff + circuit breaker. When false, restores pre-change behavior (extractor called on every triggered observe, no gate)."
+      },
+      "extractionRetryJitterRatio": {
+        "type": "number",
+        "default": 0.2,
+        "description": "Multiplicative jitter ratio (+/-) applied to each extraction backoff interval."
+      },
+      "extractionRetryMaxBackoffMs": {
+        "type": "number",
+        "default": 21600000,
+        "description": "Upper bound (ms) on any single extraction backoff interval and the long-park interval for exhausted parse_empty fingerprints."
+      },
+      "extractionRetryScheduleMs": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "default": [
+          60000,
+          300000,
+          1800000,
+          7200000
+        ],
+        "description": "Per-fingerprint exponential extraction backoff schedule (ms), indexed by attempt."
       }
     }
   },

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1,6928 +1,6976 @@
 {
-  "id": "openclaw-remnic",
-  "name": "Remnic OpenClaw Plugin",
-  "version": "9.6.39",
-  "kind": "memory",
-  "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
-  "setup": {
-    "requiresRuntime": false,
-    "providers": [
-      {
-        "id": "openai",
-        "authMethods": [
-          "api-key"
-        ],
-        "envVars": [
-          "OPENAI_API_KEY"
-        ]
-      }
+ "id": "openclaw-remnic",
+ "name": "Remnic OpenClaw Plugin",
+ "version": "9.6.39",
+ "kind": "memory",
+ "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
+ "setup": {
+  "requiresRuntime": false,
+  "providers": [
+   {
+    "id": "openai",
+    "authMethods": [
+     "api-key"
+    ],
+    "envVars": [
+     "OPENAI_API_KEY"
     ]
-  },
-  "providerAuthChoices": [
-    {
-      "provider": "openai",
-      "method": "api-key",
-      "choiceId": "remnic-openai-api-key",
-      "choiceLabel": "Optional OpenAI API key for Remnic plugin-mode extraction",
-      "choiceHint": "Not needed when Remnic uses the OpenClaw gateway model source. Set only if you intentionally use plugin mode with OpenAI or an OpenAI-compatible endpoint.",
-      "groupId": "remnic-memory",
-      "groupLabel": "Remnic memory",
-      "optionKey": "openaiApiKey",
-      "cliFlag": "--openai-api-key",
-      "cliOption": "--openai-api-key <key>",
-      "cliDescription": "Optional OpenAI API key used by Remnic plugin-mode extraction, consolidation, and embedding flows.",
-      "onboardingScopes": [
-        "text-inference"
-      ]
-    }
-  ],
-  "providerAuthEnvVars": {
-    "openai": [
-      "OPENAI_API_KEY"
-    ]
-  },
-  "supports": {
-    "memorySlot": true,
-    "dreamingSlot": true,
-    "activeMemory": true,
-    "heartbeat": true,
-    "commandsList": true,
-    "beforeReset": true
-  },
-  "contracts": {
-    "tools": [
-      "compounding_promote_candidate",
-      "compounding_weekly_synthesize",
-      "compression_guidelines_activate",
-      "compression_guidelines_optimize",
-      "context_checkpoint",
-      "continuity_audit_generate",
-      "continuity_incident_close",
-      "continuity_incident_list",
-      "continuity_incident_open",
-      "continuity_loop_add_or_update",
-      "continuity_loop_review",
-      "conversation_index_update",
-      "engram_context_describe",
-      "engram_context_expand",
-      "engram_context_search",
-      "engram_profiling_report",
-      "identity_anchor_get",
-      "identity_anchor_update",
-      "memory_action_apply",
-      "memory_capture",
-      "memory_entities",
-      "memory_feedback",
-      "memory_feedback_last_recall",
-      "memory_get",
-      "memory_governance_run",
-      "memory_graph_explain_last_recall",
-      "memory_identity",
-      "memory_intent_debug",
-      "memory_last_recall",
-      "memory_profile",
-      "memory_promote",
-      "memory_qmd_debug",
-      "memory_questions",
-      "memory_search",
-      "memory_store",
-      "memory_summarize_hourly",
-      "remnic_context_describe",
-      "remnic_context_expand",
-      "remnic_context_search",
-      "remnic_profiling_report",
-      "shared_context_cross_signals_run",
-      "shared_context_curate_daily",
-      "shared_context_write_output",
-      "shared_feedback_record",
-      "shared_priorities_append",
-      "work_board",
-      "work_project",
-      "work_task"
-    ]
-  },
-  "configSchema": {
+   }
+  ]
+ },
+ "providerAuthChoices": [
+  {
+   "provider": "openai",
+   "method": "api-key",
+   "choiceId": "remnic-openai-api-key",
+   "choiceLabel": "Optional OpenAI API key for Remnic plugin-mode extraction",
+   "choiceHint": "Not needed when Remnic uses the OpenClaw gateway model source. Set only if you intentionally use plugin mode with OpenAI or an OpenAI-compatible endpoint.",
+   "groupId": "remnic-memory",
+   "groupLabel": "Remnic memory",
+   "optionKey": "openaiApiKey",
+   "cliFlag": "--openai-api-key",
+   "cliOption": "--openai-api-key <key>",
+   "cliDescription": "Optional OpenAI API key used by Remnic plugin-mode extraction, consolidation, and embedding flows.",
+   "onboardingScopes": [
+    "text-inference"
+   ]
+  }
+ ],
+ "providerAuthEnvVars": {
+  "openai": [
+   "OPENAI_API_KEY"
+  ]
+ },
+ "supports": {
+  "memorySlot": true,
+  "dreamingSlot": true,
+  "activeMemory": true,
+  "heartbeat": true,
+  "commandsList": true,
+  "beforeReset": true
+ },
+ "contracts": {
+  "tools": [
+   "compounding_promote_candidate",
+   "compounding_weekly_synthesize",
+   "compression_guidelines_activate",
+   "compression_guidelines_optimize",
+   "context_checkpoint",
+   "continuity_audit_generate",
+   "continuity_incident_close",
+   "continuity_incident_list",
+   "continuity_incident_open",
+   "continuity_loop_add_or_update",
+   "continuity_loop_review",
+   "conversation_index_update",
+   "engram_context_describe",
+   "engram_context_expand",
+   "engram_context_search",
+   "engram_profiling_report",
+   "identity_anchor_get",
+   "identity_anchor_update",
+   "memory_action_apply",
+   "memory_capture",
+   "memory_entities",
+   "memory_feedback",
+   "memory_feedback_last_recall",
+   "memory_get",
+   "memory_governance_run",
+   "memory_graph_explain_last_recall",
+   "memory_identity",
+   "memory_intent_debug",
+   "memory_last_recall",
+   "memory_profile",
+   "memory_promote",
+   "memory_qmd_debug",
+   "memory_questions",
+   "memory_search",
+   "memory_store",
+   "memory_summarize_hourly",
+   "remnic_context_describe",
+   "remnic_context_expand",
+   "remnic_context_search",
+   "remnic_profiling_report",
+   "shared_context_cross_signals_run",
+   "shared_context_curate_daily",
+   "shared_context_write_output",
+   "shared_feedback_record",
+   "shared_priorities_append",
+   "work_board",
+   "work_project",
+   "work_task"
+  ]
+ },
+ "configSchema": {
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+   "abstractionAnchorsEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable typed cue-anchor indexing for abstraction nodes and expose it through cue-anchor status tooling."
+   },
+   "abstractionNodeStoreDir": {
+    "type": "string",
+    "description": "Override the abstraction-node store directory (defaults to {memoryDir}/state/abstraction-nodes)."
+   },
+   "accessTrackingBufferMaxSize": {
+    "type": "number",
+    "default": 100,
+    "description": "Max entries in access tracking buffer before flush"
+   },
+   "accessTrackingEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Track memory access counts and recency"
+   },
+   "actionGraphRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Write action-conditioned causal-stage edges from typed trajectory records into the causal graph."
+   },
+   "activeRecallAgents": {
+    "type": "array",
+    "items": {
+     "type": "string"
+    },
+    "description": "Optional allowlist of OpenClaw agent ids that may use active recall."
+   },
+   "activeRecallAllowChainedActiveMemory": {
+    "type": "boolean",
+    "default": false,
+    "description": "Compat-only (issue #1550): allow the Remnic active-recall block to chain into the bundled active-memory surface. Redundant in modern OpenClaw memory-slot mode; only set true when intentionally layering Remnic + bundled active-memory for the same agent."
+   },
+   "activeRecallAllowedChatTypes": {
+    "type": "array",
+    "items": {
+     "type": "string",
+     "enum": [
+      "direct",
+      "group",
+      "channel"
+     ]
+    },
+    "default": [
+     "direct",
+     "group",
+     "channel"
+    ],
+    "description": "OpenClaw chat types eligible for active recall."
+   },
+   "activeRecallAttachRecallExplain": {
+    "type": "boolean",
+    "default": false,
+    "description": "Attach recall explain output to active-recall diagnostics."
+   },
+   "activeRecallCacheTtlMs": {
+    "type": "integer",
+    "minimum": 0,
+    "maximum": 120000,
+    "default": 15000,
+    "description": "Cache TTL for active-recall summaries; 0 disables the cache."
+   },
+   "activeRecallCustomInstruction": {
+    "type": "string",
+    "description": "Optional custom guidance for the active-recall builder."
+   },
+   "activeRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Compat-only (issue #1550): enables the Remnic-native active-recall pre-reply summary block. NOT required for OpenClaw prompt injection \u2014 when Remnic is the memory slot, prompt injection runs through registerMemoryPromptSection / memory capability promptBuilder. Enable only to layer a second blocking pre-reply retrieval; a startup warning is logged when both this and memory-slot prompt injection are on."
+   },
+   "activeRecallEntityGraphDepth": {
+    "type": "integer",
+    "minimum": 0,
+    "maximum": 3,
+    "default": 1,
+    "description": "Entity-graph traversal depth used by active recall."
+   },
+   "activeRecallIncludeCausalTrajectories": {
+    "type": "boolean",
+    "default": false,
+    "description": "Include causal trajectory recall evidence in active-recall summaries."
+   },
+   "activeRecallIncludeDaySummary": {
+    "type": "boolean",
+    "default": false,
+    "description": "Include the latest day summary in active-recall context."
+   },
+   "activeRecallMaxSummaryChars": {
+    "type": "integer",
+    "minimum": 40,
+    "maximum": 1000,
+    "default": 220,
+    "description": "Maximum summary size produced by the active-recall surface."
+   },
+   "activeRecallModel": {
+    "type": "string",
+    "description": "Optional model selection for active recall."
+   },
+   "activeRecallModelFallbackPolicy": {
+    "type": "string",
+    "enum": [
+     "default-remote",
+     "resolved-only"
+    ],
+    "default": "default-remote",
+    "description": "How active recall falls back when an explicit model cannot be resolved."
+   },
+   "activeRecallPersistTranscripts": {
+    "type": "boolean",
+    "default": false,
+    "description": "Persist full active-recall request and response transcripts."
+   },
+   "activeRecallPromptAppend": {
+    "type": "string",
+    "description": "Optional additional guidance for the active-recall builder."
+   },
+   "activeRecallPromptStyle": {
+    "type": "string",
+    "enum": [
+     "balanced",
+     "strict",
+     "contextual",
+     "recall-heavy",
+     "precision-heavy",
+     "preference-only"
+    ],
+    "default": "balanced",
+    "description": "Context assembly style for the active-recall surface."
+   },
+   "activeRecallQueryMode": {
+    "type": "string",
+    "enum": [
+     "recent",
+     "message",
+     "full"
+    ],
+    "default": "recent",
+    "description": "How much recent OpenClaw conversation context is fed into the active-recall query builder."
+   },
+   "activeRecallRecentAssistantChars": {
+    "type": "integer",
+    "minimum": 40,
+    "maximum": 1000,
+    "default": 400,
+    "description": "Per-assistant-turn character cap for active-recall context assembly."
+   },
+   "activeRecallRecentAssistantTurns": {
+    "type": "integer",
+    "minimum": 0,
+    "maximum": 3,
+    "default": 1,
+    "description": "How many recent assistant turns to include in the active-recall query context."
+   },
+   "activeRecallRecentUserChars": {
+    "type": "integer",
+    "minimum": 40,
+    "maximum": 1000,
+    "default": 600,
+    "description": "Per-user-turn character cap for active-recall context assembly."
+   },
+   "activeRecallRecentUserTurns": {
+    "type": "integer",
+    "minimum": 0,
+    "maximum": 4,
+    "default": 2,
+    "description": "How many recent user turns to include in the active-recall query context."
+   },
+   "activeRecallThinking": {
+    "type": "string",
+    "enum": [
+     "off",
+     "minimal",
+     "low",
+     "medium",
+     "high",
+     "xhigh",
+     "adaptive"
+    ],
+    "default": "low",
+    "description": "Reasoning effort used by the active-recall engine."
+   },
+   "activeRecallTimeoutMs": {
+    "type": "integer",
+    "minimum": 250,
+    "default": 15000,
+    "description": "Timeout for an active-recall run."
+   },
+   "activeRecallTranscriptDir": {
+    "type": "string",
+    "default": "active-recall",
+    "description": "Memory-relative directory for active-recall transcripts."
+   },
+   "agentAccessHttp": {
     "type": "object",
     "additionalProperties": false,
+    "description": "Optional: run a local authenticated HTTP API so non-OpenClaw clients can query Engram directly.",
     "properties": {
-      "abstractionAnchorsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable typed cue-anchor indexing for abstraction nodes and expose it through cue-anchor status tooling."
-      },
-      "abstractionNodeStoreDir": {
-        "type": "string",
-        "description": "Override the abstraction-node store directory (defaults to {memoryDir}/state/abstraction-nodes)."
-      },
-      "accessTrackingBufferMaxSize": {
-        "type": "number",
-        "default": 100,
-        "description": "Max entries in access tracking buffer before flush"
-      },
-      "accessTrackingEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Track memory access counts and recency"
-      },
-      "actionGraphRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Write action-conditioned causal-stage edges from typed trajectory records into the causal graph."
-      },
-      "activeRecallAgents": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "Optional allowlist of OpenClaw agent ids that may use active recall."
-      },
-      "activeRecallAllowChainedActiveMemory": {
-        "type": "boolean",
-        "default": false,
-        "description": "Compat-only (issue #1550): allow the Remnic active-recall block to chain into the bundled active-memory surface. Redundant in modern OpenClaw memory-slot mode; only set true when intentionally layering Remnic + bundled active-memory for the same agent."
-      },
-      "activeRecallAllowedChatTypes": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "enum": [
-            "direct",
-            "group",
-            "channel"
-          ]
-        },
-        "default": [
-          "direct",
-          "group",
-          "channel"
-        ],
-        "description": "OpenClaw chat types eligible for active recall."
-      },
-      "activeRecallAttachRecallExplain": {
-        "type": "boolean",
-        "default": false,
-        "description": "Attach recall explain output to active-recall diagnostics."
-      },
-      "activeRecallCacheTtlMs": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 120000,
-        "default": 15000,
-        "description": "Cache TTL for active-recall summaries; 0 disables the cache."
-      },
-      "activeRecallCustomInstruction": {
-        "type": "string",
-        "description": "Optional custom guidance for the active-recall builder."
-      },
-      "activeRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Compat-only (issue #1550): enables the Remnic-native active-recall pre-reply summary block. NOT required for OpenClaw prompt injection — when Remnic is the memory slot, prompt injection runs through registerMemoryPromptSection / memory capability promptBuilder. Enable only to layer a second blocking pre-reply retrieval; a startup warning is logged when both this and memory-slot prompt injection are on."
-      },
-      "activeRecallEntityGraphDepth": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 3,
-        "default": 1,
-        "description": "Entity-graph traversal depth used by active recall."
-      },
-      "activeRecallIncludeCausalTrajectories": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include causal trajectory recall evidence in active-recall summaries."
-      },
-      "activeRecallIncludeDaySummary": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include the latest day summary in active-recall context."
-      },
-      "activeRecallMaxSummaryChars": {
-        "type": "integer",
-        "minimum": 40,
-        "maximum": 1000,
-        "default": 220,
-        "description": "Maximum summary size produced by the active-recall surface."
-      },
-      "activeRecallModel": {
-        "type": "string",
-        "description": "Optional model selection for active recall."
-      },
-      "activeRecallModelFallbackPolicy": {
-        "type": "string",
-        "enum": [
-          "default-remote",
-          "resolved-only"
-        ],
-        "default": "default-remote",
-        "description": "How active recall falls back when an explicit model cannot be resolved."
-      },
-      "activeRecallPersistTranscripts": {
-        "type": "boolean",
-        "default": false,
-        "description": "Persist full active-recall request and response transcripts."
-      },
-      "activeRecallPromptAppend": {
-        "type": "string",
-        "description": "Optional additional guidance for the active-recall builder."
-      },
-      "activeRecallPromptStyle": {
-        "type": "string",
-        "enum": [
-          "balanced",
-          "strict",
-          "contextual",
-          "recall-heavy",
-          "precision-heavy",
-          "preference-only"
-        ],
-        "default": "balanced",
-        "description": "Context assembly style for the active-recall surface."
-      },
-      "activeRecallQueryMode": {
-        "type": "string",
-        "enum": [
-          "recent",
-          "message",
-          "full"
-        ],
-        "default": "recent",
-        "description": "How much recent OpenClaw conversation context is fed into the active-recall query builder."
-      },
-      "activeRecallRecentAssistantChars": {
-        "type": "integer",
-        "minimum": 40,
-        "maximum": 1000,
-        "default": 400,
-        "description": "Per-assistant-turn character cap for active-recall context assembly."
-      },
-      "activeRecallRecentAssistantTurns": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 3,
-        "default": 1,
-        "description": "How many recent assistant turns to include in the active-recall query context."
-      },
-      "activeRecallRecentUserChars": {
-        "type": "integer",
-        "minimum": 40,
-        "maximum": 1000,
-        "default": 600,
-        "description": "Per-user-turn character cap for active-recall context assembly."
-      },
-      "activeRecallRecentUserTurns": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 4,
-        "default": 2,
-        "description": "How many recent user turns to include in the active-recall query context."
-      },
-      "activeRecallThinking": {
-        "type": "string",
-        "enum": [
-          "off",
-          "minimal",
-          "low",
-          "medium",
-          "high",
-          "xhigh",
-          "adaptive"
-        ],
-        "default": "low",
-        "description": "Reasoning effort used by the active-recall engine."
-      },
-      "activeRecallTimeoutMs": {
-        "type": "integer",
-        "minimum": 250,
-        "default": 15000,
-        "description": "Timeout for an active-recall run."
-      },
-      "activeRecallTranscriptDir": {
-        "type": "string",
-        "default": "active-recall",
-        "description": "Memory-relative directory for active-recall transcripts."
-      },
-      "agentAccessHttp": {
+     "enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Start the local Engram HTTP access server during plugin startup."
+     },
+     "host": {
+      "type": "string",
+      "default": "127.0.0.1",
+      "description": "Loopback host to bind for the Engram HTTP access server."
+     },
+     "port": {
+      "type": "number",
+      "default": 4318,
+      "description": "Bind port for the Engram HTTP access server. Use 0 for an ephemeral port."
+     },
+     "authToken": {
+      "description": "Bearer token for the local Remnic HTTP API. Either a literal string (supports ${ENV_VAR} expansion) or an OpenClaw SecretRef object (e.g. {\"source\":\"exec\",\"provider\":\"kc_openclaw_remnic_token\",\"id\":\"value\"}) resolved at startup via the OpenClaw gateway secret resolver (issue #757). If omitted, OPENCLAW_REMNIC_ACCESS_TOKEN / OPENCLAW_ENGRAM_ACCESS_TOKEN is used.",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
         "type": "object",
-        "additionalProperties": false,
-        "description": "Optional: run a local authenticated HTTP API so non-OpenClaw clients can query Engram directly.",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Start the local Engram HTTP access server during plugin startup."
-          },
-          "host": {
-            "type": "string",
-            "default": "127.0.0.1",
-            "description": "Loopback host to bind for the Engram HTTP access server."
-          },
-          "port": {
-            "type": "number",
-            "default": 4318,
-            "description": "Bind port for the Engram HTTP access server. Use 0 for an ephemeral port."
-          },
-          "authToken": {
-            "description": "Bearer token for the local Remnic HTTP API. Either a literal string (supports ${ENV_VAR} expansion) or an OpenClaw SecretRef object (e.g. {\"source\":\"exec\",\"provider\":\"kc_openclaw_remnic_token\",\"id\":\"value\"}) resolved at startup via the OpenClaw gateway secret resolver (issue #757). If omitted, OPENCLAW_REMNIC_ACCESS_TOKEN / OPENCLAW_ENGRAM_ACCESS_TOKEN is used.",
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "object",
-                "required": [
-                  "source"
-                ],
-                "properties": {
-                  "source": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "provider": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "string"
-                  },
-                  "command": {}
-                }
-              }
-            ]
-          },
-          "principal": {
-            "type": "string",
-            "description": "Optional trusted principal bound to the local Engram access bridge. When set, namespace write authorization is evaluated against this principal instead of any client-supplied sessionKey. If omitted, OPENCLAW_ENGRAM_ACCESS_PRINCIPAL is used when present."
-          },
-          "maxBodyBytes": {
-            "type": "number",
-            "default": 131072,
-            "description": "Maximum accepted JSON request body size for the local Remnic HTTP API."
-          }
-        },
         "required": [
-          "enabled"
-        ]
-      },
-      "autoPromoteMinConfidenceTier": {
-        "type": "string",
-        "enum": [
-          "explicit",
-          "implied"
+         "source"
         ],
-        "default": "explicit",
-        "description": "Minimum confidence tier for auto-promotion."
-      },
-      "autoPromoteToSharedCategories": {
-        "type": "array",
-        "items": {
+        "properties": {
+         "source": {
           "type": "string",
-          "enum": [
-            "fact",
-            "correction",
-            "decision",
-            "preference"
-          ]
-        },
-        "default": [
-          "fact",
-          "correction",
-          "decision",
-          "preference"
-        ],
-        "description": "Categories eligible for auto-promotion to shared."
-      },
-      "autoPromoteToSharedEnabled": {
+          "minLength": 1
+         },
+         "provider": {
+          "type": "string"
+         },
+         "id": {
+          "type": "string"
+         },
+         "command": {}
+        }
+       }
+      ]
+     },
+     "principal": {
+      "type": "string",
+      "description": "Optional trusted principal bound to the local Engram access bridge. When set, namespace write authorization is evaluated against this principal instead of any client-supplied sessionKey. If omitted, OPENCLAW_ENGRAM_ACCESS_PRINCIPAL is used when present."
+     },
+     "maxBodyBytes": {
+      "type": "number",
+      "default": 131072,
+      "description": "Maximum accepted JSON request body size for the local Remnic HTTP API."
+     }
+    },
+    "required": [
+     "enabled"
+    ]
+   },
+   "autoPromoteMinConfidenceTier": {
+    "type": "string",
+    "enum": [
+     "explicit",
+     "implied"
+    ],
+    "default": "explicit",
+    "description": "Minimum confidence tier for auto-promotion."
+   },
+   "autoPromoteToSharedCategories": {
+    "type": "array",
+    "items": {
+     "type": "string",
+     "enum": [
+      "fact",
+      "correction",
+      "decision",
+      "preference"
+     ]
+    },
+    "default": [
+     "fact",
+     "correction",
+     "decision",
+     "preference"
+    ],
+    "description": "Categories eligible for auto-promotion to shared."
+   },
+   "autoPromoteToSharedEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "If enabled, Engram may auto-promote selected categories to shared (reserved; conservative)."
+   },
+   "beforeResetTimeoutMs": {
+    "type": "integer",
+    "minimum": 100,
+    "maximum": 30000,
+    "default": 2000,
+    "description": "Maximum time to wait for a reset-triggered flush before returning control to OpenClaw."
+   },
+   "behaviorLoopAutoTuneEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable runtime behavior-loop policy auto-tuning (v8.15, default off)."
+   },
+   "behaviorLoopLearningWindowDays": {
+    "type": "number",
+    "default": 14,
+    "description": "Rolling signal window used for behavior-loop policy learning (days; 0 allowed)."
+   },
+   "behaviorLoopMaxDeltaPerCycle": {
+    "type": "number",
+    "default": 0.1,
+    "description": "Maximum absolute parameter delta allowed per learning cycle (0-1)."
+   },
+   "behaviorLoopMinSignalCount": {
+    "type": "number",
+    "default": 10,
+    "description": "Minimum signal volume required before behavior-loop adjustments are emitted (0 allowed)."
+   },
+   "behaviorLoopProtectedParams": {
+    "type": "array",
+    "items": {
+     "type": "string"
+    },
+    "default": [
+     "maxMemoryTokens",
+     "qmdMaxResults",
+     "qmdColdMaxResults",
+     "recallPlannerMaxQmdResultsMinimal",
+     "verbatimArtifactsMaxRecall"
+    ],
+    "description": "Runtime parameters that auto-tuning must never modify."
+   },
+   "benchmarkBaselineSnapshotsEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable versioned benchmark baseline snapshot artifacts under the eval store for later PR delta reporting."
+   },
+   "benchmarkDeltaReporterEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable named-baseline delta reports so PR candidates can be compared against stored benchmark baselines."
+   },
+   "benchmarkStoredBaselineEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable stored baseline comparisons for benchmark delta reporting."
+   },
+   "binaryLifecycleBackendPath": {
+    "type": "string",
+    "default": "",
+    "description": "Base path for the filesystem storage backend."
+   },
+   "binaryLifecycleBackendType": {
+    "type": "string",
+    "enum": [
+     "none",
+     "filesystem",
+     "s3"
+    ],
+    "default": "none",
+    "description": "Storage backend for binary lifecycle mirror stage."
+   },
+   "binaryLifecycleEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable binary file lifecycle management. When true, binary files in the memory directory are mirrored, redirected, and cleaned."
+   },
+   "binaryLifecycleGracePeriodDays": {
+    "type": "number",
+    "default": 7,
+    "minimum": 0,
+    "description": "Days to wait before cleaning local copies of mirrored binary files."
+   },
+   "boostAccessCount": {
+    "type": "boolean",
+    "default": true,
+    "description": "Boost frequently accessed memories in search results"
+   },
+   "boxMaxMemories": {
+    "type": "number",
+    "default": 50,
+    "description": "Maximum memories per box before forced seal."
+   },
+   "boxRecallDays": {
+    "type": "number",
+    "default": 3,
+    "description": "Number of recent days of boxes to add during recall."
+   },
+   "boxTimeGapMs": {
+    "type": "number",
+    "default": 1800000,
+    "description": "Time gap in milliseconds before an open box is sealed (default 30 min)."
+   },
+   "boxTopicShiftThreshold": {
+    "type": "number",
+    "default": 0.35,
+    "description": "Jaccard overlap threshold below which a topic shift seals the current box (0\u20131)."
+   },
+   "briefing": {
+    "type": "object",
+    "additionalProperties": false,
+    "default": {
+     "enabled": true,
+     "defaultWindow": "yesterday",
+     "defaultFormat": "markdown",
+     "maxFollowups": 5,
+     "calendarSource": null,
+     "saveByDefault": false,
+     "saveDir": null,
+     "llmFollowups": true
+    },
+    "properties": {
+     "enabled": {
+      "type": "boolean",
+      "default": true
+     },
+     "defaultWindow": {
+      "type": "string",
+      "default": "yesterday"
+     },
+     "defaultFormat": {
+      "type": "string",
+      "enum": [
+       "markdown",
+       "json"
+      ],
+      "default": "markdown"
+     },
+     "maxFollowups": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 10,
+      "default": 5
+     },
+     "calendarSource": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "default": null
+     },
+     "saveByDefault": {
+      "type": "boolean",
+      "default": false
+     },
+     "saveDir": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "default": null
+     },
+     "llmFollowups": {
+      "type": "boolean",
+      "default": true
+     }
+    },
+    "description": "Daily Context Briefing (#370). Knobs: enabled, defaultWindow ('yesterday', '3d', '1w', '24h', ...), defaultFormat (markdown|json), maxFollowups (0-10), calendarSource (path to ICS/JSON file, null = off), saveByDefault, saveDir (null = $REMNIC_HOME/briefings/), llmFollowups (disable to skip Responses API calls)."
+   },
+   "bufferMaxMinutes": {
+    "type": "number",
+    "default": 15,
+    "description": "Max minutes before forced extraction"
+   },
+   "bufferMaxTurns": {
+    "type": "number",
+    "default": 5,
+    "description": "Max turns before forced extraction"
+   },
+   "bufferSurpriseK": {
+    "type": "number",
+    "default": 5,
+    "minimum": 1,
+    "description": "Number of nearest-neighbor memories to average over when computing the surprise score. Clamped to the recent-memory window size."
+   },
+   "bufferSurpriseProbeTimeoutMs": {
+    "type": "number",
+    "default": 2000,
+    "minimum": 1,
+    "description": "Hard timeout (ms) for the surprise probe. If the probe does not resolve within this window the buffer treats it as failed and falls through to the existing triggers \u2014 a slow or hung embedder cannot stall the turn-append path."
+   },
+   "bufferSurpriseRecentMemoryCount": {
+    "type": "number",
+    "default": 20,
+    "minimum": 0,
+    "description": "Maximum number of recent memories sampled for surprise scoring. Bounds embedding cost per turn. Set to 0 to effectively disable the trigger even when the flag is on."
+   },
+   "bufferSurpriseThreshold": {
+    "type": "number",
+    "default": 0.35,
+    "minimum": 0,
+    "maximum": 1,
+    "description": "Threshold in [0, 1] above which a surprise score flushes the buffer. Higher = require more novelty to flush. Ignored when bufferSurpriseTriggerEnabled is false."
+   },
+   "bufferSurpriseTriggerEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Issue #563 (D-MEM). When true, the smart buffer flushes immediately on turns whose embedding-based surprise score exceeds bufferSurpriseThreshold, in addition to the existing turn-count / signal / time triggers. Additive only \u2014 never suppresses existing flushes. Off by default."
+   },
+   "calibrationEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable recall calibration rules (v9.0, default off)."
+   },
+   "calibrationMaxChars": {
+    "type": "number",
+    "default": 1200,
+    "description": "Maximum characters of calibration content to include per recall pass."
+   },
+   "calibrationMaxRulesPerRecall": {
+    "type": "number",
+    "default": 10,
+    "description": "Maximum number of calibration rules to include per recall pass."
+   },
+   "captureMode": {
+    "type": "string",
+    "enum": [
+     "implicit",
+     "explicit",
+     "hybrid"
+    ],
+    "default": "implicit",
+    "description": "Memory capture policy. implicit preserves normal extraction, explicit stores only structured capture, and hybrid allows both."
+   },
+   "causalGraphEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Build causal inference graph from heuristic phrases (requires multiGraphMemoryEnabled). Default true."
+   },
+   "causalRuleExtractionEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "PlugMem-inspired causal rule extraction: mine IF-THEN rules from conversations during consolidation"
+   },
+   "causalTrajectoryMemoryEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable Engram's causal-trajectory memory foundation for typed goal-action-observation-outcome chains."
+   },
+   "causalTrajectoryRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Add recall-relevant causal trajectories to recall context."
+   },
+   "causalTrajectoryStoreDir": {
+    "type": "string",
+    "description": "Override the causal-trajectory memory directory (defaults to {memoryDir}/state/causal-trajectories)."
+   },
+   "chat": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Conversational memory inspection and correction (issue #1583). A bounded tool-loop agent over read-only + confirmation-gated mutating tools. Off by default \u2014 spawns LLM calls so explicit opt-in (rule 48).",
+    "properties": {
+     "enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Master gate. Off = no chat tools/endpoints/CLI registered (byte-identical surfaces, rule 39)."
+     },
+     "model": {
+      "type": "string",
+      "default": "",
+      "description": "Routing override for the chat LLM. Empty = use the default routing chain (local Ollama/vLLM fully supported)."
+     },
+     "maxToolCallsPerTurn": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 64,
+      "default": 8,
+      "description": "Max tool calls per user turn before partial-reply fallback (rule 34 \u2014 never a silent stall)."
+     },
+     "sessionTtlHours": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 72,
+      "description": "Hours after which idle chat session state is cleaned up."
+     }
+    }
+   },
+   "checkpointEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable conversation checkpoints"
+   },
+   "checkpointTurns": {
+    "type": "number",
+    "default": 15,
+    "description": "Number of turns per checkpoint"
+   },
+   "chunkingEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable automatic chunking of long memories"
+   },
+   "chunkingMinTokens": {
+    "type": "number",
+    "default": 150,
+    "description": "Minimum tokens to trigger chunking"
+   },
+   "chunkingOverlapSentences": {
+    "type": "number",
+    "default": 2,
+    "description": "Number of sentences to overlap between chunks"
+   },
+   "chunkingTargetTokens": {
+    "type": "number",
+    "default": 200,
+    "description": "Target tokens per chunk"
+   },
+   "citationsAutoDetect": {
+    "type": "boolean",
+    "default": true,
+    "description": "Auto-enable citations when the Codex adapter is detected."
+   },
+   "citationsEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable oai-mem-citation blocks in recall responses for Codex citation parity."
+   },
+   "cmcBehaviorConfidenceThreshold": {
+    "type": "number",
+    "default": 0.6,
+    "description": "Minimum confidence threshold for CMC behavior patterns (0-1)."
+   },
+   "cmcBehaviorLearningEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable CMC behavior pattern learning (default off)."
+   },
+   "cmcBehaviorMinFrequency": {
+    "type": "number",
+    "default": 3,
+    "description": "Minimum frequency for a behavior pattern to be learned by CMC."
+   },
+   "cmcBehaviorMinSessions": {
+    "type": "number",
+    "default": 2,
+    "description": "Minimum sessions a behavior must appear in before CMC learns it."
+   },
+   "cmcConsolidationEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable CMC consolidation pass (default off)."
+   },
+   "cmcConsolidationMinRecurrence": {
+    "type": "number",
+    "default": 3,
+    "description": "Minimum recurrence count before a CMC pattern is consolidated."
+   },
+   "cmcConsolidationMinSessions": {
+    "type": "number",
+    "default": 2,
+    "description": "Minimum sessions a CMC pattern must appear in before consolidation."
+   },
+   "cmcConsolidationSuccessThreshold": {
+    "type": "number",
+    "default": 0.7,
+    "description": "Minimum success ratio required to consolidate a CMC pattern (0-1)."
+   },
+   "cmcEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable Causal Memory Consolidation (CMC) subsystem (default off)."
+   },
+   "cmcLifecycleCausalImpactWeight": {
+    "type": "number",
+    "default": 0.05,
+    "description": "Weight of causal impact score in CMC lifecycle scoring."
+   },
+   "cmcRetrievalCounterfactualBoost": {
+    "type": "number",
+    "default": 0.4,
+    "description": "Score boost applied to counterfactual nodes during CMC retrieval (0-1)."
+   },
+   "cmcRetrievalEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable CMC retrieval at recall time (default off)."
+   },
+   "cmcRetrievalMaxChars": {
+    "type": "number",
+    "default": 800,
+    "description": "Maximum characters of CMC content included per recall pass."
+   },
+   "cmcRetrievalMaxDepth": {
+    "type": "number",
+    "default": 3,
+    "description": "Maximum graph depth traversed during CMC retrieval."
+   },
+   "cmcStitchLookbackDays": {
+    "type": "number",
+    "default": 7,
+    "description": "Number of days to look back when stitching causal trajectories."
+   },
+   "cmcStitchMaxEdgesPerTrajectory": {
+    "type": "number",
+    "default": 3,
+    "description": "Maximum edges per trajectory during CMC stitching."
+   },
+   "cmcStitchMinScore": {
+    "type": "number",
+    "default": 2.5,
+    "description": "Minimum score for a causal edge to be stitched into a trajectory."
+   },
+   "codex": {
+    "type": "object",
+    "additionalProperties": false,
+    "default": {},
+    "properties": {
+     "installExtension": {
+      "type": "boolean",
+      "default": true,
+      "description": "Install the Remnic Codex memory extension during Codex connector setup."
+     },
+     "codexHome": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "default": null,
+      "description": "Optional Codex home directory override used for connector install and materialization."
+     }
+    }
+   },
+   "codexCompat": {
+    "type": "object",
+    "additionalProperties": false,
+    "default": {},
+    "properties": {
+     "enabled": {
+      "type": "boolean",
+      "default": false
+     },
+     "threadIdBufferKeying": {
+      "type": "boolean",
+      "default": true
+     },
+     "compactionFlushMode": {
+      "type": "string",
+      "enum": [
+       "signal",
+       "heuristic",
+       "auto"
+      ],
+      "default": "auto"
+     },
+     "fingerprintDedup": {
+      "type": "boolean",
+      "default": true
+     }
+    }
+   },
+   "codexMarketplaceEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable Codex marketplace integration for plugin discovery and installation."
+   },
+   "codexMaterializeMaxSummaryTokens": {
+    "type": "number",
+    "minimum": 0,
+    "default": 4500,
+    "description": "Whitespace-token cap for Codex memory summary materialization."
+   },
+   "codexMaterializeMemories": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable Codex native memory materialization into the Codex memories directory."
+   },
+   "codexMaterializeNamespace": {
+    "type": "string",
+    "default": "auto",
+    "description": "Namespace to materialize for Codex. \"auto\" derives the namespace from the active connector context."
+   },
+   "codexMaterializeOnConsolidation": {
+    "type": "boolean",
+    "default": true,
+    "description": "Run Codex memory materialization after semantic or causal consolidation completes."
+   },
+   "codexMaterializeOnSessionEnd": {
+    "type": "boolean",
+    "default": true,
+    "description": "Run Codex memory materialization from the Codex session-end hook."
+   },
+   "codexMaterializeRolloutRetentionDays": {
+    "type": "number",
+    "minimum": 0,
+    "default": 30,
+    "description": "Retention window in days for Codex rollout materialization artifacts."
+   },
+   "codingKnowledge": {
+    "type": "object",
+    "additionalProperties": false,
+    "default": {},
+    "description": "Durable coding-knowledge surface \u2014 Track A of issue #1548. Master gate + per-feature switches for decision records, architecture card, session delta, and structural-context provider. Off by default so pre-feature byte-identical behaviour is preserved when disabled.",
+    "properties": {
+     "enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Master gate. Off (default) means no Track A surface fires and no new tools / briefing lines / state directories appear. On enables the switches below."
+     },
+     "decisionRecords": {
+      "type": "boolean",
+      "default": true,
+      "description": "Decision-record surfaces (list/record/supersede) + briefing titles of standing decisions. Effective only under the master gate."
+     },
+     "architectureCard": {
+      "type": "boolean",
+      "default": true,
+      "description": "Architecture-card build/refresh + briefing injection. Effective only under the master gate."
+     },
+     "sessionDelta": {
+      "type": "boolean",
+      "default": true,
+      "description": "Last-seen-head persistence + delta briefing line. Effective only under the master gate."
+     },
+     "architectureCardLlmSummary": {
+      "type": "boolean",
+      "default": false,
+      "description": "Opt-in LLM summary pass on the architecture card. Costs tokens; default off (rule 48). Effective only under the master and card gates."
+     },
+     "structuralProvider": {
+      "type": "string",
+      "enum": [
+       "none",
+       "subprocess",
+       "native"
+      ],
+      "default": "none",
+      "description": "Structural-context provider selection: \"none\" (default) keeps review-context file-path-only, \"subprocess\" shells out to structuralProviderCommand via execFile (argv array), \"native\" adapts the in-family engine when @remnic/coding-graph is installed."
+     },
+     "structuralProviderCommand": {
+      "type": "string",
+      "default": "",
+      "description": "Absolute path to the subprocess binary when structuralProvider = \"subprocess\". Empty string = no command configured. The consumer validates existence at boot (rule 24)."
+     },
+     "codegraphTools": {
+      "type": "boolean",
+      "default": false,
+      "description": "Gate for the 14 codegraph parity tools (issue #1554). Off by default \u2014 tools/list, HTTP routes, and CLI help are byte-identical to pre-feature until this is true. Also requires @remnic/coding-graph to be installed."
+     },
+     "codegraphDbDir": {
+      "type": "string",
+      "default": "",
+      "description": "Root directory for per-project graph SQLite DBs. Empty string = derive from memoryDir (<memoryDir>/codegraph/<principal>/<projectId>.sqlite). Absolute path required when set explicitly (rule 11)."
+     },
+     "lsp": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Phase B type resolution via LSP (issue #1917). When enabled, codegraph_index invokes the LSP resolution pass after the heuristic reindex to upgrade unresolved call-site edges with real language-server definitions. Requires installed language servers on the host. Off by default (rule 48 - explicit opt-in for subprocess spawning).",
+      "properties": {
+       "enabled": {
         "type": "boolean",
         "default": false,
-        "description": "If enabled, Engram may auto-promote selected categories to shared (reserved; conservative)."
-      },
-      "beforeResetTimeoutMs": {
+        "description": "Master gate for LSP resolution. Off = heuristic edges only."
+       },
+       "servers": {
+        "type": "object",
+        "description": "Per-language server launch-spec overrides. Keys are language ids (typescript, python, go, rust, ...); values replace the built-in default command for that language.",
+        "additionalProperties": {
+         "type": "object",
+         "additionalProperties": false,
+         "required": [
+          "command"
+         ],
+         "properties": {
+          "command": {
+           "type": "string",
+           "description": "Server executable (resolved on PATH or absolute)."
+          },
+          "args": {
+           "type": "array",
+           "items": {
+            "type": "string"
+           },
+           "description": "Arguments (e.g. --stdio)."
+          }
+         }
+        }
+       },
+       "timeoutMs": {
+        "type": "number",
+        "default": 3000,
+        "description": "Handshake + per-request timeout in ms."
+       },
+       "maxRequestsPerRun": {
+        "type": "number",
+        "default": 500,
+        "description": "Max LSP definition requests per index run."
+       }
+      }
+     }
+    }
+   },
+   "codingMode": {
+    "type": "object",
+    "additionalProperties": false,
+    "default": {},
+    "description": "Coding-agent project/branch scoping (issue #569).",
+    "properties": {
+     "projectScope": {
+      "type": "boolean",
+      "default": true,
+      "description": "When true and the session has a resolved git context, memory routes to a project-scoped namespace (project:<id>). Set to false to restore pre-#569 behaviour exactly."
+     },
+     "branchScope": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, memory also overlays the current branch (project:<id>/branch:<name>). Opt-in \u2014 most development wants cross-branch recall. Wired in PR 3 of #569."
+     },
+     "globalFallback": {
+      "type": "boolean",
+      "default": true,
+      "description": "When true (default), project-scoped sessions include the root/default namespace in read fallbacks so globally useful memories remain visible. Set to false for strict project isolation."
+     }
+    }
+   },
+   "collectJudgeTrainingPairs": {
+    "type": "boolean",
+    "default": false,
+    "description": "Opt-in collector for (candidate_text, verdict_kind, reason) tuples used to prep a future GRPO training pipeline. Rows land under ~/.remnic/judge-training/<date>.jsonl (NOT in the shared memory directory). Off by default (issue #562)."
+   },
+   "commandsListEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Advertise Remnic slash-command descriptors through the registerCommand runtime surface."
+   },
+   "commitmentDecayDays": {
+    "type": "integer",
+    "minimum": 1,
+    "default": 90,
+    "description": "Days before fulfilled/expired commitments are removed"
+   },
+   "commitmentLedgerDir": {
+    "type": "string",
+    "description": "Override the commitment ledger directory (defaults to {memoryDir}/state/commitment-ledger)."
+   },
+   "commitmentLedgerEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable the explicit commitment ledger for promises, follow-ups, deadlines, and unfinished obligations."
+   },
+   "commitmentLifecycleEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable commitment lifecycle transitions, stale tracking, and resolved-entry cleanup for the commitment ledger."
+   },
+   "commitmentStaleDays": {
+    "type": "number",
+    "default": 14,
+    "description": "Days before an open commitment without a due date is considered stale in lifecycle status."
+   },
+   "compactionResetEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Trigger session reset after compaction with BOOT.md recovery context (requires OC fork with api.resetSession)"
+   },
+   "compoundingEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable compounding engine (v5.0). Default off."
+   },
+   "compoundingInjectEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Inject compounded mistakes/patterns into recall when compounding is enabled."
+   },
+   "compoundingSemanticEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable semantic compounding synthesis (reserved/experimental)."
+   },
+   "compoundingSynthesisTimeoutMs": {
+    "type": "number",
+    "default": 15000,
+    "description": "Timeout for compounding synthesis (ms)."
+   },
+   "compoundingWeeklyCronEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "If true, compounding weekly synthesis can be scheduled externally via cron."
+   },
+   "compressionGuidelineLearningEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable adaptive compression guideline learning from memory-action outcomes (v8.3, default off)."
+   },
+   "compressionGuidelineSemanticRefinementEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable optional semantic refinement pass after deterministic guideline candidate generation (v8.11, default off)."
+   },
+   "compressionGuidelineSemanticTimeoutMs": {
+    "type": "number",
+    "default": 2500,
+    "description": "Hard timeout in milliseconds for semantic refinement; timeout fail-opens to deterministic output."
+   },
+   "connectors": {
+    "type": "object",
+    "additionalProperties": false,
+    "default": {},
+    "description": "Live-connector configuration (issue #683). Each child object maps to one concrete LiveConnector. Defaults are off; operators must opt in.",
+    "properties": {
+     "googleDrive": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {},
+      "description": "Google Drive live connector (issue #683 PR 2/N). Imports text content from a user's Drive into Remnic on a poll schedule.",
+      "properties": {
+       "enabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Master gate. Default off \u2014 set to true to enable Drive imports. The connector additionally requires clientId, clientSecret, and refreshToken to be populated before it will run."
+       },
+       "clientId": {
+        "type": "string",
+        "default": "",
+        "description": "OAuth2 client id. Populate from your secret store (e.g. ${GOOGLE_DRIVE_CLIENT_ID}). Never commit a real value to source."
+       },
+       "clientSecret": {
+        "type": "string",
+        "default": "",
+        "description": "OAuth2 client secret. Populate from your secret store (e.g. ${GOOGLE_DRIVE_CLIENT_SECRET}). Never commit a real value to source."
+       },
+       "refreshToken": {
+        "type": "string",
+        "default": "",
+        "description": "OAuth2 refresh token issued for the user's Drive scope. Populate from your secret store (e.g. ${GOOGLE_DRIVE_REFRESH_TOKEN}). Never commit a real value to source."
+       },
+       "pollIntervalMs": {
         "type": "integer",
-        "minimum": 100,
-        "maximum": 30000,
-        "default": 2000,
-        "description": "Maximum time to wait for a reset-triggered flush before returning control to OpenClaw."
-      },
-      "behaviorLoopAutoTuneEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable runtime behavior-loop policy auto-tuning (v8.15, default off)."
-      },
-      "behaviorLoopLearningWindowDays": {
-        "type": "number",
-        "default": 14,
-        "description": "Rolling signal window used for behavior-loop policy learning (days; 0 allowed)."
-      },
-      "behaviorLoopMaxDeltaPerCycle": {
-        "type": "number",
-        "default": 0.1,
-        "description": "Maximum absolute parameter delta allowed per learning cycle (0-1)."
-      },
-      "behaviorLoopMinSignalCount": {
-        "type": "number",
-        "default": 10,
-        "description": "Minimum signal volume required before behavior-loop adjustments are emitted (0 allowed)."
-      },
-      "behaviorLoopProtectedParams": {
+        "minimum": 1000,
+        "maximum": 86400000,
+        "default": 300000,
+        "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+       },
+       "folderIds": {
         "type": "array",
         "items": {
-          "type": "string"
-        },
-        "default": [
-          "maxMemoryTokens",
-          "qmdMaxResults",
-          "qmdColdMaxResults",
-          "recallPlannerMaxQmdResultsMinimal",
-          "verbatimArtifactsMaxRecall"
-        ],
-        "description": "Runtime parameters that auto-tuning must never modify."
-      },
-      "benchmarkBaselineSnapshotsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable versioned benchmark baseline snapshot artifacts under the eval store for later PR delta reporting."
-      },
-      "benchmarkDeltaReporterEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable named-baseline delta reports so PR candidates can be compared against stored benchmark baselines."
-      },
-      "benchmarkStoredBaselineEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable stored baseline comparisons for benchmark delta reporting."
-      },
-      "binaryLifecycleBackendPath": {
-        "type": "string",
-        "default": "",
-        "description": "Base path for the filesystem storage backend."
-      },
-      "binaryLifecycleBackendType": {
-        "type": "string",
-        "enum": [
-          "none",
-          "filesystem",
-          "s3"
-        ],
-        "default": "none",
-        "description": "Storage backend for binary lifecycle mirror stage."
-      },
-      "binaryLifecycleEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable binary file lifecycle management. When true, binary files in the memory directory are mirrored, redirected, and cleaned."
-      },
-      "binaryLifecycleGracePeriodDays": {
-        "type": "number",
-        "default": 7,
-        "minimum": 0,
-        "description": "Days to wait before cleaning local copies of mirrored binary files."
-      },
-      "boostAccessCount": {
-        "type": "boolean",
-        "default": true,
-        "description": "Boost frequently accessed memories in search results"
-      },
-      "boxMaxMemories": {
-        "type": "number",
-        "default": 50,
-        "description": "Maximum memories per box before forced seal."
-      },
-      "boxRecallDays": {
-        "type": "number",
-        "default": 3,
-        "description": "Number of recent days of boxes to add during recall."
-      },
-      "boxTimeGapMs": {
-        "type": "number",
-        "default": 1800000,
-        "description": "Time gap in milliseconds before an open box is sealed (default 30 min)."
-      },
-      "boxTopicShiftThreshold": {
-        "type": "number",
-        "default": 0.35,
-        "description": "Jaccard overlap threshold below which a topic shift seals the current box (0–1)."
-      },
-      "briefing": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {
-          "enabled": true,
-          "defaultWindow": "yesterday",
-          "defaultFormat": "markdown",
-          "maxFollowups": 5,
-          "calendarSource": null,
-          "saveByDefault": false,
-          "saveDir": null,
-          "llmFollowups": true
-        },
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": true
-          },
-          "defaultWindow": {
-            "type": "string",
-            "default": "yesterday"
-          },
-          "defaultFormat": {
-            "type": "string",
-            "enum": [
-              "markdown",
-              "json"
-            ],
-            "default": "markdown"
-          },
-          "maxFollowups": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 10,
-            "default": 5
-          },
-          "calendarSource": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null
-          },
-          "saveByDefault": {
-            "type": "boolean",
-            "default": false
-          },
-          "saveDir": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null
-          },
-          "llmFollowups": {
-            "type": "boolean",
-            "default": true
-          }
-        },
-        "description": "Daily Context Briefing (#370). Knobs: enabled, defaultWindow ('yesterday', '3d', '1w', '24h', ...), defaultFormat (markdown|json), maxFollowups (0-10), calendarSource (path to ICS/JSON file, null = off), saveByDefault, saveDir (null = $REMNIC_HOME/briefings/), llmFollowups (disable to skip Responses API calls)."
-      },
-      "bufferMaxMinutes": {
-        "type": "number",
-        "default": 15,
-        "description": "Max minutes before forced extraction"
-      },
-      "bufferMaxTurns": {
-        "type": "number",
-        "default": 5,
-        "description": "Max turns before forced extraction"
-      },
-      "bufferSurpriseK": {
-        "type": "number",
-        "default": 5,
-        "minimum": 1,
-        "description": "Number of nearest-neighbor memories to average over when computing the surprise score. Clamped to the recent-memory window size."
-      },
-      "bufferSurpriseProbeTimeoutMs": {
-        "type": "number",
-        "default": 2000,
-        "minimum": 1,
-        "description": "Hard timeout (ms) for the surprise probe. If the probe does not resolve within this window the buffer treats it as failed and falls through to the existing triggers — a slow or hung embedder cannot stall the turn-append path."
-      },
-      "bufferSurpriseRecentMemoryCount": {
-        "type": "number",
-        "default": 20,
-        "minimum": 0,
-        "description": "Maximum number of recent memories sampled for surprise scoring. Bounds embedding cost per turn. Set to 0 to effectively disable the trigger even when the flag is on."
-      },
-      "bufferSurpriseThreshold": {
-        "type": "number",
-        "default": 0.35,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Threshold in [0, 1] above which a surprise score flushes the buffer. Higher = require more novelty to flush. Ignored when bufferSurpriseTriggerEnabled is false."
-      },
-      "bufferSurpriseTriggerEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Issue #563 (D-MEM). When true, the smart buffer flushes immediately on turns whose embedding-based surprise score exceeds bufferSurpriseThreshold, in addition to the existing turn-count / signal / time triggers. Additive only — never suppresses existing flushes. Off by default."
-      },
-      "calibrationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable recall calibration rules (v9.0, default off)."
-      },
-      "calibrationMaxChars": {
-        "type": "number",
-        "default": 1200,
-        "description": "Maximum characters of calibration content to include per recall pass."
-      },
-      "calibrationMaxRulesPerRecall": {
-        "type": "number",
-        "default": 10,
-        "description": "Maximum number of calibration rules to include per recall pass."
-      },
-      "captureMode": {
-        "type": "string",
-        "enum": [
-          "implicit",
-          "explicit",
-          "hybrid"
-        ],
-        "default": "implicit",
-        "description": "Memory capture policy. implicit preserves normal extraction, explicit stores only structured capture, and hybrid allows both."
-      },
-      "causalGraphEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Build causal inference graph from heuristic phrases (requires multiGraphMemoryEnabled). Default true."
-      },
-      "causalRuleExtractionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "PlugMem-inspired causal rule extraction: mine IF-THEN rules from conversations during consolidation"
-      },
-      "causalTrajectoryMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Engram's causal-trajectory memory foundation for typed goal-action-observation-outcome chains."
-      },
-      "causalTrajectoryRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant causal trajectories to recall context."
-      },
-      "causalTrajectoryStoreDir": {
-        "type": "string",
-        "description": "Override the causal-trajectory memory directory (defaults to {memoryDir}/state/causal-trajectories)."
-      },
-      "chat": {
-        "type": "object",
-        "additionalProperties": false,
-        "description": "Conversational memory inspection and correction (issue #1583). A bounded tool-loop agent over read-only + confirmation-gated mutating tools. Off by default — spawns LLM calls so explicit opt-in (rule 48).",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Master gate. Off = no chat tools/endpoints/CLI registered (byte-identical surfaces, rule 39)."
-          },
-          "model": {
-            "type": "string",
-            "default": "",
-            "description": "Routing override for the chat LLM. Empty = use the default routing chain (local Ollama/vLLM fully supported)."
-          },
-          "maxToolCallsPerTurn": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 64,
-            "default": 8,
-            "description": "Max tool calls per user turn before partial-reply fallback (rule 34 — never a silent stall)."
-          },
-          "sessionTtlHours": {
-            "type": "integer",
-            "minimum": 1,
-            "default": 72,
-            "description": "Hours after which idle chat session state is cleaned up."
-          }
-        }
-      },
-      "checkpointEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable conversation checkpoints"
-      },
-      "checkpointTurns": {
-        "type": "number",
-        "default": 15,
-        "description": "Number of turns per checkpoint"
-      },
-      "chunkingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic chunking of long memories"
-      },
-      "chunkingMinTokens": {
-        "type": "number",
-        "default": 150,
-        "description": "Minimum tokens to trigger chunking"
-      },
-      "chunkingOverlapSentences": {
-        "type": "number",
-        "default": 2,
-        "description": "Number of sentences to overlap between chunks"
-      },
-      "chunkingTargetTokens": {
-        "type": "number",
-        "default": 200,
-        "description": "Target tokens per chunk"
-      },
-      "citationsAutoDetect": {
-        "type": "boolean",
-        "default": true,
-        "description": "Auto-enable citations when the Codex adapter is detected."
-      },
-      "citationsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable oai-mem-citation blocks in recall responses for Codex citation parity."
-      },
-      "cmcBehaviorConfidenceThreshold": {
-        "type": "number",
-        "default": 0.6,
-        "description": "Minimum confidence threshold for CMC behavior patterns (0-1)."
-      },
-      "cmcBehaviorLearningEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable CMC behavior pattern learning (default off)."
-      },
-      "cmcBehaviorMinFrequency": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum frequency for a behavior pattern to be learned by CMC."
-      },
-      "cmcBehaviorMinSessions": {
-        "type": "number",
-        "default": 2,
-        "description": "Minimum sessions a behavior must appear in before CMC learns it."
-      },
-      "cmcConsolidationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable CMC consolidation pass (default off)."
-      },
-      "cmcConsolidationMinRecurrence": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum recurrence count before a CMC pattern is consolidated."
-      },
-      "cmcConsolidationMinSessions": {
-        "type": "number",
-        "default": 2,
-        "description": "Minimum sessions a CMC pattern must appear in before consolidation."
-      },
-      "cmcConsolidationSuccessThreshold": {
-        "type": "number",
-        "default": 0.7,
-        "description": "Minimum success ratio required to consolidate a CMC pattern (0-1)."
-      },
-      "cmcEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Causal Memory Consolidation (CMC) subsystem (default off)."
-      },
-      "cmcLifecycleCausalImpactWeight": {
-        "type": "number",
-        "default": 0.05,
-        "description": "Weight of causal impact score in CMC lifecycle scoring."
-      },
-      "cmcRetrievalCounterfactualBoost": {
-        "type": "number",
-        "default": 0.4,
-        "description": "Score boost applied to counterfactual nodes during CMC retrieval (0-1)."
-      },
-      "cmcRetrievalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable CMC retrieval at recall time (default off)."
-      },
-      "cmcRetrievalMaxChars": {
-        "type": "number",
-        "default": 800,
-        "description": "Maximum characters of CMC content included per recall pass."
-      },
-      "cmcRetrievalMaxDepth": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum graph depth traversed during CMC retrieval."
-      },
-      "cmcStitchLookbackDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Number of days to look back when stitching causal trajectories."
-      },
-      "cmcStitchMaxEdgesPerTrajectory": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum edges per trajectory during CMC stitching."
-      },
-      "cmcStitchMinScore": {
-        "type": "number",
-        "default": 2.5,
-        "description": "Minimum score for a causal edge to be stitched into a trajectory."
-      },
-      "codex": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "installExtension": {
-            "type": "boolean",
-            "default": true,
-            "description": "Install the Remnic Codex memory extension during Codex connector setup."
-          },
-          "codexHome": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null,
-            "description": "Optional Codex home directory override used for connector install and materialization."
-          }
-        }
-      },
-      "codexCompat": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false
-          },
-          "threadIdBufferKeying": {
-            "type": "boolean",
-            "default": true
-          },
-          "compactionFlushMode": {
-            "type": "string",
-            "enum": [
-              "signal",
-              "heuristic",
-              "auto"
-            ],
-            "default": "auto"
-          },
-          "fingerprintDedup": {
-            "type": "boolean",
-            "default": true
-          }
-        }
-      },
-      "codexMarketplaceEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable Codex marketplace integration for plugin discovery and installation."
-      },
-      "codexMaterializeMaxSummaryTokens": {
-        "type": "number",
-        "minimum": 0,
-        "default": 4500,
-        "description": "Whitespace-token cap for Codex memory summary materialization."
-      },
-      "codexMaterializeMemories": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable Codex native memory materialization into the Codex memories directory."
-      },
-      "codexMaterializeNamespace": {
-        "type": "string",
-        "default": "auto",
-        "description": "Namespace to materialize for Codex. \"auto\" derives the namespace from the active connector context."
-      },
-      "codexMaterializeOnConsolidation": {
-        "type": "boolean",
-        "default": true,
-        "description": "Run Codex memory materialization after semantic or causal consolidation completes."
-      },
-      "codexMaterializeOnSessionEnd": {
-        "type": "boolean",
-        "default": true,
-        "description": "Run Codex memory materialization from the Codex session-end hook."
-      },
-      "codexMaterializeRolloutRetentionDays": {
-        "type": "number",
-        "minimum": 0,
-        "default": 30,
-        "description": "Retention window in days for Codex rollout materialization artifacts."
-      },
-      "codingKnowledge": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "description": "Durable coding-knowledge surface — Track A of issue #1548. Master gate + per-feature switches for decision records, architecture card, session delta, and structural-context provider. Off by default so pre-feature byte-identical behaviour is preserved when disabled.",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Master gate. Off (default) means no Track A surface fires and no new tools / briefing lines / state directories appear. On enables the switches below."
-          },
-          "decisionRecords": {
-            "type": "boolean",
-            "default": true,
-            "description": "Decision-record surfaces (list/record/supersede) + briefing titles of standing decisions. Effective only under the master gate."
-          },
-          "architectureCard": {
-            "type": "boolean",
-            "default": true,
-            "description": "Architecture-card build/refresh + briefing injection. Effective only under the master gate."
-          },
-          "sessionDelta": {
-            "type": "boolean",
-            "default": true,
-            "description": "Last-seen-head persistence + delta briefing line. Effective only under the master gate."
-          },
-          "architectureCardLlmSummary": {
-            "type": "boolean",
-            "default": false,
-            "description": "Opt-in LLM summary pass on the architecture card. Costs tokens; default off (rule 48). Effective only under the master and card gates."
-          },
-          "structuralProvider": {
-            "type": "string",
-            "enum": [
-              "none",
-              "subprocess",
-              "native"
-            ],
-            "default": "none",
-            "description": "Structural-context provider selection: \"none\" (default) keeps review-context file-path-only, \"subprocess\" shells out to structuralProviderCommand via execFile (argv array), \"native\" adapts the in-family engine when @remnic/coding-graph is installed."
-          },
-          "structuralProviderCommand": {
-            "type": "string",
-            "default": "",
-            "description": "Absolute path to the subprocess binary when structuralProvider = \"subprocess\". Empty string = no command configured. The consumer validates existence at boot (rule 24)."
-          },
-          "codegraphTools": {
-            "type": "boolean",
-            "default": false,
-            "description": "Gate for the 14 codegraph parity tools (issue #1554). Off by default — tools/list, HTTP routes, and CLI help are byte-identical to pre-feature until this is true. Also requires @remnic/coding-graph to be installed."
-          },
-          "codegraphDbDir": {
-            "type": "string",
-            "default": "",
-            "description": "Root directory for per-project graph SQLite DBs. Empty string = derive from memoryDir (<memoryDir>/codegraph/<principal>/<projectId>.sqlite). Absolute path required when set explicitly (rule 11)."
-          },
-          "lsp": {
-            "type": "object",
-            "additionalProperties": false,
-            "description": "Phase B type resolution via LSP (issue #1917). When enabled, codegraph_index invokes the LSP resolution pass after the heuristic reindex to upgrade unresolved call-site edges with real language-server definitions. Requires installed language servers on the host. Off by default (rule 48 - explicit opt-in for subprocess spawning).",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate for LSP resolution. Off = heuristic edges only."
-              },
-              "servers": {
-                "type": "object",
-                "description": "Per-language server launch-spec overrides. Keys are language ids (typescript, python, go, rust, ...); values replace the built-in default command for that language.",
-                "additionalProperties": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "command"
-                  ],
-                  "properties": {
-                    "command": {
-                      "type": "string",
-                      "description": "Server executable (resolved on PATH or absolute)."
-                    },
-                    "args": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      },
-                      "description": "Arguments (e.g. --stdio)."
-                    }
-                  }
-                }
-              },
-              "timeoutMs": {
-                "type": "number",
-                "default": 3000,
-                "description": "Handshake + per-request timeout in ms."
-              },
-              "maxRequestsPerRun": {
-                "type": "number",
-                "default": 500,
-                "description": "Max LSP definition requests per index run."
-              }
-            }
-          }
-        }
-      },
-      "codingMode": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "description": "Coding-agent project/branch scoping (issue #569).",
-        "properties": {
-          "projectScope": {
-            "type": "boolean",
-            "default": true,
-            "description": "When true and the session has a resolved git context, memory routes to a project-scoped namespace (project:<id>). Set to false to restore pre-#569 behaviour exactly."
-          },
-          "branchScope": {
-            "type": "boolean",
-            "default": false,
-            "description": "When true, memory also overlays the current branch (project:<id>/branch:<name>). Opt-in — most development wants cross-branch recall. Wired in PR 3 of #569."
-          },
-          "globalFallback": {
-            "type": "boolean",
-            "default": true,
-            "description": "When true (default), project-scoped sessions include the root/default namespace in read fallbacks so globally useful memories remain visible. Set to false for strict project isolation."
-          }
-        }
-      },
-      "collectJudgeTrainingPairs": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt-in collector for (candidate_text, verdict_kind, reason) tuples used to prep a future GRPO training pipeline. Rows land under ~/.remnic/judge-training/<date>.jsonl (NOT in the shared memory directory). Off by default (issue #562)."
-      },
-      "commandsListEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Advertise Remnic slash-command descriptors through the registerCommand runtime surface."
-      },
-      "commitmentDecayDays": {
-        "type": "integer",
-        "minimum": 1,
-        "default": 90,
-        "description": "Days before fulfilled/expired commitments are removed"
-      },
-      "commitmentLedgerDir": {
-        "type": "string",
-        "description": "Override the commitment ledger directory (defaults to {memoryDir}/state/commitment-ledger)."
-      },
-      "commitmentLedgerEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the explicit commitment ledger for promises, follow-ups, deadlines, and unfinished obligations."
-      },
-      "commitmentLifecycleEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable commitment lifecycle transitions, stale tracking, and resolved-entry cleanup for the commitment ledger."
-      },
-      "commitmentStaleDays": {
-        "type": "number",
-        "default": 14,
-        "description": "Days before an open commitment without a due date is considered stale in lifecycle status."
-      },
-      "compactionResetEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Trigger session reset after compaction with BOOT.md recovery context (requires OC fork with api.resetSession)"
-      },
-      "compoundingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable compounding engine (v5.0). Default off."
-      },
-      "compoundingInjectEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Inject compounded mistakes/patterns into recall when compounding is enabled."
-      },
-      "compoundingSemanticEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable semantic compounding synthesis (reserved/experimental)."
-      },
-      "compoundingSynthesisTimeoutMs": {
-        "type": "number",
-        "default": 15000,
-        "description": "Timeout for compounding synthesis (ms)."
-      },
-      "compoundingWeeklyCronEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, compounding weekly synthesis can be scheduled externally via cron."
-      },
-      "compressionGuidelineLearningEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable adaptive compression guideline learning from memory-action outcomes (v8.3, default off)."
-      },
-      "compressionGuidelineSemanticRefinementEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable optional semantic refinement pass after deterministic guideline candidate generation (v8.11, default off)."
-      },
-      "compressionGuidelineSemanticTimeoutMs": {
-        "type": "number",
-        "default": 2500,
-        "description": "Hard timeout in milliseconds for semantic refinement; timeout fail-opens to deterministic output."
-      },
-      "connectors": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "description": "Live-connector configuration (issue #683). Each child object maps to one concrete LiveConnector. Defaults are off; operators must opt in.",
-        "properties": {
-          "googleDrive": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "Google Drive live connector (issue #683 PR 2/N). Imports text content from a user's Drive into Remnic on a poll schedule.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate. Default off — set to true to enable Drive imports. The connector additionally requires clientId, clientSecret, and refreshToken to be populated before it will run."
-              },
-              "clientId": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 client id. Populate from your secret store (e.g. ${GOOGLE_DRIVE_CLIENT_ID}). Never commit a real value to source."
-              },
-              "clientSecret": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 client secret. Populate from your secret store (e.g. ${GOOGLE_DRIVE_CLIENT_SECRET}). Never commit a real value to source."
-              },
-              "refreshToken": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 refresh token issued for the user's Drive scope. Populate from your secret store (e.g. ${GOOGLE_DRIVE_REFRESH_TOKEN}). Never commit a real value to source."
-              },
-              "pollIntervalMs": {
-                "type": "integer",
-                "minimum": 1000,
-                "maximum": 86400000,
-                "default": 300000,
-                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
-              },
-              "folderIds": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Optional array of Google Drive folder ids to scope the import. Empty = all accessible files. Folder ids are validated for shape; nested folders are NOT auto-included."
-              }
-            }
-          },
-          "notion": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "Notion live connector (issue #683 PR 3/N). Imports text content from Notion database pages into Remnic on a poll schedule.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate. Default off — set to true to enable Notion imports. The connector additionally requires a token and at least one databaseId to be populated before it will run."
-              },
-              "token": {
-                "type": "string",
-                "default": "",
-                "description": "Notion integration token (starts with secret_). Populate from your secret store (e.g. ${NOTION_TOKEN}). Never commit a real value to source."
-              },
-              "databaseIds": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Array of Notion database ids to import pages from. Accepts compact 32-hex-char ids or standard UUID format. Empty = connector is a no-op."
-              },
-              "pollIntervalMs": {
-                "type": "integer",
-                "minimum": 1000,
-                "maximum": 86400000,
-                "default": 300000,
-                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
-              }
-            }
-          },
-          "gmail": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "Gmail live connector (issue #683 PR 4/6). Imports new inbox messages from Gmail into Remnic on a poll schedule.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate. Default off — set to true to enable Gmail imports. The connector additionally requires clientId, clientSecret, and refreshToken to be populated before it will run."
-              },
-              "clientId": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 client id. Populate from your secret store (e.g. ${GMAIL_CLIENT_ID}). Never commit a real value to source."
-              },
-              "clientSecret": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 client secret. Populate from your secret store (e.g. ${GMAIL_CLIENT_SECRET}). Never commit a real value to source."
-              },
-              "refreshToken": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 refresh token issued for the Gmail scope. Populate from your secret store (e.g. ${GMAIL_REFRESH_TOKEN}). Never commit a real value to source."
-              },
-              "userId": {
-                "type": "string",
-                "default": "me",
-                "description": "Gmail userId. Defaults to 'me' (the authenticated user). Override only in delegated-access scenarios."
-              },
-              "query": {
-                "type": "string",
-                "default": "in:inbox",
-                "description": "Gmail search query applied in addition to the watermark after: filter. Default 'in:inbox'. Set to '' to import all mail."
-              },
-              "pollIntervalMs": {
-                "type": "integer",
-                "minimum": 1000,
-                "maximum": 86400000,
-                "default": 300000,
-                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
-              }
-            }
-          },
-          "github": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "GitHub live connector (issue #683 PR 5/6). Imports issue comments, PR review comments, and optionally discussion posts authored by the configured user from watched repos into Remnic on a poll schedule.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate. Default off — set to true to enable GitHub imports. The connector additionally requires token, userLogin, and at least one repo to be populated before it will run."
-              },
-              "token": {
-                "type": "string",
-                "default": "",
-                "description": "GitHub personal access token. Populate from your secret store (e.g. ${GITHUB_TOKEN}). Never commit a real value to source."
-              },
-              "userLogin": {
-                "type": "string",
-                "default": "",
-                "description": "GitHub login of the user whose comments will be imported. Only comments authored by this login are ingested. Required when enabled."
-              },
-              "repos": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Array of repos to poll in \"owner/repo\" format. Empty = connector is a no-op."
-              },
-              "pollIntervalMs": {
-                "type": "integer",
-                "minimum": 1000,
-                "maximum": 86400000,
-                "default": 300000,
-                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
-              },
-              "includeDiscussions": {
-                "type": "boolean",
-                "default": false,
-                "description": "Whether to import GitHub Discussion comments in addition to issue and PR review comments. Default false."
-              }
-            }
-          }
-        }
-      },
-      "consolidateEveryN": {
-        "type": "number",
-        "default": 3,
-        "description": "Run consolidation every N extractions"
-      },
-      "consolidationMinIntervalMs": {
-        "type": "number",
-        "default": 600000,
-        "description": "Minimum interval between consolidation runs (ms)."
-      },
-      "consolidationRequireNonZeroExtraction": {
-        "type": "boolean",
-        "default": true,
-        "description": "Only schedule consolidation when the last extraction produced durable outputs."
-      },
-      "contextCompressionActionsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable context compression action tooling and telemetry paths (v8.3, default off)."
-      },
-      "continuityAuditEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable continuity audit artifact generation workflows"
-      },
-      "continuityIncidentLoggingEnabled": {
-        "type": "boolean",
-        "description": "When unset, defaults to identityContinuityEnabled. Controls continuity incident logging artifacts."
-      },
-      "contradictionAutoResolve": {
-        "type": "boolean",
-        "default": true,
-        "description": "Automatically supersede contradicted memories"
-      },
-      "contradictionDetectionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic contradiction detection with LLM verification"
-      },
-      "contradictionMinConfidence": {
-        "type": "number",
-        "default": 0.9,
-        "description": "Minimum LLM confidence to auto-resolve contradictions"
-      },
-      "contradictionScan": {
-        "type": "object",
-        "description": "Configuration for the nightly contradiction-scan cron (issue #520)",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Enable the nightly contradiction scan cron (disabled by default per rule 48)"
-          },
-          "similarityFloor": {
-            "type": "number",
-            "default": 0.82,
-            "minimum": 0,
-            "maximum": 1,
-            "description": "Embedding cosine similarity floor for candidate pair generation"
-          },
-          "topicOverlapFloor": {
-            "type": "number",
-            "default": 0.4,
-            "minimum": 0,
-            "maximum": 1,
-            "description": "Minimum topic-token Jaccard overlap for unstructured pairs"
-          },
-          "maxPairsPerRun": {
-            "type": "integer",
-            "default": 500,
-            "minimum": 1,
-            "description": "Cap on candidate pairs evaluated per cron run"
-          },
-          "cooldownDays": {
-            "type": "integer",
-            "default": 14,
-            "minimum": 0,
-            "description": "Cooldown in days. 0 = always re-evaluate."
-          },
-          "autoMergeDuplicates": {
-            "type": "boolean",
-            "default": false,
-            "description": "Auto-flag pairs judged duplicates for dedup (still requires user approval)"
-          }
-        }
-      },
-      "contradictionSimilarityThreshold": {
-        "type": "number",
-        "default": 0.7,
-        "description": "QMD similarity threshold to trigger contradiction check"
-      },
-      "conversationIndexBackend": {
-        "type": "string",
-        "enum": [
-          "qmd",
-          "faiss"
-        ],
-        "default": "qmd",
-        "description": "Backend for conversation indexing. qmd indexes chunk docs into a QMD collection; faiss uses the bundled Python sidecar and local FAISS artifacts under memoryDir/state/conversation-index/faiss."
-      },
-      "conversationIndexEmbedOnUpdate": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, conversation_index_update also runs QMD embed by default. Keep false for lower load."
-      },
-      "conversationIndexEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable conversation chunk indexing + semantic recall hook (default off)."
-      },
-      "conversationIndexFaissHealthTimeoutMs": {
-        "type": "number",
-        "default": 2000,
-        "description": "Timeout (ms) for FAISS health checks. Health is fail-open and reports degraded when dependencies or local artifacts are missing."
-      },
-      "conversationIndexFaissIndexDir": {
-        "type": "string",
-        "default": "state/conversation-index/faiss",
-        "description": "Relative directory under memoryDir where FAISS sidecar artifacts are stored, including index.faiss, metadata.jsonl, and manifest.json."
-      },
-      "conversationIndexFaissMaxBatchSize": {
-        "type": "number",
-        "default": 512,
-        "description": "Maximum transcript chunk batch size per FAISS upsert call."
-      },
-      "conversationIndexFaissMaxSearchK": {
-        "type": "number",
-        "default": 50,
-        "description": "Maximum top-K allowed for FAISS search requests."
-      },
-      "conversationIndexFaissModelId": {
-        "type": "string",
-        "default": "text-embedding-3-small",
-        "description": "Embedding model identifier passed to the FAISS sidecar. By default the sidecar aliases OpenAI embedding ids to a local sentence-transformers model when REMNIC_FAISS_ENABLE_ST=1 (or legacy ENGRAM_FAISS_ENABLE_ST=1), and otherwise falls back to deterministic hash embeddings."
-      },
-      "conversationIndexFaissPythonBin": {
-        "type": "string",
-        "default": "",
-        "description": "Optional Python executable used to run the FAISS sidecar (for example python3.11)."
-      },
-      "conversationIndexFaissScriptPath": {
-        "type": "string",
-        "default": "",
-        "description": "Optional absolute path to FAISS sidecar script. If unset, uses built-in default script location."
-      },
-      "conversationIndexFaissSearchTimeoutMs": {
-        "type": "number",
-        "default": 5000,
-        "description": "Timeout (ms) for FAISS search operations."
-      },
-      "conversationIndexFaissUpsertTimeoutMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Timeout (ms) for FAISS upsert operations."
-      },
-      "conversationIndexMinUpdateIntervalMs": {
-        "type": "number",
-        "default": 900000,
-        "description": "Minimum interval between conversation_index_update runs per session (ms). Prevents redundant reindex churn."
-      },
-      "conversationIndexQmdCollection": {
-        "type": "string",
-        "default": "openclaw-engram-conversations",
-        "description": "QMD collection to use for conversation chunk search (must be configured in ~/.config/qmd/index.yml)."
-      },
-      "conversationIndexRetentionDays": {
-        "type": "number",
-        "default": 30,
-        "description": "Days to retain conversation chunk docs."
-      },
-      "conversationRecallMaxChars": {
-        "type": "number",
-        "default": 2500,
-        "description": "Max characters of semantic conversation recall to include."
-      },
-      "conversationRecallTimeoutMs": {
-        "type": "number",
-        "default": 800,
-        "description": "Timeout for semantic conversation recall search (ms). Fail-open on timeout."
-      },
-      "conversationRecallTopK": {
-        "type": "number",
-        "default": 3,
-        "description": "Top-K conversation chunks to include."
-      },
-      "correctionApplyRequiresConfirm": {
-        "type": "boolean",
-        "default": true,
-        "description": "When true (default), memory_correct_apply requires confirm: true before mutating memory (#1580). Off allows one-shot apply without an explicit confirmation."
-      },
-      "correctionCaptureAutoApplyMaxAffected": {
-        "type": "integer",
-        "minimum": 1,
-        "default": 2,
-        "description": "Maximum number of memories a passively-detected correction may affect in \"auto\" mode (#1581). Plans touching more memories than this are queued even when mode is \"auto\" — a blast-radius cap. Default 2."
-      },
-      "correctionCaptureConfidenceFloor": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.85,
-        "description": "Minimum planner confidence required to auto-apply a passively-detected correction in \"auto\" mode (#1581). Plans below this floor are queued even when mode is \"auto\". Default 0.85."
-      },
-      "correctionCaptureMode": {
-        "type": "string",
-        "enum": [
-          "off",
-          "queue",
-          "auto"
-        ],
-        "default": "off",
-        "description": "Passive correction capture (#1581) — detects corrections expressed in conversation during extraction and routes them to the Correction Contract (#1580). \"off\" disables detection (default, rule 48); \"queue\" plans corrections for human review in the review list; \"auto\" applies immediately when all safety guards pass (confidence floor, blast-radius cap, allowed action/classification), otherwise falls back to queue. Invalid values are rejected (rule 51)."
-      },
-      "correctionEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Master gate for the Correction Contract (#1580) — the unified plan/apply pipeline for memory corrections (supersede/edit/retract/rescope/never-store). When false, the correction surfaces (CLI/HTTP/MCP) are disabled."
-      },
-      "correctionMaxAffected": {
-        "type": "integer",
-        "minimum": 1,
-        "default": 10,
-        "description": "Maximum number of memories a single correction plan may affect (#1580). A plan exceeding this is refused rather than silently truncated. Invalid values (0/negative/non-numeric) are rejected."
-      },
-      "correctionPlanTtlHours": {
-        "type": "number",
-        "minimum": 1,
-        "default": 24,
-        "description": "Hours a pending correction plan remains valid before it expires and must be re-planned (#1580). Invalid values (0/negative/non-numeric) are rejected."
-      },
-      "creationMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable creation-memory foundations, including the work-product ledger for explicit outputs agents create."
-      },
-      "cronConversationRecallMode": {
-        "type": "string",
-        "enum": [
-          "auto",
-          "always",
-          "never"
-        ],
-        "default": "auto",
-        "description": "Controls conversation semantic recall in cron sessions. auto skips it for instruction-heavy prompts."
-      },
-      "cronRecallAllowlist": {
-        "type": "array",
-        "items": {
-          "type": "string"
+         "type": "string"
         },
         "default": [],
-        "description": "Session-key wildcard patterns (supports *) allowed for recall when cronRecallMode=allowlist."
-      },
-      "cronRecallInstructionHeavyTokenCap": {
-        "type": "number",
-        "default": 36,
-        "description": "Maximum token count used to build compact retrieval queries for instruction-heavy cron prompts."
-      },
-      "cronRecallMode": {
-        "type": "string",
-        "enum": [
-          "all",
-          "none",
-          "allowlist"
-        ],
-        "default": "all",
-        "description": "Recall behavior for cron sessions. Use allowlist to opt specific cron sessionKeys in."
-      },
-      "cronRecallNormalizedQueryMaxChars": {
-        "type": "number",
-        "default": 480,
-        "description": "Maximum query length (characters) used for cron recall retrieval after normalization."
-      },
-      "cronRecallPolicyEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable prompt-shape-aware recall query normalization for cron sessions."
-      },
-      "crossSignalsSemanticEnabled": {
+        "description": "Optional array of Google Drive folder ids to scope the import. Empty = all accessible files. Folder ids are validated for shape; nested folders are NOT auto-included."
+       }
+      }
+     },
+     "notion": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {},
+      "description": "Notion live connector (issue #683 PR 3/N). Imports text content from Notion database pages into Remnic on a poll schedule.",
+      "properties": {
+       "enabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable semantic cross-signal grouping (reserved/experimental)."
-      },
-      "crossSignalsSemanticTimeoutMs": {
-        "type": "number",
-        "default": 4000,
-        "description": "Timeout for semantic cross-signal grouping (ms)."
-      },
-      "daySummaryEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable end-of-day summary generation via engram.day_summary MCP tool"
-      },
-      "daySummaryTimezone": {
+        "description": "Master gate. Default off \u2014 set to true to enable Notion imports. The connector additionally requires a token and at least one databaseId to be populated before it will run."
+       },
+       "token": {
         "type": "string",
         "default": "",
-        "description": "Timezone for the day summary cron (e.g. 'America/Lima'). When empty, uses the server timezone."
-      },
-      "debug": {
+        "description": "Notion integration token (starts with secret_). Populate from your secret store (e.g. ${NOTION_TOKEN}). Never commit a real value to source."
+       },
+       "databaseIds": {
+        "type": "array",
+        "items": {
+         "type": "string"
+        },
+        "default": [],
+        "description": "Array of Notion database ids to import pages from. Accepts compact 32-hex-char ids or standard UUID format. Empty = connector is a no-op."
+       },
+       "pollIntervalMs": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 86400000,
+        "default": 300000,
+        "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+       }
+      }
+     },
+     "gmail": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {},
+      "description": "Gmail live connector (issue #683 PR 4/6). Imports new inbox messages from Gmail into Remnic on a poll schedule.",
+      "properties": {
+       "enabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable debug logging"
-      },
-      "defaultNamespace": {
+        "description": "Master gate. Default off \u2014 set to true to enable Gmail imports. The connector additionally requires clientId, clientSecret, and refreshToken to be populated before it will run."
+       },
+       "clientId": {
         "type": "string",
-        "default": "default",
-        "description": "Default namespace name."
-      },
-      "defaultRecallNamespaces": {
+        "default": "",
+        "description": "OAuth2 client id. Populate from your secret store (e.g. ${GMAIL_CLIENT_ID}). Never commit a real value to source."
+       },
+       "clientSecret": {
+        "type": "string",
+        "default": "",
+        "description": "OAuth2 client secret. Populate from your secret store (e.g. ${GMAIL_CLIENT_SECRET}). Never commit a real value to source."
+       },
+       "refreshToken": {
+        "type": "string",
+        "default": "",
+        "description": "OAuth2 refresh token issued for the Gmail scope. Populate from your secret store (e.g. ${GMAIL_REFRESH_TOKEN}). Never commit a real value to source."
+       },
+       "userId": {
+        "type": "string",
+        "default": "me",
+        "description": "Gmail userId. Defaults to 'me' (the authenticated user). Override only in delegated-access scenarios."
+       },
+       "query": {
+        "type": "string",
+        "default": "in:inbox",
+        "description": "Gmail search query applied in addition to the watermark after: filter. Default 'in:inbox'. Set to '' to import all mail."
+       },
+       "pollIntervalMs": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 86400000,
+        "default": 300000,
+        "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+       }
+      }
+     },
+     "github": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {},
+      "description": "GitHub live connector (issue #683 PR 5/6). Imports issue comments, PR review comments, and optionally discussion posts authored by the configured user from watched repos into Remnic on a poll schedule.",
+      "properties": {
+       "enabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Master gate. Default off \u2014 set to true to enable GitHub imports. The connector additionally requires token, userLogin, and at least one repo to be populated before it will run."
+       },
+       "token": {
+        "type": "string",
+        "default": "",
+        "description": "GitHub personal access token. Populate from your secret store (e.g. ${GITHUB_TOKEN}). Never commit a real value to source."
+       },
+       "userLogin": {
+        "type": "string",
+        "default": "",
+        "description": "GitHub login of the user whose comments will be imported. Only comments authored by this login are ingested. Required when enabled."
+       },
+       "repos": {
         "type": "array",
-        "description": "Which namespaces to include by default in recall.",
         "items": {
-          "type": "string",
-          "enum": [
-            "self",
-            "shared"
+         "type": "string"
+        },
+        "default": [],
+        "description": "Array of repos to poll in \"owner/repo\" format. Empty = connector is a no-op."
+       },
+       "pollIntervalMs": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 86400000,
+        "default": 300000,
+        "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+       },
+       "includeDiscussions": {
+        "type": "boolean",
+        "default": false,
+        "description": "Whether to import GitHub Discussion comments in addition to issue and PR review comments. Default false."
+       }
+      }
+     }
+    }
+   },
+   "consolidateEveryN": {
+    "type": "number",
+    "default": 3,
+    "description": "Run consolidation every N extractions"
+   },
+   "consolidationMinIntervalMs": {
+    "type": "number",
+    "default": 600000,
+    "description": "Minimum interval between consolidation runs (ms)."
+   },
+   "consolidationRequireNonZeroExtraction": {
+    "type": "boolean",
+    "default": true,
+    "description": "Only schedule consolidation when the last extraction produced durable outputs."
+   },
+   "contextCompressionActionsEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable context compression action tooling and telemetry paths (v8.3, default off)."
+   },
+   "continuityAuditEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable continuity audit artifact generation workflows"
+   },
+   "continuityIncidentLoggingEnabled": {
+    "type": "boolean",
+    "description": "When unset, defaults to identityContinuityEnabled. Controls continuity incident logging artifacts."
+   },
+   "contradictionAutoResolve": {
+    "type": "boolean",
+    "default": true,
+    "description": "Automatically supersede contradicted memories"
+   },
+   "contradictionDetectionEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable automatic contradiction detection with LLM verification"
+   },
+   "contradictionMinConfidence": {
+    "type": "number",
+    "default": 0.9,
+    "description": "Minimum LLM confidence to auto-resolve contradictions"
+   },
+   "contradictionScan": {
+    "type": "object",
+    "description": "Configuration for the nightly contradiction-scan cron (issue #520)",
+    "properties": {
+     "enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable the nightly contradiction scan cron (disabled by default per rule 48)"
+     },
+     "similarityFloor": {
+      "type": "number",
+      "default": 0.82,
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Embedding cosine similarity floor for candidate pair generation"
+     },
+     "topicOverlapFloor": {
+      "type": "number",
+      "default": 0.4,
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Minimum topic-token Jaccard overlap for unstructured pairs"
+     },
+     "maxPairsPerRun": {
+      "type": "integer",
+      "default": 500,
+      "minimum": 1,
+      "description": "Cap on candidate pairs evaluated per cron run"
+     },
+     "cooldownDays": {
+      "type": "integer",
+      "default": 14,
+      "minimum": 0,
+      "description": "Cooldown in days. 0 = always re-evaluate."
+     },
+     "autoMergeDuplicates": {
+      "type": "boolean",
+      "default": false,
+      "description": "Auto-flag pairs judged duplicates for dedup (still requires user approval)"
+     }
+    }
+   },
+   "contradictionSimilarityThreshold": {
+    "type": "number",
+    "default": 0.7,
+    "description": "QMD similarity threshold to trigger contradiction check"
+   },
+   "conversationIndexBackend": {
+    "type": "string",
+    "enum": [
+     "qmd",
+     "faiss"
+    ],
+    "default": "qmd",
+    "description": "Backend for conversation indexing. qmd indexes chunk docs into a QMD collection; faiss uses the bundled Python sidecar and local FAISS artifacts under memoryDir/state/conversation-index/faiss."
+   },
+   "conversationIndexEmbedOnUpdate": {
+    "type": "boolean",
+    "default": false,
+    "description": "If true, conversation_index_update also runs QMD embed by default. Keep false for lower load."
+   },
+   "conversationIndexEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable conversation chunk indexing + semantic recall hook (default off)."
+   },
+   "conversationIndexFaissHealthTimeoutMs": {
+    "type": "number",
+    "default": 2000,
+    "description": "Timeout (ms) for FAISS health checks. Health is fail-open and reports degraded when dependencies or local artifacts are missing."
+   },
+   "conversationIndexFaissIndexDir": {
+    "type": "string",
+    "default": "state/conversation-index/faiss",
+    "description": "Relative directory under memoryDir where FAISS sidecar artifacts are stored, including index.faiss, metadata.jsonl, and manifest.json."
+   },
+   "conversationIndexFaissMaxBatchSize": {
+    "type": "number",
+    "default": 512,
+    "description": "Maximum transcript chunk batch size per FAISS upsert call."
+   },
+   "conversationIndexFaissMaxSearchK": {
+    "type": "number",
+    "default": 50,
+    "description": "Maximum top-K allowed for FAISS search requests."
+   },
+   "conversationIndexFaissModelId": {
+    "type": "string",
+    "default": "text-embedding-3-small",
+    "description": "Embedding model identifier passed to the FAISS sidecar. By default the sidecar aliases OpenAI embedding ids to a local sentence-transformers model when REMNIC_FAISS_ENABLE_ST=1 (or legacy ENGRAM_FAISS_ENABLE_ST=1), and otherwise falls back to deterministic hash embeddings."
+   },
+   "conversationIndexFaissPythonBin": {
+    "type": "string",
+    "default": "",
+    "description": "Optional Python executable used to run the FAISS sidecar (for example python3.11)."
+   },
+   "conversationIndexFaissScriptPath": {
+    "type": "string",
+    "default": "",
+    "description": "Optional absolute path to FAISS sidecar script. If unset, uses built-in default script location."
+   },
+   "conversationIndexFaissSearchTimeoutMs": {
+    "type": "number",
+    "default": 5000,
+    "description": "Timeout (ms) for FAISS search operations."
+   },
+   "conversationIndexFaissUpsertTimeoutMs": {
+    "type": "number",
+    "default": 30000,
+    "description": "Timeout (ms) for FAISS upsert operations."
+   },
+   "conversationIndexMinUpdateIntervalMs": {
+    "type": "number",
+    "default": 900000,
+    "description": "Minimum interval between conversation_index_update runs per session (ms). Prevents redundant reindex churn."
+   },
+   "conversationIndexQmdCollection": {
+    "type": "string",
+    "default": "openclaw-engram-conversations",
+    "description": "QMD collection to use for conversation chunk search (must be configured in ~/.config/qmd/index.yml)."
+   },
+   "conversationIndexRetentionDays": {
+    "type": "number",
+    "default": 30,
+    "description": "Days to retain conversation chunk docs."
+   },
+   "conversationRecallMaxChars": {
+    "type": "number",
+    "default": 2500,
+    "description": "Max characters of semantic conversation recall to include."
+   },
+   "conversationRecallTimeoutMs": {
+    "type": "number",
+    "default": 800,
+    "description": "Timeout for semantic conversation recall search (ms). Fail-open on timeout."
+   },
+   "conversationRecallTopK": {
+    "type": "number",
+    "default": 3,
+    "description": "Top-K conversation chunks to include."
+   },
+   "correctionApplyRequiresConfirm": {
+    "type": "boolean",
+    "default": true,
+    "description": "When true (default), memory_correct_apply requires confirm: true before mutating memory (#1580). Off allows one-shot apply without an explicit confirmation."
+   },
+   "correctionCaptureAutoApplyMaxAffected": {
+    "type": "integer",
+    "minimum": 1,
+    "default": 2,
+    "description": "Maximum number of memories a passively-detected correction may affect in \"auto\" mode (#1581). Plans touching more memories than this are queued even when mode is \"auto\" \u2014 a blast-radius cap. Default 2."
+   },
+   "correctionCaptureConfidenceFloor": {
+    "type": "number",
+    "minimum": 0,
+    "maximum": 1,
+    "default": 0.85,
+    "description": "Minimum planner confidence required to auto-apply a passively-detected correction in \"auto\" mode (#1581). Plans below this floor are queued even when mode is \"auto\". Default 0.85."
+   },
+   "correctionCaptureMode": {
+    "type": "string",
+    "enum": [
+     "off",
+     "queue",
+     "auto"
+    ],
+    "default": "off",
+    "description": "Passive correction capture (#1581) \u2014 detects corrections expressed in conversation during extraction and routes them to the Correction Contract (#1580). \"off\" disables detection (default, rule 48); \"queue\" plans corrections for human review in the review list; \"auto\" applies immediately when all safety guards pass (confidence floor, blast-radius cap, allowed action/classification), otherwise falls back to queue. Invalid values are rejected (rule 51)."
+   },
+   "correctionEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Master gate for the Correction Contract (#1580) \u2014 the unified plan/apply pipeline for memory corrections (supersede/edit/retract/rescope/never-store). When false, the correction surfaces (CLI/HTTP/MCP) are disabled."
+   },
+   "correctionMaxAffected": {
+    "type": "integer",
+    "minimum": 1,
+    "default": 10,
+    "description": "Maximum number of memories a single correction plan may affect (#1580). A plan exceeding this is refused rather than silently truncated. Invalid values (0/negative/non-numeric) are rejected."
+   },
+   "correctionPlanTtlHours": {
+    "type": "number",
+    "minimum": 1,
+    "default": 24,
+    "description": "Hours a pending correction plan remains valid before it expires and must be re-planned (#1580). Invalid values (0/negative/non-numeric) are rejected."
+   },
+   "creationMemoryEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable creation-memory foundations, including the work-product ledger for explicit outputs agents create."
+   },
+   "cronConversationRecallMode": {
+    "type": "string",
+    "enum": [
+     "auto",
+     "always",
+     "never"
+    ],
+    "default": "auto",
+    "description": "Controls conversation semantic recall in cron sessions. auto skips it for instruction-heavy prompts."
+   },
+   "cronRecallAllowlist": {
+    "type": "array",
+    "items": {
+     "type": "string"
+    },
+    "default": [],
+    "description": "Session-key wildcard patterns (supports *) allowed for recall when cronRecallMode=allowlist."
+   },
+   "cronRecallInstructionHeavyTokenCap": {
+    "type": "number",
+    "default": 36,
+    "description": "Maximum token count used to build compact retrieval queries for instruction-heavy cron prompts."
+   },
+   "cronRecallMode": {
+    "type": "string",
+    "enum": [
+     "all",
+     "none",
+     "allowlist"
+    ],
+    "default": "all",
+    "description": "Recall behavior for cron sessions. Use allowlist to opt specific cron sessionKeys in."
+   },
+   "cronRecallNormalizedQueryMaxChars": {
+    "type": "number",
+    "default": 480,
+    "description": "Maximum query length (characters) used for cron recall retrieval after normalization."
+   },
+   "cronRecallPolicyEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable prompt-shape-aware recall query normalization for cron sessions."
+   },
+   "crossSignalsSemanticEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable semantic cross-signal grouping (reserved/experimental)."
+   },
+   "crossSignalsSemanticTimeoutMs": {
+    "type": "number",
+    "default": 4000,
+    "description": "Timeout for semantic cross-signal grouping (ms)."
+   },
+   "daySummaryEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable end-of-day summary generation via engram.day_summary MCP tool"
+   },
+   "daySummaryTimezone": {
+    "type": "string",
+    "default": "",
+    "description": "Timezone for the day summary cron (e.g. 'America/Lima'). When empty, uses the server timezone."
+   },
+   "debug": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable debug logging"
+   },
+   "defaultNamespace": {
+    "type": "string",
+    "default": "default",
+    "description": "Default namespace name."
+   },
+   "defaultRecallNamespaces": {
+    "type": "array",
+    "description": "Which namespaces to include by default in recall.",
+    "items": {
+     "type": "string",
+     "enum": [
+      "self",
+      "shared"
+     ]
+    },
+    "default": [
+     "self",
+     "shared"
+    ]
+   },
+   "defaultScopeProfile": {
+    "type": "string",
+    "description": "Optional key in scopeProfiles to use as the default hosted memory scope profile."
+   },
+   "delinearizeEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "SimpleMem-inspired de-linearization: resolve pronouns and anchor relative dates in extracted memories"
+   },
+   "dreaming": {
+    "type": "object",
+    "additionalProperties": false,
+    "default": {},
+    "properties": {
+     "enabled": {
+      "type": "boolean",
+      "default": false
+     },
+     "journalPath": {
+      "type": "string",
+      "default": "DREAMS.md"
+     },
+     "maxEntries": {
+      "anyOf": [
+       {
+        "type": "integer",
+        "const": 0
+       },
+       {
+        "type": "integer",
+        "minimum": 10,
+        "maximum": 10000
+       }
+      ],
+      "default": 500
+     },
+     "injectRecentCount": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 20,
+      "default": 3
+     },
+     "minIntervalMinutes": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 120
+     },
+     "narrativeModel": {
+      "type": "string",
+      "default": "",
+      "description": "Model used to write dream-journal narratives. Under modelSource=plugin this must be an OpenAI model id used with the direct OpenAI key. Under modelSource=gateway it accepts a provider-qualified id (e.g. zai/glm-4.7-flash) routed through gateway providers \u2014 no direct OpenAI key required; leave empty to fall back to taskModelChain / the gateway default chain."
+     },
+     "narrativePromptStyle": {
+      "type": "string",
+      "enum": [
+       "reflective",
+       "diary",
+       "analytical"
+      ],
+      "default": "reflective"
+     },
+     "watchFile": {
+      "type": "boolean",
+      "default": true
+     }
+    }
+   },
+   "dreams": {
+    "type": "object",
+    "additionalProperties": false,
+    "default": {},
+    "description": "Consolidation pipeline phases config (issue #678 PR 2). Groups existing lifecycle/REM/deep-sleep gates under a unified namespace. Values here WIN over equivalent legacy top-level keys when set. See docs/dreams.md. (Note: distinct from the `dreaming` diary-surface config.)",
+    "properties": {
+     "phases": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {},
+      "properties": {
+       "lightSleep": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "description": "Light-sleep phase: recent activity scoring and clustering. Mirrors lifecyclePolicyEnabled and related thresholds when not set explicitly.",
+        "properties": {
+         "enabled": {
+          "type": "boolean",
+          "description": "Master switch for the light-sleep phase. Mirrors lifecyclePolicyEnabled when not set."
+         },
+         "cadenceMs": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Minimum interval between light-sleep passes (ms). 0 = no override; orchestrator uses its internal cadence."
+         },
+         "promoteHeatThreshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.55,
+          "description": "Value score above which a memory is treated as hot. Mirrors lifecyclePromoteHeatThreshold when not set."
+         },
+         "staleDecayThreshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.65,
+          "description": "Value score below which a memory starts to decay. Mirrors lifecycleStaleDecayThreshold when not set."
+         },
+         "archiveDecayThreshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.85,
+          "description": "Value score below which a memory is eligible for archive. Mirrors lifecycleArchiveDecayThreshold when not set."
+         },
+         "filterStaleEnabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether stale memories are filtered from recall. Mirrors lifecycleFilterStaleEnabled when not set."
+         }
+        }
+       },
+       "rem": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "description": "REM phase: cross-session synthesis, supersession resolution, semantic consolidation. Mirrors semanticConsolidation* keys when not set explicitly.",
+        "properties": {
+         "enabled": {
+          "type": "boolean",
+          "description": "Master switch for the REM phase. Mirrors semanticConsolidationEnabled when not set."
+         },
+         "cadenceMs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "How often the REM pass runs (ms). Derived from semanticConsolidationIntervalHours when not set."
+         },
+         "similarityThreshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.8,
+          "description": "Cosine-similarity threshold for cluster membership. Mirrors semanticConsolidationThreshold when not set."
+         },
+         "minClusterSize": {
+          "type": "integer",
+          "minimum": 2,
+          "default": 3,
+          "description": "Minimum cluster size before consolidation runs. Mirrors semanticConsolidationMinClusterSize when not set."
+         },
+         "maxPerRun": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 100,
+          "description": "Max cluster operations per run. Mirrors semanticConsolidationMaxPerRun when not set."
+         },
+         "minIntervalMs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Minimum gap between consolidation passes (ms). Mirrors consolidationMinIntervalMs when not set."
+         }
+        }
+       },
+       "deepSleep": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "description": "Deep-sleep phase: promotion to durable memory, hot-to-cold tier migration, page-version snapshots, archive. Mirrors versioningEnabled and related keys when not set explicitly.",
+        "properties": {
+         "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Master switch for the deep-sleep phase. Defaults false unless legacy deep-sleep surfaces are explicitly enabled; set true to allow nightly governance, tier migration, and versioning surfaces."
+         },
+         "cadenceMs": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 86400000,
+          "description": "Minimum interval between deep-sleep passes (ms). Default 86400000 (24h). Informational in PR 2; PR 4 wires this into the cron scheduler."
+         },
+         "versioningEnabled": {
+          "type": "boolean",
+          "description": "Enable page-version snapshots on every overwrite. Mirrors versioningEnabled when not set."
+         },
+         "versioningMaxPerPage": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Max snapshots per memory page. Mirrors versioningMaxPerPage when not set."
+         }
+        }
+       }
+      }
+     }
+    }
+   },
+   "embeddingFallbackEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable embedding-based semantic recall fallback when QMD is unavailable or returns no matches"
+   },
+   "embeddingFallbackModel": {
+    "type": "string",
+    "description": "Optional model identifier for embedding fallback requests. Defaults to localLlmModel for legacy installs."
+   },
+   "embeddingFallbackProvider": {
+    "type": "string",
+    "enum": [
+     "auto",
+     "openai",
+     "local"
+    ],
+    "default": "auto",
+    "description": "Embedding provider selection for semantic fallback"
+   },
+   "emitLegacyTools": {
+    "type": "boolean",
+    "default": false,
+    "description": "Advertise legacy engram_* / engram.* MCP tool aliases alongside the canonical remnic_* names. Issue #1550: defaults to false on fresh installs (halving the advertised tools/list surface); when existing legacy connector entries are present on disk the default stays true so upgrades never silently break a configured legacy client. An explicit value always wins."
+   },
+   "enrichmentAutoOnCreate": {
+    "type": "boolean",
+    "default": false,
+    "description": "Automatically enrich newly created entities when the enrichment pipeline is enabled."
+   },
+   "enrichmentEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable the external enrichment pipeline (#365). When true, entities can be enriched via registered providers."
+   },
+   "enrichmentMaxCandidatesPerEntity": {
+    "type": "integer",
+    "default": 20,
+    "minimum": 0,
+    "description": "Maximum enrichment candidates accepted per entity per run. Set to 0 to accept none."
+   },
+   "entityActivityLogEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Log timestamped activity per entity"
+   },
+   "entityActivityLogMaxEntries": {
+    "type": "number",
+    "default": 20,
+    "description": "Max activity entries per entity before oldest are pruned"
+   },
+   "entityAliasesEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Store aliases per entity file"
+   },
+   "entityGraphEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Build entity co-reference graph (requires multiGraphMemoryEnabled). Default true."
+   },
+   "entityRelationshipsEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Track entity-to-entity relationships during extraction"
+   },
+   "entityRetrievalEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable entity-oriented recall hints for direct entity questions and short follow-up queries."
+   },
+   "entityRetrievalMaxChars": {
+    "type": "number",
+    "default": 2400,
+    "description": "Hard character cap for the entity retrieval section."
+   },
+   "entityRetrievalMaxHints": {
+    "type": "number",
+    "default": 2,
+    "description": "Maximum entity targets summarized in one recall pass."
+   },
+   "entityRetrievalMaxRelatedEntities": {
+    "type": "number",
+    "default": 3,
+    "description": "Maximum related entities listed per target when confidence is high."
+   },
+   "entityRetrievalMaxSupportingFacts": {
+    "type": "number",
+    "default": 6,
+    "description": "Maximum supporting fact/timeline snippets considered per entity target."
+   },
+   "entityRetrievalRecentTurns": {
+    "type": "number",
+    "default": 6,
+    "description": "Recent transcript turns scanned for pronoun carry-forward and short follow-up resolution."
+   },
+   "entitySchemas": {
+    "type": "object",
+    "description": "Optional per-entity-type structured section schema customizations.",
+    "additionalProperties": {
+     "type": "object",
+     "additionalProperties": false,
+     "properties": {
+      "sections": {
+       "type": "array",
+       "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+         "key": {
+          "type": "string"
+         },
+         "title": {
+          "type": "string"
+         },
+         "description": {
+          "type": "string"
+         },
+         "aliases": {
+          "type": "array",
+          "items": {
+           "type": "string"
+          }
+         }
+        },
+        "anyOf": [
+         {
+          "required": [
+           "key"
           ]
+         },
+         {
+          "required": [
+           "title"
+          ]
+         }
+        ]
+       }
+      }
+     },
+     "required": [
+      "sections"
+     ]
+    }
+   },
+   "entitySummaryEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Generate LLM summaries for entities during consolidation"
+   },
+   "entitySynthesisMaxTokens": {
+    "anyOf": [
+     {
+      "type": "integer",
+      "const": 0
+     },
+     {
+      "type": "integer",
+      "minimum": 10
+     }
+    ],
+    "default": 500,
+    "description": "Max tokens used when refreshing an entity synthesis from its timeline."
+   },
+   "episodeNoteModeEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable HiMem episode/note classification (v8.0 Phase 2B). Tags each extracted memory as 'episode' (time-specific event) or 'note' (stable belief/preference). Disabled by default."
+   },
+   "evalHarnessEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable Engram's benchmark/evaluation harness foundation for tracking benchmark packs and run summaries."
+   },
+   "evalShadowModeEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable shadow-mode evaluation workflows so future benchmark instrumentation can measure memory changes without changing live recall output."
+   },
+   "evalStoreDir": {
+    "type": "string",
+    "description": "Override the evaluation harness state directory (defaults to {memoryDir}/state/evals)."
+   },
+   "eventOrderRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable event-order evidence recall for chronology questions."
+   },
+   "eventOrderRecallMaxChars": {
+    "type": "integer",
+    "default": 2400,
+    "minimum": 0,
+    "description": "Character budget for the event-order evidence recall section."
+   },
+   "eventOrderRecallMaxResults": {
+    "type": "integer",
+    "default": 24,
+    "minimum": 0,
+    "description": "Maximum recalled items for event-order evidence."
+   },
+   "eventOrderRecallScanWindowTokens": {
+    "type": "integer",
+    "default": 24000,
+    "minimum": 1,
+    "description": "Recent-token scan window for event-order evidence."
+   },
+   "eventOrderRecallScanWindowTurns": {
+    "type": "integer",
+    "default": 12,
+    "minimum": 1,
+    "description": "Recent-turn scan window for event-order evidence."
+   },
+   "explicitCueRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Front-load exact LCM evidence for query-visible cues such as turns, dates, ids, files, and tools."
+   },
+   "explicitCueRecallMaxChars": {
+    "type": "number",
+    "default": 2400,
+    "minimum": 0,
+    "description": "Character budget for the explicit cue evidence recall section."
+   },
+   "explicitCueRecallMaxReferences": {
+    "type": "number",
+    "default": 24,
+    "minimum": 0,
+    "description": "Maximum query-visible cues expanded by explicit cue recall."
+   },
+   "extractionDedupeEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable deduplication of near-identical extraction batches within a time window."
+   },
+   "extractionDedupeWindowMs": {
+    "type": "number",
+    "default": 300000,
+    "description": "Window for extraction dedupe fingerprints (ms)."
+   },
+   "extractionFaithfulnessContextChars": {
+    "type": "number",
+    "default": 400,
+    "description": "Context window (chars) around the verified quote sent to the faithfulness verifier."
+   },
+   "extractionFaithfulnessGate": {
+    "type": "string",
+    "enum": [
+     "off",
+     "shadow",
+     "enforce"
+    ],
+    "default": "off",
+    "description": "Extraction faithfulness gate (issue #1576). Entailment-verification of extracted facts against their verified source spans (#1575). 'off' (default) = byte-identical pre-feature pipeline; 'shadow' = record verdicts in frontmatter + telemetry only; 'enforce' = route unsupported/contradicted to pending_review."
+   },
+   "extractionFaithfulnessModel": {
+    "type": "string",
+    "default": "",
+    "description": "Override model/endpoint for the faithfulness verifier. Empty string = default routing chain (local then fallback)."
+   },
+   "extractionFaithfulnessTimeoutMs": {
+    "type": "number",
+    "default": 8000,
+    "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
+   },
+   "extractionFaithfulnessLocalParseFallback": {
+    "type": "boolean",
+    "default": false,
+    "description": "Resilient-fallback toggle for the local model-lab faithfulness endpoint (issue #1700). Default false surfaces malformed_output when the local endpoint returns 200 with non-verdict JSON (alerts the operator to a misconfigured endpoint). Set true to instead fall back to the configured chain on local parse failure."
+   },
+   "extractionFaithfulnessBaseUrl": {
+    "type": "string",
+    "default": "",
+    "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned faithfulness gate (model-lab, issue #1585). When set AND extractionFaithfulnessModel is set, the gate routes there first and falls back to the configured chain on any failure. Empty = existing routing (byte-identical pre-feature path)."
+   },
+   "correctionIntentModel": {
+    "type": "string",
+    "default": "",
+    "description": "Model name of a local fine-tuned correction-intent classifier (model-lab, issue #1581 / #1585). When set AND correctionIntentBaseUrl is set, passive-correction detection can route to it. Empty = rule-based detectPassiveCorrections is the sole detector."
+   },
+   "correctionIntentBaseUrl": {
+    "type": "string",
+    "default": "",
+    "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned correction-intent classifier (model-lab, issue #1585). Empty = rule-based detector only."
+   },
+   "extractionJudgeBatchSize": {
+    "type": "number",
+    "default": 20,
+    "minimum": 1,
+    "description": "Maximum number of candidate facts sent to the judge LLM in a single batch call."
+   },
+   "extractionJudgeEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable the LLM-as-judge fact-worthiness gate. When enabled, extracted facts are evaluated for durability before being persisted. Off by default (opt-in)."
+   },
+   "extractionJudgeMaxDeferrals": {
+    "type": "number",
+    "default": 2,
+    "minimum": 1,
+    "description": "Maximum number of times the same candidate text may be deferred by the extraction judge before the verdict is forcibly converted to 'reject'. Prevents pathological LLM responses from looping forever on ambiguous facts (issue #562)."
+   },
+   "extractionJudgeModel": {
+    "type": "string",
+    "default": "",
+    "description": "Model override for the extraction judge LLM. Empty string uses the configured local model."
+   },
+   "extractionJudgeShadow": {
+    "type": "boolean",
+    "default": false,
+    "description": "Shadow mode for the extraction judge. When true, judge verdicts are logged but all facts are still persisted regardless of the verdict."
+   },
+   "extractionJudgeTelemetryEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Emit structured telemetry rows to state/observation-ledger/extraction-judge-verdicts.jsonl on every judge verdict. Off by default; enable to collect defer-rate and latency metrics for operator dashboards (issue #562)."
+   },
+   "extractionMaxEntitiesPerRun": {
+    "type": "number",
+    "default": 6,
+    "description": "Maximum entities persisted from a single extraction run."
+   },
+   "extractionMaxFactsPerRun": {
+    "type": "number",
+    "default": 12,
+    "description": "Maximum facts persisted from a single extraction run."
+   },
+   "extractionMaxOutputTokens": {
+    "type": "number",
+    "default": 16384,
+    "description": "Maximum output tokens (max_completion_tokens) for the direct-client extraction call."
+   },
+   "extractionMaxProfileUpdatesPerRun": {
+    "type": "number",
+    "default": 4,
+    "description": "Maximum profile updates persisted from a single extraction run."
+   },
+   "extractionMaxQuestionsPerRun": {
+    "type": "number",
+    "default": 3,
+    "description": "Maximum questions persisted from a single extraction run."
+   },
+   "extractionMaxTurnChars": {
+    "type": "number",
+    "default": 4000,
+    "description": "Maximum characters per turn fed to extraction (long turns are truncated)."
+   },
+   "extractionMinChars": {
+    "type": "number",
+    "default": 40,
+    "description": "Minimum combined user/assistant characters required before extraction runs."
+   },
+   "extractionMinImportanceLevel": {
+    "type": "string",
+    "enum": [
+     "trivial",
+     "low",
+     "normal",
+     "high",
+     "critical"
+    ],
+    "default": "low",
+    "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
+   },
+   "extractionMinUserTurns": {
+    "type": "number",
+    "default": 1,
+    "description": "Minimum number of user turns required before extraction runs."
+   },
+   "extractionScopeClassificationEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "When enabled, the extraction prompt instructs the LLM to classify each fact as 'project' (codebase-specific) or 'global' (cross-project knowledge). Global-scoped facts are promoted to the shared namespace so they are visible across all projects. Disable to restore pre-scope-classification behavior where all facts go to the session namespace."
+   },
+   "extractionTelemetryPrefilterEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Skip semantic durable-memory extraction for mechanical action/state telemetry transcripts that contain no durable-memory cue. Raw transcript storage and recall still run. Disable this if you intentionally want fact extraction from action logs."
+   },
+   "factArchivalAgeDays": {
+    "type": "number",
+    "default": 90,
+    "description": "Minimum age in days before a fact is eligible for archival."
+   },
+   "factArchivalEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable automatic archival of old, low-importance, rarely-accessed facts during consolidation."
+   },
+   "factArchivalMaxAccessCount": {
+    "type": "number",
+    "default": 2,
+    "description": "Maximum access count for archival eligibility. Only rarely-accessed facts are archived."
+   },
+   "factArchivalMaxImportance": {
+    "type": "number",
+    "default": 0.3,
+    "description": "Maximum importance score for archival eligibility (0-1). Only facts below this threshold are archived."
+   },
+   "factArchivalProtectedCategories": {
+    "type": "array",
+    "items": {
+     "type": "string"
+    },
+    "default": [
+     "commitment",
+     "preference",
+     "decision",
+     "principle",
+     "procedure"
+    ],
+    "description": "Categories that protect a fact from archival regardless of other criteria."
+   },
+   "factDeduplicationEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable content-hash deduplication to prevent storing semantically identical facts."
+   },
+   "fastGatewayAgentId": {
+    "type": "string",
+    "default": "",
+    "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
+   },
+   "feedbackEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable feedback capture tool for memory relevance (thumbs up/down)."
+   },
+   "fileHygiene": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Optional: keep OpenClaw bootstrap workspace files small and warn before silent truncation risk.",
+    "properties": {
+     "enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Master switch for file hygiene (default off)."
+     },
+     "lintEnabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "If true, warn when bootstrap files approach budget."
+     },
+     "lintBudgetBytes": {
+      "type": "number",
+      "default": 20000,
+      "description": "Budget in bytes used for lint warnings (approx)."
+     },
+     "lintWarnRatio": {
+      "type": "number",
+      "default": 0.8,
+      "description": "Warn when file size >= budget * warnRatio."
+     },
+     "lintPaths": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "default": [
+       "IDENTITY.md",
+       "MEMORY.md"
+      ],
+      "description": "Workspace-relative paths to lint (or absolute paths)."
+     },
+     "rotateEnabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, rotate oversized markdown files into an archive and replace with a lean index."
+     },
+     "rotateMaxBytes": {
+      "type": "number",
+      "default": 18000,
+      "description": "Rotate when a target file exceeds this size (bytes)."
+     },
+     "rotateKeepTailChars": {
+      "type": "number",
+      "default": 2000,
+      "description": "How many characters of the old file to keep inline (tail) for continuity."
+     },
+     "rotatePaths": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "default": [
+       "IDENTITY.md"
+      ],
+      "description": "Workspace-relative paths to rotate (or absolute paths)."
+     },
+     "archiveDir": {
+      "type": "string",
+      "default": ".engram-archive",
+      "description": "Workspace-relative archive directory where rotated files are stored."
+     },
+     "runMinIntervalMs": {
+      "type": "number",
+      "default": 300000,
+      "description": "Minimum interval between hygiene runs (ms)."
+     },
+     "warningsLogEnabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, append warnings to a log file under memoryDir."
+     },
+     "warningsLogPath": {
+      "type": "string",
+      "default": "hygiene/warnings.md",
+      "description": "memoryDir-relative path to write warnings to."
+     },
+     "indexEnabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Reserved: write an Engram index file in workspace (not required for rotation)."
+     },
+     "indexPath": {
+      "type": "string",
+      "default": "ENGRAM_INDEX.md",
+      "description": "Workspace-relative index path (if indexEnabled)."
+     }
+    },
+    "required": [
+     "enabled"
+    ]
+   },
+   "flushOnResetEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Flush buffered turns through extraction when OpenClaw resets a session."
+   },
+   "focusedListRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable focused list evidence recall for count, relation, and recommendation questions."
+   },
+   "focusedListRecallMaxChars": {
+    "type": "integer",
+    "default": 2600,
+    "minimum": 0,
+    "description": "Character budget for the focused list evidence recall section."
+   },
+   "focusedListRecallMaxResults": {
+    "type": "integer",
+    "default": 40,
+    "minimum": 0,
+    "description": "Maximum recalled items for focused list evidence."
+   },
+   "focusedListRecallScanWindowTokens": {
+    "type": "integer",
+    "default": 14000,
+    "minimum": 1,
+    "description": "Recent-token scan window for focused list evidence."
+   },
+   "focusedListRecallScanWindowTurns": {
+    "type": "integer",
+    "default": 64,
+    "minimum": 1,
+    "description": "Recent-turn scan window for focused list evidence."
+   },
+   "gatewayAgentId": {
+    "type": "string",
+    "default": "",
+    "description": "Agent persona ID (from openclaw.json agents.list[]) whose model chain to use for extraction, consolidation, and summarization. Required when modelSource is 'gateway'. Falls back to agents.defaults.model if empty."
+   },
+   "graphActivationDecay": {
+    "type": "number",
+    "default": 0.7,
+    "description": "Per-hop activation decay factor (0-1). Default 0.7."
+   },
+   "graphAssistInFullModeEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Run bounded graph expansion during full recall mode when seed results exist."
+   },
+   "graphAssistMinSeedResults": {
+    "type": "number",
+    "default": 3,
+    "description": "Minimum seed recall results required before full-mode graph assist runs."
+   },
+   "graphAssistShadowEvalEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep recall output baseline-identical."
+   },
+   "graphEdgeDecayCadenceMs": {
+    "type": "number",
+    "default": 604800000,
+    "minimum": 60000,
+    "description": "Cadence in milliseconds for the graph-edge decay cron. Default 7 days. Sub-day cadences map to a daily cron expression."
+   },
+   "graphEdgeDecayEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable the periodic graph-edge confidence decay maintenance job (issue #681 PR 2/3). Opt-in."
+   },
+   "graphEdgeDecayFloor": {
+    "type": "number",
+    "default": 0.1,
+    "minimum": 0,
+    "maximum": 1,
+    "description": "Floor confidence will not decay below. Default 0.1."
+   },
+   "graphEdgeDecayPerWindow": {
+    "type": "number",
+    "default": 0.1,
+    "minimum": 0,
+    "maximum": 1,
+    "description": "Per-window confidence drop applied during decay. Default 0.1."
+   },
+   "graphEdgeDecayVisibilityThreshold": {
+    "type": "number",
+    "default": 0.2,
+    "minimum": 0,
+    "maximum": 1,
+    "description": "Confidence threshold used by the decay telemetry counter for low-visibility edges. Default 0.2."
+   },
+   "graphEdgeDecayWindowMs": {
+    "type": "number",
+    "default": 7776000000,
+    "minimum": 60000,
+    "description": "Decay window in milliseconds passed to decayEdgeConfidence. Default 90 days."
+   },
+   "graphExpandedIntentEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Escalate broader causal/timeline phrasing into graph_mode planning."
+   },
+   "graphExpansionActivationWeight": {
+    "type": "number",
+    "default": 0.65,
+    "description": "Blend weight for graph activation when scoring expanded results (0-1). Higher values favor graph activation over seed QMD score."
+   },
+   "graphExpansionBlendMax": {
+    "type": "number",
+    "default": 0.95,
+    "description": "Upper clamp bound for blended graph-expanded recall scores (0-1)."
+   },
+   "graphExpansionBlendMin": {
+    "type": "number",
+    "default": 0.05,
+    "description": "Lower clamp bound for blended graph-expanded recall scores (0-1)."
+   },
+   "graphLateralInhibitionBeta": {
+    "type": "number",
+    "default": 0.15,
+    "description": "Inhibition strength (0-1). Higher values suppress weaker nodes more aggressively"
+   },
+   "graphLateralInhibitionEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Synapse-inspired lateral inhibition to suppress hub-node dominance in graph retrieval"
+   },
+   "graphLateralInhibitionTopM": {
+    "type": "number",
+    "default": 7,
+    "description": "Number of top competing nodes considered for lateral inhibition"
+   },
+   "graphRecallColdMirrorCollection": {
+    "type": "string",
+    "description": "QMD collection name for cold-mirror graph recall results."
+   },
+   "graphRecallColdMirrorMinAgeDays": {
+    "type": "number",
+    "default": 7,
+    "description": "Minimum age in days for a memory to qualify for cold-mirror storage."
+   },
+   "graphRecallDampingFactor": {
+    "type": "number",
+    "default": 0.85,
+    "description": "PageRank-style damping factor for graph activation propagation."
+   },
+   "graphRecallEnableDebug": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable verbose debug output for graph recall operations."
+   },
+   "graphRecallEnableTrace": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable detailed graph recall trace logging for debugging."
+   },
+   "graphRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable graph recall planner mode (`graph_mode`). Requires multiGraphMemoryEnabled. Default false."
+   },
+   "graphRecallEntityHintMax": {
+    "type": "number",
+    "default": 3,
+    "description": "Maximum number of entity hints added per graph recall result."
+   },
+   "graphRecallEntityHintMaxChars": {
+    "type": "number",
+    "default": 200,
+    "description": "Maximum characters per entity hint added during graph recall."
+   },
+   "graphRecallEntityHintsEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Inject entity hint summaries alongside graph-recalled memories."
+   },
+   "graphRecallEntityPriorBoost": {
+    "type": "number",
+    "default": 0.2,
+    "description": "Score boost applied to nodes with strong entity priors."
+   },
+   "graphRecallExpansionScoreThreshold": {
+    "type": "number",
+    "default": 0.2,
+    "description": "Minimum blended score required to include a graph-expanded node in results."
+   },
+   "graphRecallExplainEdgeLimit": {
+    "type": "number",
+    "default": 5,
+    "description": "Maximum edges described per node in a graph recall explanation."
+   },
+   "graphRecallExplainEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Append natural-language graph reasoning explanations to recall output."
+   },
+   "graphRecallExplainMaxChars": {
+    "type": "number",
+    "default": 500,
+    "description": "Maximum characters per graph recall explanation."
+   },
+   "graphRecallExplainMaxPaths": {
+    "type": "number",
+    "default": 3,
+    "description": "Maximum reasoning paths included in a graph recall explanation."
+   },
+   "graphRecallExplainToolEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Expose a graph explain tool to agents during graph recall."
+   },
+   "graphRecallHubBias": {
+    "type": "number",
+    "default": 0.3,
+    "description": "Bias weight toward hub-seed selection (0-1)."
+   },
+   "graphRecallMaxExpandedNodes": {
+    "type": "number",
+    "default": 30,
+    "description": "Maximum total nodes visited during graph recall expansion."
+   },
+   "graphRecallMaxExpansions": {
+    "type": "number",
+    "default": 3,
+    "description": "Maximum number of expansion hops per graph recall query."
+   },
+   "graphRecallMaxPerSeed": {
+    "type": "number",
+    "default": 5,
+    "description": "Maximum graph-expanded results per seed node."
+   },
+   "graphRecallMaxSeedNodes": {
+    "type": "number",
+    "default": 10,
+    "description": "Maximum number of seed nodes selected for graph recall expansion."
+   },
+   "graphRecallMaxTrailPerNode": {
+    "type": "number",
+    "default": 5,
+    "description": "Maximum trail length followed per node during graph traversal."
+   },
+   "graphRecallMinEdgeWeight": {
+    "type": "number",
+    "default": 0.1,
+    "description": "Minimum edge weight to follow during graph recall traversal."
+   },
+   "graphRecallMinSeedScore": {
+    "type": "number",
+    "default": 0.3,
+    "description": "Minimum QMD score for a memory to qualify as a graph recall seed."
+   },
+   "graphRecallPreferHubSeeds": {
+    "type": "boolean",
+    "default": false,
+    "description": "Prefer high-degree hub nodes as graph recall seeds."
+   },
+   "graphRecallRecencyHalfLifeDays": {
+    "type": "number",
+    "default": 30,
+    "description": "Half-life in days for recency decay applied to graph-expanded nodes."
+   },
+   "graphRecallShadowEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Run graph recall in shadow mode - evaluate but do not add results."
+   },
+   "graphRecallShadowSampleRate": {
+    "type": "number",
+    "default": 0.1,
+    "description": "Fraction of turns evaluated in shadow mode (0-1)."
+   },
+   "graphRecallSnapshotDir": {
+    "type": "string",
+    "description": "Directory for graph recall snapshot files (defaults to {memoryDir}/state/graph)."
+   },
+   "graphRecallSnapshotEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Write graph recall snapshots for offline analysis."
+   },
+   "graphRecallStoreColdMirror": {
+    "type": "boolean",
+    "default": false,
+    "description": "Store cold-path graph recall results in a secondary QMD collection."
+   },
+   "graphRecallUseEntityPriors": {
+    "type": "boolean",
+    "default": false,
+    "description": "Boost seed nodes using entity prior scores during graph recall."
+   },
+   "graphTraversalConfidenceFloor": {
+    "type": "number",
+    "default": 0.2,
+    "minimum": 0,
+    "maximum": 1,
+    "description": "Issue #681 PR 3/3: minimum edge confidence required for traversal during spreading activation. Edges below this floor are pruned and contribute neither activation nor downstream neighbors. Legacy edges without a confidence field are treated as 1.0. Range 0-1. Default 0.2."
+   },
+   "graphTraversalPageRankIterations": {
+    "type": "number",
+    "default": 8,
+    "minimum": 0,
+    "description": "Issue #681 PR 3/3: number of PageRank-style refinement iterations applied on top of the BFS spreading-activation scores. Each iteration redistributes a node's confidence-weighted activation along its outgoing edges. Set to 0 to disable refinement and use raw BFS scores. Default 8."
+   },
+   "graphWriteSessionAdjacencyEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Write fallback temporal adjacency edges for consecutive extracted memories in the same session."
+   },
+   "harmonicRetrievalEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
+   },
+   "heartbeat": {
+    "type": "object",
+    "additionalProperties": false,
+    "default": {},
+    "properties": {
+     "enabled": {
+      "type": "boolean",
+      "default": false
+     },
+     "journalPath": {
+      "type": "string",
+      "default": "HEARTBEAT.md"
+     },
+     "maxPreviousRuns": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 20,
+      "default": 5
+     },
+     "watchFile": {
+      "type": "boolean",
+      "default": true
+     },
+     "detectionMode": {
+      "type": "string",
+      "enum": [
+       "runtime-signal",
+       "heuristic",
+       "auto"
+      ],
+      "default": "auto"
+     },
+     "gateExtractionDuringHeartbeat": {
+      "type": "boolean",
+      "default": true
+     }
+    }
+   },
+   "highSignalPatterns": {
+    "type": "array",
+    "items": {
+     "type": "string"
+    },
+    "description": "Custom regex patterns for immediate extraction"
+   },
+   "hostEmbeddingProviderEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Prefer OpenClaw host-registered embedding providers for Remnic's semantic fallback and embedded vector backends when the OpenClaw SDK exposes them. Falls back to Remnic's existing embedding provider path on older hosts or provider setup failures."
+   },
+   "hostEmbeddingProviderId": {
+    "type": "string",
+    "description": "Optional OpenClaw embedding provider adapter id to use. Leave unset for automatic selection from OpenClaw's memory/generic embedding provider registry."
+   },
+   "hostEmbeddingProviderModel": {
+    "type": "string",
+    "description": "Optional embedding model id passed to the selected OpenClaw host embedding provider."
+   },
+   "hourlySummariesEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable hourly conversation summaries"
+   },
+   "hourlySummariesExtendedEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable structured hourly summaries (topics/decisions/action items/rejections). Default off."
+   },
+   "hourlySummariesIncludeSystemMessages": {
+    "type": "boolean",
+    "default": false,
+    "description": "Include system messages in extended hourly summaries (use with care)."
+   },
+   "hourlySummariesIncludeToolStats": {
+    "type": "boolean",
+    "default": false,
+    "description": "Include tool usage counts in extended hourly summaries (requires tool usage capture)."
+   },
+   "hourlySummariesMaxTurnsPerRun": {
+    "type": "number",
+    "default": 200,
+    "description": "Maximum transcript turns to consider per session per hourly summarizer run."
+   },
+   "hourlySummaryCronAutoRegister": {
+    "type": "boolean",
+    "default": false,
+    "description": "If true, Engram may attempt to auto-register an hourly summary cron job (default off)."
+   },
+   "identityContinuityEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable identity continuity workflows (anchor, incidents, audits)"
+   },
+   "identityEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable agent identity reflections (appends to workspace IDENTITY.md)"
+   },
+   "identityInjectionMode": {
+    "type": "string",
+    "enum": [
+     "recovery_only",
+     "minimal",
+     "full"
+    ],
+    "default": "recovery_only",
+    "description": "Controls when identity continuity context is added to recall assembly"
+   },
+   "identityMaxInjectChars": {
+    "type": "number",
+    "default": 1200,
+    "description": "Maximum characters allowed for identity continuity context"
+   },
+   "initGateTimeoutMs": {
+    "type": "integer",
+    "minimum": 1000,
+    "maximum": 120000,
+    "default": 30000,
+    "description": "Maximum time Remnic waits for cold-start initialization during recall; also registered as the OpenClaw before_prompt_build hook timeout on SDKs that support per-hook options."
+   },
+   "injectQuestions": {
+    "type": "boolean",
+    "default": false,
+    "description": "Include the most relevant open question in generated memory context"
+   },
+   "inlineSourceAttributionEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable inline source attribution markers on persisted facts for downstream provenance tracking."
+   },
+   "inlineSourceAttributionFormat": {
+    "type": "string",
+    "default": "[Source: agent={agent}, session={sessionId}, ts={ts}]",
+    "description": "Template used when inline source attribution is enabled."
+   },
+   "intentRoutingBoost": {
+    "type": "number",
+    "default": 0.12,
+    "description": "Maximum score boost applied for intent-compatible memory matches."
+   },
+   "intentRoutingEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Attach intent metadata to memories and boost compatible memories at recall."
+   },
+   "ircEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable Inductive Rule Consolidation (IRC) subsystem (default on)."
+   },
+   "ircIncludeCorrections": {
+    "type": "boolean",
+    "default": true,
+    "description": "Include corrections when building IRC rules (default on)."
+   },
+   "ircMaxPreferences": {
+    "type": "number",
+    "default": 20,
+    "description": "Maximum number of preferences to include in IRC rules."
+   },
+   "ircMinConfidence": {
+    "type": "number",
+    "default": 0.3,
+    "description": "Minimum confidence threshold for an IRC rule to be included (0-1)."
+   },
+   "judgeTrainingDir": {
+    "type": "string",
+    "default": "",
+    "description": "Override directory for judge training-pair collection. Empty string uses the default (~/.remnic/judge-training). Only consulted when collectJudgeTrainingPairs is true."
+   },
+   "knowledgeIndexEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Inject a compact Knowledge Index of top entities into every recall"
+   },
+   "knowledgeIndexMaxChars": {
+    "type": "number",
+    "default": 4000,
+    "description": "Hard character cap for the Knowledge Index section"
+   },
+   "knowledgeIndexMaxEntities": {
+    "type": "number",
+    "default": 40,
+    "description": "Max entities included in the Knowledge Index"
+   },
+   "lanceDbPath": {
+    "type": "string",
+    "description": "Directory path for LanceDB storage (when searchBackend=lancedb)"
+   },
+   "lanceEmbeddingDimension": {
+    "type": "number",
+    "default": 1536,
+    "description": "Embedding vector dimension for LanceDB (when searchBackend=lancedb)"
+   },
+   "lancedbEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable LanceDB as a supplemental search backend."
+   },
+   "lcmArchiveRetentionDays": {
+    "type": "number",
+    "default": 90,
+    "description": "Days to retain archived LCM summaries"
+   },
+   "lcmDeterministicMaxTokens": {
+    "type": "number",
+    "default": 512,
+    "description": "Max tokens for deterministic (non-LLM) summaries"
+   },
+   "lcmEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable Lossless Context Management (LCM) subsystem"
+   },
+   "lcmFreshTailTurns": {
+    "type": "number",
+    "default": 16,
+    "description": "Number of recent turns kept verbatim (not summarized)"
+   },
+   "lcmLeafBatchSize": {
+    "type": "number",
+    "default": 8,
+    "description": "Number of turns per leaf node in the LCM DAG"
+   },
+   "lcmMaxDepth": {
+    "type": "number",
+    "default": 5,
+    "description": "Maximum depth of the LCM summary DAG"
+   },
+   "lcmObserveConcurrency": {
+    "type": "number",
+    "default": 1,
+    "description": "Maximum independent LCM observe jobs to process concurrently."
+   },
+   "lcmRecallBudgetShare": {
+    "type": "number",
+    "default": 0.15,
+    "description": "Fraction of recall budget allocated to LCM compressed history (0-1)"
+   },
+   "lcmRollupFanIn": {
+    "type": "number",
+    "default": 4,
+    "description": "Number of children per rollup node in the LCM DAG"
+   },
+   "lcmTelemetryPrefilterEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Use deterministic LCM compression for mechanical action/state telemetry without durable-memory cues."
+   },
+   "lifecycleArchiveDecayThreshold": {
+    "type": "number",
+    "default": 0.85,
+    "description": "Decay threshold for lifecycle demotion to archived state semantics."
+   },
+   "lifecycleFilterStaleEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "If enabled, stale lifecycle memories can be filtered from retrieval (wired in PR20D)."
+   },
+   "lifecycleMetricsEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Emit lifecycle metrics snapshots to state/lifecycle-metrics.json when policy is enabled."
+   },
+   "lifecyclePolicyEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable the lifecycle policy engine (hot\u2194cold tier migration, value scoring, decay). Default true since #686 PR 3/6 \u2014 flipping enables the year-2 retention story by default. Set to false to opt out."
+   },
+   "lifecyclePromoteHeatThreshold": {
+    "type": "number",
+    "default": 0.55,
+    "description": "Heat threshold for lifecycle promotion to validated/active states."
+   },
+   "lifecycleProtectedCategories": {
+    "type": "array",
+    "items": {
+     "type": "string"
+    },
+    "default": [
+     "decision",
+     "principle",
+     "commitment",
+     "preference",
+     "procedure"
+    ],
+    "description": "Categories that lifecycle policy will not auto-archive."
+   },
+   "lifecycleStaleDecayThreshold": {
+    "type": "number",
+    "default": 0.65,
+    "description": "Decay threshold for lifecycle demotion to stale."
+   },
+   "localLlm400CooldownMs": {
+    "type": "number",
+    "default": 120000,
+    "description": "Cooldown duration after tripping local LLM 400 threshold (ms)."
+   },
+   "localLlm400TripThreshold": {
+    "type": "number",
+    "default": 5,
+    "description": "Consecutive 400 responses before local LLM enters temporary cooldown."
+   },
+   "localLlmApiKey": {
+    "type": "string",
+    "description": "Optional API key for authenticated OpenAI-compatible local endpoints"
+   },
+   "localLlmAuthHeader": {
+    "type": "boolean",
+    "default": true,
+    "description": "If false, do not send Authorization header even when localLlmApiKey is set"
+   },
+   "localLlmDisableThinking": {
+    "type": "boolean",
+    "default": true,
+    "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is sent only when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+   },
+   "localLlmEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable local LLM for extraction and summarization (e.g., LM Studio, Ollama)"
+   },
+   "localLlmFallback": {
+    "type": "boolean",
+    "default": true,
+    "description": "Fall back to cloud OpenAI if local LLM is unavailable"
+   },
+   "localLlmFastEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable a separate smaller/faster local LLM for quick operations (rerank, entity_summary, tmt_summary, compression_guideline)."
+   },
+   "localLlmFastModel": {
+    "type": "string",
+    "default": "",
+    "description": "Model ID for fast-tier local LLM operations. Empty string uses the primary localLlmModel."
+   },
+   "localLlmFastTimeoutMs": {
+    "type": "number",
+    "default": 15000,
+    "description": "Timeout for fast-tier local LLM requests (ms). Lower than primary since fast ops should complete quickly."
+   },
+   "localLlmFastUrl": {
+    "type": "string",
+    "description": "Endpoint for the fast-tier local LLM. Defaults to the same endpoint as localLlmUrl when not set."
+   },
+   "localLlmHeaders": {
+    "type": "object",
+    "description": "Optional additional headers for local/compatible endpoint requests",
+    "additionalProperties": {
+     "type": "string"
+    }
+   },
+   "localLlmHomeDir": {
+    "type": "string",
+    "description": "Optional home directory override for local LLM helpers (LM Studio settings + CLI PATH resolution)."
+   },
+   "localLlmMaxContext": {
+    "type": "number",
+    "description": "Override the detected context window for local LLM. Set to 32768 if your LLM server defaults to 32K context despite the model supporting 128K."
+   },
+   "localLlmModel": {
+    "type": "string",
+    "default": "local-model",
+    "description": "Model name for local LLM requests"
+   },
+   "localLlmRetry5xxCount": {
+    "type": "number",
+    "default": 1,
+    "description": "Number of retry attempts for local LLM 5xx responses."
+   },
+   "localLlmRetryBackoffMs": {
+    "type": "number",
+    "default": 400,
+    "description": "Base backoff delay between local LLM retries (ms)."
+   },
+   "localLlmTimeoutMs": {
+    "type": "number",
+    "default": 180000,
+    "description": "Hard timeout for local LLM requests (ms)"
+   },
+   "localLlmUrl": {
+    "type": "string",
+    "default": "http://localhost:1234/v1",
+    "description": "URL for local LLM OpenAI-compatible endpoint"
+   },
+   "localLmsBinDir": {
+    "type": "string",
+    "description": "Optional bin directory prepended to PATH for LMS CLI execution."
+   },
+   "localLmsCliPath": {
+    "type": "string",
+    "description": "Optional absolute path to LMS CLI binary. Preferred over auto-detected locations."
+   },
+   "maintenanceIncludeBranchNamespaces": {
+    "type": "boolean",
+    "default": false,
+    "description": "Include dynamic branch namespaces from the namespace catalog in background maintenance fanout. Defaults off to avoid high-cardinality branch churn."
+   },
+   "maintenanceIncludeProjectNamespaces": {
+    "type": "boolean",
+    "default": true,
+    "description": "Include dynamic project namespaces from the namespace catalog in background maintenance fanout."
+   },
+   "maintenanceIncludeTeamProjectNamespaces": {
+    "type": "boolean",
+    "default": true,
+    "description": "Include dynamic team-project namespaces from the namespace catalog in background maintenance fanout."
+   },
+   "maintenanceMaxNamespacesPerCycle": {
+    "type": "number",
+    "default": 20,
+    "minimum": 1,
+    "description": "Maximum namespaces a single maintenance job cycle may process. Default and shared namespaces keep priority inside this budget."
+   },
+   "maintenanceNamespaceFanoutEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "When namespaces are enabled, let background maintenance enumerate live catalog namespaces in addition to configured default/shared/policy namespaces."
+   },
+   "maintenanceNamespaceLockStaleMs": {
+    "type": "number",
+    "default": 600000,
+    "minimum": 1,
+    "description": "Stale threshold for per-job/per-namespace maintenance locks under state/maintenance-locks/."
+   },
+   "maxCompressionTokensPerHour": {
+    "type": "number",
+    "default": 1500,
+    "description": "Hourly token budget for compression actions/guideline generation (0 disables budgeted compression work)."
+   },
+   "maxEntityGraphEdgesPerMemory": {
+    "type": "number",
+    "default": 10,
+    "description": "Maximum entity graph edges written per memory write. Default 10."
+   },
+   "maxGraphTraversalSteps": {
+    "type": "number",
+    "default": 3,
+    "description": "Maximum BFS hops during spreading activation. Default 3."
+   },
+   "maxMemoryTokens": {
+    "type": "number",
+    "default": 2000,
+    "description": "Max memory-context tokens per turn"
+   },
+   "maxProactiveQuestionsPerExtraction": {
+    "type": "number",
+    "default": 2,
+    "description": "Maximum proactive self-questions generated per extraction pass (0 disables question generation)."
+   },
+   "maxSummaryCount": {
+    "type": "number",
+    "default": 6,
+    "description": "Maximum number of summaries to include"
+   },
+   "maxTranscriptTokens": {
+    "type": "number",
+    "default": 1000,
+    "description": "Maximum tokens for transcript context"
+   },
+   "maxTranscriptTurns": {
+    "type": "number",
+    "default": 50,
+    "description": "Maximum transcript turns to include"
+   },
+   "meilisearchApiKey": {
+    "type": "string",
+    "description": "API key for Meilisearch (when searchBackend=meilisearch)"
+   },
+   "meilisearchAutoIndex": {
+    "type": "boolean",
+    "default": false,
+    "description": "Automatically push local memory docs to Meilisearch on update (when searchBackend=meilisearch)"
+   },
+   "meilisearchEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable Meilisearch as a supplemental search backend."
+   },
+   "meilisearchHost": {
+    "type": "string",
+    "default": "http://localhost:7700",
+    "description": "Meilisearch server host URL (when searchBackend=meilisearch)"
+   },
+   "meilisearchTimeoutMs": {
+    "type": "number",
+    "default": 30000,
+    "description": "Timeout in ms for Meilisearch requests (when searchBackend=meilisearch)"
+   },
+   "memoryBoxesEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable Memory Boxes (v8.0 Phase 2A). Groups memories into topic-bounded windows. Disabled by default."
+   },
+   "memoryDir": {
+    "type": "string",
+    "description": "Override memory storage directory"
+   },
+   "memoryExtensionsEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Whether third-party memory extensions are discovered and included in consolidation instructions."
+   },
+   "memoryExtensionsRoot": {
+    "type": "string",
+    "default": "",
+    "description": "Root directory for memory extensions. Empty string derives from memoryDir (go up to Remnic home and append memory_extensions)."
+   },
+   "memoryLinkingEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable automatic memory linking to build knowledge graph"
+   },
+   "offlineSyncExcludes": {
+    "type": "array",
+    "items": {
+     "type": "string",
+     "minLength": 1
+    },
+    "default": [],
+    "description": "Extra offline-sync push-side exclude globs (relative to memoryDir; * within a segment, leading **/ across segments). Additive to the built-in node-local state excludes (state/*.sqlite, state/*.sqlite-*, state/index_tags.json, state/entity-mention-index.json, state/memory-governance/runs/**). Issue #1786."
+   },
+   "memoryOsPreset": {
+    "type": "string",
+    "enum": [
+     "conservative",
+     "balanced",
+     "research",
+     "research-max",
+     "local-llm-heavy"
+    ],
+    "description": "Optional named preset that seeds Engram's advanced config surface before explicit per-setting settings are applied. `research` is accepted as a backward-compatible alias for `research-max`."
+   },
+   "memoryPoisoningDefenseEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable deterministic provenance trust scoring for trust-zone records as the first poisoning-defense surface."
+   },
+   "memoryReconstructionEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "E-Mem-inspired memory reconstruction: targeted secondary retrieval for entity references lacking context in recall"
+   },
+   "memoryReconstructionMaxExpansions": {
+    "type": "number",
+    "default": 3,
+    "description": "Maximum number of entity expansions per recall cycle"
+   },
+   "memoryRedTeamBenchEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable operator-facing memory red-team benchmark packs and status accounting for poisoning-defense regression suites."
+   },
+   "memoryUtilityLearningEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable utility-learning telemetry storage so later slices can learn promotion and ranking weights from downstream outcomes."
+   },
+   "messagePartsEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Opt in to structured LCM message-part capture for tool calls, file references, patches, and reasoning markers."
+   },
+   "messagePartsRecallMaxResults": {
+    "type": "number",
+    "default": 6,
+    "description": "Maximum structured message-part matches to include in recall when messagePartsEnabled is true."
+   },
+   "model": {
+    "type": "string",
+    "default": "gpt-5.5",
+    "description": "OpenAI model for extraction/consolidation"
+   },
+   "modelSource": {
+    "type": "string",
+    "enum": [
+     "plugin",
+     "gateway"
+    ],
+    "default": "gateway",
+    "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
+   },
+   "multiGraphMemoryEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable multi-graph memory (entity, time, causal edges). Default false."
+   },
+   "namespaceCatalogEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable the rebuildable namespace catalog (issue #1499). Records cheap, failure-tolerant namespace touches in <memoryDir>/state/namespaces.jsonl for enumeration by maintenance, QMD indexing, dashboard, and doctor. Inert unless namespacesEnabled is also true; filesystem memory stays the source of truth and the catalog is rebuildable via `remnic namespaces rebuild`. Default on; set false to opt out."
+   },
+   "namespacePolicies": {
+    "type": "array",
+    "description": "Namespace access policies.",
+    "items": {
+     "type": "object",
+     "additionalProperties": false,
+     "properties": {
+      "name": {
+       "type": "string"
+      },
+      "readPrincipals": {
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "writePrincipals": {
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "includeInRecallByDefault": {
+       "type": "boolean"
+      }
+     },
+     "required": [
+      "name",
+      "readPrincipals",
+      "writePrincipals"
+     ]
+    }
+   },
+   "namespacesEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable multi-agent namespaces (v3.0). Default off."
+   },
+   "nativeKnowledge": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Optional: search curated workspace markdown files directly during recall without converting them into durable memory files.",
+    "properties": {
+     "enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Master switch for curated workspace file recall."
+     },
+     "includeFiles": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "default": [
+       "IDENTITY.md",
+       "MEMORY.md"
+      ],
+      "description": "Workspace-relative curated markdown files to scan for native knowledge recall."
+     },
+     "maxChunkChars": {
+      "type": "number",
+      "default": 900,
+      "description": "Maximum chunk size per native knowledge section before it is split."
+     },
+     "maxResults": {
+      "type": "number",
+      "default": 4,
+      "description": "Maximum native knowledge chunks to add to recall."
+     },
+     "maxChars": {
+      "type": "number",
+      "default": 2400,
+      "description": "Maximum total characters to add from native knowledge recall."
+     },
+     "stateDir": {
+      "type": "string",
+      "default": "state/native-knowledge",
+      "description": "Memory-relative directory used for backend-agnostic native knowledge sync state."
+     },
+     "openclawWorkspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional adapter for OpenClaw workspace artifacts such as bootstrap docs, handoffs, daily summaries, and automation notes.",
+      "properties": {
+       "enabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the OpenClaw workspace native-knowledge adapter."
+       },
+       "bootstrapFiles": {
+        "type": "array",
+        "items": {
+         "type": "string"
         },
         "default": [
-          "self",
-          "shared"
-        ]
-      },
-      "defaultScopeProfile": {
-        "type": "string",
-        "description": "Optional key in scopeProfiles to use as the default hosted memory scope profile."
-      },
-      "delinearizeEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "SimpleMem-inspired de-linearization: resolve pronouns and anchor relative dates in extracted memories"
-      },
-      "dreaming": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false
-          },
-          "journalPath": {
-            "type": "string",
-            "default": "DREAMS.md"
-          },
-          "maxEntries": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "const": 0
-              },
-              {
-                "type": "integer",
-                "minimum": 10,
-                "maximum": 10000
-              }
-            ],
-            "default": 500
-          },
-          "injectRecentCount": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 20,
-            "default": 3
-          },
-          "minIntervalMinutes": {
-            "type": "integer",
-            "minimum": 1,
-            "default": 120
-          },
-          "narrativeModel": {
-            "type": "string",
-            "default": "",
-            "description": "Model used to write dream-journal narratives. Under modelSource=plugin this must be an OpenAI model id used with the direct OpenAI key. Under modelSource=gateway it accepts a provider-qualified id (e.g. zai/glm-4.7-flash) routed through gateway providers — no direct OpenAI key required; leave empty to fall back to taskModelChain / the gateway default chain."
-          },
-          "narrativePromptStyle": {
-            "type": "string",
-            "enum": [
-              "reflective",
-              "diary",
-              "analytical"
-            ],
-            "default": "reflective"
-          },
-          "watchFile": {
-            "type": "boolean",
-            "default": true
-          }
-        }
-      },
-      "dreams": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "description": "Consolidation pipeline phases config (issue #678 PR 2). Groups existing lifecycle/REM/deep-sleep gates under a unified namespace. Values here WIN over equivalent legacy top-level keys when set. See docs/dreams.md. (Note: distinct from the `dreaming` diary-surface config.)",
-        "properties": {
-          "phases": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "properties": {
-              "lightSleep": {
-                "type": "object",
-                "additionalProperties": false,
-                "default": {},
-                "description": "Light-sleep phase: recent activity scoring and clustering. Mirrors lifecyclePolicyEnabled and related thresholds when not set explicitly.",
-                "properties": {
-                  "enabled": {
-                    "type": "boolean",
-                    "description": "Master switch for the light-sleep phase. Mirrors lifecyclePolicyEnabled when not set."
-                  },
-                  "cadenceMs": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "default": 0,
-                    "description": "Minimum interval between light-sleep passes (ms). 0 = no override; orchestrator uses its internal cadence."
-                  },
-                  "promoteHeatThreshold": {
-                    "type": "number",
-                    "minimum": 0,
-                    "maximum": 1,
-                    "default": 0.55,
-                    "description": "Value score above which a memory is treated as hot. Mirrors lifecyclePromoteHeatThreshold when not set."
-                  },
-                  "staleDecayThreshold": {
-                    "type": "number",
-                    "minimum": 0,
-                    "maximum": 1,
-                    "default": 0.65,
-                    "description": "Value score below which a memory starts to decay. Mirrors lifecycleStaleDecayThreshold when not set."
-                  },
-                  "archiveDecayThreshold": {
-                    "type": "number",
-                    "minimum": 0,
-                    "maximum": 1,
-                    "default": 0.85,
-                    "description": "Value score below which a memory is eligible for archive. Mirrors lifecycleArchiveDecayThreshold when not set."
-                  },
-                  "filterStaleEnabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Whether stale memories are filtered from recall. Mirrors lifecycleFilterStaleEnabled when not set."
-                  }
-                }
-              },
-              "rem": {
-                "type": "object",
-                "additionalProperties": false,
-                "default": {},
-                "description": "REM phase: cross-session synthesis, supersession resolution, semantic consolidation. Mirrors semanticConsolidation* keys when not set explicitly.",
-                "properties": {
-                  "enabled": {
-                    "type": "boolean",
-                    "description": "Master switch for the REM phase. Mirrors semanticConsolidationEnabled when not set."
-                  },
-                  "cadenceMs": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "description": "How often the REM pass runs (ms). Derived from semanticConsolidationIntervalHours when not set."
-                  },
-                  "similarityThreshold": {
-                    "type": "number",
-                    "minimum": 0,
-                    "maximum": 1,
-                    "default": 0.8,
-                    "description": "Cosine-similarity threshold for cluster membership. Mirrors semanticConsolidationThreshold when not set."
-                  },
-                  "minClusterSize": {
-                    "type": "integer",
-                    "minimum": 2,
-                    "default": 3,
-                    "description": "Minimum cluster size before consolidation runs. Mirrors semanticConsolidationMinClusterSize when not set."
-                  },
-                  "maxPerRun": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "default": 100,
-                    "description": "Max cluster operations per run. Mirrors semanticConsolidationMaxPerRun when not set."
-                  },
-                  "minIntervalMs": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "description": "Minimum gap between consolidation passes (ms). Mirrors consolidationMinIntervalMs when not set."
-                  }
-                }
-              },
-              "deepSleep": {
-                "type": "object",
-                "additionalProperties": false,
-                "default": {},
-                "description": "Deep-sleep phase: promotion to durable memory, hot-to-cold tier migration, page-version snapshots, archive. Mirrors versioningEnabled and related keys when not set explicitly.",
-                "properties": {
-                  "enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Master switch for the deep-sleep phase. Defaults false unless legacy deep-sleep surfaces are explicitly enabled; set true to allow nightly governance, tier migration, and versioning surfaces."
-                  },
-                  "cadenceMs": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "default": 86400000,
-                    "description": "Minimum interval between deep-sleep passes (ms). Default 86400000 (24h). Informational in PR 2; PR 4 wires this into the cron scheduler."
-                  },
-                  "versioningEnabled": {
-                    "type": "boolean",
-                    "description": "Enable page-version snapshots on every overwrite. Mirrors versioningEnabled when not set."
-                  },
-                  "versioningMaxPerPage": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "description": "Max snapshots per memory page. Mirrors versioningMaxPerPage when not set."
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "embeddingFallbackEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable embedding-based semantic recall fallback when QMD is unavailable or returns no matches"
-      },
-      "embeddingFallbackModel": {
-        "type": "string",
-        "description": "Optional model identifier for embedding fallback requests. Defaults to localLlmModel for legacy installs."
-      },
-      "embeddingFallbackProvider": {
-        "type": "string",
-        "enum": [
-          "auto",
-          "openai",
-          "local"
+         "IDENTITY.md",
+         "MEMORY.md",
+         "USER.md"
         ],
-        "default": "auto",
-        "description": "Embedding provider selection for semantic fallback"
+        "description": "Workspace-relative bootstrap docs treated as high-confidence native knowledge."
+       },
+       "handoffGlobs": {
+        "type": "array",
+        "items": {
+         "type": "string"
+        },
+        "default": [
+         "**/*handoff*.md",
+         "handoffs/**/*.md"
+        ],
+        "description": "Glob patterns (relative to workspaceDir) used to discover handoff notes."
+       },
+       "dailySummaryGlobs": {
+        "type": "array",
+        "items": {
+         "type": "string"
+        },
+        "default": [
+         "**/*daily*summary*.md",
+         "summaries/**/*.md"
+        ],
+        "description": "Glob patterns (relative to workspaceDir) used to discover daily summary notes."
+       },
+       "automationNoteGlobs": {
+        "type": "array",
+        "items": {
+         "type": "string"
+        },
+        "default": [],
+        "description": "Optional glob patterns for automation-written status or operating notes."
+       },
+       "workspaceDocGlobs": {
+        "type": "array",
+        "items": {
+         "type": "string"
+        },
+        "default": [],
+        "description": "Optional glob patterns for other explicitly allowlisted workspace docs."
+       },
+       "excludeGlobs": {
+        "type": "array",
+        "items": {
+         "type": "string"
+        },
+        "default": [],
+        "description": "Additional glob patterns appended to the built-in workspace safety excludes."
+       },
+       "sharedSafeGlobs": {
+        "type": "array",
+        "items": {
+         "type": "string"
+        },
+        "default": [],
+        "description": "Optional glob patterns that should be tagged as shared-safe when no explicit privacy class is present."
+       }
       },
-      "emitLegacyTools": {
-        "type": "boolean",
-        "default": false,
-        "description": "Advertise legacy engram_* / engram.* MCP tool aliases alongside the canonical remnic_* names. Issue #1550: defaults to false on fresh installs (halving the advertised tools/list surface); when existing legacy connector entries are present on disk the default stays true so upgrades never silently break a configured legacy client. An explicit value always wins."
-      },
-      "enrichmentAutoOnCreate": {
-        "type": "boolean",
-        "default": false,
-        "description": "Automatically enrich newly created entities when the enrichment pipeline is enabled."
-      },
-      "enrichmentEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the external enrichment pipeline (#365). When true, entities can be enriched via registered providers."
-      },
-      "enrichmentMaxCandidatesPerEntity": {
-        "type": "integer",
-        "default": 20,
-        "minimum": 0,
-        "description": "Maximum enrichment candidates accepted per entity per run. Set to 0 to accept none."
-      },
-      "entityActivityLogEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Log timestamped activity per entity"
-      },
-      "entityActivityLogMaxEntries": {
-        "type": "number",
-        "default": 20,
-        "description": "Max activity entries per entity before oldest are pruned"
-      },
-      "entityAliasesEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Store aliases per entity file"
-      },
-      "entityGraphEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Build entity co-reference graph (requires multiGraphMemoryEnabled). Default true."
-      },
-      "entityRelationshipsEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Track entity-to-entity relationships during extraction"
-      },
-      "entityRetrievalEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable entity-oriented recall hints for direct entity questions and short follow-up queries."
-      },
-      "entityRetrievalMaxChars": {
-        "type": "number",
-        "default": 2400,
-        "description": "Hard character cap for the entity retrieval section."
-      },
-      "entityRetrievalMaxHints": {
-        "type": "number",
-        "default": 2,
-        "description": "Maximum entity targets summarized in one recall pass."
-      },
-      "entityRetrievalMaxRelatedEntities": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum related entities listed per target when confidence is high."
-      },
-      "entityRetrievalMaxSupportingFacts": {
-        "type": "number",
-        "default": 6,
-        "description": "Maximum supporting fact/timeline snippets considered per entity target."
-      },
-      "entityRetrievalRecentTurns": {
-        "type": "number",
-        "default": 6,
-        "description": "Recent transcript turns scanned for pronoun carry-forward and short follow-up resolution."
-      },
-      "entitySchemas": {
-        "type": "object",
-        "description": "Optional per-entity-type structured section schema customizations.",
-        "additionalProperties": {
+      "required": [
+       "enabled"
+      ]
+     },
+     "obsidianVaults": {
+      "type": "array",
+      "default": [],
+      "description": "Optional Obsidian vault adapters to sync into backend-agnostic native knowledge records.",
+      "items": {
+       "type": "object",
+       "additionalProperties": false,
+       "properties": {
+        "id": {
+         "type": "string",
+         "description": "Stable vault identifier used in synced note metadata."
+        },
+        "rootDir": {
+         "type": "string",
+         "description": "Absolute path to the Obsidian vault root."
+        },
+        "includeGlobs": {
+         "type": "array",
+         "items": {
+          "type": "string"
+         },
+         "default": [
+          "**/*.md"
+         ],
+         "description": "Glob patterns (relative to the vault root) that are eligible for sync."
+        },
+        "excludeGlobs": {
+         "type": "array",
+         "items": {
+          "type": "string"
+         },
+         "default": [
+          ".obsidian/**",
+          "**/*.canvas",
+          "**/*.png",
+          "**/*.jpg",
+          "**/*.jpeg",
+          "**/*.gif",
+          "**/*.pdf"
+         ],
+         "description": "Glob patterns excluded from sync."
+        },
+        "namespace": {
+         "type": "string",
+         "description": "Default namespace assigned to records from this vault."
+        },
+        "privacyClass": {
+         "type": "string",
+         "description": "Operator-defined privacy class preserved on synced records."
+        },
+        "folderRules": {
+         "type": "array",
+         "default": [],
+         "description": "Optional per-folder overrides for namespace or privacy classification.",
+         "items": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "sections": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "key": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "aliases": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "anyOf": [
-                  {
-                    "required": [
-                      "key"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "title"
-                    ]
-                  }
-                ]
-              }
-            }
+           "pathPrefix": {
+            "type": "string",
+            "description": "Vault-relative folder prefix that activates the override."
+           },
+           "namespace": {
+            "type": "string",
+            "description": "Namespace override for matching notes."
+           },
+           "privacyClass": {
+            "type": "string",
+            "description": "Privacy-class override for matching notes."
+           }
           },
           "required": [
-            "sections"
+           "pathPrefix"
           ]
+         }
+        },
+        "dailyNotePatterns": {
+         "type": "array",
+         "items": {
+          "type": "string"
+         },
+         "default": [
+          "YYYY-MM-DD"
+         ],
+         "description": "Filename patterns used to derive daily-note dates (for example `YYYY-MM-DD` or `YYYY/MM/DD`)."
+        },
+        "materializeBacklinks": {
+         "type": "boolean",
+         "default": false,
+         "description": "If true, compute backlinks from wikilink targets for recall hints and explainability."
         }
+       },
+       "required": [
+        "rootDir"
+       ]
+      }
+     }
+    },
+    "required": [
+     "enabled"
+    ]
+   },
+   "negativeExamplesEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable negative examples (track retrieved-but-not-useful memories) and apply a small ranking penalty."
+   },
+   "negativeExamplesPenaltyCap": {
+    "type": "number",
+    "default": 0.25,
+    "description": "Maximum ranking penalty applied from negative examples."
+   },
+   "negativeExamplesPenaltyPerHit": {
+    "type": "number",
+    "default": 0.05,
+    "description": "Ranking penalty per negative example hit (keep small; QMD scores are ~0-1)."
+   },
+   "nightlyGovernanceCronAutoRegister": {
+    "type": "boolean",
+    "default": false,
+    "description": "If true, Engram may attempt to auto-register the nightly governance cron job (default off)."
+   },
+   "objectiveStateMemoryEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable Engram's objective-state memory foundation for normalized world/tool state snapshots."
+   },
+   "objectiveStateRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Add recall-relevant objective-state snapshots to recall context."
+   },
+   "objectiveStateSnapshotWritesEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Allow writing typed objective-state snapshots to the objective-state store."
+   },
+   "objectiveStateStoreDir": {
+    "type": "string",
+    "description": "Override the objective-state memory directory (defaults to {memoryDir}/state/objective-state)."
+   },
+   "openaiApiKey": {
+    "anyOf": [
+     {
+      "type": "string"
+     },
+     {
+      "const": false
+     }
+    ],
+    "description": "Optional OpenAI API key for plugin mode (or set OPENAI_API_KEY env var). Ignored by default gateway-mode installs; in plugin mode, Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
+   },
+   "openaiBaseUrl": {
+    "type": "string",
+    "description": "Set the OpenAI API base URL for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
+   },
+   "openclawChannelEnvelopeCleaningEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Use OpenClaw's canonical chat-channel envelope prefixes when the SDK exposes plugin-sdk/chat-channel-ids, while keeping the legacy OpenClaw-only cleaner on older hosts."
+   },
+   "openclawFlushPlanProcessingEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Process OpenClaw's append-only Remnic flush-plan file through Remnic extraction and clear processed content. Disable this if a future OpenClaw release owns flush-plan consumption and cleanup natively."
+   },
+   "openclawMessageReceivedCaptureEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Capture OpenClaw message_received hook content into transcripts when that hook is emitted by the host. Older OpenClaw versions that never emit the hook continue through agent_end capture."
+   },
+   "openclawReplyMetadataCaptureEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Persist bounded OpenClaw messageId, threadId, replyToId, replyToBody, and replyToSender fields in transcript metadata when available."
+   },
+   "openclawReplyMetadataExtractionHintsEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "When true, prepend bounded quoted-reply context to user turns before Remnic extraction. Leave false to store reply metadata without changing extraction behavior."
+   },
+   "openclawToolSnippetMaxChars": {
+    "type": "integer",
+    "minimum": 80,
+    "maximum": 4000,
+    "default": 600,
+    "description": "Maximum snippet size returned by the OpenClaw memory tool adapters."
+   },
+   "openclawToolsEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Register the OpenClaw memory.search and memory.get tool adapters."
+   },
+   "operatorAwareConsolidationEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Opt in to operator-aware consolidation instructions so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+   },
+   "oramaDbPath": {
+    "type": "string",
+    "description": "Directory path for Orama persistence files (when searchBackend=orama)"
+   },
+   "oramaEmbeddingDimension": {
+    "type": "number",
+    "default": 1536,
+    "description": "Embedding vector dimension for Orama (when searchBackend=orama)"
+   },
+   "oramaEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable Orama as a supplemental search backend."
+   },
+   "parallelAgentWeights": {
+    "type": "object",
+    "default": {
+     "direct": 1,
+     "contextual": 0.7,
+     "temporal": 0.85
+    },
+    "description": "Score weights per retrieval agent source applied during result merge."
+   },
+   "parallelMaxResultsPerAgent": {
+    "type": "number",
+    "default": 20,
+    "description": "Maximum results fetched per agent before merge."
+   },
+   "parallelRetrievalEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable three-agent parallel retrieval (DirectFact + Contextual + Temporal). Zero additional LLM cost. Default false."
+   },
+   "patternReinforcementCadenceMs": {
+    "type": "integer",
+    "minimum": 0,
+    "default": 604800000,
+    "description": "Minimum interval (ms) between pattern-reinforcement runs. Default 7 days. Set to 0 to disable cadence gating (manual / test invocation)."
+   },
+   "patternReinforcementCategories": {
+    "type": "array",
+    "items": {
+     "type": "string"
+    },
+    "default": [
+     "preference",
+     "fact",
+     "decision"
+    ],
+    "description": "Memory categories the pattern-reinforcement job considers. Skips procedural memories so it stays disjoint from procedural mining. Default: preference, fact, decision."
+   },
+   "patternReinforcementEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Run the pattern-reinforcement maintenance job (issue #687 PR 2/4): cluster duplicate non-procedural memories by normalized content, promote the most-recent member to canonical, and supersede the older duplicates. Off by default until bench validation lands."
+   },
+   "patternReinforcementMinCount": {
+    "type": "integer",
+    "minimum": 2,
+    "maximum": 1000,
+    "default": 3,
+    "description": "Minimum cluster size before pattern reinforcement promotes a canonical and supersedes duplicates. Default 3."
+   },
+   "peerProfileReasonerEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable the async peer profile reasoner (issue #679). Runs after semantic consolidation in the REM phase and updates per-peer profile.md files with provenance-tagged field updates derived from the peer's interaction log. Default off (opt-in)."
+   },
+   "peerProfileReasonerMaxFieldsPerRun": {
+    "type": "number",
+    "default": 8,
+    "minimum": 0,
+    "description": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
+   },
+   "peerProfileReasonerMinInteractions": {
+    "type": "number",
+    "default": 5,
+    "minimum": 0,
+    "description": "Minimum new interaction-log entries a peer must accumulate since the previous reasoner run before being processed again. Set to 0 to consider every peer on every run."
+   },
+   "peerProfileReasonerModel": {
+    "type": "string",
+    "default": "auto",
+    "description": "Model identifier used by the peer profile reasoner. 'auto' inherits the gateway's primary chain (recommended). Logged for telemetry only \u2014 actual dispatch routes through the same FallbackLlmClient used by semantic consolidation."
+   },
+   "peerProfileRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "When true, add the active peer's profile fields to the recall context as a '## Peer Profile' section (issue #679 PR 3/5). Requires the session's peer ID to be registered before recall. Default off (opt-in)."
+   },
+   "peerProfileRecallMaxFields": {
+    "type": "number",
+    "default": 5,
+    "minimum": 0,
+    "description": "Maximum number of peer profile fields to add per recall call. Only the most-recently-updated N fields are included. Set to 0 to disable field inclusion even when peerProfileRecallEnabled is true."
+   },
+   "principalFromSessionKeyMode": {
+    "type": "string",
+    "enum": [
+     "map",
+     "prefix",
+     "regex"
+    ],
+    "default": "map",
+    "description": "How to derive principal identity from sessionKey."
+   },
+   "principalFromSessionKeyRules": {
+    "type": "array",
+    "description": "Rules for resolving principal from sessionKey (ordered).",
+    "items": {
+     "type": "object",
+     "additionalProperties": false,
+     "properties": {
+      "match": {
+       "type": "string"
       },
-      "entitySummaryEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Generate LLM summaries for entities during consolidation"
+      "principal": {
+       "type": "string"
+      }
+     },
+     "required": [
+      "match",
+      "principal"
+     ]
+    }
+   },
+   "proactiveExtractionCategoryAllowlist": {
+    "type": "array",
+    "items": {
+     "type": "string"
+    },
+    "description": "Optional memory categories allowed from proactive second-pass writes. When omitted, proactive writes can emit any standard memory category."
+   },
+   "proactiveExtractionEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable proactive self-questioning extraction second-pass (v8.3, default off)."
+   },
+   "proactiveExtractionMaxTokens": {
+    "type": "number",
+    "default": 900,
+    "description": "Token budget for each proactive extraction sub-call (0 disables the proactive second pass)."
+   },
+   "proactiveExtractionTimeoutMs": {
+    "type": "number",
+    "default": 2500,
+    "description": "Hard timeout in milliseconds for proactive self-question generation and answer synthesis (0 disables the proactive second pass)."
+   },
+   "procedural": {
+    "type": "object",
+    "additionalProperties": false,
+    "default": {},
+    "properties": {
+     "enabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Master gate for procedural memory: extraction, recall boost, and mining (issue #519). Default-on since issue #567 PR 4/5; set to `false` to opt out."
+     },
+     "minOccurrences": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1000,
+      "default": 3,
+      "description": "Minimum clustered trajectory occurrences before emitting a candidate procedure (0 disables mining)."
+     },
+     "successFloor": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "default": 0.75,
+      "description": "Minimum success-rate floor (from trajectory outcomes) for miner promotion."
+     },
+     "autoPromoteOccurrences": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 10000,
+      "default": 8,
+      "description": "When auto-promotion is enabled, minimum occurrence count to move pending_review procedures to active (0 disables auto-promotion by count)."
+     },
+     "autoPromoteEnabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, miner may auto-promote trusted procedures to active after autoPromoteOccurrences."
+     },
+     "lookbackDays": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 3650,
+      "default": 14,
+      "description": "Trajectory lookback window for procedural mining."
+     },
+     "recallMaxProcedures": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10,
+      "default": 2,
+      "description": "Maximum procedure memories to add on task-initiation recall."
+     },
+     "proceduralMiningCronAutoRegister": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, installer may register the nightly procedural mining cron job."
+     }
+    }
+   },
+   "profilingEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "If true, enable performance profiling for recall and extraction pipelines. Profiling data is stored locally in the profiling storage directory."
+   },
+   "profilingMaxTraces": {
+    "type": "number",
+    "default": 100,
+    "description": "Maximum number of profiling trace files to retain. Oldest traces are pruned when this limit is exceeded."
+   },
+   "profilingStorageDir": {
+    "type": "string",
+    "default": "",
+    "description": "Directory path for storing profiling trace files. Defaults to <memoryDir>/profiling if empty."
+   },
+   "promotionByOutcomeEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable outcome-aware promotion controls that consume learned utility signals when later rollout slices activate them."
+   },
+   "provenance": {
+    "type": "object",
+    "description": "Claim-level provenance spans (issue #1575). When enabled, extracted facts carry verbatim source-utterance excerpts plus a coarse strength tag (verified/unverified/none) consumed by the faithfulness gate, correction UX, tombstone matching, and TrustScore.",
+    "additionalProperties": false,
+    "properties": {
+     "enabled": {
+      "type": "boolean",
+      "description": "Emit provenance spans on new extractions. Off = pre-feature extraction prompt/output, byte-identical (rule 39). Default: true (applied in code; no schema default so the REMNIC_/ENGRAM_ env override fires when the key is omitted)."
+     },
+     "maxQuoteChars": {
+      "type": "integer",
+      "default": 300,
+      "minimum": 1,
+      "description": "Maximum characters stored per quote; longer quotes truncate at a word boundary with an ellipsis marker. Never stores the whole turn."
+     },
+     "requireSpans": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, facts whose quote cannot be located are routed to pending_review instead of active. Stays false until #1576 lands and the bench shows the gate is safe (rule 48)."
+     }
+    }
+   },
+   "qmdAutoEmbedEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "If true, background QMD maintenance also runs embed on a throttled cadence."
+   },
+   "qmdAutoUpgradeCheckIntervalMs": {
+    "type": "number",
+    "minimum": 60000,
+    "default": 86400000,
+    "description": "Minimum interval between QMD auto-upgrade checks"
+   },
+   "qmdAutoUpgradeEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Opt-in auto-upgrade for PATH/fallback QMD installs"
+   },
+   "qmdCandidateLimit": {
+    "type": "number",
+    "minimum": 1,
+    "description": "Optional candidate limit forwarded to supported QMD query paths"
+   },
+   "qmdChunkStrategy": {
+    "type": "string",
+    "enum": [
+     "auto",
+     "regex"
+    ],
+    "default": "auto",
+    "description": "QMD chunk strategy forwarded when the installed QMD supports it"
+   },
+   "qmdColdCollection": {
+    "type": "string",
+    "default": "openclaw-engram-cold",
+    "description": "Secondary QMD collection name used for cold-tier fallback recall"
+   },
+   "qmdColdMaxResults": {
+    "type": "number",
+    "default": 8,
+    "description": "Max cold-tier QMD results considered before final recall cap"
+   },
+   "qmdColdTierEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable cold-tier QMD recall from a secondary collection when hot recall misses"
+   },
+   "qmdCollection": {
+    "type": "string",
+    "default": "openclaw-engram",
+    "description": "QMD collection name"
+   },
+   "qmdDaemonEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Prefer the shared QMD MCP session for faster searches when available."
+   },
+   "qmdDaemonRecheckIntervalMs": {
+    "type": "number",
+    "default": 60000,
+    "description": "Re-probe interval when daemon is down (ms)"
+   },
+   "qmdDaemonTimeoutMs": {
+    "type": "number",
+    "minimum": 1000,
+    "maximum": 120000,
+    "default": 8000,
+    "description": "Per-call timeout (ms) for QMD daemon searches. Default 8000; raise (e.g. 20000) to give CPU-only HyDE queries more headroom before the daemon call times out (issue #1335)."
+   },
+   "qmdDaemonUrl": {
+    "type": "string",
+    "default": "http://localhost:8181/mcp",
+    "description": "Legacy compatibility setting retained for QMD daemon configuration."
+   },
+   "qmdEmbedMinIntervalMs": {
+    "type": "number",
+    "default": 3600000,
+    "description": "Minimum interval between background QMD embed runs (ms)."
+   },
+   "qmdEmbedModel": {
+    "type": "string",
+    "description": "Optional QMD_EMBED_MODEL override"
+   },
+   "qmdEmbedParallelism": {
+    "type": "number",
+    "minimum": 1,
+    "maximum": 8,
+    "description": "Optional QMD_EMBED_PARALLELISM override, clamped to 1-8"
+   },
+   "qmdEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Use QMD for search"
+   },
+   "qmdExplainEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Request QMD explain traces for recall debugging when supported."
+   },
+   "qmdForceCpu": {
+    "type": "boolean",
+    "default": false,
+    "description": "Set QMD_FORCE_CPU=1 for QMD child processes to bypass GPU probing and run predictably on CPU"
+   },
+   "qmdGenerateModel": {
+    "type": "string",
+    "description": "Optional QMD_GENERATE_MODEL override"
+   },
+   "qmdGpuBackend": {
+    "type": [
+     "string",
+     "boolean"
+    ],
+    "enum": [
+     "auto",
+     "metal",
+     "cuda",
+     "vulkan",
+     "false",
+     false
+    ],
+    "description": "Optional QMD_LLAMA_GPU override for QMD child processes"
+   },
+   "qmdIndexName": {
+    "type": "string",
+    "description": "Optional QMD named index forwarded as qmd --index <name> when supported. Leave unset during upgrades unless existing QMD data already lives in that named index."
+   },
+   "qmdIntentHintsEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Pass Engram's inferred recall intent into QMD unified search when supported."
+   },
+   "qmdMaintenanceDebounceMs": {
+    "type": "number",
+    "default": 30000,
+    "description": "Debounce window for background QMD maintenance updates (ms)."
+   },
+   "qmdMaintenanceEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable debounced background QMD maintenance instead of immediate updates on extraction."
+   },
+   "qmdMaxResults": {
+    "type": "number",
+    "default": 8,
+    "description": "Max QMD results per search"
+   },
+   "qmdPath": {
+    "type": "string",
+    "description": "Optional absolute path to qmd binary (bypasses PATH/fallback discovery)"
+   },
+   "qmdQueryRerankEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "When false, ask supported QMD versions to skip the built-in rerank step"
+   },
+   "qmdRecallCacheMaxEntries": {
+    "type": "number",
+    "default": 128,
+    "description": "Maximum in-memory rendered QMD recall cache entries before oldest eviction."
+   },
+   "qmdRecallCacheStaleTtlMs": {
+    "type": "number",
+    "default": 600000,
+    "description": "Maximum stale TTL in ms for rendered QMD recall cache fallbacks."
+   },
+   "qmdRecallCacheTtlMs": {
+    "type": "number",
+    "default": 60000,
+    "description": "Fresh TTL in ms for rendered QMD recall enrichment cache entries."
+   },
+   "qmdRerankModel": {
+    "type": "string",
+    "description": "Optional QMD_RERANK_MODEL override"
+   },
+   "qmdSearchStrategy": {
+    "type": "string",
+    "enum": [
+     "hybrid",
+     "lex-vec",
+     "lex"
+    ],
+    "default": "hybrid",
+    "description": "Daemon search plan. 'hybrid' (default) runs lex+vec+hyde for best recall; 'lex-vec' drops the expensive HyDE generate leg; 'lex' is BM25-only (fastest). Lower tiers trade recall for latency on CPU-only models. Default preserves existing behavior (issue #1335)."
+   },
+   "qmdSubprocessStrategy": {
+    "type": "string",
+    "enum": [
+     "query",
+     "search"
+    ],
+    "default": "query",
+    "description": "Command for the QMD CLI subprocess fallback, used only when the daemon is unavailable. 'query' (default) keeps LLM query expansion + rerank; 'search' is BM25-only and faster on very large collections but loses expansion/rerank. Default preserves existing behavior (issue #1335)."
+   },
+   "qmdSupportedVersion": {
+    "type": "string",
+    "default": "2.5.3",
+    "description": "Highest QMD version this Remnic build will auto-install"
+   },
+   "qmdTierAutoBackfillEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Allow automated cold-tier backfill jobs to repair parity gaps"
+   },
+   "qmdTierDemotionMinAgeDays": {
+    "type": "number",
+    "default": 14,
+    "description": "Minimum hot-memory age in days before tier demotion is eligible"
+   },
+   "qmdTierDemotionValueThreshold": {
+    "type": "number",
+    "default": 0.35,
+    "description": "Value-score threshold at or below which hot memories are eligible for cold demotion"
+   },
+   "qmdTierMigrationEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable value-aware migration between hot and cold QMD tiers"
+   },
+   "qmdTierParityGraphEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Apply graph-assist parity checks across hot and cold retrieval tiers"
+   },
+   "qmdTierParityHiMemEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Apply HiMem episode/note parity checks across hot and cold retrieval tiers"
+   },
+   "qmdTierPromotionValueThreshold": {
+    "type": "number",
+    "default": 0.7,
+    "description": "Value-score threshold at or above which cold memories are eligible for hot promotion"
+   },
+   "qmdUpdateMinIntervalMs": {
+    "type": "number",
+    "default": 900000,
+    "description": "Minimum interval between QMD update executions (ms). Useful because current QMD update runs globally across collections."
+   },
+   "qmdUpdateTimeoutMs": {
+    "type": "number",
+    "default": 90000,
+    "description": "Timeout for QMD update command (ms). Increase if your index grows and updates exceed 30s."
+   },
+   "quarantinePromotionEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Reserve future promotion flows from quarantine into higher-trust zones."
+   },
+   "queryAwareIndexingEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable temporal and tag indexes (v8.1). Maintains state/index_time.json and state/index_tags.json for fast prefiltering. At recall time, temporal queries and #tag tokens receive a small score boost from the index. Disabled by default."
+   },
+   "queryAwareIndexingMaxCandidates": {
+    "type": "number",
+    "default": 200,
+    "description": "Max candidate paths returned from index prefilter before scoring (0 = no cap)."
+   },
+   "queryExpansionEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable heuristic query expansion for retrieval (no LLM calls)."
+   },
+   "queryExpansionMaxQueries": {
+    "type": "number",
+    "default": 4,
+    "description": "Max expanded queries to run (including the original prompt)."
+   },
+   "queryExpansionMinTokenLen": {
+    "type": "number",
+    "default": 3,
+    "description": "Minimum token length to include in heuristic query expansion."
+   },
+   "reasoningEffort": {
+    "type": "string",
+    "enum": [
+     "none",
+     "low",
+     "medium",
+     "high"
+    ],
+    "default": "low",
+    "description": "Reasoning effort for extraction"
+   },
+   "recallAuditAnomalyDetectionEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "When true, access surfaces (MCP, HTTP) run the anomaly detector over a tail of the audit trail after each recall and surface flags via logs/metrics. Ships disabled \u2014 enable explicitly."
+   },
+   "recallAuditAnomalyHighCardinalityLimit": {
+    "type": "number",
+    "minimum": 1,
+    "default": 50,
+    "description": "Threshold for the high-cardinality-return anomaly flag: number of distinct results returned within the window before flagging."
+   },
+   "recallAuditAnomalyNamespaceWalkLimit": {
+    "type": "number",
+    "minimum": 1,
+    "default": 3,
+    "description": "Threshold for the namespace-walk anomaly flag: number of distinct namespaces queried within the window before flagging."
+   },
+   "recallAuditAnomalyRapidFireLimit": {
+    "type": "number",
+    "minimum": 1,
+    "default": 30,
+    "description": "Threshold for the rapid-fire anomaly flag: number of recall requests within the window before flagging."
+   },
+   "recallAuditAnomalyRepeatQueryLimit": {
+    "type": "number",
+    "minimum": 1,
+    "default": 5,
+    "description": "Threshold for the repeat-query anomaly flag: number of identical queries within the window before flagging."
+   },
+   "recallAuditAnomalyWindowMs": {
+    "type": "number",
+    "minimum": 1,
+    "default": 300000,
+    "description": "Rolling window (ms) over which audit entries are analyzed by the anomaly detector. Default 5 minutes."
+   },
+   "recallBudgetChars": {
+    "type": "number",
+    "description": "Hard character cap for total recall context. Defaults to maxMemoryTokens * 4."
+   },
+   "recallConfidenceGateEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Synapse-inspired confidence gate: skip memory context when top recall score is below threshold"
+   },
+   "recallConfidenceGateThreshold": {
+    "type": "number",
+    "default": 0.12,
+    "description": "Minimum top recall score to include memories (0-1). Below this, memories are rejected as too uncertain"
+   },
+   "recallCoreDeadlineMs": {
+    "type": "number",
+    "default": 75000,
+    "description": "Default deadline in ms recorded for core recall sections."
+   },
+   "recallCrossNamespaceBudgetEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
+   },
+   "recallCrossNamespaceBudgetHardLimit": {
+    "type": "number",
+    "minimum": 1,
+    "default": 30,
+    "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
+   },
+   "recallCrossNamespaceBudgetSoftLimit": {
+    "type": "number",
+    "minimum": 0,
+    "default": 10,
+    "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
+   },
+   "recallCrossNamespaceBudgetWindowMs": {
+    "type": "number",
+    "minimum": 1,
+    "default": 60000,
+    "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
+   },
+   "recallDirectAnswerAmbiguityMargin": {
+    "type": "number",
+    "minimum": 0,
+    "maximum": 1,
+    "default": 0.15,
+    "description": "If the second-best candidate scores within this ratio of the top, direct-answer defers to hybrid."
+   },
+   "recallDirectAnswerEligibleTaxonomyBuckets": {
+    "type": "array",
+    "items": {
+     "type": "string"
+    },
+    "default": [
+     "decisions",
+     "principles",
+     "conventions",
+     "runbooks",
+     "entities"
+    ],
+    "description": "Taxonomy category IDs eligible for direct-answer routing."
+   },
+   "recallDirectAnswerEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
+   },
+   "recallDirectAnswerImportanceFloor": {
+    "type": "number",
+    "minimum": 0,
+    "maximum": 1,
+    "default": 0.7,
+    "description": "Minimum calibrated importance score for direct-answer eligibility. Set to 0 to disable the gate."
+   },
+   "recallDirectAnswerTokenOverlapFloor": {
+    "type": "number",
+    "minimum": 0,
+    "maximum": 1,
+    "default": 0.55,
+    "description": "Minimum query\u2194memory token-overlap ratio for direct-answer eligibility. Set to 0 to disable the gate."
+   },
+   "recallDisclosureEscalation": {
+    "type": "string",
+    "enum": [
+     "manual",
+     "auto"
+    ],
+    "default": "manual",
+    "description": "Disclosure auto-escalation policy (issue #677 PR 4/4). When 'auto', recalls without an explicit caller-supplied disclosure escalate from chunk to section if the top-K confidence falls below recallDisclosureEscalationThreshold. 'raw' is never auto-selected. Default 'manual' preserves pre-#677 behavior."
+   },
+   "recallDisclosureEscalationThreshold": {
+    "type": "number",
+    "minimum": 0,
+    "maximum": 1,
+    "default": 0.5,
+    "description": "Top-K confidence threshold (0-1) below which auto-escalation promotes chunk to section. Only consulted when recallDisclosureEscalation is 'auto'. Default 0.5."
+   },
+   "recallEnrichmentDeadlineMs": {
+    "type": "number",
+    "default": 25000,
+    "description": "Default deadline in ms recorded for enrichment recall sections."
+   },
+   "recallGraphDamping": {
+    "type": "number",
+    "minimum": 0,
+    "maximum": 0.999999999,
+    "default": 0.85,
+    "description": "PPR damping factor used by the graph retrieval tier (issue #559)."
+   },
+   "recallGraphEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "When true, recall builds a retrieval graph from memory frontmatter and runs Personalized PageRank, merging the result with QMD via MMR (issue #559 PR 4). Default false \u2014 ships off pending the retrieval-graph bench in PR 5."
+   },
+   "recallGraphIterations": {
+    "type": "integer",
+    "minimum": 0,
+    "maximum": 500,
+    "default": 20,
+    "description": "Maximum power-iteration rounds for PPR. Higher values trade latency for convergence."
+   },
+   "recallGraphTopK": {
+    "type": "integer",
+    "minimum": 0,
+    "maximum": 10000,
+    "default": 50,
+    "description": "Maximum memories returned by the graph retrieval tier before the MMR diversifier runs."
+   },
+   "recallHandleSnapshotDepth": {
+    "type": "number",
+    "minimum": 1,
+    "maximum": 50,
+    "default": 5,
+    "description": "Issue #1582 \u2014 number of recent per-session recall snapshots searched when resolving a `[m:xxxx]` handle to a memory id. Older-than-N snapshots are not searched; a miss is tagged rather than widening the window."
+   },
+   "recallMemoryHandles": {
+    "type": "boolean",
+    "default": false,
+    "description": "Issue #1582 \u2014 append stable short handles (`[m:4f2a]`) to injected memory lines at recall render time. Default false: off = byte-identical injection. Token cost ~9 chars/memory; flip the default only with benchmark evidence that answer quality is unaffected."
+   },
+   "recallMemoryWorthFilterEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "When true, recall multiplies candidate scores by the Memory Worth factor (mw_success / mw_fail counters, see issue #560). Memories with a history of failed sessions sink; neutral/uninstrumented memories are untouched. PR 5 bench: +0.60 precision@5 vs baseline on all 50 seeded cases. Operators can opt out with false."
+   },
+   "recallMemoryWorthHalfLifeMs": {
+    "type": "number",
+    "minimum": 0,
+    "default": 0,
+    "description": "Half-life (ms) for Memory Worth decay. Positive values exponentially decay older outcomes toward the neutral prior; 0 disables decay."
+   },
+   "recallMmrEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the included context."
+   },
+   "recallMmrLambda": {
+    "type": "number",
+    "default": 0.7,
+    "minimum": 0,
+    "maximum": 1,
+    "description": "MMR lambda parameter. 1.0 = pure relevance, 0.0 = pure diversity. Default 0.7 tilts toward relevance with meaningful diversity."
+   },
+   "recallMmrTopN": {
+    "type": "number",
+    "default": 40,
+    "minimum": 0,
+    "description": "Number of top candidates per section to run MMR over. Candidates past this remain in original order."
+   },
+   "recallOuterTimeoutMs": {
+    "type": "number",
+    "default": 75000,
+    "description": "Outer timeout in ms for the full recall pipeline."
+   },
+   "recallPipeline": {
+    "type": "array",
+    "description": "Ordered recall sections with per-section budgets and feature knobs.",
+    "items": {
+     "type": "object",
+     "properties": {
+      "id": {
+       "type": "string"
       },
-      "entitySynthesisMaxTokens": {
-        "anyOf": [
-          {
-            "type": "integer",
-            "const": 0
-          },
-          {
-            "type": "integer",
-            "minimum": 10
-          }
-        ],
-        "default": 500,
-        "description": "Max tokens used when refreshing an entity synthesis from its timeline."
+      "enabled": {
+       "type": "boolean",
+       "default": true
       },
-      "episodeNoteModeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable HiMem episode/note classification (v8.0 Phase 2B). Tags each extracted memory as 'episode' (time-specific event) or 'note' (stable belief/preference). Disabled by default."
+      "maxChars": {
+       "type": [
+        "number",
+        "null"
+       ]
       },
-      "evalHarnessEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Engram's benchmark/evaluation harness foundation for tracking benchmark packs and run summaries."
+      "consolidateTriggerLines": {
+       "type": "number"
       },
-      "evalShadowModeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable shadow-mode evaluation workflows so future benchmark instrumentation can measure memory changes without changing live recall output."
+      "consolidateTargetLines": {
+       "type": "number"
       },
-      "evalStoreDir": {
-        "type": "string",
-        "description": "Override the evaluation harness state directory (defaults to {memoryDir}/state/evals)."
+      "maxEntities": {
+       "type": "number"
       },
-      "eventOrderRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable event-order evidence recall for chronology questions."
+      "maxResults": {
+       "type": "number"
       },
-      "eventOrderRecallMaxChars": {
-        "type": "integer",
-        "default": 2400,
-        "minimum": 0,
-        "description": "Character budget for the event-order evidence recall section."
+      "maxTurns": {
+       "type": "number"
       },
-      "eventOrderRecallMaxResults": {
-        "type": "integer",
-        "default": 24,
-        "minimum": 0,
-        "description": "Maximum recalled items for event-order evidence."
+      "maxTokens": {
+       "type": "number"
       },
-      "eventOrderRecallScanWindowTokens": {
-        "type": "integer",
-        "default": 24000,
-        "minimum": 1,
-        "description": "Recent-token scan window for event-order evidence."
+      "lookbackHours": {
+       "type": "number"
       },
-      "eventOrderRecallScanWindowTurns": {
-        "type": "integer",
-        "default": 12,
-        "minimum": 1,
-        "description": "Recent-turn scan window for event-order evidence."
+      "maxCount": {
+       "type": "number"
       },
-      "explicitCueRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Front-load exact LCM evidence for query-visible cues such as turns, dates, ids, files, and tools."
+      "topK": {
+       "type": "number"
       },
-      "explicitCueRecallMaxChars": {
-        "type": "number",
-        "default": 2400,
-        "minimum": 0,
-        "description": "Character budget for the explicit cue evidence recall section."
+      "timeoutMs": {
+       "type": "number"
       },
-      "explicitCueRecallMaxReferences": {
-        "type": "number",
-        "default": 24,
-        "minimum": 0,
-        "description": "Maximum query-visible cues expanded by explicit cue recall."
+      "maxPatterns": {
+       "type": "number"
       },
-      "extractionDedupeEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable deduplication of near-identical extraction batches within a time window."
-      },
-      "extractionDedupeWindowMs": {
-        "type": "number",
-        "default": 300000,
-        "description": "Window for extraction dedupe fingerprints (ms)."
-      },
-      "extractionFaithfulnessContextChars": {
-        "type": "number",
-        "default": 400,
-        "description": "Context window (chars) around the verified quote sent to the faithfulness verifier."
-      },
-      "extractionFaithfulnessGate": {
+      "forceGeneric": {
+       "type": "boolean"
+      }
+     },
+     "required": [
+      "id"
+     ]
+    }
+   },
+   "recallPlannerEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Use lightweight retrieve-vs-think planning to avoid unnecessary recall work."
+   },
+   "recallPlannerLlmEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Opt in to LLM-based recall planning (issue #1367). When false, recall mode is decided by the regex heuristic. When true, the configured recallPlannerModel classifies recall intent via the gateway/fallback LLM chain (provider-agnostic) and falls back to the heuristic on timeout/error. Requires recallPlannerEnabled."
+   },
+   "recallPlannerMaxMemoryHints": {
+    "type": "number",
+    "default": 24,
+    "description": "Reserved. Caps recent-memory hints in the recall planner prompt when a caller supplies them; the default recall path does not populate hints (the LLM planner classifies on the prompt alone)."
+   },
+   "recallPlannerMaxPromptChars": {
+    "type": "number",
+    "default": 4000,
+    "description": "Maximum characters of prompt context to send to the recall planner."
+   },
+   "recallPlannerMaxQmdResultsFull": {
+    "type": "number",
+    "default": 8,
+    "description": "QMD cap used when recall planner selects full mode."
+   },
+   "recallPlannerMaxQmdResultsMinimal": {
+    "type": "number",
+    "default": 4,
+    "description": "QMD cap used when recall planner selects minimal mode."
+   },
+   "recallPlannerModel": {
+    "type": "string",
+    "default": "gpt-5.5",
+    "description": "Model for LLM-based recall planning (recallPlannerLlmEnabled). A 'provider/model' string resolved through the gateway providers/chain \u2014 any configured provider works (OpenAI, Anthropic, Ollama, Codex, gateway personas). Tried first, with taskModelChain / gateway defaults as fallback."
+   },
+   "recallPlannerShadowMode": {
+    "type": "boolean",
+    "default": false,
+    "description": "Run recall planner in shadow mode \u2014 evaluate but do not apply results."
+   },
+   "recallPlannerTelemetryEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Emit telemetry events for recall planner decisions."
+   },
+   "recallPlannerTimeoutMs": {
+    "type": "number",
+    "default": 1500,
+    "description": "Timeout in ms for recall planner inference."
+   },
+   "recallPlannerUseResponsesApi": {
+    "type": "boolean",
+    "default": true,
+    "description": "Reserved. The chat vs Responses API dialect is chosen per-provider by the gateway/fallback client based on each provider's api field, so this flag does not override routing; OpenAI providers already use Responses (gotcha #1)."
+   },
+   "recallReasoningTraceBoostEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Boost stored reasoning_trace memories in recall results when the incoming query reads like a problem-solving ask (e.g. 'how do I...', 'step by step', 'walk me through...'). Default false - opt in after benchmarking (issue #564)."
+   },
+   "recallTranscriptRetentionDays": {
+    "type": "integer",
+    "minimum": 1,
+    "maximum": 365,
+    "default": 30,
+    "description": "Days of runtime recall audit transcripts to retain before pruning."
+   },
+   "recallTranscriptsEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Write JSONL recall audit transcripts for runtime recall-context assembly."
+   },
+   "recencyWeight": {
+    "type": "number",
+    "default": 0.2,
+    "description": "Weight for recency boosting in search (0-1)"
+   },
+   "recordEmptyRecallImpressions": {
+    "type": "boolean",
+    "default": false,
+    "description": "Record recall impressions with empty memoryIds when no memory context is added."
+   },
+   "reinforcementRecallBoostEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "When true, memories with reinforcement_count frontmatter receive an additive recall score boost (issue #687 PR 3/4). Default: false (opt-in)."
+   },
+   "reinforcementRecallBoostMax": {
+    "type": "number",
+    "minimum": 0,
+    "maximum": 1,
+    "default": 0.3,
+    "description": "Maximum additive reinforcement boost per result. Range [0, 1]. Default: 0.3."
+   },
+   "reinforcementRecallBoostWeight": {
+    "type": "number",
+    "minimum": 0,
+    "maximum": 1,
+    "default": 0.05,
+    "description": "Score bonus per unit of reinforcement_count (weight * count, capped at max). Range [0, 1]. Default: 0.05."
+   },
+   "remoteSearchApiKey": {
+    "type": "string",
+    "description": "API key for remote search backend (when searchBackend=remote)"
+   },
+   "remoteSearchBaseUrl": {
+    "type": "string",
+    "description": "Base URL for remote search backend (when searchBackend=remote)"
+   },
+   "remoteSearchTimeoutMs": {
+    "type": "number",
+    "default": 30000,
+    "description": "Timeout in ms for remote search backend requests"
+   },
+   "rerankCacheEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Cache re-ranking results in-memory for repeated queries."
+   },
+   "rerankCacheTtlMs": {
+    "type": "number",
+    "default": 3600000,
+    "description": "TTL for in-memory re-ranking cache (ms)."
+   },
+   "rerankEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable LLM re-ranking of retrieved memories. Default off."
+   },
+   "rerankMaxCandidates": {
+    "type": "number",
+    "default": 20,
+    "description": "Max candidates to send to the re-ranker."
+   },
+   "rerankProvider": {
+    "type": "string",
+    "default": "local",
+    "description": "Re-ranking provider: 'local' uses local LLM only. 'cloud' is reserved/experimental (currently treated as no-op).",
+    "enum": [
+     "local",
+     "cloud"
+    ]
+   },
+   "rerankTimeoutMs": {
+    "type": "number",
+    "default": 8000,
+    "description": "Timeout for re-ranking requests (ms). Fail-open on timeout."
+   },
+   "respectBundledActiveMemoryToggle": {
+    "type": "boolean",
+    "default": true,
+    "description": "Compat-only (issue #1550): honor the bundled active-memory session toggle file when resolving Remnic recall toggles. Modern OpenClaw memory-slot mode + registerMemoryPromptSection is the primary prompt-injection path; this knob only matters when explicitly chaining Remnic active recall into the bundled `active-memory` plugin."
+   },
+   "responseGuidanceRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable response guidance recall for user answer-shape preferences."
+   },
+   "responseGuidanceRecallMaxChars": {
+    "type": "integer",
+    "default": 2400,
+    "minimum": 0,
+    "description": "Character budget for the response guidance recall section."
+   },
+   "responseGuidanceRecallMaxResults": {
+    "type": "integer",
+    "default": 48,
+    "minimum": 0,
+    "description": "Maximum recalled items for response guidance."
+   },
+   "responseGuidanceRecallScanWindowTokens": {
+    "type": "integer",
+    "default": 16000,
+    "minimum": 1,
+    "description": "Recent-token scan window for response guidance."
+   },
+   "responseGuidanceRecallScanWindowTurns": {
+    "type": "integer",
+    "default": 64,
+    "minimum": 1,
+    "description": "Recent-turn scan window for response guidance."
+   },
+   "resumeBundleDir": {
+    "type": "string",
+    "description": "Override the resume-bundle directory (defaults to {memoryDir}/state/resume-bundles)."
+   },
+   "resumeBundlesEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable deterministic resume-bundle storage and operator-facing handoff bundle commands."
+   },
+   "routingRulesEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable custom memory routing rules (v8.7). Default off."
+   },
+   "routingRulesStateFile": {
+    "type": "string",
+    "default": "state/routing-rules.json",
+    "description": "Relative path under memoryDir for persisted routing rules."
+   },
+   "scopeProfiles": {
+    "type": "object",
+    "default": {},
+    "description": "Optional hosted-team memory scope profiles. Profiles define ordered read layers, the default write layer, and authorized promotion target aliases without changing behavior when absent.",
+    "additionalProperties": {
+     "type": "object",
+     "properties": {
+      "readOrder": {
+       "type": "array",
+       "items": {
         "type": "string",
         "enum": [
+         "userProject",
+         "teamProject",
+         "userGlobal",
+         "serverShared"
+        ]
+       }
+      },
+      "writeDefault": {
+       "type": "string",
+       "enum": [
+        "userProject",
+        "teamProject",
+        "userGlobal",
+        "serverShared"
+       ]
+      },
+      "promotionTargets": {
+       "type": "array",
+       "items": {
+        "type": "string",
+        "enum": [
+         "userProject",
+         "teamProject",
+         "userGlobal",
+         "serverShared"
+        ]
+       }
+      },
+      "teamProject": {
+       "type": "object",
+       "properties": {
+        "namespaceTemplate": {
+         "type": "string"
+        },
+        "teamId": {
+         "type": "string"
+        }
+       }
+      },
+      "autoPromote": {
+       "type": "object",
+       "properties": {
+        "enabled": {
+         "type": "boolean"
+        },
+        "targets": {
+         "type": "array",
+         "items": {
+          "type": "string",
+          "enum": [
+           "teamProject",
+           "serverShared",
+           "userGlobal",
+           "userProject"
+          ]
+         }
+        },
+        "categories": {
+         "type": "array",
+         "items": {
+          "type": "string"
+         }
+        },
+        "minConfidenceTier": {
+         "type": "string",
+         "enum": [
+          "explicit",
+          "implied",
+          "inferred",
+          "speculative"
+         ]
+        }
+       }
+      }
+     }
+    }
+   },
+   "searchBackend": {
+    "type": "string",
+    "enum": [
+     "qmd",
+     "remote",
+     "noop",
+     "lancedb",
+     "meilisearch",
+     "orama"
+    ],
+    "default": "qmd",
+    "description": "Search backend: qmd (local hybrid), remote (HTTP REST), noop (disabled), lancedb (embedded hybrid), meilisearch (server-based), orama (embedded JS)"
+   },
+   "secureStoreEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable at-rest AES-256-GCM encryption for memory files (issue #690). When true, the daemon reads and writes memory files through the secure-fs layer. The store must be unlocked via `remnic secure-store unlock` after each daemon start. Default false."
+   },
+   "secureStoreEncryptOnWrite": {
+    "type": "boolean",
+    "default": true,
+    "description": "When secureStoreEnabled is true, encrypt new memory writes. Set to false to pause new encryptions while still decrypting existing encrypted files (useful during incremental migration). Default true."
+   },
+   "semanticChunkingConfig": {
+    "type": "object",
+    "default": {},
+    "description": "Optional overrides for the semantic chunking algorithm",
+    "properties": {
+     "targetTokens": {
+      "type": "number",
+      "default": 200,
+      "description": "Target tokens per chunk"
+     },
+     "minTokens": {
+      "type": "number",
+      "default": 100,
+      "description": "Minimum tokens for a segment before merging with neighbor"
+     },
+     "maxTokens": {
+      "type": "number",
+      "default": 400,
+      "description": "Maximum tokens for a segment before recursive splitting"
+     },
+     "smoothingWindowSize": {
+      "type": "number",
+      "default": 3,
+      "description": "Window size for the moving-average smoothing filter (auto-rounded to odd)"
+     },
+     "boundaryThresholdStdDevs": {
+      "type": "number",
+      "default": 1,
+      "description": "Standard deviations below mean for boundary detection"
+     },
+     "embeddingBatchSize": {
+      "type": "number",
+      "default": 32,
+      "description": "Batch size for embedding requests"
+     },
+     "fallbackToRecursive": {
+      "type": "boolean",
+      "default": true,
+      "description": "Fall back to recursive chunking when embeddings are unavailable"
+     }
+    }
+   },
+   "semanticChunkingEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable semantic chunking with embedding-based topic boundary detection (requires embedding provider)"
+   },
+   "semanticConsolidationEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable periodic semantic consolidation of similar memories."
+   },
+   "semanticConsolidationExcludeCategories": {
+    "type": "array",
+    "items": {
+     "type": "string"
+    },
+    "default": [
+     "correction",
+     "commitment",
+     "procedure"
+    ],
+    "description": "Memory categories excluded from semantic consolidation."
+   },
+   "semanticConsolidationIntervalHours": {
+    "type": "number",
+    "default": 168,
+    "description": "Hours between automatic consolidation runs (168 = weekly)."
+   },
+   "semanticConsolidationMaxPerRun": {
+    "type": "number",
+    "default": 100,
+    "description": "Max memories to consolidate per run to limit LLM cost."
+   },
+   "semanticConsolidationMinClusterSize": {
+    "type": "number",
+    "default": 3,
+    "description": "Minimum cluster size before consolidation triggers."
+   },
+   "semanticConsolidationModel": {
+    "type": "string",
+    "default": "auto",
+    "description": "LLM for consolidation synthesis: 'auto' (primary model), 'fast' (fast local model), or a specific model name."
+   },
+   "semanticConsolidationThreshold": {
+    "type": "number",
+    "default": 0.8,
+    "description": "Token overlap threshold (0-1) for grouping similar memories. 0.8=conservative, 0.6=aggressive."
+   },
+   "semanticDedupCandidates": {
+    "type": "number",
+    "default": 5,
+    "minimum": 0,
+    "description": "Number of nearest-neighbor candidates to inspect during the write-time semantic dedup check. Set to 0 to disable the embedding lookup entirely (equivalent to semanticDedupEnabled=false)."
+   },
+   "semanticDedupEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Issue #373 \u2014 enable write-time semantic similarity guard that skips near-duplicate facts by comparing embeddings to existing memories. Fails open when the embedding backend is unavailable."
+   },
+   "semanticDedupThreshold": {
+    "type": "number",
+    "default": 0.92,
+    "minimum": 0,
+    "maximum": 1,
+    "description": "Cosine similarity threshold in [0, 1]. Candidate facts whose nearest neighbor scores at or above this value are treated as duplicates and skipped."
+   },
+   "semanticRulePromotionEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable deterministic promotion of explicit IF/THEN rules from verified episodic memories."
+   },
+   "semanticRuleVerificationEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Verify promoted semantic rules against their cited source episodes at recall time before surfacing them in recall."
+   },
+   "sessionObserverBands": {
+    "type": "array",
+    "description": "Session size bands and growth thresholds for heartbeat observer triggers.",
+    "items": {
+     "type": "object",
+     "additionalProperties": false,
+     "properties": {
+      "maxBytes": {
+       "type": "number"
+      },
+      "triggerDeltaBytes": {
+       "type": "number"
+      },
+      "triggerDeltaTokens": {
+       "type": "number"
+      }
+     },
+     "required": [
+      "maxBytes",
+      "triggerDeltaBytes",
+      "triggerDeltaTokens"
+     ]
+    },
+    "default": [
+     {
+      "maxBytes": 50000,
+      "triggerDeltaBytes": 4800,
+      "triggerDeltaTokens": 1200
+     },
+     {
+      "maxBytes": 200000,
+      "triggerDeltaBytes": 9600,
+      "triggerDeltaTokens": 2400
+     },
+     {
+      "maxBytes": 1000000000,
+      "triggerDeltaBytes": 19200,
+      "triggerDeltaTokens": 4800
+     }
+    ]
+   },
+   "sessionObserverDebounceMs": {
+    "type": "number",
+    "default": 120000,
+    "description": "Minimum interval between heartbeat observer triggers per session (ms)."
+   },
+   "sessionObserverEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable heartbeat-driven active session observer checks for proactive extraction triggers."
+   },
+   "sessionTogglesEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable per-session recall toggle state for OpenClaw runtime surfaces."
+   },
+   "sharedContextDir": {
+    "type": "string",
+    "description": "Override shared-context directory (default: ~/.openclaw/workspace/shared-context)."
+   },
+   "sharedContextEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable shared-context assembly and tools (v4.0). Default off."
+   },
+   "sharedContextMaxInjectChars": {
+    "type": "number",
+    "default": 4000,
+    "description": "Max characters of shared-context to include in each recall context."
+   },
+   "sharedCrossSignalSemanticEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable semantic cross-signal enhancer during shared-context daily curation."
+   },
+   "sharedCrossSignalSemanticMaxCandidates": {
+    "type": "number",
+    "default": 120,
+    "description": "Maximum candidate topic tokens considered by semantic cross-signal enhancer."
+   },
+   "sharedCrossSignalSemanticTimeoutMs": {
+    "type": "number",
+    "default": 4000,
+    "description": "Timeout budget for shared-context semantic cross-signal enhancer (ms)."
+   },
+   "sharedNamespace": {
+    "type": "string",
+    "default": "shared",
+    "description": "Shared namespace name."
+   },
+   "slotBehavior": {
+    "type": "object",
+    "additionalProperties": false,
+    "default": {},
+    "properties": {
+     "requireExclusiveMemorySlot": {
+      "type": "boolean",
+      "default": true
+     },
+     "onSlotMismatch": {
+      "type": "string",
+      "enum": [
+       "error",
+       "warn",
+       "silent"
+      ],
+      "default": "error"
+     }
+    }
+   },
+   "slowLogEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "If enabled, log slow operations (durations + metadata; never logs content)"
+   },
+   "slowLogThresholdMs": {
+    "type": "number",
+    "default": 30000,
+    "description": "Threshold for slow operation logging (ms)"
+   },
+   "summarizationEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable automatic memory summarization/compression"
+   },
+   "summarizationImportanceThreshold": {
+    "type": "number",
+    "default": 0.3,
+    "description": "Only compress memories with importance below this threshold"
+   },
+   "summarizationProtectedTags": {
+    "type": "array",
+    "items": {
+     "type": "string"
+    },
+    "default": [
+     "commitment",
+     "preference",
+     "decision",
+     "principle"
+    ],
+    "description": "Tags that protect memories from compression"
+   },
+   "summarizationRecentToKeep": {
+    "type": "number",
+    "default": 300,
+    "description": "Number of recent memories to keep uncompressed"
+   },
+   "summarizationTriggerCount": {
+    "type": "number",
+    "default": 1000,
+    "description": "Memory count threshold to trigger summarization"
+   },
+   "summaryModel": {
+    "type": "string",
+    "description": "Model for hourly summaries (defaults to main model)"
+   },
+   "summaryRecallHours": {
+    "type": "number",
+    "default": 24,
+    "description": "Hours of summary history to recall"
+   },
+   "tagIndexMaxEntries": {
+    "type": "number",
+    "default": 10000,
+    "description": "Maximum number of entries in the tag index."
+   },
+   "tagMaxPerMemory": {
+    "type": "number",
+    "default": 5,
+    "description": "Maximum number of tags assigned per memory."
+   },
+   "tagMemoryEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable tag-based memory indexing and recall boosting."
+   },
+   "tagRecallBoost": {
+    "type": "number",
+    "default": 0.15,
+    "description": "Score boost applied to memories whose tags match the query."
+   },
+   "tagRecallMaxMatches": {
+    "type": "number",
+    "default": 10,
+    "description": "Maximum number of tag-matched memories added per recall."
+   },
+   "targetedFactRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable targeted fact evidence recall for direct answer questions."
+   },
+   "targetedFactRecallMaxChars": {
+    "type": "integer",
+    "default": 2400,
+    "minimum": 0,
+    "description": "Character budget for the targeted fact evidence recall section."
+   },
+   "targetedFactRecallMaxResults": {
+    "type": "integer",
+    "default": 48,
+    "minimum": 0,
+    "description": "Maximum recalled items for targeted fact evidence."
+   },
+   "targetedFactRecallScanWindowTokens": {
+    "type": "integer",
+    "default": 12000,
+    "minimum": 1,
+    "description": "Recent-token scan window for targeted fact evidence."
+   },
+   "targetedFactRecallScanWindowTurns": {
+    "type": "integer",
+    "default": 8,
+    "minimum": 1,
+    "description": "Recent-turn scan window for targeted fact evidence."
+   },
+   "taskModelChain": {
+    "type": "object",
+    "description": "Optional task-specific gateway model chain for Remnic's background LLM work (extraction, fact/profile/identity consolidation, summarization, causal consolidation). When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model. Only applies when modelSource is 'gateway'.",
+    "required": [
+     "primary"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "primary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
+     },
+     "fallbacks": {
+      "type": "array",
+      "items": {
+       "type": "string",
+       "minLength": 1
+      },
+      "default": [],
+      "description": "Fallback gateway models tried after primary"
+     }
+    }
+   },
+   "taxonomyAutoGenResolver": {
+    "type": "boolean",
+    "default": true,
+    "description": "Auto-regenerate RESOLVER.md when the taxonomy changes."
+   },
+   "taxonomyEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable the MECE taxonomy knowledge directory for categorizing memories."
+   },
+   "teams": {
+    "type": "object",
+    "default": {},
+    "description": "Trusted team membership and team-project namespace templates used by scopeProfiles.",
+    "additionalProperties": {
+     "type": "object",
+     "properties": {
+      "principals": {
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "projectNamespaceTemplate": {
+       "type": "string"
+      },
+      "read": {
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "write": {
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "promote": {
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "temporalBiTemporal": {
+    "type": "boolean",
+    "default": false,
+    "description": "Bi-temporal validity master gate (issue #1578). When false (default), recall behaves byte-identically to pre-#1578. Turn on to exclude validity-expired facts from default injection candidates (they stay findable by explicit search and as_of). Storage round-trips observedAt/eventTimeSource; extraction event-time write-time wiring lands in a follow-on PR."
+   },
+   "temporalBoostRecentDays": {
+    "type": "number",
+    "default": 7,
+    "description": "Memories from the last N days receive a recency boost during recall."
+   },
+   "temporalBoostScore": {
+    "type": "number",
+    "default": 0.15,
+    "description": "Score boost applied to recent memories during recall."
+   },
+   "temporalDecayEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Apply temporal decay to older memories during recall scoring."
+   },
+   "temporalExpiredInInjection": {
+    "type": "boolean",
+    "default": false,
+    "description": "Escape hatch for the bi-temporal injection filter (issue #1578). When true, facts whose [valid_at, invalid_at) interval ended before now are kept in injection candidates even with temporalBiTemporal on \u2014 some deployments prefer the older (always-inject) behavior."
+   },
+   "temporalIndexMaxEntries": {
+    "type": "number",
+    "default": 5000,
+    "description": "Maximum number of entries in the temporal index."
+   },
+   "temporalIndexWindowDays": {
+    "type": "number",
+    "default": 30,
+    "description": "Number of days to include in the temporal index window."
+   },
+   "temporalMemoryTreeEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Build a hierarchical memory summary tree (hour/day/week/persona nodes). Default: false."
+   },
+   "temporalSupersessionEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Mark older facts superseded when a new fact writes a conflicting value for the same entityRef + structuredAttribute key (issue #375)"
+   },
+   "temporalSupersessionIncludeInRecall": {
+    "type": "boolean",
+    "default": false,
+    "description": "If true, include temporally-superseded facts in recall results (for audit/history). Default: exclude."
+   },
+   "threadingEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable conversation threading"
+   },
+   "threadingGapMinutes": {
+    "type": "number",
+    "default": 30,
+    "description": "Minutes of gap to start a new thread"
+   },
+   "timeGraphEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Build temporal sequence graph within threads (requires multiGraphMemoryEnabled). Default true."
+   },
+   "tmtHourlyMinMemories": {
+    "type": "number",
+    "default": 3,
+    "description": "Minimum new memories in an hour to trigger an hour-level TMT node. Default: 3."
+   },
+   "tmtSummaryMaxTokens": {
+    "type": "number",
+    "default": 300,
+    "description": "Max tokens for each TMT summary node. Default: 300."
+   },
+   "tombstonesEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Master gate for the tombstone non-resurrection invariant (#1579). When true, a fact that matches an active tombstone at the storage chokepoint is persisted as pending_review + blockedBy instead of becoming active \u2014 visible, never a silent drop. Off restores pre-feature behavior for rollback safety."
+   },
+   "tombstonesSemanticMatch": {
+    "type": "boolean",
+    "default": false,
+    "description": "Tier-4 semantic tombstone matching (#1579). Off by default; when true the tombstone lookup also checks embedding cosine similarity against tombstoned normalized text. Ships dark until MemCorrect (#1584) shows an acceptable false-block rate."
+   },
+   "tombstonesSemanticThreshold": {
+    "type": "number",
+    "default": 0.9,
+    "description": "Cosine threshold for tier-4 semantic tombstone matching. Only consulted when tombstonesSemanticMatch is true."
+   },
+   "topicExtractionEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable topic extraction during consolidation"
+   },
+   "topicExtractionTopN": {
+    "type": "number",
+    "default": 50,
+    "description": "Number of top topics to extract"
+   },
+   "traceRecallContent": {
+    "type": "boolean",
+    "default": false,
+    "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default - only enable when you want external trace collectors to capture memory context."
+   },
+   "traceWeaverEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable Trace Weaving (v8.0 Phase 2A). Links recurring topic boxes with a shared traceId."
+   },
+   "traceWeaverLookbackDays": {
+    "type": "number",
+    "default": 7,
+    "description": "Days back to search for trace links."
+   },
+   "traceWeaverOverlapThreshold": {
+    "type": "number",
+    "default": 0.4,
+    "description": "Minimum Jaccard topic overlap to assign the same traceId (0\u20131)."
+   },
+   "transcriptEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable transcript archiving"
+   },
+   "transcriptRecallHours": {
+    "type": "number",
+    "default": 12,
+    "description": "Hours of transcript history to recall"
+   },
+   "transcriptRetentionDays": {
+    "type": "number",
+    "default": 7,
+    "description": "Days to retain transcript entries"
+   },
+   "transcriptSkipChannelTypes": {
+    "type": "array",
+    "items": {
+     "type": "string"
+    },
+    "default": [
+     "cron"
+    ],
+    "description": "Channel types to skip from transcript logging (e.g., cron)"
+   },
+   "triggerMode": {
+    "type": "string",
+    "enum": [
+     "smart",
+     "every_n",
+     "time_based"
+    ],
+    "default": "smart",
+    "description": "Buffer trigger mode"
+   },
+   "trustScoreEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Master gate for the unified TrustScore recall stage (#1577). When off the stage is absent and ranking is byte-identical to the pre-feature pipeline. Flip via #1574 ablation evidence only."
+   },
+   "trustScoreEpistemicRendering": {
+    "type": "boolean",
+    "default": false,
+    "description": "Append deterministic trust hedges to injected memory lines so the downstream model knows each memory's epistemic status (#1577). Separate gate from scoring."
+   },
+   "trustScoreMaxMultiplier": {
+    "type": "number",
+    "default": 1.25,
+    "description": "Upper bound of the trust multiplier mapping [0,1] \u2192 [minMultiplier, maxMultiplier] (#1577)."
+   },
+   "trustScoreMinMultiplier": {
+    "type": "number",
+    "default": 0.5,
+    "description": "Lower bound of the trust multiplier mapping [0,1] \u2192 [minMultiplier, maxMultiplier] (#1577)."
+   },
+   "trustScoreQuarantine": {
+    "type": "boolean",
+    "default": true,
+    "description": "Exclude hard-negative (quarantine-band) memories from injection while keeping them visible in X-ray with the reason (#1577). Only effective under trustScoreEnabled."
+   },
+   "trustScoreWeights": {
+    "type": "object",
+    "description": "Per-component trust weights (#1577). Keys: memoryWorth, provenance, faithfulness, corroboration, contradiction, domainCalibration, feedback, recency. Values are numbers in [0,1]; sum-normalized at parse. Invalid entries are dropped (rule 51).",
+    "default": {},
+    "properties": {
+     "memoryWorth": {
+      "type": "number"
+     },
+     "provenance": {
+      "type": "number"
+     },
+     "faithfulness": {
+      "type": "number"
+     },
+     "corroboration": {
+      "type": "number"
+     },
+     "contradiction": {
+      "type": "number"
+     },
+     "domainCalibration": {
+      "type": "number"
+     },
+     "feedback": {
+      "type": "number"
+     },
+     "recency": {
+      "type": "number"
+     }
+    }
+   },
+   "trustZoneRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Add recall-relevant working and trusted trust-zone records to recall context."
+   },
+   "trustZoneStoreDir": {
+    "type": "string",
+    "description": "Override the trust-zone store directory (defaults to {memoryDir}/state/trust-zones)."
+   },
+   "trustZonesEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable Engram's trust-zone memory foundation for quarantine, working, and trusted records."
+   },
+   "verbatimArtifactCategories": {
+    "type": "array",
+    "items": {
+     "type": "string",
+     "enum": [
+      "fact",
+      "preference",
+      "correction",
+      "entity",
+      "decision",
+      "relationship",
+      "principle",
+      "commitment",
+      "moment",
+      "skill",
+      "procedure"
+     ]
+    },
+    "default": [
+     "decision",
+     "correction",
+     "principle",
+     "commitment"
+    ],
+    "description": "Memory categories eligible for artifact extraction."
+   },
+   "verbatimArtifactsEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Write quote-first artifact anchors during extraction and include them in recall."
+   },
+   "verbatimArtifactsMaxRecall": {
+    "type": "number",
+    "default": 5,
+    "description": "Maximum artifact anchors added per recall."
+   },
+   "verbatimArtifactsMinConfidence": {
+    "type": "number",
+    "default": 0.8,
+    "description": "Minimum extraction confidence required before writing an artifact."
+   },
+   "verboseRecallVisibility": {
+    "type": "boolean",
+    "default": true,
+    "description": "Allow verbose recall headers to surface runtime recall diagnostics in prompts."
+   },
+   "verifiedRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
+   },
+   "versioningEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable page-level versioning with sidecar snapshots."
+   },
+   "versioningMaxPerPage": {
+    "type": "integer",
+    "default": 50,
+    "minimum": 0,
+    "description": "Maximum number of version snapshots per page. Set to 0 to disable pruning."
+   },
+   "versioningSidecarDir": {
+    "type": "string",
+    "default": ".versions",
+    "description": "Name of the sidecar directory inside memoryDir for version snapshots."
+   },
+   "wearables": {
+    "type": "object",
+    "additionalProperties": false,
+    "default": {},
+    "description": "Wearable transcript ingestion (Limitless / Bee / Omi). Connector packages install a la carte: @remnic/connector-limitless, @remnic/connector-bee, @remnic/connector-omi. See docs/wearables.md.",
+    "properties": {
+     "enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Master gate for the wearables subsystem."
+     },
+     "timezone": {
+      "type": "string",
+      "description": "IANA timezone used to bucket transcripts into days. Defaults to the host timezone."
+     },
+     "redactionEnabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Redact SSN / payment-card patterns from transcripts before storage and extraction."
+     },
+     "redactionPatterns": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "default": [],
+      "description": "Additional user-supplied redaction regexes (validated at config load)."
+     },
+     "offTheRecordEnabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Honor a spoken 'off the record' marker by eliding segments until 'back on the record'."
+     },
+     "digestEnabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Write one compact daily-digest memory per synced source/day."
+     },
+     "autoSyncEnabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Periodically refresh transcripts in-process on long-lived hosts. Every tick re-syncs a rolling window ending today (existing day files included)."
+     },
+     "autoSyncIntervalMinutes": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1440,
+      "default": 15,
+      "description": "Minutes between auto-sync ticks."
+     },
+     "autoSyncDays": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 90,
+      "default": 2,
+      "description": "Rolling window (days ending today) refreshed on each auto-sync tick."
+     },
+     "autoSyncDeepDays": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 90,
+      "default": 7,
+      "description": "Once-per-local-day deep refresh window (days) for late uploads and provider re-processing. 0 disables; otherwise must be >= autoSyncDays."
+     },
+     "corrections": {
+      "type": "array",
+      "default": [],
+      "description": "User-specific transcript correction rules applied on every sync (merged with CLI-managed rules).",
+      "items": {
+       "type": "object",
+       "additionalProperties": false,
+       "required": [
+        "match",
+        "replace"
+       ],
+       "properties": {
+        "match": {
+         "type": "string",
+         "description": "Text (or regex when regex=true) to match."
+        },
+        "replace": {
+         "type": "string",
+         "description": "Replacement text."
+        },
+        "regex": {
+         "type": "boolean",
+         "default": false,
+         "description": "Treat match as a regular expression."
+        },
+        "caseInsensitive": {
+         "type": "boolean",
+         "default": true,
+         "description": "Case-insensitive matching."
+        },
+        "sources": {
+         "type": "array",
+         "items": {
+          "type": "string"
+         },
+         "description": "Restrict the rule to specific source ids."
+        }
+       }
+      }
+     },
+     "sources": {
+      "type": "object",
+      "default": {},
+      "description": "Per-source settings keyed by connector id (limitless, bee, omi, or a custom connector id).",
+      "additionalProperties": {
+       "type": "object",
+       "additionalProperties": false,
+       "properties": {
+        "enabled": {
+         "type": "boolean",
+         "default": false,
+         "description": "Enable syncing from this wearable source."
+        },
+        "apiKey": {
+         "type": "string",
+         "description": "Provider API credential. Prefer the per-connector environment variable (e.g. ${LIMITLESS_API_KEY}); a config value takes precedence when both are set."
+        },
+        "baseUrl": {
+         "type": "string",
+         "description": "Override the provider base URL (self-hosted / local-proxy setups, e.g. the Bee local proxy)."
+        },
+        "appId": {
+         "type": "string",
+         "description": "Omi only: integration app id (the {app_id} path component of the Omi Integrations API)."
+        },
+        "userId": {
+         "type": "string",
+         "description": "Omi only: target user id supplied as the uid query parameter."
+        },
+        "memoryMode": {
+         "type": "string",
+         "enum": [
           "off",
-          "shadow",
-          "enforce"
-        ],
-        "default": "off",
-        "description": "Extraction faithfulness gate (issue #1576). Entailment-verification of extracted facts against their verified source spans (#1575). 'off' (default) = byte-identical pre-feature pipeline; 'shadow' = record verdicts in frontmatter + telemetry only; 'enforce' = route unsupported/contradicted to pending_review."
-      },
-      "extractionFaithfulnessModel": {
-        "type": "string",
-        "default": "",
-        "description": "Override model/endpoint for the faithfulness verifier. Empty string = default routing chain (local then fallback)."
-      },
-      "extractionFaithfulnessTimeoutMs": {
-        "type": "number",
-        "default": 8000,
-        "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
-      },
-      "extractionFaithfulnessLocalParseFallback": {
-        "type": "boolean",
-        "default": false,
-        "description": "Resilient-fallback toggle for the local model-lab faithfulness endpoint (issue #1700). Default false surfaces malformed_output when the local endpoint returns 200 with non-verdict JSON (alerts the operator to a misconfigured endpoint). Set true to instead fall back to the configured chain on local parse failure."
-      },
-      "extractionFaithfulnessBaseUrl": {
-        "type": "string",
-        "default": "",
-        "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned faithfulness gate (model-lab, issue #1585). When set AND extractionFaithfulnessModel is set, the gate routes there first and falls back to the configured chain on any failure. Empty = existing routing (byte-identical pre-feature path)."
-      },
-      "correctionIntentModel": {
-        "type": "string",
-        "default": "",
-        "description": "Model name of a local fine-tuned correction-intent classifier (model-lab, issue #1581 / #1585). When set AND correctionIntentBaseUrl is set, passive-correction detection can route to it. Empty = rule-based detectPassiveCorrections is the sole detector."
-      },
-      "correctionIntentBaseUrl": {
-        "type": "string",
-        "default": "",
-        "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned correction-intent classifier (model-lab, issue #1585). Empty = rule-based detector only."
-      },
-      "extractionJudgeBatchSize": {
-        "type": "number",
-        "default": 20,
-        "minimum": 1,
-        "description": "Maximum number of candidate facts sent to the judge LLM in a single batch call."
-      },
-      "extractionJudgeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the LLM-as-judge fact-worthiness gate. When enabled, extracted facts are evaluated for durability before being persisted. Off by default (opt-in)."
-      },
-      "extractionJudgeMaxDeferrals": {
-        "type": "number",
-        "default": 2,
-        "minimum": 1,
-        "description": "Maximum number of times the same candidate text may be deferred by the extraction judge before the verdict is forcibly converted to 'reject'. Prevents pathological LLM responses from looping forever on ambiguous facts (issue #562)."
-      },
-      "extractionJudgeModel": {
-        "type": "string",
-        "default": "",
-        "description": "Model override for the extraction judge LLM. Empty string uses the configured local model."
-      },
-      "extractionJudgeShadow": {
-        "type": "boolean",
-        "default": false,
-        "description": "Shadow mode for the extraction judge. When true, judge verdicts are logged but all facts are still persisted regardless of the verdict."
-      },
-      "extractionJudgeTelemetryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Emit structured telemetry rows to state/observation-ledger/extraction-judge-verdicts.jsonl on every judge verdict. Off by default; enable to collect defer-rate and latency metrics for operator dashboards (issue #562)."
-      },
-      "extractionMaxEntitiesPerRun": {
-        "type": "number",
-        "default": 6,
-        "description": "Maximum entities persisted from a single extraction run."
-      },
-      "extractionMaxFactsPerRun": {
-        "type": "number",
-        "default": 12,
-        "description": "Maximum facts persisted from a single extraction run."
-      },
-      "extractionMaxOutputTokens": {
-        "type": "number",
-        "default": 16384,
-        "description": "Maximum output tokens (max_completion_tokens) for the direct-client extraction call."
-      },
-      "extractionMaxProfileUpdatesPerRun": {
-        "type": "number",
-        "default": 4,
-        "description": "Maximum profile updates persisted from a single extraction run."
-      },
-      "extractionMaxQuestionsPerRun": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum questions persisted from a single extraction run."
-      },
-      "extractionMaxTurnChars": {
-        "type": "number",
-        "default": 4000,
-        "description": "Maximum characters per turn fed to extraction (long turns are truncated)."
-      },
-      "extractionMinChars": {
-        "type": "number",
-        "default": 40,
-        "description": "Minimum combined user/assistant characters required before extraction runs."
-      },
-      "extractionMinImportanceLevel": {
-        "type": "string",
-        "enum": [
+          "review",
+          "auto",
+          "smart"
+         ],
+         "default": "smart",
+         "description": "Memory creation trust gate: smart (default) = LLM-judge + per-source trust prior + cross-device corroboration decide active/review/drop automatically; off = transcripts only; review = every candidate lands pending_review; auto = deterministic gates only, survivors active."
+        },
+        "sourceTrust": {
+         "type": "number",
+         "minimum": 0,
+         "maximum": 1,
+         "default": 0.8,
+         "description": "Trust prior for this source's transcription quality (0..1). Multiplies extraction confidence in smart mode \u2014 lower it for a device that mis-transcribes often."
+        },
+        "autoApproveTrust": {
+         "type": "number",
+         "minimum": 0,
+         "maximum": 1,
+         "default": 0.7,
+         "description": "Smart mode: trust score at/above which facts are written active."
+        },
+        "reviewTrust": {
+         "type": "number",
+         "minimum": 0,
+         "maximum": 1,
+         "default": 0.45,
+         "description": "Smart mode: trust score at/above which borderline facts are queued for review instead of dropped. Must be below autoApproveTrust."
+        },
+        "minConfidence": {
+         "type": "number",
+         "minimum": 0,
+         "maximum": 1,
+         "default": 0.6,
+         "description": "Drop extracted facts below this confidence."
+        },
+        "minImportance": {
+         "type": "string",
+         "enum": [
           "trivial",
           "low",
           "normal",
           "high",
           "critical"
-        ],
-        "default": "low",
-        "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
-      },
-      "extractionMinUserTurns": {
-        "type": "number",
-        "default": 1,
-        "description": "Minimum number of user turns required before extraction runs."
-      },
-      "extractionScopeClassificationEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "When enabled, the extraction prompt instructs the LLM to classify each fact as 'project' (codebase-specific) or 'global' (cross-project knowledge). Global-scoped facts are promoted to the shared namespace so they are visible across all projects. Disable to restore pre-scope-classification behavior where all facts go to the session namespace."
-      },
-      "extractionTelemetryPrefilterEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Skip semantic durable-memory extraction for mechanical action/state telemetry transcripts that contain no durable-memory cue. Raw transcript storage and recall still run. Disable this if you intentionally want fact extraction from action logs."
-      },
-      "factArchivalAgeDays": {
-        "type": "number",
-        "default": 90,
-        "description": "Minimum age in days before a fact is eligible for archival."
-      },
-      "factArchivalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic archival of old, low-importance, rarely-accessed facts during consolidation."
-      },
-      "factArchivalMaxAccessCount": {
-        "type": "number",
-        "default": 2,
-        "description": "Maximum access count for archival eligibility. Only rarely-accessed facts are archived."
-      },
-      "factArchivalMaxImportance": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Maximum importance score for archival eligibility (0-1). Only facts below this threshold are archived."
-      },
-      "factArchivalProtectedCategories": {
-        "type": "array",
-        "items": {
-          "type": "string"
+         ],
+         "default": "low",
+         "description": "Drop extracted facts scored below this importance level."
         },
-        "default": [
-          "commitment",
-          "preference",
-          "decision",
-          "principle",
-          "procedure"
-        ],
-        "description": "Categories that protect a fact from archival regardless of other criteria."
-      },
-      "factDeduplicationEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable content-hash deduplication to prevent storing semantically identical facts."
-      },
-      "fastGatewayAgentId": {
-        "type": "string",
-        "default": "",
-        "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
-      },
-      "feedbackEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable feedback capture tool for memory relevance (thumbs up/down)."
-      },
-      "fileHygiene": {
-        "type": "object",
-        "additionalProperties": false,
-        "description": "Optional: keep OpenClaw bootstrap workspace files small and warn before silent truncation risk.",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Master switch for file hygiene (default off)."
+        "maxMemoriesPerDay": {
+         "type": "integer",
+         "minimum": 0,
+         "default": 0,
+         "description": "Cap on memories created per source per day. 0 (the default) disables the cap."
+        },
+        "importNativeMemories": {
+         "type": "string",
+         "enum": [
+          "off",
+          "review",
+          "smart"
+         ],
+         "default": "smart",
+         "description": "Import provider-extracted memories (Bee facts / Omi memories): smart (default) routes them through the same judge + trust pipeline with a reduced prior; review always queues; off skips."
+        },
+        "cleanup": {
+         "type": "object",
+         "additionalProperties": false,
+         "default": {},
+         "properties": {
+          "mergeSameSpeaker": {
+           "type": "boolean",
+           "default": true,
+           "description": "Merge consecutive same-speaker segments."
           },
-          "lintEnabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "If true, warn when bootstrap files approach budget."
+          "stripFillers": {
+           "type": "boolean",
+           "default": true,
+           "description": "Strip standalone filler tokens (um, uh, ...)."
           },
-          "lintBudgetBytes": {
-            "type": "number",
-            "default": 20000,
-            "description": "Budget in bytes used for lint warnings (approx)."
+          "collapseRepeats": {
+           "type": "boolean",
+           "default": true,
+           "description": "Collapse immediately repeated phrases (ASR stutter)."
           },
-          "lintWarnRatio": {
-            "type": "number",
-            "default": 0.8,
-            "description": "Warn when file size >= budget * warnRatio."
+          "dropLowQuality": {
+           "type": "boolean",
+           "default": true,
+           "description": "Drop segments that look like ASR garbage."
           },
-          "lintPaths": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "default": [
-              "IDENTITY.md",
-              "MEMORY.md"
-            ],
-            "description": "Workspace-relative paths to lint (or absolute paths)."
-          },
-          "rotateEnabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "If true, rotate oversized markdown files into an archive and replace with a lean index."
-          },
-          "rotateMaxBytes": {
-            "type": "number",
-            "default": 18000,
-            "description": "Rotate when a target file exceeds this size (bytes)."
-          },
-          "rotateKeepTailChars": {
-            "type": "number",
-            "default": 2000,
-            "description": "How many characters of the old file to keep inline (tail) for continuity."
-          },
-          "rotatePaths": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "default": [
-              "IDENTITY.md"
-            ],
-            "description": "Workspace-relative paths to rotate (or absolute paths)."
-          },
-          "archiveDir": {
-            "type": "string",
-            "default": ".engram-archive",
-            "description": "Workspace-relative archive directory where rotated files are stored."
-          },
-          "runMinIntervalMs": {
-            "type": "number",
-            "default": 300000,
-            "description": "Minimum interval between hygiene runs (ms)."
-          },
-          "warningsLogEnabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "If true, append warnings to a log file under memoryDir."
-          },
-          "warningsLogPath": {
-            "type": "string",
-            "default": "hygiene/warnings.md",
-            "description": "memoryDir-relative path to write warnings to."
-          },
-          "indexEnabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Reserved: write an Engram index file in workspace (not required for rotation)."
-          },
-          "indexPath": {
-            "type": "string",
-            "default": "ENGRAM_INDEX.md",
-            "description": "Workspace-relative index path (if indexEnabled)."
+          "preserveUtteranceBoundaries": {
+           "type": "boolean",
+           "default": false,
+           "description": "Keep utterance-level boundaries (one segment per utterance) instead of merging consecutive same-speaker segments. Defaults off; Bee enables this by default. (issue #1811)"
           }
-        },
-        "required": [
-          "enabled"
-        ]
-      },
-      "flushOnResetEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Flush buffered turns through extraction when OpenClaw resets a session."
-      },
-      "focusedListRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable focused list evidence recall for count, relation, and recommendation questions."
-      },
-      "focusedListRecallMaxChars": {
-        "type": "integer",
-        "default": 2600,
-        "minimum": 0,
-        "description": "Character budget for the focused list evidence recall section."
-      },
-      "focusedListRecallMaxResults": {
-        "type": "integer",
-        "default": 40,
-        "minimum": 0,
-        "description": "Maximum recalled items for focused list evidence."
-      },
-      "focusedListRecallScanWindowTokens": {
-        "type": "integer",
-        "default": 14000,
-        "minimum": 1,
-        "description": "Recent-token scan window for focused list evidence."
-      },
-      "focusedListRecallScanWindowTurns": {
-        "type": "integer",
-        "default": 64,
-        "minimum": 1,
-        "description": "Recent-turn scan window for focused list evidence."
-      },
-      "gatewayAgentId": {
-        "type": "string",
-        "default": "",
-        "description": "Agent persona ID (from openclaw.json agents.list[]) whose model chain to use for extraction, consolidation, and summarization. Required when modelSource is 'gateway'. Falls back to agents.defaults.model if empty."
-      },
-      "graphActivationDecay": {
-        "type": "number",
-        "default": 0.7,
-        "description": "Per-hop activation decay factor (0-1). Default 0.7."
-      },
-      "graphAssistInFullModeEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Run bounded graph expansion during full recall mode when seed results exist."
-      },
-      "graphAssistMinSeedResults": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum seed recall results required before full-mode graph assist runs."
-      },
-      "graphAssistShadowEvalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep recall output baseline-identical."
-      },
-      "graphEdgeDecayCadenceMs": {
-        "type": "number",
-        "default": 604800000,
-        "minimum": 60000,
-        "description": "Cadence in milliseconds for the graph-edge decay cron. Default 7 days. Sub-day cadences map to a daily cron expression."
-      },
-      "graphEdgeDecayEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the periodic graph-edge confidence decay maintenance job (issue #681 PR 2/3). Opt-in."
-      },
-      "graphEdgeDecayFloor": {
-        "type": "number",
-        "default": 0.1,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Floor confidence will not decay below. Default 0.1."
-      },
-      "graphEdgeDecayPerWindow": {
-        "type": "number",
-        "default": 0.1,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Per-window confidence drop applied during decay. Default 0.1."
-      },
-      "graphEdgeDecayVisibilityThreshold": {
-        "type": "number",
-        "default": 0.2,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Confidence threshold used by the decay telemetry counter for low-visibility edges. Default 0.2."
-      },
-      "graphEdgeDecayWindowMs": {
-        "type": "number",
-        "default": 7776000000,
-        "minimum": 60000,
-        "description": "Decay window in milliseconds passed to decayEdgeConfidence. Default 90 days."
-      },
-      "graphExpandedIntentEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Escalate broader causal/timeline phrasing into graph_mode planning."
-      },
-      "graphExpansionActivationWeight": {
-        "type": "number",
-        "default": 0.65,
-        "description": "Blend weight for graph activation when scoring expanded results (0-1). Higher values favor graph activation over seed QMD score."
-      },
-      "graphExpansionBlendMax": {
-        "type": "number",
-        "default": 0.95,
-        "description": "Upper clamp bound for blended graph-expanded recall scores (0-1)."
-      },
-      "graphExpansionBlendMin": {
-        "type": "number",
-        "default": 0.05,
-        "description": "Lower clamp bound for blended graph-expanded recall scores (0-1)."
-      },
-      "graphLateralInhibitionBeta": {
-        "type": "number",
-        "default": 0.15,
-        "description": "Inhibition strength (0-1). Higher values suppress weaker nodes more aggressively"
-      },
-      "graphLateralInhibitionEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Synapse-inspired lateral inhibition to suppress hub-node dominance in graph retrieval"
-      },
-      "graphLateralInhibitionTopM": {
-        "type": "number",
-        "default": 7,
-        "description": "Number of top competing nodes considered for lateral inhibition"
-      },
-      "graphRecallColdMirrorCollection": {
-        "type": "string",
-        "description": "QMD collection name for cold-mirror graph recall results."
-      },
-      "graphRecallColdMirrorMinAgeDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Minimum age in days for a memory to qualify for cold-mirror storage."
-      },
-      "graphRecallDampingFactor": {
-        "type": "number",
-        "default": 0.85,
-        "description": "PageRank-style damping factor for graph activation propagation."
-      },
-      "graphRecallEnableDebug": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable verbose debug output for graph recall operations."
-      },
-      "graphRecallEnableTrace": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable detailed graph recall trace logging for debugging."
-      },
-      "graphRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable graph recall planner mode (`graph_mode`). Requires multiGraphMemoryEnabled. Default false."
-      },
-      "graphRecallEntityHintMax": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum number of entity hints added per graph recall result."
-      },
-      "graphRecallEntityHintMaxChars": {
-        "type": "number",
-        "default": 200,
-        "description": "Maximum characters per entity hint added during graph recall."
-      },
-      "graphRecallEntityHintsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Inject entity hint summaries alongside graph-recalled memories."
-      },
-      "graphRecallEntityPriorBoost": {
-        "type": "number",
-        "default": 0.2,
-        "description": "Score boost applied to nodes with strong entity priors."
-      },
-      "graphRecallExpansionScoreThreshold": {
-        "type": "number",
-        "default": 0.2,
-        "description": "Minimum blended score required to include a graph-expanded node in results."
-      },
-      "graphRecallExplainEdgeLimit": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum edges described per node in a graph recall explanation."
-      },
-      "graphRecallExplainEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Append natural-language graph reasoning explanations to recall output."
-      },
-      "graphRecallExplainMaxChars": {
-        "type": "number",
-        "default": 500,
-        "description": "Maximum characters per graph recall explanation."
-      },
-      "graphRecallExplainMaxPaths": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum reasoning paths included in a graph recall explanation."
-      },
-      "graphRecallExplainToolEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Expose a graph explain tool to agents during graph recall."
-      },
-      "graphRecallHubBias": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Bias weight toward hub-seed selection (0-1)."
-      },
-      "graphRecallMaxExpandedNodes": {
-        "type": "number",
-        "default": 30,
-        "description": "Maximum total nodes visited during graph recall expansion."
-      },
-      "graphRecallMaxExpansions": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum number of expansion hops per graph recall query."
-      },
-      "graphRecallMaxPerSeed": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum graph-expanded results per seed node."
-      },
-      "graphRecallMaxSeedNodes": {
-        "type": "number",
-        "default": 10,
-        "description": "Maximum number of seed nodes selected for graph recall expansion."
-      },
-      "graphRecallMaxTrailPerNode": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum trail length followed per node during graph traversal."
-      },
-      "graphRecallMinEdgeWeight": {
-        "type": "number",
-        "default": 0.1,
-        "description": "Minimum edge weight to follow during graph recall traversal."
-      },
-      "graphRecallMinSeedScore": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Minimum QMD score for a memory to qualify as a graph recall seed."
-      },
-      "graphRecallPreferHubSeeds": {
-        "type": "boolean",
-        "default": false,
-        "description": "Prefer high-degree hub nodes as graph recall seeds."
-      },
-      "graphRecallRecencyHalfLifeDays": {
-        "type": "number",
-        "default": 30,
-        "description": "Half-life in days for recency decay applied to graph-expanded nodes."
-      },
-      "graphRecallShadowEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Run graph recall in shadow mode - evaluate but do not add results."
-      },
-      "graphRecallShadowSampleRate": {
-        "type": "number",
-        "default": 0.1,
-        "description": "Fraction of turns evaluated in shadow mode (0-1)."
-      },
-      "graphRecallSnapshotDir": {
-        "type": "string",
-        "description": "Directory for graph recall snapshot files (defaults to {memoryDir}/state/graph)."
-      },
-      "graphRecallSnapshotEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Write graph recall snapshots for offline analysis."
-      },
-      "graphRecallStoreColdMirror": {
-        "type": "boolean",
-        "default": false,
-        "description": "Store cold-path graph recall results in a secondary QMD collection."
-      },
-      "graphRecallUseEntityPriors": {
-        "type": "boolean",
-        "default": false,
-        "description": "Boost seed nodes using entity prior scores during graph recall."
-      },
-      "graphTraversalConfidenceFloor": {
-        "type": "number",
-        "default": 0.2,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Issue #681 PR 3/3: minimum edge confidence required for traversal during spreading activation. Edges below this floor are pruned and contribute neither activation nor downstream neighbors. Legacy edges without a confidence field are treated as 1.0. Range 0-1. Default 0.2."
-      },
-      "graphTraversalPageRankIterations": {
-        "type": "number",
-        "default": 8,
-        "minimum": 0,
-        "description": "Issue #681 PR 3/3: number of PageRank-style refinement iterations applied on top of the BFS spreading-activation scores. Each iteration redistributes a node's confidence-weighted activation along its outgoing edges. Set to 0 to disable refinement and use raw BFS scores. Default 8."
-      },
-      "graphWriteSessionAdjacencyEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Write fallback temporal adjacency edges for consecutive extracted memories in the same session."
-      },
-      "harmonicRetrievalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
-      },
-      "heartbeat": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false
-          },
-          "journalPath": {
-            "type": "string",
-            "default": "HEARTBEAT.md"
-          },
-          "maxPreviousRuns": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 20,
-            "default": 5
-          },
-          "watchFile": {
-            "type": "boolean",
-            "default": true
-          },
-          "detectionMode": {
-            "type": "string",
-            "enum": [
-              "runtime-signal",
-              "heuristic",
-              "auto"
-            ],
-            "default": "auto"
-          },
-          "gateExtractionDuringHeartbeat": {
-            "type": "boolean",
-            "default": true
-          }
+         }
         }
-      },
-      "highSignalPatterns": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "Custom regex patterns for immediate extraction"
-      },
-      "hostEmbeddingProviderEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Prefer OpenClaw host-registered embedding providers for Remnic's semantic fallback and embedded vector backends when the OpenClaw SDK exposes them. Falls back to Remnic's existing embedding provider path on older hosts or provider setup failures."
-      },
-      "hostEmbeddingProviderId": {
-        "type": "string",
-        "description": "Optional OpenClaw embedding provider adapter id to use. Leave unset for automatic selection from OpenClaw's memory/generic embedding provider registry."
-      },
-      "hostEmbeddingProviderModel": {
-        "type": "string",
-        "description": "Optional embedding model id passed to the selected OpenClaw host embedding provider."
-      },
-      "hourlySummariesEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable hourly conversation summaries"
-      },
-      "hourlySummariesExtendedEnabled": {
+       }
+      }
+     },
+     "fusion": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {},
+      "description": "Cross-source fusion of multi-source wearable transcripts into one reconciled artifact per real-world conversation (issue #1810). Deterministic and disabled by default.",
+      "properties": {
+       "enabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable structured hourly summaries (topics/decisions/action items/rejections). Default off."
-      },
-      "hourlySummariesIncludeSystemMessages": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include system messages in extended hourly summaries (use with care)."
-      },
-      "hourlySummariesIncludeToolStats": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include tool usage counts in extended hourly summaries (requires tool usage capture)."
-      },
-      "hourlySummariesMaxTurnsPerRun": {
-        "type": "number",
-        "default": 200,
-        "description": "Maximum transcript turns to consider per session per hourly summarizer run."
-      },
-      "hourlySummaryCronAutoRegister": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, Engram may attempt to auto-register an hourly summary cron job (default off)."
-      },
-      "identityContinuityEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable identity continuity workflows (anchor, incidents, audits)"
-      },
-      "identityEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable agent identity reflections (appends to workspace IDENTITY.md)"
-      },
-      "identityInjectionMode": {
-        "type": "string",
-        "enum": [
-          "recovery_only",
-          "minimal",
-          "full"
-        ],
-        "default": "recovery_only",
-        "description": "Controls when identity continuity context is added to recall assembly"
-      },
-      "identityMaxInjectChars": {
-        "type": "number",
-        "default": 1200,
-        "description": "Maximum characters allowed for identity continuity context"
-      },
-      "initGateTimeoutMs": {
+        "description": "Master gate for cross-source fusion. When false, no fusion artifacts are written and no behavior changes."
+       },
+       "proximityGapMs": {
         "type": "integer",
-        "minimum": 1000,
-        "maximum": 120000,
-        "default": 30000,
-        "description": "Maximum time Remnic waits for cold-start initialization during recall; also registered as the OpenClaw before_prompt_build hook timeout on SDKs that support per-hook options."
-      },
-      "injectQuestions": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include the most relevant open question in generated memory context"
-      },
-      "inlineSourceAttributionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable inline source attribution markers on persisted facts for downstream provenance tracking."
-      },
-      "inlineSourceAttributionFormat": {
-        "type": "string",
-        "default": "[Source: agent={agent}, session={sessionId}, ts={ts}]",
-        "description": "Template used when inline source attribution is enabled."
-      },
-      "intentRoutingBoost": {
-        "type": "number",
-        "default": 0.12,
-        "description": "Maximum score boost applied for intent-compatible memory matches."
-      },
-      "intentRoutingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Attach intent metadata to memories and boost compatible memories at recall."
-      },
-      "ircEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable Inductive Rule Consolidation (IRC) subsystem (default on)."
-      },
-      "ircIncludeCorrections": {
-        "type": "boolean",
-        "default": true,
-        "description": "Include corrections when building IRC rules (default on)."
-      },
-      "ircMaxPreferences": {
-        "type": "number",
-        "default": 20,
-        "description": "Maximum number of preferences to include in IRC rules."
-      },
-      "ircMinConfidence": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Minimum confidence threshold for an IRC rule to be included (0-1)."
-      },
-      "judgeTrainingDir": {
-        "type": "string",
-        "default": "",
-        "description": "Override directory for judge training-pair collection. Empty string uses the default (~/.remnic/judge-training). Only consulted when collectJudgeTrainingPairs is true."
-      },
-      "knowledgeIndexEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Inject a compact Knowledge Index of top entities into every recall"
-      },
-      "knowledgeIndexMaxChars": {
-        "type": "number",
-        "default": 4000,
-        "description": "Hard character cap for the Knowledge Index section"
-      },
-      "knowledgeIndexMaxEntities": {
-        "type": "number",
-        "default": 40,
-        "description": "Max entities included in the Knowledge Index"
-      },
-      "lanceDbPath": {
-        "type": "string",
-        "description": "Directory path for LanceDB storage (when searchBackend=lancedb)"
-      },
-      "lanceEmbeddingDimension": {
-        "type": "number",
-        "default": 1536,
-        "description": "Embedding vector dimension for LanceDB (when searchBackend=lancedb)"
-      },
-      "lancedbEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable LanceDB as a supplemental search backend."
-      },
-      "lcmArchiveRetentionDays": {
-        "type": "number",
-        "default": 90,
-        "description": "Days to retain archived LCM summaries"
-      },
-      "lcmDeterministicMaxTokens": {
-        "type": "number",
-        "default": 512,
-        "description": "Max tokens for deterministic (non-LLM) summaries"
-      },
-      "lcmEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Lossless Context Management (LCM) subsystem"
-      },
-      "lcmFreshTailTurns": {
-        "type": "number",
-        "default": 16,
-        "description": "Number of recent turns kept verbatim (not summarized)"
-      },
-      "lcmLeafBatchSize": {
-        "type": "number",
-        "default": 8,
-        "description": "Number of turns per leaf node in the LCM DAG"
-      },
-      "lcmMaxDepth": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum depth of the LCM summary DAG"
-      },
-      "lcmObserveConcurrency": {
-        "type": "number",
-        "default": 1,
-        "description": "Maximum independent LCM observe jobs to process concurrently."
-      },
-      "lcmRecallBudgetShare": {
-        "type": "number",
-        "default": 0.15,
-        "description": "Fraction of recall budget allocated to LCM compressed history (0-1)"
-      },
-      "lcmRollupFanIn": {
-        "type": "number",
-        "default": 4,
-        "description": "Number of children per rollup node in the LCM DAG"
-      },
-      "lcmTelemetryPrefilterEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Use deterministic LCM compression for mechanical action/state telemetry without durable-memory cues."
-      },
-      "lifecycleArchiveDecayThreshold": {
-        "type": "number",
-        "default": 0.85,
-        "description": "Decay threshold for lifecycle demotion to archived state semantics."
-      },
-      "lifecycleFilterStaleEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If enabled, stale lifecycle memories can be filtered from retrieval (wired in PR20D)."
-      },
-      "lifecycleMetricsEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Emit lifecycle metrics snapshots to state/lifecycle-metrics.json when policy is enabled."
-      },
-      "lifecyclePolicyEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable the lifecycle policy engine (hot↔cold tier migration, value scoring, decay). Default true since #686 PR 3/6 — flipping enables the year-2 retention story by default. Set to false to opt out."
-      },
-      "lifecyclePromoteHeatThreshold": {
-        "type": "number",
-        "default": 0.55,
-        "description": "Heat threshold for lifecycle promotion to validated/active states."
-      },
-      "lifecycleProtectedCategories": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "decision",
-          "principle",
-          "commitment",
-          "preference",
-          "procedure"
-        ],
-        "description": "Categories that lifecycle policy will not auto-archive."
-      },
-      "lifecycleStaleDecayThreshold": {
-        "type": "number",
-        "default": 0.65,
-        "description": "Decay threshold for lifecycle demotion to stale."
-      },
-      "localLlm400CooldownMs": {
-        "type": "number",
-        "default": 120000,
-        "description": "Cooldown duration after tripping local LLM 400 threshold (ms)."
-      },
-      "localLlm400TripThreshold": {
-        "type": "number",
-        "default": 5,
-        "description": "Consecutive 400 responses before local LLM enters temporary cooldown."
-      },
-      "localLlmApiKey": {
-        "type": "string",
-        "description": "Optional API key for authenticated OpenAI-compatible local endpoints"
-      },
-      "localLlmAuthHeader": {
-        "type": "boolean",
-        "default": true,
-        "description": "If false, do not send Authorization header even when localLlmApiKey is set"
-      },
-      "localLlmDisableThinking": {
-        "type": "boolean",
-        "default": true,
-        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is sent only when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
-      },
-      "localLlmEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable local LLM for extraction and summarization (e.g., LM Studio, Ollama)"
-      },
-      "localLlmFallback": {
-        "type": "boolean",
-        "default": true,
-        "description": "Fall back to cloud OpenAI if local LLM is unavailable"
-      },
-      "localLlmFastEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable a separate smaller/faster local LLM for quick operations (rerank, entity_summary, tmt_summary, compression_guideline)."
-      },
-      "localLlmFastModel": {
-        "type": "string",
-        "default": "",
-        "description": "Model ID for fast-tier local LLM operations. Empty string uses the primary localLlmModel."
-      },
-      "localLlmFastTimeoutMs": {
-        "type": "number",
-        "default": 15000,
-        "description": "Timeout for fast-tier local LLM requests (ms). Lower than primary since fast ops should complete quickly."
-      },
-      "localLlmFastUrl": {
-        "type": "string",
-        "description": "Endpoint for the fast-tier local LLM. Defaults to the same endpoint as localLlmUrl when not set."
-      },
-      "localLlmHeaders": {
-        "type": "object",
-        "description": "Optional additional headers for local/compatible endpoint requests",
-        "additionalProperties": {
-          "type": "string"
-        }
-      },
-      "localLlmHomeDir": {
-        "type": "string",
-        "description": "Optional home directory override for local LLM helpers (LM Studio settings + CLI PATH resolution)."
-      },
-      "localLlmMaxContext": {
-        "type": "number",
-        "description": "Override the detected context window for local LLM. Set to 32768 if your LLM server defaults to 32K context despite the model supporting 128K."
-      },
-      "localLlmModel": {
-        "type": "string",
-        "default": "local-model",
-        "description": "Model name for local LLM requests"
-      },
-      "localLlmRetry5xxCount": {
-        "type": "number",
-        "default": 1,
-        "description": "Number of retry attempts for local LLM 5xx responses."
-      },
-      "localLlmRetryBackoffMs": {
-        "type": "number",
-        "default": 400,
-        "description": "Base backoff delay between local LLM retries (ms)."
-      },
-      "localLlmTimeoutMs": {
-        "type": "number",
-        "default": 180000,
-        "description": "Hard timeout for local LLM requests (ms)"
-      },
-      "localLlmUrl": {
-        "type": "string",
-        "default": "http://localhost:1234/v1",
-        "description": "URL for local LLM OpenAI-compatible endpoint"
-      },
-      "localLmsBinDir": {
-        "type": "string",
-        "description": "Optional bin directory prepended to PATH for LMS CLI execution."
-      },
-      "localLmsCliPath": {
-        "type": "string",
-        "description": "Optional absolute path to LMS CLI binary. Preferred over auto-detected locations."
-      },
-      "maintenanceIncludeBranchNamespaces": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include dynamic branch namespaces from the namespace catalog in background maintenance fanout. Defaults off to avoid high-cardinality branch churn."
-      },
-      "maintenanceIncludeProjectNamespaces": {
-        "type": "boolean",
-        "default": true,
-        "description": "Include dynamic project namespaces from the namespace catalog in background maintenance fanout."
-      },
-      "maintenanceIncludeTeamProjectNamespaces": {
-        "type": "boolean",
-        "default": true,
-        "description": "Include dynamic team-project namespaces from the namespace catalog in background maintenance fanout."
-      },
-      "maintenanceMaxNamespacesPerCycle": {
-        "type": "number",
-        "default": 20,
-        "minimum": 1,
-        "description": "Maximum namespaces a single maintenance job cycle may process. Default and shared namespaces keep priority inside this budget."
-      },
-      "maintenanceNamespaceFanoutEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "When namespaces are enabled, let background maintenance enumerate live catalog namespaces in addition to configured default/shared/policy namespaces."
-      },
-      "maintenanceNamespaceLockStaleMs": {
-        "type": "number",
-        "default": 600000,
-        "minimum": 1,
-        "description": "Stale threshold for per-job/per-namespace maintenance locks under state/maintenance-locks/."
-      },
-      "maxCompressionTokensPerHour": {
-        "type": "number",
-        "default": 1500,
-        "description": "Hourly token budget for compression actions/guideline generation (0 disables budgeted compression work)."
-      },
-      "maxEntityGraphEdgesPerMemory": {
-        "type": "number",
-        "default": 10,
-        "description": "Maximum entity graph edges written per memory write. Default 10."
-      },
-      "maxGraphTraversalSteps": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum BFS hops during spreading activation. Default 3."
-      },
-      "maxMemoryTokens": {
-        "type": "number",
-        "default": 2000,
-        "description": "Max memory-context tokens per turn"
-      },
-      "maxProactiveQuestionsPerExtraction": {
-        "type": "number",
-        "default": 2,
-        "description": "Maximum proactive self-questions generated per extraction pass (0 disables question generation)."
-      },
-      "maxSummaryCount": {
-        "type": "number",
-        "default": 6,
-        "description": "Maximum number of summaries to include"
-      },
-      "maxTranscriptTokens": {
-        "type": "number",
-        "default": 1000,
-        "description": "Maximum tokens for transcript context"
-      },
-      "maxTranscriptTurns": {
-        "type": "number",
-        "default": 50,
-        "description": "Maximum transcript turns to include"
-      },
-      "meilisearchApiKey": {
-        "type": "string",
-        "description": "API key for Meilisearch (when searchBackend=meilisearch)"
-      },
-      "meilisearchAutoIndex": {
-        "type": "boolean",
-        "default": false,
-        "description": "Automatically push local memory docs to Meilisearch on update (when searchBackend=meilisearch)"
-      },
-      "meilisearchEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Meilisearch as a supplemental search backend."
-      },
-      "meilisearchHost": {
-        "type": "string",
-        "default": "http://localhost:7700",
-        "description": "Meilisearch server host URL (when searchBackend=meilisearch)"
-      },
-      "meilisearchTimeoutMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Timeout in ms for Meilisearch requests (when searchBackend=meilisearch)"
-      },
-      "memoryBoxesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Memory Boxes (v8.0 Phase 2A). Groups memories into topic-bounded windows. Disabled by default."
-      },
-      "memoryDir": {
-        "type": "string",
-        "description": "Override memory storage directory"
-      },
-      "memoryExtensionsEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Whether third-party memory extensions are discovered and included in consolidation instructions."
-      },
-      "memoryExtensionsRoot": {
-        "type": "string",
-        "default": "",
-        "description": "Root directory for memory extensions. Empty string derives from memoryDir (go up to Remnic home and append memory_extensions)."
-      },
-      "memoryLinkingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic memory linking to build knowledge graph"
-      },
-      "offlineSyncExcludes": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "minLength": 1
-        },
-        "default": [],
-        "description": "Extra offline-sync push-side exclude globs (relative to memoryDir; * within a segment, leading **/ across segments). Additive to the built-in node-local state excludes (state/*.sqlite, state/*.sqlite-*, state/index_tags.json, state/entity-mention-index.json, state/memory-governance/runs/**). Issue #1786."
-      },
-      "memoryOsPreset": {
-        "type": "string",
-        "enum": [
-          "conservative",
-          "balanced",
-          "research",
-          "research-max",
-          "local-llm-heavy"
-        ],
-        "description": "Optional named preset that seeds Engram's advanced config surface before explicit per-setting settings are applied. `research` is accepted as a backward-compatible alias for `research-max`."
-      },
-      "memoryPoisoningDefenseEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable deterministic provenance trust scoring for trust-zone records as the first poisoning-defense surface."
-      },
-      "memoryReconstructionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "E-Mem-inspired memory reconstruction: targeted secondary retrieval for entity references lacking context in recall"
-      },
-      "memoryReconstructionMaxExpansions": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum number of entity expansions per recall cycle"
-      },
-      "memoryRedTeamBenchEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable operator-facing memory red-team benchmark packs and status accounting for poisoning-defense regression suites."
-      },
-      "memoryUtilityLearningEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable utility-learning telemetry storage so later slices can learn promotion and ranking weights from downstream outcomes."
-      },
-      "messagePartsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt in to structured LCM message-part capture for tool calls, file references, patches, and reasoning markers."
-      },
-      "messagePartsRecallMaxResults": {
-        "type": "number",
-        "default": 6,
-        "description": "Maximum structured message-part matches to include in recall when messagePartsEnabled is true."
-      },
-      "model": {
-        "type": "string",
-        "default": "gpt-5.5",
-        "description": "OpenAI model for extraction/consolidation"
-      },
-      "modelSource": {
-        "type": "string",
-        "enum": [
-          "plugin",
-          "gateway"
-        ],
-        "default": "gateway",
-        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
-      },
-      "multiGraphMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable multi-graph memory (entity, time, causal edges). Default false."
-      },
-      "namespaceCatalogEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable the rebuildable namespace catalog (issue #1499). Records cheap, failure-tolerant namespace touches in <memoryDir>/state/namespaces.jsonl for enumeration by maintenance, QMD indexing, dashboard, and doctor. Inert unless namespacesEnabled is also true; filesystem memory stays the source of truth and the catalog is rebuildable via `remnic namespaces rebuild`. Default on; set false to opt out."
-      },
-      "namespacePolicies": {
-        "type": "array",
-        "description": "Namespace access policies.",
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "readPrincipals": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "writePrincipals": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "includeInRecallByDefault": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "name",
-            "readPrincipals",
-            "writePrincipals"
-          ]
-        }
-      },
-      "namespacesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable multi-agent namespaces (v3.0). Default off."
-      },
-      "nativeKnowledge": {
-        "type": "object",
-        "additionalProperties": false,
-        "description": "Optional: search curated workspace markdown files directly during recall without converting them into durable memory files.",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Master switch for curated workspace file recall."
-          },
-          "includeFiles": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "default": [
-              "IDENTITY.md",
-              "MEMORY.md"
-            ],
-            "description": "Workspace-relative curated markdown files to scan for native knowledge recall."
-          },
-          "maxChunkChars": {
-            "type": "number",
-            "default": 900,
-            "description": "Maximum chunk size per native knowledge section before it is split."
-          },
-          "maxResults": {
-            "type": "number",
-            "default": 4,
-            "description": "Maximum native knowledge chunks to add to recall."
-          },
-          "maxChars": {
-            "type": "number",
-            "default": 2400,
-            "description": "Maximum total characters to add from native knowledge recall."
-          },
-          "stateDir": {
-            "type": "string",
-            "default": "state/native-knowledge",
-            "description": "Memory-relative directory used for backend-agnostic native knowledge sync state."
-          },
-          "openclawWorkspace": {
-            "type": "object",
-            "additionalProperties": false,
-            "description": "Optional adapter for OpenClaw workspace artifacts such as bootstrap docs, handoffs, daily summaries, and automation notes.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Enable the OpenClaw workspace native-knowledge adapter."
-              },
-              "bootstrapFiles": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [
-                  "IDENTITY.md",
-                  "MEMORY.md",
-                  "USER.md"
-                ],
-                "description": "Workspace-relative bootstrap docs treated as high-confidence native knowledge."
-              },
-              "handoffGlobs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [
-                  "**/*handoff*.md",
-                  "handoffs/**/*.md"
-                ],
-                "description": "Glob patterns (relative to workspaceDir) used to discover handoff notes."
-              },
-              "dailySummaryGlobs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [
-                  "**/*daily*summary*.md",
-                  "summaries/**/*.md"
-                ],
-                "description": "Glob patterns (relative to workspaceDir) used to discover daily summary notes."
-              },
-              "automationNoteGlobs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Optional glob patterns for automation-written status or operating notes."
-              },
-              "workspaceDocGlobs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Optional glob patterns for other explicitly allowlisted workspace docs."
-              },
-              "excludeGlobs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Additional glob patterns appended to the built-in workspace safety excludes."
-              },
-              "sharedSafeGlobs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Optional glob patterns that should be tagged as shared-safe when no explicit privacy class is present."
-              }
-            },
-            "required": [
-              "enabled"
-            ]
-          },
-          "obsidianVaults": {
-            "type": "array",
-            "default": [],
-            "description": "Optional Obsidian vault adapters to sync into backend-agnostic native knowledge records.",
-            "items": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "description": "Stable vault identifier used in synced note metadata."
-                },
-                "rootDir": {
-                  "type": "string",
-                  "description": "Absolute path to the Obsidian vault root."
-                },
-                "includeGlobs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "default": [
-                    "**/*.md"
-                  ],
-                  "description": "Glob patterns (relative to the vault root) that are eligible for sync."
-                },
-                "excludeGlobs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "default": [
-                    ".obsidian/**",
-                    "**/*.canvas",
-                    "**/*.png",
-                    "**/*.jpg",
-                    "**/*.jpeg",
-                    "**/*.gif",
-                    "**/*.pdf"
-                  ],
-                  "description": "Glob patterns excluded from sync."
-                },
-                "namespace": {
-                  "type": "string",
-                  "description": "Default namespace assigned to records from this vault."
-                },
-                "privacyClass": {
-                  "type": "string",
-                  "description": "Operator-defined privacy class preserved on synced records."
-                },
-                "folderRules": {
-                  "type": "array",
-                  "default": [],
-                  "description": "Optional per-folder overrides for namespace or privacy classification.",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                      "pathPrefix": {
-                        "type": "string",
-                        "description": "Vault-relative folder prefix that activates the override."
-                      },
-                      "namespace": {
-                        "type": "string",
-                        "description": "Namespace override for matching notes."
-                      },
-                      "privacyClass": {
-                        "type": "string",
-                        "description": "Privacy-class override for matching notes."
-                      }
-                    },
-                    "required": [
-                      "pathPrefix"
-                    ]
-                  }
-                },
-                "dailyNotePatterns": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "default": [
-                    "YYYY-MM-DD"
-                  ],
-                  "description": "Filename patterns used to derive daily-note dates (for example `YYYY-MM-DD` or `YYYY/MM/DD`)."
-                },
-                "materializeBacklinks": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "If true, compute backlinks from wikilink targets for recall hints and explainability."
-                }
-              },
-              "required": [
-                "rootDir"
-              ]
-            }
-          }
-        },
-        "required": [
-          "enabled"
-        ]
-      },
-      "negativeExamplesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable negative examples (track retrieved-but-not-useful memories) and apply a small ranking penalty."
-      },
-      "negativeExamplesPenaltyCap": {
-        "type": "number",
-        "default": 0.25,
-        "description": "Maximum ranking penalty applied from negative examples."
-      },
-      "negativeExamplesPenaltyPerHit": {
-        "type": "number",
-        "default": 0.05,
-        "description": "Ranking penalty per negative example hit (keep small; QMD scores are ~0-1)."
-      },
-      "nightlyGovernanceCronAutoRegister": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, Engram may attempt to auto-register the nightly governance cron job (default off)."
-      },
-      "objectiveStateMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Engram's objective-state memory foundation for normalized world/tool state snapshots."
-      },
-      "objectiveStateRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant objective-state snapshots to recall context."
-      },
-      "objectiveStateSnapshotWritesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Allow writing typed objective-state snapshots to the objective-state store."
-      },
-      "objectiveStateStoreDir": {
-        "type": "string",
-        "description": "Override the objective-state memory directory (defaults to {memoryDir}/state/objective-state)."
-      },
-      "openaiApiKey": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "const": false
-          }
-        ],
-        "description": "Optional OpenAI API key for plugin mode (or set OPENAI_API_KEY env var). Ignored by default gateway-mode installs; in plugin mode, Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
-      },
-      "openaiBaseUrl": {
-        "type": "string",
-        "description": "Set the OpenAI API base URL for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
-      },
-      "openclawChannelEnvelopeCleaningEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Use OpenClaw's canonical chat-channel envelope prefixes when the SDK exposes plugin-sdk/chat-channel-ids, while keeping the legacy OpenClaw-only cleaner on older hosts."
-      },
-      "openclawFlushPlanProcessingEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Process OpenClaw's append-only Remnic flush-plan file through Remnic extraction and clear processed content. Disable this if a future OpenClaw release owns flush-plan consumption and cleanup natively."
-      },
-      "openclawMessageReceivedCaptureEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Capture OpenClaw message_received hook content into transcripts when that hook is emitted by the host. Older OpenClaw versions that never emit the hook continue through agent_end capture."
-      },
-      "openclawReplyMetadataCaptureEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Persist bounded OpenClaw messageId, threadId, replyToId, replyToBody, and replyToSender fields in transcript metadata when available."
-      },
-      "openclawReplyMetadataExtractionHintsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, prepend bounded quoted-reply context to user turns before Remnic extraction. Leave false to store reply metadata without changing extraction behavior."
-      },
-      "openclawToolSnippetMaxChars": {
-        "type": "integer",
-        "minimum": 80,
-        "maximum": 4000,
-        "default": 600,
-        "description": "Maximum snippet size returned by the OpenClaw memory tool adapters."
-      },
-      "openclawToolsEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Register the OpenClaw memory.search and memory.get tool adapters."
-      },
-      "operatorAwareConsolidationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt in to operator-aware consolidation instructions so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
-      },
-      "oramaDbPath": {
-        "type": "string",
-        "description": "Directory path for Orama persistence files (when searchBackend=orama)"
-      },
-      "oramaEmbeddingDimension": {
-        "type": "number",
-        "default": 1536,
-        "description": "Embedding vector dimension for Orama (when searchBackend=orama)"
-      },
-      "oramaEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Orama as a supplemental search backend."
-      },
-      "parallelAgentWeights": {
-        "type": "object",
-        "default": {
-          "direct": 1,
-          "contextual": 0.7,
-          "temporal": 0.85
-        },
-        "description": "Score weights per retrieval agent source applied during result merge."
-      },
-      "parallelMaxResultsPerAgent": {
-        "type": "number",
-        "default": 20,
-        "description": "Maximum results fetched per agent before merge."
-      },
-      "parallelRetrievalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable three-agent parallel retrieval (DirectFact + Contextual + Temporal). Zero additional LLM cost. Default false."
-      },
-      "patternReinforcementCadenceMs": {
-        "type": "integer",
-        "minimum": 0,
-        "default": 604800000,
-        "description": "Minimum interval (ms) between pattern-reinforcement runs. Default 7 days. Set to 0 to disable cadence gating (manual / test invocation)."
-      },
-      "patternReinforcementCategories": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "preference",
-          "fact",
-          "decision"
-        ],
-        "description": "Memory categories the pattern-reinforcement job considers. Skips procedural memories so it stays disjoint from procedural mining. Default: preference, fact, decision."
-      },
-      "patternReinforcementEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Run the pattern-reinforcement maintenance job (issue #687 PR 2/4): cluster duplicate non-procedural memories by normalized content, promote the most-recent member to canonical, and supersede the older duplicates. Off by default until bench validation lands."
-      },
-      "patternReinforcementMinCount": {
-        "type": "integer",
-        "minimum": 2,
-        "maximum": 1000,
-        "default": 3,
-        "description": "Minimum cluster size before pattern reinforcement promotes a canonical and supersedes duplicates. Default 3."
-      },
-      "peerProfileReasonerEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the async peer profile reasoner (issue #679). Runs after semantic consolidation in the REM phase and updates per-peer profile.md files with provenance-tagged field updates derived from the peer's interaction log. Default off (opt-in)."
-      },
-      "peerProfileReasonerMaxFieldsPerRun": {
-        "type": "number",
-        "default": 8,
-        "minimum": 0,
-        "description": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
-      },
-      "peerProfileReasonerMinInteractions": {
-        "type": "number",
-        "default": 5,
-        "minimum": 0,
-        "description": "Minimum new interaction-log entries a peer must accumulate since the previous reasoner run before being processed again. Set to 0 to consider every peer on every run."
-      },
-      "peerProfileReasonerModel": {
-        "type": "string",
-        "default": "auto",
-        "description": "Model identifier used by the peer profile reasoner. 'auto' inherits the gateway's primary chain (recommended). Logged for telemetry only — actual dispatch routes through the same FallbackLlmClient used by semantic consolidation."
-      },
-      "peerProfileRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, add the active peer's profile fields to the recall context as a '## Peer Profile' section (issue #679 PR 3/5). Requires the session's peer ID to be registered before recall. Default off (opt-in)."
-      },
-      "peerProfileRecallMaxFields": {
-        "type": "number",
-        "default": 5,
-        "minimum": 0,
-        "description": "Maximum number of peer profile fields to add per recall call. Only the most-recently-updated N fields are included. Set to 0 to disable field inclusion even when peerProfileRecallEnabled is true."
-      },
-      "principalFromSessionKeyMode": {
-        "type": "string",
-        "enum": [
-          "map",
-          "prefix",
-          "regex"
-        ],
-        "default": "map",
-        "description": "How to derive principal identity from sessionKey."
-      },
-      "principalFromSessionKeyRules": {
-        "type": "array",
-        "description": "Rules for resolving principal from sessionKey (ordered).",
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "match": {
-              "type": "string"
-            },
-            "principal": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "match",
-            "principal"
-          ]
-        }
-      },
-      "proactiveExtractionCategoryAllowlist": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "Optional memory categories allowed from proactive second-pass writes. When omitted, proactive writes can emit any standard memory category."
-      },
-      "proactiveExtractionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable proactive self-questioning extraction second-pass (v8.3, default off)."
-      },
-      "proactiveExtractionMaxTokens": {
-        "type": "number",
-        "default": 900,
-        "description": "Token budget for each proactive extraction sub-call (0 disables the proactive second pass)."
-      },
-      "proactiveExtractionTimeoutMs": {
-        "type": "number",
-        "default": 2500,
-        "description": "Hard timeout in milliseconds for proactive self-question generation and answer synthesis (0 disables the proactive second pass)."
-      },
-      "procedural": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "Master gate for procedural memory: extraction, recall boost, and mining (issue #519). Default-on since issue #567 PR 4/5; set to `false` to opt out."
-          },
-          "minOccurrences": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 1000,
-            "default": 3,
-            "description": "Minimum clustered trajectory occurrences before emitting a candidate procedure (0 disables mining)."
-          },
-          "successFloor": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 1,
-            "default": 0.75,
-            "description": "Minimum success-rate floor (from trajectory outcomes) for miner promotion."
-          },
-          "autoPromoteOccurrences": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 10000,
-            "default": 8,
-            "description": "When auto-promotion is enabled, minimum occurrence count to move pending_review procedures to active (0 disables auto-promotion by count)."
-          },
-          "autoPromoteEnabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "When true, miner may auto-promote trusted procedures to active after autoPromoteOccurrences."
-          },
-          "lookbackDays": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 3650,
-            "default": 14,
-            "description": "Trajectory lookback window for procedural mining."
-          },
-          "recallMaxProcedures": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 10,
-            "default": 2,
-            "description": "Maximum procedure memories to add on task-initiation recall."
-          },
-          "proceduralMiningCronAutoRegister": {
-            "type": "boolean",
-            "default": false,
-            "description": "When true, installer may register the nightly procedural mining cron job."
-          }
-        }
-      },
-      "profilingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, enable performance profiling for recall and extraction pipelines. Profiling data is stored locally in the profiling storage directory."
-      },
-      "profilingMaxTraces": {
-        "type": "number",
-        "default": 100,
-        "description": "Maximum number of profiling trace files to retain. Oldest traces are pruned when this limit is exceeded."
-      },
-      "profilingStorageDir": {
-        "type": "string",
-        "default": "",
-        "description": "Directory path for storing profiling trace files. Defaults to <memoryDir>/profiling if empty."
-      },
-      "promotionByOutcomeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable outcome-aware promotion controls that consume learned utility signals when later rollout slices activate them."
-      },
-      "provenance": {
-        "type": "object",
-        "description": "Claim-level provenance spans (issue #1575). When enabled, extracted facts carry verbatim source-utterance excerpts plus a coarse strength tag (verified/unverified/none) consumed by the faithfulness gate, correction UX, tombstone matching, and TrustScore.",
-        "additionalProperties": false,
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "description": "Emit provenance spans on new extractions. Off = pre-feature extraction prompt/output, byte-identical (rule 39). Default: true (applied in code; no schema default so the REMNIC_/ENGRAM_ env override fires when the key is omitted)."
-          },
-          "maxQuoteChars": {
-            "type": "integer",
-            "default": 300,
-            "minimum": 1,
-            "description": "Maximum characters stored per quote; longer quotes truncate at a word boundary with an ellipsis marker. Never stores the whole turn."
-          },
-          "requireSpans": {
-            "type": "boolean",
-            "default": false,
-            "description": "When true, facts whose quote cannot be located are routed to pending_review instead of active. Stays false until #1576 lands and the bench shows the gate is safe (rule 48)."
-          }
-        }
-      },
-      "qmdAutoEmbedEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, background QMD maintenance also runs embed on a throttled cadence."
-      },
-      "qmdAutoUpgradeCheckIntervalMs": {
-        "type": "number",
-        "minimum": 60000,
-        "default": 86400000,
-        "description": "Minimum interval between QMD auto-upgrade checks"
-      },
-      "qmdAutoUpgradeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt-in auto-upgrade for PATH/fallback QMD installs"
-      },
-      "qmdCandidateLimit": {
-        "type": "number",
-        "minimum": 1,
-        "description": "Optional candidate limit forwarded to supported QMD query paths"
-      },
-      "qmdChunkStrategy": {
-        "type": "string",
-        "enum": [
-          "auto",
-          "regex"
-        ],
-        "default": "auto",
-        "description": "QMD chunk strategy forwarded when the installed QMD supports it"
-      },
-      "qmdColdCollection": {
-        "type": "string",
-        "default": "openclaw-engram-cold",
-        "description": "Secondary QMD collection name used for cold-tier fallback recall"
-      },
-      "qmdColdMaxResults": {
-        "type": "number",
-        "default": 8,
-        "description": "Max cold-tier QMD results considered before final recall cap"
-      },
-      "qmdColdTierEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable cold-tier QMD recall from a secondary collection when hot recall misses"
-      },
-      "qmdCollection": {
-        "type": "string",
-        "default": "openclaw-engram",
-        "description": "QMD collection name"
-      },
-      "qmdDaemonEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Prefer the shared QMD MCP session for faster searches when available."
-      },
-      "qmdDaemonRecheckIntervalMs": {
-        "type": "number",
-        "default": 60000,
-        "description": "Re-probe interval when daemon is down (ms)"
-      },
-      "qmdDaemonTimeoutMs": {
-        "type": "number",
-        "minimum": 1000,
-        "maximum": 120000,
-        "default": 8000,
-        "description": "Per-call timeout (ms) for QMD daemon searches. Default 8000; raise (e.g. 20000) to give CPU-only HyDE queries more headroom before the daemon call times out (issue #1335)."
-      },
-      "qmdDaemonUrl": {
-        "type": "string",
-        "default": "http://localhost:8181/mcp",
-        "description": "Legacy compatibility setting retained for QMD daemon configuration."
-      },
-      "qmdEmbedMinIntervalMs": {
-        "type": "number",
-        "default": 3600000,
-        "description": "Minimum interval between background QMD embed runs (ms)."
-      },
-      "qmdEmbedModel": {
-        "type": "string",
-        "description": "Optional QMD_EMBED_MODEL override"
-      },
-      "qmdEmbedParallelism": {
-        "type": "number",
-        "minimum": 1,
-        "maximum": 8,
-        "description": "Optional QMD_EMBED_PARALLELISM override, clamped to 1-8"
-      },
-      "qmdEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Use QMD for search"
-      },
-      "qmdExplainEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Request QMD explain traces for recall debugging when supported."
-      },
-      "qmdForceCpu": {
-        "type": "boolean",
-        "default": false,
-        "description": "Set QMD_FORCE_CPU=1 for QMD child processes to bypass GPU probing and run predictably on CPU"
-      },
-      "qmdGenerateModel": {
-        "type": "string",
-        "description": "Optional QMD_GENERATE_MODEL override"
-      },
-      "qmdGpuBackend": {
-        "type": [
-          "string",
-          "boolean"
-        ],
-        "enum": [
-          "auto",
-          "metal",
-          "cuda",
-          "vulkan",
-          "false",
-          false
-        ],
-        "description": "Optional QMD_LLAMA_GPU override for QMD child processes"
-      },
-      "qmdIndexName": {
-        "type": "string",
-        "description": "Optional QMD named index forwarded as qmd --index <name> when supported. Leave unset during upgrades unless existing QMD data already lives in that named index."
-      },
-      "qmdIntentHintsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Pass Engram's inferred recall intent into QMD unified search when supported."
-      },
-      "qmdMaintenanceDebounceMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Debounce window for background QMD maintenance updates (ms)."
-      },
-      "qmdMaintenanceEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable debounced background QMD maintenance instead of immediate updates on extraction."
-      },
-      "qmdMaxResults": {
-        "type": "number",
-        "default": 8,
-        "description": "Max QMD results per search"
-      },
-      "qmdPath": {
-        "type": "string",
-        "description": "Optional absolute path to qmd binary (bypasses PATH/fallback discovery)"
-      },
-      "qmdQueryRerankEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "When false, ask supported QMD versions to skip the built-in rerank step"
-      },
-      "qmdRecallCacheMaxEntries": {
-        "type": "number",
-        "default": 128,
-        "description": "Maximum in-memory rendered QMD recall cache entries before oldest eviction."
-      },
-      "qmdRecallCacheStaleTtlMs": {
-        "type": "number",
-        "default": 600000,
-        "description": "Maximum stale TTL in ms for rendered QMD recall cache fallbacks."
-      },
-      "qmdRecallCacheTtlMs": {
-        "type": "number",
-        "default": 60000,
-        "description": "Fresh TTL in ms for rendered QMD recall enrichment cache entries."
-      },
-      "qmdRerankModel": {
-        "type": "string",
-        "description": "Optional QMD_RERANK_MODEL override"
-      },
-      "qmdSearchStrategy": {
-        "type": "string",
-        "enum": [
-          "hybrid",
-          "lex-vec",
-          "lex"
-        ],
-        "default": "hybrid",
-        "description": "Daemon search plan. 'hybrid' (default) runs lex+vec+hyde for best recall; 'lex-vec' drops the expensive HyDE generate leg; 'lex' is BM25-only (fastest). Lower tiers trade recall for latency on CPU-only models. Default preserves existing behavior (issue #1335)."
-      },
-      "qmdSubprocessStrategy": {
-        "type": "string",
-        "enum": [
-          "query",
-          "search"
-        ],
-        "default": "query",
-        "description": "Command for the QMD CLI subprocess fallback, used only when the daemon is unavailable. 'query' (default) keeps LLM query expansion + rerank; 'search' is BM25-only and faster on very large collections but loses expansion/rerank. Default preserves existing behavior (issue #1335)."
-      },
-      "qmdSupportedVersion": {
-        "type": "string",
-        "default": "2.5.3",
-        "description": "Highest QMD version this Remnic build will auto-install"
-      },
-      "qmdTierAutoBackfillEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Allow automated cold-tier backfill jobs to repair parity gaps"
-      },
-      "qmdTierDemotionMinAgeDays": {
-        "type": "number",
-        "default": 14,
-        "description": "Minimum hot-memory age in days before tier demotion is eligible"
-      },
-      "qmdTierDemotionValueThreshold": {
-        "type": "number",
-        "default": 0.35,
-        "description": "Value-score threshold at or below which hot memories are eligible for cold demotion"
-      },
-      "qmdTierMigrationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable value-aware migration between hot and cold QMD tiers"
-      },
-      "qmdTierParityGraphEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Apply graph-assist parity checks across hot and cold retrieval tiers"
-      },
-      "qmdTierParityHiMemEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Apply HiMem episode/note parity checks across hot and cold retrieval tiers"
-      },
-      "qmdTierPromotionValueThreshold": {
-        "type": "number",
-        "default": 0.7,
-        "description": "Value-score threshold at or above which cold memories are eligible for hot promotion"
-      },
-      "qmdUpdateMinIntervalMs": {
-        "type": "number",
-        "default": 900000,
-        "description": "Minimum interval between QMD update executions (ms). Useful because current QMD update runs globally across collections."
-      },
-      "qmdUpdateTimeoutMs": {
-        "type": "number",
-        "default": 90000,
-        "description": "Timeout for QMD update command (ms). Increase if your index grows and updates exceed 30s."
-      },
-      "quarantinePromotionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Reserve future promotion flows from quarantine into higher-trust zones."
-      },
-      "queryAwareIndexingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable temporal and tag indexes (v8.1). Maintains state/index_time.json and state/index_tags.json for fast prefiltering. At recall time, temporal queries and #tag tokens receive a small score boost from the index. Disabled by default."
-      },
-      "queryAwareIndexingMaxCandidates": {
-        "type": "number",
-        "default": 200,
-        "description": "Max candidate paths returned from index prefilter before scoring (0 = no cap)."
-      },
-      "queryExpansionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable heuristic query expansion for retrieval (no LLM calls)."
-      },
-      "queryExpansionMaxQueries": {
-        "type": "number",
-        "default": 4,
-        "description": "Max expanded queries to run (including the original prompt)."
-      },
-      "queryExpansionMinTokenLen": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum token length to include in heuristic query expansion."
-      },
-      "reasoningEffort": {
-        "type": "string",
-        "enum": [
-          "none",
-          "low",
-          "medium",
-          "high"
-        ],
-        "default": "low",
-        "description": "Reasoning effort for extraction"
-      },
-      "recallAuditAnomalyDetectionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, access surfaces (MCP, HTTP) run the anomaly detector over a tail of the audit trail after each recall and surface flags via logs/metrics. Ships disabled — enable explicitly."
-      },
-      "recallAuditAnomalyHighCardinalityLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 50,
-        "description": "Threshold for the high-cardinality-return anomaly flag: number of distinct results returned within the window before flagging."
-      },
-      "recallAuditAnomalyNamespaceWalkLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 3,
-        "description": "Threshold for the namespace-walk anomaly flag: number of distinct namespaces queried within the window before flagging."
-      },
-      "recallAuditAnomalyRapidFireLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 30,
-        "description": "Threshold for the rapid-fire anomaly flag: number of recall requests within the window before flagging."
-      },
-      "recallAuditAnomalyRepeatQueryLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 5,
-        "description": "Threshold for the repeat-query anomaly flag: number of identical queries within the window before flagging."
-      },
-      "recallAuditAnomalyWindowMs": {
-        "type": "number",
         "minimum": 1,
         "default": 300000,
-        "description": "Rolling window (ms) over which audit entries are analyzed by the anomaly detector. Default 5 minutes."
-      },
-      "recallBudgetChars": {
-        "type": "number",
-        "description": "Hard character cap for total recall context. Defaults to maxMemoryTokens * 4."
-      },
-      "recallConfidenceGateEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Synapse-inspired confidence gate: skip memory context when top recall score is below threshold"
-      },
-      "recallConfidenceGateThreshold": {
-        "type": "number",
-        "default": 0.12,
-        "description": "Minimum top recall score to include memories (0-1). Below this, memories are rejected as too uncertain"
-      },
-      "recallCoreDeadlineMs": {
-        "type": "number",
-        "default": 75000,
-        "description": "Default deadline in ms recorded for core recall sections."
-      },
-      "recallCrossNamespaceBudgetEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
-      },
-      "recallCrossNamespaceBudgetHardLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 30,
-        "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
-      },
-      "recallCrossNamespaceBudgetSoftLimit": {
-        "type": "number",
-        "minimum": 0,
-        "default": 10,
-        "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
-      },
-      "recallCrossNamespaceBudgetWindowMs": {
-        "type": "number",
-        "minimum": 1,
-        "default": 60000,
-        "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
-      },
-      "recallDirectAnswerAmbiguityMargin": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.15,
-        "description": "If the second-best candidate scores within this ratio of the top, direct-answer defers to hybrid."
-      },
-      "recallDirectAnswerEligibleTaxonomyBuckets": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "decisions",
-          "principles",
-          "conventions",
-          "runbooks",
-          "entities"
-        ],
-        "description": "Taxonomy category IDs eligible for direct-answer routing."
-      },
-      "recallDirectAnswerEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
-      },
-      "recallDirectAnswerImportanceFloor": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.7,
-        "description": "Minimum calibrated importance score for direct-answer eligibility. Set to 0 to disable the gate."
-      },
-      "recallDirectAnswerTokenOverlapFloor": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.55,
-        "description": "Minimum query↔memory token-overlap ratio for direct-answer eligibility. Set to 0 to disable the gate."
-      },
-      "recallDisclosureEscalation": {
-        "type": "string",
-        "enum": [
-          "manual",
-          "auto"
-        ],
-        "default": "manual",
-        "description": "Disclosure auto-escalation policy (issue #677 PR 4/4). When 'auto', recalls without an explicit caller-supplied disclosure escalate from chunk to section if the top-K confidence falls below recallDisclosureEscalationThreshold. 'raw' is never auto-selected. Default 'manual' preserves pre-#677 behavior."
-      },
-      "recallDisclosureEscalationThreshold": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.5,
-        "description": "Top-K confidence threshold (0-1) below which auto-escalation promotes chunk to section. Only consulted when recallDisclosureEscalation is 'auto'. Default 0.5."
-      },
-      "recallEnrichmentDeadlineMs": {
-        "type": "number",
-        "default": 25000,
-        "description": "Default deadline in ms recorded for enrichment recall sections."
-      },
-      "recallGraphDamping": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 0.999999999,
-        "default": 0.85,
-        "description": "PPR damping factor used by the graph retrieval tier (issue #559)."
-      },
-      "recallGraphEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, recall builds a retrieval graph from memory frontmatter and runs Personalized PageRank, merging the result with QMD via MMR (issue #559 PR 4). Default false — ships off pending the retrieval-graph bench in PR 5."
-      },
-      "recallGraphIterations": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 500,
-        "default": 20,
-        "description": "Maximum power-iteration rounds for PPR. Higher values trade latency for convergence."
-      },
-      "recallGraphTopK": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 10000,
-        "default": 50,
-        "description": "Maximum memories returned by the graph retrieval tier before the MMR diversifier runs."
-      },
-      "recallHandleSnapshotDepth": {
-        "type": "number",
-        "minimum": 1,
-        "maximum": 50,
-        "default": 5,
-        "description": "Issue #1582 — number of recent per-session recall snapshots searched when resolving a `[m:xxxx]` handle to a memory id. Older-than-N snapshots are not searched; a miss is tagged rather than widening the window."
-      },
-      "recallMemoryHandles": {
-        "type": "boolean",
-        "default": false,
-        "description": "Issue #1582 — append stable short handles (`[m:4f2a]`) to injected memory lines at recall render time. Default false: off = byte-identical injection. Token cost ~9 chars/memory; flip the default only with benchmark evidence that answer quality is unaffected."
-      },
-      "recallMemoryWorthFilterEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "When true, recall multiplies candidate scores by the Memory Worth factor (mw_success / mw_fail counters, see issue #560). Memories with a history of failed sessions sink; neutral/uninstrumented memories are untouched. PR 5 bench: +0.60 precision@5 vs baseline on all 50 seeded cases. Operators can opt out with false."
-      },
-      "recallMemoryWorthHalfLifeMs": {
-        "type": "number",
-        "minimum": 0,
-        "default": 0,
-        "description": "Half-life (ms) for Memory Worth decay. Positive values exponentially decay older outcomes toward the neutral prior; 0 disables decay."
-      },
-      "recallMmrEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the included context."
-      },
-      "recallMmrLambda": {
-        "type": "number",
-        "default": 0.7,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "MMR lambda parameter. 1.0 = pure relevance, 0.0 = pure diversity. Default 0.7 tilts toward relevance with meaningful diversity."
-      },
-      "recallMmrTopN": {
-        "type": "number",
-        "default": 40,
-        "minimum": 0,
-        "description": "Number of top candidates per section to run MMR over. Candidates past this remain in original order."
-      },
-      "recallOuterTimeoutMs": {
-        "type": "number",
-        "default": 75000,
-        "description": "Outer timeout in ms for the full recall pipeline."
-      },
-      "recallPipeline": {
-        "type": "array",
-        "description": "Ordered recall sections with per-section budgets and feature knobs.",
-        "items": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string"
-            },
-            "enabled": {
-              "type": "boolean",
-              "default": true
-            },
-            "maxChars": {
-              "type": [
-                "number",
-                "null"
-              ]
-            },
-            "consolidateTriggerLines": {
-              "type": "number"
-            },
-            "consolidateTargetLines": {
-              "type": "number"
-            },
-            "maxEntities": {
-              "type": "number"
-            },
-            "maxResults": {
-              "type": "number"
-            },
-            "maxTurns": {
-              "type": "number"
-            },
-            "maxTokens": {
-              "type": "number"
-            },
-            "lookbackHours": {
-              "type": "number"
-            },
-            "maxCount": {
-              "type": "number"
-            },
-            "topK": {
-              "type": "number"
-            },
-            "timeoutMs": {
-              "type": "number"
-            },
-            "maxPatterns": {
-              "type": "number"
-            },
-            "forceGeneric": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "id"
-          ]
-        }
-      },
-      "recallPlannerEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Use lightweight retrieve-vs-think planning to avoid unnecessary recall work."
-      },
-      "recallPlannerLlmEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt in to LLM-based recall planning (issue #1367). When false, recall mode is decided by the regex heuristic. When true, the configured recallPlannerModel classifies recall intent via the gateway/fallback LLM chain (provider-agnostic) and falls back to the heuristic on timeout/error. Requires recallPlannerEnabled."
-      },
-      "recallPlannerMaxMemoryHints": {
-        "type": "number",
-        "default": 24,
-        "description": "Reserved. Caps recent-memory hints in the recall planner prompt when a caller supplies them; the default recall path does not populate hints (the LLM planner classifies on the prompt alone)."
-      },
-      "recallPlannerMaxPromptChars": {
-        "type": "number",
-        "default": 4000,
-        "description": "Maximum characters of prompt context to send to the recall planner."
-      },
-      "recallPlannerMaxQmdResultsFull": {
-        "type": "number",
-        "default": 8,
-        "description": "QMD cap used when recall planner selects full mode."
-      },
-      "recallPlannerMaxQmdResultsMinimal": {
-        "type": "number",
-        "default": 4,
-        "description": "QMD cap used when recall planner selects minimal mode."
-      },
-      "recallPlannerModel": {
-        "type": "string",
-        "default": "gpt-5.5",
-        "description": "Model for LLM-based recall planning (recallPlannerLlmEnabled). A 'provider/model' string resolved through the gateway providers/chain — any configured provider works (OpenAI, Anthropic, Ollama, Codex, gateway personas). Tried first, with taskModelChain / gateway defaults as fallback."
-      },
-      "recallPlannerShadowMode": {
-        "type": "boolean",
-        "default": false,
-        "description": "Run recall planner in shadow mode — evaluate but do not apply results."
-      },
-      "recallPlannerTelemetryEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Emit telemetry events for recall planner decisions."
-      },
-      "recallPlannerTimeoutMs": {
-        "type": "number",
-        "default": 1500,
-        "description": "Timeout in ms for recall planner inference."
-      },
-      "recallPlannerUseResponsesApi": {
-        "type": "boolean",
-        "default": true,
-        "description": "Reserved. The chat vs Responses API dialect is chosen per-provider by the gateway/fallback client based on each provider's api field, so this flag does not override routing; OpenAI providers already use Responses (gotcha #1)."
-      },
-      "recallReasoningTraceBoostEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Boost stored reasoning_trace memories in recall results when the incoming query reads like a problem-solving ask (e.g. 'how do I...', 'step by step', 'walk me through...'). Default false - opt in after benchmarking (issue #564)."
-      },
-      "recallTranscriptRetentionDays": {
+        "description": "Max gap (ms) between two conversations to merge into one fused cluster."
+       },
+       "windowToleranceMs": {
         "type": "integer",
         "minimum": 1,
-        "maximum": 365,
-        "default": 30,
-        "description": "Days of runtime recall audit transcripts to retain before pruning."
-      },
-      "recallTranscriptsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Write JSONL recall audit transcripts for runtime recall-context assembly."
-      },
-      "recencyWeight": {
-        "type": "number",
-        "default": 0.2,
-        "description": "Weight for recency boosting in search (0-1)"
-      },
-      "recordEmptyRecallImpressions": {
-        "type": "boolean",
-        "default": false,
-        "description": "Record recall impressions with empty memoryIds when no memory context is added."
-      },
-      "reinforcementRecallBoostEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, memories with reinforcement_count frontmatter receive an additive recall score boost (issue #687 PR 3/4). Default: false (opt-in)."
-      },
-      "reinforcementRecallBoostMax": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.3,
-        "description": "Maximum additive reinforcement boost per result. Range [0, 1]. Default: 0.3."
-      },
-      "reinforcementRecallBoostWeight": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.05,
-        "description": "Score bonus per unit of reinforcement_count (weight * count, capped at max). Range [0, 1]. Default: 0.05."
-      },
-      "remoteSearchApiKey": {
-        "type": "string",
-        "description": "API key for remote search backend (when searchBackend=remote)"
-      },
-      "remoteSearchBaseUrl": {
-        "type": "string",
-        "description": "Base URL for remote search backend (when searchBackend=remote)"
-      },
-      "remoteSearchTimeoutMs": {
-        "type": "number",
         "default": 30000,
-        "description": "Timeout in ms for remote search backend requests"
-      },
-      "rerankCacheEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Cache re-ranking results in-memory for repeated queries."
-      },
-      "rerankCacheTtlMs": {
-        "type": "number",
-        "default": 3600000,
-        "description": "TTL for in-memory re-ranking cache (ms)."
-      },
-      "rerankEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable LLM re-ranking of retrieved memories. Default off."
-      },
-      "rerankMaxCandidates": {
-        "type": "number",
-        "default": 20,
-        "description": "Max candidates to send to the re-ranker."
-      },
-      "rerankProvider": {
-        "type": "string",
-        "default": "local",
-        "description": "Re-ranking provider: 'local' uses local LLM only. 'cloud' is reserved/experimental (currently treated as no-op).",
-        "enum": [
-          "local",
-          "cloud"
-        ]
-      },
-      "rerankTimeoutMs": {
-        "type": "number",
-        "default": 8000,
-        "description": "Timeout for re-ranking requests (ms). Fail-open on timeout."
-      },
-      "respectBundledActiveMemoryToggle": {
-        "type": "boolean",
-        "default": true,
-        "description": "Compat-only (issue #1550): honor the bundled active-memory session toggle file when resolving Remnic recall toggles. Modern OpenClaw memory-slot mode + registerMemoryPromptSection is the primary prompt-injection path; this knob only matters when explicitly chaining Remnic active recall into the bundled `active-memory` plugin."
-      },
-      "responseGuidanceRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable response guidance recall for user answer-shape preferences."
-      },
-      "responseGuidanceRecallMaxChars": {
-        "type": "integer",
-        "default": 2400,
-        "minimum": 0,
-        "description": "Character budget for the response guidance recall section."
-      },
-      "responseGuidanceRecallMaxResults": {
-        "type": "integer",
-        "default": 48,
-        "minimum": 0,
-        "description": "Maximum recalled items for response guidance."
-      },
-      "responseGuidanceRecallScanWindowTokens": {
-        "type": "integer",
-        "default": 16000,
-        "minimum": 1,
-        "description": "Recent-token scan window for response guidance."
-      },
-      "responseGuidanceRecallScanWindowTurns": {
-        "type": "integer",
-        "default": 64,
-        "minimum": 1,
-        "description": "Recent-turn scan window for response guidance."
-      },
-      "resumeBundleDir": {
-        "type": "string",
-        "description": "Override the resume-bundle directory (defaults to {memoryDir}/state/resume-bundles)."
-      },
-      "resumeBundlesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable deterministic resume-bundle storage and operator-facing handoff bundle commands."
-      },
-      "routingRulesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable custom memory routing rules (v8.7). Default off."
-      },
-      "routingRulesStateFile": {
-        "type": "string",
-        "default": "state/routing-rules.json",
-        "description": "Relative path under memoryDir for persisted routing rules."
-      },
-      "scopeProfiles": {
-        "type": "object",
-        "default": {},
-        "description": "Optional hosted-team memory scope profiles. Profiles define ordered read layers, the default write layer, and authorized promotion target aliases without changing behavior when absent.",
-        "additionalProperties": {
-          "type": "object",
-          "properties": {
-            "readOrder": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "userProject",
-                  "teamProject",
-                  "userGlobal",
-                  "serverShared"
-                ]
-              }
-            },
-            "writeDefault": {
-              "type": "string",
-              "enum": [
-                "userProject",
-                "teamProject",
-                "userGlobal",
-                "serverShared"
-              ]
-            },
-            "promotionTargets": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "userProject",
-                  "teamProject",
-                  "userGlobal",
-                  "serverShared"
-                ]
-              }
-            },
-            "teamProject": {
-              "type": "object",
-              "properties": {
-                "namespaceTemplate": {
-                  "type": "string"
-                },
-                "teamId": {
-                  "type": "string"
-                }
-              }
-            },
-            "autoPromote": {
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "type": "boolean"
-                },
-                "targets": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "teamProject",
-                      "serverShared",
-                      "userGlobal",
-                      "userProject"
-                    ]
-                  }
-                },
-                "categories": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "minConfidenceTier": {
-                  "type": "string",
-                  "enum": [
-                    "explicit",
-                    "implied",
-                    "inferred",
-                    "speculative"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "searchBackend": {
-        "type": "string",
-        "enum": [
-          "qmd",
-          "remote",
-          "noop",
-          "lancedb",
-          "meilisearch",
-          "orama"
-        ],
-        "default": "qmd",
-        "description": "Search backend: qmd (local hybrid), remote (HTTP REST), noop (disabled), lancedb (embedded hybrid), meilisearch (server-based), orama (embedded JS)"
-      },
-      "secureStoreEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable at-rest AES-256-GCM encryption for memory files (issue #690). When true, the daemon reads and writes memory files through the secure-fs layer. The store must be unlocked via `remnic secure-store unlock` after each daemon start. Default false."
-      },
-      "secureStoreEncryptOnWrite": {
-        "type": "boolean",
-        "default": true,
-        "description": "When secureStoreEnabled is true, encrypt new memory writes. Set to false to pause new encryptions while still decrypting existing encrypted files (useful during incremental migration). Default true."
-      },
-      "semanticChunkingConfig": {
-        "type": "object",
-        "default": {},
-        "description": "Optional overrides for the semantic chunking algorithm",
-        "properties": {
-          "targetTokens": {
-            "type": "number",
-            "default": 200,
-            "description": "Target tokens per chunk"
-          },
-          "minTokens": {
-            "type": "number",
-            "default": 100,
-            "description": "Minimum tokens for a segment before merging with neighbor"
-          },
-          "maxTokens": {
-            "type": "number",
-            "default": 400,
-            "description": "Maximum tokens for a segment before recursive splitting"
-          },
-          "smoothingWindowSize": {
-            "type": "number",
-            "default": 3,
-            "description": "Window size for the moving-average smoothing filter (auto-rounded to odd)"
-          },
-          "boundaryThresholdStdDevs": {
-            "type": "number",
-            "default": 1,
-            "description": "Standard deviations below mean for boundary detection"
-          },
-          "embeddingBatchSize": {
-            "type": "number",
-            "default": 32,
-            "description": "Batch size for embedding requests"
-          },
-          "fallbackToRecursive": {
-            "type": "boolean",
-            "default": true,
-            "description": "Fall back to recursive chunking when embeddings are unavailable"
-          }
-        }
-      },
-      "semanticChunkingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable semantic chunking with embedding-based topic boundary detection (requires embedding provider)"
-      },
-      "semanticConsolidationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable periodic semantic consolidation of similar memories."
-      },
-      "semanticConsolidationExcludeCategories": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "correction",
-          "commitment",
-          "procedure"
-        ],
-        "description": "Memory categories excluded from semantic consolidation."
-      },
-      "semanticConsolidationIntervalHours": {
-        "type": "number",
-        "default": 168,
-        "description": "Hours between automatic consolidation runs (168 = weekly)."
-      },
-      "semanticConsolidationMaxPerRun": {
-        "type": "number",
-        "default": 100,
-        "description": "Max memories to consolidate per run to limit LLM cost."
-      },
-      "semanticConsolidationMinClusterSize": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum cluster size before consolidation triggers."
-      },
-      "semanticConsolidationModel": {
-        "type": "string",
-        "default": "auto",
-        "description": "LLM for consolidation synthesis: 'auto' (primary model), 'fast' (fast local model), or a specific model name."
-      },
-      "semanticConsolidationThreshold": {
-        "type": "number",
-        "default": 0.8,
-        "description": "Token overlap threshold (0-1) for grouping similar memories. 0.8=conservative, 0.6=aggressive."
-      },
-      "semanticDedupCandidates": {
-        "type": "number",
-        "default": 5,
-        "minimum": 0,
-        "description": "Number of nearest-neighbor candidates to inspect during the write-time semantic dedup check. Set to 0 to disable the embedding lookup entirely (equivalent to semanticDedupEnabled=false)."
-      },
-      "semanticDedupEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Issue #373 — enable write-time semantic similarity guard that skips near-duplicate facts by comparing embeddings to existing memories. Fails open when the embedding backend is unavailable."
-      },
-      "semanticDedupThreshold": {
-        "type": "number",
-        "default": 0.92,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Cosine similarity threshold in [0, 1]. Candidate facts whose nearest neighbor scores at or above this value are treated as duplicates and skipped."
-      },
-      "semanticRulePromotionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable deterministic promotion of explicit IF/THEN rules from verified episodic memories."
-      },
-      "semanticRuleVerificationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Verify promoted semantic rules against their cited source episodes at recall time before surfacing them in recall."
-      },
-      "sessionObserverBands": {
-        "type": "array",
-        "description": "Session size bands and growth thresholds for heartbeat observer triggers.",
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "maxBytes": {
-              "type": "number"
-            },
-            "triggerDeltaBytes": {
-              "type": "number"
-            },
-            "triggerDeltaTokens": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "maxBytes",
-            "triggerDeltaBytes",
-            "triggerDeltaTokens"
-          ]
-        },
-        "default": [
-          {
-            "maxBytes": 50000,
-            "triggerDeltaBytes": 4800,
-            "triggerDeltaTokens": 1200
-          },
-          {
-            "maxBytes": 200000,
-            "triggerDeltaBytes": 9600,
-            "triggerDeltaTokens": 2400
-          },
-          {
-            "maxBytes": 1000000000,
-            "triggerDeltaBytes": 19200,
-            "triggerDeltaTokens": 4800
-          }
-        ]
-      },
-      "sessionObserverDebounceMs": {
-        "type": "number",
-        "default": 120000,
-        "description": "Minimum interval between heartbeat observer triggers per session (ms)."
-      },
-      "sessionObserverEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable heartbeat-driven active session observer checks for proactive extraction triggers."
-      },
-      "sessionTogglesEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable per-session recall toggle state for OpenClaw runtime surfaces."
-      },
-      "sharedContextDir": {
-        "type": "string",
-        "description": "Override shared-context directory (default: ~/.openclaw/workspace/shared-context)."
-      },
-      "sharedContextEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable shared-context assembly and tools (v4.0). Default off."
-      },
-      "sharedContextMaxInjectChars": {
-        "type": "number",
-        "default": 4000,
-        "description": "Max characters of shared-context to include in each recall context."
-      },
-      "sharedCrossSignalSemanticEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable semantic cross-signal enhancer during shared-context daily curation."
-      },
-      "sharedCrossSignalSemanticMaxCandidates": {
-        "type": "number",
-        "default": 120,
-        "description": "Maximum candidate topic tokens considered by semantic cross-signal enhancer."
-      },
-      "sharedCrossSignalSemanticTimeoutMs": {
-        "type": "number",
-        "default": 4000,
-        "description": "Timeout budget for shared-context semantic cross-signal enhancer (ms)."
-      },
-      "sharedNamespace": {
-        "type": "string",
-        "default": "shared",
-        "description": "Shared namespace name."
-      },
-      "slotBehavior": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "requireExclusiveMemorySlot": {
-            "type": "boolean",
-            "default": true
-          },
-          "onSlotMismatch": {
-            "type": "string",
-            "enum": [
-              "error",
-              "warn",
-              "silent"
-            ],
-            "default": "error"
-          }
-        }
-      },
-      "slowLogEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If enabled, log slow operations (durations + metadata; never logs content)"
-      },
-      "slowLogThresholdMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Threshold for slow operation logging (ms)"
-      },
-      "summarizationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic memory summarization/compression"
-      },
-      "summarizationImportanceThreshold": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Only compress memories with importance below this threshold"
-      },
-      "summarizationProtectedTags": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "commitment",
-          "preference",
-          "decision",
-          "principle"
-        ],
-        "description": "Tags that protect memories from compression"
-      },
-      "summarizationRecentToKeep": {
-        "type": "number",
-        "default": 300,
-        "description": "Number of recent memories to keep uncompressed"
-      },
-      "summarizationTriggerCount": {
-        "type": "number",
-        "default": 1000,
-        "description": "Memory count threshold to trigger summarization"
-      },
-      "summaryModel": {
-        "type": "string",
-        "description": "Model for hourly summaries (defaults to main model)"
-      },
-      "summaryRecallHours": {
-        "type": "number",
-        "default": 24,
-        "description": "Hours of summary history to recall"
-      },
-      "tagIndexMaxEntries": {
-        "type": "number",
-        "default": 10000,
-        "description": "Maximum number of entries in the tag index."
-      },
-      "tagMaxPerMemory": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum number of tags assigned per memory."
-      },
-      "tagMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable tag-based memory indexing and recall boosting."
-      },
-      "tagRecallBoost": {
-        "type": "number",
-        "default": 0.15,
-        "description": "Score boost applied to memories whose tags match the query."
-      },
-      "tagRecallMaxMatches": {
-        "type": "number",
-        "default": 10,
-        "description": "Maximum number of tag-matched memories added per recall."
-      },
-      "targetedFactRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable targeted fact evidence recall for direct answer questions."
-      },
-      "targetedFactRecallMaxChars": {
-        "type": "integer",
-        "default": 2400,
-        "minimum": 0,
-        "description": "Character budget for the targeted fact evidence recall section."
-      },
-      "targetedFactRecallMaxResults": {
-        "type": "integer",
-        "default": 48,
-        "minimum": 0,
-        "description": "Maximum recalled items for targeted fact evidence."
-      },
-      "targetedFactRecallScanWindowTokens": {
-        "type": "integer",
-        "default": 12000,
-        "minimum": 1,
-        "description": "Recent-token scan window for targeted fact evidence."
-      },
-      "targetedFactRecallScanWindowTurns": {
-        "type": "integer",
-        "default": 8,
-        "minimum": 1,
-        "description": "Recent-turn scan window for targeted fact evidence."
-      },
-      "taskModelChain": {
-        "type": "object",
-        "description": "Optional task-specific gateway model chain for Remnic's background LLM work (extraction, fact/profile/identity consolidation, summarization, causal consolidation). When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model. Only applies when modelSource is 'gateway'.",
-        "required": [
-          "primary"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "primary": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
-          },
-          "fallbacks": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "minLength": 1
-            },
-            "default": [],
-            "description": "Fallback gateway models tried after primary"
-          }
-        }
-      },
-      "taxonomyAutoGenResolver": {
-        "type": "boolean",
-        "default": true,
-        "description": "Auto-regenerate RESOLVER.md when the taxonomy changes."
-      },
-      "taxonomyEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the MECE taxonomy knowledge directory for categorizing memories."
-      },
-      "teams": {
-        "type": "object",
-        "default": {},
-        "description": "Trusted team membership and team-project namespace templates used by scopeProfiles.",
-        "additionalProperties": {
-          "type": "object",
-          "properties": {
-            "principals": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "projectNamespaceTemplate": {
-              "type": "string"
-            },
-            "read": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "write": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "promote": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
-      "temporalBiTemporal": {
-        "type": "boolean",
-        "default": false,
-        "description": "Bi-temporal validity master gate (issue #1578). When false (default), recall behaves byte-identically to pre-#1578. Turn on to exclude validity-expired facts from default injection candidates (they stay findable by explicit search and as_of). Storage round-trips observedAt/eventTimeSource; extraction event-time write-time wiring lands in a follow-on PR."
-      },
-      "temporalBoostRecentDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Memories from the last N days receive a recency boost during recall."
-      },
-      "temporalBoostScore": {
-        "type": "number",
-        "default": 0.15,
-        "description": "Score boost applied to recent memories during recall."
-      },
-      "temporalDecayEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Apply temporal decay to older memories during recall scoring."
-      },
-      "temporalExpiredInInjection": {
-        "type": "boolean",
-        "default": false,
-        "description": "Escape hatch for the bi-temporal injection filter (issue #1578). When true, facts whose [valid_at, invalid_at) interval ended before now are kept in injection candidates even with temporalBiTemporal on — some deployments prefer the older (always-inject) behavior."
-      },
-      "temporalIndexMaxEntries": {
-        "type": "number",
-        "default": 5000,
-        "description": "Maximum number of entries in the temporal index."
-      },
-      "temporalIndexWindowDays": {
-        "type": "number",
-        "default": 30,
-        "description": "Number of days to include in the temporal index window."
-      },
-      "temporalMemoryTreeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Build a hierarchical memory summary tree (hour/day/week/persona nodes). Default: false."
-      },
-      "temporalSupersessionEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Mark older facts superseded when a new fact writes a conflicting value for the same entityRef + structuredAttribute key (issue #375)"
-      },
-      "temporalSupersessionIncludeInRecall": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, include temporally-superseded facts in recall results (for audit/history). Default: exclude."
-      },
-      "threadingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable conversation threading"
-      },
-      "threadingGapMinutes": {
-        "type": "number",
-        "default": 30,
-        "description": "Minutes of gap to start a new thread"
-      },
-      "timeGraphEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Build temporal sequence graph within threads (requires multiGraphMemoryEnabled). Default true."
-      },
-      "tmtHourlyMinMemories": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum new memories in an hour to trigger an hour-level TMT node. Default: 3."
-      },
-      "tmtSummaryMaxTokens": {
-        "type": "number",
-        "default": 300,
-        "description": "Max tokens for each TMT summary node. Default: 300."
-      },
-      "tombstonesEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Master gate for the tombstone non-resurrection invariant (#1579). When true, a fact that matches an active tombstone at the storage chokepoint is persisted as pending_review + blockedBy instead of becoming active — visible, never a silent drop. Off restores pre-feature behavior for rollback safety."
-      },
-      "tombstonesSemanticMatch": {
-        "type": "boolean",
-        "default": false,
-        "description": "Tier-4 semantic tombstone matching (#1579). Off by default; when true the tombstone lookup also checks embedding cosine similarity against tombstoned normalized text. Ships dark until MemCorrect (#1584) shows an acceptable false-block rate."
-      },
-      "tombstonesSemanticThreshold": {
-        "type": "number",
-        "default": 0.9,
-        "description": "Cosine threshold for tier-4 semantic tombstone matching. Only consulted when tombstonesSemanticMatch is true."
-      },
-      "topicExtractionEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable topic extraction during consolidation"
-      },
-      "topicExtractionTopN": {
-        "type": "number",
-        "default": 50,
-        "description": "Number of top topics to extract"
-      },
-      "traceRecallContent": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default - only enable when you want external trace collectors to capture memory context."
-      },
-      "traceWeaverEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Trace Weaving (v8.0 Phase 2A). Links recurring topic boxes with a shared traceId."
-      },
-      "traceWeaverLookbackDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Days back to search for trace links."
-      },
-      "traceWeaverOverlapThreshold": {
-        "type": "number",
-        "default": 0.4,
-        "description": "Minimum Jaccard topic overlap to assign the same traceId (0–1)."
-      },
-      "transcriptEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable transcript archiving"
-      },
-      "transcriptRecallHours": {
-        "type": "number",
-        "default": 12,
-        "description": "Hours of transcript history to recall"
-      },
-      "transcriptRetentionDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Days to retain transcript entries"
-      },
-      "transcriptSkipChannelTypes": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "cron"
-        ],
-        "description": "Channel types to skip from transcript logging (e.g., cron)"
-      },
-      "triggerMode": {
-        "type": "string",
-        "enum": [
-          "smart",
-          "every_n",
-          "time_based"
-        ],
-        "default": "smart",
-        "description": "Buffer trigger mode"
-      },
-      "trustScoreEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Master gate for the unified TrustScore recall stage (#1577). When off the stage is absent and ranking is byte-identical to the pre-feature pipeline. Flip via #1574 ablation evidence only."
-      },
-      "trustScoreEpistemicRendering": {
-        "type": "boolean",
-        "default": false,
-        "description": "Append deterministic trust hedges to injected memory lines so the downstream model knows each memory's epistemic status (#1577). Separate gate from scoring."
-      },
-      "trustScoreMaxMultiplier": {
-        "type": "number",
-        "default": 1.25,
-        "description": "Upper bound of the trust multiplier mapping [0,1] → [minMultiplier, maxMultiplier] (#1577)."
-      },
-      "trustScoreMinMultiplier": {
-        "type": "number",
-        "default": 0.5,
-        "description": "Lower bound of the trust multiplier mapping [0,1] → [minMultiplier, maxMultiplier] (#1577)."
-      },
-      "trustScoreQuarantine": {
-        "type": "boolean",
-        "default": true,
-        "description": "Exclude hard-negative (quarantine-band) memories from injection while keeping them visible in X-ray with the reason (#1577). Only effective under trustScoreEnabled."
-      },
-      "trustScoreWeights": {
-        "type": "object",
-        "description": "Per-component trust weights (#1577). Keys: memoryWorth, provenance, faithfulness, corroboration, contradiction, domainCalibration, feedback, recency. Values are numbers in [0,1]; sum-normalized at parse. Invalid entries are dropped (rule 51).",
-        "default": {},
-        "properties": {
-          "memoryWorth": {
-            "type": "number"
-          },
-          "provenance": {
-            "type": "number"
-          },
-          "faithfulness": {
-            "type": "number"
-          },
-          "corroboration": {
-            "type": "number"
-          },
-          "contradiction": {
-            "type": "number"
-          },
-          "domainCalibration": {
-            "type": "number"
-          },
-          "feedback": {
-            "type": "number"
-          },
-          "recency": {
-            "type": "number"
-          }
-        }
-      },
-      "trustZoneRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant working and trusted trust-zone records to recall context."
-      },
-      "trustZoneStoreDir": {
-        "type": "string",
-        "description": "Override the trust-zone store directory (defaults to {memoryDir}/state/trust-zones)."
-      },
-      "trustZonesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Engram's trust-zone memory foundation for quarantine, working, and trusted records."
-      },
-      "verbatimArtifactCategories": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "enum": [
-            "fact",
-            "preference",
-            "correction",
-            "entity",
-            "decision",
-            "relationship",
-            "principle",
-            "commitment",
-            "moment",
-            "skill",
-            "procedure"
-          ]
-        },
-        "default": [
-          "decision",
-          "correction",
-          "principle",
-          "commitment"
-        ],
-        "description": "Memory categories eligible for artifact extraction."
-      },
-      "verbatimArtifactsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Write quote-first artifact anchors during extraction and include them in recall."
-      },
-      "verbatimArtifactsMaxRecall": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum artifact anchors added per recall."
-      },
-      "verbatimArtifactsMinConfidence": {
-        "type": "number",
-        "default": 0.8,
-        "description": "Minimum extraction confidence required before writing an artifact."
-      },
-      "verboseRecallVisibility": {
-        "type": "boolean",
-        "default": true,
-        "description": "Allow verbose recall headers to surface runtime recall diagnostics in prompts."
-      },
-      "verifiedRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
-      },
-      "versioningEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable page-level versioning with sidecar snapshots."
-      },
-      "versioningMaxPerPage": {
-        "type": "integer",
-        "default": 50,
-        "minimum": 0,
-        "description": "Maximum number of version snapshots per page. Set to 0 to disable pruning."
-      },
-      "versioningSidecarDir": {
-        "type": "string",
-        "default": ".versions",
-        "description": "Name of the sidecar directory inside memoryDir for version snapshots."
-      },
-      "wearables": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "description": "Wearable transcript ingestion (Limitless / Bee / Omi). Connector packages install a la carte: @remnic/connector-limitless, @remnic/connector-bee, @remnic/connector-omi. See docs/wearables.md.",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Master gate for the wearables subsystem."
-          },
-          "timezone": {
-            "type": "string",
-            "description": "IANA timezone used to bucket transcripts into days. Defaults to the host timezone."
-          },
-          "redactionEnabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "Redact SSN / payment-card patterns from transcripts before storage and extraction."
-          },
-          "redactionPatterns": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "default": [],
-            "description": "Additional user-supplied redaction regexes (validated at config load)."
-          },
-          "offTheRecordEnabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "Honor a spoken 'off the record' marker by eliding segments until 'back on the record'."
-          },
-          "digestEnabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "Write one compact daily-digest memory per synced source/day."
-          },
-          "autoSyncEnabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "Periodically refresh transcripts in-process on long-lived hosts. Every tick re-syncs a rolling window ending today (existing day files included)."
-          },
-          "autoSyncIntervalMinutes": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 1440,
-            "default": 15,
-            "description": "Minutes between auto-sync ticks."
-          },
-          "autoSyncDays": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 90,
-            "default": 2,
-            "description": "Rolling window (days ending today) refreshed on each auto-sync tick."
-          },
-          "autoSyncDeepDays": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 90,
-            "default": 7,
-            "description": "Once-per-local-day deep refresh window (days) for late uploads and provider re-processing. 0 disables; otherwise must be >= autoSyncDays."
-          },
-          "corrections": {
-            "type": "array",
-            "default": [],
-            "description": "User-specific transcript correction rules applied on every sync (merged with CLI-managed rules).",
-            "items": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "match",
-                "replace"
-              ],
-              "properties": {
-                "match": {
-                  "type": "string",
-                  "description": "Text (or regex when regex=true) to match."
-                },
-                "replace": {
-                  "type": "string",
-                  "description": "Replacement text."
-                },
-                "regex": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "Treat match as a regular expression."
-                },
-                "caseInsensitive": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "Case-insensitive matching."
-                },
-                "sources": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Restrict the rule to specific source ids."
-                }
-              }
-            }
-          },
-          "sources": {
-            "type": "object",
-            "default": {},
-            "description": "Per-source settings keyed by connector id (limitless, bee, omi, or a custom connector id).",
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "enabled": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "Enable syncing from this wearable source."
-                },
-                "apiKey": {
-                  "type": "string",
-                  "description": "Provider API credential. Prefer the per-connector environment variable (e.g. ${LIMITLESS_API_KEY}); a config value takes precedence when both are set."
-                },
-                "baseUrl": {
-                  "type": "string",
-                  "description": "Override the provider base URL (self-hosted / local-proxy setups, e.g. the Bee local proxy)."
-                },
-                "appId": {
-                  "type": "string",
-                  "description": "Omi only: integration app id (the {app_id} path component of the Omi Integrations API)."
-                },
-                "userId": {
-                  "type": "string",
-                  "description": "Omi only: target user id supplied as the uid query parameter."
-                },
-                "memoryMode": {
-                  "type": "string",
-                  "enum": [
-                    "off",
-                    "review",
-                    "auto",
-                    "smart"
-                  ],
-                  "default": "smart",
-                  "description": "Memory creation trust gate: smart (default) = LLM-judge + per-source trust prior + cross-device corroboration decide active/review/drop automatically; off = transcripts only; review = every candidate lands pending_review; auto = deterministic gates only, survivors active."
-                },
-                "sourceTrust": {
-                  "type": "number",
-                  "minimum": 0,
-                  "maximum": 1,
-                  "default": 0.8,
-                  "description": "Trust prior for this source's transcription quality (0..1). Multiplies extraction confidence in smart mode — lower it for a device that mis-transcribes often."
-                },
-                "autoApproveTrust": {
-                  "type": "number",
-                  "minimum": 0,
-                  "maximum": 1,
-                  "default": 0.7,
-                  "description": "Smart mode: trust score at/above which facts are written active."
-                },
-                "reviewTrust": {
-                  "type": "number",
-                  "minimum": 0,
-                  "maximum": 1,
-                  "default": 0.45,
-                  "description": "Smart mode: trust score at/above which borderline facts are queued for review instead of dropped. Must be below autoApproveTrust."
-                },
-                "minConfidence": {
-                  "type": "number",
-                  "minimum": 0,
-                  "maximum": 1,
-                  "default": 0.6,
-                  "description": "Drop extracted facts below this confidence."
-                },
-                "minImportance": {
-                  "type": "string",
-                  "enum": [
-                    "trivial",
-                    "low",
-                    "normal",
-                    "high",
-                    "critical"
-                  ],
-                  "default": "low",
-                  "description": "Drop extracted facts scored below this importance level."
-                },
-                "maxMemoriesPerDay": {
-                  "type": "integer",
-                  "minimum": 0,
-                  "default": 0,
-                  "description": "Cap on memories created per source per day. 0 (the default) disables the cap."
-                },
-                "importNativeMemories": {
-                  "type": "string",
-                  "enum": [
-                    "off",
-                    "review",
-                    "smart"
-                  ],
-                  "default": "smart",
-                  "description": "Import provider-extracted memories (Bee facts / Omi memories): smart (default) routes them through the same judge + trust pipeline with a reduced prior; review always queues; off skips."
-                },
-                "cleanup": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "default": {},
-                  "properties": {
-                    "mergeSameSpeaker": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Merge consecutive same-speaker segments."
-                    },
-                    "stripFillers": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Strip standalone filler tokens (um, uh, ...)."
-                    },
-                    "collapseRepeats": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Collapse immediately repeated phrases (ASR stutter)."
-                    },
-                    "dropLowQuality": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Drop segments that look like ASR garbage."
-                    },
-                    "preserveUtteranceBoundaries": {
-                      "type": "boolean",
-                      "default": false,
-                      "description": "Keep utterance-level boundaries (one segment per utterance) instead of merging consecutive same-speaker segments. Defaults off; Bee enables this by default. (issue #1811)"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "fusion": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "Cross-source fusion of multi-source wearable transcripts into one reconciled artifact per real-world conversation (issue #1810). Deterministic and disabled by default.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate for cross-source fusion. When false, no fusion artifacts are written and no behavior changes."
-              },
-              "proximityGapMs": {
-                "type": "integer",
-                "minimum": 1,
-                "default": 300000,
-                "description": "Max gap (ms) between two conversations to merge into one fused cluster."
-              },
-              "windowToleranceMs": {
-                "type": "integer",
-                "minimum": 1,
-                "default": 30000,
-                "description": "Max drift (ms) for two segments to align across sources."
-              }
-            }
-          }
-        }
-      },
-      "workIndexAutoRebuildDebounceMs": {
-        "type": "number",
-        "default": 1000,
-        "description": "Debounce delay in ms before triggering auto-rebuild of the work index."
-      },
-      "workIndexAutoRebuildEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Automatically rebuild the work index when tasks or projects change."
-      },
-      "workIndexDir": {
-        "type": "string",
-        "description": "Override the work index directory (defaults to {memoryDir}/work/index)."
-      },
-      "workIndexEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable search index for work tasks and projects."
-      },
-      "workProductLedgerDir": {
-        "type": "string",
-        "description": "Override the work-product ledger directory (defaults to {memoryDir}/state/work-product-ledger)."
-      },
-      "workProductRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
-      },
-      "workProjectIndexEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include projects in the work search index."
-      },
-      "workProjectsDir": {
-        "type": "string",
-        "description": "Override the work projects directory (defaults to {memoryDir}/work/projects)."
-      },
-      "workProjectsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable project tracking within the work product system."
-      },
-      "workTaskIndexEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include tasks in the work search index."
-      },
-      "workTasksDir": {
-        "type": "string",
-        "description": "Override the work tasks directory (defaults to {memoryDir}/work/tasks)."
-      },
-      "workTasksEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable task tracking within the work product system."
-      },
-      "workspaceDir": {
-        "type": "string",
-        "description": "Override workspace directory path"
+        "description": "Max drift (ms) for two segments to align across sources."
+       }
       }
+     }
     }
-  },
-  "uiHints": {
-    "openaiApiKey": {
-      "label": "OpenAI API Key",
-      "sensitive": true,
-      "placeholder": "sk-...",
-      "help": "Optional API key for plugin mode only. Not needed when Model Source is gateway."
-    },
-    "openaiBaseUrl": {
-      "label": "OpenAI Base URL",
-      "advanced": true,
-      "placeholder": "https://api.openai.com/v1",
-      "help": "Override for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
-    },
-    "model": {
-      "label": "Extraction Model",
-      "advanced": true,
-      "placeholder": "gpt-5.5"
-    },
-    "reasoningEffort": {
-      "label": "Reasoning Effort",
-      "advanced": true
-    },
-    "triggerMode": {
-      "label": "Trigger Mode",
-      "advanced": true
-    },
-    "bufferMaxTurns": {
-      "label": "Buffer Max Turns",
-      "advanced": true,
-      "placeholder": "5"
-    },
-    "bufferMaxMinutes": {
-      "label": "Buffer Max Minutes",
-      "advanced": true,
-      "placeholder": "15"
-    },
-    "consolidateEveryN": {
-      "label": "Consolidation Frequency",
-      "advanced": true,
-      "placeholder": "3"
-    },
-    "maxMemoryTokens": {
-      "label": "Max Memory Tokens",
-      "advanced": true,
-      "placeholder": "2000"
-    },
-    "memoryOsPreset": {
-      "label": "Memory OS Preset",
-      "advanced": true,
-      "help": "Optional preset: conservative, balanced, research-max, or local-llm-heavy. `research` remains accepted as a backward-compatible alias. Explicit settings still win."
-    },
-    "qmdEnabled": {
-      "label": "Enable QMD",
-      "help": "Enable QMD for memory search/indexing"
-    },
-    "hostEmbeddingProviderEnabled": {
-      "label": "Use Host Embeddings",
-      "advanced": true,
-      "help": "Prefer OpenClaw's registered embedding providers when available; Remnic falls back automatically."
-    },
-    "hostEmbeddingProviderId": {
-      "label": "Host Embedding Provider",
-      "advanced": true,
-      "placeholder": "openai-compatible"
-    },
-    "hostEmbeddingProviderModel": {
-      "label": "Host Embedding Model",
-      "advanced": true,
-      "placeholder": "text-embedding-3-small"
-    },
-    "openclawMessageReceivedCaptureEnabled": {
-      "label": "Capture Inbound Messages",
-      "advanced": true,
-      "help": "Use OpenClaw message_received transcript capture when the host emits it."
-    },
-    "openclawReplyMetadataCaptureEnabled": {
-      "label": "Capture Reply Metadata",
-      "advanced": true,
-      "help": "Store bounded message/thread/reply fields in transcript metadata."
-    },
-    "openclawReplyMetadataExtractionHintsEnabled": {
-      "label": "Use Reply Extraction Hints",
-      "advanced": true,
-      "help": "Include bounded quoted-reply context in extraction prompts. Off by default."
-    },
-    "openclawChannelEnvelopeCleaningEnabled": {
-      "label": "Clean Channel Envelopes",
-      "advanced": true,
-      "help": "Use OpenClaw's canonical channel envelope prefixes when available."
-    },
-    "openclawFlushPlanProcessingEnabled": {
-      "label": "Process Flush Plans",
-      "advanced": true,
-      "help": "Have Remnic ingest and clear OpenClaw's append-only flush-plan file. Disable when OpenClaw owns this lifecycle natively."
-    },
-    "qmdCollection": {
-      "label": "QMD Collection",
-      "advanced": true,
-      "placeholder": "openclaw-engram"
-    },
-    "qmdMaxResults": {
-      "label": "QMD Max Results",
-      "advanced": true,
-      "placeholder": "8"
-    },
-    "qmdColdTierEnabled": {
-      "label": "Enable Cold QMD Tier",
-      "advanced": true,
-      "help": "When hot recall misses, query a secondary cold QMD collection before archive scan fallback"
-    },
-    "qmdColdCollection": {
-      "label": "Cold QMD Collection",
-      "advanced": true,
-      "placeholder": "openclaw-engram-cold"
-    },
-    "qmdColdMaxResults": {
-      "label": "Cold QMD Max Results",
-      "advanced": true,
-      "placeholder": "8"
-    },
-    "qmdTierMigrationEnabled": {
-      "label": "Enable Tier Migration",
-      "advanced": true,
-      "help": "Enable value-aware hot/cold migration controls"
-    },
-    "qmdTierDemotionMinAgeDays": {
-      "label": "Tier Demotion Min Age Days",
-      "advanced": true,
-      "placeholder": "14"
-    },
-    "qmdTierDemotionValueThreshold": {
-      "label": "Tier Demotion Value Threshold",
-      "advanced": true,
-      "placeholder": "0.35"
-    },
-    "qmdTierPromotionValueThreshold": {
-      "label": "Tier Promotion Value Threshold",
-      "advanced": true,
-      "placeholder": "0.7"
-    },
-    "qmdTierParityGraphEnabled": {
-      "label": "Tier Parity Graph Checks",
-      "advanced": true
-    },
-    "qmdTierParityHiMemEnabled": {
-      "label": "Tier Parity HiMem Checks",
-      "advanced": true
-    },
-    "qmdTierAutoBackfillEnabled": {
-      "label": "Tier Auto Backfill",
-      "advanced": true,
-      "help": "Enable automated cold-tier backfill runs for parity repair"
-    },
-    "qmdSupportedVersion": {
-      "label": "QMD Supported Version",
-      "advanced": true,
-      "placeholder": "2.5.3"
-    },
-    "qmdAutoUpgradeEnabled": {
-      "label": "QMD Auto Upgrade",
-      "advanced": true,
-      "help": "Upgrade PATH/fallback QMD installs to the supported version; explicit qmdPath installs are skipped"
-    },
-    "qmdAutoUpgradeCheckIntervalMs": {
-      "label": "QMD Auto Upgrade Interval",
-      "advanced": true,
-      "placeholder": "86400000"
-    },
-    "qmdChunkStrategy": {
-      "label": "QMD Chunk Strategy",
-      "advanced": true,
-      "placeholder": "auto"
-    },
-    "qmdCandidateLimit": {
-      "label": "QMD Candidate Limit",
-      "advanced": true
-    },
-    "qmdQueryRerankEnabled": {
-      "label": "QMD Query Rerank",
-      "advanced": true
-    },
-    "qmdSearchStrategy": {
-      "label": "QMD Search Strategy",
-      "advanced": true,
-      "placeholder": "hybrid",
-      "help": "hybrid = lex+vec+hyde (default, best recall). lex-vec drops HyDE. lex = BM25-only (fastest). Lower tiers reduce CPU latency at the cost of recall."
-    },
-    "qmdSubprocessStrategy": {
-      "label": "QMD Subprocess Strategy",
-      "advanced": true,
-      "placeholder": "query",
-      "help": "query = qmd query with LLM expansion + rerank (default). search = BM25-only fallback, faster on huge collections but loses expansion/rerank."
-    },
-    "qmdDaemonTimeoutMs": {
-      "label": "QMD Daemon Timeout (ms)",
-      "advanced": true,
-      "placeholder": "8000"
-    },
-    "qmdIndexName": {
-      "label": "QMD Index Name",
-      "advanced": true,
-      "help": "Use a named QMD index when QMD 2.5+ supports --index. Changing this selects a different SQLite DB; keep it unset for existing default-index installs."
-    },
-    "qmdForceCpu": {
-      "label": "QMD Force CPU",
-      "advanced": true,
-      "help": "Set QMD_FORCE_CPU=1 for QMD child processes"
-    },
-    "qmdGpuBackend": {
-      "label": "QMD GPU Backend",
-      "advanced": true,
-      "placeholder": "metal"
-    },
-    "qmdEmbedParallelism": {
-      "label": "QMD Embed Parallelism",
-      "advanced": true,
-      "placeholder": "4"
-    },
-    "qmdEmbedModel": {
-      "label": "QMD Embed Model",
-      "advanced": true
-    },
-    "qmdRerankModel": {
-      "label": "QMD Rerank Model",
-      "advanced": true
-    },
-    "qmdGenerateModel": {
-      "label": "QMD Generate Model",
-      "advanced": true
-    },
-    "embeddingFallbackEnabled": {
-      "label": "Embedding Fallback",
-      "help": "Use semantic embeddings when QMD is unavailable or no results are found"
-    },
-    "embeddingFallbackProvider": {
-      "label": "Embedding Provider",
-      "advanced": true,
-      "placeholder": "auto"
-    },
-    "embeddingFallbackModel": {
-      "label": "Embedding Model",
-      "advanced": true,
-      "placeholder": "(defaults to local LLM model)",
-      "help": "Optional embedding model for semantic fallback. Use this when the local chat model and embedding model are different."
-    },
-    "qmdPath": {
-      "label": "QMD Path",
-      "advanced": true,
-      "placeholder": "/opt/homebrew/bin/qmd",
-      "help": "Optional absolute path to qmd binary for environments with unstable PATH/bun shims"
-    },
-    "memoryDir": {
-      "label": "Memory Directory",
-      "advanced": true,
-      "placeholder": "~/.openclaw/workspace/memory/local"
-    },
-    "debug": {
-      "label": "Debug Mode",
-      "advanced": true
-    },
-    "identityEnabled": {
-      "label": "Identity Reflections",
-      "help": "Append self-reflections to workspace IDENTITY.md after each extraction"
-    },
-    "identityContinuityEnabled": {
-      "label": "Identity Continuity",
-      "help": "Enable identity continuity workflows (anchor, incidents, audits)"
-    },
-    "identityInjectionMode": {
-      "label": "Identity Context Mode",
-      "advanced": true,
-      "placeholder": "recovery_only",
-      "help": "When to add identity continuity context: recovery_only, minimal, or full"
-    },
-    "identityMaxInjectChars": {
-      "label": "Identity Max Context Chars",
-      "advanced": true,
-      "placeholder": "1200"
-    },
-    "continuityIncidentLoggingEnabled": {
-      "label": "Continuity Incident Logging",
-      "advanced": true,
-      "help": "When omitted, follows Identity Continuity enabled state"
-    },
-    "continuityAuditEnabled": {
-      "label": "Continuity Audits",
-      "advanced": true,
-      "help": "Generate continuity audit artifacts"
-    },
-    "sessionObserverEnabled": {
-      "label": "Session Observer",
-      "advanced": true,
-      "help": "Observe heartbeat growth and proactively trigger extraction when configured thresholds are crossed"
-    },
-    "sessionObserverDebounceMs": {
-      "label": "Observer Debounce (ms)",
-      "advanced": true,
-      "placeholder": "120000"
-    },
-    "sessionObserverBands": {
-      "label": "Observer Size Bands",
-      "advanced": true,
-      "help": "Array of {maxBytes, triggerDeltaBytes, triggerDeltaTokens} threshold objects"
-    },
-    "injectQuestions": {
-      "label": "Inject Questions",
-      "help": "Include the most relevant open question in generated memory context"
-    },
-    "commitmentDecayDays": {
-      "label": "Commitment Decay (days)",
-      "advanced": true,
-      "placeholder": "90",
-      "help": "Positive integer days before fulfilled/expired commitments are removed."
-    },
-    "workspaceDir": {
-      "label": "Workspace Directory",
-      "advanced": true,
-      "placeholder": "~/.openclaw/workspace"
-    },
-    "accessTrackingEnabled": {
-      "label": "Access Tracking",
-      "help": "Track which memories are accessed most frequently"
-    },
-    "accessTrackingBufferMaxSize": {
-      "label": "Access Buffer Size",
-      "advanced": true,
-      "placeholder": "100"
-    },
-    "recencyWeight": {
-      "label": "Recency Weight",
-      "advanced": true,
-      "help": "How much to boost recent memories in search (0-1)",
-      "placeholder": "0.2"
-    },
-    "boostAccessCount": {
-      "label": "Boost Frequent Access",
-      "help": "Rank frequently accessed memories higher in search"
-    },
-    "captureMode": {
-      "label": "Capture Mode",
-      "help": "Choose whether Engram stores only explicit notes, normal extraction, or both."
-    },
-    "agentAccessHttp": {
-      "label": "Local HTTP Access",
-      "help": "Enable a local authenticated HTTP API for external Engram clients"
-    },
-    "negativeExamplesEnabled": {
-      "label": "Negative Examples",
-      "help": "Track retrieved-but-not-useful memories and apply a small ranking penalty (optional)"
-    },
-    "negativeExamplesPenaltyPerHit": {
-      "label": "Negative Penalty / Hit",
-      "advanced": true,
-      "placeholder": "0.05"
-    },
-    "negativeExamplesPenaltyCap": {
-      "label": "Negative Penalty Cap",
-      "advanced": true,
-      "placeholder": "0.25"
-    },
-    "chunkingEnabled": {
-      "label": "Enable Chunking",
-      "help": "Automatically split long memories into overlapping chunks for better retrieval"
-    },
-    "chunkingTargetTokens": {
-      "label": "Chunk Target Tokens",
-      "advanced": true,
-      "placeholder": "200"
-    },
-    "chunkingMinTokens": {
-      "label": "Chunk Min Tokens",
-      "advanced": true,
-      "placeholder": "150"
-    },
-    "chunkingOverlapSentences": {
-      "label": "Chunk Overlap Sentences",
-      "advanced": true,
-      "placeholder": "2"
-    },
-    "semanticChunkingEnabled": {
-      "label": "Semantic Chunking",
-      "help": "Use embedding-based topic detection for more coherent chunks (requires chunking enabled)"
-    },
-    "semanticChunkingConfig": {
-      "label": "Semantic Chunking Config",
-      "advanced": true,
-      "help": "Override defaults for semantic chunking algorithm parameters"
-    },
-    "contradictionDetectionEnabled": {
-      "label": "Contradiction Detection",
-      "help": "Detect and resolve conflicting memories using LLM verification"
-    },
-    "contradictionSimilarityThreshold": {
-      "label": "Contradiction Similarity Threshold",
-      "advanced": true,
-      "placeholder": "0.7"
-    },
-    "contradictionMinConfidence": {
-      "label": "Contradiction Min Confidence",
-      "advanced": true,
-      "placeholder": "0.9"
-    },
-    "contradictionAutoResolve": {
-      "label": "Auto-Resolve Contradictions",
-      "help": "Automatically supersede old memories when contradiction is confirmed"
-    },
-    "contradictionScan": {
-      "label": "Contradiction Scan",
-      "help": "Nightly cron that pairs similar memories and flags contradictions for review (issue #520)"
-    },
-    "temporalSupersessionEnabled": {
-      "label": "Temporal Supersession",
-      "help": "Mark older facts superseded when a newer fact writes a conflicting value for the same entityRef + structured attribute (issue #375)"
-    },
-    "temporalSupersessionIncludeInRecall": {
-      "label": "Include Superseded Facts In Recall",
-      "advanced": true,
-      "help": "If enabled, superseded facts still surface in recall (audit/history mode)."
-    },
-    "temporalBiTemporal": {
-      "label": "Bi-temporal Validity",
-      "advanced": true,
-      "help": "Master gate (issue #1578): resolve per-fact event-time at write time and exclude validity-expired facts from injection by default. Off = byte-identical to pre-#1578."
-    },
-    "temporalExpiredInInjection": {
-      "label": "Keep Expired-Validity Facts In Injection",
-      "advanced": true,
-      "help": "Escape hatch (issue #1578): keep facts whose event-time interval ended in injection candidates even with bi-temporal on."
-    },
-    "recallDirectAnswerEnabled": {
-      "label": "Direct-Answer Retrieval Tier",
-      "help": "Opt in to the direct-answer retrieval tier for validated high-trust queries before QMD (issue #518)."
-    },
-    "recallDisclosureEscalation": {
-      "label": "Disclosure Auto-Escalation",
-      "help": "Auto-promote default chunk recalls to section when top-K confidence is low (issue #677 PR 4/4). Set to 'auto' to enable; 'manual' (default) preserves pre-#677 behavior."
-    },
-    "recallDisclosureEscalationThreshold": {
-      "label": "Disclosure Escalation Threshold",
-      "advanced": true,
-      "placeholder": "0.5",
-      "help": "Top-K confidence (0-1) below which auto-escalation triggers. Only consulted when Disclosure Auto-Escalation is set to 'auto'."
-    },
-    "recallGraphEnabled": {
-      "label": "Graph Retrieval (PPR)",
-      "help": "Run Personalized PageRank on the retrieval graph and merge with QMD via MMR (issue #559)."
-    },
-    "recallGraphDamping": {
-      "label": "Graph Recall Damping",
-      "advanced": true,
-      "placeholder": "0.85"
-    },
-    "recallGraphIterations": {
-      "label": "Graph Recall Iterations",
-      "advanced": true,
-      "placeholder": "20"
-    },
-    "recallGraphTopK": {
-      "label": "Graph Recall Top-K",
-      "advanced": true,
-      "placeholder": "50"
-    },
-    "recallDirectAnswerTokenOverlapFloor": {
-      "label": "Direct-Answer Token Overlap Floor",
-      "advanced": true,
-      "placeholder": "0.55"
-    },
-    "recallDirectAnswerImportanceFloor": {
-      "label": "Direct-Answer Importance Floor",
-      "advanced": true,
-      "placeholder": "0.7"
-    },
-    "recallDirectAnswerAmbiguityMargin": {
-      "label": "Direct-Answer Ambiguity Margin",
-      "advanced": true,
-      "placeholder": "0.15"
-    },
-    "recallDirectAnswerEligibleTaxonomyBuckets": {
-      "label": "Direct-Answer Eligible Taxonomy Buckets",
-      "advanced": true,
-      "help": "Taxonomy category IDs eligible for direct-answer routing."
-    },
-    "memoryLinkingEnabled": {
-      "label": "Memory Linking",
-      "help": "Build knowledge graph by linking related memories"
-    },
-    "threadingEnabled": {
-      "label": "Conversation Threading",
-      "help": "Group memories into conversation threads with auto-titles"
-    },
-    "threadingGapMinutes": {
-      "label": "Thread Gap (minutes)",
-      "advanced": true,
-      "placeholder": "30"
-    },
-    "summarizationEnabled": {
-      "label": "Memory Summarization",
-      "help": "Compress old, low-importance memories into summaries"
-    },
-    "summarizationTriggerCount": {
-      "label": "Summarization Trigger",
-      "advanced": true,
-      "placeholder": "1000"
-    },
-    "summarizationRecentToKeep": {
-      "label": "Recent to Keep",
-      "advanced": true,
-      "placeholder": "300"
-    },
-    "summarizationImportanceThreshold": {
-      "label": "Importance Threshold",
-      "advanced": true,
-      "placeholder": "0.3"
-    },
-    "topicExtractionEnabled": {
-      "label": "Topic Extraction",
-      "help": "Extract key topics from memory corpus"
-    },
-    "topicExtractionTopN": {
-      "label": "Top N Topics",
-      "advanced": true,
-      "placeholder": "50"
-    },
-    "transcriptEnabled": {
-      "label": "Enable Transcript Archive",
-      "help": "Archive conversation transcripts for context preservation"
-    },
-    "transcriptRetentionDays": {
-      "label": "Transcript Retention (days)",
-      "advanced": true,
-      "placeholder": "7"
-    },
-    "transcriptSkipChannelTypes": {
-      "label": "Skip Channel Types",
-      "advanced": true,
-      "help": "Channel types to exclude from transcript logging (default: cron)"
-    },
-    "transcriptRecallHours": {
-      "label": "Transcript Recall (hours)",
-      "advanced": true,
-      "placeholder": "12"
-    },
-    "maxTranscriptTurns": {
-      "label": "Max Transcript Turns",
-      "advanced": true,
-      "placeholder": "50"
-    },
-    "maxTranscriptTokens": {
-      "label": "Max Transcript Tokens",
-      "advanced": true,
-      "placeholder": "1000"
-    },
-    "checkpointEnabled": {
-      "label": "Enable Checkpoints",
-      "help": "Capture conversation checkpoints for resuming context"
-    },
-    "checkpointTurns": {
-      "label": "Checkpoint Turn Interval",
-      "advanced": true,
-      "placeholder": "15"
-    },
-    "compactionResetEnabled": {
-      "label": "Compaction Reset",
-      "help": "Reset session after compaction and add BOOT.md recovery context",
-      "advanced": true
-    },
-    "hourlySummariesEnabled": {
-      "label": "Enable Hourly Summaries",
-      "help": "Generate hourly summaries of conversation activity"
-    },
-    "summaryRecallHours": {
-      "label": "Summary Recall (hours)",
-      "advanced": true,
-      "placeholder": "24"
-    },
-    "maxSummaryCount": {
-      "label": "Max Summary Count",
-      "advanced": true,
-      "placeholder": "6"
-    },
-    "summaryModel": {
-      "label": "Summary Model",
-      "advanced": true,
-      "placeholder": "(same as extraction model)"
-    },
-    "modelSource": {
-      "label": "Model Source",
-      "help": "Route LLM calls through the gateway's agent model chain instead of Engram's own config. Default for OpenClaw installs. When set to 'gateway', localLlm and openai settings are ignored."
-    },
-    "gatewayAgentId": {
-      "label": "Gateway Agent ID",
-      "advanced": true,
-      "placeholder": "engram-llm",
-      "help": "Agent persona ID from openclaw.json agents.list[] whose model chain to use. Leave empty to use global defaults."
-    },
-    "fastGatewayAgentId": {
-      "label": "Fast Gateway Agent ID",
-      "advanced": true,
-      "placeholder": "engram-llm-fast",
-      "help": "Agent persona ID for fast-tier ops. Leave empty to use the primary gatewayAgentId."
-    },
-    "taskModelChain": {
-      "label": "Task Model Chain",
-      "advanced": true,
-      "help": "Optional primary/fallback gateway model chain for Remnic background tasks (extraction, consolidation, summarization). Overrides gatewayAgentId/defaults for these tasks only. Requires modelSource: 'gateway'."
-    },
-    "localLlmEnabled": {
-      "label": "Enable Local LLM",
-      "help": "Use local LLM (LM Studio, Ollama, etc.) for extraction and summaries. Falls back to OpenAI if unavailable."
-    },
-    "localLlmUrl": {
-      "label": "Local LLM URL",
-      "advanced": true,
-      "placeholder": "http://localhost:1234/v1",
-      "help": "OpenAI-compatible endpoint URL for local LLM"
-    },
-    "localLlmModel": {
-      "label": "Local LLM Model",
-      "advanced": true,
-      "placeholder": "local-model",
-      "help": "Model identifier for local LLM requests"
-    },
-    "localLlmApiKey": {
-      "label": "Local LLM API Key",
-      "advanced": true,
-      "sensitive": true,
-      "placeholder": "sk-...",
-      "help": "Optional API key for authenticated OpenAI-compatible endpoints"
-    },
-    "localLlmHeaders": {
-      "label": "Local LLM Headers",
-      "advanced": true,
-      "help": "Optional extra headers for provider-specific routing/auth"
-    },
-    "localLlmAuthHeader": {
-      "label": "Send Auth Header",
-      "advanced": true,
-      "help": "When false, do not send Authorization header even if localLlmApiKey is set"
-    },
-    "localLlmFallback": {
-      "label": "Local LLM Fallback",
-      "advanced": true,
-      "help": "Fall back to cloud OpenAI if local LLM fails or is unavailable"
-    },
-    "localLlmHomeDir": {
-      "label": "Local LLM Home Dir",
-      "advanced": true,
-      "placeholder": "(auto: HOME / os.homedir)",
-      "help": "Optional home directory override for LM Studio settings and local helper paths."
-    },
-    "localLmsCliPath": {
-      "label": "LMS CLI Path",
-      "advanced": true,
-      "placeholder": "/path/to/lms",
-      "help": "Optional absolute path to LMS CLI. Overrides auto-detection."
-    },
-    "localLmsBinDir": {
-      "label": "LMS Bin Dir",
-      "advanced": true,
-      "placeholder": "/path/to/bin",
-      "help": "Optional bin directory prepended to PATH for LMS CLI execution."
-    },
-    "localLlmMaxContext": {
-      "label": "Local LLM Max Context",
-      "advanced": true,
-      "placeholder": "(auto-detected from model)",
-      "help": "Override context window if your LLM server uses smaller default (e.g., 32768 for LM Studio default)"
-    },
-    "localLlmFastEnabled": {
-      "label": "Fast LLM Tier",
-      "help": "Use a separate smaller model for quick operations (rerank, entity summaries, compression guidelines)"
-    },
-    "localLlmFastModel": {
-      "label": "Fast LLM Model",
-      "placeholder": "qwen3.5-4b-mlx",
-      "help": "Model ID for fast-tier operations. Must be loaded in LM Studio alongside the primary model."
-    },
-    "localLlmFastUrl": {
-      "label": "Fast LLM URL",
-      "advanced": true,
-      "placeholder": "(defaults to localLlmUrl)",
-      "help": "Endpoint for fast-tier model. When not set, inherits the primary localLlmUrl."
-    },
-    "localLlmFastTimeoutMs": {
-      "label": "Fast LLM Timeout (ms)",
-      "advanced": true,
-      "help": "Timeout for fast-tier requests. Lower than primary since fast ops should complete quickly."
-    },
-    "localLlmDisableThinking": {
-      "label": "Disable Local LLM Thinking Mode",
-      "advanced": true,
-      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. The suppression field (chat_template_kwargs) is only sent when the backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
-    },
-    "evalHarnessEnabled": {
-      "label": "Evaluation Harness",
-      "help": "Enable Engram's benchmark/evaluation harness foundation and benchmark-status diagnostics."
-    },
-    "evalShadowModeEnabled": {
-      "label": "Evaluation Shadow Mode",
-      "advanced": true,
-      "help": "Reserve shadow-mode measurement paths so future benchmark instrumentation can compare memory behavior without affecting live recall."
-    },
-    "benchmarkBaselineSnapshotsEnabled": {
-      "label": "Benchmark Baseline Snapshots",
-      "advanced": true,
-      "help": "Enable versioned benchmark baseline snapshot artifacts for later PR delta reporting."
-    },
-    "benchmarkDeltaReporterEnabled": {
-      "label": "Benchmark Delta Reporter",
-      "advanced": true,
-      "help": "Enable named-baseline delta reports that compare the current eval store against a stored benchmark baseline snapshot."
-    },
-    "evalStoreDir": {
-      "label": "Evaluation Store Directory",
-      "advanced": true,
-      "placeholder": "{memoryDir}/state/evals",
-      "help": "Override where benchmark packs and run summaries are stored."
-    },
-    "objectiveStateMemoryEnabled": {
-      "label": "Objective-State Memory",
-      "help": "Enable the objective-state memory foundation for normalized world and tool state snapshots."
-    },
-    "objectiveStateSnapshotWritesEnabled": {
-      "label": "Objective-State Snapshot Writes",
-      "advanced": true,
-      "help": "Allow snapshot writers to persist objective-state records into the objective-state store."
-    },
-    "objectiveStateRecallEnabled": {
-      "label": "Objective-State Recall",
-      "advanced": true,
-      "help": "Add recall-relevant objective-state snapshots to recall context."
-    },
-    "objectiveStateStoreDir": {
-      "label": "Objective-State Store Directory",
-      "advanced": true,
-      "placeholder": "{memoryDir}/state/objective-state",
-      "help": "Override where objective-state snapshots are stored."
-    },
-    "causalTrajectoryMemoryEnabled": {
-      "label": "Causal Trajectory Memory",
-      "help": "Enable the causal-trajectory memory foundation for typed goal-action-observation-outcome chains."
-    },
-    "causalTrajectoryStoreDir": {
-      "label": "Causal Trajectory Store Directory",
-      "advanced": true,
-      "placeholder": "{memoryDir}/state/causal-trajectories",
-      "help": "Override where causal-trajectory records are stored."
-    },
-    "causalTrajectoryRecallEnabled": {
-      "label": "Causal Trajectory Recall",
-      "advanced": true,
-      "help": "Add recall-relevant causal trajectories to recall context."
-    },
-    "trustZonesEnabled": {
-      "label": "Trust Zones",
-      "help": "Enable the trust-zone memory foundation for quarantine, working, and trusted records."
-    },
-    "quarantinePromotionEnabled": {
-      "label": "Quarantine Promotion",
-      "advanced": true,
-      "help": "Reserve future promotion flows from quarantine into higher-trust zones."
-    },
-    "trustZoneStoreDir": {
-      "label": "Trust-Zone Store Directory",
-      "advanced": true,
-      "placeholder": "{memoryDir}/state/trust-zones",
-      "help": "Override where trust-zone records are stored."
-    },
-    "trustZoneRecallEnabled": {
-      "label": "Trust-Zone Recall",
-      "advanced": true,
-      "help": "Add recall-relevant working and trusted trust-zone records to recall context."
-    },
-    "memoryPoisoningDefenseEnabled": {
-      "label": "Memory Poisoning Defense",
-      "advanced": true,
-      "help": "Enable provenance trust scoring in trust-zone status output as the first poisoning-defense signal."
-    },
-    "memoryRedTeamBenchEnabled": {
-      "label": "Memory Red-Team Benchmarks",
-      "advanced": true,
-      "help": "Enable operator-facing red-team benchmark pack support and status accounting for poisoning-defense suites."
-    },
-    "harmonicRetrievalEnabled": {
-      "label": "Harmonic Retrieval",
-      "help": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
-    },
-    "abstractionAnchorsEnabled": {
-      "label": "Abstraction Anchors",
-      "advanced": true,
-      "help": "Enable typed cue-anchor indexing for abstraction nodes and expose it through cue-anchor status tooling."
-    },
-    "abstractionNodeStoreDir": {
-      "label": "Abstraction-Node Store Directory",
-      "advanced": true,
-      "placeholder": "{memoryDir}/state/abstraction-nodes",
-      "help": "Override where abstraction nodes are stored."
-    },
-    "verifiedRecallEnabled": {
-      "label": "Verified Recall",
-      "help": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
-    },
-    "semanticRulePromotionEnabled": {
-      "label": "Semantic Rule Promotion",
-      "advanced": true,
-      "help": "Promote explicit IF/THEN rules from verified episodic memories into durable rule memories."
-    },
-    "semanticRuleVerificationEnabled": {
-      "label": "Semantic Rule Verification",
-      "advanced": true,
-      "help": "Verify promoted semantic rules against their cited source episodes at recall time before surfacing them in recall."
-    },
-    "semanticConsolidationEnabled": {
-      "label": "Semantic Consolidation",
-      "advanced": true,
-      "help": "Enable periodic semantic consolidation of similar memories."
-    },
-    "semanticConsolidationModel": {
-      "label": "Semantic Consolidation Model",
-      "advanced": true,
-      "help": "LLM for consolidation synthesis: 'auto' (primary model), 'fast' (fast local model), or a specific model name."
-    },
-    "semanticConsolidationThreshold": {
-      "label": "Semantic Consolidation Threshold",
-      "advanced": true,
-      "help": "Token overlap threshold (0-1) for grouping similar memories. 0.8=conservative, 0.6=aggressive."
-    },
-    "semanticConsolidationMinClusterSize": {
-      "label": "Semantic Consolidation Min Cluster Size",
-      "advanced": true,
-      "help": "Minimum cluster size before consolidation triggers."
-    },
-    "semanticConsolidationExcludeCategories": {
-      "label": "Semantic Consolidation Exclude Categories",
-      "advanced": true,
-      "help": "Memory categories excluded from semantic consolidation."
-    },
-    "semanticConsolidationIntervalHours": {
-      "label": "Semantic Consolidation Interval (Hours)",
-      "advanced": true,
-      "help": "Hours between automatic consolidation runs (168 = weekly)."
-    },
-    "semanticConsolidationMaxPerRun": {
-      "label": "Semantic Consolidation Max Per Run",
-      "advanced": true,
-      "help": "Max memories to consolidate per run to limit LLM cost."
-    },
-    "operatorAwareConsolidationEnabled": {
-      "label": "Operator-Aware Consolidation",
-      "advanced": true,
-      "help": "Opt in to operator-aware consolidation instructions (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
-    },
-    "peerProfileReasonerEnabled": {
-      "label": "Peer Profile Reasoner",
-      "advanced": true,
-      "help": "Enable the async peer profile reasoner (issue #679). Runs in the REM phase after semantic consolidation and updates per-peer profile.md files with provenance-tagged field updates derived from each peer's interaction log. Default off (opt-in)."
-    },
-    "peerProfileReasonerModel": {
-      "label": "Peer Profile Reasoner Model",
-      "advanced": true,
-      "help": "Model identifier the peer profile reasoner records on telemetry. Dispatch still routes through the FallbackLlmClient used by semantic consolidation."
-    },
-    "peerProfileReasonerMinInteractions": {
-      "label": "Peer Profile Reasoner Min Interactions",
-      "advanced": true,
-      "help": "Minimum new interaction-log entries a peer must accumulate since the previous reasoner run before being processed again. Set to 0 to consider every peer on every run."
-    },
-    "peerProfileReasonerMaxFieldsPerRun": {
-      "label": "Peer Profile Reasoner Max Fields Per Run",
-      "advanced": true,
-      "help": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
-    },
-    "peerProfileRecallEnabled": {
-      "label": "Peer Profile Recall",
-      "advanced": true,
-      "help": "When enabled, adds the active peer's profile fields to recall context as a '## Peer Profile' section. Requires the session peer ID to be registered. Default off."
-    },
-    "peerProfileRecallMaxFields": {
-      "label": "Peer Profile Recall Max Fields",
-      "advanced": true,
-      "help": "Maximum number of peer profile fields to add per recall. Only the most-recently-updated N fields are included. Set to 0 to disable this feature."
-    },
-    "creationMemoryEnabled": {
-      "label": "Creation Memory",
-      "advanced": true,
-      "help": "Enable creation-memory foundations, including the work-product ledger for explicit outputs agents create."
-    },
-    "memoryUtilityLearningEnabled": {
-      "label": "Utility Learning",
-      "advanced": true,
-      "help": "Enable utility-learning telemetry storage so later slices can learn promotion and ranking weights from downstream outcomes."
-    },
-    "promotionByOutcomeEnabled": {
-      "label": "Promotion By Outcome",
-      "advanced": true,
-      "help": "Enable outcome-aware promotion controls that will consume learned utility signals in later rollout slices."
-    },
-    "commitmentLedgerEnabled": {
-      "label": "Commitment Ledger",
-      "advanced": true,
-      "help": "Enable the explicit commitment ledger for promises, follow-ups, deadlines, and unfinished obligations."
-    },
-    "commitmentLifecycleEnabled": {
-      "label": "Commitment Lifecycle",
-      "advanced": true,
-      "help": "Enable fulfillment transitions, stale tracking, and resolved-entry cleanup for the commitment ledger."
-    },
-    "commitmentStaleDays": {
-      "label": "Commitment Stale Days",
-      "advanced": true,
-      "help": "Days before an open commitment without a due date counts as stale."
-    },
-    "commitmentLedgerDir": {
-      "label": "Commitment Ledger Directory",
-      "advanced": true,
-      "placeholder": "{memoryDir}/state/commitment-ledger",
-      "help": "Override where commitment ledger entries are stored."
-    },
-    "resumeBundlesEnabled": {
-      "label": "Resume Bundles",
-      "advanced": true,
-      "help": "Enable deterministic resume-bundle storage and explicit handoff bundle commands."
-    },
-    "resumeBundleDir": {
-      "label": "Resume Bundle Directory",
-      "advanced": true,
-      "placeholder": "{memoryDir}/state/resume-bundles",
-      "help": "Override where resume bundles are stored."
-    },
-    "workProductRecallEnabled": {
-      "label": "Work-Product Recall",
-      "advanced": true,
-      "help": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
-    },
-    "workProductLedgerDir": {
-      "label": "Work-Product Ledger Directory",
-      "advanced": true,
-      "placeholder": "{memoryDir}/state/work-product-ledger",
-      "help": "Override where work-product ledger entries are stored."
-    },
-    "actionGraphRecallEnabled": {
-      "label": "Action Graph Recall",
-      "help": "Write action-conditioned causal-stage edges from typed trajectory records into the causal graph."
-    },
-    "factDeduplicationEnabled": {
-      "label": "Fact Deduplication",
-      "help": "Prevent storing semantically identical facts using content hashing"
-    },
-    "semanticDedupEnabled": {
-      "label": "Semantic Dedup (write-time)",
-      "help": "Skip near-duplicate facts at write time by comparing embeddings to existing memories (issue #373)."
-    },
-    "semanticDedupThreshold": {
-      "label": "Semantic Dedup Threshold",
-      "advanced": true,
-      "placeholder": "0.92"
-    },
-    "semanticDedupCandidates": {
-      "label": "Semantic Dedup Candidates",
-      "advanced": true,
-      "placeholder": "5"
-    },
-    "factArchivalEnabled": {
-      "label": "Fact Archival",
-      "help": "Automatically archive old, low-importance, rarely-accessed facts during consolidation"
-    },
-    "factArchivalAgeDays": {
-      "label": "Archival Age (days)",
-      "advanced": true,
-      "placeholder": "90"
-    },
-    "factArchivalMaxImportance": {
-      "label": "Archival Max Importance",
-      "advanced": true,
-      "placeholder": "0.3"
-    },
-    "factArchivalMaxAccessCount": {
-      "label": "Archival Max Access Count",
-      "advanced": true,
-      "placeholder": "2"
-    },
-    "factArchivalProtectedCategories": {
-      "label": "Archival Protected Categories",
-      "advanced": true,
-      "help": "Categories that are never archived regardless of age or importance"
-    },
-    "lifecyclePolicyEnabled": {
-      "label": "Lifecycle Policy Engine",
-      "help": "Enable lifecycle scoring/promotions during consolidation (v8.3)"
-    },
-    "lifecycleFilterStaleEnabled": {
-      "label": "Filter Stale Lifecycle Memories",
-      "advanced": true,
-      "help": "If enabled, retrieval may filter stale lifecycle memories (activated in PR20D)"
-    },
-    "lifecyclePromoteHeatThreshold": {
-      "label": "Lifecycle Promote Heat Threshold",
-      "advanced": true,
-      "placeholder": "0.55"
-    },
-    "lifecycleStaleDecayThreshold": {
-      "label": "Lifecycle Stale Decay Threshold",
-      "advanced": true,
-      "placeholder": "0.65"
-    },
-    "lifecycleArchiveDecayThreshold": {
-      "label": "Lifecycle Archive Decay Threshold",
-      "advanced": true,
-      "placeholder": "0.85"
-    },
-    "lifecycleProtectedCategories": {
-      "label": "Lifecycle Protected Categories",
-      "advanced": true,
-      "help": "Categories lifecycle policy should not auto-archive"
-    },
-    "lifecycleMetricsEnabled": {
-      "label": "Lifecycle Metrics",
-      "advanced": true,
-      "help": "Write lifecycle metrics snapshots to state/lifecycle-metrics.json"
-    },
-    "proactiveExtractionEnabled": {
-      "label": "Proactive Extraction",
-      "help": "Enable proactive self-questioning extraction second-pass (v8.3, default off)"
-    },
-    "contextCompressionActionsEnabled": {
-      "label": "Context Compression Actions",
-      "help": "Enable context compression action tools and action telemetry (v8.3, default off)"
-    },
-    "compressionGuidelineLearningEnabled": {
-      "label": "Compression Guideline Learning",
-      "help": "Enable adaptive compression guideline learning from action outcomes (v8.3, default off)"
-    },
-    "compressionGuidelineSemanticRefinementEnabled": {
-      "label": "Compression Semantic Refinement",
-      "advanced": true,
-      "help": "Enable optional semantic refinement after deterministic guideline generation (v8.11, default off)"
-    },
-    "compressionGuidelineSemanticTimeoutMs": {
-      "label": "Compression Semantic Timeout (ms)",
-      "advanced": true,
-      "placeholder": "2500"
-    },
-    "maxProactiveQuestionsPerExtraction": {
-      "label": "Max Proactive Questions / Extraction",
-      "advanced": true,
-      "placeholder": "2"
-    },
-    "proactiveExtractionTimeoutMs": {
-      "label": "Proactive Extraction Timeout (ms)",
-      "advanced": true,
-      "placeholder": "2500"
-    },
-    "proactiveExtractionMaxTokens": {
-      "label": "Proactive Extraction Max Tokens",
-      "advanced": true,
-      "placeholder": "900"
-    },
-    "extractionMaxOutputTokens": {
-      "label": "Extraction Max Output Tokens",
-      "advanced": true,
-      "placeholder": "16384"
-    },
-    "proactiveExtractionCategoryAllowlist": {
-      "label": "Proactive Category Allowlist",
-      "advanced": true,
-      "help": "Optional list of memory categories that proactive second-pass writes may emit"
-    },
-    "maxCompressionTokensPerHour": {
-      "label": "Max Compression Tokens / Hour",
-      "advanced": true,
-      "placeholder": "1500"
-    },
-    "behaviorLoopAutoTuneEnabled": {
-      "label": "Behavior Loop Auto-Tune",
-      "help": "Enable bounded runtime policy auto-tuning from correction/preference signals (v8.15, default off)"
-    },
-    "behaviorLoopLearningWindowDays": {
-      "label": "Behavior Learning Window (days)",
-      "advanced": true,
-      "placeholder": "14"
-    },
-    "behaviorLoopMinSignalCount": {
-      "label": "Behavior Min Signal Count",
-      "advanced": true,
-      "placeholder": "10"
-    },
-    "behaviorLoopMaxDeltaPerCycle": {
-      "label": "Behavior Max Delta / Cycle",
-      "advanced": true,
-      "placeholder": "0.1"
-    },
-    "behaviorLoopProtectedParams": {
-      "label": "Behavior Protected Params",
-      "advanced": true,
-      "help": "Parameter keys that auto-tuning must never change"
-    },
-    "knowledgeIndexEnabled": {
-      "label": "Knowledge Index",
-      "help": "Inject a compact table of top entities into every recall"
-    },
-    "knowledgeIndexMaxEntities": {
-      "label": "Knowledge Index Max Entities",
-      "advanced": true,
-      "placeholder": "40"
-    },
-    "knowledgeIndexMaxChars": {
-      "label": "Knowledge Index Max Chars",
-      "advanced": true,
-      "placeholder": "4000"
-    },
-    "entityRetrievalEnabled": {
-      "label": "Entity Retrieval",
-      "help": "Inject direct-answer entity hints for entity questions and short follow-up queries"
-    },
-    "entityRetrievalMaxChars": {
-      "label": "Entity Retrieval Max Chars",
-      "advanced": true,
-      "placeholder": "2400"
-    },
-    "entityRetrievalMaxHints": {
-      "label": "Entity Retrieval Max Hints",
-      "advanced": true,
-      "placeholder": "2"
-    },
-    "entityRetrievalMaxSupportingFacts": {
-      "label": "Entity Retrieval Max Supporting Facts",
-      "advanced": true,
-      "placeholder": "6"
-    },
-    "entityRetrievalMaxRelatedEntities": {
-      "label": "Entity Retrieval Max Related Entities",
-      "advanced": true,
-      "placeholder": "3"
-    },
-    "entityRetrievalRecentTurns": {
-      "label": "Entity Retrieval Recent Turns",
-      "advanced": true,
-      "placeholder": "6"
-    },
-    "entityRelationshipsEnabled": {
-      "label": "Entity Relationships",
-      "help": "Track entity-to-entity relationships during extraction"
-    },
-    "entityActivityLogEnabled": {
-      "label": "Entity Activity Log",
-      "help": "Log timestamped activity per entity"
-    },
-    "entityActivityLogMaxEntries": {
-      "label": "Activity Log Max Entries",
-      "advanced": true,
-      "placeholder": "20"
-    },
-    "entityAliasesEnabled": {
-      "label": "Entity Aliases",
-      "help": "Store aliases per entity file"
-    },
-    "entitySummaryEnabled": {
-      "label": "Entity Summaries",
-      "help": "Generate LLM summaries for entities during consolidation"
-    },
-    "entitySynthesisMaxTokens": {
-      "label": "Entity Synthesis Max Tokens",
-      "advanced": true,
-      "placeholder": "500",
-      "help": "Max tokens used when refreshing an entity synthesis from its timeline."
-    },
-    "recallBudgetChars": {
-      "label": "Recall Budget (Chars)",
-      "advanced": true,
-      "placeholder": "8000"
-    },
-    "recallPipeline": {
-      "label": "Recall Pipeline",
-      "advanced": true,
-      "help": "Ordered section configuration for recall assembly and per-section limits"
-    },
-    "recallMmrEnabled": {
-      "label": "Recall MMR (Diversity)",
-      "advanced": true,
-      "help": "Apply Maximal Marginal Relevance per-section so duplicate clusters cannot dominate the recall budget"
-    },
-    "recallMmrLambda": {
-      "label": "MMR Lambda",
-      "advanced": true,
-      "placeholder": "0.7",
-      "help": "1.0 = pure relevance, 0.0 = pure diversity. Default 0.7."
-    },
-    "recallMmrTopN": {
-      "label": "MMR Top-N",
-      "advanced": true,
-      "placeholder": "40",
-      "help": "Number of top candidates per section over which MMR is applied"
-    },
-    "recallReasoningTraceBoostEnabled": {
-      "label": "Boost Reasoning Traces on Problem-Solving Queries",
-      "advanced": true,
-      "help": "Promote stored reasoning_trace memories to the top of recall results when the incoming query reads like a problem-solving ask. Default off; enable after benchmarking (issue #564)."
-    }
-  },
-  "commandAliases": [
-    {
-      "name": "remnic",
-      "kind": "runtime-slash",
-      "cliCommand": "remnic"
-    }
-  ],
-  "activation": {
-    "onStartup": false,
-    "onCommands": [
-      "remnic"
+   },
+   "workIndexAutoRebuildDebounceMs": {
+    "type": "number",
+    "default": 1000,
+    "description": "Debounce delay in ms before triggering auto-rebuild of the work index."
+   },
+   "workIndexAutoRebuildEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Automatically rebuild the work index when tasks or projects change."
+   },
+   "workIndexDir": {
+    "type": "string",
+    "description": "Override the work index directory (defaults to {memoryDir}/work/index)."
+   },
+   "workIndexEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable search index for work tasks and projects."
+   },
+   "workProductLedgerDir": {
+    "type": "string",
+    "description": "Override the work-product ledger directory (defaults to {memoryDir}/state/work-product-ledger)."
+   },
+   "workProductRecallEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
+   },
+   "workProjectIndexEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Include projects in the work search index."
+   },
+   "workProjectsDir": {
+    "type": "string",
+    "description": "Override the work projects directory (defaults to {memoryDir}/work/projects)."
+   },
+   "workProjectsEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable project tracking within the work product system."
+   },
+   "workTaskIndexEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Include tasks in the work search index."
+   },
+   "workTasksDir": {
+    "type": "string",
+    "description": "Override the work tasks directory (defaults to {memoryDir}/work/tasks)."
+   },
+   "workTasksEnabled": {
+    "type": "boolean",
+    "default": false,
+    "description": "Enable task tracking within the work product system."
+   },
+   "workspaceDir": {
+    "type": "string",
+    "description": "Override workspace directory path"
+   },
+   "extractionBreakerAuthCooldownMs": {
+    "type": "number",
+    "default": 1800000,
+    "description": "Extraction circuit-breaker open cooldown (ms) for auth/config failures (401/403 or no models configured)."
+   },
+   "extractionBreakerCooldownMs": {
+    "type": "number",
+    "default": 300000,
+    "description": "Extraction circuit-breaker open cooldown (ms) for transient provider failures (429/5xx/network)."
+   },
+   "extractionBreakerFailureThreshold": {
+    "type": "number",
+    "default": 5,
+    "description": "Consecutive provider failures before the extraction circuit breaker opens and short-circuits extraction."
+   },
+   "extractionParseEmptyMaxAttempts": {
+    "type": "number",
+    "default": 3,
+    "description": "Attempts for a parse_empty extraction fingerprint before it is long-parked (still never marked processed)."
+   },
+   "extractionRetryEnabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Master gate for extraction retry backoff + circuit breaker. When false, restores pre-change behavior (extractor called on every triggered observe, no gate)."
+   },
+   "extractionRetryJitterRatio": {
+    "type": "number",
+    "default": 0.2,
+    "description": "Multiplicative jitter ratio (+/-) applied to each extraction backoff interval."
+   },
+   "extractionRetryMaxBackoffMs": {
+    "type": "number",
+    "default": 21600000,
+    "description": "Upper bound (ms) on any single extraction backoff interval and the long-park interval for exhausted parse_empty fingerprints."
+   },
+   "extractionRetryScheduleMs": {
+    "type": "array",
+    "items": {
+     "type": "number"
+    },
+    "default": [
+     60000,
+     300000,
+     1800000,
+     7200000
     ],
-    "onCapabilities": [
-      "tool",
-      "hook"
-    ]
+    "description": "Per-fingerprint exponential extraction backoff schedule (ms), indexed by attempt."
+   }
   }
+ },
+ "uiHints": {
+  "openaiApiKey": {
+   "label": "OpenAI API Key",
+   "sensitive": true,
+   "placeholder": "sk-...",
+   "help": "Optional API key for plugin mode only. Not needed when Model Source is gateway."
+  },
+  "openaiBaseUrl": {
+   "label": "OpenAI Base URL",
+   "advanced": true,
+   "placeholder": "https://api.openai.com/v1",
+   "help": "Override for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
+  },
+  "model": {
+   "label": "Extraction Model",
+   "advanced": true,
+   "placeholder": "gpt-5.5"
+  },
+  "reasoningEffort": {
+   "label": "Reasoning Effort",
+   "advanced": true
+  },
+  "triggerMode": {
+   "label": "Trigger Mode",
+   "advanced": true
+  },
+  "bufferMaxTurns": {
+   "label": "Buffer Max Turns",
+   "advanced": true,
+   "placeholder": "5"
+  },
+  "bufferMaxMinutes": {
+   "label": "Buffer Max Minutes",
+   "advanced": true,
+   "placeholder": "15"
+  },
+  "consolidateEveryN": {
+   "label": "Consolidation Frequency",
+   "advanced": true,
+   "placeholder": "3"
+  },
+  "maxMemoryTokens": {
+   "label": "Max Memory Tokens",
+   "advanced": true,
+   "placeholder": "2000"
+  },
+  "memoryOsPreset": {
+   "label": "Memory OS Preset",
+   "advanced": true,
+   "help": "Optional preset: conservative, balanced, research-max, or local-llm-heavy. `research` remains accepted as a backward-compatible alias. Explicit settings still win."
+  },
+  "qmdEnabled": {
+   "label": "Enable QMD",
+   "help": "Enable QMD for memory search/indexing"
+  },
+  "hostEmbeddingProviderEnabled": {
+   "label": "Use Host Embeddings",
+   "advanced": true,
+   "help": "Prefer OpenClaw's registered embedding providers when available; Remnic falls back automatically."
+  },
+  "hostEmbeddingProviderId": {
+   "label": "Host Embedding Provider",
+   "advanced": true,
+   "placeholder": "openai-compatible"
+  },
+  "hostEmbeddingProviderModel": {
+   "label": "Host Embedding Model",
+   "advanced": true,
+   "placeholder": "text-embedding-3-small"
+  },
+  "openclawMessageReceivedCaptureEnabled": {
+   "label": "Capture Inbound Messages",
+   "advanced": true,
+   "help": "Use OpenClaw message_received transcript capture when the host emits it."
+  },
+  "openclawReplyMetadataCaptureEnabled": {
+   "label": "Capture Reply Metadata",
+   "advanced": true,
+   "help": "Store bounded message/thread/reply fields in transcript metadata."
+  },
+  "openclawReplyMetadataExtractionHintsEnabled": {
+   "label": "Use Reply Extraction Hints",
+   "advanced": true,
+   "help": "Include bounded quoted-reply context in extraction prompts. Off by default."
+  },
+  "openclawChannelEnvelopeCleaningEnabled": {
+   "label": "Clean Channel Envelopes",
+   "advanced": true,
+   "help": "Use OpenClaw's canonical channel envelope prefixes when available."
+  },
+  "openclawFlushPlanProcessingEnabled": {
+   "label": "Process Flush Plans",
+   "advanced": true,
+   "help": "Have Remnic ingest and clear OpenClaw's append-only flush-plan file. Disable when OpenClaw owns this lifecycle natively."
+  },
+  "qmdCollection": {
+   "label": "QMD Collection",
+   "advanced": true,
+   "placeholder": "openclaw-engram"
+  },
+  "qmdMaxResults": {
+   "label": "QMD Max Results",
+   "advanced": true,
+   "placeholder": "8"
+  },
+  "qmdColdTierEnabled": {
+   "label": "Enable Cold QMD Tier",
+   "advanced": true,
+   "help": "When hot recall misses, query a secondary cold QMD collection before archive scan fallback"
+  },
+  "qmdColdCollection": {
+   "label": "Cold QMD Collection",
+   "advanced": true,
+   "placeholder": "openclaw-engram-cold"
+  },
+  "qmdColdMaxResults": {
+   "label": "Cold QMD Max Results",
+   "advanced": true,
+   "placeholder": "8"
+  },
+  "qmdTierMigrationEnabled": {
+   "label": "Enable Tier Migration",
+   "advanced": true,
+   "help": "Enable value-aware hot/cold migration controls"
+  },
+  "qmdTierDemotionMinAgeDays": {
+   "label": "Tier Demotion Min Age Days",
+   "advanced": true,
+   "placeholder": "14"
+  },
+  "qmdTierDemotionValueThreshold": {
+   "label": "Tier Demotion Value Threshold",
+   "advanced": true,
+   "placeholder": "0.35"
+  },
+  "qmdTierPromotionValueThreshold": {
+   "label": "Tier Promotion Value Threshold",
+   "advanced": true,
+   "placeholder": "0.7"
+  },
+  "qmdTierParityGraphEnabled": {
+   "label": "Tier Parity Graph Checks",
+   "advanced": true
+  },
+  "qmdTierParityHiMemEnabled": {
+   "label": "Tier Parity HiMem Checks",
+   "advanced": true
+  },
+  "qmdTierAutoBackfillEnabled": {
+   "label": "Tier Auto Backfill",
+   "advanced": true,
+   "help": "Enable automated cold-tier backfill runs for parity repair"
+  },
+  "qmdSupportedVersion": {
+   "label": "QMD Supported Version",
+   "advanced": true,
+   "placeholder": "2.5.3"
+  },
+  "qmdAutoUpgradeEnabled": {
+   "label": "QMD Auto Upgrade",
+   "advanced": true,
+   "help": "Upgrade PATH/fallback QMD installs to the supported version; explicit qmdPath installs are skipped"
+  },
+  "qmdAutoUpgradeCheckIntervalMs": {
+   "label": "QMD Auto Upgrade Interval",
+   "advanced": true,
+   "placeholder": "86400000"
+  },
+  "qmdChunkStrategy": {
+   "label": "QMD Chunk Strategy",
+   "advanced": true,
+   "placeholder": "auto"
+  },
+  "qmdCandidateLimit": {
+   "label": "QMD Candidate Limit",
+   "advanced": true
+  },
+  "qmdQueryRerankEnabled": {
+   "label": "QMD Query Rerank",
+   "advanced": true
+  },
+  "qmdSearchStrategy": {
+   "label": "QMD Search Strategy",
+   "advanced": true,
+   "placeholder": "hybrid",
+   "help": "hybrid = lex+vec+hyde (default, best recall). lex-vec drops HyDE. lex = BM25-only (fastest). Lower tiers reduce CPU latency at the cost of recall."
+  },
+  "qmdSubprocessStrategy": {
+   "label": "QMD Subprocess Strategy",
+   "advanced": true,
+   "placeholder": "query",
+   "help": "query = qmd query with LLM expansion + rerank (default). search = BM25-only fallback, faster on huge collections but loses expansion/rerank."
+  },
+  "qmdDaemonTimeoutMs": {
+   "label": "QMD Daemon Timeout (ms)",
+   "advanced": true,
+   "placeholder": "8000"
+  },
+  "qmdIndexName": {
+   "label": "QMD Index Name",
+   "advanced": true,
+   "help": "Use a named QMD index when QMD 2.5+ supports --index. Changing this selects a different SQLite DB; keep it unset for existing default-index installs."
+  },
+  "qmdForceCpu": {
+   "label": "QMD Force CPU",
+   "advanced": true,
+   "help": "Set QMD_FORCE_CPU=1 for QMD child processes"
+  },
+  "qmdGpuBackend": {
+   "label": "QMD GPU Backend",
+   "advanced": true,
+   "placeholder": "metal"
+  },
+  "qmdEmbedParallelism": {
+   "label": "QMD Embed Parallelism",
+   "advanced": true,
+   "placeholder": "4"
+  },
+  "qmdEmbedModel": {
+   "label": "QMD Embed Model",
+   "advanced": true
+  },
+  "qmdRerankModel": {
+   "label": "QMD Rerank Model",
+   "advanced": true
+  },
+  "qmdGenerateModel": {
+   "label": "QMD Generate Model",
+   "advanced": true
+  },
+  "embeddingFallbackEnabled": {
+   "label": "Embedding Fallback",
+   "help": "Use semantic embeddings when QMD is unavailable or no results are found"
+  },
+  "embeddingFallbackProvider": {
+   "label": "Embedding Provider",
+   "advanced": true,
+   "placeholder": "auto"
+  },
+  "embeddingFallbackModel": {
+   "label": "Embedding Model",
+   "advanced": true,
+   "placeholder": "(defaults to local LLM model)",
+   "help": "Optional embedding model for semantic fallback. Use this when the local chat model and embedding model are different."
+  },
+  "qmdPath": {
+   "label": "QMD Path",
+   "advanced": true,
+   "placeholder": "/opt/homebrew/bin/qmd",
+   "help": "Optional absolute path to qmd binary for environments with unstable PATH/bun shims"
+  },
+  "memoryDir": {
+   "label": "Memory Directory",
+   "advanced": true,
+   "placeholder": "~/.openclaw/workspace/memory/local"
+  },
+  "debug": {
+   "label": "Debug Mode",
+   "advanced": true
+  },
+  "identityEnabled": {
+   "label": "Identity Reflections",
+   "help": "Append self-reflections to workspace IDENTITY.md after each extraction"
+  },
+  "identityContinuityEnabled": {
+   "label": "Identity Continuity",
+   "help": "Enable identity continuity workflows (anchor, incidents, audits)"
+  },
+  "identityInjectionMode": {
+   "label": "Identity Context Mode",
+   "advanced": true,
+   "placeholder": "recovery_only",
+   "help": "When to add identity continuity context: recovery_only, minimal, or full"
+  },
+  "identityMaxInjectChars": {
+   "label": "Identity Max Context Chars",
+   "advanced": true,
+   "placeholder": "1200"
+  },
+  "continuityIncidentLoggingEnabled": {
+   "label": "Continuity Incident Logging",
+   "advanced": true,
+   "help": "When omitted, follows Identity Continuity enabled state"
+  },
+  "continuityAuditEnabled": {
+   "label": "Continuity Audits",
+   "advanced": true,
+   "help": "Generate continuity audit artifacts"
+  },
+  "sessionObserverEnabled": {
+   "label": "Session Observer",
+   "advanced": true,
+   "help": "Observe heartbeat growth and proactively trigger extraction when configured thresholds are crossed"
+  },
+  "sessionObserverDebounceMs": {
+   "label": "Observer Debounce (ms)",
+   "advanced": true,
+   "placeholder": "120000"
+  },
+  "sessionObserverBands": {
+   "label": "Observer Size Bands",
+   "advanced": true,
+   "help": "Array of {maxBytes, triggerDeltaBytes, triggerDeltaTokens} threshold objects"
+  },
+  "injectQuestions": {
+   "label": "Inject Questions",
+   "help": "Include the most relevant open question in generated memory context"
+  },
+  "commitmentDecayDays": {
+   "label": "Commitment Decay (days)",
+   "advanced": true,
+   "placeholder": "90",
+   "help": "Positive integer days before fulfilled/expired commitments are removed."
+  },
+  "workspaceDir": {
+   "label": "Workspace Directory",
+   "advanced": true,
+   "placeholder": "~/.openclaw/workspace"
+  },
+  "accessTrackingEnabled": {
+   "label": "Access Tracking",
+   "help": "Track which memories are accessed most frequently"
+  },
+  "accessTrackingBufferMaxSize": {
+   "label": "Access Buffer Size",
+   "advanced": true,
+   "placeholder": "100"
+  },
+  "recencyWeight": {
+   "label": "Recency Weight",
+   "advanced": true,
+   "help": "How much to boost recent memories in search (0-1)",
+   "placeholder": "0.2"
+  },
+  "boostAccessCount": {
+   "label": "Boost Frequent Access",
+   "help": "Rank frequently accessed memories higher in search"
+  },
+  "captureMode": {
+   "label": "Capture Mode",
+   "help": "Choose whether Engram stores only explicit notes, normal extraction, or both."
+  },
+  "agentAccessHttp": {
+   "label": "Local HTTP Access",
+   "help": "Enable a local authenticated HTTP API for external Engram clients"
+  },
+  "negativeExamplesEnabled": {
+   "label": "Negative Examples",
+   "help": "Track retrieved-but-not-useful memories and apply a small ranking penalty (optional)"
+  },
+  "negativeExamplesPenaltyPerHit": {
+   "label": "Negative Penalty / Hit",
+   "advanced": true,
+   "placeholder": "0.05"
+  },
+  "negativeExamplesPenaltyCap": {
+   "label": "Negative Penalty Cap",
+   "advanced": true,
+   "placeholder": "0.25"
+  },
+  "chunkingEnabled": {
+   "label": "Enable Chunking",
+   "help": "Automatically split long memories into overlapping chunks for better retrieval"
+  },
+  "chunkingTargetTokens": {
+   "label": "Chunk Target Tokens",
+   "advanced": true,
+   "placeholder": "200"
+  },
+  "chunkingMinTokens": {
+   "label": "Chunk Min Tokens",
+   "advanced": true,
+   "placeholder": "150"
+  },
+  "chunkingOverlapSentences": {
+   "label": "Chunk Overlap Sentences",
+   "advanced": true,
+   "placeholder": "2"
+  },
+  "semanticChunkingEnabled": {
+   "label": "Semantic Chunking",
+   "help": "Use embedding-based topic detection for more coherent chunks (requires chunking enabled)"
+  },
+  "semanticChunkingConfig": {
+   "label": "Semantic Chunking Config",
+   "advanced": true,
+   "help": "Override defaults for semantic chunking algorithm parameters"
+  },
+  "contradictionDetectionEnabled": {
+   "label": "Contradiction Detection",
+   "help": "Detect and resolve conflicting memories using LLM verification"
+  },
+  "contradictionSimilarityThreshold": {
+   "label": "Contradiction Similarity Threshold",
+   "advanced": true,
+   "placeholder": "0.7"
+  },
+  "contradictionMinConfidence": {
+   "label": "Contradiction Min Confidence",
+   "advanced": true,
+   "placeholder": "0.9"
+  },
+  "contradictionAutoResolve": {
+   "label": "Auto-Resolve Contradictions",
+   "help": "Automatically supersede old memories when contradiction is confirmed"
+  },
+  "contradictionScan": {
+   "label": "Contradiction Scan",
+   "help": "Nightly cron that pairs similar memories and flags contradictions for review (issue #520)"
+  },
+  "temporalSupersessionEnabled": {
+   "label": "Temporal Supersession",
+   "help": "Mark older facts superseded when a newer fact writes a conflicting value for the same entityRef + structured attribute (issue #375)"
+  },
+  "temporalSupersessionIncludeInRecall": {
+   "label": "Include Superseded Facts In Recall",
+   "advanced": true,
+   "help": "If enabled, superseded facts still surface in recall (audit/history mode)."
+  },
+  "temporalBiTemporal": {
+   "label": "Bi-temporal Validity",
+   "advanced": true,
+   "help": "Master gate (issue #1578): resolve per-fact event-time at write time and exclude validity-expired facts from injection by default. Off = byte-identical to pre-#1578."
+  },
+  "temporalExpiredInInjection": {
+   "label": "Keep Expired-Validity Facts In Injection",
+   "advanced": true,
+   "help": "Escape hatch (issue #1578): keep facts whose event-time interval ended in injection candidates even with bi-temporal on."
+  },
+  "recallDirectAnswerEnabled": {
+   "label": "Direct-Answer Retrieval Tier",
+   "help": "Opt in to the direct-answer retrieval tier for validated high-trust queries before QMD (issue #518)."
+  },
+  "recallDisclosureEscalation": {
+   "label": "Disclosure Auto-Escalation",
+   "help": "Auto-promote default chunk recalls to section when top-K confidence is low (issue #677 PR 4/4). Set to 'auto' to enable; 'manual' (default) preserves pre-#677 behavior."
+  },
+  "recallDisclosureEscalationThreshold": {
+   "label": "Disclosure Escalation Threshold",
+   "advanced": true,
+   "placeholder": "0.5",
+   "help": "Top-K confidence (0-1) below which auto-escalation triggers. Only consulted when Disclosure Auto-Escalation is set to 'auto'."
+  },
+  "recallGraphEnabled": {
+   "label": "Graph Retrieval (PPR)",
+   "help": "Run Personalized PageRank on the retrieval graph and merge with QMD via MMR (issue #559)."
+  },
+  "recallGraphDamping": {
+   "label": "Graph Recall Damping",
+   "advanced": true,
+   "placeholder": "0.85"
+  },
+  "recallGraphIterations": {
+   "label": "Graph Recall Iterations",
+   "advanced": true,
+   "placeholder": "20"
+  },
+  "recallGraphTopK": {
+   "label": "Graph Recall Top-K",
+   "advanced": true,
+   "placeholder": "50"
+  },
+  "recallDirectAnswerTokenOverlapFloor": {
+   "label": "Direct-Answer Token Overlap Floor",
+   "advanced": true,
+   "placeholder": "0.55"
+  },
+  "recallDirectAnswerImportanceFloor": {
+   "label": "Direct-Answer Importance Floor",
+   "advanced": true,
+   "placeholder": "0.7"
+  },
+  "recallDirectAnswerAmbiguityMargin": {
+   "label": "Direct-Answer Ambiguity Margin",
+   "advanced": true,
+   "placeholder": "0.15"
+  },
+  "recallDirectAnswerEligibleTaxonomyBuckets": {
+   "label": "Direct-Answer Eligible Taxonomy Buckets",
+   "advanced": true,
+   "help": "Taxonomy category IDs eligible for direct-answer routing."
+  },
+  "memoryLinkingEnabled": {
+   "label": "Memory Linking",
+   "help": "Build knowledge graph by linking related memories"
+  },
+  "threadingEnabled": {
+   "label": "Conversation Threading",
+   "help": "Group memories into conversation threads with auto-titles"
+  },
+  "threadingGapMinutes": {
+   "label": "Thread Gap (minutes)",
+   "advanced": true,
+   "placeholder": "30"
+  },
+  "summarizationEnabled": {
+   "label": "Memory Summarization",
+   "help": "Compress old, low-importance memories into summaries"
+  },
+  "summarizationTriggerCount": {
+   "label": "Summarization Trigger",
+   "advanced": true,
+   "placeholder": "1000"
+  },
+  "summarizationRecentToKeep": {
+   "label": "Recent to Keep",
+   "advanced": true,
+   "placeholder": "300"
+  },
+  "summarizationImportanceThreshold": {
+   "label": "Importance Threshold",
+   "advanced": true,
+   "placeholder": "0.3"
+  },
+  "topicExtractionEnabled": {
+   "label": "Topic Extraction",
+   "help": "Extract key topics from memory corpus"
+  },
+  "topicExtractionTopN": {
+   "label": "Top N Topics",
+   "advanced": true,
+   "placeholder": "50"
+  },
+  "transcriptEnabled": {
+   "label": "Enable Transcript Archive",
+   "help": "Archive conversation transcripts for context preservation"
+  },
+  "transcriptRetentionDays": {
+   "label": "Transcript Retention (days)",
+   "advanced": true,
+   "placeholder": "7"
+  },
+  "transcriptSkipChannelTypes": {
+   "label": "Skip Channel Types",
+   "advanced": true,
+   "help": "Channel types to exclude from transcript logging (default: cron)"
+  },
+  "transcriptRecallHours": {
+   "label": "Transcript Recall (hours)",
+   "advanced": true,
+   "placeholder": "12"
+  },
+  "maxTranscriptTurns": {
+   "label": "Max Transcript Turns",
+   "advanced": true,
+   "placeholder": "50"
+  },
+  "maxTranscriptTokens": {
+   "label": "Max Transcript Tokens",
+   "advanced": true,
+   "placeholder": "1000"
+  },
+  "checkpointEnabled": {
+   "label": "Enable Checkpoints",
+   "help": "Capture conversation checkpoints for resuming context"
+  },
+  "checkpointTurns": {
+   "label": "Checkpoint Turn Interval",
+   "advanced": true,
+   "placeholder": "15"
+  },
+  "compactionResetEnabled": {
+   "label": "Compaction Reset",
+   "help": "Reset session after compaction and add BOOT.md recovery context",
+   "advanced": true
+  },
+  "hourlySummariesEnabled": {
+   "label": "Enable Hourly Summaries",
+   "help": "Generate hourly summaries of conversation activity"
+  },
+  "summaryRecallHours": {
+   "label": "Summary Recall (hours)",
+   "advanced": true,
+   "placeholder": "24"
+  },
+  "maxSummaryCount": {
+   "label": "Max Summary Count",
+   "advanced": true,
+   "placeholder": "6"
+  },
+  "summaryModel": {
+   "label": "Summary Model",
+   "advanced": true,
+   "placeholder": "(same as extraction model)"
+  },
+  "modelSource": {
+   "label": "Model Source",
+   "help": "Route LLM calls through the gateway's agent model chain instead of Engram's own config. Default for OpenClaw installs. When set to 'gateway', localLlm and openai settings are ignored."
+  },
+  "gatewayAgentId": {
+   "label": "Gateway Agent ID",
+   "advanced": true,
+   "placeholder": "engram-llm",
+   "help": "Agent persona ID from openclaw.json agents.list[] whose model chain to use. Leave empty to use global defaults."
+  },
+  "fastGatewayAgentId": {
+   "label": "Fast Gateway Agent ID",
+   "advanced": true,
+   "placeholder": "engram-llm-fast",
+   "help": "Agent persona ID for fast-tier ops. Leave empty to use the primary gatewayAgentId."
+  },
+  "taskModelChain": {
+   "label": "Task Model Chain",
+   "advanced": true,
+   "help": "Optional primary/fallback gateway model chain for Remnic background tasks (extraction, consolidation, summarization). Overrides gatewayAgentId/defaults for these tasks only. Requires modelSource: 'gateway'."
+  },
+  "localLlmEnabled": {
+   "label": "Enable Local LLM",
+   "help": "Use local LLM (LM Studio, Ollama, etc.) for extraction and summaries. Falls back to OpenAI if unavailable."
+  },
+  "localLlmUrl": {
+   "label": "Local LLM URL",
+   "advanced": true,
+   "placeholder": "http://localhost:1234/v1",
+   "help": "OpenAI-compatible endpoint URL for local LLM"
+  },
+  "localLlmModel": {
+   "label": "Local LLM Model",
+   "advanced": true,
+   "placeholder": "local-model",
+   "help": "Model identifier for local LLM requests"
+  },
+  "localLlmApiKey": {
+   "label": "Local LLM API Key",
+   "advanced": true,
+   "sensitive": true,
+   "placeholder": "sk-...",
+   "help": "Optional API key for authenticated OpenAI-compatible endpoints"
+  },
+  "localLlmHeaders": {
+   "label": "Local LLM Headers",
+   "advanced": true,
+   "help": "Optional extra headers for provider-specific routing/auth"
+  },
+  "localLlmAuthHeader": {
+   "label": "Send Auth Header",
+   "advanced": true,
+   "help": "When false, do not send Authorization header even if localLlmApiKey is set"
+  },
+  "localLlmFallback": {
+   "label": "Local LLM Fallback",
+   "advanced": true,
+   "help": "Fall back to cloud OpenAI if local LLM fails or is unavailable"
+  },
+  "localLlmHomeDir": {
+   "label": "Local LLM Home Dir",
+   "advanced": true,
+   "placeholder": "(auto: HOME / os.homedir)",
+   "help": "Optional home directory override for LM Studio settings and local helper paths."
+  },
+  "localLmsCliPath": {
+   "label": "LMS CLI Path",
+   "advanced": true,
+   "placeholder": "/path/to/lms",
+   "help": "Optional absolute path to LMS CLI. Overrides auto-detection."
+  },
+  "localLmsBinDir": {
+   "label": "LMS Bin Dir",
+   "advanced": true,
+   "placeholder": "/path/to/bin",
+   "help": "Optional bin directory prepended to PATH for LMS CLI execution."
+  },
+  "localLlmMaxContext": {
+   "label": "Local LLM Max Context",
+   "advanced": true,
+   "placeholder": "(auto-detected from model)",
+   "help": "Override context window if your LLM server uses smaller default (e.g., 32768 for LM Studio default)"
+  },
+  "localLlmFastEnabled": {
+   "label": "Fast LLM Tier",
+   "help": "Use a separate smaller model for quick operations (rerank, entity summaries, compression guidelines)"
+  },
+  "localLlmFastModel": {
+   "label": "Fast LLM Model",
+   "placeholder": "qwen3.5-4b-mlx",
+   "help": "Model ID for fast-tier operations. Must be loaded in LM Studio alongside the primary model."
+  },
+  "localLlmFastUrl": {
+   "label": "Fast LLM URL",
+   "advanced": true,
+   "placeholder": "(defaults to localLlmUrl)",
+   "help": "Endpoint for fast-tier model. When not set, inherits the primary localLlmUrl."
+  },
+  "localLlmFastTimeoutMs": {
+   "label": "Fast LLM Timeout (ms)",
+   "advanced": true,
+   "help": "Timeout for fast-tier requests. Lower than primary since fast ops should complete quickly."
+  },
+  "localLlmDisableThinking": {
+   "label": "Disable Local LLM Thinking Mode",
+   "advanced": true,
+   "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on \u2014 extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. The suppression field (chat_template_kwargs) is only sent when the backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
+  },
+  "evalHarnessEnabled": {
+   "label": "Evaluation Harness",
+   "help": "Enable Engram's benchmark/evaluation harness foundation and benchmark-status diagnostics."
+  },
+  "evalShadowModeEnabled": {
+   "label": "Evaluation Shadow Mode",
+   "advanced": true,
+   "help": "Reserve shadow-mode measurement paths so future benchmark instrumentation can compare memory behavior without affecting live recall."
+  },
+  "benchmarkBaselineSnapshotsEnabled": {
+   "label": "Benchmark Baseline Snapshots",
+   "advanced": true,
+   "help": "Enable versioned benchmark baseline snapshot artifacts for later PR delta reporting."
+  },
+  "benchmarkDeltaReporterEnabled": {
+   "label": "Benchmark Delta Reporter",
+   "advanced": true,
+   "help": "Enable named-baseline delta reports that compare the current eval store against a stored benchmark baseline snapshot."
+  },
+  "evalStoreDir": {
+   "label": "Evaluation Store Directory",
+   "advanced": true,
+   "placeholder": "{memoryDir}/state/evals",
+   "help": "Override where benchmark packs and run summaries are stored."
+  },
+  "objectiveStateMemoryEnabled": {
+   "label": "Objective-State Memory",
+   "help": "Enable the objective-state memory foundation for normalized world and tool state snapshots."
+  },
+  "objectiveStateSnapshotWritesEnabled": {
+   "label": "Objective-State Snapshot Writes",
+   "advanced": true,
+   "help": "Allow snapshot writers to persist objective-state records into the objective-state store."
+  },
+  "objectiveStateRecallEnabled": {
+   "label": "Objective-State Recall",
+   "advanced": true,
+   "help": "Add recall-relevant objective-state snapshots to recall context."
+  },
+  "objectiveStateStoreDir": {
+   "label": "Objective-State Store Directory",
+   "advanced": true,
+   "placeholder": "{memoryDir}/state/objective-state",
+   "help": "Override where objective-state snapshots are stored."
+  },
+  "causalTrajectoryMemoryEnabled": {
+   "label": "Causal Trajectory Memory",
+   "help": "Enable the causal-trajectory memory foundation for typed goal-action-observation-outcome chains."
+  },
+  "causalTrajectoryStoreDir": {
+   "label": "Causal Trajectory Store Directory",
+   "advanced": true,
+   "placeholder": "{memoryDir}/state/causal-trajectories",
+   "help": "Override where causal-trajectory records are stored."
+  },
+  "causalTrajectoryRecallEnabled": {
+   "label": "Causal Trajectory Recall",
+   "advanced": true,
+   "help": "Add recall-relevant causal trajectories to recall context."
+  },
+  "trustZonesEnabled": {
+   "label": "Trust Zones",
+   "help": "Enable the trust-zone memory foundation for quarantine, working, and trusted records."
+  },
+  "quarantinePromotionEnabled": {
+   "label": "Quarantine Promotion",
+   "advanced": true,
+   "help": "Reserve future promotion flows from quarantine into higher-trust zones."
+  },
+  "trustZoneStoreDir": {
+   "label": "Trust-Zone Store Directory",
+   "advanced": true,
+   "placeholder": "{memoryDir}/state/trust-zones",
+   "help": "Override where trust-zone records are stored."
+  },
+  "trustZoneRecallEnabled": {
+   "label": "Trust-Zone Recall",
+   "advanced": true,
+   "help": "Add recall-relevant working and trusted trust-zone records to recall context."
+  },
+  "memoryPoisoningDefenseEnabled": {
+   "label": "Memory Poisoning Defense",
+   "advanced": true,
+   "help": "Enable provenance trust scoring in trust-zone status output as the first poisoning-defense signal."
+  },
+  "memoryRedTeamBenchEnabled": {
+   "label": "Memory Red-Team Benchmarks",
+   "advanced": true,
+   "help": "Enable operator-facing red-team benchmark pack support and status accounting for poisoning-defense suites."
+  },
+  "harmonicRetrievalEnabled": {
+   "label": "Harmonic Retrieval",
+   "help": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
+  },
+  "abstractionAnchorsEnabled": {
+   "label": "Abstraction Anchors",
+   "advanced": true,
+   "help": "Enable typed cue-anchor indexing for abstraction nodes and expose it through cue-anchor status tooling."
+  },
+  "abstractionNodeStoreDir": {
+   "label": "Abstraction-Node Store Directory",
+   "advanced": true,
+   "placeholder": "{memoryDir}/state/abstraction-nodes",
+   "help": "Override where abstraction nodes are stored."
+  },
+  "verifiedRecallEnabled": {
+   "label": "Verified Recall",
+   "help": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
+  },
+  "semanticRulePromotionEnabled": {
+   "label": "Semantic Rule Promotion",
+   "advanced": true,
+   "help": "Promote explicit IF/THEN rules from verified episodic memories into durable rule memories."
+  },
+  "semanticRuleVerificationEnabled": {
+   "label": "Semantic Rule Verification",
+   "advanced": true,
+   "help": "Verify promoted semantic rules against their cited source episodes at recall time before surfacing them in recall."
+  },
+  "semanticConsolidationEnabled": {
+   "label": "Semantic Consolidation",
+   "advanced": true,
+   "help": "Enable periodic semantic consolidation of similar memories."
+  },
+  "semanticConsolidationModel": {
+   "label": "Semantic Consolidation Model",
+   "advanced": true,
+   "help": "LLM for consolidation synthesis: 'auto' (primary model), 'fast' (fast local model), or a specific model name."
+  },
+  "semanticConsolidationThreshold": {
+   "label": "Semantic Consolidation Threshold",
+   "advanced": true,
+   "help": "Token overlap threshold (0-1) for grouping similar memories. 0.8=conservative, 0.6=aggressive."
+  },
+  "semanticConsolidationMinClusterSize": {
+   "label": "Semantic Consolidation Min Cluster Size",
+   "advanced": true,
+   "help": "Minimum cluster size before consolidation triggers."
+  },
+  "semanticConsolidationExcludeCategories": {
+   "label": "Semantic Consolidation Exclude Categories",
+   "advanced": true,
+   "help": "Memory categories excluded from semantic consolidation."
+  },
+  "semanticConsolidationIntervalHours": {
+   "label": "Semantic Consolidation Interval (Hours)",
+   "advanced": true,
+   "help": "Hours between automatic consolidation runs (168 = weekly)."
+  },
+  "semanticConsolidationMaxPerRun": {
+   "label": "Semantic Consolidation Max Per Run",
+   "advanced": true,
+   "help": "Max memories to consolidate per run to limit LLM cost."
+  },
+  "operatorAwareConsolidationEnabled": {
+   "label": "Operator-Aware Consolidation",
+   "advanced": true,
+   "help": "Opt in to operator-aware consolidation instructions (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+  },
+  "peerProfileReasonerEnabled": {
+   "label": "Peer Profile Reasoner",
+   "advanced": true,
+   "help": "Enable the async peer profile reasoner (issue #679). Runs in the REM phase after semantic consolidation and updates per-peer profile.md files with provenance-tagged field updates derived from each peer's interaction log. Default off (opt-in)."
+  },
+  "peerProfileReasonerModel": {
+   "label": "Peer Profile Reasoner Model",
+   "advanced": true,
+   "help": "Model identifier the peer profile reasoner records on telemetry. Dispatch still routes through the FallbackLlmClient used by semantic consolidation."
+  },
+  "peerProfileReasonerMinInteractions": {
+   "label": "Peer Profile Reasoner Min Interactions",
+   "advanced": true,
+   "help": "Minimum new interaction-log entries a peer must accumulate since the previous reasoner run before being processed again. Set to 0 to consider every peer on every run."
+  },
+  "peerProfileReasonerMaxFieldsPerRun": {
+   "label": "Peer Profile Reasoner Max Fields Per Run",
+   "advanced": true,
+   "help": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
+  },
+  "peerProfileRecallEnabled": {
+   "label": "Peer Profile Recall",
+   "advanced": true,
+   "help": "When enabled, adds the active peer's profile fields to recall context as a '## Peer Profile' section. Requires the session peer ID to be registered. Default off."
+  },
+  "peerProfileRecallMaxFields": {
+   "label": "Peer Profile Recall Max Fields",
+   "advanced": true,
+   "help": "Maximum number of peer profile fields to add per recall. Only the most-recently-updated N fields are included. Set to 0 to disable this feature."
+  },
+  "creationMemoryEnabled": {
+   "label": "Creation Memory",
+   "advanced": true,
+   "help": "Enable creation-memory foundations, including the work-product ledger for explicit outputs agents create."
+  },
+  "memoryUtilityLearningEnabled": {
+   "label": "Utility Learning",
+   "advanced": true,
+   "help": "Enable utility-learning telemetry storage so later slices can learn promotion and ranking weights from downstream outcomes."
+  },
+  "promotionByOutcomeEnabled": {
+   "label": "Promotion By Outcome",
+   "advanced": true,
+   "help": "Enable outcome-aware promotion controls that will consume learned utility signals in later rollout slices."
+  },
+  "commitmentLedgerEnabled": {
+   "label": "Commitment Ledger",
+   "advanced": true,
+   "help": "Enable the explicit commitment ledger for promises, follow-ups, deadlines, and unfinished obligations."
+  },
+  "commitmentLifecycleEnabled": {
+   "label": "Commitment Lifecycle",
+   "advanced": true,
+   "help": "Enable fulfillment transitions, stale tracking, and resolved-entry cleanup for the commitment ledger."
+  },
+  "commitmentStaleDays": {
+   "label": "Commitment Stale Days",
+   "advanced": true,
+   "help": "Days before an open commitment without a due date counts as stale."
+  },
+  "commitmentLedgerDir": {
+   "label": "Commitment Ledger Directory",
+   "advanced": true,
+   "placeholder": "{memoryDir}/state/commitment-ledger",
+   "help": "Override where commitment ledger entries are stored."
+  },
+  "resumeBundlesEnabled": {
+   "label": "Resume Bundles",
+   "advanced": true,
+   "help": "Enable deterministic resume-bundle storage and explicit handoff bundle commands."
+  },
+  "resumeBundleDir": {
+   "label": "Resume Bundle Directory",
+   "advanced": true,
+   "placeholder": "{memoryDir}/state/resume-bundles",
+   "help": "Override where resume bundles are stored."
+  },
+  "workProductRecallEnabled": {
+   "label": "Work-Product Recall",
+   "advanced": true,
+   "help": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
+  },
+  "workProductLedgerDir": {
+   "label": "Work-Product Ledger Directory",
+   "advanced": true,
+   "placeholder": "{memoryDir}/state/work-product-ledger",
+   "help": "Override where work-product ledger entries are stored."
+  },
+  "actionGraphRecallEnabled": {
+   "label": "Action Graph Recall",
+   "help": "Write action-conditioned causal-stage edges from typed trajectory records into the causal graph."
+  },
+  "factDeduplicationEnabled": {
+   "label": "Fact Deduplication",
+   "help": "Prevent storing semantically identical facts using content hashing"
+  },
+  "semanticDedupEnabled": {
+   "label": "Semantic Dedup (write-time)",
+   "help": "Skip near-duplicate facts at write time by comparing embeddings to existing memories (issue #373)."
+  },
+  "semanticDedupThreshold": {
+   "label": "Semantic Dedup Threshold",
+   "advanced": true,
+   "placeholder": "0.92"
+  },
+  "semanticDedupCandidates": {
+   "label": "Semantic Dedup Candidates",
+   "advanced": true,
+   "placeholder": "5"
+  },
+  "factArchivalEnabled": {
+   "label": "Fact Archival",
+   "help": "Automatically archive old, low-importance, rarely-accessed facts during consolidation"
+  },
+  "factArchivalAgeDays": {
+   "label": "Archival Age (days)",
+   "advanced": true,
+   "placeholder": "90"
+  },
+  "factArchivalMaxImportance": {
+   "label": "Archival Max Importance",
+   "advanced": true,
+   "placeholder": "0.3"
+  },
+  "factArchivalMaxAccessCount": {
+   "label": "Archival Max Access Count",
+   "advanced": true,
+   "placeholder": "2"
+  },
+  "factArchivalProtectedCategories": {
+   "label": "Archival Protected Categories",
+   "advanced": true,
+   "help": "Categories that are never archived regardless of age or importance"
+  },
+  "lifecyclePolicyEnabled": {
+   "label": "Lifecycle Policy Engine",
+   "help": "Enable lifecycle scoring/promotions during consolidation (v8.3)"
+  },
+  "lifecycleFilterStaleEnabled": {
+   "label": "Filter Stale Lifecycle Memories",
+   "advanced": true,
+   "help": "If enabled, retrieval may filter stale lifecycle memories (activated in PR20D)"
+  },
+  "lifecyclePromoteHeatThreshold": {
+   "label": "Lifecycle Promote Heat Threshold",
+   "advanced": true,
+   "placeholder": "0.55"
+  },
+  "lifecycleStaleDecayThreshold": {
+   "label": "Lifecycle Stale Decay Threshold",
+   "advanced": true,
+   "placeholder": "0.65"
+  },
+  "lifecycleArchiveDecayThreshold": {
+   "label": "Lifecycle Archive Decay Threshold",
+   "advanced": true,
+   "placeholder": "0.85"
+  },
+  "lifecycleProtectedCategories": {
+   "label": "Lifecycle Protected Categories",
+   "advanced": true,
+   "help": "Categories lifecycle policy should not auto-archive"
+  },
+  "lifecycleMetricsEnabled": {
+   "label": "Lifecycle Metrics",
+   "advanced": true,
+   "help": "Write lifecycle metrics snapshots to state/lifecycle-metrics.json"
+  },
+  "proactiveExtractionEnabled": {
+   "label": "Proactive Extraction",
+   "help": "Enable proactive self-questioning extraction second-pass (v8.3, default off)"
+  },
+  "contextCompressionActionsEnabled": {
+   "label": "Context Compression Actions",
+   "help": "Enable context compression action tools and action telemetry (v8.3, default off)"
+  },
+  "compressionGuidelineLearningEnabled": {
+   "label": "Compression Guideline Learning",
+   "help": "Enable adaptive compression guideline learning from action outcomes (v8.3, default off)"
+  },
+  "compressionGuidelineSemanticRefinementEnabled": {
+   "label": "Compression Semantic Refinement",
+   "advanced": true,
+   "help": "Enable optional semantic refinement after deterministic guideline generation (v8.11, default off)"
+  },
+  "compressionGuidelineSemanticTimeoutMs": {
+   "label": "Compression Semantic Timeout (ms)",
+   "advanced": true,
+   "placeholder": "2500"
+  },
+  "maxProactiveQuestionsPerExtraction": {
+   "label": "Max Proactive Questions / Extraction",
+   "advanced": true,
+   "placeholder": "2"
+  },
+  "proactiveExtractionTimeoutMs": {
+   "label": "Proactive Extraction Timeout (ms)",
+   "advanced": true,
+   "placeholder": "2500"
+  },
+  "proactiveExtractionMaxTokens": {
+   "label": "Proactive Extraction Max Tokens",
+   "advanced": true,
+   "placeholder": "900"
+  },
+  "extractionMaxOutputTokens": {
+   "label": "Extraction Max Output Tokens",
+   "advanced": true,
+   "placeholder": "16384"
+  },
+  "proactiveExtractionCategoryAllowlist": {
+   "label": "Proactive Category Allowlist",
+   "advanced": true,
+   "help": "Optional list of memory categories that proactive second-pass writes may emit"
+  },
+  "maxCompressionTokensPerHour": {
+   "label": "Max Compression Tokens / Hour",
+   "advanced": true,
+   "placeholder": "1500"
+  },
+  "behaviorLoopAutoTuneEnabled": {
+   "label": "Behavior Loop Auto-Tune",
+   "help": "Enable bounded runtime policy auto-tuning from correction/preference signals (v8.15, default off)"
+  },
+  "behaviorLoopLearningWindowDays": {
+   "label": "Behavior Learning Window (days)",
+   "advanced": true,
+   "placeholder": "14"
+  },
+  "behaviorLoopMinSignalCount": {
+   "label": "Behavior Min Signal Count",
+   "advanced": true,
+   "placeholder": "10"
+  },
+  "behaviorLoopMaxDeltaPerCycle": {
+   "label": "Behavior Max Delta / Cycle",
+   "advanced": true,
+   "placeholder": "0.1"
+  },
+  "behaviorLoopProtectedParams": {
+   "label": "Behavior Protected Params",
+   "advanced": true,
+   "help": "Parameter keys that auto-tuning must never change"
+  },
+  "knowledgeIndexEnabled": {
+   "label": "Knowledge Index",
+   "help": "Inject a compact table of top entities into every recall"
+  },
+  "knowledgeIndexMaxEntities": {
+   "label": "Knowledge Index Max Entities",
+   "advanced": true,
+   "placeholder": "40"
+  },
+  "knowledgeIndexMaxChars": {
+   "label": "Knowledge Index Max Chars",
+   "advanced": true,
+   "placeholder": "4000"
+  },
+  "entityRetrievalEnabled": {
+   "label": "Entity Retrieval",
+   "help": "Inject direct-answer entity hints for entity questions and short follow-up queries"
+  },
+  "entityRetrievalMaxChars": {
+   "label": "Entity Retrieval Max Chars",
+   "advanced": true,
+   "placeholder": "2400"
+  },
+  "entityRetrievalMaxHints": {
+   "label": "Entity Retrieval Max Hints",
+   "advanced": true,
+   "placeholder": "2"
+  },
+  "entityRetrievalMaxSupportingFacts": {
+   "label": "Entity Retrieval Max Supporting Facts",
+   "advanced": true,
+   "placeholder": "6"
+  },
+  "entityRetrievalMaxRelatedEntities": {
+   "label": "Entity Retrieval Max Related Entities",
+   "advanced": true,
+   "placeholder": "3"
+  },
+  "entityRetrievalRecentTurns": {
+   "label": "Entity Retrieval Recent Turns",
+   "advanced": true,
+   "placeholder": "6"
+  },
+  "entityRelationshipsEnabled": {
+   "label": "Entity Relationships",
+   "help": "Track entity-to-entity relationships during extraction"
+  },
+  "entityActivityLogEnabled": {
+   "label": "Entity Activity Log",
+   "help": "Log timestamped activity per entity"
+  },
+  "entityActivityLogMaxEntries": {
+   "label": "Activity Log Max Entries",
+   "advanced": true,
+   "placeholder": "20"
+  },
+  "entityAliasesEnabled": {
+   "label": "Entity Aliases",
+   "help": "Store aliases per entity file"
+  },
+  "entitySummaryEnabled": {
+   "label": "Entity Summaries",
+   "help": "Generate LLM summaries for entities during consolidation"
+  },
+  "entitySynthesisMaxTokens": {
+   "label": "Entity Synthesis Max Tokens",
+   "advanced": true,
+   "placeholder": "500",
+   "help": "Max tokens used when refreshing an entity synthesis from its timeline."
+  },
+  "recallBudgetChars": {
+   "label": "Recall Budget (Chars)",
+   "advanced": true,
+   "placeholder": "8000"
+  },
+  "recallPipeline": {
+   "label": "Recall Pipeline",
+   "advanced": true,
+   "help": "Ordered section configuration for recall assembly and per-section limits"
+  },
+  "recallMmrEnabled": {
+   "label": "Recall MMR (Diversity)",
+   "advanced": true,
+   "help": "Apply Maximal Marginal Relevance per-section so duplicate clusters cannot dominate the recall budget"
+  },
+  "recallMmrLambda": {
+   "label": "MMR Lambda",
+   "advanced": true,
+   "placeholder": "0.7",
+   "help": "1.0 = pure relevance, 0.0 = pure diversity. Default 0.7."
+  },
+  "recallMmrTopN": {
+   "label": "MMR Top-N",
+   "advanced": true,
+   "placeholder": "40",
+   "help": "Number of top candidates per section over which MMR is applied"
+  },
+  "recallReasoningTraceBoostEnabled": {
+   "label": "Boost Reasoning Traces on Problem-Solving Queries",
+   "advanced": true,
+   "help": "Promote stored reasoning_trace memories to the top of recall results when the incoming query reads like a problem-solving ask. Default off; enable after benchmarking (issue #564)."
+  }
+ },
+ "commandAliases": [
+  {
+   "name": "remnic",
+   "kind": "runtime-slash",
+   "cliCommand": "remnic"
+  }
+ ],
+ "activation": {
+  "onStartup": false,
+  "onCommands": [
+   "remnic"
+  ],
+  "onCapabilities": [
+   "tool",
+   "hook"
+  ]
+ }
 }

--- a/packages/remnic-core/src/buffer-session.test.ts
+++ b/packages/remnic-core/src/buffer-session.test.ts
@@ -492,13 +492,19 @@ test("getTurns prepends retained deferred turns before live turns", async () => 
   assert.equal(all[1]?.content, "new live turn");
 });
 
-test("SmartBuffer never prunes logical session buffers that still have pending turns", async () => {
+test("SmartBuffer prefers pruning empty entries and bounds pending-turn buffers at the cap (#1908 policy)", async () => {
+  // Pre-#1908 this contract was "never prune non-empty entries". With retry
+  // retention (failed extractions keep their turns), unbounded non-empty
+  // growth during a provider outage would eventually OOM the daemon — the
+  // documented policy (#1908 step 7) is: retain up to MAX_BUFFER_ENTRY_COUNT
+  // session entries, then prune the OLDEST sessions with a loud warning.
+  // Empty entries are still evicted first.
   const entries = Object.fromEntries(
     Array.from({ length: 205 }, (_, index) => [
       `thread-${index}`,
       {
         turns: [makeTurn(`thread-${index}`, `memory ${index}`)],
-        lastExtractionAt: null,
+        lastExtractionAt: new Date(1_700_000_000_000 + index * 60_000).toISOString(),
         extractionCount: 0,
       },
     ]),
@@ -516,14 +522,40 @@ test("SmartBuffer never prunes logical session buffers that still have pending t
       ...entries,
     },
   });
-  const buffer = new SmartBuffer(parseConfig({}), storage as any);
+  const buffer = new SmartBuffer(parseConfig({}), storage as unknown as ConstructorParameters<typeof SmartBuffer>[1]);
 
   await buffer.addTurn("active-thread", makeTurn("active-thread", "pending memory"));
 
   const persistedKeys = Object.keys(storage.saved?.entries ?? {});
-  assert.equal(persistedKeys.length, 207);
-  assert.ok(persistedKeys.includes("default"));
-  assert.ok(persistedKeys.includes("active-thread"));
-  assert.ok(persistedKeys.includes("thread-0"));
-  assert.ok(persistedKeys.includes("thread-204"));
+  assert.ok(persistedKeys.length <= 201, `bounded at the cap plus default (got ${persistedKeys.length})`);
+  assert.ok(persistedKeys.includes("default"), "default entry never pruned");
+  assert.ok(persistedKeys.includes("active-thread"), "the just-written key is retained");
+  assert.ok(!persistedKeys.includes("thread-0"), "oldest pending entry pruned once over the cap");
+  assert.ok(persistedKeys.includes("thread-204"), "newest pending entry survives");
+});
+
+test("pruneEntries evicts oldest NON-empty session entries past the cap (#1908 retry-retention bound)", async () => {
+  // Retained failed extractions keep their turns in the buffer, so during a
+  // provider outage non-empty entries can exceed MAX_BUFFER_ENTRY_COUNT (200).
+  // The cap is the documented bound: the oldest non-empty sessions must be
+  // evicted (loudly) rather than growing without bound (codex review).
+  const entries: NonNullable<BufferState["entries"]> = {};
+  for (let i = 0; i < 210; i += 1) {
+    const at = new Date(1_700_000_000_000 + i * 60_000).toISOString();
+    entries[`session-${String(i).padStart(3, "0")}`] = {
+      turns: [{ role: "user", content: `retained turn ${i}`, timestamp: at, sessionKey: `session-${i}` }],
+      lastExtractionAt: at,
+      extractionCount: 0,
+    };
+  }
+  const storage = new FakeStorage({ turns: [], lastExtractionAt: null, extractionCount: 0, entries });
+  const buffer = new SmartBuffer(parseConfig({}), storage as unknown as ConstructorParameters<typeof SmartBuffer>[1]);
+  await buffer.load();
+  await buffer.addTurn("session-newest", makeTurn("session-newest", "new turn"));
+
+  const savedKeys = Object.keys(storage.saved?.entries ?? {});
+  assert.ok(savedKeys.length <= 200, `entries bounded at MAX_BUFFER_ENTRY_COUNT (got ${savedKeys.length})`);
+  assert.ok(savedKeys.includes("session-newest"), "the just-written key is retained");
+  assert.equal(buffer.getTurns("session-000").length, 0, "oldest non-empty entry was evicted");
+  assert.ok(buffer.getTurns("session-209").length > 0, "newest pre-existing entry survives");
 });

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -225,8 +225,20 @@ export class SmartBuffer {
       });
 
     const removableCount = Math.max(0, keys.length - MAX_BUFFER_ENTRY_COUNT);
-    for (const key of removable.slice(0, removableCount)) {
+    const evicted = removable.slice(0, removableCount);
+    for (const key of evicted) {
       delete entries[key];
+    }
+    if (evicted.length > 0) {
+      // Loud degradation (extraction hot-loop hardening, Step 7): during a
+      // prolonged provider outage the breaker holds extraction off and buffered
+      // sessions accumulate. Eviction of the oldest empty session entries past
+      // MAX_BUFFER_ENTRY_COUNT is bounded and expected, but must be observable —
+      // not silent — so operators can see buffer pressure.
+      log.warn(
+        `buffer: pruned ${evicted.length} oldest session entr${evicted.length === 1 ? "y" : "ies"} ` +
+          `past MAX_BUFFER_ENTRY_COUNT=${MAX_BUFFER_ENTRY_COUNT}; buffered turn data for those sessions was dropped`,
+      );
     }
   }
 

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -206,26 +206,38 @@ export class SmartBuffer {
     if (keys.length <= MAX_BUFFER_ENTRY_COUNT) return;
 
     const insertionOrder = new Map(keys.map((key, index) => [key, index]));
-    const removable = keys
-      .filter((key) => key !== "default" && !retainKeys.includes(key))
-      .filter((key) => (entries[key]?.turns.length ?? 0) === 0)
-      .sort((left, right) => {
-        const leftAt = this.entryActivityAt(entries[left] ?? {
-          turns: [],
-          lastExtractionAt: null,
-          extractionCount: 0,
-        });
-        const rightAt = this.entryActivityAt(entries[right] ?? {
-          turns: [],
-          lastExtractionAt: null,
-          extractionCount: 0,
-        });
-        if (leftAt !== rightAt) return leftAt - rightAt;
-        return (insertionOrder.get(left) ?? 0) - (insertionOrder.get(right) ?? 0);
+    const byOldestActivity = (left: string, right: string): number => {
+      const leftAt = this.entryActivityAt(entries[left] ?? {
+        turns: [],
+        lastExtractionAt: null,
+        extractionCount: 0,
       });
+      const rightAt = this.entryActivityAt(entries[right] ?? {
+        turns: [],
+        lastExtractionAt: null,
+        extractionCount: 0,
+      });
+      if (leftAt !== rightAt) return leftAt - rightAt;
+      return (insertionOrder.get(left) ?? 0) - (insertionOrder.get(right) ?? 0);
+    };
+    const candidates = keys.filter((key) => key !== "default" && !retainKeys.includes(key));
+    const emptyRemovable = candidates
+      .filter((key) => (entries[key]?.turns.length ?? 0) === 0)
+      .sort(byOldestActivity);
 
     const removableCount = Math.max(0, keys.length - MAX_BUFFER_ENTRY_COUNT);
-    const evicted = removable.slice(0, removableCount);
+    let evicted = emptyRemovable.slice(0, removableCount);
+    if (evicted.length < removableCount) {
+      // Retained failed extractions (#1908 retry retention) keep their turns in
+      // the buffer, so empty entries alone may not bring the map back under the
+      // cap during a provider outage. The cap is the documented bound — evict
+      // the oldest NON-empty sessions too rather than growing unboundedly
+      // (codex review).
+      const nonEmptyRemovable = candidates
+        .filter((key) => (entries[key]?.turns.length ?? 0) > 0)
+        .sort(byOldestActivity);
+      evicted = evicted.concat(nonEmptyRemovable.slice(0, removableCount - evicted.length));
+    }
     for (const key of evicted) {
       delete entries[key];
     }

--- a/packages/remnic-core/src/capabilities.test.ts
+++ b/packages/remnic-core/src/capabilities.test.ts
@@ -366,6 +366,7 @@ const LIFECYCLE_FIELD_TO_FLAG: Record<keyof MemoryLifecycleCapabilitySet, string
   extractionScopeClassification: "extractionScopeClassificationEnabled",
   extractionJudge: "extractionJudgeEnabled",
   extractionDedupe: "extractionDedupeEnabled",
+  extractionRetry: "extractionRetryEnabled",
   extractionTelemetryPrefilter: "extractionTelemetryPrefilterEnabled",
   extractionJudgeTelemetry: "extractionJudgeTelemetryEnabled",
   embeddingFallback: "embeddingFallbackEnabled",

--- a/packages/remnic-core/src/capabilities.ts
+++ b/packages/remnic-core/src/capabilities.ts
@@ -257,6 +257,8 @@ export interface MemoryLifecycleCapabilitySet {
   readonly extractionJudgeTelemetry: boolean;
   /** `embeddingFallbackEnabled` — semantic-dedup / archive-search embedding fallback. */
   readonly embeddingFallback: boolean;
+  /** `extractionRetryEnabled` — per-fingerprint backoff + provider circuit breaker on the extraction retry path. */
+  readonly extractionRetry: boolean;
 }
 
 /**
@@ -275,6 +277,7 @@ export type MemoryLifecycleConfigProjection = Pick<
   | "extractionTelemetryPrefilterEnabled"
   | "extractionJudgeTelemetryEnabled"
   | "embeddingFallbackEnabled"
+  | "extractionRetryEnabled"
 >;
 
 /**
@@ -299,6 +302,7 @@ export function resolveMemoryLifecycleCapabilities(
     extractionTelemetryPrefilter: config.extractionTelemetryPrefilterEnabled,
     extractionJudgeTelemetry: config.extractionJudgeTelemetryEnabled,
     embeddingFallback: config.embeddingFallbackEnabled,
+    extractionRetry: config.extractionRetryEnabled,
   });
 }
 

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -2142,3 +2142,22 @@ test("parseConfig correction.maxAffected rejects non-integers (Number.isInteger,
   assert.equal(parseConfig({ correctionMaxAffected: 20 }).correctionMaxAffected, 20);
   assert.equal(parseConfig({}).correctionMaxAffected, 10, "absent → documented default");
 });
+
+test("parseConfig rejects non-positive extraction retry/breaker numerics and falls back to defaults (codex review, rule 17)", () => {
+  const c = parseConfig({
+    extractionRetryMaxBackoffMs: 0,
+    extractionRetryJitterRatio: -0.5,
+    extractionParseEmptyMaxAttempts: 0,
+    extractionBreakerFailureThreshold: -1,
+    extractionBreakerCooldownMs: 0,
+    extractionBreakerAuthCooldownMs: -100,
+    extractionRetryScheduleMs: [1000, 0, -5],
+  });
+  assert.equal(c.extractionRetryMaxBackoffMs, 21_600_000, "non-positive cap -> default");
+  assert.equal(c.extractionRetryJitterRatio, 0.2, "out-of-range jitter -> default");
+  assert.equal(c.extractionParseEmptyMaxAttempts, 3, "non-positive attempts -> default");
+  assert.equal(c.extractionBreakerFailureThreshold, 5, "non-positive threshold -> default");
+  assert.equal(c.extractionBreakerCooldownMs, 300_000, "non-positive cooldown -> default");
+  assert.equal(c.extractionBreakerAuthCooldownMs, 1_800_000, "non-positive auth cooldown -> default");
+  assert.deepEqual(c.extractionRetryScheduleMs, [60_000, 300_000, 1_800_000, 7_200_000], "schedule with non-positive entry -> default");
+});

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -2149,7 +2149,7 @@ test("parseConfig rejects non-positive extraction retry/breaker numerics and fal
     extractionRetryJitterRatio: -0.5,
     extractionParseEmptyMaxAttempts: 0,
     extractionBreakerFailureThreshold: -1,
-    extractionBreakerCooldownMs: 0,
+    extractionBreakerCooldownMs: -5, // 0 is a valid "half-open immediately" escape hatch; only negative is rejected
     extractionBreakerAuthCooldownMs: -100,
     extractionRetryScheduleMs: [1000, 0, -5],
   });

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2850,10 +2850,10 @@ export function parseConfig(
       Number.isInteger(cfg.extractionBreakerFailureThreshold) && cfg.extractionBreakerFailureThreshold > 0
         ? cfg.extractionBreakerFailureThreshold : 5,
     extractionBreakerCooldownMs:
-      typeof cfg.extractionBreakerCooldownMs === "number" && cfg.extractionBreakerCooldownMs > 0
+      typeof cfg.extractionBreakerCooldownMs === "number" && cfg.extractionBreakerCooldownMs >= 0
         ? cfg.extractionBreakerCooldownMs : 300_000,
     extractionBreakerAuthCooldownMs:
-      typeof cfg.extractionBreakerAuthCooldownMs === "number" && cfg.extractionBreakerAuthCooldownMs > 0
+      typeof cfg.extractionBreakerAuthCooldownMs === "number" && cfg.extractionBreakerAuthCooldownMs >= 0
         ? cfg.extractionBreakerAuthCooldownMs : 1_800_000,
     // Local LLM fast tier (v9.1)
     localLlmFastEnabled: cfg.localLlmFastEnabled === true,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2835,17 +2835,26 @@ export function parseConfig(
         ? (cfg.extractionRetryScheduleMs as number[])
         : [60_000, 300_000, 1_800_000, 7_200_000],
     extractionRetryMaxBackoffMs:
-      typeof cfg.extractionRetryMaxBackoffMs === "number" ? cfg.extractionRetryMaxBackoffMs : 21_600_000,
+      typeof cfg.extractionRetryMaxBackoffMs === "number" && cfg.extractionRetryMaxBackoffMs > 0
+        ? cfg.extractionRetryMaxBackoffMs : 21_600_000,
     extractionRetryJitterRatio:
-      typeof cfg.extractionRetryJitterRatio === "number" ? cfg.extractionRetryJitterRatio : 0.2,
+      typeof cfg.extractionRetryJitterRatio === "number" &&
+      cfg.extractionRetryJitterRatio >= 0 && cfg.extractionRetryJitterRatio <= 1
+        ? cfg.extractionRetryJitterRatio : 0.2,
     extractionParseEmptyMaxAttempts:
-      typeof cfg.extractionParseEmptyMaxAttempts === "number" ? cfg.extractionParseEmptyMaxAttempts : 3,
+      typeof cfg.extractionParseEmptyMaxAttempts === "number" &&
+      Number.isInteger(cfg.extractionParseEmptyMaxAttempts) && cfg.extractionParseEmptyMaxAttempts > 0
+        ? cfg.extractionParseEmptyMaxAttempts : 3,
     extractionBreakerFailureThreshold:
-      typeof cfg.extractionBreakerFailureThreshold === "number" ? cfg.extractionBreakerFailureThreshold : 5,
+      typeof cfg.extractionBreakerFailureThreshold === "number" &&
+      Number.isInteger(cfg.extractionBreakerFailureThreshold) && cfg.extractionBreakerFailureThreshold > 0
+        ? cfg.extractionBreakerFailureThreshold : 5,
     extractionBreakerCooldownMs:
-      typeof cfg.extractionBreakerCooldownMs === "number" ? cfg.extractionBreakerCooldownMs : 300_000,
+      typeof cfg.extractionBreakerCooldownMs === "number" && cfg.extractionBreakerCooldownMs > 0
+        ? cfg.extractionBreakerCooldownMs : 300_000,
     extractionBreakerAuthCooldownMs:
-      typeof cfg.extractionBreakerAuthCooldownMs === "number" ? cfg.extractionBreakerAuthCooldownMs : 1_800_000,
+      typeof cfg.extractionBreakerAuthCooldownMs === "number" && cfg.extractionBreakerAuthCooldownMs > 0
+        ? cfg.extractionBreakerAuthCooldownMs : 1_800_000,
     // Local LLM fast tier (v9.1)
     localLlmFastEnabled: cfg.localLlmFastEnabled === true,
     localLlmFastModel:

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2826,6 +2826,26 @@ export function parseConfig(
       typeof cfg.localLlm400TripThreshold === "number" ? cfg.localLlm400TripThreshold : 5,
     localLlm400CooldownMs:
       typeof cfg.localLlm400CooldownMs === "number" ? cfg.localLlm400CooldownMs : 120_000,
+    // Extraction retry/backoff + circuit breaker (extraction hot-loop hardening)
+    extractionRetryEnabled: cfg.extractionRetryEnabled !== false,
+    extractionRetryScheduleMs:
+      Array.isArray(cfg.extractionRetryScheduleMs) &&
+      cfg.extractionRetryScheduleMs.length > 0 &&
+      cfg.extractionRetryScheduleMs.every((n) => typeof n === "number" && Number.isFinite(n) && n > 0)
+        ? (cfg.extractionRetryScheduleMs as number[])
+        : [60_000, 300_000, 1_800_000, 7_200_000],
+    extractionRetryMaxBackoffMs:
+      typeof cfg.extractionRetryMaxBackoffMs === "number" ? cfg.extractionRetryMaxBackoffMs : 21_600_000,
+    extractionRetryJitterRatio:
+      typeof cfg.extractionRetryJitterRatio === "number" ? cfg.extractionRetryJitterRatio : 0.2,
+    extractionParseEmptyMaxAttempts:
+      typeof cfg.extractionParseEmptyMaxAttempts === "number" ? cfg.extractionParseEmptyMaxAttempts : 3,
+    extractionBreakerFailureThreshold:
+      typeof cfg.extractionBreakerFailureThreshold === "number" ? cfg.extractionBreakerFailureThreshold : 5,
+    extractionBreakerCooldownMs:
+      typeof cfg.extractionBreakerCooldownMs === "number" ? cfg.extractionBreakerCooldownMs : 300_000,
+    extractionBreakerAuthCooldownMs:
+      typeof cfg.extractionBreakerAuthCooldownMs === "number" ? cfg.extractionBreakerAuthCooldownMs : 1_800_000,
     // Local LLM fast tier (v9.1)
     localLlmFastEnabled: cfg.localLlmFastEnabled === true,
     localLlmFastModel:

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2827,7 +2827,7 @@ export function parseConfig(
     localLlm400CooldownMs:
       typeof cfg.localLlm400CooldownMs === "number" ? cfg.localLlm400CooldownMs : 120_000,
     // Extraction retry/backoff + circuit breaker (extraction hot-loop hardening)
-    extractionRetryEnabled: cfg.extractionRetryEnabled !== false,
+    extractionRetryEnabled: coerceBooleanLike(cfg.extractionRetryEnabled) ?? true,
     extractionRetryScheduleMs:
       Array.isArray(cfg.extractionRetryScheduleMs) &&
       cfg.extractionRetryScheduleMs.length > 0 &&

--- a/packages/remnic-core/src/extraction.test.ts
+++ b/packages/remnic-core/src/extraction.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Extraction failure-classification tests (extraction hot-loop hardening).
+ *
+ * The retry/backoff + circuit-breaker layer keys off `ExtractionFailureClass`.
+ * These tests lock the mapping from synthetic provider errors (429/500/401/
+ * no-models/parse-empty) to the coarse class, reusing the shared
+ * `isTransientHttpError` classifier rather than a bespoke copy.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { classifyExtractionThrownError, classifyFallbackParseFailure } from "./extraction.js";
+
+test("classifyExtractionThrownError: 401/403 → auth_config", () => {
+  assert.equal(classifyExtractionThrownError({ status: 401 }), "auth_config");
+  assert.equal(classifyExtractionThrownError({ status: 403 }), "auth_config");
+  assert.equal(classifyExtractionThrownError({ statusCode: 401 }), "auth_config");
+});
+
+test("classifyExtractionThrownError: 429/5xx → provider_retryable", () => {
+  assert.equal(classifyExtractionThrownError({ status: 429 }), "provider_retryable");
+  assert.equal(classifyExtractionThrownError({ status: 500 }), "provider_retryable");
+  assert.equal(classifyExtractionThrownError({ status: 503 }), "provider_retryable");
+});
+
+test("classifyExtractionThrownError: bare network error / unknown → provider_retryable (fail-open toward retry)", () => {
+  assert.equal(classifyExtractionThrownError(new Error("socket hang up")), "provider_retryable");
+  // A terminal non-auth 4xx still defaults to retryable (capped by the attempt budget).
+  assert.equal(classifyExtractionThrownError({ status: 400 }), "provider_retryable");
+  assert.equal(classifyExtractionThrownError(null), "provider_retryable");
+  assert.equal(classifyExtractionThrownError("not an object"), "provider_retryable");
+});
+
+test("classifyFallbackParseFailure: maps the gateway parse-failure reasons", () => {
+  assert.equal(classifyFallbackParseFailure("no_models"), "auth_config");
+  assert.equal(classifyFallbackParseFailure("http_error"), "provider_retryable");
+  assert.equal(classifyFallbackParseFailure("empty"), "parse_empty");
+});

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -1171,11 +1171,16 @@ export class ExtractionEngine {
       localLlm: resolveLocalLlmCapabilities(this.config).localLlm,
     });
     this.profiler.startSpan("total", extractionTraceId);
+    // True when a local or direct extractor was attempted before the gateway
+    // fallback, so a gateway "no models" result doesn't re-classify a real
+    // primary failure as auth_config (codex review: preserve direct/local failures).
+    let primaryExtractorAttempted = false;
 
     try {
     // Try local LLM first if enabled
     if (this.shouldUseLocalLlm) {
       this.profiler.startSpan("local-llm", extractionTraceId);
+      primaryExtractorAttempted = true;
       try {
         const localResult = await this.extractWithLocalLlm(conversation, existingEntities);
         if (localResult) {
@@ -1222,6 +1227,7 @@ export class ExtractionEngine {
     // Try direct OpenAI-compatible client (Scryr, OpenRouter, etc.)
     if (this.shouldUseDirectClient) {
       this.profiler.startSpan("direct-client", extractionTraceId);
+      primaryExtractorAttempted = true;
       try {
         const directResult = await this.extractWithDirectClient(conversation, existingEntities);
         if (directResult) {
@@ -1354,7 +1360,13 @@ export class ExtractionEngine {
       });
       log.warn("extraction fallback returned no parsed output");
       const fallbackParseFailureClass: ExtractionFailureClass =
-        detailed.result === null ? classifyFallbackParseFailure(detailed.failureReason) : "parse_empty";
+        detailed.result === null
+          ? detailed.failureReason === "no_models" && primaryExtractorAttempted
+            ? // Gateway had no models, but a local/direct extractor already failed —
+              // the root cause is the primary (transient), not gateway auth/config.
+              "provider_retryable"
+            : classifyFallbackParseFailure(detailed.failureReason)
+          : "parse_empty";
       return {
         facts: [],
         profileUpdates: [],

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -26,6 +26,7 @@ import type {
   GatewayConfig,
   MemoryCategory,
   DaySummaryResult as DaySummaryResultShape,
+  ExtractionFailureClass,
 } from "./types.js";
 import { ModelRegistry } from "./model-registry.js";
 import { extractJsonCandidates } from "./json-extract.js";
@@ -38,6 +39,7 @@ import { normalizeProcedureSteps } from "./procedural/procedure-types.js";
 import { normalizeReasoningTrace } from "./reasoning-trace-types.js";
 import { looksLikeMechanicalTelemetryTranscript } from "./telemetry-transcript.js";
 import { buildFactProvenance, type ProvenanceTurnInput } from "./provenance.js";
+import { isTransientHttpError } from "./connectors/live/transient-errors.js";
 import { resolvePipelineProcessingCapabilities } from "./capabilities.js";
 import { resolveMemoryLifecycleCapabilities,
   resolveLocalLlmCapabilities,resolveRecallAuxiliaryCapabilities } from "./capabilities.js";
@@ -46,6 +48,56 @@ type ExtractionQuestion = ExtractionResult["questions"][number];
 type ExtractedFactResult = ExtractionResult["facts"][number];
 type ExtractedEntityResult = ExtractionResult["entities"][number];
 type ExtractedRelationshipResult = NonNullable<ExtractionResult["relationships"]>[number];
+
+/**
+ * Read a numeric HTTP status off a thrown error without re-implementing the
+ * shared transient classifier. Uses `in`/typeof narrowing (no inline casts).
+ */
+function httpStatusFromError(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  if ("status" in err && typeof err.status === "number" && Number.isFinite(err.status)) return err.status;
+  if ("statusCode" in err && typeof err.statusCode === "number" && Number.isFinite(err.statusCode)) {
+    return err.statusCode;
+  }
+  return undefined;
+}
+
+/**
+ * Map a thrown extraction error to a coarse failure class for the retry/breaker
+ * layer. 401/403 → `auth_config` (misconfigured provider, open the breaker);
+ * transient (429/5xx/network, per the shared `isTransientHttpError`) → back off;
+ * anything else defaults to `provider_retryable` (fail-open toward retry, but
+ * capped by the per-fingerprint attempt budget). Never throws.
+ */
+export function classifyExtractionThrownError(err: unknown): ExtractionFailureClass {
+  try {
+    const status = httpStatusFromError(err);
+    if (status === 401 || status === 403) return "auth_config";
+    if (isTransientHttpError(err)) return "provider_retryable";
+    return "provider_retryable";
+  } catch {
+    return "provider_retryable";
+  }
+}
+
+/**
+ * Map the gateway fallback's discriminated parse-failure reason to a coarse
+ * extraction failure class. "no models configured" is an auth/config problem;
+ * an HTTP/transport failure backs off; an unparseable-but-present response is a
+ * genuine empty-parse.
+ */
+export function classifyFallbackParseFailure(
+  reason: "no_models" | "empty" | "http_error",
+): ExtractionFailureClass {
+  switch (reason) {
+    case "no_models":
+      return "auth_config";
+    case "http_error":
+      return "provider_retryable";
+    case "empty":
+      return "parse_empty";
+  }
+}
 const PROACTIVE_MIN_CONFIDENCE = 0.8;
 const CONSOLIDATION_RESPONSE_SCHEMA = `{
   "items": [
@@ -975,7 +1027,7 @@ export class ExtractionEngine {
     options: { temperature?: number; maxTokens?: number } = {},
   ): Promise<T | null> {
     const detailed = await this.fallbackLlm.parseWithSchemaDetailed(messages, schema, this.withGatewayAgent(options));
-    if (detailed?.result) {
+    if ("modelUsed" in detailed) {
       const durationMs = Date.now() - startedAtMs;
       this.emit({
         kind: "llm_end",
@@ -1144,6 +1196,7 @@ export class ExtractionEngine {
             entities: [],
             questions: [],
             extractionFailure: "local_llm_unavailable",
+            extractionFailureClass: "provider_retryable",
           };
         }
         log.info("extraction: local LLM unavailable, falling back to gateway default AI");
@@ -1156,6 +1209,7 @@ export class ExtractionEngine {
             entities: [],
             questions: [],
             extractionFailure: "local_llm_error",
+            extractionFailureClass: "provider_retryable",
           };
         }
         log.info("extraction: local LLM error, falling back to gateway default AI:", err);
@@ -1250,7 +1304,7 @@ export class ExtractionEngine {
 
       const fallbackDurationMs = Date.now() - fallbackStartTime;
 
-      if (detailed?.result && Array.isArray(detailed.result.facts)) {
+      if ("modelUsed" in detailed && Array.isArray(detailed.result.facts)) {
         const result = detailed.result;
         this.emit({
           kind: "llm_end", traceId: fallbackTraceId, model: detailed.modelUsed, operation: "extraction",
@@ -1299,12 +1353,15 @@ export class ExtractionEngine {
         durationMs: fallbackDurationMs, error: "fallback returned no parsed output",
       });
       log.warn("extraction fallback returned no parsed output");
+      const fallbackParseFailureClass: ExtractionFailureClass =
+        detailed.result === null ? classifyFallbackParseFailure(detailed.failureReason) : "parse_empty";
       return {
         facts: [],
         profileUpdates: [],
         entities: [],
         questions: [],
         extractionFailure: "fallback_no_parsed_output",
+        extractionFailureClass: fallbackParseFailureClass,
       };
     } catch (err) {
       this.emit({
@@ -1318,6 +1375,7 @@ export class ExtractionEngine {
         entities: [],
         questions: [],
         extractionFailure: "fallback_failed",
+        extractionFailureClass: classifyExtractionThrownError(err),
       };
     } finally {
       try { this.profiler.endSpan("gateway-fallback", extractionTraceId); } catch { /* span may already be closed */ }

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -280,9 +280,28 @@ export class FallbackLlmClient {
     messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
     schema: { parse: (data: unknown) => T },
     options: FallbackLlmOptions = {},
-  ): Promise<{ result: T; modelUsed: string } | null> {
-    const response = await this.chatCompletion(messages, options);
-    if (!response?.content) return null;
+  ): Promise<
+    | { result: T; modelUsed: string }
+    | { result: null; failureReason: "no_models" | "empty" | "http_error" }
+  > {
+    let response: FallbackLlmResponse | null;
+    try {
+      response = await this.chatCompletion(messages, options);
+    } catch (err) {
+      // chatCompletion only throws on caller abort / unexpected fatal errors;
+      // treat as a transient provider failure so the retry layer backs off.
+      log.warn("fallback LLM: chatCompletion threw during structured parse:", err);
+      return { result: null, failureReason: "http_error" };
+    }
+    if (!response?.content) {
+      // chatCompletion returns null both when no models are configured
+      // (auth/config) and when every configured model errored (transient).
+      // Disambiguate via the resolved model chain so the retry layer can pick
+      // the right failure class.
+      const hasModels =
+        this.getModelChain(options.agentId, options.model, options.modelChain).length > 0;
+      return { result: null, failureReason: hasModels ? "http_error" : "no_models" };
+    }
 
     try {
       const candidates = extractJsonCandidates(response.content);
@@ -294,10 +313,10 @@ export class FallbackLlmClient {
           // keep trying other candidates
         }
       }
-      return null;
+      return { result: null, failureReason: "empty" };
     } catch (err) {
       log.warn("fallback LLM: failed to parse structured output:", err);
-      return null;
+      return { result: null, failureReason: "empty" };
     }
   }
 

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -288,8 +288,10 @@ export class FallbackLlmClient {
     try {
       response = await this.chatCompletion(messages, options);
     } catch (err) {
-      // chatCompletion only throws on caller abort / unexpected fatal errors;
-      // treat as a transient provider failure so the retry layer backs off.
+      // Caller aborts must propagate (e.g. recall planner cancellation) — do
+      // not swallow them as a provider failure, or abort-driven callers lose
+      // cancellation and treat it as an extraction error (codex review).
+      if (options.signal?.aborted) throw err;
       log.warn("fallback LLM: chatCompletion threw during structured parse:", err);
       return { result: null, failureReason: "http_error" };
     }

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1286,6 +1286,14 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
     const eligibleAt = Date.parse(entry.nextEligibleAt);
     return Number.isFinite(eligibleAt) && eligibleAt > nowMs;
   });
+  // Transient (provider_retryable) parked entries imply the in-memory circuit
+  // breaker is likely open in the daemon (it opens after N consecutive
+  // provider failures, each of which parks a fingerprint). The breaker itself
+  // is per-process (daemon-only), so doctor infers from this durable signal.
+  const providerRetryableParked = parkedFingerprints.filter(
+    (entry) => entry.lastFailureClass === "provider_retryable",
+  );
+  const breakerLikelyOpen = providerRetryableParked.length > 0;
   const resilienceStatus: "ok" | "warn" | "error" =
     authConfigFailures.length > 0 ? "error" : parkedFingerprints.length > 0 ? "warn" : "ok";
   checks.push({
@@ -1295,7 +1303,9 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
       resilienceStatus === "error"
         ? `Extraction provider has ${authConfigFailures.length} auth/config failure(s); the circuit breaker opens immediately and extraction is suspended.`
         : resilienceStatus === "warn"
-          ? `${parkedFingerprints.length} extraction fingerprint(s) are in backoff after transient provider failures.`
+          ? `${parkedFingerprints.length} extraction fingerprint(s) in backoff after transient provider failures${
+              breakerLikelyOpen ? "; the provider circuit breaker is likely OPEN in the daemon (non-forced extraction is suspended until it half-opens)" : ""
+            }.`
           : "No extraction provider failures are currently parked.",
     remediation:
       resilienceStatus === "error"
@@ -1307,6 +1317,8 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
       backoffFingerprintCount: retryEntries.length,
       authConfigFailureCount: authConfigFailures.length,
       parkedFingerprintCount: parkedFingerprints.length,
+      providerRetryableParkedCount: providerRetryableParked.length,
+      breakerLikelyOpen,
     },
   });
 

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1286,14 +1286,17 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
     const eligibleAt = Date.parse(entry.nextEligibleAt);
     return Number.isFinite(eligibleAt) && eligibleAt > nowMs;
   });
-  // Transient (provider_retryable) parked entries imply the in-memory circuit
-  // breaker is likely open in the daemon (it opens after N consecutive
-  // provider failures, each of which parks a fingerprint). The breaker itself
-  // is per-process (daemon-only), so doctor infers from this durable signal.
+  // The in-memory breaker opens only after extractionBreakerFailureThreshold
+  // CONSECUTIVE provider failures, each of which parks a fingerprint — so
+  // doctor infers "likely open" only when the parked transient count reaches
+  // that threshold. A single parked fingerprint is ordinary backoff, not a
+  // suspended-extraction signal (cursor review: don't overclaim). The breaker
+  // itself is per-process (daemon-only), hence the durable-signal inference.
   const providerRetryableParked = parkedFingerprints.filter(
     (entry) => entry.lastFailureClass === "provider_retryable",
   );
-  const breakerLikelyOpen = providerRetryableParked.length > 0;
+  const breakerLikelyOpen =
+    providerRetryableParked.length >= Math.max(1, config.extractionBreakerFailureThreshold);
   const resilienceStatus: "ok" | "warn" | "error" =
     authConfigFailures.length > 0 ? "error" : parkedFingerprints.length > 0 ? "warn" : "ok";
   checks.push({

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1272,6 +1272,44 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
     details: meta,
   });
 
+  // Extraction resilience (extraction hot-loop hardening). Surfaces the
+  // persisted per-fingerprint retry/backoff state so an operator can see when
+  // the extraction provider is failing without tailing logs. auth/config
+  // failures are an error (misconfigured provider, will not self-heal at the
+  // current cadence); transient backoff is a warn; a clean state is ok. Reads
+  // the already-loaded meta — no extra I/O, cross-process safe (the in-memory
+  // breaker lives in the daemon; this derives from durable state).
+  const retryEntries = meta.extractionRetryState ?? [];
+  const authConfigFailures = retryEntries.filter((entry) => entry.lastFailureClass === "auth_config");
+  const nowMs = Date.now();
+  const parkedFingerprints = retryEntries.filter((entry) => {
+    const eligibleAt = Date.parse(entry.nextEligibleAt);
+    return Number.isFinite(eligibleAt) && eligibleAt > nowMs;
+  });
+  const resilienceStatus: "ok" | "warn" | "error" =
+    authConfigFailures.length > 0 ? "error" : parkedFingerprints.length > 0 ? "warn" : "ok";
+  checks.push({
+    key: "extraction-resilience",
+    status: resilienceStatus,
+    summary:
+      resilienceStatus === "error"
+        ? `Extraction provider has ${authConfigFailures.length} auth/config failure(s); the circuit breaker opens immediately and extraction is suspended.`
+        : resilienceStatus === "warn"
+          ? `${parkedFingerprints.length} extraction fingerprint(s) are in backoff after transient provider failures.`
+          : "No extraction provider failures are currently parked.",
+    remediation:
+      resilienceStatus === "error"
+        ? 'Check the extraction LLM gateway/model configuration (a 401/403 or "no models configured" was seen). Extraction resumes automatically once the provider is reachable.'
+        : resilienceStatus === "warn"
+          ? "Transient provider failures (e.g. 429/5xx). Backoff clears automatically as the provider recovers; no action needed unless it persists."
+          : undefined,
+    details: {
+      backoffFingerprintCount: retryEntries.length,
+      authConfigFailureCount: authConfigFailures.length,
+      parkedFingerprintCount: parkedFingerprints.length,
+    },
+  });
+
   // Memory projection health (issue #1829). Surfaces a present-but-unopenable
   // projection (wrong ABI / corrupt) that previously degraded every memory
   // list to a silent full-corpus scan. Absent and openable are both "ok".

--- a/packages/remnic-core/src/orchestration/extraction-run.test.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.test.ts
@@ -410,6 +410,39 @@ test("recovery: a successful extract clears the fingerprint's retry state so it 
   }
 });
 
+test("recovery: a successful FORCED flush on a fresh coordinator clears a persisted backoff entry (cursor/codex review)", async () => {
+  // A forced flush bypasses the retry gate and never hydrates the in-memory
+  // mirror, so the success-heal path must still clear the persisted meta entry
+  // — otherwise a stale backoff survives a successful forced flush and keeps
+  // blocking normal extraction until the timer expires.
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 100,
+  });
+  try {
+    const coordA = h.newCoordinator();
+    h.setRespond(() => failureResult("provider_retryable"));
+    await h.run(coordA, "fp-heal"); // fail → parked, persisted to meta.json
+    const storage = await h.storageForNs("default");
+    let meta = await storage.loadMeta();
+    assert.equal((meta.extractionRetryState ?? []).length, 1, "failure persisted");
+
+    // Fresh coordinator (mirror empty, namespace not hydrated) — forced success.
+    const coordB = h.newCoordinator();
+    h.setRespond(() => successResult());
+    await h.run(coordB, "fp-heal", { force: true });
+
+    meta = await storage.loadMeta();
+    assert.equal(
+      (meta.extractionRetryState ?? []).length,
+      0,
+      "successful forced flush must clear the persisted backoff entry",
+    );
+  } finally {
+    await h.cleanup();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Class-specific caps
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/orchestration/extraction-run.test.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.test.ts
@@ -385,6 +385,43 @@ test("recovery: half-open probe succeeds → breaker closes", async () => {
   }
 });
 
+test("recovery: a FAILED half-open probe re-opens the breaker (cursor review)", async () => {
+  // An auth_config failure trips the breaker below the consecutive-failure
+  // threshold. After the auth cooldown elapses (half_open), a transient probe
+  // failure must re-open the breaker — not leave it stuck half_open where it
+  // no longer suppresses anything.
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 100, // auth trips below threshold
+    extractionBreakerAuthCooldownMs: 0, // half-open on the next call
+    extractionBreakerCooldownMs: 3_600_000, // a re-open parks for a long time
+  });
+  try {
+    const coord = h.newCoordinator();
+    h.setRespond(() => failureResult("auth_config"));
+    await h.run(coord, "fp-a"); // auth failure → breaker opens immediately
+    assert.equal(coord.getExtractionResilienceStatus().breaker.state, "open");
+
+    // Auth cooldown 0 → this call flips open→half_open and probes; the probe
+    // fails transiently → the breaker must re-open with the transient cooldown.
+    h.setRespond(() => failureResult("provider_retryable"));
+    await h.run(coord, "fp-b");
+    assert.equal(
+      coord.getExtractionResilienceStatus().breaker.state,
+      "open",
+      "failed half-open probe re-opens the breaker",
+    );
+
+    // While re-opened, a third fingerprint is suppressed without calling extract().
+    const calls = h.engineCalls();
+    const r3 = await h.run(coord, "fp-c");
+    assert.equal(r3.reason, "provider_circuit_open", "re-opened breaker suppresses");
+    assert.equal(h.engineCalls(), calls, "no extract() call while re-opened");
+  } finally {
+    await h.cleanup();
+  }
+});
+
 test("recovery: a successful extract clears the fingerprint's retry state so it proceeds again", async () => {
   const h = await makeHarness({
     extractionRetryScheduleMs: [3_600_000],

--- a/packages/remnic-core/src/orchestration/extraction-run.test.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.test.ts
@@ -1,0 +1,569 @@
+/**
+ * Extraction retry/backoff + circuit-breaker tests (extraction hot-loop
+ * hardening). Drives a real ExtractionRunCoordinator over tmpdir StorageManager
+ * instances with a fake extraction engine so the retry gate, per-fingerprint
+ * backoff, provider circuit breaker, recovery, class-specific caps, the
+ * never-mark-processed invariant, force-flush bypass, config parity, backoff
+ * math, cache coherence, and namespace isolation are all exercised end to end.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { SmartBuffer } from "../buffer.js";
+import {
+  ExtractionRunCoordinator,
+  type ExtractionRunCoordinatorDeps,
+  computeExtractionRetryNextEligibleMs,
+  capExtractionRetryStateEntries,
+} from "./extraction-run.js";
+import { StorageManager } from "../storage.js";
+import { parseConfig } from "../config.js";
+import type { ExtractionEngine } from "../extraction.js";
+import type { ThreadingManager } from "../threading.js";
+import type { BufferTurn, ExtractionResult, ExtractionFailureClass, PluginConfig } from "../types.js";
+import type { TierMigrationCycleSummary } from "../recall-state.js";
+
+// ---------------------------------------------------------------------------
+// Result factories
+// ---------------------------------------------------------------------------
+
+function failureResult(cls: ExtractionFailureClass): ExtractionResult {
+  return {
+    facts: [],
+    profileUpdates: [],
+    entities: [],
+    questions: [],
+    extractionFailure: `synthetic_${cls}`,
+    extractionFailureClass: cls,
+  };
+}
+
+function successResult(): ExtractionResult {
+  return {
+    facts: [{ content: "a durable fact", category: "fact", confidence: 0.9, tags: [] }],
+    profileUpdates: [],
+    entities: [],
+    questions: [],
+  };
+}
+
+function makeTurns(content: string): BufferTurn[] {
+  return [
+    {
+      role: "user",
+      content: `u:${content}`,
+      timestamp: "2026-07-15T00:00:00Z",
+      persistProcessedFingerprint: true,
+    },
+    {
+      role: "assistant",
+      content: `a:${content}`,
+      timestamp: "2026-07-15T00:00:01Z",
+      persistProcessedFingerprint: true,
+    },
+  ] as BufferTurn[];
+}
+
+const migrationSummary: TierMigrationCycleSummary = {
+  trigger: "extraction",
+  scanned: 0,
+  migrated: 0,
+  promoted: 0,
+  demoted: 0,
+  limit: 0,
+  dryRun: false,
+};
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+interface Harness {
+  config: PluginConfig;
+  storageForNs: (ns: string) => Promise<StorageManager>;
+  newCoordinator: () => ExtractionRunCoordinator;
+  engineCalls: () => number;
+  setRespond: (fn: (turns: BufferTurn[]) => ExtractionResult) => void;
+  recordedProcessedCount: () => number;
+  run: (
+    coord: ExtractionRunCoordinator,
+    content: string,
+    opts?: { force?: boolean; failClosed?: boolean; writeNamespaceOverride?: string },
+  ) => Promise<{ status: string; reason?: string }>;
+  cleanup: () => Promise<void>;
+}
+
+async function makeHarness(overrides: Record<string, unknown> = {}): Promise<Harness> {
+  StorageManager.clearAllStaticCaches();
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "extraction-retry-"));
+  const config = parseConfig({
+    memoryDir: baseDir,
+    qmdEnabled: false,
+    ...overrides,
+  });
+
+  const storages = new Map<string, StorageManager>();
+  const storageForNs = async (ns: string): Promise<StorageManager> => {
+    let s = storages.get(ns);
+    if (!s) {
+      s = new StorageManager(path.join(baseDir, `ns-${ns.replace(/[^a-z0-9]+/gi, "_")}`));
+      await s.ensureDirectories();
+      storages.set(ns, s);
+    }
+    return s;
+  };
+
+  const defaultStorage = await storageForNs("default");
+  const buffer = new SmartBuffer(config, defaultStorage);
+  await buffer.load();
+
+  let engineCalls = 0;
+  let respond: (turns: BufferTurn[]) => ExtractionResult = () => successResult();
+  let recordedProcessedCount = 0;
+
+  const makeDeps = (): ExtractionRunCoordinatorDeps => ({
+    config,
+    getBuffer: () => buffer,
+    getExtraction: () => ({
+      extract: async (turns: Parameters<ExtractionEngine["extract"]>[0]): Promise<ExtractionResult> => {
+        engineCalls += 1;
+        return respond(turns as BufferTurn[]);
+      },
+    }),
+    getStorageRouter: () => ({
+      storageFor: async (ns: string) => storageForNs(ns),
+    }),
+    getThreading: () => ({
+      processTurn: async (..._args: Parameters<ThreadingManager["processTurn"]>) => "thread-1",
+      updateThreadTitle: async (..._args: Parameters<ThreadingManager["updateThreadTitle"]>) => {},
+    }),
+    persistExtraction: async () => ["memory-1"],
+    maybeCapturePassiveCorrections: async () => {},
+    resolveSelfNamespace: () => "default",
+    getCodingContextForSession: () => null,
+    applyCodingNamespaceOverlay: () => "default",
+    boxBuilderFor: () => ({ onExtraction: async () => {} }),
+    appendPersistedThreadEpisodes: async () => {},
+    maybeScheduleConsolidation: () => {},
+    requestQmdMaintenance: () => {},
+    runTierMigrationCycle: async () => migrationSummary,
+    getLastPersistExtractionDeferredCount: () => 0,
+    recordProcessedExtractionFingerprint: async () => {
+      recordedProcessedCount += 1;
+    },
+  });
+
+  return {
+    config,
+    storageForNs,
+    newCoordinator: () => new ExtractionRunCoordinator(makeDeps()),
+    engineCalls: () => engineCalls,
+    setRespond: (fn) => {
+      respond = fn;
+    },
+    recordedProcessedCount: () => recordedProcessedCount,
+    run: async (coord, content, opts = {}) => {
+      const result = await coord.runExtraction(makeTurns(content), {
+        skipCharThreshold: true,
+        skipUserTurnThreshold: true,
+        clearBufferAfterExtraction: false,
+        bufferKey: content,
+        failOnExtractionFailure: opts.failClosed === true,
+        forceExtractionAttempt: opts.force === true,
+        writeNamespaceOverride: opts.writeNamespaceOverride,
+      });
+      return { status: result.status, reason: result.reason };
+    },
+    cleanup: async () => {
+      StorageManager.clearAllStaticCaches();
+      await rm(baseDir, { recursive: true, force: true });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Backoff math (pure)
+// ---------------------------------------------------------------------------
+
+test("computeExtractionRetryNextEligibleMs: progresses through schedule and caps", () => {
+  const sched = [1000, 5000, 30000];
+  const cap = 60000;
+  const noJitter = () => 0.5; // jitter factor = 1 exactly
+  assert.equal(computeExtractionRetryNextEligibleMs(1, sched, cap, 0.2, 0, noJitter), 1000);
+  assert.equal(computeExtractionRetryNextEligibleMs(2, sched, cap, 0.2, 0, noJitter), 5000);
+  assert.equal(computeExtractionRetryNextEligibleMs(3, sched, cap, 0.2, 0, noJitter), 30000);
+  // Past the schedule end → clamps to the last step, then to cap.
+  assert.equal(computeExtractionRetryNextEligibleMs(9, sched, cap, 0.2, 0, noJitter), 30000);
+  // A schedule value above the cap is clamped to the cap.
+  assert.equal(computeExtractionRetryNextEligibleMs(1, [999999], cap, 0.2, 0, noJitter), cap);
+});
+
+test("computeExtractionRetryNextEligibleMs: jitter stays within +/- ratio", () => {
+  const base = 10000;
+  const ratio = 0.2;
+  for (const r of [0, 0.25, 0.5, 0.75, 1]) {
+    const value = computeExtractionRetryNextEligibleMs(1, [base], base * 100, ratio, 0, () => r);
+    assert.ok(value >= base * (1 - ratio) - 1, `>= lower bound for rng=${r} (${value})`);
+    assert.ok(value <= base * (1 + ratio) + 1, `<= upper bound for rng=${r} (${value})`);
+  }
+});
+
+test("capExtractionRetryStateEntries: caps to newest and guards maxEntries<=0", () => {
+  const entries = Array.from({ length: 10 }, (_, i) => ({
+    fingerprint: `fp${i}`,
+    firstFailedAt: `2026-07-15T00:00:0${i}.000Z`,
+  }));
+  const capped = capExtractionRetryStateEntries(entries, 3);
+  assert.equal(capped.length, 3);
+  assert.deepEqual(
+    capped.map((e) => e.fingerprint),
+    ["fp7", "fp8", "fp9"],
+  );
+  // maxEntries<=0 must return [] (not ALL entries via slice(-0)).
+  assert.deepEqual(capExtractionRetryStateEntries(entries, 0), []);
+  assert.deepEqual(capExtractionRetryStateEntries(entries, -5), []);
+});
+
+// ---------------------------------------------------------------------------
+// Backoff eligibility gate
+// ---------------------------------------------------------------------------
+
+test("backoff: a provider_retryable failure parks the same fingerprint; extract() not called again", async () => {
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 100,
+  });
+  try {
+    const coord = h.newCoordinator();
+    h.setRespond(() => failureResult("provider_retryable"));
+    const r1 = await h.run(coord, "topic-a");
+    assert.equal(r1.status, "skipped");
+    assert.equal(h.engineCalls(), 1, "first attempt calls extract()");
+
+    const r2 = await h.run(coord, "topic-a");
+    assert.equal(r2.reason, "extraction_backoff");
+    assert.equal(h.engineCalls(), 1, "second attempt is suppressed by backoff");
+
+    // A distinct fingerprint is unaffected by another fingerprint's backoff.
+    const r3 = await h.run(coord, "topic-b");
+    assert.equal(h.engineCalls(), 2, "distinct fingerprint still runs");
+    assert.equal(r3.status, "skipped");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("backoff: rewriting nextEligibleAt to the past re-enables the fingerprint (restart-safe hydration)", async () => {
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 100,
+  });
+  try {
+    h.setRespond(() => failureResult("provider_retryable"));
+    const coord = h.newCoordinator();
+    await h.run(coord, "topic-a");
+    assert.equal(h.engineCalls(), 1);
+
+    // Simulate the backoff window elapsing by rewinding the persisted state,
+    // then hydrate a FRESH coordinator (as a daemon restart would).
+    const storage = await h.storageForNs("default");
+    const meta = await storage.loadMeta();
+    assert.equal(meta.extractionRetryState?.length, 1, "failure persisted to meta.json");
+    meta.extractionRetryState = (meta.extractionRetryState ?? []).map((e) => ({
+      ...e,
+      nextEligibleAt: "2000-01-01T00:00:00.000Z",
+    }));
+    await storage.saveMeta(meta);
+
+    h.setRespond(() => successResult());
+    const coord2 = h.newCoordinator();
+    const r = await h.run(coord2, "topic-a");
+    assert.equal(h.engineCalls(), 2, "eligible-again fingerprint runs after restart hydration");
+    assert.equal(r.status, "completed");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Circuit breaker
+// ---------------------------------------------------------------------------
+
+test("circuit breaker: opens after threshold failures and suppresses distinct fingerprints", async () => {
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 2,
+    extractionBreakerCooldownMs: 3_600_000,
+  });
+  try {
+    const coord = h.newCoordinator();
+    h.setRespond(() => failureResult("provider_retryable"));
+    await h.run(coord, "fp-1");
+    await h.run(coord, "fp-2");
+    assert.equal(h.engineCalls(), 2, "two distinct fingerprints failed, tripping the breaker");
+    assert.equal(coord.getExtractionResilienceStatus().breaker.state, "open");
+
+    // A THIRD distinct fingerprint is short-circuited without calling extract().
+    const r = await h.run(coord, "fp-3");
+    assert.equal(r.reason, "provider_circuit_open");
+    assert.equal(h.engineCalls(), 2, "breaker-open suppresses distinct fingerprints too");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("circuit breaker: a forced flush still calls extract() while the breaker is open and records the failure", async () => {
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 1,
+    extractionBreakerCooldownMs: 3_600_000,
+  });
+  try {
+    const coord = h.newCoordinator();
+    h.setRespond(() => failureResult("provider_retryable"));
+    await h.run(coord, "fp-1");
+    assert.equal(coord.getExtractionResilienceStatus().breaker.state, "open");
+    assert.equal(h.engineCalls(), 1);
+
+    // Force-flush bypasses the gate (rule 18) but still records the failure.
+    const r = await h.run(coord, "fp-2", { force: true });
+    assert.equal(h.engineCalls(), 2, "forced attempt calls extract() despite open breaker");
+    assert.equal(r.status, "skipped");
+    const storage = await h.storageForNs("default");
+    const meta = await storage.loadMeta();
+    const fps = (meta.extractionRetryState ?? []).map((e) => e.fingerprint);
+    assert.equal(fps.length, 2, "forced failure was recorded into retry state");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("circuit breaker: auth_config failure opens the breaker immediately (no hot loop)", async () => {
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 100, // far above one failure
+    extractionBreakerAuthCooldownMs: 3_600_000,
+  });
+  try {
+    const coord = h.newCoordinator();
+    h.setRespond(() => failureResult("auth_config"));
+    await h.run(coord, "fp-1");
+    assert.equal(coord.getExtractionResilienceStatus().breaker.state, "open");
+
+    const r = await h.run(coord, "fp-2");
+    assert.equal(r.reason, "provider_circuit_open");
+    assert.equal(h.engineCalls(), 1, "one auth_config failure suppresses subsequent extraction");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("recovery: half-open probe succeeds → breaker closes", async () => {
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 1,
+    extractionBreakerCooldownMs: 0, // cooldown already elapsed on the next call
+  });
+  try {
+    const coord = h.newCoordinator();
+    h.setRespond(() => failureResult("provider_retryable"));
+    await h.run(coord, "fp-1");
+    assert.equal(coord.getExtractionResilienceStatus().breaker.state, "open");
+
+    // Cooldown 0 → next call flips open→half_open and allows one probe.
+    h.setRespond(() => successResult());
+    const r = await h.run(coord, "fp-2");
+    assert.equal(r.status, "completed", "half-open probe runs");
+    assert.equal(coord.getExtractionResilienceStatus().breaker.state, "closed");
+    assert.equal(coord.getExtractionResilienceStatus().breaker.consecutiveFailures, 0);
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("recovery: a successful extract clears the fingerprint's retry state so it proceeds again", async () => {
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 100,
+  });
+  try {
+    const coord = h.newCoordinator();
+    h.setRespond(() => failureResult("provider_retryable"));
+    await h.run(coord, "fp-1"); // fail → parked
+    await h.run(coord, "fp-1"); // suppressed
+    assert.equal(h.engineCalls(), 1);
+
+    h.setRespond(() => successResult());
+    await h.run(coord, "fp-1", { force: true }); // forced probe succeeds → clears state
+    assert.equal(h.engineCalls(), 2);
+    assert.equal(coord.getExtractionResilienceStatus().backoffFingerprintCount, 0, "retry state cleared on success");
+
+    // Same fingerprint, non-forced, now proceeds because the entry cleared.
+    await h.run(coord, "fp-1");
+    assert.equal(h.engineCalls(), 3, "cleared fingerprint runs without the gate");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Class-specific caps
+// ---------------------------------------------------------------------------
+
+test("parse_empty: long-parks a fingerprint after extractionParseEmptyMaxAttempts", async () => {
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [1000],
+    extractionRetryMaxBackoffMs: 9_000_000,
+    extractionParseEmptyMaxAttempts: 2,
+    extractionBreakerFailureThreshold: 100,
+    extractionRetryJitterRatio: 0,
+  });
+  try {
+    const coord = h.newCoordinator();
+    h.setRespond(() => failureResult("parse_empty"));
+    // Force each attempt so the gate does not suppress; drive past the cap.
+    await h.run(coord, "fp-1", { force: true });
+    await h.run(coord, "fp-1", { force: true });
+    await h.run(coord, "fp-1", { force: true }); // attempt 3 > cap of 2 → long-park
+
+    const storage = await h.storageForNs("default");
+    const meta = await storage.loadMeta();
+    const entry = (meta.extractionRetryState ?? [])[0];
+    assert.ok(entry, "retry state entry exists");
+    assert.equal(entry.attempts, 3);
+    assert.equal(entry.lastFailureClass, "parse_empty");
+    const parkMs = Date.parse(entry.nextEligibleAt) - Date.now();
+    assert.ok(parkMs > 8_000_000, `long-parked to ~maxBackoff (got ${parkMs}ms)`);
+    assert.equal(h.recordedProcessedCount(), 0, "parse_empty fingerprint is never marked processed");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Invariant guard (regression): never mark processed on failure
+// ---------------------------------------------------------------------------
+
+test("invariant: a failing extraction never records a processed fingerprint", async () => {
+  const h = await makeHarness({ extractionBreakerFailureThreshold: 100 });
+  try {
+    const coord = h.newCoordinator();
+    for (const cls of ["provider_retryable", "parse_empty", "auth_config"] as ExtractionFailureClass[]) {
+      h.setRespond(() => failureResult(cls));
+      await h.run(coord, `fp-${cls}`, { force: true });
+    }
+    assert.equal(h.recordedProcessedCount(), 0, "no processed fingerprint recorded across all failure classes");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Config parity: extractionRetryEnabled=false restores pre-change behavior
+// ---------------------------------------------------------------------------
+
+test("extractionRetryEnabled=false: extractor is called on every observe with no gate", async () => {
+  const h = await makeHarness({
+    extractionRetryEnabled: false,
+    extractionBreakerFailureThreshold: 1,
+  });
+  try {
+    const coord = h.newCoordinator();
+    h.setRespond(() => failureResult("provider_retryable"));
+    await h.run(coord, "fp-1");
+    await h.run(coord, "fp-1");
+    await h.run(coord, "fp-1");
+    assert.equal(h.engineCalls(), 3, "no backoff/breaker gate when the feature is disabled");
+    assert.equal(coord.getExtractionResilienceStatus().breaker.state, "closed");
+    const storage = await h.storageForNs("default");
+    const meta = await storage.loadMeta();
+    assert.equal((meta.extractionRetryState ?? []).length, 0, "no retry state persisted when disabled");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Cache coherence across instances
+// ---------------------------------------------------------------------------
+
+test("cache coherence: a failure recorded by one coordinator gates a second over the same meta", async () => {
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 100,
+  });
+  try {
+    const coordA = h.newCoordinator();
+    h.setRespond(() => failureResult("provider_retryable"));
+    await h.run(coordA, "shared-fp");
+    assert.equal(h.engineCalls(), 1);
+
+    // A second coordinator over the same memory dir hydrates from meta.json and
+    // honors the persisted backoff without calling extract().
+    const coordB = h.newCoordinator();
+    const r = await h.run(coordB, "shared-fp");
+    assert.equal(r.reason, "extraction_backoff");
+    assert.equal(h.engineCalls(), 1, "coordinator B honors coordinator A's persisted failure");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Namespace isolation vs. provider-global breaker
+// ---------------------------------------------------------------------------
+
+test("namespace isolation: per-fingerprint backoff is namespace-scoped; breaker is provider-global", async () => {
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 100, // keep the breaker closed for the per-fp assertion
+  });
+  try {
+    const coord = h.newCoordinator();
+    h.setRespond(() => failureResult("provider_retryable"));
+    // Same fingerprint content, routed to namespace A → parked in A only.
+    await h.run(coord, "same-content", { writeNamespaceOverride: "nsA" });
+    assert.equal(h.engineCalls(), 1);
+    const rA = await h.run(coord, "same-content", { writeNamespaceOverride: "nsA" });
+    assert.equal(rA.reason, "extraction_backoff", "namespace A fingerprint is parked");
+    assert.equal(h.engineCalls(), 1);
+
+    // The identical content routed to namespace B is NOT gated by A's backoff.
+    const rB = await h.run(coord, "same-content", { writeNamespaceOverride: "nsB" });
+    assert.equal(h.engineCalls(), 2, "namespace B is not gated by namespace A's per-fingerprint backoff");
+    assert.equal(rB.status, "skipped");
+
+    // Meta isolation: each namespace persists only its own retry state.
+    const metaA = await (await h.storageForNs("nsA")).loadMeta();
+    const metaB = await (await h.storageForNs("nsB")).loadMeta();
+    assert.equal((metaA.extractionRetryState ?? []).length, 1);
+    assert.equal((metaB.extractionRetryState ?? []).length, 1);
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("namespace isolation: the provider breaker suppresses extraction across namespaces", async () => {
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 1,
+    extractionBreakerCooldownMs: 3_600_000,
+  });
+  try {
+    const coord = h.newCoordinator();
+    h.setRespond(() => failureResult("provider_retryable"));
+    await h.run(coord, "fp-a", { writeNamespaceOverride: "nsA" });
+    assert.equal(coord.getExtractionResilienceStatus().breaker.state, "open");
+
+    // A different namespace is still suppressed — the breaker is provider-global.
+    const r = await h.run(coord, "fp-b", { writeNamespaceOverride: "nsB" });
+    assert.equal(r.reason, "provider_circuit_open");
+    assert.equal(h.engineCalls(), 1, "provider-global breaker suppresses namespace B too");
+  } finally {
+    await h.cleanup();
+  }
+});

--- a/packages/remnic-core/src/orchestration/extraction-run.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.ts
@@ -830,18 +830,27 @@ export class ExtractionRunCoordinator {
     // extractionRetryEnabled so a disabled feature restores prior behavior.
     if (extractionFingerprint && extractionRetryEnabled) {
       if (extractionFailure) {
-        meta ??= await storage.loadMeta();
-        await this.recordExtractionFailure(
-          storage,
-          selfNamespace,
-          extractionFingerprint,
-          result.extractionFailureClass ?? "provider_retryable",
-          meta,
-          Date.now(),
-        );
-        // The buffer is retained below so the backoff gate can re-attempt these
-        // turns after nextEligibleAt — clearing would orphan the retry state.
-        recordedRetryFailure = true;
+        try {
+          meta ??= await storage.loadMeta();
+          await this.recordExtractionFailure(
+            storage,
+            selfNamespace,
+            extractionFingerprint,
+            result.extractionFailureClass ?? "provider_retryable",
+            meta,
+            Date.now(),
+          );
+          // The buffer is retained below so the backoff gate can re-attempt
+          // these turns after nextEligibleAt — clearing would orphan the
+          // retry state.
+          recordedRetryFailure = true;
+        } catch (err) {
+          // Fail-open (codex review): retry bookkeeping is best-effort — a
+          // corrupt or locked meta store must not reject the extraction task.
+          // With no backoff recorded there is nothing to retain for, so the
+          // pre-#1908 clear-buffer behavior applies below.
+          log.warn("runExtraction: failed to load meta for retry bookkeeping (non-fatal)", err);
+        }
       } else {
         // Provider responded without failure → breaker heals; clear any
         // parked backoff for this fingerprint so it proceeds normally.

--- a/packages/remnic-core/src/orchestration/extraction-run.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.ts
@@ -40,7 +40,7 @@ import {
 } from "../capabilities.js";
 import { parseFlexibleIsoTimestamp } from "../utils/iso-timestamp.js";
 import { log } from "../logger.js";
-import type { PluginConfig, BufferTurn, ExtractionResult } from "../types.js";
+import type { PluginConfig, BufferTurn, ExtractionResult, MetaState, ExtractionFailureClass } from "../types.js";
 import type { TierMigrationCycleSummary } from "../recall-state.js";
 
 export interface ExtractionRunResult {
@@ -130,6 +130,66 @@ export function deriveTopicsFromExtraction(result: ExtractionResult): string[] {
   return [...topics].slice(0, 16);
 }
 
+/** Bounded cap on persisted per-fingerprint retry-state entries (per namespace meta). */
+const EXTRACTION_RETRY_STATE_MAX_ENTRIES = 500;
+
+interface ExtractionRetryStateEntry {
+  attempts: number;
+  nextEligibleAtMs: number;
+  firstFailedAtMs: number;
+  lastFailureClass: ExtractionFailureClass;
+}
+
+export interface ExtractionResilienceStatus {
+  breaker: {
+    state: "closed" | "open" | "half_open";
+    openUntilMs: number;
+    consecutiveFailures: number;
+    lastReason: string;
+  };
+  backoffFingerprintCount: number;
+}
+
+/**
+ * Pure backoff scheduler. Returns the absolute ms timestamp at which a
+ * fingerprint that has failed `attempts` times becomes eligible again:
+ * exponential via the configured schedule, clamped to `maxBackoffMs`, with
+ * ±`jitterRatio` multiplicative jitter. `rng` is injectable for deterministic
+ * tests. Never returns a timestamp before `now`.
+ */
+export function computeExtractionRetryNextEligibleMs(
+  attempts: number,
+  scheduleMs: readonly number[],
+  maxBackoffMs: number,
+  jitterRatio: number,
+  now: number,
+  rng: () => number = Math.random,
+): number {
+  const cap = Number.isFinite(maxBackoffMs) && maxBackoffMs > 0 ? maxBackoffMs : 0;
+  if (!Array.isArray(scheduleMs) || scheduleMs.length === 0) {
+    return now + cap;
+  }
+  const idx = Math.min(Math.max(attempts - 1, 0), scheduleMs.length - 1);
+  const step = scheduleMs[idx];
+  const base = Math.min(typeof step === "number" && step > 0 ? step : cap, cap);
+  const jitter = 1 + (rng() * 2 - 1) * jitterRatio;
+  return now + Math.max(0, Math.round(base * jitter));
+}
+
+/**
+ * Cap the persisted retry-state array to the newest `maxEntries` by
+ * firstFailedAt. Guards `maxEntries <= 0` so a zero cap returns [] rather than
+ * `slice(-0)`, which returns ALL entries (AGENTS.md rule 17).
+ */
+export function capExtractionRetryStateEntries<T extends { firstFailedAt: string }>(
+  entries: readonly T[],
+  maxEntries: number,
+): T[] {
+  if (maxEntries <= 0) return [];
+  const sorted = [...entries].sort((a, b) => a.firstFailedAt.localeCompare(b.firstFailedAt));
+  return sorted.slice(-maxEntries);
+}
+
 /**
  * Coordinates the extraction run pipeline. Holds the dedupe fingerprint
  * cache (`recentExtractionFingerprints`) and delegates all side effects
@@ -137,6 +197,21 @@ export function deriveTopicsFromExtraction(result: ExtractionResult): string[] {
  */
 export class ExtractionRunCoordinator {
   private readonly recentExtractionFingerprints = new Map<string, number>();
+  // Per-fingerprint extraction retry/backoff state (extraction hot-loop
+  // hardening). Outer key = namespace, inner key = fingerprint. Hydrated lazily
+  // from namespace-scoped meta so the hot path is a Map lookup; persisted back
+  // to meta on change (restart-safe, cross-process coherent via the shared
+  // meta.json). The breaker below is intentionally per-process in-memory
+  // (mirrors local-llm.cooldownUntilMs); a restart clears it but the persisted
+  // backoff still throttles, so a restart can't resurrect the hot loop.
+  private readonly extractionRetryState = new Map<string, Map<string, ExtractionRetryStateEntry>>();
+  private readonly hydratedRetryNamespaces = new Set<string>();
+  private providerBreaker: {
+    consecutiveFailures: number;
+    openUntilMs: number;
+    state: "closed" | "open" | "half_open";
+    lastReason: string;
+  } = { consecutiveFailures: 0, openUntilMs: 0, state: "closed", lastReason: "" };
 
   constructor(private readonly deps: ExtractionRunCoordinatorDeps) {}
 
@@ -239,6 +314,177 @@ export class ExtractionRunCoordinator {
   }
 
   // -------------------------------------------------------------------------
+  // Extraction retry/backoff + circuit breaker (extraction hot-loop hardening)
+  // -------------------------------------------------------------------------
+
+  /** Lazily hydrate the in-memory retry-state mirror for a namespace from meta.
+   *  One-time per namespace per coordinator; the hot path is then a Map lookup.
+   *  Cross-process coherence: a fresh coordinator hydrates from the shared
+   *  meta.json, so a failure persisted by another process is honored here. */
+  private hydrateRetryStateFromMeta(namespace: string, meta: MetaState): void {
+    if (this.hydratedRetryNamespaces.has(namespace)) return;
+    this.hydratedRetryNamespaces.add(namespace);
+    const nsMap = this.extractionRetryState.get(namespace) ?? new Map<string, ExtractionRetryStateEntry>();
+    for (const entry of meta.extractionRetryState ?? []) {
+      const nextEligibleAtMs = Date.parse(entry.nextEligibleAt);
+      const firstFailedAtMs = Date.parse(entry.firstFailedAt);
+      nsMap.set(entry.fingerprint, {
+        attempts: entry.attempts,
+        nextEligibleAtMs: Number.isFinite(nextEligibleAtMs) ? nextEligibleAtMs : 0,
+        firstFailedAtMs: Number.isFinite(firstFailedAtMs) ? firstFailedAtMs : Date.now(),
+        lastFailureClass: entry.lastFailureClass,
+      });
+    }
+    this.extractionRetryState.set(namespace, nsMap);
+  }
+
+  private logBreakerTransition(state: "closed" | "open" | "half_open"): void {
+    // Once per state change (not per attempt) — AGENTS.md observability rule.
+    log.warn("extraction: provider circuit breaker transition", {
+      state,
+      consecutiveFailures: this.providerBreaker.consecutiveFailures,
+      lastReason: this.providerBreaker.lastReason,
+      openUntilMs: this.providerBreaker.openUntilMs,
+    });
+  }
+
+  /** True while the breaker suppresses non-forced attempts. Flips an expired
+   *  `open` breaker to `half_open`, which allows exactly one probe (the next
+   *  non-forced attempt) because the extraction queue is a serial drain. */
+  private isProviderBreakerOpen(now: number): boolean {
+    if (now < this.providerBreaker.openUntilMs) return true;
+    if (this.providerBreaker.state === "open") {
+      this.providerBreaker.state = "half_open";
+      this.logBreakerTransition("half_open");
+    }
+    return false;
+  }
+
+  private onProviderFailure(cls: ExtractionFailureClass, now: number): void {
+    this.providerBreaker.consecutiveFailures += 1;
+    const trip =
+      cls === "auth_config" ||
+      this.providerBreaker.consecutiveFailures >= this.config.extractionBreakerFailureThreshold;
+    if (!trip) return;
+    const cooldown =
+      cls === "auth_config"
+        ? this.config.extractionBreakerAuthCooldownMs
+        : this.config.extractionBreakerCooldownMs;
+    this.providerBreaker.openUntilMs = now + Math.max(0, cooldown);
+    this.providerBreaker.lastReason = cls;
+    if (this.providerBreaker.state !== "open") {
+      this.providerBreaker.state = "open";
+      this.logBreakerTransition("open");
+    }
+  }
+
+  private resetProviderBreakerOnSuccess(): void {
+    const wasDisturbed =
+      this.providerBreaker.state !== "closed" ||
+      this.providerBreaker.consecutiveFailures > 0 ||
+      this.providerBreaker.openUntilMs > 0;
+    if (!wasDisturbed) return;
+    const wasOpen = this.providerBreaker.state !== "closed";
+    this.providerBreaker.consecutiveFailures = 0;
+    this.providerBreaker.openUntilMs = 0;
+    this.providerBreaker.lastReason = "";
+    this.providerBreaker.state = "closed";
+    if (wasOpen) this.logBreakerTransition("closed");
+  }
+
+  /** Rebuild `meta.extractionRetryState` from the in-memory namespace mirror,
+   *  bounded to the newest entries, and prune the mirror to match. */
+  private persistRetryStateToMeta(namespace: string, meta: MetaState): void {
+    const nsMap = this.extractionRetryState.get(namespace);
+    const entries = nsMap
+      ? Array.from(nsMap.entries()).map(([fingerprint, st]) => ({
+          fingerprint,
+          attempts: st.attempts,
+          nextEligibleAt: new Date(st.nextEligibleAtMs).toISOString(),
+          firstFailedAt: new Date(st.firstFailedAtMs).toISOString(),
+          lastFailureClass: st.lastFailureClass,
+        }))
+      : [];
+    const capped = capExtractionRetryStateEntries(entries, EXTRACTION_RETRY_STATE_MAX_ENTRIES);
+    meta.extractionRetryState = capped;
+    if (nsMap && capped.length < nsMap.size) {
+      const kept = new Set(capped.map((e) => e.fingerprint));
+      for (const key of Array.from(nsMap.keys())) {
+        if (!kept.has(key)) nsMap.delete(key);
+      }
+    }
+  }
+
+  /** Record an extraction failure into per-fingerprint backoff state + breaker,
+   *  persisting to namespace meta. Fail-open: never throws upward. */
+  private async recordExtractionFailure(
+    storage: StorageManager,
+    namespace: string,
+    fingerprint: string,
+    cls: ExtractionFailureClass,
+    meta: MetaState,
+    now: number,
+  ): Promise<void> {
+    try {
+      this.hydrateRetryStateFromMeta(namespace, meta);
+      const nsMap = this.extractionRetryState.get(namespace) ?? new Map<string, ExtractionRetryStateEntry>();
+      const prev = nsMap.get(fingerprint);
+      const attempts = (prev?.attempts ?? 0) + 1;
+      const firstFailedAtMs = prev?.firstFailedAtMs ?? now;
+      let nextEligibleAtMs: number;
+      if (cls === "parse_empty" && attempts > this.config.extractionParseEmptyMaxAttempts) {
+        // parse_empty exhausted its attempt budget → long-park (still never
+        // marked processed). A dead gateway also yields unparseable output.
+        nextEligibleAtMs = now + Math.max(0, this.config.extractionRetryMaxBackoffMs);
+      } else {
+        nextEligibleAtMs = computeExtractionRetryNextEligibleMs(
+          attempts,
+          this.config.extractionRetryScheduleMs,
+          this.config.extractionRetryMaxBackoffMs,
+          this.config.extractionRetryJitterRatio,
+          now,
+        );
+      }
+      nsMap.set(fingerprint, { attempts, nextEligibleAtMs, firstFailedAtMs, lastFailureClass: cls });
+      this.extractionRetryState.set(namespace, nsMap);
+      this.onProviderFailure(cls, now);
+      this.persistRetryStateToMeta(namespace, meta);
+      await storage.saveMeta(meta);
+    } catch (err) {
+      // Fail-open: recording failure state must never crash observe/recall.
+      log.warn("runExtraction: failed to record extraction retry state (non-fatal)", err);
+    }
+  }
+
+  /** Delete a fingerprint's retry entry from the mirror + meta. Returns whether
+   *  meta changed (so the caller can decide to persist). Does not touch the
+   *  breaker — callers pair this with `resetProviderBreakerOnSuccess`. */
+  private clearExtractionRetryEntry(namespace: string, fingerprint: string, meta: MetaState): boolean {
+    const nsMap = this.extractionRetryState.get(namespace);
+    if (!nsMap?.has(fingerprint)) return false;
+    nsMap.delete(fingerprint);
+    this.persistRetryStateToMeta(namespace, meta);
+    return true;
+  }
+
+  /** Live in-process resilience snapshot (breaker + backoff population). */
+  getExtractionResilienceStatus(): ExtractionResilienceStatus {
+    let backoffFingerprintCount = 0;
+    for (const nsMap of this.extractionRetryState.values()) {
+      backoffFingerprintCount += nsMap.size;
+    }
+    return {
+      breaker: {
+        state: this.providerBreaker.state,
+        openUntilMs: this.providerBreaker.openUntilMs,
+        consecutiveFailures: this.providerBreaker.consecutiveFailures,
+        lastReason: this.providerBreaker.lastReason,
+      },
+      backoffFingerprintCount,
+    };
+  }
+
+  // -------------------------------------------------------------------------
   // Main extraction pipeline
   // -------------------------------------------------------------------------
 
@@ -268,6 +514,14 @@ export class ExtractionRunCoordinator {
        * (un-prefixed) key and storage is pinned via `writeNamespaceOverride`.
        */
       principalOverride?: string;
+      /**
+       * Force the extractor call, bypassing the retry-backoff / circuit-breaker
+       * gate (extraction hot-loop hardening). Set by explicit flush paths
+       * (before_reset / session flush / replay / bulk import) that already pass
+       * `skipDedupeCheck: true` — AGENTS.md rule 18. A forced attempt still
+       * records its failure into retry-state/breaker.
+       */
+      forceExtractionAttempt?: boolean;
     } = {}
   ): Promise<ExtractionRunResult> {
     log.debug(`running extraction on ${turns.length} turns`);
@@ -463,6 +717,37 @@ export class ExtractionRunCoordinator {
       };
     }
 
+    // Extraction retry/backoff + circuit-breaker gate (extraction hot-loop
+    // hardening). Suppresses re-attempts of a recently-failed fingerprint and
+    // short-circuits every fingerprint while the provider breaker is open, so a
+    // failing LLM endpoint is not hammered once per observe. Forced flushes and
+    // fail-closed callers bypass the gate (rule 18) but still record failures.
+    // On a suppressed attempt the buffer is deliberately NOT cleared, so no
+    // extractable turn is dropped — it is retried after cooldown/nextEligibleAt.
+    const forcedExtractionAttempt =
+      options.failOnExtractionFailure === true || options.forceExtractionAttempt === true;
+    // Resolve the gate through the shared lifecycle capability plan (issue
+    // #1523) rather than reading the raw config flag at each call site.
+    const extractionRetryEnabled = resolveMemoryLifecycleCapabilities(this.config).extractionRetry;
+    if (extractionFingerprint && !forcedExtractionAttempt && extractionRetryEnabled) {
+      try {
+        meta ??= await storage.loadMeta();
+        this.hydrateRetryStateFromMeta(selfNamespace, meta);
+        const nowMs = Date.now();
+        if (this.isProviderBreakerOpen(nowMs)) {
+          return { status: "skipped", reason: "provider_circuit_open", persistedCount: 0, durableOutputCount: 0 };
+        }
+        const nsMap = this.extractionRetryState.get(selfNamespace);
+        const st = nsMap?.get(extractionFingerprint);
+        if (st && nowMs < st.nextEligibleAtMs) {
+          return { status: "skipped", reason: "extraction_backoff", persistedCount: 0, durableOutputCount: 0 };
+        }
+      } catch (err) {
+        // Fail-open: a gate error must never block extraction.
+        log.warn("runExtraction: extraction retry gate check failed; proceeding (fail-open)", err);
+      }
+    }
+
     // Pass existing entity names so the LLM can reuse them instead of inventing variants
     const existingEntities = await storage.listEntityNames();
     const result = await raceRecallAbort(
@@ -517,6 +802,38 @@ export class ExtractionRunCoordinator {
       typeof result.extractionFailure === "string" && result.extractionFailure.trim().length > 0
         ? result.extractionFailure
         : undefined;
+    // Record failure into backoff/breaker state, or heal on success. Runs for
+    // every result path (empty and durable), before the fail-closed throw, so a
+    // forced flush still records its failure (rule 18). Gated by
+    // extractionRetryEnabled so a disabled feature restores prior behavior.
+    if (extractionFingerprint && extractionRetryEnabled) {
+      if (extractionFailure) {
+        meta ??= await storage.loadMeta();
+        await this.recordExtractionFailure(
+          storage,
+          selfNamespace,
+          extractionFingerprint,
+          result.extractionFailureClass ?? "provider_retryable",
+          meta,
+          Date.now(),
+        );
+      } else {
+        // Provider responded without failure → breaker heals; clear any
+        // parked backoff for this fingerprint so it proceeds normally.
+        this.resetProviderBreakerOnSuccess();
+        const nsMap = this.extractionRetryState.get(selfNamespace);
+        if (nsMap?.has(extractionFingerprint)) {
+          try {
+            meta ??= await storage.loadMeta();
+            if (this.clearExtractionRetryEntry(selfNamespace, extractionFingerprint, meta)) {
+              await storage.saveMeta(meta);
+            }
+          } catch (err) {
+            log.warn("runExtraction: failed to persist cleared retry state (non-fatal)", err);
+          }
+        }
+      }
+    }
     if (options.failOnExtractionFailure && extractionFailure) {
       throw new Error(`extraction failed: ${extractionFailure}`);
     }

--- a/packages/remnic-core/src/orchestration/extraction-run.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.ts
@@ -364,6 +364,11 @@ export class ExtractionRunCoordinator {
     this.providerBreaker.consecutiveFailures += 1;
     const trip =
       cls === "auth_config" ||
+      // A failed half-open probe re-opens immediately (standard breaker
+      // semantics). Without this, an auth_config-opened breaker (which trips
+      // below the threshold) would get stuck half_open after a transient
+      // probe failure and stop suppressing (cursor review).
+      this.providerBreaker.state === "half_open" ||
       this.providerBreaker.consecutiveFailures >= this.config.extractionBreakerFailureThreshold;
     if (!trip) return;
     const cooldown =

--- a/packages/remnic-core/src/orchestration/extraction-run.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.ts
@@ -802,6 +802,7 @@ export class ExtractionRunCoordinator {
       typeof result.extractionFailure === "string" && result.extractionFailure.trim().length > 0
         ? result.extractionFailure
         : undefined;
+    let recordedRetryFailure = false;
     // Record failure into backoff/breaker state, or heal on success. Runs for
     // every result path (empty and durable), before the fail-closed throw, so a
     // forced flush still records its failure (rule 18). Gated by
@@ -817,6 +818,9 @@ export class ExtractionRunCoordinator {
           meta,
           Date.now(),
         );
+        // The buffer is retained below so the backoff gate can re-attempt these
+        // turns after nextEligibleAt — clearing would orphan the retry state.
+        recordedRetryFailure = true;
       } else {
         // Provider responded without failure → breaker heals; clear any
         // parked backoff for this fingerprint so it proceeds normally.
@@ -870,7 +874,17 @@ export class ExtractionRunCoordinator {
         bufferKey,
         isLiveSession: clearBufferAfterExtraction,
       });
-      await clearBuffer();
+      if (recordedRetryFailure) {
+        // Retain the failed turns so the backoff gate can re-attempt them after
+        // nextEligibleAt. Clearing here would lose the data the retry state
+        // points at (cursor high + codex P1). Trigger/forced paths already
+        // retain via clearBufferAfterExtraction=false; this covers the normal
+        // live-session path. Overflow is bounded by MAX_BUFFER_ENTRY_COUNT
+        // with a loud eviction log.
+        log.debug("runExtraction: retaining buffer for backoff retry after failure");
+      } else {
+        await clearBuffer();
+      }
       return { status: "skipped", reason: "empty_extraction_result", persistedCount: 0, durableOutputCount: 0 };
     }
 

--- a/packages/remnic-core/src/orchestration/extraction-run.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.ts
@@ -738,13 +738,30 @@ export class ExtractionRunCoordinator {
         meta ??= await storage.loadMeta();
         this.hydrateRetryStateFromMeta(selfNamespace, meta);
         const nowMs = Date.now();
+        let suppressReason: "provider_circuit_open" | "extraction_backoff" | null = null;
         if (this.isProviderBreakerOpen(nowMs)) {
-          return { status: "skipped", reason: "provider_circuit_open", persistedCount: 0, durableOutputCount: 0 };
+          suppressReason = "provider_circuit_open";
+        } else {
+          const st = this.extractionRetryState.get(selfNamespace)?.get(extractionFingerprint);
+          if (st && nowMs < st.nextEligibleAtMs) suppressReason = "extraction_backoff";
         }
-        const nsMap = this.extractionRetryState.get(selfNamespace);
-        const st = nsMap?.get(extractionFingerprint);
-        if (st && nowMs < st.nextEligibleAtMs) {
-          return { status: "skipped", reason: "extraction_backoff", persistedCount: 0, durableOutputCount: 0 };
+        if (suppressReason) {
+          // Parity with the other skip paths: passive correction capture is
+          // local (no provider call) and must not be delayed by a provider
+          // cooldown — "stop calling me X" style turns should register during
+          // a 30-minute breaker window too (codex review). Fail-open.
+          try {
+            await this.deps.maybeCapturePassiveCorrections(normalizedTurns as BufferTurn[], {
+              sessionKey,
+              principal,
+              namespace: selfNamespace,
+              bufferKey,
+              isLiveSession: clearBufferAfterExtraction,
+            });
+          } catch (captureErr) {
+            log.warn("runExtraction: passive correction capture failed on suppressed attempt (non-fatal)", captureErr);
+          }
+          return { status: "skipped", reason: suppressReason, persistedCount: 0, durableOutputCount: 0 };
         }
       } catch (err) {
         // Fail-open: a gate error must never block extraction.

--- a/packages/remnic-core/src/orchestration/extraction-run.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.ts
@@ -821,16 +821,19 @@ export class ExtractionRunCoordinator {
         // Provider responded without failure → breaker heals; clear any
         // parked backoff for this fingerprint so it proceeds normally.
         this.resetProviderBreakerOnSuccess();
-        const nsMap = this.extractionRetryState.get(selfNamespace);
-        if (nsMap?.has(extractionFingerprint)) {
-          try {
-            meta ??= await storage.loadMeta();
-            if (this.clearExtractionRetryEntry(selfNamespace, extractionFingerprint, meta)) {
-              await storage.saveMeta(meta);
-            }
-          } catch (err) {
-            log.warn("runExtraction: failed to persist cleared retry state (non-fatal)", err);
+        try {
+          meta ??= await storage.loadMeta();
+          // Hydrate the in-memory mirror from persisted meta before clearing.
+          // A forced flush (forceExtractionAttempt) bypasses the retry gate and
+          // never hydrated, so without this a stale persisted backoff entry
+          // would survive a successful forced flush and keep blocking normal
+          // extraction until the timer expired (cursor/codex review).
+          this.hydrateRetryStateFromMeta(selfNamespace, meta);
+          if (this.clearExtractionRetryEntry(selfNamespace, extractionFingerprint, meta)) {
+            await storage.saveMeta(meta);
           }
+        } catch (err) {
+          log.warn("runExtraction: failed to persist cleared retry state (non-fatal)", err);
         }
       }
     }

--- a/packages/remnic-core/src/orchestration/extraction-run.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.ts
@@ -414,7 +414,6 @@ export class ExtractionRunCoordinator {
       }
     }
   }
-
   /** Record an extraction failure into per-fingerprint backoff state + breaker,
    *  persisting to namespace meta. Fail-open: never throws upward. */
   private async recordExtractionFailure(

--- a/packages/remnic-core/src/orchestration/session-context.ts
+++ b/packages/remnic-core/src/orchestration/session-context.ts
@@ -52,6 +52,7 @@ export interface SessionContextDeps {
       skipUserTurnThreshold?: boolean;
       extractionDeadlineMs?: number;
       failOnExtractionFailure?: boolean;
+      forceExtractionAttempt?: boolean;
       onTaskSettled?: (
         error?: unknown,
         result?: ExtractionRunResult,
@@ -347,6 +348,7 @@ export class SessionContextCoordinator {
             bufferKey,
             clearBufferAfterExtraction: true,
             skipDedupeCheck: true,
+            forceExtractionAttempt: true,
             abortSignal: options.abortSignal,
             onTaskSettled: (error) => (error ? reject(error) : resolve()),
           })

--- a/packages/remnic-core/src/orchestration/turn-ingestion.ts
+++ b/packages/remnic-core/src/orchestration/turn-ingestion.ts
@@ -68,6 +68,7 @@ export interface TurnIngestionDeps {
       skipUserTurnThreshold?: boolean;
       extractionDeadlineMs?: number;
       failOnExtractionFailure?: boolean;
+      forceExtractionAttempt?: boolean;
       onTaskSettled?: (
         error?: unknown,
         result?: ExtractionRunResult,
@@ -288,6 +289,7 @@ export class TurnIngestionCoordinator {
           new Promise<void>((resolve, reject) => {
             void this.deps.queueBufferedExtraction(sessionSlice, "trigger_mode", {
               skipDedupeCheck: true,
+              forceExtractionAttempt: true,
               clearBufferAfterExtraction: false,
               skipCharThreshold: true,
               skipUserTurnThreshold: true,
@@ -463,6 +465,7 @@ export class TurnIngestionCoordinator {
           (resolve, reject) => {
             void this.deps.queueBufferedExtraction(sessionSlice, "trigger_mode", {
               skipDedupeCheck: true,
+              forceExtractionAttempt: true,
               clearBufferAfterExtraction: false,
               skipCharThreshold: true,
               skipUserTurnThreshold: true,
@@ -606,6 +609,7 @@ export class TurnIngestionCoordinator {
       skipUserTurnThreshold?: boolean;
       extractionDeadlineMs?: number;
       failOnExtractionFailure?: boolean;
+      forceExtractionAttempt?: boolean;
       onTaskSettled?: (
         error?: unknown,
         result?: ExtractionRunResult,
@@ -700,6 +704,7 @@ export class TurnIngestionCoordinator {
           failOnExtractionFailure: options.failOnExtractionFailure === true,
           writeNamespaceOverride: options.writeNamespaceOverride,
           principalOverride: options.principalOverride,
+          forceExtractionAttempt: options.forceExtractionAttempt === true,
         });
         settleTask(undefined, result);
       } catch (err) {

--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -1064,8 +1064,39 @@ test("runExtraction does not persist processed fingerprints for failed empty ext
   // saveMeta call), but MUST NOT record a processed fingerprint — the invariant
   // below (processedExtractionFingerprints stays []) is the real contract.
   assert.ok(saveMetaCalls <= 1, `expected at most one retry-state meta save, got ${saveMetaCalls}`);
-  assert.equal(clearCalls, 1);
+  // #1908: a retryable failure retains the buffer (clearCalls===0) so the backoff
+  // gate can re-attempt the turns after nextEligibleAt — clearing would orphan
+  // the persisted retry state (cursor high + codex P1).
+  assert.equal(clearCalls, 0);
   assert.deepEqual(meta.processedExtractionFingerprints, []);
+});
+
+test("runExtraction clears the buffer on a failed extraction when extractionRetryEnabled=false (behavior parity)", async () => {
+  // With retry disabled the failure path must match pre-#1908 behavior: the
+  // buffer is cleared (no retry state is recorded, so there is nothing to retain).
+  const config = parseConfig({ extractionRetryEnabled: false });
+  config.extractionMinChars = 0;
+  config.extractionMinUserTurns = 1;
+  let clearCalls = 0;
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  orchestrator.config = config;
+  orchestrator.buffer = { clearAfterExtraction: async () => { clearCalls += 1; } };
+  orchestrator.storageRouter = {
+    storageFor: async () => ({
+      listEntityNames: async () => [],
+      loadMeta: async () => ({ extractionCount: 0, lastExtractionAt: null, lastConsolidationAt: null, totalMemories: 0, totalEntities: 0, processedExtractionFingerprints: [] }),
+      saveMeta: async () => {},
+    }),
+  };
+  orchestrator.extraction = {
+    extract: async () => ({ facts: [], entities: [], questions: [], profileUpdates: [], extractionFailure: "gateway_unavailable" }),
+  };
+  orchestrator.persistExtraction = async () => [];
+  const turns = [{ ...makeTurn("session-retry-off", "failed gateway"), logicalSessionKey: "logical-thread:retry-off", turnFingerprint: "fp-retry-off", persistProcessedFingerprint: true }];
+  const result = await orchestrator.runExtraction(turns, { bufferKey: "logical-thread:retry-off" });
+  assert.equal(result.status, "skipped");
+  assert.equal(result.reason, "empty_extraction_result");
+  assert.equal(clearCalls, 1, "retry disabled → buffer cleared (pre-#1908 behavior)");
 });
 
 test("runExtraction preserves empty-result buffers when fingerprint persistence fails", async () => {

--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -1060,7 +1060,10 @@ test("runExtraction does not persist processed fingerprints for failed empty ext
   assert.equal(result.status, "skipped");
   assert.equal(result.reason, "empty_extraction_result");
   assert.equal(persistCalls, 0);
-  assert.equal(saveMetaCalls, 0);
+  // #1908: a failed extraction now persists per-fingerprint retry-state to meta (one
+  // saveMeta call), but MUST NOT record a processed fingerprint — the invariant
+  // below (processedExtractionFingerprints stays []) is the real contract.
+  assert.ok(saveMetaCalls <= 1, `expected at most one retry-state meta save, got ${saveMetaCalls}`);
   assert.equal(clearCalls, 1);
   assert.deepEqual(meta.processedExtractionFingerprints, []);
 });

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -106,7 +106,11 @@ import { RecallRerankCoordinator } from "./orchestration/recall-rerank-coordinat
 import { RecallSectionCoordinator } from "./orchestration/recall-section-coordinator.js";
 import { QmdResultResolver, qmdCollectionPathParts, qmdResultPathCandidates } from "./orchestration/qmd-result-resolver.js";
 import { ContradictionLinkingCoordinator } from "./orchestration/contradiction-linking-coordinator.js";
-import { ExtractionRunCoordinator, type ExtractionRunResult } from "./orchestration/extraction-run.js";
+import {
+  ExtractionRunCoordinator,
+  type ExtractionRunResult,
+  type ExtractionResilienceStatus,
+} from "./orchestration/extraction-run.js";
 import { ConsolidationRunCoordinator } from "./orchestration/consolidation-run.js";
 import { ExtractionPersistCoordinator } from "./orchestration/extraction-persist.js";
 import { RecallInternalCoordinator } from "./orchestration/recall-internal.js";
@@ -2937,6 +2941,7 @@ export class Orchestrator {
       skipUserTurnThreshold?: boolean;
       extractionDeadlineMs?: number;
       failOnExtractionFailure?: boolean;
+      forceExtractionAttempt?: boolean;
       onTaskSettled?: (
         error?: unknown,
         result?: ExtractionRunResult,
@@ -3008,6 +3013,12 @@ export class Orchestrator {
     ...args: Parameters<ExtractionRunCoordinator["runExtraction"]>
   ): Promise<ExtractionRunResult> {
     return this.extractionRunCoordinator.runExtraction(...args);
+  }
+
+  /** Live extraction resilience snapshot (provider circuit breaker + per-
+   *  fingerprint backoff population) for status/doctor surfaces. */
+  getExtractionResilienceStatus(): ExtractionResilienceStatus {
+    return this.extractionRunCoordinator.getExtractionResilienceStatus();
   }
 
   private async recordProcessedExtractionFingerprint(

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -110,6 +110,7 @@ import type {
   BufferSurpriseEvent,
   MemorySummary,
   MetaState,
+  ExtractionFailureClass,
   CompressionGuidelineOptimizerState,
   PluginConfig,
   ScoredEntity,
@@ -2261,6 +2262,38 @@ export interface MemoryWriteResult {
   tombstoneBlocked: boolean;
   /** The tombstone id that blocked the write, when `tombstoneBlocked`. */
   blockedBy?: string;
+}
+
+/**
+ * Defensively parse the persisted per-fingerprint extraction retry state from
+ * meta.json. Mirrors the tolerance of the `processedExtractionFingerprints`
+ * loader: unknown/legacy shapes are dropped, never thrown on. Uses `in`/typeof
+ * narrowing (no inline casts) so a malformed entry can't slip through typed.
+ */
+function parseExtractionRetryStateEntries(
+  raw: unknown,
+): NonNullable<MetaState["extractionRetryState"]> {
+  if (!Array.isArray(raw)) return [];
+  const valid: NonNullable<MetaState["extractionRetryState"]> = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    if (!("fingerprint" in entry) || typeof entry.fingerprint !== "string") continue;
+    if (!("attempts" in entry) || typeof entry.attempts !== "number" || !Number.isFinite(entry.attempts)) continue;
+    if (!("nextEligibleAt" in entry) || typeof entry.nextEligibleAt !== "string") continue;
+    if (!("firstFailedAt" in entry) || typeof entry.firstFailedAt !== "string") continue;
+    if (!("lastFailureClass" in entry)) continue;
+    const cls = entry.lastFailureClass;
+    if (cls !== "provider_retryable" && cls !== "parse_empty" && cls !== "auth_config") continue;
+    const lastFailureClass: ExtractionFailureClass = cls;
+    valid.push({
+      fingerprint: entry.fingerprint,
+      attempts: entry.attempts,
+      nextEligibleAt: entry.nextEligibleAt,
+      firstFailedAt: entry.firstFailedAt,
+      lastFailureClass,
+    });
+  }
+  return valid;
 }
 
 export class StorageManager {
@@ -4917,6 +4950,7 @@ export class StorageManager {
                 observedAt: (entry as { observedAt: string }).observedAt,
               }))
           : [],
+        extractionRetryState: parseExtractionRetryStateEntries(parsed.extractionRetryState),
       };
     } catch (err) {
       if (err instanceof SecureStoreLockedError) throw err;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1564,6 +1564,23 @@ export interface PluginConfig {
   localLlmRetryBackoffMs: number;
   localLlm400TripThreshold: number;
   localLlm400CooldownMs: number;
+  // Extraction retry/backoff + circuit breaker (extraction hot-loop hardening)
+  /** Master gate. When false, restores pre-change behavior (extractor called on every triggered observe; no gate). */
+  extractionRetryEnabled: boolean;
+  /** Per-fingerprint exponential backoff schedule (ms), indexed by attempt number. */
+  extractionRetryScheduleMs: number[];
+  /** Upper bound on any single backoff interval (ms). */
+  extractionRetryMaxBackoffMs: number;
+  /** Jitter ratio applied to each backoff interval (±ratio). */
+  extractionRetryJitterRatio: number;
+  /** Max attempts for a `parse_empty` fingerprint before it is long-parked. */
+  extractionParseEmptyMaxAttempts: number;
+  /** Consecutive provider failures before the circuit breaker opens. */
+  extractionBreakerFailureThreshold: number;
+  /** Breaker open cooldown (ms) for transient provider failures. */
+  extractionBreakerCooldownMs: number;
+  /** Breaker open cooldown (ms) for auth/config failures (longer — provider is misconfigured). */
+  extractionBreakerAuthCooldownMs: number;
   // Local LLM fast tier (v9.1) — smaller model for quick ops
   localLlmFastEnabled: boolean;
   localLlmFastModel: string;
@@ -3162,6 +3179,15 @@ export interface QuestionEntry {
   resolvedAt?: string;
 }
 
+/**
+ * Coarse failure class consumed by the extraction retry/backoff + circuit
+ * breaker layer (extraction hot-loop hardening). Kept deliberately small:
+ * - `provider_retryable`: transient provider failure (429/5xx/network) — back off and retry.
+ * - `parse_empty`: provider responded but produced no parseable output — retry with a low attempt cap.
+ * - `auth_config`: auth/config failure (401/403/"no models configured") — open the breaker immediately.
+ */
+export type ExtractionFailureClass = "provider_retryable" | "parse_empty" | "auth_config";
+
 export interface ExtractionResult {
   facts: ExtractedFact[];
   profileUpdates: string[];
@@ -3170,6 +3196,8 @@ export interface ExtractionResult {
   identityReflection?: string;
   relationships?: ExtractedRelationship[];
   extractionFailure?: string;
+  /** Coarse class used by the retry/backoff + circuit-breaker layer (extraction hot loop). */
+  extractionFailureClass?: ExtractionFailureClass;
 }
 
 export interface EntityMention {
@@ -3321,6 +3349,18 @@ export interface MetaState {
   processedExtractionFingerprints?: Array<{
     fingerprint: string;
     observedAt: string;
+  }>;
+  /**
+   * Per-fingerprint extraction retry/backoff state (extraction hot-loop
+   * hardening). Optional and default-safe: older meta files without it load
+   * unchanged. Bounded to the newest entries at write time.
+   */
+  extractionRetryState?: Array<{
+    fingerprint: string;
+    attempts: number;
+    nextEligibleAt: string; // ISO
+    firstFailedAt: string; // ISO
+    lastFailureClass: ExtractionFailureClass;
   }>;
 }
 

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1489,6 +1489,16 @@
         "default": true,
         "description": "Master gate for the Correction Contract (#1580) — the unified plan/apply pipeline for memory corrections (supersede/edit/retract/rescope/never-store). When false, the correction surfaces (CLI/HTTP/MCP) are disabled."
       },
+      "correctionIntentBaseUrl": {
+        "type": "string",
+        "default": "",
+        "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned correction-intent classifier (model-lab, issue #1585). Empty = rule-based detector only."
+      },
+      "correctionIntentModel": {
+        "type": "string",
+        "default": "",
+        "description": "Model name of a local fine-tuned correction-intent classifier (model-lab, issue #1581 / #1585). When set AND correctionIntentBaseUrl is set, passive-correction detection can route to it. Empty = rule-based detectPassiveCorrections is the sole detector."
+      },
       "correctionMaxAffected": {
         "type": "integer",
         "minimum": 1,
@@ -2017,6 +2027,21 @@
         "minimum": 0,
         "description": "Maximum query-visible cues expanded by explicit cue recall."
       },
+      "extractionBreakerAuthCooldownMs": {
+        "type": "number",
+        "default": 1800000,
+        "description": "Extraction circuit-breaker open cooldown (ms) for auth/config failures (401/403 or no models configured)."
+      },
+      "extractionBreakerCooldownMs": {
+        "type": "number",
+        "default": 300000,
+        "description": "Extraction circuit-breaker open cooldown (ms) for transient provider failures (429/5xx/network)."
+      },
+      "extractionBreakerFailureThreshold": {
+        "type": "number",
+        "default": 5,
+        "description": "Consecutive provider failures before the extraction circuit breaker opens and short-circuits extraction."
+      },
       "extractionDedupeEnabled": {
         "type": "boolean",
         "default": true,
@@ -2026,6 +2051,11 @@
         "type": "number",
         "default": 300000,
         "description": "Window for extraction dedupe fingerprints (ms)."
+      },
+      "extractionFaithfulnessBaseUrl": {
+        "type": "string",
+        "default": "",
+        "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned faithfulness gate (model-lab, issue #1585). When set AND extractionFaithfulnessModel is set, the gate routes there first and falls back to the configured chain on any failure. Empty = existing routing (byte-identical pre-feature path)."
       },
       "extractionFaithfulnessContextChars": {
         "type": "number",
@@ -2042,6 +2072,11 @@
         "default": "off",
         "description": "Extraction faithfulness gate (issue #1576). Entailment-verification of extracted facts against their verified source spans (#1575). 'off' (default) = byte-identical pre-feature pipeline; 'shadow' = record verdicts in frontmatter + telemetry only; 'enforce' = route unsupported/contradicted to pending_review."
       },
+      "extractionFaithfulnessLocalParseFallback": {
+        "type": "boolean",
+        "default": false,
+        "description": "Resilient-fallback toggle for the local model-lab faithfulness endpoint (issue #1700). Default false surfaces malformed_output when the local endpoint returns 200 with non-verdict JSON (alerts the operator to a misconfigured endpoint). Set true to instead fall back to the configured chain on local parse failure."
+      },
       "extractionFaithfulnessModel": {
         "type": "string",
         "default": "",
@@ -2051,26 +2086,6 @@
         "type": "number",
         "default": 8000,
         "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
-      },
-      "extractionFaithfulnessLocalParseFallback": {
-        "type": "boolean",
-        "default": false,
-        "description": "Resilient-fallback toggle for the local model-lab faithfulness endpoint (issue #1700). Default false surfaces malformed_output when the local endpoint returns 200 with non-verdict JSON (alerts the operator to a misconfigured endpoint). Set true to instead fall back to the configured chain on local parse failure."
-      },
-      "extractionFaithfulnessBaseUrl": {
-        "type": "string",
-        "default": "",
-        "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned faithfulness gate (model-lab, issue #1585). When set AND extractionFaithfulnessModel is set, the gate routes there first and falls back to the configured chain on any failure. Empty = existing routing (byte-identical pre-feature path)."
-      },
-      "correctionIntentModel": {
-        "type": "string",
-        "default": "",
-        "description": "Model name of a local fine-tuned correction-intent classifier (model-lab, issue #1581 / #1585). When set AND correctionIntentBaseUrl is set, passive-correction detection can route to it. Empty = rule-based detectPassiveCorrections is the sole detector."
-      },
-      "correctionIntentBaseUrl": {
-        "type": "string",
-        "default": "",
-        "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned correction-intent classifier (model-lab, issue #1585). Empty = rule-based detector only."
       },
       "extractionJudgeBatchSize": {
         "type": "number",
@@ -2155,6 +2170,39 @@
         "type": "number",
         "default": 1,
         "description": "Minimum number of user turns required before extraction runs."
+      },
+      "extractionParseEmptyMaxAttempts": {
+        "type": "number",
+        "default": 3,
+        "description": "Attempts for a parse_empty extraction fingerprint before it is long-parked (still never marked processed)."
+      },
+      "extractionRetryEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Master gate for extraction retry backoff + circuit breaker. When false, restores pre-change behavior (extractor called on every triggered observe, no gate)."
+      },
+      "extractionRetryJitterRatio": {
+        "type": "number",
+        "default": 0.2,
+        "description": "Multiplicative jitter ratio (+/-) applied to each extraction backoff interval."
+      },
+      "extractionRetryMaxBackoffMs": {
+        "type": "number",
+        "default": 21600000,
+        "description": "Upper bound (ms) on any single extraction backoff interval and the long-park interval for exhausted parse_empty fingerprints."
+      },
+      "extractionRetryScheduleMs": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "default": [
+          60000,
+          300000,
+          1800000,
+          7200000
+        ],
+        "description": "Per-fingerprint exponential extraction backoff schedule (ms), indexed by attempt."
       },
       "extractionScopeClassificationEnabled": {
         "type": "boolean",
@@ -3138,15 +3186,6 @@
         "default": false,
         "description": "Enable automatic memory linking to build knowledge graph"
       },
-      "offlineSyncExcludes": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "minLength": 1
-        },
-        "default": [],
-        "description": "Extra offline-sync push-side exclude globs (relative to memoryDir; * within a segment, leading **/ across segments). Additive to the built-in node-local state excludes (state/*.sqlite, state/*.sqlite-*, state/index_tags.json, state/entity-mention-index.json, state/memory-governance/runs/**). Issue #1786."
-      },
       "memoryOsPreset": {
         "type": "string",
         "enum": [
@@ -3517,6 +3556,15 @@
       "objectiveStateStoreDir": {
         "type": "string",
         "description": "Override the objective-state memory directory (defaults to {memoryDir}/state/objective-state)."
+      },
+      "offlineSyncExcludes": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "default": [],
+        "description": "Extra offline-sync push-side exclude globs (relative to memoryDir; * within a segment, leading **/ across segments). Additive to the built-in node-local state excludes (state/*.sqlite, state/*.sqlite-*, state/index_tags.json, state/entity-mention-index.json, state/memory-governance/runs/**). Issue #1786."
       },
       "openaiApiKey": {
         "anyOf": [

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 3930,
+      "packages/remnic-core/src/orchestrator.ts": 3941,
       "packages/remnic-core/src/cli.ts": 9476,
       "packages/remnic-core/src/access-service.ts": 5910,
       "packages/remnic-core/src/storage.ts": 6455,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -7,8 +7,8 @@
       "packages/remnic-core/src/orchestrator.ts": 3930,
       "packages/remnic-core/src/cli.ts": 9476,
       "packages/remnic-core/src/access-service.ts": 5910,
-      "packages/remnic-core/src/storage.ts": 6421,
-      "packages/remnic-core/src/config.ts": 4438
+      "packages/remnic-core/src/storage.ts": 6455,
+      "packages/remnic-core/src/config.ts": 4458
     },
     "oversizedFileCount": 11,
     "scatteredConfigFlagReads": 0,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -8,7 +8,7 @@
       "packages/remnic-core/src/cli.ts": 9476,
       "packages/remnic-core/src/access-service.ts": 5910,
       "packages/remnic-core/src/storage.ts": 6455,
-      "packages/remnic-core/src/config.ts": 4458
+      "packages/remnic-core/src/config.ts": 4467
     },
     "oversizedFileCount": 11,
     "scatteredConfigFlagReads": 0,

--- a/tests/orchestrator-replay-ingestion.test.ts
+++ b/tests/orchestrator-replay-ingestion.test.ts
@@ -19,7 +19,7 @@ test("ingestReplayBatch enqueues replay slices without clearing shared buffer", 
   );
   assert.match(
     source,
-    /skipDedupeCheck:\s*true,\s*clearBufferAfterExtraction:\s*false,\s*skipCharThreshold:\s*true,/m,
+    /skipDedupeCheck:\s*true,\s*forceExtractionAttempt:\s*true,\s*clearBufferAfterExtraction:\s*false,\s*skipCharThreshold:\s*true,/m,
     "replay ingestion should bypass dedupe/minimum thresholds and preserve the live smart buffer",
   );
   assert.match(


### PR DESCRIPTION
Implements #1908. Full design, guardrails, and acceptance criteria in the issue.

## What
When the extraction LLM endpoint is failing (rate-limited, down, or misconfigured), `runExtraction` re-attempted the same buffered turns on every `observe` with no backoff, breaker, or retry cap — in production this produced ~20 failed LLM round-trips/min, pinning the daemon's single event loop and starving concurrent recalls. This adds three independent, config-gated mechanisms, all fail-open and behavior-preserving:

1. **Failure classification** — `ExtractionResult.extractionFailureClass` (`provider_retryable` | `parse_empty` | `auth_config`), populated at every failure return; reuses the shared `isTransientHttpError` (no fourth copy, per AGENTS.md rule 8).
2. **Per-fingerprint exponential backoff with jitter** — persisted in namespace-scoped `meta.json` (restart-safe), hydrated lazily into an in-memory mirror; bounded to the 500 newest entries with a `maxEntries<=0` guard (rule 17).
3. **Provider circuit breaker** — closed/open/half_open with once-per-transition logging; opens immediately on `auth_config` (e.g. "no models configured"), after `extractionBreakerFailureThreshold` consecutive failures otherwise; half-open probe on cooldown expiry.

## Guardrails (what does NOT change)
- A fingerprint is **never** marked processed without durable outputs (the invariant at extraction-run.ts is preserved verbatim).
- Suppressed attempts (`provider_circuit_open` / `extraction_backoff`) **retain the buffer** — no silent turn loss; overflow is bounded by `MAX_BUFFER_ENTRY_COUNT` and now logged loudly.
- Explicit flushes (`before_reset` / session flush / `failOnExtractionFailure`) bypass the gate via `forceExtractionAttempt` but still record failures (rule 18).
- `extractionRetryEnabled=false` restores today's behavior exactly (rule 16).
- All new code is fail-open; classification, meta persistence, and hydration catch and default.

## Acceptance criteria → evidence
- [x] 20 new tests (`extraction.test.ts` 4 + `extraction-run.test.ts` 16): classification mapping, backoff eligibility, breaker open/half-open/closed, recovery clearing retry state, `parse_empty` cap, `auth_config` immediate-open, NEVER-mark-processed invariant regression, force-flush bypass, `extractionRetryEnabled=false` parity, backoff-math (jitter bounds + cap), `maxEntries<=0` guard, cross-coordinator meta coherence.
- [x] `npm run preflight:quick` — green (config-contract, review-pattern, ratchet; storage.ts/config.ts baseline bumped to reflect legitimate feature growth).
- [x] `npm run test:entity-hardening` — 246/246 pass.

Closes #1908

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This diff only updates documentation and plugin JSON schema; it does not change runtime extraction logic. Wrong operator tuning of the new keys could still affect extraction retry behavior wherever the feature is implemented.
> 
> **Overview**
> Documents and schema-validates the **extraction failure damping** controls added for #1908: per-fingerprint retry backoff, a process-level circuit breaker, and related tuning knobs.
> 
> **Config reference** (`docs/config-reference.md`) adds eight settings under Local LLM (`extractionRetryEnabled`, schedule/max backoff/jitter, `extractionParseEmptyMaxAttempts`, breaker threshold and cooldowns), duplicates them in the schema appendix, and adds a **Buffer & Triggers** note that buffered turns are retained (not dropped) while the breaker is open, with session-buffer pruning at `MAX_BUFFER_ENTRY_COUNT` (200) logged as a warning.
> 
> **Operator tuning** (`docs/setup-config-tuning.md`) mirrors the local-LLM damping checklist with recommended values, rollback via `extractionRetryEnabled: false`, and points operators at `extraction-resilience` in doctor.
> 
> **Plugin schema** (`openclaw.plugin.json`) registers the same keys with defaults (e.g. backoff schedule `[60s, 5m, 30m, 2h]`, 5m transient / 30m auth breaker cooldowns).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a29f49065b0903d66443980821dca5c75e89e05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->