### PR TITLE
fix(core): preserve LCM row lineage in recall

### DIFF
--- a/packages/remnic-core/src/access-lcm-surface.ts
+++ b/packages/remnic-core/src/access-lcm-surface.ts
@@ -11,6 +11,7 @@
 import { resolveNamespaceCapabilities } from "./capabilities.js";
 import { combineNamespaces, lcmSessionKeyForNamespace, resolveCodingNamespaceOverlay } from "./coding/coding-namespace.js";
 import { log } from "./logger.js";
+import { lcmEvidenceIdentity } from "./lcm/evidence-identity.js";
 import { canWriteNamespace, defaultNamespaceForPrincipal, recallNamespacesForPrincipal } from "./namespaces/principal.js";
 import type { Orchestrator } from "./orchestrator.js";
 import {
@@ -207,8 +208,8 @@ export class AccessLcmSurface {
         lcmEnabled: true,
       };
     }
-    // Query each LCM read key in order, merging + deduping rows (by
-    // sessionId+turnIndex) and preserving first-seen order, capped at `limit`.
+    // Query each LCM read key in order, merging + deduping by stable archive-row
+    // identity and preserving first-seen order, capped at `limit`.
     // Use allSettled so one corrupt/failed namespace key cannot discard sibling
     // results from other authorized profile namespaces.
     const seenRows = new Set<string>();
@@ -216,7 +217,14 @@ export class AccessLcmSurface {
     const lcmSearches: Array<{
       key: string | undefined;
       prefix: string | undefined;
-      promise: Promise<Array<{ session_id: string; content: string; turn_index: number }>>;
+      promise: Promise<
+        Array<{
+          id?: number;
+          session_id: string;
+          content: string;
+          turn_index: number;
+        }>
+      >;
     }> = [];
     for (const lcmSessionKey of lcmSessionKeyIds) {
       for (const lcmSessionPrefix of lcmSessionPrefixes) {
@@ -228,7 +236,14 @@ export class AccessLcmSurface {
             limit,
             lcmSessionKey,
             lcmSessionPrefix,
-          ) as Promise<Array<{ session_id: string; content: string; turn_index: number }>>,
+          ) as Promise<
+            Array<{
+              id?: number;
+              session_id: string;
+              content: string;
+              turn_index: number;
+            }>
+          >,
         });
       }
     }
@@ -246,7 +261,7 @@ export class AccessLcmSurface {
         continue;
       }
       for (const r of settled.value) {
-        const dedupeKey = `${r.session_id}\0${r.turn_index}`;
+        const dedupeKey = lcmEvidenceIdentity(r, r.session_id).id;
         if (seenRows.has(dedupeKey)) continue;
         seenRows.add(dedupeKey);
         results.push({

--- a/packages/remnic-core/src/access-recall-surface.ts
+++ b/packages/remnic-core/src/access-recall-surface.ts
@@ -18,6 +18,7 @@ import { throwIfAborted } from "./abort-error.js";
 import { resolveNamespaceCapabilities } from "./capabilities.js";
 import { resolveCodingNamespaceOverlay } from "./coding/coding-namespace.js";
 import { type BudgetDecision, CrossNamespaceBudget } from "./cross-namespace-budget.js";
+import { lcmEvidenceIdentity } from "./lcm/evidence-identity.js";
 import { normalizeProjectionTags } from "./memory-projection-format.js";
 import { namespaceIdentityFromToken } from "./namespaces/identity.js";
 import { canReadNamespace, defaultNamespaceForPrincipal, recallNamespacesForPrincipal, resolvePrincipal } from "./namespaces/principal.js";
@@ -593,7 +594,7 @@ export class AccessRecallSurface {
         if (excerpts.length >= limit) break;
         if (result.status !== "fulfilled") continue;
         for (const r of result.value) {
-          const dedupeKey = `${r.session_id} ${r.turn_index}`;
+          const dedupeKey = lcmEvidenceIdentity(r, r.session_id).id;
           if (seenRows.has(dedupeKey)) continue;
           seenRows.add(dedupeKey);
           excerpts.push({

--- a/packages/remnic-core/src/event-order-recall.ts
+++ b/packages/remnic-core/src/event-order-recall.ts
@@ -1,5 +1,6 @@
 import { buildEvidencePack, type EvidencePackItem } from "./evidence-pack.js";
 import type { ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
+import { lcmEvidenceIdentity } from "./lcm/evidence-identity.js";
 
 import {
   unifiedDedupeAndRank,
@@ -205,13 +206,14 @@ async function collectEventOrderItems(
       windowTokens,
     );
     for (const message of messages) {
-      const id = `${options.sessionId}:${message.turn_index}`;
+      const identity = lcmEvidenceIdentity(message, options.sessionId);
+      const id = identity.id;
       if (seen.has(id)) continue;
       if (!isEventOrderCandidate(message.content, message.role, options.query)) continue;
       seen.add(id);
       items.push({
-        id,
-        sessionId: options.sessionId,
+        ...identity,
+        sessionId: message.session_id ?? options.sessionId,
         turnIndex: message.turn_index,
         role: message.role,
         content: appendChronologicalCues(message.content, options.query),

--- a/packages/remnic-core/src/evidence-pack.ts
+++ b/packages/remnic-core/src/evidence-pack.ts
@@ -1,5 +1,7 @@
 export interface EvidencePackItem {
   id?: string;
+  /** Stable SQLite row lineage for diagnostics; intentionally not rendered. */
+  archiveRowId?: number;
   sessionId?: string;
   turnIndex?: number;
   role?: string;

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -4,6 +4,10 @@ import {
   resolveLcmReadSessionIds,
 } from "./lcm-fallback-read.js";
 import { unifiedDedupeAndRank } from "./recall-pipeline-stages.js";
+import {
+  lcmArchiveRowId,
+  lcmEvidenceIdentity,
+} from "./lcm/evidence-identity.js";
 
 export interface ExplicitCueRecallEngine {
   expandContext(
@@ -11,7 +15,15 @@ export interface ExplicitCueRecallEngine {
     fromTurn: number,
     toTurn: number,
     maxTokens: number,
-  ): Promise<Array<{ turn_index: number; role: string; content: string }>>;
+  ): Promise<
+    Array<{
+      id?: number;
+      session_id?: string;
+      turn_index: number;
+      role: string;
+      content: string;
+    }>
+  >;
   getStats?(sessionId?: string): Promise<{
     totalMessages: number;
     maxTurnIndex?: number;
@@ -22,6 +34,7 @@ export interface ExplicitCueRecallEngine {
     sessionId?: string,
   ): Promise<
     Array<{
+      id?: number;
       turn_index: number;
       role: string;
       content: string;
@@ -61,6 +74,16 @@ export type ExplicitTurnReference = {
   number: number;
   includeDirectTurn: boolean;
 };
+
+interface ExplicitCueEvidenceItem {
+  id: string;
+  archiveRowId?: number;
+  sessionId: string;
+  turnIndex: number;
+  role: string;
+  content: string;
+  score?: number;
+}
 
 const DEFAULT_MAX_CHARS = 2_400;
 const DEFAULT_MAX_ITEM_CHARS = 1_200;
@@ -326,23 +349,17 @@ export async function buildExplicitCueRecallSection(
     return "";
   }
 
-  const evidenceItems: Array<{
-    id: string;
-    sessionId: string;
-    turnIndex: number;
-    role: string;
-    content: string;
-    score?: number;
-  }> = [];
+  const evidenceItems: ExplicitCueEvidenceItem[] = [];
   const seenTurns = new Set<string>();
 
   // #1505 codex P2: gather cue evidence across the ordered LCM read key set
   // (primary overlay → project/root fallbacks) into ONE shared accumulator
   // (`evidenceItems` / `seenTurns`), so a branch-scoped session's project/root
   // fallback cues are RECOVERED instead of being skipped by the old
-  // first-non-empty short-circuit. `seenTurns` dedupes across keys by
-  // `session_id`+`turn_index`; the budget is applied exactly once in the
-  // `buildEvidencePack` call below. `gatherAcrossReadSessions` isolates a
+  // first-non-empty short-circuit. `seenTurns` is the historical local name;
+  // its keys use archive-row identity when available and fall back to
+  // `session_id`+`turn_index` for legacy engines. The budget is applied exactly
+  // once in the `buildEvidencePack` call below. `gatherAcrossReadSessions` isolates a
   // per-key read failure (a corrupt/locked fallback index must not discard the
   // other keys' cues); single-key recall runs each collector directly, so a
   // failure propagates exactly as before.
@@ -510,13 +527,7 @@ async function collectTurnReferenceEvidence(options: {
   sessionId?: string;
   query: string;
   maxReferences: number;
-  evidenceItems: Array<{
-    id: string;
-    sessionId: string;
-    turnIndex: number;
-    role: string;
-    content: string;
-  }>;
+  evidenceItems: ExplicitCueEvidenceItem[];
   seenTurns: Set<string>;
 }): Promise<void> {
   if (!options.sessionId) {
@@ -575,13 +586,7 @@ async function collectFocusedTranscriptCueEvidence(options: {
   engine: ExplicitCueRecallEngine;
   sessionId?: string;
   query: string;
-  evidenceItems: Array<{
-    id: string;
-    sessionId: string;
-    turnIndex: number;
-    role: string;
-    content: string;
-  }>;
+  evidenceItems: ExplicitCueEvidenceItem[];
   seenTurns: Set<string>;
 }): Promise<void> {
   if (!options.sessionId || !options.engine.getStats) {
@@ -611,8 +616,8 @@ async function collectFocusedTranscriptCueEvidence(options: {
         continue;
       }
       appendEvidenceItem(options.evidenceItems, options.seenTurns, {
-        id: `${options.sessionId}:${message.turn_index}`,
-        sessionId: options.sessionId,
+        ...lcmEvidenceIdentity(message, options.sessionId),
+        sessionId: message.session_id ?? options.sessionId,
         turnIndex: message.turn_index,
         role: message.role,
         content: message.content,
@@ -772,13 +777,7 @@ async function collectContentLabelReferenceEvidence(options: {
   sessionId?: string;
   query: string;
   references: ExplicitTurnReference[];
-  evidenceItems: Array<{
-    id: string;
-    sessionId: string;
-    turnIndex: number;
-    role: string;
-    content: string;
-  }>;
+  evidenceItems: ExplicitCueEvidenceItem[];
   seenTurns: Set<string>;
 }): Promise<Set<number>> {
   const resolved = new Set<number>();
@@ -818,7 +817,7 @@ async function collectContentLabelReferenceEvidence(options: {
       }
       if (expanded.length === 0) {
         appendEvidenceItem(options.evidenceItems, options.seenTurns, {
-          id: `${hit.session_id}:${hit.turn_index}`,
+          ...lcmEvidenceIdentity(hit, hit.session_id),
           sessionId: hit.session_id,
           turnIndex: hit.turn_index,
           role: hit.role,
@@ -845,6 +844,7 @@ async function searchReferenceContentLabels(
   sessionId?: string,
 ): Promise<
   Array<{
+    id?: number;
     turn_index: number;
     role: string;
     content: string;
@@ -855,6 +855,7 @@ async function searchReferenceContentLabels(
   const hits = new Map<
     string,
     {
+      id?: number;
       turn_index: number;
       role: string;
       content: string;
@@ -878,7 +879,8 @@ async function searchReferenceContentLabels(
         ) {
           continue;
         }
-        hits.set(`${result.session_id}:${result.turn_index}:${labelKind}`, {
+        hits.set(`${lcmEvidenceIdentity(result, result.session_id).id}:${labelKind}`, {
+          ...(typeof result.id === "number" ? { id: result.id } : {}),
           turn_index: result.turn_index,
           role: result.role,
           content: result.content,
@@ -1054,14 +1056,7 @@ async function collectLexicalCueEvidence(options: {
   includeBenchmarkAnchorCues?: boolean;
   includeContentLexicalCues?: boolean;
   includeStructuredPlanCues?: boolean;
-  evidenceItems: Array<{
-    id: string;
-    sessionId: string;
-    turnIndex: number;
-    role: string;
-    content: string;
-    score?: number;
-  }>;
+  evidenceItems: ExplicitCueEvidenceItem[];
   seenTurns: Set<string>;
 }): Promise<void> {
   const cues = prioritizeLexicalCueSearchCues(
@@ -1096,7 +1091,7 @@ async function collectLexicalCueEvidence(options: {
       );
       if (expanded.length === 0) {
         appendEvidenceItem(options.evidenceItems, options.seenTurns, {
-          id: `${result.session_id}:${result.turn_index}`,
+          ...lcmEvidenceIdentity(result, result.session_id),
           sessionId: result.session_id,
           turnIndex: result.turn_index,
           role: result.role,
@@ -1107,7 +1102,7 @@ async function collectLexicalCueEvidence(options: {
       }
       if (exactHitFirst) {
         appendEvidenceItem(options.evidenceItems, options.seenTurns, {
-          id: `${result.session_id}:${result.turn_index}`,
+          ...lcmEvidenceIdentity(result, result.session_id),
           sessionId: result.session_id,
           turnIndex: result.turn_index,
           role: result.role,
@@ -1131,6 +1126,8 @@ interface LabeledTrajectoryStep {
   observation?: string;
   actionTurnIndex?: number;
   observationTurnIndex?: number;
+  actionArchiveRowId?: number;
+  observationArchiveRowId?: number;
 }
 
 interface TrajectoryBounds {
@@ -1187,7 +1184,12 @@ function hasTrajectoryAnalysisIntent(query: string): boolean {
 }
 
 function parseLabeledTrajectory(
-  messages: Array<{ turn_index: number; role: string; content: string }>,
+  messages: Array<{
+    id?: number;
+    turn_index: number;
+    role: string;
+    content: string;
+  }>,
 ): LabeledTrajectoryStep[] {
   const byStep = new Map<number, LabeledTrajectoryStep>();
 
@@ -1197,6 +1199,8 @@ function parseLabeledTrajectory(
       const step = getOrCreateTrajectoryStep(byStep, action.step);
       step.action = action.value;
       step.actionTurnIndex = message.turn_index;
+      const archiveRowId = lcmArchiveRowId(message);
+      if (archiveRowId !== undefined) step.actionArchiveRowId = archiveRowId;
       continue;
     }
 
@@ -1205,6 +1209,10 @@ function parseLabeledTrajectory(
       const step = getOrCreateTrajectoryStep(byStep, observation.step);
       step.observation = observation.value;
       step.observationTurnIndex = message.turn_index;
+      const archiveRowId = lcmArchiveRowId(message);
+      if (archiveRowId !== undefined) {
+        step.observationArchiveRowId = archiveRowId;
+      }
     }
   }
 
@@ -4538,21 +4546,21 @@ function normalizeTrajectoryQuery(value: string): string {
 }
 
 function appendExpandedEvidence(
-  evidenceItems: Array<{
-    id: string;
-    sessionId: string;
-    turnIndex: number;
+  evidenceItems: ExplicitCueEvidenceItem[],
+  seenTurns: Set<string>,
+  sessionId: string,
+  expanded: Array<{
+    id?: number;
+    session_id?: string;
+    turn_index: number;
     role: string;
     content: string;
   }>,
-  seenTurns: Set<string>,
-  sessionId: string,
-  expanded: Array<{ turn_index: number; role: string; content: string }>,
 ): void {
   for (const message of expanded) {
     appendEvidenceItem(evidenceItems, seenTurns, {
-      id: `${sessionId}:${message.turn_index}`,
-      sessionId,
+      ...lcmEvidenceIdentity(message, sessionId),
+      sessionId: message.session_id ?? sessionId,
       turnIndex: message.turn_index,
       role: message.role,
       content: message.content,
@@ -4689,14 +4697,7 @@ async function collectNamedMeetingFactEvidence(options: {
   sessionId?: string;
   query: string;
   maxReferences: number;
-  evidenceItems: Array<{
-    id: string;
-    sessionId: string;
-    turnIndex: number;
-    role: string;
-    content: string;
-    score?: number;
-  }>;
+  evidenceItems: ExplicitCueEvidenceItem[];
   seenTurns: Set<string>;
 }): Promise<void> {
   const cues = collectMeetingFactCues(options.query)
@@ -4712,7 +4713,7 @@ async function collectNamedMeetingFactEvidence(options: {
     for (const result of results) {
       if (!isNamedMeetingFactEvidence(result.content, options.query)) continue;
       appendEvidenceItem(options.evidenceItems, options.seenTurns, {
-        id: `${result.session_id}:${result.turn_index}`,
+        ...lcmEvidenceIdentity(result, result.session_id),
         sessionId: result.session_id,
         turnIndex: result.turn_index,
         role: result.role,

--- a/packages/remnic-core/src/focused-list-recall.ts
+++ b/packages/remnic-core/src/focused-list-recall.ts
@@ -8,6 +8,7 @@ import {
   gatherAcrossReadSessions,
   resolveLcmReadSessionIds,
 } from "./lcm-fallback-read.js";
+import { isSameLcmRow, lcmEvidenceIdentity } from "./lcm/evidence-identity.js";
 
 export interface FocusedListRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
@@ -134,27 +135,35 @@ async function collectFocusedListItems(
       result.turn_index + searchWindowAfter,
       searchWindowTokens,
     );
+    const searchIdentity = lcmEvidenceIdentity(result, result.session_id);
     const searchHit: EvidencePackItem = {
-      id: `${result.session_id}:${result.turn_index}`,
+      ...searchIdentity,
       sessionId: result.session_id,
       turnIndex: result.turn_index,
       role: result.role,
       content: result.content,
       ...(typeof result.score === "number" ? { score: result.score } : {}),
     };
-    const candidates: EvidencePackItem[] = expanded.map((message) => ({
-      id: `${result.session_id}:${message.turn_index}`,
-      sessionId: result.session_id,
-      turnIndex: message.turn_index,
-      role: message.role,
-      content: message.content,
-      ...(message.turn_index === result.turn_index &&
-      typeof result.score === "number"
-        ? { score: result.score }
-        : {}),
-    }));
-    const hitIndex = candidates.findIndex((candidate) =>
-      candidate.turnIndex === result.turn_index
+    const candidates: EvidencePackItem[] = expanded.map((message) => {
+      const matchesSearchHit = isSameLcmRow(
+        message,
+        result.session_id,
+        result,
+        result.session_id,
+      );
+      return {
+        ...lcmEvidenceIdentity(message, result.session_id),
+        sessionId: message.session_id ?? result.session_id,
+        turnIndex: message.turn_index,
+        role: message.role,
+        content: message.content,
+        ...(matchesSearchHit && typeof result.score === "number"
+          ? { score: result.score }
+          : {}),
+      };
+    });
+    const hitIndex = expanded.findIndex((message) =>
+      isSameLcmRow(message, result.session_id, result, result.session_id)
     );
     if (hitIndex >= 0) {
       candidates[hitIndex] = searchHit;
@@ -221,8 +230,8 @@ async function collectFocusedListScanItems(
   );
   for (const message of messages) {
     const candidate = {
-      id: `${options.sessionId}:${message.turn_index}`,
-      sessionId: options.sessionId,
+      ...lcmEvidenceIdentity(message, options.sessionId),
+      sessionId: message.session_id ?? options.sessionId,
       turnIndex: message.turn_index,
       role: message.role,
       content: message.content,

--- a/packages/remnic-core/src/lcm-retrieval-lineage.test.ts
+++ b/packages/remnic-core/src/lcm-retrieval-lineage.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AccessLcmSurface, type AccessLcmSurfaceDeps } from "./access-lcm-surface.js";
+import {
+  AccessRecallSurface,
+  type AccessRecallSurfaceDeps,
+} from "./access-recall-surface.js";
+import { buildEventOrderRecallSection } from "./event-order-recall.js";
+import { buildExplicitCueRecallSection, type ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
+import { buildFocusedListRecallSection } from "./focused-list-recall.js";
+import {
+  isSameLcmRow,
+  lcmEvidenceIdentity,
+} from "./lcm/evidence-identity.js";
+import { buildResponseGuidanceRecallSection } from "./response-guidance-recall.js";
+import { buildTargetedFactRecallSection } from "./targeted-fact-recall.js";
+
+interface TestRow {
+  id?: number;
+  session_id: string;
+  turn_index: number;
+  role: string;
+  content: string;
+}
+
+class LineageEngine implements ExplicitCueRecallEngine {
+  constructor(
+    private readonly rows: TestRow[],
+    private readonly searchRowId?: number,
+    private readonly searchContent?: string,
+  ) {}
+
+  async expandContext(
+    sessionId: string,
+    fromTurn: number,
+    toTurn: number,
+    _maxTokens: number,
+  ): Promise<TestRow[]> {
+    return this.rows.filter((row) =>
+      row.session_id === sessionId &&
+      row.turn_index >= fromTurn &&
+      row.turn_index <= toTurn
+    );
+  }
+
+  async searchContextFull(): Promise<
+    Array<TestRow & { score: number }>
+  > {
+    const row = this.rows.find((candidate) => candidate.id === this.searchRowId);
+    return row
+      ? [{
+          ...row,
+          content: this.searchContent ?? row.content,
+          score: 99,
+        }]
+      : [];
+  }
+
+  async getStats(sessionId?: string): Promise<{
+    totalMessages: number;
+    maxTurnIndex?: number;
+  }> {
+    const rows = sessionId
+      ? this.rows.filter((row) => row.session_id === sessionId)
+      : this.rows;
+    return {
+      totalMessages: rows.length,
+      maxTurnIndex: rows.length > 0
+        ? Math.max(...rows.map((row) => row.turn_index))
+        : undefined,
+    };
+  }
+}
+
+test("LCM evidence identity distinguishes sibling rows and preserves the legacy fallback", () => {
+  const first = { id: 41, session_id: "session", turn_index: 7 };
+  const second = { id: 42, session_id: "session", turn_index: 7 };
+  assert.notEqual(
+    lcmEvidenceIdentity(first, "session").id,
+    lcmEvidenceIdentity(second, "session").id,
+  );
+  assert.equal(isSameLcmRow(first, "session", second, "session"), false);
+  assert.equal(
+    lcmEvidenceIdentity({ turn_index: 7 }, "session").id,
+    "session:7",
+  );
+  assert.equal(
+    isSameLcmRow(
+      { turn_index: 7 },
+      "session",
+      { turn_index: 7 },
+      "session",
+    ),
+    true,
+  );
+});
+
+test("explicit-cue recall keeps distinct archive rows that share a turn", async () => {
+  const engine = new LineageEngine([
+    { id: 101, session_id: "s", turn_index: 7, role: "user", content: "First row at the referenced turn." },
+    { id: 102, session_id: "s", turn_index: 7, role: "assistant", content: "Second row at the referenced turn." },
+  ]);
+  const recalled = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "s",
+    query: "Review turn 7",
+    maxChars: 4_000,
+  });
+  assert.match(recalled, /First row at the referenced turn/);
+  assert.match(recalled, /Second row at the referenced turn/);
+});
+
+test("targeted recall replaces and scores only the matching same-turn row", async () => {
+  const engine = new LineageEngine([
+    { id: 101, session_id: "s", turn_index: 7, role: "user", content: "I earn approximately $100,000 CAD annually as a senior engineer." },
+    { id: 102, session_id: "s", turn_index: 7, role: "user", content: "My recent raise to $110,000 CAD as a senior engineer at Saint Pierre Manufacturing Ltd is now effective." },
+  ], 102, "The matching row records my recent raise to $110,000 CAD as a senior engineer at Saint Pierre Manufacturing Ltd.");
+  const recalled = await buildTargetedFactRecallSection({
+    engine,
+    sessionId: "s",
+    query: "What is my annual salary as a senior engineer at Saint Pierre Manufacturing Ltd?",
+    maxChars: 6_000,
+  });
+  assert.match(recalled, /earn approximately \$100,000 CAD annually/);
+  assert.match(recalled, /matching row records my recent raise to \$110,000 CAD/);
+});
+
+test("focused-list recall keeps distinct same-turn calculations while matching the search row", async () => {
+  const engine = new LineageEngine([
+    { id: 101, session_id: "s", turn_index: 7, role: "user", content: "Can you help me calculate P(both heads) = 1/2 x 1/2 = 1/4 so I can make sure I get it right?" },
+    { id: 102, session_id: "s", turn_index: 7, role: "user", content: "I am trying to verify if P(rolling a number greater than 4) = 2/6 = 1/3 is correct." },
+  ], 102, "I confirmed P(rolling a number greater than 4) = 2/6 = 1/3.");
+  const recalled = await buildFocusedListRecallSection({
+    engine,
+    sessionId: "s",
+    query: "In my questions about tossing coins and rolling dice, how many different probability calculations did I try to confirm?",
+    maxChars: 6_000,
+  });
+  assert.match(recalled, /P\(both heads\)/);
+  assert.match(recalled, /P\(rolling a number greater than 4\)/);
+});
+
+test("response guidance keeps distinct same-turn rows while preserving its existing filters", async () => {
+  const engine = new LineageEngine([
+    { id: 101, session_id: "s", turn_index: 7, role: "user", content: "I prefer a structured daily routine with a written priority list each morning." },
+    { id: 102, session_id: "s", turn_index: 7, role: "user", content: "My structured daily routine schedules focused work blocks and buffer time between meetings." },
+  ], 102, "My structured daily routine schedules focused work blocks and buffer time between meetings.");
+  const recalled = await buildResponseGuidanceRecallSection({
+    engine,
+    sessionId: "s",
+    query: "How should I organize my day to stay on track?",
+    maxChars: 6_000,
+  });
+  assert.match(recalled, /written priority list each morning/);
+  assert.match(recalled, /focused work blocks/);
+});
+
+test("event-order recall keeps distinct same-turn chronological rows", async () => {
+  const engine = new LineageEngine([
+    { id: 101, session_id: "s", turn_index: 7, role: "user", content: "Patrick suggested a March workshop on workflow optimization." },
+    { id: 102, session_id: "s", turn_index: 7, role: "user", content: "Patrick and I planned an interview tips meeting for tomorrow." },
+  ]);
+  const recalled = await buildEventOrderRecallSection({
+    engine,
+    sessionId: "s",
+    query: "Walk me through my interactions with Patrick in order.",
+    maxChars: 6_000,
+  });
+  assert.match(recalled, /workshop suggestion/);
+  assert.match(recalled, /interview tips meeting/);
+});
+
+function accessSearchDeps(rows: TestRow[]): AccessLcmSurfaceDeps {
+  const orchestrator = {
+    config: {
+      defaultNamespace: "default",
+      namespaces: false,
+    },
+    lcmEngine: {
+      enabled: true,
+      searchContextFull: async () => rows,
+    },
+  };
+  return {
+    orchestrator,
+    lcmSessionIdsForNamespaces: () => ["primary", "fallback"],
+    resolveImplicitLcmReadFallbackNamespace: () => "default",
+    resolveLcmReadNamespace: () => "default",
+    resolveLcmReadSessionIds: () => ["primary", "fallback"],
+    resolveLcmReadSessionKey: () => "primary",
+    resolveReadableNamespace: () => "default",
+    resolveRequestPrincipal: () => "default",
+    resolveScopeProfileLcmReadNamespaces: () => null,
+  } as unknown as AccessLcmSurfaceDeps;
+}
+
+test("access LCM search dedupes repeated rows but retains same-turn siblings", async () => {
+  const rows: TestRow[] = [
+    { id: 101, session_id: "s", turn_index: 7, role: "user", content: "first sibling" },
+    { id: 102, session_id: "s", turn_index: 7, role: "assistant", content: "second sibling" },
+  ];
+  const response = await new AccessLcmSurface(accessSearchDeps(rows)).lcmSearch({
+    query: "sibling",
+    sessionKey: "s",
+  });
+  assert.deepEqual(response.results.map((row) => row.content), [
+    "first sibling",
+    "second sibling",
+  ]);
+});
+
+test("raw excerpts dedupe repeated rows but retain same-turn siblings", async () => {
+  const rows: TestRow[] = [
+    { id: 101, session_id: "s", turn_index: 7, role: "user", content: "first sibling" },
+    { id: 102, session_id: "s", turn_index: 7, role: "assistant", content: "second sibling" },
+  ];
+  const deps = {
+    orchestrator: {
+      config: { defaultNamespace: "default" },
+      lcmEngine: {
+        enabled: true,
+        searchContextFull: async () => rows,
+      },
+    },
+  } as unknown as AccessRecallSurfaceDeps;
+  const excerpts = await new AccessRecallSurface(deps).fetchRawExcerpts("raw", {
+    query: "sibling",
+    sessionKey: "s",
+    lcmSessionIds: ["primary", "fallback"],
+  });
+  assert.deepEqual(excerpts?.map((row) => row.content), [
+    "first sibling",
+    "second sibling",
+  ]);
+});

--- a/packages/remnic-core/src/lcm/evidence-identity.ts
+++ b/packages/remnic-core/src/lcm/evidence-identity.ts
@@ -1,0 +1,59 @@
+export interface LcmRowIdentity {
+  id?: number;
+  session_id?: string;
+  turn_index: number;
+}
+
+export interface LcmEvidenceIdentity {
+  id: string;
+  archiveRowId?: number;
+}
+
+export function lcmArchiveRowId(row: Pick<LcmRowIdentity, "id">): number | undefined {
+  const value = row.id;
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function resolveSessionId(row: LcmRowIdentity, fallbackSessionId: string): string {
+  return row.session_id ?? fallbackSessionId;
+}
+
+/**
+ * Build the non-rendered evidence identity for an LCM archive row.
+ *
+ * Older adapters and test doubles may omit the SQLite row id. Those callers
+ * retain the historical session+turn identity until they adopt row lineage.
+ */
+export function lcmEvidenceIdentity(
+  row: LcmRowIdentity,
+  fallbackSessionId: string,
+): LcmEvidenceIdentity {
+  const sessionId = resolveSessionId(row, fallbackSessionId);
+  const archiveRowId = lcmArchiveRowId(row);
+  if (archiveRowId === undefined) {
+    return { id: `${sessionId}:${row.turn_index}` };
+  }
+  return {
+    id: JSON.stringify(["lcm-row", sessionId, archiveRowId]),
+    archiveRowId,
+  };
+}
+
+/** Match a search hit to its expanded archive row without conflating siblings. */
+export function isSameLcmRow(
+  left: LcmRowIdentity,
+  leftFallbackSessionId: string,
+  right: LcmRowIdentity,
+  rightFallbackSessionId: string,
+): boolean {
+  const leftRowId = lcmArchiveRowId(left);
+  const rightRowId = lcmArchiveRowId(right);
+  const leftSessionId = resolveSessionId(left, leftFallbackSessionId);
+  const rightSessionId = resolveSessionId(right, rightFallbackSessionId);
+  if (leftRowId !== undefined && rightRowId !== undefined) {
+    return leftRowId === rightRowId && leftSessionId === rightSessionId;
+  }
+  return leftSessionId === rightSessionId && left.turn_index === right.turn_index;
+}

--- a/packages/remnic-core/src/lcm/index.ts
+++ b/packages/remnic-core/src/lcm/index.ts
@@ -4,6 +4,13 @@ export {
   type LcmEngineConfig,
   type LcmExpandedMessage,
 } from "./engine.js";
+export {
+  isSameLcmRow,
+  lcmArchiveRowId,
+  lcmEvidenceIdentity,
+  type LcmEvidenceIdentity,
+  type LcmRowIdentity,
+} from "./evidence-identity.js";
 export { LcmArchive, estimateTokens } from "./archive.js";
 export { LcmDag, type SummaryNode } from "./dag.js";
 export { LcmSummarizer, type SummarizeFn } from "./summarizer.js";

--- a/packages/remnic-core/src/response-guidance-recall.ts
+++ b/packages/remnic-core/src/response-guidance-recall.ts
@@ -1,5 +1,6 @@
 import { buildEvidencePack, type EvidencePackItem } from "./evidence-pack.js";
 import type { ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
+import { isSameLcmRow, lcmEvidenceIdentity } from "./lcm/evidence-identity.js";
 import {
   gatherAcrossReadSessions,
   resolveLcmReadSessionIds,
@@ -252,19 +253,26 @@ async function collectGuidanceItems(
       searchWindowTokens,
     );
     const candidates = expanded.length > 0
-      ? expanded.map((message) => ({
-          id: `${result.session_id}:${message.turn_index}`,
-          sessionId: result.session_id,
-          turnIndex: message.turn_index,
-          role: message.role,
-          content: message.content,
-          ...(message.turn_index === result.turn_index &&
-          typeof result.score === "number"
-            ? { score: result.score }
-            : {}),
-        }))
+      ? expanded.map((message) => {
+          const matchesSearchHit = isSameLcmRow(
+            message,
+            result.session_id,
+            result,
+            result.session_id,
+          );
+          return {
+            ...lcmEvidenceIdentity(message, result.session_id),
+            sessionId: message.session_id ?? result.session_id,
+            turnIndex: message.turn_index,
+            role: message.role,
+            content: message.content,
+            ...(matchesSearchHit && typeof result.score === "number"
+              ? { score: result.score }
+              : {}),
+          };
+        })
       : [{
-          id: `${result.session_id}:${result.turn_index}`,
+          ...lcmEvidenceIdentity(result, result.session_id),
           sessionId: result.session_id,
           turnIndex: result.turn_index,
           role: result.role,
@@ -331,8 +339,8 @@ async function collectGuidanceScanItems(
   for (const message of messages) {
     if (!isGuidanceEvidence(message.content, options.query, intents, options.forceGeneric === true)) continue;
     items.push({
-      id: `${options.sessionId}:${message.turn_index}`,
-      sessionId: options.sessionId,
+      ...lcmEvidenceIdentity(message, options.sessionId),
+      sessionId: message.session_id ?? options.sessionId,
       turnIndex: message.turn_index,
       role: message.role,
       content: message.content,

--- a/packages/remnic-core/src/targeted-fact-recall.ts
+++ b/packages/remnic-core/src/targeted-fact-recall.ts
@@ -8,6 +8,7 @@ import {
   gatherAcrossReadSessions,
   resolveLcmReadSessionIds,
 } from "./lcm-fallback-read.js";
+import { isSameLcmRow, lcmEvidenceIdentity } from "./lcm/evidence-identity.js";
 
 import {
   unifiedDedupeAndRank,
@@ -124,27 +125,35 @@ async function collectTargetedFactSearchItems(
       result.turn_index + searchWindowAfter,
       searchWindowTokens,
     );
+    const searchIdentity = lcmEvidenceIdentity(result, result.session_id);
     const searchHit: EvidencePackItem = {
-      id: `${result.session_id}:${result.turn_index}`,
+      ...searchIdentity,
       sessionId: result.session_id,
       turnIndex: result.turn_index,
       role: result.role,
       content: result.content,
       ...(typeof result.score === "number" ? { score: result.score } : {}),
     };
-    const candidates: EvidencePackItem[] = expanded.map((message) => ({
-      id: `${result.session_id}:${message.turn_index}`,
-      sessionId: result.session_id,
-      turnIndex: message.turn_index,
-      role: message.role,
-      content: message.content,
-      ...(message.turn_index === result.turn_index &&
-      typeof result.score === "number"
-        ? { score: result.score }
-        : {}),
-    }));
-    const hitIndex = candidates.findIndex((candidate) =>
-      candidate.turnIndex === result.turn_index
+    const candidates: EvidencePackItem[] = expanded.map((message) => {
+      const matchesSearchHit = isSameLcmRow(
+        message,
+        result.session_id,
+        result,
+        result.session_id,
+      );
+      return {
+        ...lcmEvidenceIdentity(message, result.session_id),
+        sessionId: message.session_id ?? result.session_id,
+        turnIndex: message.turn_index,
+        role: message.role,
+        content: message.content,
+        ...(matchesSearchHit && typeof result.score === "number"
+          ? { score: result.score }
+          : {}),
+      };
+    });
+    const hitIndex = expanded.findIndex((message) =>
+      isSameLcmRow(message, result.session_id, result, result.session_id)
     );
     if (hitIndex >= 0) {
       candidates[hitIndex] = searchHit;
@@ -200,8 +209,8 @@ async function collectTargetedFactScanItems(
   for (const message of messages) {
     if (!isTargetedFactEvidence(message.content, options.query)) continue;
     items.push({
-      id: `${options.sessionId}:${message.turn_index}`,
-      sessionId: options.sessionId,
+      ...lcmEvidenceIdentity(message, options.sessionId),
+      sessionId: message.session_id ?? options.sessionId,
       turnIndex: message.turn_index,
       role: message.role,
       content: message.content,


### PR DESCRIPTION
## Summary
- carry stable numeric LCM archive-row identity through explicit, targeted, focused, guidance, event, and access recall paths
- match search replacements and score inheritance by physical row instead of conflating same-turn siblings
- retain legacy session/turn fallback for adapters and mocks without row IDs
- keep rendered output, ranking policy, and each tier's existing content-deduplication behavior unchanged

## Verification
- focused lineage + characterization suites (293/293)
- `pnpm --filter @remnic/core check-types`
- `npm run test:entity-hardening` (246/246)
- `npm run preflight:quick`
- `git diff --check origin/main...HEAD`
- independent review: no actionable findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many recall and access read paths where wrong dedupe would drop or merge transcript evidence; behavior is intentionally backward-compatible when row ids are absent, but same-turn multi-row archives change materially when ids are present.
> 
> **Overview**
> Introduces **`lcm/evidence-identity`** (`lcmEvidenceIdentity`, `isSameLcmRow`, optional `archiveRowId`) so LCM archive rows are keyed by SQLite row id when present, with **`session:turn`** fallback when ids are missing.
> 
> **Deduping and evidence IDs** across `lcmSearch`, raw excerpts, explicit-cue, targeted/focused-list/response-guidance/event-order recall, and related paths now use that stable identity instead of **`session_id` + `turn_index`**, so multiple messages at the same turn are no longer collapsed into one row.
> 
> **Search-hit handling** in targeted, focused-list, and response-guidance recall uses **`isSameLcmRow`** to attach relevance scores and replace the correct physical row when expanding context around a hit.
> 
> `EvidencePackItem` gains optional **`archiveRowId`** for diagnostics (not rendered). Engine typings accept optional **`id`** on LCM rows. **`lcm-retrieval-lineage.test.ts`** characterizes sibling same-turn behavior end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0f53d829a95b483db801af82f549e115353e9bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->