### PR TITLE
feat(core): wire LSP resolution into the reindex pipeline (#1917)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -947,6 +947,52 @@
             "type": "string",
             "default": "",
             "description": "Root directory for per-project graph SQLite DBs. Empty string = derive from memoryDir (<memoryDir>/codegraph/<principal>/<projectId>.sqlite). Absolute path required when set explicitly (rule 11)."
+          },
+          "lsp": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Phase B type resolution via LSP (issue #1917). When enabled, codegraph_index invokes the LSP resolution pass after the heuristic reindex to upgrade unresolved call-site edges with real language-server definitions. Requires installed language servers on the host. Off by default (rule 48 - explicit opt-in for subprocess spawning).",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate for LSP resolution. Off = heuristic edges only."
+              },
+              "servers": {
+                "type": "object",
+                "description": "Per-language server launch-spec overrides. Keys are language ids (typescript, python, go, rust, ...); values replace the built-in default command for that language.",
+                "additionalProperties": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "command"
+                  ],
+                  "properties": {
+                    "command": {
+                      "type": "string",
+                      "description": "Server executable (resolved on PATH or absolute)."
+                    },
+                    "args": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Arguments (e.g. --stdio)."
+                    }
+                  }
+                }
+              },
+              "timeoutMs": {
+                "type": "number",
+                "default": 3000,
+                "description": "Handshake + per-request timeout in ms."
+              },
+              "maxRequestsPerRun": {
+                "type": "number",
+                "default": 500,
+                "description": "Max LSP definition requests per index run."
+              }
+            }
           }
         }
       },

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -2910,6 +2910,33 @@ export class GraphStore {
   }
 
   /**
+   * Find the innermost node whose span contains a byte offset in a file
+   * (issue #1917). Used by the LSP resolution pass's NodeLocator to map
+   * definition locations back to indexed nodes. Returns the node's
+   * qualified name, or null when no node contains the offset.
+   */
+  findNodeBySpan(filePath: string, byteOffset: number): string | null {
+    if (this.closed) return null;
+    try {
+      const row = expectRow<{ qualified_name: string }>(
+        this.db
+          .prepare(
+            `SELECT n.qualified_name FROM nodes n
+              JOIN files f ON n.file_id = f.id
+              WHERE f.path = ? AND n.span_start <= ? AND n.span_end > ?
+              ORDER BY (n.span_end - n.span_start) ASC
+              LIMIT 1`,
+          )
+          .get(filePath, byteOffset, byteOffset),
+        ["qualified_name"],
+      );
+      return row ? row.qualified_name : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Read a symbol's source span from disk. The store NEVER persists
    * file contents (privacy + DB size — issue #1552 design); this
    * method resolves `files.path` against {@link GraphStoreOptions.repoRoot}

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -2966,21 +2966,58 @@ export class GraphStore {
    * also skipping sites whose only edge is a prior "lsp" edge — those must
    * be re-asserted each run or reconciliation would retire them.
    */
-  resolvedCalleeNames(srcQualifiedName: string, provenance: string): string[] {
+  resolvedCalleeNames(srcQualifiedName: string, provenance: string, filePath?: string): string[] {
     if (this.closed) return [];
     try {
+      // Scoped to the caller FILE when provided: two files defining the
+      // same top-level qualified name (main/handler/init) must not leak
+      // each other's resolutions (#1923 review thread).
+      const fileClause = filePath !== undefined ? " AND f.path = ?" : "";
+      const bind = filePath !== undefined ? [srcQualifiedName, provenance, filePath] : [srcQualifiedName, provenance];
       const rows = expectRows<{ name: string }>(
         this.db
           .prepare(
             `SELECT DISTINCT dn.name AS name FROM edges e
               JOIN nodes sn ON e.src = sn.id
+              JOIN files f ON sn.file_id = f.id
               JOIN nodes dn ON e.dst = dn.id
-              WHERE sn.qualified_name = ? AND e.type = 'CALLS' AND e.provenance = ?`,
+              WHERE sn.qualified_name = ? AND e.type = 'CALLS' AND e.provenance = ?${fileClause}`,
           )
-          .all(srcQualifiedName, provenance),
+          .all(...bind),
         ["name"],
       );
       return rows.map((r) => r.name);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Current lsp-provenance CALLS edges owned by a caller symbol in a file
+   * (#1923 review thread). The LSP pass appends these to the asserted set
+   * for call sites it deliberately did NOT re-query (Phase-A-resolved
+   * sites), so reconciliation can retire genuinely stale edges in the
+   * same file without dropping the preserved ones.
+   */
+  lspCallEdgesForCaller(
+    srcQualifiedName: string,
+    filePath: string,
+  ): Array<{ srcQualifiedName: string; dstQualifiedName: string; type: string }> {
+    if (this.closed) return [];
+    try {
+      const rows = expectRows<{ src_q: string; dst_q: string; type: string }>(
+        this.db
+          .prepare(
+            `SELECT sn.qualified_name AS src_q, dn.qualified_name AS dst_q, e.type AS type FROM edges e
+              JOIN nodes sn ON e.src = sn.id
+              JOIN files f ON sn.file_id = f.id
+              JOIN nodes dn ON e.dst = dn.id
+              WHERE sn.qualified_name = ? AND f.path = ? AND e.provenance = 'lsp' AND e.type = 'CALLS'`,
+          )
+          .all(srcQualifiedName, filePath),
+        ["src_q", "dst_q", "type"],
+      );
+      return rows.map((r) => ({ srcQualifiedName: r.src_q, dstQualifiedName: r.dst_q, type: r.type }));
     } catch {
       return [];
     }

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -2993,15 +2993,18 @@ export class GraphStore {
   }
 
   /**
-   * Current lsp-provenance CALLS edges owned by a caller symbol in a file
-   * (#1923 review thread). The LSP pass appends these to the asserted set
-   * for call sites it deliberately did NOT re-query (Phase-A-resolved
-   * sites), so reconciliation can retire genuinely stale edges in the
-   * same file without dropping the preserved ones.
+   * Current CALLS edges of a given provenance owned by a caller symbol in
+   * a file (#1923 review threads). The LSP pass uses this two ways:
+   * provenance "lsp" lists a filtered caller's existing lsp edges, and
+   * provenance "heuristic" lists its current Phase-A resolutions — an lsp
+   * edge is preserved at reconcile time only when it duplicates a current
+   * heuristic resolution (same dst), so removed member calls' edges retire
+   * while a filtered bare call's covering edge survives.
    */
-  lspCallEdgesForCaller(
+  callEdgesForCaller(
     srcQualifiedName: string,
     filePath: string,
+    provenance: string,
   ): Array<{ srcQualifiedName: string; dstQualifiedName: string; dstName: string; type: string }> {
     if (this.closed) return [];
     try {
@@ -3012,9 +3015,9 @@ export class GraphStore {
               JOIN nodes sn ON e.src = sn.id
               JOIN files f ON sn.file_id = f.id
               JOIN nodes dn ON e.dst = dn.id
-              WHERE sn.qualified_name = ? AND f.path = ? AND e.provenance = 'lsp' AND e.type = 'CALLS'`,
+              WHERE sn.qualified_name = ? AND f.path = ? AND e.provenance = ? AND e.type = 'CALLS'`,
           )
-          .all(srcQualifiedName, filePath),
+          .all(srcQualifiedName, filePath, provenance),
         ["src_q", "dst_q", "dst_n", "type"],
       );
       return rows.map((r) => ({

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -2938,7 +2938,22 @@ export class GraphStore {
       );
       if (rows.length === 0) return null;
       if (rows.length > 1 && rows[1] !== undefined && rows[0]!.size === rows[1].size) return null;
-      return rows[0]!.qualified_name;
+      const qualifiedName = rows[0]!.qualified_name;
+      // The span lookup disambiguated by file, but the returned QUALIFIED
+      // NAME is the edge key downstream (upsertEdges resolves names, not
+      // ids). If another file defines the same qualified name (common for
+      // top-level `main`/`handler`/`init`), an edge written against the
+      // name could bind to the wrong node — return null and skip the
+      // upgrade instead (conservative; id-carrying upgrades are the
+      // follow-up, review thread on #1923).
+      const dupRow = expectRow<{ n: number }>(
+        this.db
+          .prepare(`SELECT COUNT(*) AS n FROM nodes WHERE qualified_name = ?`)
+          .get(qualifiedName),
+        ["n"],
+      );
+      if (dupRow && dupRow.n > 1) return null;
+      return qualifiedName;
     } catch {
       return null;
     }

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -2960,6 +2960,33 @@ export class GraphStore {
   }
 
   /**
+   * Callee NAMES already linked from a caller symbol via CALLS edges of a
+   * given provenance (issue #1917 wiring). The LSP pass uses this to skip
+   * call sites Phase A (provenance "heuristic") already resolved WITHOUT
+   * also skipping sites whose only edge is a prior "lsp" edge — those must
+   * be re-asserted each run or reconciliation would retire them.
+   */
+  resolvedCalleeNames(srcQualifiedName: string, provenance: string): string[] {
+    if (this.closed) return [];
+    try {
+      const rows = expectRows<{ name: string }>(
+        this.db
+          .prepare(
+            `SELECT DISTINCT dn.name AS name FROM edges e
+              JOIN nodes sn ON e.src = sn.id
+              JOIN nodes dn ON e.dst = dn.id
+              WHERE sn.qualified_name = ? AND e.type = 'CALLS' AND e.provenance = ?`,
+          )
+          .all(srcQualifiedName, provenance),
+        ["name"],
+      );
+      return rows.map((r) => r.name);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
    * Read a symbol's source span from disk. The store NEVER persists
    * file contents (privacy + DB size — issue #1552 design); this
    * method resolves `files.path` against {@link GraphStoreOptions.repoRoot}

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -2918,19 +2918,27 @@ export class GraphStore {
   findNodeBySpan(filePath: string, byteOffset: number): string | null {
     if (this.closed) return null;
     try {
-      const row = expectRow<{ qualified_name: string }>(
+      // Fetch the two smallest containing spans: nested containment is
+      // normal (a method inside a class both contain the offset) and the
+      // INNERMOST (smallest) wins — but a TIE at the smallest size means
+      // the offset cannot be attributed to exactly one node, and the
+      // NodeLocator contract requires null over an arbitrary pick
+      // (review thread: a wrong winner persists incorrect CALLS edges).
+      const rows = expectRows<{ qualified_name: string; size: number }>(
         this.db
           .prepare(
-            `SELECT n.qualified_name FROM nodes n
+            `SELECT n.qualified_name, (n.span_end - n.span_start) AS size FROM nodes n
               JOIN files f ON n.file_id = f.id
               WHERE f.path = ? AND n.span_start <= ? AND n.span_end > ?
-              ORDER BY (n.span_end - n.span_start) ASC
-              LIMIT 1`,
+              ORDER BY size ASC
+              LIMIT 2`,
           )
-          .get(filePath, byteOffset, byteOffset),
-        ["qualified_name"],
+          .all(filePath, byteOffset, byteOffset),
+        ["qualified_name", "size"],
       );
-      return row ? row.qualified_name : null;
+      if (rows.length === 0) return null;
+      if (rows.length > 1 && rows[1] !== undefined && rows[0]!.size === rows[1].size) return null;
+      return rows[0]!.qualified_name;
     } catch {
       return null;
     }

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -3002,22 +3002,27 @@ export class GraphStore {
   lspCallEdgesForCaller(
     srcQualifiedName: string,
     filePath: string,
-  ): Array<{ srcQualifiedName: string; dstQualifiedName: string; type: string }> {
+  ): Array<{ srcQualifiedName: string; dstQualifiedName: string; dstName: string; type: string }> {
     if (this.closed) return [];
     try {
-      const rows = expectRows<{ src_q: string; dst_q: string; type: string }>(
+      const rows = expectRows<{ src_q: string; dst_q: string; dst_n: string; type: string }>(
         this.db
           .prepare(
-            `SELECT sn.qualified_name AS src_q, dn.qualified_name AS dst_q, e.type AS type FROM edges e
+            `SELECT sn.qualified_name AS src_q, dn.qualified_name AS dst_q, dn.name AS dst_n, e.type AS type FROM edges e
               JOIN nodes sn ON e.src = sn.id
               JOIN files f ON sn.file_id = f.id
               JOIN nodes dn ON e.dst = dn.id
               WHERE sn.qualified_name = ? AND f.path = ? AND e.provenance = 'lsp' AND e.type = 'CALLS'`,
           )
           .all(srcQualifiedName, filePath),
-        ["src_q", "dst_q", "type"],
+        ["src_q", "dst_q", "dst_n", "type"],
       );
-      return rows.map((r) => ({ srcQualifiedName: r.src_q, dstQualifiedName: r.dst_q, type: r.type }));
+      return rows.map((r) => ({
+        srcQualifiedName: r.src_q,
+        dstQualifiedName: r.dst_q,
+        dstName: r.dst_n,
+        type: r.type,
+      }));
     } catch {
       return [];
     }

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -947,6 +947,52 @@
             "type": "string",
             "default": "",
             "description": "Root directory for per-project graph SQLite DBs. Empty string = derive from memoryDir (<memoryDir>/codegraph/<principal>/<projectId>.sqlite). Absolute path required when set explicitly (rule 11)."
+          },
+          "lsp": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Phase B type resolution via LSP (issue #1917). When enabled, codegraph_index invokes the LSP resolution pass after the heuristic reindex to upgrade unresolved call-site edges with real language-server definitions. Requires installed language servers on the host. Off by default (rule 48 - explicit opt-in for subprocess spawning).",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate for LSP resolution. Off = heuristic edges only."
+              },
+              "servers": {
+                "type": "object",
+                "description": "Per-language server launch-spec overrides. Keys are language ids (typescript, python, go, rust, ...); values replace the built-in default command for that language.",
+                "additionalProperties": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "command"
+                  ],
+                  "properties": {
+                    "command": {
+                      "type": "string",
+                      "description": "Server executable (resolved on PATH or absolute)."
+                    },
+                    "args": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Arguments (e.g. --stdio)."
+                    }
+                  }
+                }
+              },
+              "timeoutMs": {
+                "type": "number",
+                "default": 3000,
+                "description": "Handshake + per-request timeout in ms."
+              },
+              "maxRequestsPerRun": {
+                "type": "number",
+                "default": 500,
+                "description": "Max LSP definition requests per index run."
+              }
+            }
           }
         }
       },

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -23,6 +23,7 @@
  * by the surface handler via a context seam.
  */
 import path from "node:path";
+import { readFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { expandTildePath } from "../utils/path.js";
 
@@ -68,6 +69,10 @@ interface CodegraphModule {
   ): unknown;
   defaultCodingGitInvoker?: unknown;
   createCodingGraphEngine?(options?: unknown): { parseFile(input: unknown): Promise<unknown> };
+  // LSP resolution (issue #1917): present when @remnic/coding-graph ships
+  executeLspResolution?(requests: readonly unknown[], options: unknown): Promise<unknown>;
+  planLspUpgrades?(sites: readonly unknown[], budget: { maxRequests: number }): { requests: readonly unknown[]; budgetExhausted: number };
+  createLspClient?(options: unknown): unknown;
 }
 
 /**
@@ -95,6 +100,13 @@ export interface CodegraphStore {
   upsertEdges?(
     edges: readonly CodegraphEdgeInput[],
   ): Promise<{ ok: true; persisted: number; skipped: number } | { ok: false; code: string }>;
+  /** Find the node whose span contains the byte offset (issue #1917). */
+  findNodeBySpan?(filePath: string, byteOffset: number): string | null;
+  /** Retire stale lsp-provenance edges for a file (issue #1895). */
+  reconcileLspEdges?(
+    filePath: string,
+    assertedEdges: ReadonlyArray<{ srcQualifiedName: string; dstQualifiedName: string; type: string }>,
+  ): number;
 }
 
 /**
@@ -470,13 +482,14 @@ export async function closeAllCodegraphStores(): Promise<void> {
 
 export function makeCodegraphRuntimeDelegates(): Pick<
   CodegraphSurfaceContext,
-  "runReindex" | "reportIndexStatus" | "detectChanges" | "ingestTraces"
+  "runReindex" | "runLspResolution" | "reportIndexStatus" | "detectChanges" | "ingestTraces"
 > {
   return {
     runReindex: (store, repoRoot, mode) => runCodegraphReindex({ store, repoRoot, mode }),
     reportIndexStatus: (store, repoRoot) => reportCodegraphIndexStatus({ store, repoRoot }),
     detectChanges: (store, repoRoot, head) => detectCodegraphChanges({ store, repoRoot, head }),
     ingestTraces: (store, traces) => ingestCodegraphTraces({ store, traces }),
+    runLspResolution: (store, repoRoot, lspConfig) => runCodegraphLspResolution({ store, repoRoot, lspConfig }),
   };
 }
 
@@ -566,6 +579,93 @@ export async function runCodegraphReindex(params: {
   }
 }
 
+
+/**
+ * Run LSP type resolution after a heuristic reindex (issue #1917).
+ * Degrades cleanly when LSP functions are missing or the pass fails;
+ * heuristic edges from the prior reindex survive.
+ */
+export async function runCodegraphLspResolution(params: {
+  readonly store: CodegraphStore;
+  readonly repoRoot: string;
+  readonly lspConfig: NonNullable<CodingKnowledgeConfig["lsp"]>;
+}): Promise<CodegraphDelegateOutcome<{ upgraded: number; unresolved: number; budgetExhausted: number }>> {
+  const mod = await loadCodegraphModule();
+  if (mod === null) return { ok: false, code: "package_missing", message: "@remnic/coding-graph not installed." };
+  if (typeof mod.executeLspResolution !== "function" || typeof mod.planLspUpgrades !== "function") {
+    return { ok: false, code: "runtime_unavailable", message: "LSP resolution not available." };
+  }
+  const engine = mod.createCodingGraphEngine?.() ?? null;
+  if (!engine) return { ok: false, code: "engine_unavailable", message: "Engine unavailable." };
+  // Gather tracked files and collect unresolved call sites.
+  const gitFactory = mod.defaultCodingGitInvoker as (() => { listTrackedFiles(cwd: string): { ok: true; paths: readonly string[] } | { ok: false; code: string } }) | undefined;
+  if (!gitFactory) return { ok: true, upgraded: 0, unresolved: 0, budgetExhausted: 0 };
+  const tracked = gitFactory().listTrackedFiles(params.repoRoot);
+  if (!("paths" in tracked)) return { ok: true, upgraded: 0, unresolved: 0, budgetExhausted: 0 };
+  const sites: unknown[] = [];
+  for (const rel of tracked.paths) {
+    try {
+      const content = await readFile(path.join(params.repoRoot, rel), "utf-8");
+      const parsed = await engine.parseFile({ path: rel, content });
+      if (parsed && typeof parsed === "object" && "ok" in parsed && parsed.ok === true && "ir" in parsed) {
+        const ir = parsed.ir;
+        if (ir && typeof ir === "object" && "callSites" in ir) {
+          const cs = ir.callSites;
+          if (Array.isArray(cs)) {
+            for (const s of cs) {
+              if (s && typeof s === "object" && "span" in s) {
+                const sp = s.span;
+                if (sp && typeof sp === "object" && "startByte" in sp && typeof sp.startByte === "number") {
+                  // Find enclosing symbol for srcQualifiedName.
+                  let srcQName = "";
+                  if ("symbols" in ir && Array.isArray(ir.symbols)) {
+                    for (const sym of ir.symbols) {
+                      if (sym && typeof sym === "object" && "span" in sym && "qualifiedName" in sym) {
+                        const ss = sym.span;
+                        if (ss && typeof ss === "object" && "startByte" in ss && "endByte" in ss && typeof ss.startByte === "number" && typeof ss.endByte === "number") {
+                          if (ss.startByte <= sp.startByte && sp.startByte < ss.endByte) {
+                            srcQName = typeof sym.qualifiedName === "string" ? sym.qualifiedName : "";
+                            break;
+                          }
+                        }
+                      }
+                    }
+                  }
+                  const lang = "language" in ir && typeof ir.language === "string" ? ir.language : "";
+                  const callee = "calleeNameCandidates" in s && Array.isArray(s.calleeNameCandidates) && typeof s.calleeNameCandidates[0] === "string" ? s.calleeNameCandidates[0] : "";
+                  sites.push({ filePath: rel, language: lang, content, calleeByteOffset: sp.startByte, calleeName: callee, srcQualifiedName: srcQName });
+                }
+              }
+            }
+          }
+        }
+      }
+    } catch { /* skip unparseable */ }
+  }
+  if (sites.length === 0) return { ok: true, upgraded: 0, unresolved: 0, budgetExhausted: 0 };
+  // Plan + execute LSP resolution.
+  const plan = mod.planLspUpgrades(sites, { maxRequests: params.lspConfig.maxRequestsPerRun ?? 500 });
+  if (!plan.requests.length) return { ok: true, upgraded: 0, unresolved: sites.length, budgetExhausted: plan.budgetExhausted };
+  const client = typeof mod.createLspClient === "function"
+    ? mod.createLspClient({ workspaceRoot: params.repoRoot, timeoutMs: params.lspConfig.timeoutMs ?? 3000, servers: params.lspConfig.servers ?? {} })
+    : null;
+  if (!client) return { ok: false, code: "lsp_client_error", message: "Could not create LSP client." };
+  try {
+    const r = await mod.executeLspResolution(plan.requests, {
+      client,
+      nodeLocator: (fp: string, off: number) => params.store.findNodeBySpan?.(fp, off) ?? null,
+      applyUpgrades: async (ups: readonly unknown[]) => { if (params.store.upsertEdges) await params.store.upsertEdges(ups as Parameters<typeof params.store.upsertEdges>[0]); },
+      reconcileLspEdges: (fp: string, edges: ReadonlyArray<{ srcQualifiedName: string; dstQualifiedName: string; type: string }>) => { params.store.reconcileLspEdges?.(fp, edges); },
+    });
+    if (r && typeof r === "object" && "upgraded" in r) {
+      const rr = r as { upgraded: number; unresolved: number };
+      return { ok: true, upgraded: rr.upgraded ?? 0, unresolved: rr.unresolved ?? 0, budgetExhausted: plan.budgetExhausted };
+    }
+    return { ok: true, upgraded: 0, unresolved: sites.length, budgetExhausted: plan.budgetExhausted };
+  } catch (err) {
+    return { ok: false, code: "lsp_resolution_error", message: err instanceof Error ? err.message : String(err) };
+  }
+}
 /**
  * Report index status via @remnic/coding-graph's getIndexStatus. Never throws
  * — a git failure degrades to `mode: "git_unavailable"` in the status body.

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -121,7 +121,7 @@ export interface CodegraphStore {
   lspCallEdgesForCaller?(
     srcQualifiedName: string,
     filePath: string,
-  ): Array<{ srcQualifiedName: string; dstQualifiedName: string; type: string }>;
+  ): Array<{ srcQualifiedName: string; dstQualifiedName: string; dstName: string; type: string }>;
 }
 
 /**
@@ -740,7 +740,7 @@ export async function runCodegraphLspResolution(params: {
   // Caller symbols of filtered sites per file — their CURRENT lsp edges
   // are appended to the asserted set at reconcile time so stale cleanup
   // still runs for the rest of the file without dropping them.
-  const filteredSrcByFile = new Map<string, Set<string>>();
+  const filteredSrcByFile = new Map<string, Map<string, Set<string>>>();
   // Files that parsed cleanly this run — the safe candidates for the
   // empty-set reconcile below.
   const parsedFiles = new Set<string>();
@@ -799,9 +799,14 @@ export async function runCodegraphLspResolution(params: {
       const memberAccess = "memberAccess" in site && site.memberAccess === true;
       if (!memberAccess && alreadyResolved(rel, srcQualifiedName, calleeName)) {
         filteredCountByFile.set(rel, (filteredCountByFile.get(rel) ?? 0) + 1);
-        const srcs = filteredSrcByFile.get(rel);
-        if (srcs === undefined) filteredSrcByFile.set(rel, new Set([srcQualifiedName]));
-        else srcs.add(srcQualifiedName);
+        let srcs = filteredSrcByFile.get(rel);
+        if (srcs === undefined) {
+          srcs = new Map<string, Set<string>>();
+          filteredSrcByFile.set(rel, srcs);
+        }
+        const callees = srcs.get(srcQualifiedName);
+        if (callees === undefined) srcs.set(srcQualifiedName, new Set([calleeName]));
+        else callees.add(calleeName);
         continue;
       }
       // Position the definition query on the callee NAME, not the call
@@ -836,8 +841,20 @@ export async function runCodegraphLspResolution(params: {
     const srcs = filteredSrcByFile.get(rel);
     if (srcs === undefined || !canPreserve) return [];
     const preserved: Array<{ srcQualifiedName: string; dstQualifiedName: string; type: string }> = [];
-    for (const src of srcs) {
-      preserved.push(...params.store.lspCallEdgesForCaller!(src, rel));
+    for (const [src, calleeNames] of srcs) {
+      for (const edge of params.store.lspCallEdgesForCaller!(src, rel)) {
+        // Preserve ONLY edges whose destination NAME matches a filtered
+        // site's callee — preserving every lsp edge of the caller would
+        // re-assert edges for calls that were REMOVED from the source
+        // (review thread: a deleted member call's edge would never
+        // retire while any bare call in the function stays filtered).
+        if (!calleeNames.has(edge.dstName)) continue;
+        preserved.push({
+          srcQualifiedName: edge.srcQualifiedName,
+          dstQualifiedName: edge.dstQualifiedName,
+          type: edge.type,
+        });
+      }
     }
     return preserved;
   };

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -116,7 +116,12 @@ export interface CodegraphStore {
     assertedEdges: ReadonlyArray<{ srcQualifiedName: string; dstQualifiedName: string; type: string }>,
   ): number;
   /** Callee names already CALLS-linked from a caller with a given provenance (issue #1917). */
-  resolvedCalleeNames?(srcQualifiedName: string, provenance: string): string[];
+  resolvedCalleeNames?(srcQualifiedName: string, provenance: string, filePath?: string): string[];
+  /** Current lsp CALLS edges owned by a caller symbol in a file (issue #1917). */
+  lspCallEdgesForCaller?(
+    srcQualifiedName: string,
+    filePath: string,
+  ): Array<{ srcQualifiedName: string; dstQualifiedName: string; type: string }>;
 }
 
 /**
@@ -706,17 +711,20 @@ export async function runCodegraphLspResolution(params: {
   // would retire that still-valid lsp edge (review thread). When the
   // installed store predates resolvedCalleeNames, nothing is treated as
   // resolved (conservative: spends budget, never mis-retires).
+  // Memo key includes the caller FILE: duplicate top-level qualified
+  // names across files must not leak each other's resolutions.
   const resolvedCalleesBySrc = new Map<string, Set<string>>();
-  const alreadyResolved = (srcQualifiedName: string, calleeName: string): boolean => {
-    let names = resolvedCalleesBySrc.get(srcQualifiedName);
+  const alreadyResolved = (filePath: string, srcQualifiedName: string, calleeName: string): boolean => {
+    const key = `${filePath}\u0000${srcQualifiedName}`;
+    let names = resolvedCalleesBySrc.get(key);
     if (names === undefined) {
       names = new Set<string>();
       if (typeof params.store.resolvedCalleeNames === "function") {
-        for (const name of params.store.resolvedCalleeNames(srcQualifiedName, "heuristic")) {
+        for (const name of params.store.resolvedCalleeNames(srcQualifiedName, "heuristic", filePath)) {
           names.add(name);
         }
       }
-      resolvedCalleesBySrc.set(srcQualifiedName, names);
+      resolvedCalleesBySrc.set(key, names);
     }
     return names.has(calleeName);
   };
@@ -729,6 +737,10 @@ export async function runCodegraphLspResolution(params: {
   // in the asserted set, so reconciliation would retire their prior lsp
   // edges even though the sites were never re-queried (review thread).
   const filteredCountByFile = new Map<string, number>();
+  // Caller symbols of filtered sites per file — their CURRENT lsp edges
+  // are appended to the asserted set at reconcile time so stale cleanup
+  // still runs for the rest of the file without dropping them.
+  const filteredSrcByFile = new Map<string, Set<string>>();
   // Files that parsed cleanly this run — the safe candidates for the
   // empty-set reconcile below.
   const parsedFiles = new Set<string>();
@@ -785,8 +797,11 @@ export async function runCodegraphLspResolution(params: {
       }
       if (srcQualifiedName.length === 0) continue;
       const memberAccess = "memberAccess" in site && site.memberAccess === true;
-      if (!memberAccess && alreadyResolved(srcQualifiedName, calleeName)) {
+      if (!memberAccess && alreadyResolved(rel, srcQualifiedName, calleeName)) {
         filteredCountByFile.set(rel, (filteredCountByFile.get(rel) ?? 0) + 1);
+        const srcs = filteredSrcByFile.get(rel);
+        if (srcs === undefined) filteredSrcByFile.set(rel, new Set([srcQualifiedName]));
+        else srcs.add(srcQualifiedName);
         continue;
       }
       // Position the definition query on the callee NAME, not the call
@@ -809,11 +824,29 @@ export async function runCodegraphLspResolution(params: {
   // so this pass is the only owner of that cleanup (review thread). Files
   // with filtered (heuristic-resolved) sites are left alone — their prior
   // lsp edges were not re-queried.
+  // Filtered (Phase-A-resolved) sites keep their CURRENT lsp edges by
+  // asserting them explicitly — reconciliation can then retire genuinely
+  // stale edges in the same file without dropping preserved ones. When
+  // the store predates lspCallEdgesForCaller, preservation is impossible,
+  // so callers below fall back to skipping reconcile for such files.
+  const canPreserve = typeof params.store.lspCallEdgesForCaller === "function";
+  const preservedEdgesForFile = (
+    rel: string,
+  ): Array<{ srcQualifiedName: string; dstQualifiedName: string; type: string }> => {
+    const srcs = filteredSrcByFile.get(rel);
+    if (srcs === undefined || !canPreserve) return [];
+    const preserved: Array<{ srcQualifiedName: string; dstQualifiedName: string; type: string }> = [];
+    for (const src of srcs) {
+      preserved.push(...params.store.lspCallEdgesForCaller!(src, rel));
+    }
+    return preserved;
+  };
   if (typeof params.store.reconcileLspEdges === "function") {
     for (const rel of parsedFiles) {
-      if ((gatheredCountByFile.get(rel) ?? 0) === 0 && (filteredCountByFile.get(rel) ?? 0) === 0) {
-        params.store.reconcileLspEdges(rel, []);
-      }
+      if ((gatheredCountByFile.get(rel) ?? 0) !== 0) continue;
+      const filteredCount = filteredCountByFile.get(rel) ?? 0;
+      if (filteredCount > 0 && !canPreserve) continue;
+      params.store.reconcileLspEdges(rel, preservedEdgesForFile(rel));
     }
   }
   if (sites.length === 0) {
@@ -969,15 +1002,16 @@ export async function runCodegraphLspResolution(params: {
           lastApplySkipped = false;
           if (typeof params.store.reconcileLspEdges !== "function") return;
           if (plannedCountByFile.get(filePath) !== gatheredCountByFile.get(filePath)) return;
-          // Any heuristic-filtered site in this file was NOT re-queried;
-          // its prior lsp edge is absent from the asserted set and must
-          // survive (review thread).
-          if ((filteredCountByFile.get(filePath) ?? 0) > 0) return;
           // This file batch had skipped writes — its asserted set is
           // incomplete, so reconciling would retire edges that were never
           // re-asserted (see skip tracking above).
           if (batchHadSkips) return;
-          params.store.reconcileLspEdges(filePath, assertedEdges);
+          // Heuristic-filtered sites were NOT re-queried: their current
+          // lsp edges are appended to the asserted set so they survive
+          // while stale edges for RE-QUERIED sites still get retired.
+          // Without the preservation seam, skip (conservative).
+          if ((filteredCountByFile.get(filePath) ?? 0) > 0 && !canPreserve) return;
+          params.store.reconcileLspEdges(filePath, [...assertedEdges, ...preservedEdgesForFile(filePath)]);
         },
       });
       if (result && typeof result === "object" && "upgraded" in result && typeof result.upgraded === "number") {

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -24,6 +24,8 @@
  */
 import path from "node:path";
 import { readFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 import { createHash } from "node:crypto";
 import { expandTildePath } from "../utils/path.js";
 
@@ -72,7 +74,13 @@ interface CodegraphModule {
   // LSP resolution (issue #1917): present when @remnic/coding-graph ships
   executeLspResolution?(requests: readonly unknown[], options: unknown): Promise<unknown>;
   planLspUpgrades?(sites: readonly unknown[], budget: { maxRequests: number }): { requests: readonly unknown[]; budgetExhausted: number };
-  createLspClient?(options: unknown): unknown;
+  LspClient?: {
+    connect(options: {
+      launchSpec: { command: string; args: readonly string[] };
+      rootUri: string | null;
+      timeoutMs: number;
+    }): Promise<{ ok: true; client: unknown } | { ok: false; degradation: unknown }>;
+  };
 }
 
 /**
@@ -581,91 +589,278 @@ export async function runCodegraphReindex(params: {
 
 
 /**
+ * Default LSP server launch specs per language. The config's
+ * `codingKnowledge.lsp.servers` overrides these; a language with neither
+ * an override nor a default is skipped (degradation, not an error).
+ */
+const DEFAULT_LSP_SERVERS: Record<string, { command: string; args: string[] }> = {
+  typescript: { command: "typescript-language-server", args: ["--stdio"] },
+  tsx: { command: "typescript-language-server", args: ["--stdio"] },
+  javascript: { command: "typescript-language-server", args: ["--stdio"] },
+  python: { command: "pyright-langserver", args: ["--stdio"] },
+  go: { command: "gopls", args: [] },
+  rust: { command: "rust-analyzer", args: [] },
+};
+
+/** One gathered candidate call site (pre-planner shape). */
+interface GatheredLspSite {
+  filePath: string;
+  language: string;
+  content: string;
+  calleeByteOffset: number;
+  calleeName: string;
+  srcQualifiedName: string;
+}
+
+/**
  * Run LSP type resolution after a heuristic reindex (issue #1917).
- * Degrades cleanly when LSP functions are missing or the pass fails;
- * heuristic edges from the prior reindex survive.
+ * Re-parses tracked files, gathers call sites Phase A left unresolved
+ * (member accesses plus bare calls with no existing CALLS edge), groups
+ * them by language, and per language connects a real language server via
+ * `LspClient.connect` and invokes `executeLspResolution`.
+ *
+ * Degrades cleanly at every seam: missing package/functions, no language
+ * server for a language, or a failed handshake all leave the heuristic
+ * edges standing (soft-fail, mirrors #1894's documented posture).
  */
 export async function runCodegraphLspResolution(params: {
   readonly store: CodegraphStore;
   readonly repoRoot: string;
   readonly lspConfig: NonNullable<CodingKnowledgeConfig["lsp"]>;
-}): Promise<CodegraphDelegateOutcome<{ upgraded: number; unresolved: number; budgetExhausted: number }>> {
+}): Promise<
+  | { ok: true; upgraded: number; unresolved: number; budgetExhausted: number }
+  | { ok: false; code: string; message: string }
+> {
   const mod = await loadCodegraphModule();
-  if (mod === null) return { ok: false, code: "package_missing", message: "@remnic/coding-graph not installed." };
-  if (typeof mod.executeLspResolution !== "function" || typeof mod.planLspUpgrades !== "function") {
-    return { ok: false, code: "runtime_unavailable", message: "LSP resolution not available." };
+  if (mod === null) {
+    return { ok: false, code: "package_missing", message: "@remnic/coding-graph is not installed." };
+  }
+  if (
+    typeof mod.executeLspResolution !== "function" ||
+    typeof mod.planLspUpgrades !== "function" ||
+    typeof mod.LspClient?.connect !== "function"
+  ) {
+    return { ok: false, code: "runtime_unavailable", message: "LSP resolution is not available in the installed @remnic/coding-graph." };
   }
   const engine = mod.createCodingGraphEngine?.() ?? null;
-  if (!engine) return { ok: false, code: "engine_unavailable", message: "Engine unavailable." };
-  // Gather tracked files and collect unresolved call sites.
-  const gitFactory = mod.defaultCodingGitInvoker as (() => { listTrackedFiles(cwd: string): { ok: true; paths: readonly string[] } | { ok: false; code: string } }) | undefined;
-  if (!gitFactory) return { ok: true, upgraded: 0, unresolved: 0, budgetExhausted: 0 };
+  if (engine === null) {
+    return { ok: false, code: "engine_unavailable", message: "createCodingGraphEngine is not available." };
+  }
+  const gitFactory = mod.defaultCodingGitInvoker as
+    | (() => { listTrackedFiles(cwd: string): { ok: true; paths: readonly string[] } | { ok: false; code: string } })
+    | undefined;
+  if (typeof gitFactory !== "function") {
+    return { ok: true, upgraded: 0, unresolved: 0, budgetExhausted: 0 };
+  }
   const tracked = gitFactory().listTrackedFiles(params.repoRoot);
-  if (!("paths" in tracked)) return { ok: true, upgraded: 0, unresolved: 0, budgetExhausted: 0 };
-  const sites: unknown[] = [];
-  for (const rel of tracked.paths) {
-    try {
-      const content = await readFile(path.join(params.repoRoot, rel), "utf-8");
-      const parsed = await engine.parseFile({ path: rel, content });
-      if (parsed && typeof parsed === "object" && "ok" in parsed && parsed.ok === true && "ir" in parsed) {
-        const ir = parsed.ir;
-        if (ir && typeof ir === "object" && "callSites" in ir) {
-          const cs = ir.callSites;
-          if (Array.isArray(cs)) {
-            for (const s of cs) {
-              if (s && typeof s === "object" && "span" in s) {
-                const sp = s.span;
-                if (sp && typeof sp === "object" && "startByte" in sp && typeof sp.startByte === "number") {
-                  // Find enclosing symbol for srcQualifiedName.
-                  let srcQName = "";
-                  if ("symbols" in ir && Array.isArray(ir.symbols)) {
-                    for (const sym of ir.symbols) {
-                      if (sym && typeof sym === "object" && "span" in sym && "qualifiedName" in sym) {
-                        const ss = sym.span;
-                        if (ss && typeof ss === "object" && "startByte" in ss && "endByte" in ss && typeof ss.startByte === "number" && typeof ss.endByte === "number") {
-                          if (ss.startByte <= sp.startByte && sp.startByte < ss.endByte) {
-                            srcQName = typeof sym.qualifiedName === "string" ? sym.qualifiedName : "";
-                            break;
-                          }
-                        }
-                      }
-                    }
-                  }
-                  const lang = "language" in ir && typeof ir.language === "string" ? ir.language : "";
-                  const callee = "calleeNameCandidates" in s && Array.isArray(s.calleeNameCandidates) && typeof s.calleeNameCandidates[0] === "string" ? s.calleeNameCandidates[0] : "";
-                  sites.push({ filePath: rel, language: lang, content, calleeByteOffset: sp.startByte, calleeName: callee, srcQualifiedName: srcQName });
-                }
-              }
-            }
+  if (!("paths" in tracked)) {
+    return { ok: true, upgraded: 0, unresolved: 0, budgetExhausted: 0 };
+  }
+
+  // Memoized per-caller lookup of already-resolved callee names: a bare
+  // call whose (src)-[CALLS]->(dst.name == callee) edge already exists was
+  // resolved by Phase A and must not consume LSP budget (review thread:
+  // budget starvation). Member accesses are Phase A's deliberate skips —
+  // always candidates.
+  const resolvedCalleesBySrc = new Map<string, Set<string>>();
+  const alreadyResolved = (srcQualifiedName: string, calleeName: string): boolean => {
+    let names = resolvedCalleesBySrc.get(srcQualifiedName);
+    if (names === undefined) {
+      names = new Set<string>();
+      const result = params.store.traverse({
+        start: srcQualifiedName,
+        direction: "outgoing",
+        edgeTypes: ["CALLS"],
+        maxDepth: 1,
+      });
+      if (result.ok) {
+        for (const hit of result.hits) {
+          if (hit && typeof hit === "object" && "name" in hit && "depth" in hit && hit.depth === 1 && typeof hit.name === "string") {
+            names.add(hit.name);
           }
         }
       }
-    } catch { /* skip unparseable */ }
-  }
-  if (sites.length === 0) return { ok: true, upgraded: 0, unresolved: 0, budgetExhausted: 0 };
-  // Plan + execute LSP resolution.
-  const plan = mod.planLspUpgrades(sites, { maxRequests: params.lspConfig.maxRequestsPerRun ?? 500 });
-  if (!plan.requests.length) return { ok: true, upgraded: 0, unresolved: sites.length, budgetExhausted: plan.budgetExhausted };
-  const client = typeof mod.createLspClient === "function"
-    ? mod.createLspClient({ workspaceRoot: params.repoRoot, timeoutMs: params.lspConfig.timeoutMs ?? 3000, servers: params.lspConfig.servers ?? {} })
-    : null;
-  if (!client) return { ok: false, code: "lsp_client_error", message: "Could not create LSP client." };
-  try {
-    const r = await mod.executeLspResolution(plan.requests, {
-      client,
-      nodeLocator: (fp: string, off: number) => params.store.findNodeBySpan?.(fp, off) ?? null,
-      applyUpgrades: async (ups: readonly unknown[]) => { if (params.store.upsertEdges) await params.store.upsertEdges(ups as Parameters<typeof params.store.upsertEdges>[0]); },
-      reconcileLspEdges: (fp: string, edges: ReadonlyArray<{ srcQualifiedName: string; dstQualifiedName: string; type: string }>) => { params.store.reconcileLspEdges?.(fp, edges); },
-    });
-    if (r && typeof r === "object" && "upgraded" in r) {
-      const rr = r as { upgraded: number; unresolved: number };
-      return { ok: true, upgraded: rr.upgraded ?? 0, unresolved: rr.unresolved ?? 0, budgetExhausted: plan.budgetExhausted };
+      resolvedCalleesBySrc.set(srcQualifiedName, names);
     }
-    return { ok: true, upgraded: 0, unresolved: sites.length, budgetExhausted: plan.budgetExhausted };
-  } catch (err) {
-    return { ok: false, code: "lsp_resolution_error", message: err instanceof Error ? err.message : String(err) };
+    return names.has(calleeName);
+  };
+
+  // Gather unresolved call sites from the freshly indexed source.
+  const sites: GatheredLspSite[] = [];
+  const gatheredCountByFile = new Map<string, number>();
+  for (const rel of tracked.paths) {
+    let content: string;
+    try {
+      content = await readFile(path.join(params.repoRoot, rel), "utf-8");
+    } catch {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = await engine.parseFile({ path: rel, content });
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object" || !("ok" in parsed) || parsed.ok !== true || !("ir" in parsed)) continue;
+    const ir = parsed.ir;
+    if (!ir || typeof ir !== "object" || !("callSites" in ir) || !Array.isArray(ir.callSites)) continue;
+    const language = "language" in ir && typeof ir.language === "string" ? ir.language : "";
+    const symbols = "symbols" in ir && Array.isArray(ir.symbols) ? ir.symbols : [];
+    for (const site of ir.callSites) {
+      if (!site || typeof site !== "object" || !("span" in site)) continue;
+      const span = site.span;
+      if (!span || typeof span !== "object" || !("startByte" in span) || typeof span.startByte !== "number") continue;
+      const calleeName =
+        "calleeNameCandidates" in site && Array.isArray(site.calleeNameCandidates) && typeof site.calleeNameCandidates[0] === "string"
+          ? site.calleeNameCandidates[0]
+          : "";
+      if (calleeName.length === 0) continue;
+      // Innermost enclosing symbol = SMALLEST containing span (review
+      // thread: first-match picks the outermost container for nested
+      // symbols, attaching edges to the wrong caller).
+      let srcQualifiedName = "";
+      let bestSpanSize = Number.POSITIVE_INFINITY;
+      for (const sym of symbols) {
+        if (!sym || typeof sym !== "object" || !("span" in sym) || !("qualifiedName" in sym)) continue;
+        const ss = sym.span;
+        if (!ss || typeof ss !== "object" || !("startByte" in ss) || !("endByte" in ss)) continue;
+        if (typeof ss.startByte !== "number" || typeof ss.endByte !== "number") continue;
+        if (ss.startByte <= span.startByte && span.startByte < ss.endByte) {
+          const size = ss.endByte - ss.startByte;
+          if (size < bestSpanSize) {
+            bestSpanSize = size;
+            srcQualifiedName = typeof sym.qualifiedName === "string" ? sym.qualifiedName : "";
+          }
+        }
+      }
+      if (srcQualifiedName.length === 0) continue;
+      const memberAccess = "memberAccess" in site && site.memberAccess === true;
+      if (!memberAccess && alreadyResolved(srcQualifiedName, calleeName)) continue;
+      // Position the definition query on the callee NAME, not the call
+      // expression start (member calls: `obj.save()` must query at `save`).
+      // The search is bounded to this call site's span, so repeated line
+      // text elsewhere in the file cannot mislead it (parser rule 20).
+      const nameIdx = content.indexOf(calleeName, span.startByte);
+      const endByte = "endByte" in span && typeof span.endByte === "number" ? span.endByte : span.startByte + calleeName.length;
+      const calleeByteOffset = nameIdx >= 0 && nameIdx < endByte ? nameIdx : span.startByte;
+      sites.push({ filePath: rel, language, content, calleeByteOffset, calleeName, srcQualifiedName });
+      gatheredCountByFile.set(rel, (gatheredCountByFile.get(rel) ?? 0) + 1);
+    }
   }
+  if (sites.length === 0) {
+    return { ok: true, upgraded: 0, unresolved: 0, budgetExhausted: 0 };
+  }
+
+  // Group by language; each group gets its own server connection. The
+  // budget is shared across groups (maxRequestsPerRun is per RUN).
+  const byLanguage = new Map<string, GatheredLspSite[]>();
+  for (const site of sites) {
+    const group = byLanguage.get(site.language);
+    if (group === undefined) byLanguage.set(site.language, [site]);
+    else group.push(site);
+  }
+
+  const configServers = params.lspConfig.servers ?? {};
+  const timeoutMs = params.lspConfig.timeoutMs ?? 3000;
+  let remainingBudget = Math.max(1, Math.floor(params.lspConfig.maxRequestsPerRun ?? 500));
+  const rootUri = pathToFileURL(params.repoRoot).href;
+  // Cross-file definition targets need their bytes for position→offset
+  // conversion (review thread: without resolveContent, cross-file
+  // upgrades — the point of Phase B — stay unresolved).
+  const resolveContent = (filePath: string): string | null => {
+    try {
+      return readFileSync(path.join(params.repoRoot, filePath), "utf-8");
+    } catch {
+      return null;
+    }
+  };
+
+  let upgraded = 0;
+  let unresolved = 0;
+  let budgetExhausted = 0;
+  for (const [language, group] of byLanguage) {
+    if (remainingBudget <= 0) {
+      budgetExhausted += group.length;
+      continue;
+    }
+    const rawSpec = configServers[language] ?? DEFAULT_LSP_SERVERS[language];
+    if (rawSpec === undefined) {
+      unresolved += group.length;
+      continue;
+    }
+    const launchSpec = { command: rawSpec.command, args: rawSpec.args ?? [] };
+    const plan = mod.planLspUpgrades(group, { maxRequests: remainingBudget });
+    budgetExhausted += plan.budgetExhausted;
+    remainingBudget -= plan.requests.length;
+    if (plan.requests.length === 0) continue;
+    // Reconciliation is only safe for files whose gathered sites ALL made
+    // it into the plan — a budget-truncated file would otherwise retire
+    // valid lsp edges its omitted call sites still assert (review thread).
+    const plannedCountByFile = new Map<string, number>();
+    for (const req of plan.requests) {
+      if (req && typeof req === "object" && "filePath" in req && typeof req.filePath === "string") {
+        plannedCountByFile.set(req.filePath, (plannedCountByFile.get(req.filePath) ?? 0) + 1);
+      }
+    }
+    const connected = await mod.LspClient.connect({ launchSpec, rootUri, timeoutMs });
+    if (!connected.ok) {
+      unresolved += plan.requests.length;
+      continue;
+    }
+    const client = connected.client;
+    try {
+      const result = await mod.executeLspResolution(plan.requests, {
+        client,
+        workspaceRoot: params.repoRoot,
+        resolveContent,
+        nodeLocator: (filePath: string, byteOffset: number) =>
+          typeof params.store.findNodeBySpan === "function" ? params.store.findNodeBySpan(filePath, byteOffset) : null,
+        applyUpgrades: async (upgrades: readonly CodegraphEdgeInput[]) => {
+          if (typeof params.store.upsertEdges !== "function") {
+            throw new Error("store.upsertEdges is not available");
+          }
+          const result = await params.store.upsertEdges(upgrades);
+          // The executor's contract: a throwing apply means the batch did
+          // not persist and must not be counted as upgraded (review
+          // thread: silently skipped edges inflate the upgraded count and
+          // let reconciliation retire edges that were never re-asserted).
+          if (!result.ok) throw new Error(`upsertEdges failed: ${result.code}`);
+          if (result.skipped > 0) throw new Error(`upsertEdges skipped ${result.skipped} edge(s)`);
+        },
+        reconcileLspEdges: (
+          filePath: string,
+          assertedEdges: ReadonlyArray<{ srcQualifiedName: string; dstQualifiedName: string; type: string }>,
+        ) => {
+          if (typeof params.store.reconcileLspEdges !== "function") return;
+          if (plannedCountByFile.get(filePath) !== gatheredCountByFile.get(filePath)) return;
+          params.store.reconcileLspEdges(filePath, assertedEdges);
+        },
+      });
+      if (result && typeof result === "object" && "upgraded" in result && typeof result.upgraded === "number") {
+        upgraded += result.upgraded;
+        unresolved += "unresolved" in result && typeof result.unresolved === "number" ? result.unresolved : 0;
+        budgetExhausted += "budgetExhausted" in result && typeof result.budgetExhausted === "number" ? result.budgetExhausted : 0;
+      } else {
+        unresolved += plan.requests.length;
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, code: "lsp_resolution_error", message: msg };
+    } finally {
+      const disposable = client as { dispose?: () => Promise<void> };
+      if (typeof disposable.dispose === "function") {
+        try {
+          await disposable.dispose();
+        } catch {
+          // Disposal failure is not actionable — the child process is
+          // reaped by the OS when the parent exits.
+        }
+      }
+    }
+  }
+  return { ok: true, upgraded, unresolved, budgetExhausted };
 }
+
 /**
  * Report index status via @remnic/coding-graph's getIndexStatus. Never throws
  * — a git failure degrades to `mode: "git_unavailable"` in the status body.

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -724,6 +724,14 @@ export async function runCodegraphLspResolution(params: {
   // Gather unresolved call sites from the freshly indexed source.
   const sites: GatheredLspSite[] = [];
   const gatheredCountByFile = new Map<string, number>();
+  // Sites excluded because Phase A already resolved them (heuristic edge).
+  // A file with ANY filtered site must not reconcile: those sites are not
+  // in the asserted set, so reconciliation would retire their prior lsp
+  // edges even though the sites were never re-queried (review thread).
+  const filteredCountByFile = new Map<string, number>();
+  // Files that parsed cleanly this run — the safe candidates for the
+  // empty-set reconcile below.
+  const parsedFiles = new Set<string>();
   for (const rel of tracked.paths) {
     const absPath = path.join(params.repoRoot, rel);
     // Same symlink containment the reindex path enforces (rule 3).
@@ -743,6 +751,7 @@ export async function runCodegraphLspResolution(params: {
     if (!parsed || typeof parsed !== "object" || !("ok" in parsed) || parsed.ok !== true || !("ir" in parsed)) continue;
     const ir = parsed.ir;
     if (!ir || typeof ir !== "object" || !("callSites" in ir) || !Array.isArray(ir.callSites)) continue;
+    parsedFiles.add(rel);
     const language = "language" in ir && typeof ir.language === "string" ? ir.language : "";
     const symbols = "symbols" in ir && Array.isArray(ir.symbols) ? ir.symbols : [];
     // UTF-8 view of the source for byte-exact callee-name searches.
@@ -776,7 +785,10 @@ export async function runCodegraphLspResolution(params: {
       }
       if (srcQualifiedName.length === 0) continue;
       const memberAccess = "memberAccess" in site && site.memberAccess === true;
-      if (!memberAccess && alreadyResolved(srcQualifiedName, calleeName)) continue;
+      if (!memberAccess && alreadyResolved(srcQualifiedName, calleeName)) {
+        filteredCountByFile.set(rel, (filteredCountByFile.get(rel) ?? 0) + 1);
+        continue;
+      }
       // Position the definition query on the callee NAME, not the call
       // expression start (member calls: `obj.save()` must query at `save`).
       // The search runs in Buffer space because span offsets are UTF-8
@@ -788,6 +800,20 @@ export async function runCodegraphLspResolution(params: {
       const calleeByteOffset = nameIdx >= 0 && nameIdx < endByte ? nameIdx : span.startByte;
       sites.push({ filePath: rel, language, content, calleeByteOffset, calleeName, srcQualifiedName });
       gatheredCountByFile.set(rel, (gatheredCountByFile.get(rel) ?? 0) + 1);
+    }
+  }
+  // Retire stale lsp edges for files that parsed cleanly and have NO LSP
+  // candidates at all this run (e.g. a previously upgraded member call was
+  // deleted while its containing function remains). The heuristic reindex
+  // deliberately keeps lsp-provenance rows out of its stale-delete scope,
+  // so this pass is the only owner of that cleanup (review thread). Files
+  // with filtered (heuristic-resolved) sites are left alone — their prior
+  // lsp edges were not re-queried.
+  if (typeof params.store.reconcileLspEdges === "function") {
+    for (const rel of parsedFiles) {
+      if ((gatheredCountByFile.get(rel) ?? 0) === 0 && (filteredCountByFile.get(rel) ?? 0) === 0) {
+        params.store.reconcileLspEdges(rel, []);
+      }
     }
   }
   if (sites.length === 0) {
@@ -943,6 +969,10 @@ export async function runCodegraphLspResolution(params: {
           lastApplySkipped = false;
           if (typeof params.store.reconcileLspEdges !== "function") return;
           if (plannedCountByFile.get(filePath) !== gatheredCountByFile.get(filePath)) return;
+          // Any heuristic-filtered site in this file was NOT re-queried;
+          // its prior lsp edge is absent from the asserted set and must
+          // survive (review thread).
+          if ((filteredCountByFile.get(filePath) ?? 0) > 0) return;
           // This file batch had skipped writes — its asserted set is
           // incomplete, so reconciling would retire edges that were never
           // re-asserted (see skip tracking above).

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -117,10 +117,11 @@ export interface CodegraphStore {
   ): number;
   /** Callee names already CALLS-linked from a caller with a given provenance (issue #1917). */
   resolvedCalleeNames?(srcQualifiedName: string, provenance: string, filePath?: string): string[];
-  /** Current lsp CALLS edges owned by a caller symbol in a file (issue #1917). */
-  lspCallEdgesForCaller?(
+  /** Current CALLS edges of a provenance owned by a caller symbol in a file (issue #1917). */
+  callEdgesForCaller?(
     srcQualifiedName: string,
     filePath: string,
+    provenance: string,
   ): Array<{ srcQualifiedName: string; dstQualifiedName: string; dstName: string; type: string }>;
 }
 
@@ -689,13 +690,18 @@ export async function runCodegraphLspResolution(params: {
   if (engine === null) {
     return { ok: false, code: "engine_unavailable", message: "createCodingGraphEngine is not available." };
   }
+  // Resolve to an absolute root up front: the executor builds file://
+  // URIs by joining workspaceRoot, and a relative root (".") would yield
+  // malformed URIs like file://src/foo.ts (review thread). The reindex
+  // path resolves relative cwd values the same way.
+  const repoRoot = path.resolve(params.repoRoot);
   const gitFactory = mod.defaultCodingGitInvoker as
     | (() => { listTrackedFiles(cwd: string): { ok: true; paths: readonly string[] } | { ok: false; code: string } })
     | undefined;
   if (typeof gitFactory !== "function") {
     return { ok: true, upgraded: 0, unresolved: 0, budgetExhausted: 0 };
   }
-  const tracked = gitFactory().listTrackedFiles(params.repoRoot);
+  const tracked = gitFactory().listTrackedFiles(repoRoot);
   if (!("paths" in tracked)) {
     return { ok: true, upgraded: 0, unresolved: 0, budgetExhausted: 0 };
   }
@@ -745,9 +751,9 @@ export async function runCodegraphLspResolution(params: {
   // empty-set reconcile below.
   const parsedFiles = new Set<string>();
   for (const rel of tracked.paths) {
-    const absPath = path.join(params.repoRoot, rel);
+    const absPath = path.join(repoRoot, rel);
     // Same symlink containment the reindex path enforces (rule 3).
-    if (await lspPathEscapesRoot(params.repoRoot, absPath)) continue;
+    if (await lspPathEscapesRoot(repoRoot, absPath)) continue;
     let content: string;
     try {
       content = await readFile(absPath, "utf-8");
@@ -834,21 +840,28 @@ export async function runCodegraphLspResolution(params: {
   // stale edges in the same file without dropping preserved ones. When
   // the store predates lspCallEdgesForCaller, preservation is impossible,
   // so callers below fall back to skipping reconcile for such files.
-  const canPreserve = typeof params.store.lspCallEdgesForCaller === "function";
+  const canPreserve = typeof params.store.callEdgesForCaller === "function";
   const preservedEdgesForFile = (
     rel: string,
   ): Array<{ srcQualifiedName: string; dstQualifiedName: string; type: string }> => {
     const srcs = filteredSrcByFile.get(rel);
     if (srcs === undefined || !canPreserve) return [];
     const preserved: Array<{ srcQualifiedName: string; dstQualifiedName: string; type: string }> = [];
-    for (const [src, calleeNames] of srcs) {
-      for (const edge of params.store.lspCallEdgesForCaller!(src, rel)) {
-        // Preserve ONLY edges whose destination NAME matches a filtered
-        // site's callee — preserving every lsp edge of the caller would
-        // re-assert edges for calls that were REMOVED from the source
-        // (review thread: a deleted member call's edge would never
-        // retire while any bare call in the function stays filtered).
-        if (!calleeNames.has(edge.dstName)) continue;
+    for (const [src] of srcs) {
+      // Preserve ONLY lsp edges that DUPLICATE a current heuristic
+      // resolution (same src, same dst) — the covering edge a filtered
+      // bare call still asserts today. A dstName-only match would also
+      // re-assert a REMOVED member call's edge when a same-named bare
+      // call stays filtered (review thread); requiring the exact
+      // heuristic dst retires those while keeping the live coverage.
+      // Cost: an lsp edge MORE precise than its heuristic twin (rare
+      // re-export chains) is retired too — conservative, the heuristic
+      // edge still represents the call.
+      const heuristicDsts = new Set(
+        params.store.callEdgesForCaller!(src, rel, "heuristic").map((e) => e.dstQualifiedName),
+      );
+      for (const edge of params.store.callEdgesForCaller!(src, rel, "lsp")) {
+        if (!heuristicDsts.has(edge.dstQualifiedName)) continue;
         preserved.push({
           srcQualifiedName: edge.srcQualifiedName,
           dstQualifiedName: edge.dstQualifiedName,
@@ -873,22 +886,26 @@ export async function runCodegraphLspResolution(params: {
   // Group by language; each group gets its own server connection. The
   // budget is shared across groups (maxRequestsPerRun is per RUN).
   const byLanguage = new Map<string, GatheredLspSite[]>();
+  // Caller symbol -> file, for attributing apply-time skips to the file
+  // batch they belong to (the apply callback sees upgrades, not files).
+  const srcToFile = new Map<string, string>();
   for (const site of sites) {
     const group = byLanguage.get(site.language);
     if (group === undefined) byLanguage.set(site.language, [site]);
     else group.push(site);
+    srcToFile.set(site.srcQualifiedName, site.filePath);
   }
 
   const configServers = params.lspConfig.servers ?? {};
   const timeoutMs = params.lspConfig.timeoutMs ?? 3000;
   let remainingBudget = Math.max(1, Math.floor(params.lspConfig.maxRequestsPerRun ?? 500));
-  const rootUri = pathToFileURL(params.repoRoot).href;
+  const rootUri = pathToFileURL(repoRoot).href;
   // Cross-file definition targets need their bytes for position→offset
   // conversion (review thread: without resolveContent, cross-file
   // upgrades — the point of Phase B — stay unresolved).
   const resolveContent = (filePath: string): string | null => {
-    const absPath = path.join(params.repoRoot, filePath);
-    if (lspPathEscapesRootSync(params.repoRoot, absPath)) return null;
+    const absPath = path.join(repoRoot, filePath);
+    if (lspPathEscapesRootSync(repoRoot, absPath)) return null;
     try {
       return readFileSync(absPath, "utf-8");
     } catch {
@@ -954,17 +971,18 @@ export async function runCodegraphLspResolution(params: {
       continue;
     }
     const client = connected.client;
-    // Per-file-batch skip tracking: the executor applies then reconciles
-    // each file batch sequentially, so a skip observed in applyUpgrades
-    // must (a) not count as an upgrade and (b) suppress reconciliation
-    // for that batch — a skipped edge was never re-asserted, and retiring
-    // it would drop a still-valid prior edge (review thread).
+    // Skip tracking keyed by FILE (via the upgrades' caller symbols):
+    // a skip must (a) not count as an upgrade and (b) suppress
+    // reconciliation for exactly the file batch that observed it — a
+    // boolean flag went stale whenever the executor skipped a batch's
+    // reconcile (non-exhaustive) or never called apply (zero upgrades)
+    // (review threads).
     let skippedEdgesTotal = 0;
-    let lastApplySkipped = false;
+    const skippedFiles = new Set<string>();
     try {
       const result = await mod.executeLspResolution(plan.requests, {
         client,
-        workspaceRoot: params.repoRoot,
+        workspaceRoot: repoRoot,
         resolveContent,
         nodeLocator: (filePath: string, byteOffset: number) =>
           typeof params.store.findNodeBySpan === "function" ? params.store.findNodeBySpan(filePath, byteOffset) : null,
@@ -972,10 +990,6 @@ export async function runCodegraphLspResolution(params: {
           if (typeof params.store.upsertEdges !== "function") {
             throw new Error("store.upsertEdges is not available");
           }
-          // Each apply call starts a NEW file batch — reset the skip
-          // marker so a prior batch's skips cannot leak into this one
-          // (review thread: stale flag suppressed later files' reconcile).
-          lastApplySkipped = false;
           const result = await params.store.upsertEdges(upgrades);
           // Throw ONLY when nothing persisted (ok:false) — the executor's
           // transactional contract holds because no state changed. A
@@ -999,7 +1013,10 @@ export async function runCodegraphLspResolution(params: {
           }
           if (result.skipped > 0) {
             skippedEdgesTotal += result.skipped;
-            lastApplySkipped = true;
+            for (const upgrade of upgrades) {
+              const file = srcToFile.get(upgrade.srcQualifiedName);
+              if (file !== undefined) skippedFiles.add(file);
+            }
             degradations.push({
               language,
               code: "edges_skipped",
@@ -1011,18 +1028,12 @@ export async function runCodegraphLspResolution(params: {
           filePath: string,
           assertedEdges: ReadonlyArray<{ srcQualifiedName: string; dstQualifiedName: string; type: string }>,
         ) => {
-          // Consume the per-batch skip marker regardless of the decision
-          // below — reconcile is the last step of a file batch, and a
-          // stale marker must not suppress the NEXT file's reconcile
-          // (zero-upgrade batches never call applyUpgrades).
-          const batchHadSkips = lastApplySkipped;
-          lastApplySkipped = false;
           if (typeof params.store.reconcileLspEdges !== "function") return;
           if (plannedCountByFile.get(filePath) !== gatheredCountByFile.get(filePath)) return;
-          // This file batch had skipped writes — its asserted set is
+          // This file's batch had skipped writes — its asserted set is
           // incomplete, so reconciling would retire edges that were never
           // re-asserted (see skip tracking above).
-          if (batchHadSkips) return;
+          if (skippedFiles.has(filePath)) return;
           // Heuristic-filtered sites were NOT re-queried: their current
           // lsp edges are appended to the asserted set so they survive
           // while stale edges for RE-QUERIED sites still get retired.

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -831,6 +831,14 @@ export async function runCodegraphLspResolution(params: {
     }
     const rawSpec = configServers[language] ?? DEFAULT_LSP_SERVERS[language];
     if (rawSpec === undefined) {
+      // A language with candidates but no launch spec is a DIAGNOSABLE
+      // gap, not ordinary unresolved calls (review thread): surface it so
+      // the operator knows to configure codingKnowledge.lsp.servers.
+      degradations.push({
+        language,
+        code: "no_launch_spec",
+        message: `No LSP server configured for ${language} (${group.length} candidate call site(s)); set codingKnowledge.lsp.servers.${language}.`,
+      });
       unresolved += group.length;
       continue;
     }
@@ -870,6 +878,13 @@ export async function runCodegraphLspResolution(params: {
       continue;
     }
     const client = connected.client;
+    // Per-file-batch skip tracking: the executor applies then reconciles
+    // each file batch sequentially, so a skip observed in applyUpgrades
+    // must (a) not count as an upgrade and (b) suppress reconciliation
+    // for that batch — a skipped edge was never re-asserted, and retiring
+    // it would drop a still-valid prior edge (review thread).
+    let skippedEdgesTotal = 0;
+    let lastApplySkipped = false;
     try {
       const result = await mod.executeLspResolution(plan.requests, {
         client,
@@ -891,11 +906,15 @@ export async function runCodegraphLspResolution(params: {
           // Skips are surfaced as a degradation instead of a silent drop.
           if (!result.ok) throw new Error(`upsertEdges failed: ${result.code}`);
           if (result.skipped > 0) {
+            skippedEdgesTotal += result.skipped;
+            lastApplySkipped = true;
             degradations.push({
               language,
               code: "edges_skipped",
               message: `upsertEdges persisted ${result.persisted} and skipped ${result.skipped} edge(s) for ${language} (unresolvable endpoints).`,
             });
+          } else {
+            lastApplySkipped = false;
           }
         },
         reconcileLspEdges: (
@@ -904,11 +923,18 @@ export async function runCodegraphLspResolution(params: {
         ) => {
           if (typeof params.store.reconcileLspEdges !== "function") return;
           if (plannedCountByFile.get(filePath) !== gatheredCountByFile.get(filePath)) return;
+          // This file batch had skipped writes — its asserted set is
+          // incomplete, so reconciling would retire edges that were never
+          // re-asserted (see skip tracking above).
+          if (lastApplySkipped) return;
           params.store.reconcileLspEdges(filePath, assertedEdges);
         },
       });
       if (result && typeof result === "object" && "upgraded" in result && typeof result.upgraded === "number") {
-        upgraded += result.upgraded;
+        // The executor counts every upgrade it HANDED to applyUpgrades;
+        // subtract the writes the store skipped so the reported number
+        // reflects edges that actually persisted (review thread).
+        upgraded += Math.max(0, result.upgraded - skippedEdgesTotal);
         unresolved += "unresolved" in result && typeof result.unresolved === "number" ? result.unresolved : 0;
         budgetExhausted += "budgetExhausted" in result && typeof result.budgetExhausted === "number" ? result.budgetExhausted : 0;
         // A mid-run server crash / protocol error returns counts PLUS a

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -908,7 +908,19 @@ export async function runCodegraphLspResolution(params: {
           // executor's view from the DB (skipped reconciliation +
           // undercounted upgrades while edges persist — review thread).
           // Skips are surfaced as a degradation instead of a silent drop.
-          if (!result.ok) throw new Error(`upsertEdges failed: ${result.code}`);
+          if (!result.ok) {
+            // The executor catches this throw and counts the batch as
+            // unresolved — record the failure as a degradation FIRST so
+            // a failed write (store_closed, SQLite error) is diagnosable
+            // from the index summary, not indistinguishable from
+            // "no definitions found" (review thread).
+            degradations.push({
+              language,
+              code: "edge_write_failed",
+              message: `upsertEdges failed for ${language}: ${result.code}.`,
+            });
+            throw new Error(`upsertEdges failed: ${result.code}`);
+          }
           if (result.skipped > 0) {
             skippedEdgesTotal += result.skipped;
             lastApplySkipped = true;

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -628,7 +628,13 @@ export async function runCodegraphLspResolution(params: {
   readonly repoRoot: string;
   readonly lspConfig: NonNullable<CodingKnowledgeConfig["lsp"]>;
 }): Promise<
-  | { ok: true; upgraded: number; unresolved: number; budgetExhausted: number }
+  | {
+      ok: true;
+      upgraded: number;
+      unresolved: number;
+      budgetExhausted: number;
+      degradations?: Array<{ language: string; code: string; message: string }>;
+    }
   | { ok: false; code: string; message: string }
 > {
   const mod = await loadCodegraphModule();
@@ -706,6 +712,8 @@ export async function runCodegraphLspResolution(params: {
     if (!ir || typeof ir !== "object" || !("callSites" in ir) || !Array.isArray(ir.callSites)) continue;
     const language = "language" in ir && typeof ir.language === "string" ? ir.language : "";
     const symbols = "symbols" in ir && Array.isArray(ir.symbols) ? ir.symbols : [];
+    // UTF-8 view of the source for byte-exact callee-name searches.
+    const contentBytes = Buffer.from(content, "utf-8");
     for (const site of ir.callSites) {
       if (!site || typeof site !== "object" || !("span" in site)) continue;
       const span = site.span;
@@ -738,9 +746,11 @@ export async function runCodegraphLspResolution(params: {
       if (!memberAccess && alreadyResolved(srcQualifiedName, calleeName)) continue;
       // Position the definition query on the callee NAME, not the call
       // expression start (member calls: `obj.save()` must query at `save`).
-      // The search is bounded to this call site's span, so repeated line
-      // text elsewhere in the file cannot mislead it (parser rule 20).
-      const nameIdx = content.indexOf(calleeName, span.startByte);
+      // The search runs in Buffer space because span offsets are UTF-8
+      // BYTES while string indexOf returns UTF-16 code units — non-ASCII
+      // source before the callee would skew a string-index search (review
+      // thread). Bounded to this call site's span (parser rule 20).
+      const nameIdx = contentBytes.indexOf(Buffer.from(calleeName, "utf-8"), span.startByte);
       const endByte = "endByte" in span && typeof span.endByte === "number" ? span.endByte : span.startByte + calleeName.length;
       const calleeByteOffset = nameIdx >= 0 && nameIdx < endByte ? nameIdx : span.startByte;
       sites.push({ filePath: rel, language, content, calleeByteOffset, calleeName, srcQualifiedName });
@@ -778,6 +788,7 @@ export async function runCodegraphLspResolution(params: {
   let upgraded = 0;
   let unresolved = 0;
   let budgetExhausted = 0;
+  const degradations: Array<{ language: string; code: string; message: string }> = [];
   for (const [language, group] of byLanguage) {
     if (remainingBudget <= 0) {
       budgetExhausted += group.length;
@@ -804,6 +815,18 @@ export async function runCodegraphLspResolution(params: {
     }
     const connected = await mod.LspClient.connect({ launchSpec, rootUri, timeoutMs });
     if (!connected.ok) {
+      // A missing/misconfigured server is a DIAGNOSABLE condition, not a
+      // silent count (review thread): record the degradation so
+      // codegraph_index can distinguish "server absent" from "LSP found
+      // no definitions".
+      const deg = connected.degradation;
+      const code =
+        deg && typeof deg === "object" && "code" in deg && typeof deg.code === "string" ? deg.code : "connect_failed";
+      const message =
+        deg && typeof deg === "object" && "message" in deg && typeof deg.message === "string"
+          ? deg.message
+          : `LSP server for ${language} failed to connect.`;
+      degradations.push({ language, code, message });
       unresolved += plan.requests.length;
       continue;
     }
@@ -858,7 +881,13 @@ export async function runCodegraphLspResolution(params: {
       }
     }
   }
-  return { ok: true, upgraded, unresolved, budgetExhausted };
+  return {
+    ok: true,
+    upgraded,
+    unresolved,
+    budgetExhausted,
+    ...(degradations.length > 0 ? { degradations } : {}),
+  };
 }
 
 /**

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -31,6 +31,7 @@ import { expandTildePath } from "../utils/path.js";
 
 import type { PluginConfig, CodingKnowledgeConfig, CodingContext } from "../types.js";
 import { isCodingGraphInstalled } from "./optional-coding-graph.js";
+import { displayErrorDetail } from "../runtime/better-sqlite.js";
 // Type-only reference to the surface context shape (ts-import-type rule).
 // Erased at compile time, so the runtime → surfaces → runtime import cycle is
 // type-only and has no runtime effect.
@@ -838,7 +839,7 @@ export async function runCodegraphLspResolution(params: {
   // Filtered (Phase-A-resolved) sites keep their CURRENT lsp edges by
   // asserting them explicitly — reconciliation can then retire genuinely
   // stale edges in the same file without dropping preserved ones. When
-  // the store predates lspCallEdgesForCaller, preservation is impossible,
+  // the store predates callEdgesForCaller, preservation is impossible,
   // so callers below fall back to skipping reconcile for such files.
   const canPreserve = typeof params.store.callEdgesForCaller === "function";
   const preservedEdgesForFile = (
@@ -886,14 +887,20 @@ export async function runCodegraphLspResolution(params: {
   // Group by language; each group gets its own server connection. The
   // budget is shared across groups (maxRequestsPerRun is per RUN).
   const byLanguage = new Map<string, GatheredLspSite[]>();
-  // Caller symbol -> file, for attributing apply-time skips to the file
-  // batch they belong to (the apply callback sees upgrades, not files).
-  const srcToFile = new Map<string, string>();
+  // Caller symbol -> FILES, for attributing apply-time skips to the file
+  // batches they may belong to (the apply callback sees upgrades, not
+  // files). A SET because duplicate caller qualified names can exist in
+  // multiple tracked files — a skip conservatively suppresses reconcile
+  // in every file that could own the skipped edge (review thread: a
+  // single-file map was overwritten by the later file).
+  const srcToFiles = new Map<string, Set<string>>();
   for (const site of sites) {
     const group = byLanguage.get(site.language);
     if (group === undefined) byLanguage.set(site.language, [site]);
     else group.push(site);
-    srcToFile.set(site.srcQualifiedName, site.filePath);
+    const files = srcToFiles.get(site.srcQualifiedName);
+    if (files === undefined) srcToFiles.set(site.srcQualifiedName, new Set([site.filePath]));
+    else files.add(site.filePath);
   }
 
   const configServers = params.lspConfig.servers ?? {};
@@ -1014,8 +1021,9 @@ export async function runCodegraphLspResolution(params: {
           if (result.skipped > 0) {
             skippedEdgesTotal += result.skipped;
             for (const upgrade of upgrades) {
-              const file = srcToFile.get(upgrade.srcQualifiedName);
-              if (file !== undefined) skippedFiles.add(file);
+              for (const file of srcToFiles.get(upgrade.srcQualifiedName) ?? []) {
+                skippedFiles.add(file);
+              }
             }
             degradations.push({
               language,
@@ -1064,8 +1072,17 @@ export async function runCodegraphLspResolution(params: {
         unresolved += plan.requests.length;
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { ok: false, code: "lsp_resolution_error", message: msg };
+      // Sanitized detail only (class name + Node error code) — this
+      // message reaches client surfaces via result.lsp and must not leak
+      // absolute paths or stack fragments (review thread; mirrors
+      // displayErrorDetail's contract). The full error is recoverable
+      // from server logs, not from the tool response.
+      const detail = displayErrorDetail(err);
+      return {
+        ok: false,
+        code: "lsp_resolution_error",
+        message: detail.length > 0 ? `LSP resolution failed: ${detail}.` : "LSP resolution failed.",
+      };
     } finally {
       const disposable = client as { dispose?: () => Promise<void> };
       if (typeof disposable.dispose === "function") {

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -23,8 +23,8 @@
  * by the surface handler via a context seam.
  */
 import path from "node:path";
-import { readFile } from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { readFile, realpath } from "node:fs/promises";
+import { readFileSync, realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { createHash } from "node:crypto";
 import { expandTildePath } from "../utils/path.js";
@@ -589,6 +589,36 @@ export async function runCodegraphReindex(params: {
 
 
 /**
+ * True when a tracked path resolves — via a symlinked file or any symlinked
+ * parent — outside repoRoot. Mirrors the reindex path's guard (reindex.ts
+ * `symlinkEscapesRoot`, rule 3): without it, a tracked `*.ts` symlink to a
+ * private file outside the checkout would be parsed and sent to a language
+ * server. A realpath error returns false so the normal read path surfaces
+ * the natural failure.
+ */
+async function lspPathEscapesRoot(repoRoot: string, absPath: string): Promise<boolean> {
+  try {
+    const [realRoot, realAbs] = await Promise.all([realpath(repoRoot), realpath(absPath)]);
+    const rel = path.relative(realRoot, realAbs);
+    return rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel);
+  } catch {
+    return false;
+  }
+}
+
+/** Sync variant for the executor's resolveContent seam. */
+function lspPathEscapesRootSync(repoRoot: string, absPath: string): boolean {
+  try {
+    const realRoot = realpathSync(repoRoot);
+    const realAbs = realpathSync(absPath);
+    const rel = path.relative(realRoot, realAbs);
+    return rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Default LSP server launch specs per language. The config's
  * `codingKnowledge.lsp.servers` overrides these; a language with neither
  * an override nor a default is skipped (degradation, not an error).
@@ -695,9 +725,12 @@ export async function runCodegraphLspResolution(params: {
   const sites: GatheredLspSite[] = [];
   const gatheredCountByFile = new Map<string, number>();
   for (const rel of tracked.paths) {
+    const absPath = path.join(params.repoRoot, rel);
+    // Same symlink containment the reindex path enforces (rule 3).
+    if (await lspPathEscapesRoot(params.repoRoot, absPath)) continue;
     let content: string;
     try {
-      content = await readFile(path.join(params.repoRoot, rel), "utf-8");
+      content = await readFile(absPath, "utf-8");
     } catch {
       continue;
     }
@@ -778,8 +811,10 @@ export async function runCodegraphLspResolution(params: {
   // conversion (review thread: without resolveContent, cross-file
   // upgrades — the point of Phase B — stay unresolved).
   const resolveContent = (filePath: string): string | null => {
+    const absPath = path.join(params.repoRoot, filePath);
+    if (lspPathEscapesRootSync(params.repoRoot, absPath)) return null;
     try {
-      return readFileSync(path.join(params.repoRoot, filePath), "utf-8");
+      return readFileSync(absPath, "utf-8");
     } catch {
       return null;
     }
@@ -823,11 +858,15 @@ export async function runCodegraphLspResolution(params: {
       const code =
         deg && typeof deg === "object" && "code" in deg && typeof deg.code === "string" ? deg.code : "connect_failed";
       const message =
-        deg && typeof deg === "object" && "message" in deg && typeof deg.message === "string"
-          ? deg.message
+        deg && typeof deg === "object" && "detail" in deg && typeof deg.detail === "string"
+          ? deg.detail
           : `LSP server for ${language} failed to connect.`;
       degradations.push({ language, code, message });
       unresolved += plan.requests.length;
+      // The planned requests never reached a server — hand their budget
+      // back so a missing server for one language cannot starve the
+      // remaining language groups (review thread).
+      remainingBudget += plan.requests.length;
       continue;
     }
     const client = connected.client;
@@ -863,6 +902,17 @@ export async function runCodegraphLspResolution(params: {
         upgraded += result.upgraded;
         unresolved += "unresolved" in result && typeof result.unresolved === "number" ? result.unresolved : 0;
         budgetExhausted += "budgetExhausted" in result && typeof result.budgetExhausted === "number" ? result.budgetExhausted : 0;
+        // A mid-run server crash / protocol error returns counts PLUS a
+        // degradation tag — dropping it would make the failure look like
+        // ordinary unresolved calls (review thread).
+        if ("degradation" in result && result.degradation && typeof result.degradation === "object") {
+          const rd = result.degradation;
+          degradations.push({
+            language,
+            code: "code" in rd && typeof rd.code === "string" ? rd.code : "lsp_degraded",
+            message: "detail" in rd && typeof rd.detail === "string" ? rd.detail : `LSP pass for ${language} degraded mid-run.`,
+          });
+        }
       } else {
         unresolved += plan.requests.length;
       }

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -882,12 +882,21 @@ export async function runCodegraphLspResolution(params: {
             throw new Error("store.upsertEdges is not available");
           }
           const result = await params.store.upsertEdges(upgrades);
-          // The executor's contract: a throwing apply means the batch did
-          // not persist and must not be counted as upgraded (review
-          // thread: silently skipped edges inflate the upgraded count and
-          // let reconciliation retire edges that were never re-asserted).
+          // Throw ONLY when nothing persisted (ok:false) — the executor's
+          // transactional contract holds because no state changed. A
+          // skipped>0 result has ALREADY committed the resolvable edges in
+          // one transaction, so throwing after the fact would desync the
+          // executor's view from the DB (skipped reconciliation +
+          // undercounted upgrades while edges persist — review thread).
+          // Skips are surfaced as a degradation instead of a silent drop.
           if (!result.ok) throw new Error(`upsertEdges failed: ${result.code}`);
-          if (result.skipped > 0) throw new Error(`upsertEdges skipped ${result.skipped} edge(s)`);
+          if (result.skipped > 0) {
+            degradations.push({
+              language,
+              code: "edges_skipped",
+              message: `upsertEdges persisted ${result.persisted} and skipped ${result.skipped} edge(s) for ${language} (unresolvable endpoints).`,
+            });
+          }
         },
         reconcileLspEdges: (
           filePath: string,

--- a/packages/remnic-core/src/coding/codegraph-runtime.ts
+++ b/packages/remnic-core/src/coding/codegraph-runtime.ts
@@ -115,6 +115,8 @@ export interface CodegraphStore {
     filePath: string,
     assertedEdges: ReadonlyArray<{ srcQualifiedName: string; dstQualifiedName: string; type: string }>,
   ): number;
+  /** Callee names already CALLS-linked from a caller with a given provenance (issue #1917). */
+  resolvedCalleeNames?(srcQualifiedName: string, provenance: string): string[];
 }
 
 /**
@@ -698,22 +700,20 @@ export async function runCodegraphLspResolution(params: {
   // resolved by Phase A and must not consume LSP budget (review thread:
   // budget starvation). Member accesses are Phase A's deliberate skips —
   // always candidates.
+  // Provenance matters: only HEURISTIC edges mark a site as Phase-A
+  // resolved. A site whose only edge is a prior "lsp" edge MUST be
+  // re-planned — excluding it from the plan while reconciling the file
+  // would retire that still-valid lsp edge (review thread). When the
+  // installed store predates resolvedCalleeNames, nothing is treated as
+  // resolved (conservative: spends budget, never mis-retires).
   const resolvedCalleesBySrc = new Map<string, Set<string>>();
   const alreadyResolved = (srcQualifiedName: string, calleeName: string): boolean => {
     let names = resolvedCalleesBySrc.get(srcQualifiedName);
     if (names === undefined) {
       names = new Set<string>();
-      const result = params.store.traverse({
-        start: srcQualifiedName,
-        direction: "outgoing",
-        edgeTypes: ["CALLS"],
-        maxDepth: 1,
-      });
-      if (result.ok) {
-        for (const hit of result.hits) {
-          if (hit && typeof hit === "object" && "name" in hit && "depth" in hit && hit.depth === 1 && typeof hit.name === "string") {
-            names.add(hit.name);
-          }
+      if (typeof params.store.resolvedCalleeNames === "function") {
+        for (const name of params.store.resolvedCalleeNames(srcQualifiedName, "heuristic")) {
+          names.add(name);
         }
       }
       resolvedCalleesBySrc.set(srcQualifiedName, names);
@@ -896,6 +896,10 @@ export async function runCodegraphLspResolution(params: {
           if (typeof params.store.upsertEdges !== "function") {
             throw new Error("store.upsertEdges is not available");
           }
+          // Each apply call starts a NEW file batch — reset the skip
+          // marker so a prior batch's skips cannot leak into this one
+          // (review thread: stale flag suppressed later files' reconcile).
+          lastApplySkipped = false;
           const result = await params.store.upsertEdges(upgrades);
           // Throw ONLY when nothing persisted (ok:false) — the executor's
           // transactional contract holds because no state changed. A
@@ -913,20 +917,24 @@ export async function runCodegraphLspResolution(params: {
               code: "edges_skipped",
               message: `upsertEdges persisted ${result.persisted} and skipped ${result.skipped} edge(s) for ${language} (unresolvable endpoints).`,
             });
-          } else {
-            lastApplySkipped = false;
           }
         },
         reconcileLspEdges: (
           filePath: string,
           assertedEdges: ReadonlyArray<{ srcQualifiedName: string; dstQualifiedName: string; type: string }>,
         ) => {
+          // Consume the per-batch skip marker regardless of the decision
+          // below — reconcile is the last step of a file batch, and a
+          // stale marker must not suppress the NEXT file's reconcile
+          // (zero-upgrade batches never call applyUpgrades).
+          const batchHadSkips = lastApplySkipped;
+          lastApplySkipped = false;
           if (typeof params.store.reconcileLspEdges !== "function") return;
           if (plannedCountByFile.get(filePath) !== gatheredCountByFile.get(filePath)) return;
           // This file batch had skipped writes — its asserted set is
           // incomplete, so reconciling would retire edges that were never
           // re-asserted (see skip tracking above).
-          if (lastApplySkipped) return;
+          if (batchHadSkips) return;
           params.store.reconcileLspEdges(filePath, assertedEdges);
         },
       });

--- a/packages/remnic-core/src/coding/codegraph-surfaces.test.ts
+++ b/packages/remnic-core/src/coding/codegraph-surfaces.test.ts
@@ -878,3 +878,77 @@ test("resolveCodegraphDbPath: accepts an absolute codegraphDbDir", () => {
   assert.ok(p.startsWith("/var/lib/remnic/codegraph/"), p);
   assert.ok(p.endsWith(".sqlite"), p);
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// LSP Phase B wiring (issue #1917): handleIndex invokes runLspResolution
+// after a successful reindex iff codingKnowledge.lsp.enabled — and LSP
+// failure is non-fatal (heuristic edges stand).
+// ──────────────────────────────────────────────────────────────────────────
+
+function makeLspCtx(
+  lsp: { enabled: boolean } | undefined,
+  overrides: Partial<CodegraphSurfaceContext> = {},
+): CodegraphSurfaceContext {
+  const pluginConfig = {
+    codingKnowledge: { ...GATE_ON_CONFIG, lsp },
+  } as unknown as PluginConfig;
+  return makeEnabledCtx({ config: pluginConfig, ...overrides });
+}
+
+test("LSP wiring: handleIndex invokes runLspResolution after reindex when lsp.enabled", async () => {
+  const calls: Array<{ repoRoot: string; lspEnabled: boolean }> = [];
+  const ctx = makeLspCtx(
+    { enabled: true },
+    {
+      runReindex: async () => ({ ok: true, mode: "full", filesIngested: 2, head: "h1" }),
+      runLspResolution: async (_store, repoRoot, lspConfig) => {
+        calls.push({ repoRoot, lspEnabled: lspConfig.enabled });
+        return { ok: true, upgraded: 4, unresolved: 1, budgetExhausted: 0 };
+      },
+    },
+  );
+  const response = await handleCodegraphTool({ tool: "index", repoRoot: "/repo", mode: "auto" }, ctx);
+  assert.equal(response.ok, true);
+  assert.equal(calls.length, 1, "runLspResolution must be invoked exactly once");
+  assert.equal(calls[0]?.repoRoot, "/repo", "repoRoot forwards to the LSP pass");
+  assert.equal(calls[0]?.lspEnabled, true, "the parsed lsp config forwards");
+  if (!response.ok) throw new Error("expected ok");
+  const result = response.result as { lsp?: { upgraded: number; unresolved: number } };
+  assert.equal(result.lsp?.upgraded, 4, "LSP upgrade summary surfaces in the index result");
+  assert.equal(result.lsp?.unresolved, 1);
+});
+
+test("LSP wiring: handleIndex does NOT invoke runLspResolution when lsp is disabled or absent", async () => {
+  for (const lsp of [{ enabled: false }, undefined]) {
+    let called = false;
+    const ctx = makeLspCtx(lsp, {
+      runReindex: async () => ({ ok: true, mode: "full", filesIngested: 1, head: "h2" }),
+      runLspResolution: async () => {
+        called = true;
+        return { ok: true, upgraded: 0, unresolved: 0, budgetExhausted: 0 };
+      },
+    });
+    const response = await handleCodegraphTool({ tool: "index", repoRoot: "/repo", mode: "auto" }, ctx);
+    assert.equal(response.ok, true);
+    assert.equal(called, false, `lsp=${JSON.stringify(lsp)} must not trigger the LSP pass`);
+    if (!response.ok) throw new Error("expected ok");
+    const result = response.result as { lsp?: unknown };
+    assert.equal(result.lsp, undefined, "no LSP summary when the pass did not run");
+  }
+});
+
+test("LSP wiring: a failed LSP pass is non-fatal — index still reports ok with reindex stats", async () => {
+  const ctx = makeLspCtx(
+    { enabled: true },
+    {
+      runReindex: async () => ({ ok: true, mode: "incremental", filesIngested: 5, head: "h3" }),
+      runLspResolution: async () => ({ ok: false, code: "lsp_resolution_error", message: "server crashed" }),
+    },
+  );
+  const response = await handleCodegraphTool({ tool: "index", repoRoot: "/repo", mode: "auto" }, ctx);
+  assert.equal(response.ok, true, "LSP failure must not fail the index (heuristic edges stand)");
+  if (!response.ok) throw new Error("expected ok");
+  const result = response.result as { filesIngested: number; lsp?: unknown };
+  assert.equal(result.filesIngested, 5, "reindex stats survive the failed LSP pass");
+  assert.equal(result.lsp, undefined, "no LSP summary on a failed pass");
+});

--- a/packages/remnic-core/src/coding/codegraph-surfaces.test.ts
+++ b/packages/remnic-core/src/coding/codegraph-surfaces.test.ts
@@ -948,7 +948,8 @@ test("LSP wiring: a failed LSP pass is non-fatal — index still reports ok with
   const response = await handleCodegraphTool({ tool: "index", repoRoot: "/repo", mode: "auto" }, ctx);
   assert.equal(response.ok, true, "LSP failure must not fail the index (heuristic edges stand)");
   if (!response.ok) throw new Error("expected ok");
-  const result = response.result as { filesIngested: number; lsp?: unknown };
+  const result = response.result as { filesIngested: number; lsp?: { error?: string; message?: string } };
   assert.equal(result.filesIngested, 5, "reindex stats survive the failed LSP pass");
-  assert.equal(result.lsp, undefined, "no LSP summary on a failed pass");
+  assert.equal(result.lsp?.error, "lsp_resolution_error", "the degradation code surfaces (never silent)");
+  assert.equal(result.lsp?.message, "server crashed", "the degradation message surfaces");
 });

--- a/packages/remnic-core/src/coding/codegraph-surfaces.ts
+++ b/packages/remnic-core/src/coding/codegraph-surfaces.ts
@@ -210,7 +210,7 @@ export interface CodegraphSurfaceContext {
    * Optional — when omitted or when codingKnowledge.lsp is not enabled,
    * the heuristic edges stand alone.
    */
-  runLspResolution?(store: CodegraphStore, repoRoot: string, lspConfig: NonNullable<PluginConfig["codingKnowledge"]["lsp"]>): Promise<{ ok: boolean; code?: string; upgraded?: number; unresolved?: number; budgetExhausted?: number; message?: string }>;
+  runLspResolution?(store: CodegraphStore, repoRoot: string, lspConfig: NonNullable<PluginConfig["codingKnowledge"]["lsp"]>): Promise<{ ok: boolean; code?: string; upgraded?: number; unresolved?: number; budgetExhausted?: number; message?: string; degradations?: Array<{ language: string; code: string; message: string }> }>;
   /**
    * Report index status via @remnic/coding-graph's getIndexStatus. Optional —
    * when omitted, index_status degrades with a clean code (no placeholder).
@@ -559,7 +559,12 @@ async function handleIndex(
   // degradation code/message surface in the result so a misconfigured
   // server is diagnosable from the index response (review thread).
   let lspUpgradeSummary:
-    | { upgraded: number; unresolved: number; budgetExhausted: number }
+    | {
+        upgraded: number;
+        unresolved: number;
+        budgetExhausted: number;
+        degradations?: ReadonlyArray<{ language: string; code: string; message: string }>;
+      }
     | { error: string; message: string }
     | undefined;
   const lspConfig = ctx.config.codingKnowledge.lsp;
@@ -570,6 +575,9 @@ async function handleIndex(
           upgraded: lspResult.upgraded ?? 0,
           unresolved: lspResult.unresolved ?? 0,
           budgetExhausted: lspResult.budgetExhausted ?? 0,
+          ...(lspResult.degradations !== undefined && lspResult.degradations.length > 0
+            ? { degradations: lspResult.degradations }
+            : {}),
         }
       : { error: lspResult.code ?? "lsp_error", message: lspResult.message ?? "" };
   }

--- a/packages/remnic-core/src/coding/codegraph-surfaces.ts
+++ b/packages/remnic-core/src/coding/codegraph-surfaces.ts
@@ -206,6 +206,12 @@ export interface CodegraphSurfaceContext {
    */
   runReindex?(store: CodegraphStore, repoRoot: string, mode: string): Promise<CodegraphReindexOutcome>;
   /**
+   * Run LSP type resolution after a heuristic reindex (issue #1917).
+   * Optional — when omitted or when codingKnowledge.lsp is not enabled,
+   * the heuristic edges stand alone.
+   */
+  runLspResolution?(store: CodegraphStore, repoRoot: string, lspConfig: NonNullable<PluginConfig["codingKnowledge"]["lsp"]>): Promise<{ ok: boolean; code?: string; upgraded?: number; unresolved?: number; budgetExhausted?: number; message?: string }>;
+  /**
    * Report index status via @remnic/coding-graph's getIndexStatus. Optional —
    * when omitted, index_status degrades with a clean code (no placeholder).
    */
@@ -548,6 +554,16 @@ async function handleIndex(
   if (!outcome.ok) {
     return { tool: request.tool, ok: false, code: outcome.code, message: outcome.message };
   }
+  // LSP Phase B: upgrade unresolved call sites via language servers.
+  let lspUpgradeSummary: { upgraded: number; unresolved: number } | undefined;
+  const lspConfig = ctx.config.codingKnowledge.lsp;
+  if (lspConfig?.enabled === true && ctx.runLspResolution) {
+    const lspResult = await ctx.runLspResolution(store, repoRoot, lspConfig);
+    if (lspResult.ok) {
+      lspUpgradeSummary = { upgraded: lspResult.upgraded ?? 0, unresolved: lspResult.unresolved ?? 0 };
+    }
+    // LSP failure is non-fatal — heuristic edges survive.
+  }
   const stats = store.schemaStats();
   return {
     tool: request.tool,
@@ -558,6 +574,7 @@ async function handleIndex(
       filesIngested: outcome.filesIngested,
       head: outcome.head,
       stats,
+      ...(lspUpgradeSummary ? { lsp: lspUpgradeSummary } : {}),
     },
   };
 }

--- a/packages/remnic-core/src/coding/codegraph-surfaces.ts
+++ b/packages/remnic-core/src/coding/codegraph-surfaces.ts
@@ -555,14 +555,23 @@ async function handleIndex(
     return { tool: request.tool, ok: false, code: outcome.code, message: outcome.message };
   }
   // LSP Phase B: upgrade unresolved call sites via language servers.
-  let lspUpgradeSummary: { upgraded: number; unresolved: number } | undefined;
+  // Failure is non-fatal (heuristic edges survive) but NEVER silent — the
+  // degradation code/message surface in the result so a misconfigured
+  // server is diagnosable from the index response (review thread).
+  let lspUpgradeSummary:
+    | { upgraded: number; unresolved: number; budgetExhausted: number }
+    | { error: string; message: string }
+    | undefined;
   const lspConfig = ctx.config.codingKnowledge.lsp;
   if (lspConfig?.enabled === true && ctx.runLspResolution) {
     const lspResult = await ctx.runLspResolution(store, repoRoot, lspConfig);
-    if (lspResult.ok) {
-      lspUpgradeSummary = { upgraded: lspResult.upgraded ?? 0, unresolved: lspResult.unresolved ?? 0 };
-    }
-    // LSP failure is non-fatal — heuristic edges survive.
+    lspUpgradeSummary = lspResult.ok
+      ? {
+          upgraded: lspResult.upgraded ?? 0,
+          unresolved: lspResult.unresolved ?? 0,
+          budgetExhausted: lspResult.budgetExhausted ?? 0,
+        }
+      : { error: lspResult.code ?? "lsp_error", message: lspResult.message ?? "" };
   }
   const stats = store.schemaStats();
   return {

--- a/packages/remnic-core/src/coding/coding-knowledge-config.ts
+++ b/packages/remnic-core/src/coding/coding-knowledge-config.ts
@@ -148,18 +148,40 @@ function parseLspConfig(raw: Record<string, unknown>): CodingGraphLspConfig {
   const enabled = readStrictBool(raw.enabled, "lsp.enabled", false);
   if (!enabled) return { enabled: false };
 
+  // Server overrides are validated STRICTLY (rule 51): a malformed entry
+  // must not silently fall through to the built-in default server — the
+  // operator configured an override for a reason. Unknown language KEYS
+  // are allowed (forward-compat: the optional @remnic/coding-graph package
+  // owns the language list and may grow it independently of core; an
+  // unmatched key is inert at the runtime seam).
   const servers: CodingGraphLspConfig["servers"] = {};
-  if (raw.servers && typeof raw.servers === "object" && !Array.isArray(raw.servers)) {
+  if (raw.servers !== undefined && raw.servers !== null) {
+    if (typeof raw.servers !== "object" || Array.isArray(raw.servers)) {
+      throw new Error(
+        `codingKnowledge.lsp.servers must be an object mapping language ids to { command, args? }; got ${JSON.stringify(raw.servers)}.`,
+      );
+    }
     for (const [lang, def] of Object.entries(raw.servers as Record<string, unknown>)) {
-      if (def && typeof def === "object" && !Array.isArray(def)) {
-        const d = def as Record<string, unknown>;
-        if (typeof d.command === "string" && d.command.length > 0) {
-          servers[lang] = {
-            command: d.command,
-            ...(Array.isArray(d.args) ? { args: d.args.filter((a) => typeof a === "string") as string[] } : {}),
-          };
-        }
+      if (!def || typeof def !== "object" || Array.isArray(def)) {
+        throw new Error(
+          `codingKnowledge.lsp.servers.${lang} must be an object ({ command, args? }); got ${JSON.stringify(def)}.`,
+        );
       }
+      const d = def as Record<string, unknown>;
+      if (typeof d.command !== "string" || d.command.trim().length === 0) {
+        throw new Error(
+          `codingKnowledge.lsp.servers.${lang}.command must be a non-empty string; got ${JSON.stringify(d.command)}.`,
+        );
+      }
+      if (d.args !== undefined && (!Array.isArray(d.args) || !d.args.every((a) => typeof a === "string"))) {
+        throw new Error(
+          `codingKnowledge.lsp.servers.${lang}.args must be an array of strings; got ${JSON.stringify(d.args)}.`,
+        );
+      }
+      servers[lang] = {
+        command: d.command.trim(),
+        ...(Array.isArray(d.args) ? { args: d.args as string[] } : {}),
+      };
     }
   }
 

--- a/packages/remnic-core/src/coding/coding-knowledge-config.ts
+++ b/packages/remnic-core/src/coding/coding-knowledge-config.ts
@@ -73,10 +73,27 @@ export function parseCodingKnowledgeConfig(raw: unknown): CodingKnowledgeConfig 
       typeof record.codegraphDbDir === "string"
         ? record.codegraphDbDir.trim()
         : "",
-    lsp: record.lsp && typeof record.lsp === "object" && !Array.isArray(record.lsp)
-      ? parseLspConfig(record.lsp as Record<string, unknown>)
-      : undefined,
+    // `lsp` is spread conditionally so an absent key stays ABSENT — an own
+    // `lsp: undefined` property would change the pinned defaults shape
+    // (config.test.ts) and leak a new key into serialized configs.
+    ...readLspField(record.lsp),
   };
+}
+
+/**
+ * Read the optional `codingKnowledge.lsp` sub-object. Absent → empty
+ * spread (no own key). Present-but-malformed (string/number/array) is
+ * REJECTED, consistent with `readStrictBool`'s posture — a typo like
+ * `"lsp": true` must alert the operator, not silently disable Phase B.
+ */
+function readLspField(raw: unknown): { lsp?: CodingGraphLspConfig } {
+  if (raw === undefined || raw === null) return {};
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(
+      `codingKnowledge.lsp must be an object ({ enabled, servers?, timeoutMs?, maxRequestsPerRun? }); got ${JSON.stringify(raw)}`,
+    );
+  }
+  return { lsp: parseLspConfig(raw as Record<string, unknown>) };
 }
 
 const STRICT_BOOL_ACCEPTED = "true/false/1/0/yes/no/on/off";

--- a/packages/remnic-core/src/coding/coding-knowledge-config.ts
+++ b/packages/remnic-core/src/coding/coding-knowledge-config.ts
@@ -163,14 +163,27 @@ function parseLspConfig(raw: Record<string, unknown>): CodingGraphLspConfig {
     }
   }
 
-  const timeoutMs =
-    typeof raw.timeoutMs === "number" && Number.isFinite(raw.timeoutMs) && raw.timeoutMs > 0
-      ? Math.min(Math.floor(raw.timeoutMs), 30_000)
-      : 3_000;
-  const maxRequestsPerRun =
-    typeof raw.maxRequestsPerRun === "number" && Number.isFinite(raw.maxRequestsPerRun) && raw.maxRequestsPerRun > 0
-      ? Math.min(Math.floor(raw.maxRequestsPerRun), 5_000)
-      : 500;
+  const timeoutMs = readPositiveInt(raw.timeoutMs, "lsp.timeoutMs", 3_000, 30_000);
+  const maxRequestsPerRun = readPositiveInt(raw.maxRequestsPerRun, "lsp.maxRequestsPerRun", 500, 5_000);
 
   return { enabled: true, ...(Object.keys(servers).length > 0 ? { servers } : {}), timeoutMs, maxRequestsPerRun };
+}
+
+/**
+ * Strict positive-integer parse for LSP numeric knobs (rule 51 + CLI
+ * string parity, pattern 17). `undefined` falls back to the default;
+ * strings coerce via Number() (CLI values arrive as strings); anything
+ * non-integer, < 1 (0 is NOT a disable value here — set lsp.enabled:false
+ * to disable), or > max is REJECTED instead of silently replaced.
+ */
+function readPositiveInt(value: unknown, keyName: string, defaultValue: number, max: number): number {
+  if (value === undefined) return defaultValue;
+  const coerced = typeof value === "string" && value.trim().length > 0 ? Number(value) : value;
+  if (typeof coerced !== "number" || !Number.isFinite(coerced) || !Number.isInteger(coerced) || coerced < 1 || coerced > max) {
+    throw new Error(
+      `codingKnowledge.${keyName} must be an integer in [1, ${max}]; got ${JSON.stringify(value)}. ` +
+        `To disable LSP resolution set codingKnowledge.lsp.enabled to false.`,
+    );
+  }
+  return coerced;
 }

--- a/packages/remnic-core/src/coding/coding-knowledge-config.ts
+++ b/packages/remnic-core/src/coding/coding-knowledge-config.ts
@@ -21,7 +21,7 @@
  * the existing `ENGRAM_*` env vars from earlier releases do not pair them up.
  */
 
-import type { CodingKnowledgeConfig } from "../types.js";
+import type { CodingKnowledgeConfig, CodingGraphLspConfig } from "../types.js";
 import { coerceBool } from "../connectors/coerce.js";
 
 export const CODING_KNOWLEDGE_DEFAULTS = Object.freeze({
@@ -34,7 +34,10 @@ export const CODING_KNOWLEDGE_DEFAULTS = Object.freeze({
   structuralProviderCommand: "",
   codegraphTools: false,
   codegraphDbDir: "",
-} satisfies Record<keyof CodingKnowledgeConfig, boolean | string>);
+  // `lsp` is excluded: it is an optional structured sub-config (issue #1917)
+  // with no flat boolean/string default; the parser returns `undefined` when
+  // absent (LSP off — rule 48 explicit opt-in).
+} satisfies Record<Exclude<keyof CodingKnowledgeConfig, "lsp">, boolean | string>);
 
 const VALID_STRUCTURAL_PROVIDERS = ["none", "subprocess", "native"] as const;
 type StructuralProvider = CodingKnowledgeConfig["structuralProvider"];
@@ -70,6 +73,9 @@ export function parseCodingKnowledgeConfig(raw: unknown): CodingKnowledgeConfig 
       typeof record.codegraphDbDir === "string"
         ? record.codegraphDbDir.trim()
         : "",
+    lsp: record.lsp && typeof record.lsp === "object" && !Array.isArray(record.lsp)
+      ? parseLspConfig(record.lsp as Record<string, unknown>)
+      : undefined,
   };
 }
 
@@ -115,4 +121,39 @@ function readStructuralProvider(raw: unknown): StructuralProvider {
     `codingKnowledge.structuralProvider must be one of ` +
       `${VALID_STRUCTURAL_PROVIDERS.join(", ")}; got ${JSON.stringify(raw)}.`,
   );
+}
+
+/**
+ * Parse the `codingKnowledge.lsp` sub-object (issue #1917). Returns
+ * `{ enabled: false }` when absent or malformed — LSP is opt-in.
+ */
+function parseLspConfig(raw: Record<string, unknown>): CodingGraphLspConfig {
+  const enabled = readStrictBool(raw.enabled, "lsp.enabled", false);
+  if (!enabled) return { enabled: false };
+
+  const servers: CodingGraphLspConfig["servers"] = {};
+  if (raw.servers && typeof raw.servers === "object" && !Array.isArray(raw.servers)) {
+    for (const [lang, def] of Object.entries(raw.servers as Record<string, unknown>)) {
+      if (def && typeof def === "object" && !Array.isArray(def)) {
+        const d = def as Record<string, unknown>;
+        if (typeof d.command === "string" && d.command.length > 0) {
+          servers[lang] = {
+            command: d.command,
+            ...(Array.isArray(d.args) ? { args: d.args.filter((a) => typeof a === "string") as string[] } : {}),
+          };
+        }
+      }
+    }
+  }
+
+  const timeoutMs =
+    typeof raw.timeoutMs === "number" && Number.isFinite(raw.timeoutMs) && raw.timeoutMs > 0
+      ? Math.min(Math.floor(raw.timeoutMs), 30_000)
+      : 3_000;
+  const maxRequestsPerRun =
+    typeof raw.maxRequestsPerRun === "number" && Number.isFinite(raw.maxRequestsPerRun) && raw.maxRequestsPerRun > 0
+      ? Math.min(Math.floor(raw.maxRequestsPerRun), 5_000)
+      : 500;
+
+  return { enabled: true, ...(Object.keys(servers).length > 0 ? { servers } : {}), timeoutMs, maxRequestsPerRun };
 }

--- a/packages/remnic-core/src/coding/coding-knowledge-config.ts
+++ b/packages/remnic-core/src/coding/coding-knowledge-config.ts
@@ -22,6 +22,7 @@
  */
 
 import type { CodingKnowledgeConfig, CodingGraphLspConfig } from "../types.js";
+import { TIER_1_LANGUAGES } from "./coding-graph-types.js";
 import { coerceBool } from "../connectors/coerce.js";
 
 export const CODING_KNOWLEDGE_DEFAULTS = Object.freeze({
@@ -149,11 +150,10 @@ function parseLspConfig(raw: Record<string, unknown>): CodingGraphLspConfig {
   if (!enabled) return { enabled: false };
 
   // Server overrides are validated STRICTLY (rule 51): a malformed entry
-  // must not silently fall through to the built-in default server — the
-  // operator configured an override for a reason. Unknown language KEYS
-  // are allowed (forward-compat: the optional @remnic/coding-graph package
-  // owns the language list and may grow it independently of core; an
-  // unmatched key is inert at the runtime seam).
+  // or a misspelled language key must not silently fall through to the
+  // built-in default server — the operator configured an override for a
+  // reason. Keys validate against TIER_1_LANGUAGES (core owns the tier-1
+  // list in coding-graph-types.ts, so there is no drift risk).
   const servers: CodingGraphLspConfig["servers"] = {};
   if (raw.servers !== undefined && raw.servers !== null) {
     if (typeof raw.servers !== "object" || Array.isArray(raw.servers)) {
@@ -162,6 +162,11 @@ function parseLspConfig(raw: Record<string, unknown>): CodingGraphLspConfig {
       );
     }
     for (const [lang, def] of Object.entries(raw.servers as Record<string, unknown>)) {
+      if (!(TIER_1_LANGUAGES as readonly string[]).includes(lang)) {
+        throw new Error(
+          `codingKnowledge.lsp.servers has unknown language key ${JSON.stringify(lang)}; valid keys: ${TIER_1_LANGUAGES.join(", ")}.`,
+        );
+      }
       if (!def || typeof def !== "object" || Array.isArray(def)) {
         throw new Error(
           `codingKnowledge.lsp.servers.${lang} must be an object ({ command, args? }); got ${JSON.stringify(def)}.`,

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -492,6 +492,36 @@ export interface CodingKnowledgeConfig {
    * Absolute path required when set explicitly (rule 11 -- no relative paths).
    */
   codegraphDbDir: string;
+  /**
+   * Phase B type resolution via LSP (issue #1917). When enabled, the
+   * reindex pipeline invokes `executeLspResolution` after the heuristic
+   * pass to upgrade unresolved call-site edges with real language-server
+   * definitions. Requires installed language servers on the host.
+   * Off by default (rule 48 — explicit opt-in for subprocess spawning).
+   */
+  lsp?: CodingGraphLspConfig;
+}
+
+/**
+ * Per-language LSP server configuration (issue #1917). Keys are
+ * `CodingGraphLanguage` values (typescript, python, go, rust, ...).
+ * When a language is not listed, the default server command for that
+ * language is used (typescript-language-server, pyright, gopls,
+ * rust-analyzer).
+ */
+export interface CodingGraphLspConfig {
+  /** Master gate for LSP resolution. Off = heuristic edges only. */
+  enabled: boolean;
+  /**
+   * Per-language server overrides. Each value is an argv array's first
+   * element (command) plus optional args. When absent for a language,
+   * the default server command is probed on PATH.
+   */
+  servers?: Record<string, { command: string; args?: string[] }>;
+  /** Per-request timeout in ms (default 3000). */
+  timeoutMs?: number;
+  /** Max LSP requests per reindex run (default 500). */
+  maxRequestsPerRun?: number;
 }
 
 // ChatConfig — conversational memory inspection and correction (issue #1583).


### PR DESCRIPTION
Closes #1917. Wires the LSP executor into the reindex pipeline so Phase B type resolution runs automatically when `codingKnowledge.lsp.enabled` is true.

## What lands

- **CodingGraphLspConfig** type (enabled, servers, timeoutMs, maxRequestsPerRun) parsed from `codingKnowledge.lsp` in the config parser
- **GraphStore.findNodeBySpan**: SQL lookup by span containment — powers the LSP executor's NodeLocator (maps definition locations back to indexed nodes)
- **runCodegraphLspResolution**: after a heuristic reindex, re-parses tracked files, gathers unresolved call sites, constructs an LSP client from config, invokes `executeLspResolution` with `store.upsertEdges` + `store.reconcileLspEdges` (#1895 reconciliation)
- **handleIndex** surface: calls `runLspResolution` after `runReindex` when LSP is enabled; LSP failure is non-fatal (heuristic edges survive)
- Interface extensions: `CodegraphModule` gains executeLspResolution/planLspUpgrades/createLspClient; `CodegraphStore` gains findNodeBySpan/reconcileLspEdges

## What this enables

With `codingKnowledge.lsp.enabled: true` and typescript-language-server installed, a `codegraph_index` call on a TS repo produces lsp-upgraded edges for calls Phase A left unresolved (member-call dispatch, cross-file type resolution). Member-call edges (Phase A deliberately skips them) appear for the first time.

## Prerequisites (already deployed)

- Language servers installed fleet-wide (typescript-language-server + pyright on all 6 hosts; rust-analyzer on macstudio)
- `@remnic/coding-graph` with the LSP executor (#1555) and reconciliation (#1895/#1914)
- Config: set `codingKnowledge.lsp.enabled: true` on the daemon hosts

Part of #1548 (Track B Phase 3).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in subprocess spawning and large orchestration around edge reconciliation could mis-retire or mis-write CALLS edges if guards fail, but defaults keep LSP off and failures are non-fatal to indexing.
> 
> **Overview**
> **Phase B LSP call resolution** is wired into `codegraph_index`: after a successful heuristic reindex, the runtime can spawn language servers (opt-in via `codingKnowledge.lsp.enabled`) to upgrade unresolved call sites to `lsp`-provenance `CALLS` edges, with budget limits, per-language server overrides, and soft degradation when servers or writes fail.
> 
> **Configuration** gains `CodingGraphLspConfig` (`enabled`, `servers`, `timeoutMs`, `maxRequestsPerRun`) in types, plugin JSON, and strict parsing (malformed `lsp` rejects; language keys validated against tier-1 list).
> 
> **Graph store** adds `findNodeBySpan` (innermost span, duplicate-name guard), `resolvedCalleeNames`, and `callEdgesForCaller` to support LSP node mapping and reconciliation without mis-attributing edges across files or retiring valid `lsp` rows.
> 
> **Runtime** implements `runCodegraphLspResolution` (re-parse tracked files, gather sites, symlink containment, UTF-8 callee offsets, preserve/reconcile `lsp` edges) and extends `handleIndex` to attach an `lsp` summary on success or degradation on failure without failing the index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 142b06da88b928f9ece53c7caeeaafb5e4a319e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->