### PR TITLE
feat(core): add recall selection receipts

### DIFF
--- a/packages/remnic-core/src/evidence-pack.test.ts
+++ b/packages/remnic-core/src/evidence-pack.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildEvidencePack } from "./evidence-pack.js";
+import {
+  buildEvidencePack,
+  type EvidencePackSelectionReceipt,
+} from "./evidence-pack.js";
 
 test("buildEvidencePack deduplicates evidence and stays within budget", () => {
   const pack = buildEvidencePack(
@@ -86,4 +89,66 @@ test("buildEvidencePack keeps query-focused evidence from later long turns", () 
   assert.match(pack, /source_chat_id=2/);
   assert.match(pack, /Dec 16, 2023 - Jan 15, 2024/);
   assert.match(pack, /Feb 16 - Mar 15, 2024/);
+});
+
+test("buildEvidencePack reports only appended blocks with exact content-free offsets", () => {
+  const receipts: EvidencePackSelectionReceipt[] = [];
+  const items = [
+    {
+      id: "selected",
+      archiveRowId: 41,
+      sessionId: "private-session",
+      turnIndex: 7,
+      role: "user",
+      content: "selected private evidence",
+      score: 2,
+    },
+    {
+      id: "duplicate-content",
+      archiveRowId: 42,
+      sessionId: "private-session",
+      turnIndex: 8,
+      role: "assistant",
+      content: "selected private evidence",
+      score: 1,
+    },
+    {
+      id: "budget-rejected",
+      archiveRowId: 43,
+      sessionId: "private-session",
+      turnIndex: 9,
+      role: "assistant",
+      content: "this block cannot fit inside the remaining budget",
+    },
+  ];
+  const options = {
+    title: "Receipt evidence",
+    maxChars:
+      "## Receipt evidence".length +
+      2 +
+      "[private-session, turn 7, user, score 2.000]: selected private evidence".length,
+    maxItemChars: 200,
+  };
+
+  const baseline = buildEvidencePack(items, options);
+  const traced = buildEvidencePack(items, {
+    ...options,
+    onSelection: (receipt) => receipts.push(receipt),
+  });
+
+  assert.equal(traced, baseline);
+  assert.equal(receipts.length, 1);
+  const receipt = receipts[0]!;
+  assert.equal(
+    traced.slice(receipt.blockStart, receipt.blockEnd),
+    "[private-session, turn 7, user, score 2.000]: selected private evidence",
+  );
+  assert.deepEqual(receipt.item, {
+    archiveRowId: 41,
+    turnIndex: 7,
+    role: "user",
+    score: 2,
+  });
+  assert.equal("content" in receipt.item, false);
+  assert.equal("sessionId" in receipt.item, false);
 });

--- a/packages/remnic-core/src/evidence-pack.ts
+++ b/packages/remnic-core/src/evidence-pack.ts
@@ -14,6 +14,23 @@ export interface EvidencePackOptions {
   maxChars: number;
   maxItemChars?: number;
   query?: string;
+  /** Optional non-rendering receipt for each block actually appended. */
+  onSelection?: (receipt: EvidencePackSelectionReceipt) => void;
+}
+
+/** Content-free identity fields for an evidence item that survived selection. */
+export interface EvidencePackSelectedItem {
+  archiveRowId?: number;
+  turnIndex?: number;
+  role?: string;
+  score?: number;
+}
+
+export interface EvidencePackSelectionReceipt {
+  item: EvidencePackSelectedItem;
+  /** Half-open offsets within the returned evidence-pack string. */
+  blockStart: number;
+  blockEnd: number;
 }
 
 const DEFAULT_MAX_ITEM_CHARS = 1_200;
@@ -96,13 +113,35 @@ export function buildEvidencePack(
       block.length > remaining ? clipText(block, remaining) : block;
     if (!finalBlock.trim()) break;
 
+    const blockStart = used + separatorLength;
+    const blockEnd = blockStart + finalBlock.length;
     lines.push(finalBlock);
     used += separatorLength + finalBlock.length;
     if (id) seenIds.add(id);
     seenContent.add(contentKey);
+    options.onSelection?.({
+      item: evidencePackSelectedItem(item),
+      blockStart,
+      blockEnd,
+    });
   }
 
   return lines.length === 1 ? "" : lines.join("\n\n");
+}
+
+function evidencePackSelectedItem(
+  item: EvidencePackItem,
+): EvidencePackSelectedItem {
+  return {
+    ...(typeof item.archiveRowId === "number"
+      ? { archiveRowId: item.archiveRowId }
+      : {}),
+    ...(typeof item.turnIndex === "number" ? { turnIndex: item.turnIndex } : {}),
+    ...(typeof item.role === "string" ? { role: item.role } : {}),
+    ...(typeof item.score === "number" && Number.isFinite(item.score)
+      ? { score: item.score }
+      : {}),
+  };
 }
 
 export function insertAfterEvidenceHeading(

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -1,4 +1,7 @@
-import { buildEvidencePack } from "./evidence-pack.js";
+import {
+  buildEvidencePack,
+  type EvidencePackSelectionReceipt,
+} from "./evidence-pack.js";
 import {
   gatherAcrossReadSessions,
   resolveLcmReadSessionIds,
@@ -61,6 +64,8 @@ export interface ExplicitCueRecallOptions {
   includeBenchmarkAnchorCues?: boolean;
   includeContentLexicalCues?: boolean;
   includeStructuredPlanCues?: boolean;
+  /** Observe selected evidence blocks without changing rendered output. */
+  onEvidenceSelected?: (receipt: EvidencePackSelectionReceipt) => void;
 }
 
 export interface TrajectoryAnalysisRecallOptions {
@@ -68,6 +73,18 @@ export interface TrajectoryAnalysisRecallOptions {
   sessionId?: string;
   query: string;
   maxChars: number;
+  /** Observe only emitted lines; unavailable lineage is never guessed. */
+  onLineSelected?: (receipt: TrajectoryAnalysisLineReceipt) => void;
+}
+
+export interface TrajectoryAnalysisLineReceipt {
+  /** Half-open offsets within the returned trajectory section. */
+  lineStart: number;
+  lineEnd: number;
+  /** Whether the source row set is structurally exact or unavailable. */
+  lineageStatus: "exact" | "unavailable";
+  actionArchiveRowIds: number[];
+  observationArchiveRowIds: number[];
 }
 
 export type ExplicitTurnReference = {
@@ -455,6 +472,9 @@ export async function buildExplicitCueRecallSection(
       options.maxItemChars,
       DEFAULT_MAX_ITEM_CHARS,
     ),
+    ...(options.onEvidenceSelected
+      ? { onSelection: options.onEvidenceSelected }
+      : {}),
   });
 }
 
@@ -519,7 +539,32 @@ export async function buildTrajectoryAnalysisRecallSection(
   }
 
   const clipped = truncateTrajectoryAnalysisLines(lines, bodyBudget);
-  return clipped.length === 0 ? "" : `${header}\n${clipped.join("\n")}`;
+  if (clipped.length === 0) return "";
+  const text = `${header}\n${clipped.map((line) => line.text).join("\n")}`;
+  if (options.onLineSelected) {
+    let lineStart = header.length + 1;
+    for (const line of clipped) {
+      const lineEnd = lineStart + line.text.length;
+      options.onLineSelected({
+        lineStart,
+        lineEnd,
+        lineageStatus: line.lineageStatus,
+        actionArchiveRowIds: [...line.actionArchiveRowIds],
+        observationArchiveRowIds: [...line.observationArchiveRowIds],
+      });
+      lineStart = lineEnd + 1;
+    }
+  }
+  return text;
+}
+
+function uniqueSortedArchiveRowIds(
+  values: readonly (number | undefined)[],
+): number[] {
+  return [...new Set(values.filter(
+    (value): value is number =>
+      typeof value === "number" && Number.isSafeInteger(value) && value > 0,
+  ))].sort((left, right) => left - right);
 }
 
 async function collectTurnReferenceEvidence(options: {
@@ -1130,6 +1175,65 @@ interface LabeledTrajectoryStep {
   observationArchiveRowId?: number;
 }
 
+interface TrajectoryLineSource {
+  lineageStatus: "exact" | "unavailable";
+  actionArchiveRowIds: number[];
+  observationArchiveRowIds: number[];
+}
+
+interface SelectedTrajectoryLine extends TrajectoryLineSource {
+  text: string;
+}
+
+class TrajectoryAnalysisLines extends Array<string> {
+  private readonly sources = new Map<number, TrajectoryLineSource>();
+
+  pushWithSources(
+    text: string,
+    actionSteps: readonly LabeledTrajectoryStep[] = [],
+    observationSteps: readonly LabeledTrajectoryStep[] = [],
+  ): number {
+    const index = this.length;
+    const length = super.push(text);
+    const hasUnavailableSource =
+      actionSteps.some((step) =>
+        lcmArchiveRowId({ id: step.actionArchiveRowId }) === undefined
+      ) ||
+      observationSteps.some((step) =>
+        lcmArchiveRowId({ id: step.observationArchiveRowId }) === undefined
+      );
+    this.sources.set(index, {
+      lineageStatus: hasUnavailableSource ? "unavailable" : "exact",
+      actionArchiveRowIds: hasUnavailableSource
+        ? []
+        : uniqueSortedArchiveRowIds(
+            actionSteps.map((step) => step.actionArchiveRowId),
+          ),
+      observationArchiveRowIds: hasUnavailableSource
+        ? []
+        : uniqueSortedArchiveRowIds(
+            observationSteps.map((step) => step.observationArchiveRowId),
+          ),
+    });
+    return length;
+  }
+
+  sourceAt(index: number): TrajectoryLineSource {
+    const source = this.sources.get(index);
+    return source
+      ? {
+          lineageStatus: source.lineageStatus,
+          actionArchiveRowIds: [...source.actionArchiveRowIds],
+          observationArchiveRowIds: [...source.observationArchiveRowIds],
+        }
+      : {
+          lineageStatus: "unavailable",
+          actionArchiveRowIds: [],
+          observationArchiveRowIds: [],
+        };
+  }
+}
+
 interface TrajectoryBounds {
   start: number;
   end: number;
@@ -1315,12 +1419,13 @@ function buildTrajectoryAnalysisLines(
   query: string,
   trajectory: readonly LabeledTrajectoryStep[],
   bounds: TrajectoryBounds,
-): string[] {
+): TrajectoryAnalysisLines {
   const normalized = normalizeTrajectoryQuery(query);
   const explicitReferences = collectExplicitTurnReferences(query);
-  const lines: string[] = [
+  const lines = new TrajectoryAnalysisLines();
+  lines.pushWithSources(
     `Analyzed labeled action/observation transcript window: steps ${bounds.start}-${bounds.end} (${bounds.reason}).`,
-  ];
+  );
   const hasQuotedObservationPair = extractQuotedObservations(query).length >= 2;
   const transition = findObservationTransition(query, trajectory);
   const entities = extractNumberedEntities(query);
@@ -1340,8 +1445,14 @@ function buildTrajectoryAnalysisLines(
     /\bwhat\s+will\s+be\s+the\s+resulting\b/.test(normalized);
 
   if (transition) {
-    lines.push(
+    const fromStep = trajectory.find((step) => step.step === transition.fromStep);
+    const toStep = trajectory.find((step) => step.step === transition.toStep);
+    lines.pushWithSources(
       `Matched quoted observations: Observation ${transition.fromStep} -> Observation ${transition.toStep}.`,
+      [],
+      [fromStep, toStep].filter(
+        (step): step is LabeledTrajectoryStep => step !== undefined,
+      ),
     );
     appendActionSequenceSummary(
       lines,
@@ -1424,11 +1535,11 @@ function buildTrajectoryAnalysisLines(
     }
   }
 
-  return lines.length === 1 ? [] : lines;
+  return lines.length === 1 ? new TrajectoryAnalysisLines() : lines;
 }
 
 function appendReferencedTrajectoryLines(
-  lines: string[],
+  lines: TrajectoryAnalysisLines,
   trajectory: readonly LabeledTrajectoryStep[],
   references: readonly ExplicitTurnReference[],
   options: { includeObservations: boolean; heading: string },
@@ -1442,19 +1553,23 @@ function appendReferencedTrajectoryLines(
     return;
   }
 
-  lines.push(options.heading);
+  lines.pushWithSources(options.heading);
   for (const step of window) {
     if (step.action) {
-      lines.push(`[Action ${step.step}]: ${step.action}`);
+      lines.pushWithSources(`[Action ${step.step}]: ${step.action}`, [step]);
     }
     if (options.includeObservations && step.observation) {
-      lines.push(`[Observation ${step.step}]: ${oneLine(step.observation)}`);
+      lines.pushWithSources(
+        `[Observation ${step.step}]: ${oneLine(step.observation)}`,
+        [],
+        [step],
+      );
     }
   }
 }
 
 function appendActionRangeLines(
-  lines: string[],
+  lines: TrajectoryAnalysisLines,
   trajectory: readonly LabeledTrajectoryStep[],
   start: number,
   end: number,
@@ -1470,19 +1585,23 @@ function appendActionRangeLines(
   if (window.length === 0) {
     return;
   }
-  lines.push(options.heading);
+  lines.pushWithSources(options.heading);
   for (const step of window) {
     if (step.action) {
-      lines.push(`[Action ${step.step}]: ${step.action}`);
+      lines.pushWithSources(`[Action ${step.step}]: ${step.action}`, [step]);
     }
     if (options.includeObservations && step.observation) {
-      lines.push(`[Observation ${step.step}]: ${oneLine(step.observation)}`);
+      lines.pushWithSources(
+        `[Observation ${step.step}]: ${oneLine(step.observation)}`,
+        [],
+        [step],
+      );
     }
   }
 }
 
 function appendActionSequenceSummary(
-  lines: string[],
+  lines: TrajectoryAnalysisLines,
   trajectory: readonly LabeledTrajectoryStep[],
   start: number,
   end: number,
@@ -1490,17 +1609,18 @@ function appendActionSequenceSummary(
 ): void {
   const low = Math.min(start, end);
   const high = Math.max(start, end);
-  const actions = trajectory
-    .filter((step) => step.step >= low && step.step <= high && step.action)
+  const actionSteps = trajectory
+    .filter((step) => step.step >= low && step.step <= high && step.action);
+  const actions = actionSteps
     .map((step) => `step ${step.step}: ${step.action}`);
   if (actions.length === 0) {
     return;
   }
-  lines.push(`${heading} ${actions.join("; ")}.`);
+  lines.pushWithSources(`${heading} ${actions.join("; ")}.`, actionSteps);
 }
 
 function appendResultingObservationLine(
-  lines: string[],
+  lines: TrajectoryAnalysisLines,
   trajectory: readonly LabeledTrajectoryStep[],
   stepNumber: number,
 ): void {
@@ -1508,11 +1628,15 @@ function appendResultingObservationLine(
   if (!step?.observation) {
     return;
   }
-  lines.push(`Resulting observation after Action ${step.step}: ${oneLine(step.observation)}`);
+  lines.pushWithSources(
+    `Resulting observation after Action ${step.step}: ${oneLine(step.observation)}`,
+    [],
+    [step],
+  );
 }
 
 function appendSpatialTrajectoryInferenceLines(
-  lines: string[],
+  lines: TrajectoryAnalysisLines,
   query: string,
   trajectory: readonly LabeledTrajectoryStep[],
   bounds: TrajectoryBounds,
@@ -1536,23 +1660,23 @@ function appendSpatialTrajectoryInferenceLines(
   const window = spatialTrajectoryWindowForQuery(query, trajectory, bounds);
   const counterfactualContactLines = collectCounterfactualContactLines(query, trajectory, normalized);
   if (counterfactualContactLines.length > 0) {
-    lines.push("Counterfactual contact cues:");
+    lines.pushWithSources("Counterfactual contact cues:");
     lines.push(...counterfactualContactLines);
   }
 
   const selfReversingLines = collectSelfReversingProgressLines(query, window, normalized);
   if (selfReversingLines.length > 0) {
-    lines.push("Self-reversing sequence cues:");
+    lines.pushWithSources("Self-reversing sequence cues:");
     lines.push(...selfReversingLines);
   }
   const onlyEffectiveActionLines = collectOnlyEffectiveActionLines(window, normalized);
   if (onlyEffectiveActionLines.length > 0) {
-    lines.push("Only-effective action cues:");
+    lines.pushWithSources("Only-effective action cues:");
     lines.push(...onlyEffectiveActionLines);
   }
   const pushedPhraseGroupLines = collectPushedPhraseGroupShiftLines(query, window, normalized);
   if (pushedPhraseGroupLines.length > 0) {
-    lines.push("Pushed phrase-group shift cues:");
+    lines.pushWithSources("Pushed phrase-group shift cues:");
     lines.push(...pushedPhraseGroupLines);
   }
   const suppressMovementProgressEvidence = onlyEffectiveActionLines.length > 0 ||
@@ -1566,7 +1690,7 @@ function appendSpatialTrajectoryInferenceLines(
     ? []
     : collectActionMovementSummaryLines(query, window, bounds);
   if (actionMovementLines.length > 0) {
-    lines.push("Action movement summary cues:");
+    lines.pushWithSources("Action movement summary cues:");
     lines.push(...actionMovementLines);
   }
 
@@ -1574,7 +1698,7 @@ function appendSpatialTrajectoryInferenceLines(
     ? []
     : collectMovementDeltaLines(query, window);
   if (movementLines.length > 0) {
-    lines.push("Relative-position movement cues:");
+    lines.pushWithSources("Relative-position movement cues:");
     lines.push(...movementLines);
   }
 
@@ -1585,37 +1709,37 @@ function appendSpatialTrajectoryInferenceLines(
     normalized,
   );
   if (objectAlignmentLines.length > 0) {
-    lines.push("Object alignment cues:");
+    lines.pushWithSources("Object alignment cues:");
     lines.push(...objectAlignmentLines);
   }
 
   const alternativeActionLines = collectAlternativeActionLines(query, trajectory);
   if (alternativeActionLines.length > 0) {
-    lines.push("Counterfactual action cues:");
+    lines.pushWithSources("Counterfactual action cues:");
     lines.push(...alternativeActionLines);
   }
 
   const adjacentRuleSetupLines = collectAdjacentRuleSetupLines(window, normalized);
   if (adjacentRuleSetupLines.length > 0) {
-    lines.push("Adjacent rule-block setup cues:");
+    lines.pushWithSources("Adjacent rule-block setup cues:");
     lines.push(...adjacentRuleSetupLines);
   }
 
   const blockedMoveLines = collectBlockedMoveLines(query, window, normalized);
   if (blockedMoveLines.length > 0) {
-    lines.push("Blocked-move cues:");
+    lines.pushWithSources("Blocked-move cues:");
     lines.push(...blockedMoveLines);
   }
 
   const failedEscapeLines = collectFailedEscapeLines(query, trajectory, normalized);
   if (failedEscapeLines.length > 0) {
-    lines.push("Failed-move escape cues:");
+    lines.pushWithSources("Failed-move escape cues:");
     lines.push(...failedEscapeLines);
   }
 
   const sameRelativeTextPushLines = collectSameRelativeTextPushLines(window, normalized);
   if (sameRelativeTextPushLines.length > 0) {
-    lines.push("Same-relative text-push cues:");
+    lines.pushWithSources("Same-relative text-push cues:");
     lines.push(...sameRelativeTextPushLines);
   }
 
@@ -1623,43 +1747,43 @@ function appendSpatialTrajectoryInferenceLines(
     ? []
     : collectFailedContactBoundaryLines(window, normalized);
   if (failedContactLines.length > 0) {
-    lines.push("Failed-push boundary cues:");
+    lines.pushWithSources("Failed-push boundary cues:");
     lines.push(...failedContactLines);
   }
 
   const transformationLines = collectTemporaryRuleTransformationLines(window, normalized);
   if (transformationLines.length > 0) {
-    lines.push("Temporary transformation cues:");
+    lines.pushWithSources("Temporary transformation cues:");
     lines.push(...transformationLines);
   }
 
   const wholeConfigurationShiftLines = collectWholeConfigurationShiftLines(window, normalized);
   if (wholeConfigurationShiftLines.length > 0) {
-    lines.push("Whole-configuration shift cues:");
+    lines.pushWithSources("Whole-configuration shift cues:");
     lines.push(...wholeConfigurationShiftLines);
   }
 
   const ruleInterventionLines = collectRuleInterventionStrategyLines(window, normalized);
   if (ruleInterventionLines.length > 0) {
-    lines.push("Rule-intervention strategy cues:");
+    lines.pushWithSources("Rule-intervention strategy cues:");
     lines.push(...ruleInterventionLines);
   }
 
   const missingPushTargetLines = collectMissingPushTargetLines(window, normalized);
   if (missingPushTargetLines.length > 0) {
-    lines.push("Missing-interaction cues:");
+    lines.pushWithSources("Missing-interaction cues:");
     lines.push(...missingPushTargetLines);
   }
 
   const rulePhraseAlignmentLines = collectRulePhraseAlignmentLines(window, normalized);
   if (rulePhraseAlignmentLines.length > 0) {
-    lines.push("Rule-phrase alignment cues:");
+    lines.pushWithSources("Rule-phrase alignment cues:");
     lines.push(...rulePhraseAlignmentLines);
   }
 
   const controlRuleInteractionLines = collectControlRuleInteractionLines(window, normalized);
   if (controlRuleInteractionLines.length > 0) {
-    lines.push("Control-rule interaction cues:");
+    lines.pushWithSources("Control-rule interaction cues:");
     lines.push(...controlRuleInteractionLines);
   }
 
@@ -1667,13 +1791,13 @@ function appendSpatialTrajectoryInferenceLines(
     ? []
     : collectRuleTextPositionLines(window, normalized);
   if (ruleTextPositionLines.length > 0) {
-    lines.push("Rule-text positioning cues:");
+    lines.pushWithSources("Rule-text positioning cues:");
     lines.push(...ruleTextPositionLines);
   }
 
   const ruleLines = collectRuleStateLines(window, normalized);
   if (ruleLines.length > 0) {
-    lines.push("Rule-state cues:");
+    lines.pushWithSources("Rule-state cues:");
     lines.push(...ruleLines);
   }
 }
@@ -3466,12 +3590,15 @@ function uniqueLines(lines: readonly string[]): string[] {
 }
 
 function appendActionFrequencyLines(
-  lines: string[],
+  lines: TrajectoryAnalysisLines,
   trajectory: readonly LabeledTrajectoryStep[],
   bounds: TrajectoryBounds,
 ): void {
+  const actionSteps = boundedTrajectory(trajectory, bounds).filter(
+    (step) => step.action !== undefined,
+  );
   const counts = new Map<string, number>();
-  for (const step of boundedTrajectory(trajectory, bounds)) {
+  for (const step of actionSteps) {
     if (!step.action) continue;
     const verb = normalizeActionVerb(step.action);
     if (!verb) continue;
@@ -3483,15 +3610,16 @@ function appendActionFrequencyLines(
   const frequencies = [...counts.entries()].sort((left, right) =>
     right[1] - left[1] || left[0].localeCompare(right[0]),
   );
-  lines.push(
+  lines.pushWithSources(
     `Action frequency through requested window: ${frequencies
       .map(([verb, count]) => `${verb}=${count}`)
       .join(", ")}.`,
+    actionSteps,
   );
 }
 
 function appendInventoryChangeLines(
-  lines: string[],
+  lines: TrajectoryAnalysisLines,
   trajectory: readonly LabeledTrajectoryStep[],
   bounds: TrajectoryBounds,
 ): void {
@@ -3507,16 +3635,24 @@ function appendInventoryChangeLines(
   if (changes.length === 0) {
     return;
   }
-  lines.push("Inventory changes from action transcript:");
+  const changeSteps = changes
+    .map((change) => trajectory.find((step) => step.step === change.step))
+    .filter((step): step is LabeledTrajectoryStep => step !== undefined);
+  lines.pushWithSources("Inventory changes from action transcript:");
   if (changes.length > 5) {
-    lines.push(
+    lines.pushWithSources(
       `First five inventory changes: ${formatInventoryChangeSummary(changes.slice(0, 5))}.`,
+      changeSteps.slice(0, 5),
     );
-    lines.push(
+    lines.pushWithSources(
       `Complete inventory changes: ${formatInventoryChangeSummary(changes)}.`,
+      changeSteps,
     );
   }
   for (const change of changes) {
+    // The rendered change is stateful: whether a place/move removes an item
+    // depends on earlier take actions in `held`. Until the parser returns that
+    // full dependency chain, do not publish a misleading partial row receipt.
     lines.push(`[Action ${change.step}]: ${change.action} => ${change.change}`);
   }
 }
@@ -3543,7 +3679,7 @@ function summarizeInventoryChange(change: string): string {
 }
 
 function appendContainerStateChangeLines(
-  lines: string[],
+  lines: TrajectoryAnalysisLines,
   trajectory: readonly LabeledTrajectoryStep[],
   bounds: TrajectoryBounds,
 ): void {
@@ -3551,14 +3687,18 @@ function appendContainerStateChangeLines(
   if (changes.length === 0) {
     return;
   }
-  lines.push("Container open/close state changes:");
+  lines.pushWithSources("Container open/close state changes:");
   for (const change of changes) {
-    lines.push(`[Action ${change.step}]: ${change.action} => ${change.entity} ${change.state}`);
+    const step = trajectory.find((candidate) => candidate.step === change.step);
+    lines.pushWithSources(
+      `[Action ${change.step}]: ${change.action} => ${change.entity} ${change.state}`,
+      step ? [step] : [],
+    );
   }
 }
 
 function appendEntityTimelineLines(
-  lines: string[],
+  lines: TrajectoryAnalysisLines,
   trajectory: readonly LabeledTrajectoryStep[],
   bounds: TrajectoryBounds,
   entities: readonly string[],
@@ -3594,28 +3734,37 @@ function appendEntityTimelineLines(
       continue;
     }
 
-    lines.push(`Timeline for ${entity}:`);
+    lines.pushWithSources(`Timeline for ${entity}:`);
     for (const step of directActions) {
-      lines.push(`[Action ${step.step}]: ${step.action}`);
+      lines.pushWithSources(`[Action ${step.step}]: ${step.action}`, [step]);
     }
     if (objectTransfers.length > 0) {
-      lines.push(`Object transfers involving ${entity}:`);
+      lines.pushWithSources(`Object transfers involving ${entity}:`);
       for (const transfer of objectTransfers) {
-        lines.push(`[Action ${transfer.step}]: ${transfer.action} => ${formatContainerTransfer(transfer)}`);
+        const step = trajectory.find((candidate) => candidate.step === transfer.step);
+        lines.pushWithSources(
+          `[Action ${transfer.step}]: ${transfer.action} => ${formatContainerTransfer(transfer)}`,
+          step ? [step] : [],
+        );
       }
     }
     const inferredLocation = inferEntityLocation(trajectory, bounds, entity);
     if (inferredLocation) {
-      lines.push(
-        `Inferred ${entity} location at step ${bounds.end}: ${inferredLocation}.`,
+      lines.pushWithSources(
+        `Inferred ${entity} location at step ${bounds.end}: ${inferredLocation.location}.`,
+        [inferredLocation.sourceStep],
       );
     }
     if (stateChanges.length > 0) {
       const latest = stateChanges[stateChanges.length - 1]!;
-      lines.push(
+      const stateSteps = stateChanges
+        .map((change) => trajectory.find((step) => step.step === change.step))
+        .filter((step): step is LabeledTrajectoryStep => step !== undefined);
+      lines.pushWithSources(
         `Latest ${entity} state at step ${bounds.end}: ${latest.state}; state changes: ${stateChanges
           .map((change) => `${change.step}:${change.state}`)
           .join(", ")}.`,
+        stateSteps,
       );
     }
   }
@@ -3966,15 +4115,17 @@ function inferEntityLocation(
   trajectory: readonly LabeledTrajectoryStep[],
   bounds: TrajectoryBounds,
   entity: string,
-): string | undefined {
+): { location: string; sourceStep: LabeledTrajectoryStep } | undefined {
   const normalizedEntity = normalizeEntity(entity);
   let location: string | undefined;
+  let sourceStep: LabeledTrajectoryStep | undefined;
   for (const step of boundedTrajectory(trajectory, bounds)) {
     if (!step.action) continue;
     const action = step.action.trim();
     const take = /^take\s+(.+?)\s+from\s+(.+)$/i.exec(action);
     if (take && normalizeEntity(take[1]!) === normalizedEntity) {
       location = "inventory";
+      sourceStep = step;
       continue;
     }
     const move = /^(?:move|put|place|insert)\s+(.+?)\s+(?:to|in|into|on)\s+(.+)$/i.exec(
@@ -3982,9 +4133,10 @@ function inferEntityLocation(
     );
     if (move && normalizeEntity(move[1]!) === normalizedEntity) {
       location = move[2]!.trim();
+      sourceStep = step;
     }
   }
-  return location;
+  return location && sourceStep ? { location, sourceStep } : undefined;
 }
 
 function normalizeActionVerb(action: string): string | undefined {
@@ -4028,10 +4180,15 @@ export function normalizeTurnExpansionEnd(stats: {
   return Math.max(messageCountEnd, Math.floor(stats.maxTurnIndex));
 }
 
-function truncateTrajectoryAnalysisLines(lines: string[], maxChars: number): string[] {
-  const result: string[] = [];
+function truncateTrajectoryAnalysisLines(
+  lines: TrajectoryAnalysisLines,
+  maxChars: number,
+): SelectedTrajectoryLine[] {
+  const result: SelectedTrajectoryLine[] = [];
   let used = 0;
-  for (const line of lines.slice(0, TRAJECTORY_ANALYSIS_MAX_LINES)) {
+  const limit = Math.min(lines.length, TRAJECTORY_ANALYSIS_MAX_LINES);
+  for (let index = 0; index < limit; index += 1) {
+    const line = lines[index]!;
     const separator = result.length === 0 ? 0 : 1;
     const remaining = maxChars - used - separator;
     if (remaining <= 0) {
@@ -4045,7 +4202,7 @@ function truncateTrajectoryAnalysisLines(lines: string[], maxChars: number): str
     if (clipped.length === 0) {
       break;
     }
-    result.push(clipped);
+    result.push({ text: clipped, ...lines.sourceAt(index) });
     used += separator + clipped.length;
   }
   return result;

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -58,6 +58,8 @@ export {
   buildEvidencePack,
   type EvidencePackItem,
   type EvidencePackOptions,
+  type EvidencePackSelectedItem,
+  type EvidencePackSelectionReceipt,
 } from "./evidence-pack.js";
 export {
   buildExplicitCueRecallSection,
@@ -74,6 +76,7 @@ export {
   type ExplicitCueRecallOptions,
   type ExplicitTurnReference,
   type TrajectoryAnalysisRecallOptions,
+  type TrajectoryAnalysisLineReceipt,
 } from "./explicit-cue-recall.js";
 export {
   buildTargetedFactRecallSection,

--- a/packages/remnic-core/src/lcm-engine.test.ts
+++ b/packages/remnic-core/src/lcm-engine.test.ts
@@ -676,6 +676,52 @@ test("expandContext preserves first, middle, and last row identity when truncate
   }
 });
 
+test("assembleRecallWithTrace preserves text and reports selected summary metadata", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-lcm-summary-receipts-"),
+  );
+
+  try {
+    const engine = new LcmEngine(
+      createPluginConfig(memoryDir),
+      async () => "private summary body",
+    );
+    await engine.observeMessages(
+      "private-session",
+      Array.from({ length: 8 }, (_, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `private message ${index}`,
+      })),
+    );
+    await engine.waitForSessionObserveIdle("private-session");
+
+    const baseline = await engine.assembleRecall("private-session", 10_000);
+    const traced = await engine.assembleRecallWithTrace(
+      "private-session",
+      10_000,
+    );
+
+    assert.equal(traced.text, baseline);
+    assert.ok(traced.selectedSummaries.length > 0);
+    assert.ok(
+      traced.selectedSummaries.every((receipt) =>
+        receipt.entryStart < receipt.entryEnd &&
+        receipt.msgStart <= receipt.msgEnd
+      ),
+    );
+    assert.equal(
+      JSON.stringify(traced.selectedSummaries).includes("private summary body"),
+      false,
+    );
+    assert.equal(
+      JSON.stringify(traced.selectedSummaries).includes("private-session"),
+      false,
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("close prevents deferred observe work from reinitializing the engine", async () => {
   const memoryDir = await mkdtemp(
     path.join(os.tmpdir(), "engram-lcm-engine-close-"),

--- a/packages/remnic-core/src/lcm-recall.test.ts
+++ b/packages/remnic-core/src/lcm-recall.test.ts
@@ -6,7 +6,10 @@ import test from "node:test";
 
 import { LcmArchive } from "./lcm/archive.js";
 import { LcmDag } from "./lcm/dag.js";
-import { assembleCompressedHistory } from "./lcm/recall.js";
+import {
+  assembleCompressedHistory,
+  assembleCompressedHistoryWithTrace,
+} from "./lcm/recall.js";
 import { ensureLcmStateDir, openLcmDatabase } from "./lcm/schema.js";
 
 test("assembleCompressedHistory excludes old summaries that straddle the fresh tail", async () => {
@@ -58,12 +61,56 @@ test("assembleCompressedHistory excludes old summaries that straddle the fresh t
       freshTailTurns: 16,
       budgetChars: 10_000,
     });
+    const traced = assembleCompressedHistoryWithTrace(
+      dag,
+      archive,
+      sessionId,
+      { freshTailTurns: 16, budgetChars: 10_000 },
+    );
 
+    assert.equal(traced.text, section);
     assert.doesNotMatch(section, /parent summary 0-31/);
     assert.match(section, /leaf summary 0-7/);
     assert.match(section, /leaf summary 8-15/);
     assert.match(section, /leaf summary 16-23/);
     assert.match(section, /leaf summary 24-31/);
+    assert.deepEqual(
+      traced.selectedSummaries.map(({ id, depth, msgStart, msgEnd }) => ({
+        id,
+        depth,
+        msgStart,
+        msgEnd,
+      })),
+      [
+        { id: "leaf-0-7", depth: 0, msgStart: 0, msgEnd: 7 },
+        { id: "leaf-8-15", depth: 0, msgStart: 8, msgEnd: 15 },
+        { id: "leaf-16-23", depth: 0, msgStart: 16, msgEnd: 23 },
+        { id: "leaf-24-31", depth: 0, msgStart: 24, msgEnd: 31 },
+      ],
+    );
+    for (const receipt of traced.selectedSummaries) {
+      assert.ok(receipt.entryStart < receipt.entryEnd);
+      const expectedSummary = receipt.id.replace("leaf-", "leaf summary ");
+      assert.equal(
+        traced.text.slice(receipt.entryStart, receipt.entryEnd).includes(expectedSummary),
+        true,
+      );
+      assert.equal("summary" in receipt, false);
+      assert.equal("sessionId" in receipt, false);
+    }
+
+    const first = traced.selectedSummaries[0]!;
+    const firstEntryBudget = first.entryEnd - first.entryStart;
+    const limited = assembleCompressedHistoryWithTrace(
+      dag,
+      archive,
+      sessionId,
+      { freshTailTurns: 16, budgetChars: firstEntryBudget },
+    );
+    assert.deepEqual(
+      limited.selectedSummaries.map((receipt) => receipt.id),
+      ["leaf-0-7"],
+    );
   } finally {
     db.close();
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/remnic-core/src/lcm/engine.ts
+++ b/packages/remnic-core/src/lcm/engine.ts
@@ -3,7 +3,11 @@ import { openLcmDatabase, ensureLcmStateDir } from "./schema.js";
 import { LcmArchive, type LcmStructuredRecallMatch } from "./archive.js";
 import { LcmDag } from "./dag.js";
 import { LcmSummarizer, type SummarizeFn } from "./summarizer.js";
-import { assembleCompressedHistory, type LcmRecallConfig } from "./recall.js";
+import {
+  assembleCompressedHistoryWithTrace,
+  type LcmRecallConfig,
+  type LcmRecallWithTraceResult,
+} from "./recall.js";
 import { LcmWorkQueue, type LcmObserveMessage } from "./queue.js";
 import type { PluginConfig } from "../types.js";
 import { log } from "../logger.js";
@@ -336,17 +340,25 @@ export class LcmEngine {
     sessionId: string,
     budgetChars: number,
   ): Promise<string> {
-    if (!this.config.enabled) return "";
+    return (await this.assembleRecallWithTrace(sessionId, budgetChars)).text;
+  }
+
+  /** Build compressed recall plus content-free selected-summary receipts. */
+  async assembleRecallWithTrace(
+    sessionId: string,
+    budgetChars: number,
+  ): Promise<LcmRecallWithTraceResult> {
+    if (!this.config.enabled) return { text: "", selectedSummaries: [] };
     const normalizedSessionId = normalizeLcmSessionId(sessionId);
-    if (!normalizedSessionId) return "";
+    if (!normalizedSessionId) return { text: "", selectedSummaries: [] };
     await this.ensureInitialized();
 
     const effectiveBudget = Math.ceil(
       budgetChars * this.config.recallBudgetShare,
     );
-    if (effectiveBudget <= 0) return "";
+    if (effectiveBudget <= 0) return { text: "", selectedSummaries: [] };
 
-    return assembleCompressedHistory(this.dag!, this.archive!, normalizedSessionId, {
+    return assembleCompressedHistoryWithTrace(this.dag!, this.archive!, normalizedSessionId, {
       freshTailTurns: this.config.freshTailTurns,
       budgetChars: effectiveBudget,
     });

--- a/packages/remnic-core/src/lcm/index.ts
+++ b/packages/remnic-core/src/lcm/index.ts
@@ -14,6 +14,11 @@ export {
 export { LcmArchive, estimateTokens } from "./archive.js";
 export { LcmDag, type SummaryNode } from "./dag.js";
 export { LcmSummarizer, type SummarizeFn } from "./summarizer.js";
-export { assembleCompressedHistory } from "./recall.js";
+export {
+  assembleCompressedHistory,
+  assembleCompressedHistoryWithTrace,
+  type LcmRecallWithTraceResult,
+  type LcmSummarySelectionReceipt,
+} from "./recall.js";
 export { registerLcmTools } from "./tools.js";
 export { openLcmDatabase, ensureLcmStateDir } from "./schema.js";

--- a/packages/remnic-core/src/lcm/recall.ts
+++ b/packages/remnic-core/src/lcm/recall.ts
@@ -7,6 +7,21 @@ export interface LcmRecallConfig {
   budgetChars: number;
 }
 
+export interface LcmSummarySelectionReceipt {
+  id: string;
+  depth: number;
+  msgStart: number;
+  msgEnd: number;
+  /** Half-open offsets within the returned compressed-history string. */
+  entryStart: number;
+  entryEnd: number;
+}
+
+export interface LcmRecallWithTraceResult {
+  text: string;
+  selectedSummaries: LcmSummarySelectionReceipt[];
+}
+
 /**
  * Assemble a compressed session history section from the summary DAG.
  *
@@ -21,14 +36,24 @@ export function assembleCompressedHistory(
   sessionId: string,
   config: LcmRecallConfig,
 ): string {
+  return assembleCompressedHistoryWithTrace(dag, archive, sessionId, config).text;
+}
+
+export function assembleCompressedHistoryWithTrace(
+  dag: LcmDag,
+  archive: LcmArchive,
+  sessionId: string,
+  config: LcmRecallConfig,
+): LcmRecallWithTraceResult {
   const maxTurn = archive.getMaxTurnIndex(sessionId);
-  if (maxTurn < 0) return "";
+  if (maxTurn < 0) return { text: "", selectedSummaries: [] };
 
   const allNodes = dag.getAllNodes(sessionId);
-  if (allNodes.length === 0) return "";
+  if (allNodes.length === 0) return { text: "", selectedSummaries: [] };
 
   const freshTailStart = Math.max(0, maxTurn - config.freshTailTurns + 1);
   const sections: string[] = [];
+  const selectedNodes: SummaryNode[] = [];
   let usedChars = 0;
 
   // Collect nodes covering the "old" portion (before fresh tail)
@@ -39,6 +64,7 @@ export function assembleCompressedHistory(
       const entry = `**${label}** (depth ${node.depth}):\n${node.summary_text}`;
       if (usedChars + entry.length > config.budgetChars) break;
       sections.push(entry);
+      selectedNodes.push(node);
       usedChars += entry.length;
     }
   }
@@ -58,12 +84,29 @@ export function assembleCompressedHistory(
     const entry = `**${label}**:\n${node.summary_text}`;
     if (usedChars + entry.length > config.budgetChars) break;
     sections.push(entry);
+    selectedNodes.push(node);
     usedChars += entry.length;
   }
 
-  if (sections.length === 0) return "";
+  if (sections.length === 0) return { text: "", selectedSummaries: [] };
 
-  return `## Session History (Compressed)\n\n${sections.join("\n\n")}`;
+  const prefix = "## Session History (Compressed)\n\n";
+  const text = `${prefix}${sections.join("\n\n")}`;
+  let entryStart = prefix.length;
+  const selectedSummaries = selectedNodes.map((node, index) => {
+    const entryEnd = entryStart + sections[index]!.length;
+    const receipt: LcmSummarySelectionReceipt = {
+      id: node.id,
+      depth: node.depth,
+      msgStart: node.msg_start,
+      msgEnd: node.msg_end,
+      entryStart,
+      entryEnd,
+    };
+    entryStart = entryEnd + 2;
+    return receipt;
+  });
+  return { text, selectedSummaries };
 }
 
 /**

--- a/packages/remnic-core/src/recall-trace-receipts.test.ts
+++ b/packages/remnic-core/src/recall-trace-receipts.test.ts
@@ -1,0 +1,380 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildExplicitCueRecallSection,
+  buildTrajectoryAnalysisRecallSection,
+  type ExplicitCueRecallEngine,
+  type TrajectoryAnalysisLineReceipt,
+} from "./explicit-cue-recall.js";
+import type { EvidencePackSelectionReceipt } from "./evidence-pack.js";
+
+interface ReceiptRow {
+  id?: number;
+  session_id: string;
+  turn_index: number;
+  role: string;
+  content: string;
+}
+
+class ReceiptEngine implements ExplicitCueRecallEngine {
+  constructor(private readonly rows: ReceiptRow[]) {}
+
+  async expandContext(
+    sessionId: string,
+    fromTurn: number,
+    toTurn: number,
+  ): Promise<ReceiptRow[]> {
+    return this.rows.filter((row) =>
+      row.session_id === sessionId &&
+      row.turn_index >= fromTurn &&
+      row.turn_index <= toTurn
+    );
+  }
+
+  async searchContextFull(): Promise<Array<ReceiptRow & { score: number }>> {
+    return [];
+  }
+
+  async getStats(): Promise<{ totalMessages: number; maxTurnIndex?: number }> {
+    return {
+      totalMessages: this.rows.length,
+      maxTurnIndex: this.rows.length > 0
+        ? Math.max(...this.rows.map((row) => row.turn_index))
+        : undefined,
+    };
+  }
+}
+
+test("explicit-cue receipts identify only blocks that survive selection", async () => {
+  const engine = new ReceiptEngine([
+    {
+      id: 101,
+      session_id: "s",
+      turn_index: 7,
+      role: "user",
+      content: "first selected row",
+    },
+    {
+      id: 102,
+      session_id: "s",
+      turn_index: 7,
+      role: "assistant",
+      content: "second row that the deliberately narrow section budget rejects",
+    },
+  ]);
+  const receipts: EvidencePackSelectionReceipt[] = [];
+  const options = {
+    engine,
+    sessionId: "s",
+    query: "Review turn 7",
+    maxChars:
+      "## Explicit Cue Evidence".length +
+      2 +
+      "[s, turn 7, user]: first selected row".length,
+    maxItemChars: 200,
+  };
+
+  const baseline = await buildExplicitCueRecallSection(options);
+  const traced = await buildExplicitCueRecallSection({
+    ...options,
+    onEvidenceSelected: (receipt) => receipts.push(receipt),
+  });
+
+  assert.equal(traced, baseline);
+  assert.deepEqual(receipts.map((receipt) => receipt.item.archiveRowId), [101]);
+  assert.equal(
+    traced.slice(receipts[0]!.blockStart, receipts[0]!.blockEnd).includes(
+      "first selected row",
+    ),
+    true,
+  );
+  assert.equal(JSON.stringify(receipts).includes("first selected row"), false);
+  assert.equal(JSON.stringify(receipts).includes("second row"), false);
+});
+
+test("trajectory receipts retain row lineage only for emitted clipped lines", async () => {
+  const engine = new ReceiptEngine([
+    {
+      id: 201,
+      session_id: "ama",
+      turn_index: 1,
+      role: "user",
+      content: "[Action 1]: move right",
+    },
+    {
+      id: 202,
+      session_id: "ama",
+      turn_index: 1,
+      role: "assistant",
+      content: "[Observation 1]: reached the wall",
+    },
+    {
+      id: 203,
+      session_id: "ama",
+      turn_index: 2,
+      role: "user",
+      content: "[Action 2]: move left",
+    },
+    {
+      id: 204,
+      session_id: "ama",
+      turn_index: 2,
+      role: "assistant",
+      content: "[Observation 2]: reached the door",
+    },
+  ]);
+  const receipts: TrajectoryAnalysisLineReceipt[] = [];
+  const options = {
+    engine,
+    sessionId: "ama",
+    query:
+      "What will be the resulting state at action 1? Provide the full observation.",
+    maxChars: 4_000,
+  };
+
+  const baseline = await buildTrajectoryAnalysisRecallSection(options);
+  const traced = await buildTrajectoryAnalysisRecallSection({
+    ...options,
+    onLineSelected: (receipt) => receipts.push(receipt),
+  });
+
+  assert.equal(traced, baseline);
+  const actionOne = receipts.find((receipt) =>
+    traced.slice(receipt.lineStart, receipt.lineEnd).startsWith("[Action 1]")
+  );
+  const observationOne = receipts.find((receipt) =>
+    traced.slice(receipt.lineStart, receipt.lineEnd).startsWith("[Observation 1]")
+  );
+  assert.ok(actionOne);
+  assert.ok(observationOne);
+  assert.equal(actionOne.lineageStatus, "exact");
+  assert.equal(observationOne.lineageStatus, "exact");
+  assert.deepEqual(actionOne.actionArchiveRowIds, [201]);
+  assert.deepEqual(actionOne.observationArchiveRowIds, []);
+  assert.deepEqual(observationOne.actionArchiveRowIds, []);
+  assert.deepEqual(observationOne.observationArchiveRowIds, [202]);
+  assert.equal(actionOne.actionArchiveRowIds.includes(203), false);
+  assert.equal(observationOne.observationArchiveRowIds.includes(204), false);
+
+  const clippedReceipts: TrajectoryAnalysisLineReceipt[] = [];
+  const clipped = await buildTrajectoryAnalysisRecallSection({
+    ...options,
+    maxChars: actionOne.lineStart + 8,
+    onLineSelected: (receipt) => clippedReceipts.push(receipt),
+  });
+  const partialAction = clippedReceipts.at(-1)!;
+  assert.equal(partialAction.lineStart, actionOne.lineStart);
+  assert.equal(partialAction.lineEnd, clipped.length);
+  assert.equal(partialAction.lineageStatus, "exact");
+  assert.deepEqual(partialAction.actionArchiveRowIds, [201]);
+  assert.equal(partialAction.actionArchiveRowIds.includes(203), false);
+  assert.equal(JSON.stringify(receipts).includes("move right"), false);
+  assert.equal(JSON.stringify(receipts).includes("reached the wall"), false);
+});
+
+test("spatial derived-line receipts mark lineage unavailable without guessing siblings", async () => {
+  const engine = new ReceiptEngine([
+    {
+      id: 301,
+      session_id: "ama",
+      turn_index: 20,
+      role: "user",
+      content: "[Action 20]: right",
+    },
+    {
+      id: 302,
+      session_id: "ama",
+      turn_index: 20,
+      role: "assistant",
+      content: [
+        "[Observation 20]: Active rules:",
+        "baba is you",
+        "",
+        "Objects on the map:",
+        "rule `win` 3 step to the left",
+      ].join("\n"),
+    },
+    {
+      id: 303,
+      session_id: "ama",
+      turn_index: 21,
+      role: "user",
+      content: "[Action 21]: left",
+    },
+    {
+      id: 304,
+      session_id: "ama",
+      turn_index: 21,
+      role: "assistant",
+      content: [
+        "[Observation 21]: Active rules:",
+        "baba is you",
+        "",
+        "Objects on the map:",
+        "rule `win` 2 step to the left",
+      ].join("\n"),
+    },
+  ]);
+  const receipts: TrajectoryAnalysisLineReceipt[] = [];
+  const options = {
+    engine,
+    sessionId: "ama",
+    query:
+      "Between steps 20 and 21, the rule 'win' block's relative position changed from 3 step to the left to 2 step to the left. What was the actual movement?",
+    maxChars: 4_000,
+  };
+
+  const baseline = await buildTrajectoryAnalysisRecallSection(options);
+  const traced = await buildTrajectoryAnalysisRecallSection({
+    ...options,
+    onLineSelected: (receipt) => receipts.push(receipt),
+  });
+
+  assert.equal(traced, baseline);
+  const heading = receipts.find((receipt) =>
+    traced.slice(receipt.lineStart, receipt.lineEnd) === "Relative-position movement cues:"
+  );
+  const movement = receipts.find((receipt) =>
+    traced.slice(receipt.lineStart, receipt.lineEnd).startsWith("Observation 20->21:")
+  );
+  assert.ok(heading);
+  assert.ok(movement);
+  assert.equal(heading.lineageStatus, "exact");
+  assert.deepEqual(heading.actionArchiveRowIds, []);
+  assert.deepEqual(heading.observationArchiveRowIds, []);
+  assert.equal(movement.lineageStatus, "unavailable");
+  assert.deepEqual(movement.actionArchiveRowIds, []);
+  assert.deepEqual(movement.observationArchiveRowIds, []);
+  assert.equal(JSON.stringify(movement).includes("rule win"), false);
+});
+
+test("trajectory receipts mark id-less and partially id-less direct sources unavailable", async () => {
+  const engine = new ReceiptEngine([
+    {
+      session_id: "ama",
+      turn_index: 1,
+      role: "user",
+      content: "[Action 1]: move right",
+    },
+    {
+      id: 402,
+      session_id: "ama",
+      turn_index: 1,
+      role: "assistant",
+      content: "[Observation 1]: reached the wall",
+    },
+    {
+      session_id: "ama",
+      turn_index: 2,
+      role: "user",
+      content: "[Action 2]: move left",
+    },
+    {
+      session_id: "ama",
+      turn_index: 2,
+      role: "assistant",
+      content: "[Observation 2]: reached the door",
+    },
+  ]);
+  const receipts: TrajectoryAnalysisLineReceipt[] = [];
+  const text = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query: "Compare steps 1 and 2 and provide the full observations.",
+    maxChars: 4_000,
+    onLineSelected: (receipt) => receipts.push(receipt),
+  });
+  const findLine = (prefix: string) => receipts.find((receipt) =>
+    text.slice(receipt.lineStart, receipt.lineEnd).startsWith(prefix)
+  );
+
+  const idLessAction = findLine("[Action 1]");
+  const identifiedObservation = findLine("[Observation 1]");
+  const idLessObservation = findLine("[Observation 2]");
+  assert.ok(idLessAction);
+  assert.ok(identifiedObservation);
+  assert.ok(idLessObservation);
+  assert.equal(idLessAction.lineageStatus, "unavailable");
+  assert.deepEqual(idLessAction.actionArchiveRowIds, []);
+  assert.equal(identifiedObservation.lineageStatus, "exact");
+  assert.deepEqual(identifiedObservation.observationArchiveRowIds, [402]);
+  assert.equal(idLessObservation.lineageStatus, "unavailable");
+  assert.deepEqual(idLessObservation.observationArchiveRowIds, []);
+});
+
+test("inferred-location receipts identify only the action that establishes the final location", async () => {
+  const engine = new ReceiptEngine([
+    {
+      id: 501,
+      session_id: "ama",
+      turn_index: 1,
+      role: "user",
+      content: "[Action 1]: open cabinet 1",
+    },
+    {
+      id: 502,
+      session_id: "ama",
+      turn_index: 2,
+      role: "user",
+      content: "[Action 2]: move cabinet 1 to kitchen",
+    },
+  ]);
+  const receipts: TrajectoryAnalysisLineReceipt[] = [];
+  const text = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query:
+      "What is the state of cabinet 1 at step 2 and what was its prior whole changes history?",
+    maxChars: 4_000,
+    onLineSelected: (receipt) => receipts.push(receipt),
+  });
+  const location = receipts.find((receipt) =>
+    text.slice(receipt.lineStart, receipt.lineEnd).startsWith(
+      "Inferred cabinet 1 location at step 2: kitchen",
+    )
+  );
+
+  assert.ok(location);
+  assert.equal(location.lineageStatus, "exact");
+  assert.deepEqual(location.actionArchiveRowIds, [502]);
+  assert.equal(location.actionArchiveRowIds.includes(501), false);
+  assert.deepEqual(location.observationArchiveRowIds, []);
+});
+
+test("stateful inventory-change lines do not publish partial current-row lineage", async () => {
+  const engine = new ReceiptEngine([
+    {
+      id: 601,
+      session_id: "ama",
+      turn_index: 1,
+      role: "user",
+      content: "[Action 1]: take apple 1 from shelf 1",
+    },
+    {
+      id: 602,
+      session_id: "ama",
+      turn_index: 2,
+      role: "user",
+      content: "[Action 2]: place apple 1 into bowl 1",
+    },
+  ]);
+  const receipts: TrajectoryAnalysisLineReceipt[] = [];
+  const text = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query: "What changes occurred to the inventory throughout the trajectory?",
+    maxChars: 4_000,
+    onLineSelected: (receipt) => receipts.push(receipt),
+  });
+  const placed = receipts.find((receipt) =>
+    text.slice(receipt.lineStart, receipt.lineEnd).startsWith(
+      "[Action 2]: place apple 1 into bowl 1 => inventory removed apple 1",
+    )
+  );
+
+  assert.ok(placed);
+  assert.equal(placed.lineageStatus, "unavailable");
+  assert.deepEqual(placed.actionArchiveRowIds, []);
+  assert.deepEqual(placed.observationArchiveRowIds, []);
+});


### PR DESCRIPTION
## Summary

- add content-free selection receipts for evidence-pack blocks and trajectory-analysis lines
- add traced LCM assembly APIs that preserve the existing rendered string byte-for-byte
- expose exact archive-row lineage only when structural provenance is complete; mark legacy/stateful derived lines unavailable instead of guessing
- keep every existing API compatible by making callbacks additive and delegating string APIs to traced assembly

This is the narrow core-contract prerequisite for retrieval-only LoCoMo X-ray artifacts in #1879. It does not claim the benchmark acceptance criteria are complete.

## Verification

- `npm run test:entity-hardening` (246/246)
- `npm run preflight:quick`
- focused receipt + explicit-cue + LCM tests (110/110 before final dead-code cleanup; receipt suite 6/6 after cleanup)
- `pnpm --filter @remnic/core check-types`
- `git diff --check origin/main...HEAD`
- independent read-only review: clean after three provenance fixes and one dead-code cleanup
- `npm run review:cursor` (skipped: Cursor CLI unavailable locally)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches large trajectory recall logic and recall output contracts; behavior is guarded by byte-identical string tests and conservative lineage rules, but provenance mistakes could mislead downstream X-ray tooling.
> 
> **Overview**
> Adds **content-free selection receipts** across recall assembly so callers can map rendered output back to archive rows without changing strings when callbacks are omitted.
> 
> **Evidence packs** gain optional `onSelection` with half-open `blockStart`/`blockEnd` offsets and identity-only `EvidencePackSelectedItem` (no session/content in receipts).
> 
> **Explicit cue recall** wires `onEvidenceSelected`; **trajectory analysis** wires `onLineSelected` with `lineageStatus` (`exact` | `unavailable`) and action/observation archive row IDs. Trajectory line building tracks per-line provenance via `TrajectoryAnalysisLines`; derived/spatial and stateful inventory lines mark lineage unavailable rather than guessing partial rows. Inferred entity locations now tie receipts to the establishing action step.
> 
> **LCM compressed history** adds `assembleCompressedHistoryWithTrace` and `LcmEngine.assembleRecallWithTrace`, returning the same text as before plus summary selection receipts (id, depth, msg range, entry offsets). `assembleRecall` / `assembleCompressedHistory` delegate to traced paths for identical output.
> 
> New types and APIs are exported from `@remnic/core`; tests cover evidence, LCM, engine, and trajectory receipt behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa9ae8d529a8843077ff5633857c72dd9c02af7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->