### PR TITLE
feat(bench): capture provider-free LoCoMo retrieval traces

### DIFF
--- a/packages/bench/src/benchmarks/published/dataset-loader.ts
+++ b/packages/bench/src/benchmarks/published/dataset-loader.ts
@@ -22,16 +22,17 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import { hashCanonicalJson, hashString } from "../../integrity/hash-verification.js";
 import type { BenchmarkMode } from "../../types.js";
-import {
-  LONG_MEM_EVAL_SMOKE_FIXTURE,
-  type LongMemEvalItem,
-} from "./longmemeval/fixture.js";
 import {
   LOCOMO_SMOKE_FIXTURE,
   type LoCoMoConversation,
   type LoCoMoQA,
 } from "./locomo/fixture.js";
+import {
+  LONG_MEM_EVAL_SMOKE_FIXTURE,
+  type LongMemEvalItem,
+} from "./longmemeval/fixture.js";
 
 /** Canonical LongMemEval-S filenames probed by the loader, in priority order. */
 export const LONG_MEM_EVAL_DATASET_FILENAMES = Object.freeze([
@@ -53,6 +54,8 @@ export interface LoadedDataset<T> {
   source: DatasetSource;
   /** Filename relative to `datasetDir` when source === "dataset". */
   filename?: string;
+  /** SHA-256 of the exact dataset file, or canonical bundled smoke fixture. */
+  sha256?: string;
   items: T[];
   /** Parse/read errors encountered while probing candidate filenames. */
   errors: string[];
@@ -126,6 +129,7 @@ async function loadDataset<T>(
         return {
           source: "dataset",
           filename,
+          sha256: hashString(raw),
           items: applyLimit(parsed, limit),
           errors,
         };
@@ -146,6 +150,7 @@ async function loadDataset<T>(
   // probe errors so operators can tell why the real dataset wasn't used.
   return {
     source: "smoke",
+    sha256: hashCanonicalJson(options.smokeFixture),
     items: applyLimit([...options.smokeFixture], limit),
     errors,
   };

--- a/packages/bench/src/benchmarks/published/locomo/retrieval-trace-runner.test.ts
+++ b/packages/bench/src/benchmarks/published/locomo/retrieval-trace-runner.test.ts
@@ -1,0 +1,431 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { BenchMemoryAdapter, BenchRecallTrace, Message } from "../../../adapters/types.js";
+import {
+  buildProviderFreeLoCoMoRetrievalConfig,
+  captureLoCoMoRetrievalTrace,
+  preflightLoCoMoRetrievalTraceCapture,
+  selectLoCoMoRetrievalTraceTasks,
+} from "./retrieval-trace-runner.js";
+import { prioritizeLoCoMoRecallTextWithTrace, transformLoCoMoRecallText } from "./runner.js";
+
+const RAW_RECALL_SENTINEL = "RAW-RECALL-MUST-NOT-PERSIST";
+const QUESTION_SENTINEL = "QUESTION-MUST-NOT-PERSIST";
+const GOLD_SENTINEL = "GOLD-MUST-NOT-PERSIST";
+const EVIDENCE_SENTINEL = "D99:99-MUST-NOT-PERSIST";
+const RAW_MEMORY_ID_SENTINEL = "RAW-MEMORY-ID-MUST-NOT-PERSIST";
+const FUTURE_RESULT_SENTINEL = "FUTURE-RESULT-FIELD-MUST-NOT-PERSIST";
+const FUTURE_SCORE_SENTINEL = "FUTURE-SCORE-FIELD-MUST-NOT-PERSIST";
+const PROVIDER_CONFIG_SENTINEL = "PROVIDER-CONFIG-MUST-NOT-PERSIST";
+
+function structuralTrace(): BenchRecallTrace {
+  const trace: BenchRecallTrace = {
+    schemaVersion: 1,
+    sensitivity: {
+      classification: "restricted",
+      contentEncoding: "sha256+length",
+      containsGold: false,
+    },
+    sections: [
+      {
+        id: "lcm-summary",
+        source: "lcm-summary",
+        separatorStart: 0,
+        contentStart: 0,
+        contentEnd: 8,
+        composedStart: 0,
+        composedEnd: 8,
+        visibleStart: 0,
+        visibleEnd: 8,
+        visibleChars: 8,
+      },
+    ],
+    selections: [
+      {
+        sectionId: "lcm-summary",
+        kind: "lcm-summary",
+        lineageStatus: "exact",
+        composedStart: 0,
+        composedEnd: 8,
+        visibleStart: 0,
+        visibleEnd: 8,
+        summary: { id: "NONDETERMINISTIC-SUMMARY", depth: 1, msgStart: 0, msgEnd: 2 },
+      },
+    ],
+    lcmCandidates: [],
+    coreCapture: {
+      snapshotId: "NONDETERMINISTIC-SNAPSHOT",
+      capturedAt: 999999,
+      traceId: "NONDETERMINISTIC-TRACE",
+      budget: { chars: 10, used: 8 },
+      filters: [{ name: "validity", considered: 1, admitted: 1 }],
+      results: [
+        {
+          memoryIdRef: {
+            sha256: "41e54cfc49c4c28e85951506dd19bce5742464feefdcaa17556f8a8b63d30d98",
+            length: 23,
+          },
+          servedBy: "hybrid",
+          scoreDecomposition: { final: 0.8 },
+          admittedBy: ["validity"],
+        },
+      ],
+    },
+    budget: { requestedChars: 10, composedChars: 8, returnedChars: 8, truncated: false },
+  };
+  const result = trace.coreCapture?.results[0] as unknown as Record<string, unknown>;
+  result.memoryId = RAW_MEMORY_ID_SENTINEL;
+  result.futureSensitiveField = FUTURE_RESULT_SENTINEL;
+  (result.scoreDecomposition as Record<string, unknown>).futureSensitiveScore = FUTURE_SCORE_SENTINEL;
+  return trace;
+}
+
+function fakeAdapter(calls: string[], traceFactory: () => BenchRecallTrace = structuralTrace): BenchMemoryAdapter {
+  return {
+    async reset() {
+      calls.push("reset");
+    },
+    async store(sessionId: string, _messages: Message[]) {
+      calls.push(`store:${sessionId}`);
+    },
+    async drain() {
+      calls.push("drain");
+    },
+    async recall() {
+      throw new Error("plain recall must not be called");
+    },
+    async recallWithTrace(sessionId, question, budgetChars) {
+      calls.push(`trace:${sessionId}:${budgetChars}`);
+      assert.match(question, new RegExp(QUESTION_SENTINEL));
+      return { text: `${RAW_RECALL_SENTINEL} Maya moved to Seattle.`, trace: traceFactory() };
+    },
+    async assessRecallSupport() {
+      throw new Error("support must not be called");
+    },
+    async search() {
+      throw new Error("search must not be called by the capture runner");
+    },
+    async getStats() {
+      return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+    },
+    async destroy() {},
+    responder: {
+      async respond() {
+        throw new Error("responder must not be called");
+      },
+    },
+    judge: {
+      async score() {
+        throw new Error("judge must not be called");
+      },
+    },
+  };
+}
+
+async function withDataset(run: (datasetDir: string) => Promise<void>): Promise<void> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-locomo-trace-"));
+  try {
+    await writeFile(
+      path.join(directory, "locomo10.json"),
+      JSON.stringify([
+        {
+          sample_id: "safe-conversation",
+          conversation: {
+            speaker_a: "Maya",
+            session_1: [{ speaker: "Maya", dia_id: "D1:1", text: "Maya moved to Seattle." }],
+          },
+          qa: [
+            {
+              question: `${QUESTION_SENTINEL}: where did Maya move?`,
+              answer: GOLD_SENTINEL,
+              evidence: [EVIDENCE_SENTINEL],
+              category: 1,
+            },
+          ],
+        },
+      ])
+    );
+    await run(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test("capture emits deterministic restricted retrieval-only receipts without provider surfaces", async () => {
+  await withDataset(async (datasetDir) => {
+    const calls: string[] = [];
+    const options = {
+      datasetDir,
+      runtimeProfile: "real" as const,
+      system: fakeAdapter(calls),
+      retrievalConfig: buildProviderFreeLoCoMoRetrievalConfig({
+        lcmEnabled: true,
+        skipExtractionLcmFirst: true,
+        openaiApiKey: PROVIDER_CONFIG_SENTINEL,
+        gatewayConfig: { token: PROVIDER_CONFIG_SENTINEL },
+        internalProvider: { provider: PROVIDER_CONFIG_SENTINEL },
+      }),
+      selector: { taskIds: ["safe-conversation-q0-single_hop"] },
+      gitSha: "abc123",
+      remnicVersion: "9.6.31",
+      providerFreeConfirmed: true as const,
+    };
+    const first = await captureLoCoMoRetrievalTrace(options);
+    const second = await captureLoCoMoRetrievalTrace({ ...options, system: fakeAdapter([]) });
+    assert.deepEqual(first, second);
+    assert.deepEqual(calls, [
+      "reset",
+      "store:safe-conversation-session_1",
+      "drain",
+      "trace:safe-conversation-session_1:24000",
+    ]);
+    assert.equal(first.sensitivity.containsGold, false);
+    assert.equal(first.sensitivity.containsRawContent, false);
+    assert.equal(first.provenance.providerFree, true);
+    assert.equal(first.provenance.replayExtractionMode, "skip");
+    assert.match(first.artifactHash, /^[0-9a-f]{64}$/u);
+
+    const serialized = JSON.stringify(first);
+    for (const forbidden of [
+      RAW_RECALL_SENTINEL,
+      QUESTION_SENTINEL,
+      GOLD_SENTINEL,
+      EVIDENCE_SENTINEL,
+      "safe-conversation-session_1",
+      "NONDETERMINISTIC-SNAPSHOT",
+      "NONDETERMINISTIC-TRACE",
+      "NONDETERMINISTIC-MEMORY",
+      "NONDETERMINISTIC-SUMMARY",
+      RAW_MEMORY_ID_SENTINEL,
+      FUTURE_RESULT_SENTINEL,
+      FUTURE_SCORE_SENTINEL,
+      PROVIDER_CONFIG_SENTINEL,
+    ]) {
+      assert.equal(serialized.includes(forbidden), false, forbidden);
+    }
+    assert.deepEqual(first.tasks[0]?.sessions[0]?.trace.coreCapture?.results[0]?.memoryIdRef, {
+      sha256: "41e54cfc49c4c28e85951506dd19bce5742464feefdcaa17556f8a8b63d30d98",
+      length: 23,
+    });
+  });
+});
+
+test("provider-free config disables every model and embedding escape hatch", () => {
+  const input = {
+    lcmEnabled: true,
+    recallPlannerTimeoutMs: 4321,
+    nestedSafe: {
+      threshold: 0.75,
+      apiKey: PROVIDER_CONFIG_SENTINEL,
+      gatewayConfig: { token: PROVIDER_CONFIG_SENTINEL },
+      llmModel: PROVIDER_CONFIG_SENTINEL,
+    },
+    openaiApiKey: PROVIDER_CONFIG_SENTINEL,
+    authorization: PROVIDER_CONFIG_SENTINEL,
+    gatewayConfig: { token: PROVIDER_CONFIG_SENTINEL },
+    gatewayAgentId: PROVIDER_CONFIG_SENTINEL,
+    fastGatewayAgentId: PROVIDER_CONFIG_SENTINEL,
+    internalProvider: { provider: PROVIDER_CONFIG_SENTINEL },
+    llmProvider: PROVIDER_CONFIG_SENTINEL,
+    llmModel: PROVIDER_CONFIG_SENTINEL,
+    modelSource: "gateway",
+    localLlmEnabled: true,
+    localLlmFastEnabled: true,
+    recallPlannerEnabled: true,
+    embeddingFallbackEnabled: true,
+    hostEmbeddingProviderEnabled: true,
+  };
+  const original = structuredClone(input);
+  const config = buildProviderFreeLoCoMoRetrievalConfig(input);
+  assert.deepEqual(input, original);
+  assert.equal(config.lcmEnabled, true);
+  assert.equal(config.recallPlannerTimeoutMs, 4321);
+  assert.deepEqual(config.nestedSafe, { threshold: 0.75 });
+  assert.equal(JSON.stringify(config).includes(PROVIDER_CONFIG_SENTINEL), false);
+  assert.deepEqual(
+    config,
+    buildProviderFreeLoCoMoRetrievalConfig({
+      lcmEnabled: true,
+      recallPlannerTimeoutMs: 4321,
+      nestedSafe: { threshold: 0.75 },
+    }),
+    "omitted provider material must not influence the hashed retrieval config"
+  );
+  assert.deepEqual(
+    {
+      localLlmEnabled: config.localLlmEnabled,
+      localLlmFastEnabled: config.localLlmFastEnabled,
+      recallPlannerEnabled: config.recallPlannerEnabled,
+      embeddingFallbackEnabled: config.embeddingFallbackEnabled,
+      hostEmbeddingProviderEnabled: config.hostEmbeddingProviderEnabled,
+      openaiApiKey: config.openaiApiKey,
+      modelSource: config.modelSource,
+    },
+    {
+      localLlmEnabled: false,
+      localLlmFastEnabled: false,
+      recallPlannerEnabled: false,
+      embeddingFallbackEnabled: false,
+      hostEmbeddingProviderEnabled: false,
+      openaiApiKey: false,
+      modelSource: "plugin",
+    }
+  );
+  assert.doesNotThrow(() => buildProviderFreeLoCoMoRetrievalConfig({ openaiApiKey: false }));
+});
+
+test("capture fails closed without recallWithTrace and rejects secret or provider-capable config", async () => {
+  await withDataset(async (datasetDir) => {
+    const base = fakeAdapter([]);
+    const withoutTrace = { ...base, recallWithTrace: undefined };
+    await assert.rejects(
+      captureLoCoMoRetrievalTrace({
+        datasetDir,
+        runtimeProfile: "baseline",
+        system: withoutTrace,
+        retrievalConfig: buildProviderFreeLoCoMoRetrievalConfig({}),
+        selector: { taskIds: ["safe-conversation-q0-single_hop"] },
+        gitSha: "abc",
+        remnicVersion: "1",
+        providerFreeConfirmed: true,
+      }),
+      /requires system\.recallWithTrace/
+    );
+    const providerFree = buildProviderFreeLoCoMoRetrievalConfig({});
+    for (const retrievalConfig of [
+      { ...providerFree, openaiApiKey: "secret" },
+      { ...providerFree, modelSource: "gateway" },
+      { ...providerFree, localLlmEnabled: true },
+      { ...providerFree, embeddingFallbackEnabled: true },
+      { ...providerFree, hostEmbeddingProviderEnabled: true },
+      { ...providerFree, gatewayConfig: { token: "secret" } },
+      { ...providerFree, nested: { clientSecret: "secret" } },
+      { ...providerFree, llmProvider: "openai" },
+    ]) {
+      await assert.rejects(
+        captureLoCoMoRetrievalTrace({
+          datasetDir,
+          runtimeProfile: "baseline",
+          system: fakeAdapter([]),
+          retrievalConfig,
+          selector: { taskIds: ["safe-conversation-q0-single_hop"] },
+          gitSha: "abc",
+          remnicVersion: "1",
+          providerFreeConfirmed: true,
+        }),
+        /configuration|provider-free/
+      );
+    }
+  });
+});
+
+test("capture fails closed on malformed content-free memory references", async () => {
+  await withDataset(async (datasetDir) => {
+    const invalidTrace = structuralTrace();
+    const invalidResult = invalidTrace.coreCapture?.results[0];
+    assert.ok(invalidResult);
+    for (const memoryIdRef of [
+      { sha256: "invalid", length: 1 },
+      { sha256: "A".repeat(64), length: 1 },
+      { sha256: "a".repeat(64), length: 0 },
+    ]) {
+      invalidResult.memoryIdRef = memoryIdRef;
+      await assert.rejects(
+        captureLoCoMoRetrievalTrace({
+          datasetDir,
+          runtimeProfile: "baseline",
+          system: fakeAdapter([], () => invalidTrace),
+          retrievalConfig: buildProviderFreeLoCoMoRetrievalConfig({}),
+          selector: { taskIds: ["safe-conversation-q0-single_hop"] },
+          gitSha: "abc",
+          remnicVersion: "1",
+          providerFreeConfirmed: true,
+        }),
+        /valid content-free memoryIdRef/
+      );
+    }
+  });
+});
+
+test("task selectors validate explicit ids and use stable seeded sampling in dataset order", () => {
+  const tasks = ["task-c", "task-a", "task-b"].map((taskId) => ({ taskId }));
+  const first = selectLoCoMoRetrievalTraceTasks(tasks, { sampleSize: 2, seed: 42 });
+  const second = selectLoCoMoRetrievalTraceTasks([...tasks].reverse(), { sampleSize: 2, seed: 42 });
+  assert.deepEqual(new Set(first.selectedTaskIds), new Set(second.selectedTaskIds));
+  assert.deepEqual(
+    first.selectedTaskIds,
+    tasks.map((task) => task.taskId).filter((id) => first.selectedTaskIds.includes(id))
+  );
+  assert.throws(() => selectLoCoMoRetrievalTraceTasks(tasks, { taskIds: ["task-a", "task-a"] }), /duplicates/);
+  assert.throws(() => selectLoCoMoRetrievalTraceTasks(tasks, { taskIds: ["unknown"] }), /Unknown/);
+  assert.throws(() => selectLoCoMoRetrievalTraceTasks(tasks, { sampleSize: 0, seed: 1 }), /sampleSize/);
+  assert.throws(
+    () => selectLoCoMoRetrievalTraceTasks(tasks, { taskIds: ["task-a"], sampleSize: 1, seed: 1 } as never),
+    /exactly one/
+  );
+});
+
+test("composition tracing preserves normal transform bytes and maps duplicate lines by running ordinal", () => {
+  const question = "Which organization is associated with Maya's sister?";
+  const recalledText = ["Maya's sister is Lena.", "Maya's sister is Lena.", "Lena volunteers at Harbor Aid."].join(
+    "\n"
+  );
+  const traced = prioritizeLoCoMoRecallTextWithTrace({
+    question,
+    recalledText,
+    multiHopRecallComposition: true,
+  });
+  assert.equal(transformLoCoMoRecallText({ question, recalledText, multiHopRecallComposition: true }), traced.text);
+  assert.equal(traced.receipt.selectedLines[0]?.inputOrdinal, 0);
+  assert.equal(
+    traced.receipt.selectedLines.some((line) => line.inputOrdinal === 1),
+    false
+  );
+  assert.equal(JSON.stringify(traced.receipt).includes(recalledText), false);
+  for (const line of traced.receipt.selectedLines) {
+    assert.equal(line.outputEnd - line.outputStart, line.output.charCount);
+    assert.equal(line.visibleEnd - line.visibleStart, line.visible ? line.output.charCount : 0);
+  }
+});
+
+test("composition visibility never credits the truncation marker to a dropped bracket-prefixed row", () => {
+  const direct = Array.from(
+    { length: 10 },
+    (_, index) => `needle BridgeToken direct-${index} ${"d".repeat(430 - String(index).length)}`
+  );
+  const linked = Array.from({ length: 4 }, (_, index) => {
+    const prefix = index === 3 ? "[ BridgeToken" : "BridgeToken";
+    return `${prefix} linked-${index} ${"l".repeat(430 - String(index).length)}`;
+  });
+  const traced = prioritizeLoCoMoRecallTextWithTrace({
+    question: "needle",
+    recalledText: [...direct, ...linked].join("\n"),
+    multiHopRecallComposition: true,
+  });
+  assert.match(traced.text, /\[LoCoMo context truncated to 6000 characters\]$/u);
+  const dropped = traced.receipt.selectedLines.find((line) => line.inputOrdinal === 13);
+  assert.ok(dropped);
+  assert.equal(dropped.visible, false);
+  assert.equal(dropped.visibleEnd - dropped.visibleStart, 0);
+});
+
+test("preflight rejects invalid selectors before any adapter is required", async () => {
+  await withDataset(async (datasetDir) => {
+    await assert.rejects(
+      preflightLoCoMoRetrievalTraceCapture({
+        datasetDir,
+        runtimeProfile: "baseline",
+        retrievalConfig: buildProviderFreeLoCoMoRetrievalConfig({}),
+        selector: { taskIds: ["unknown"] },
+        gitSha: "abc",
+        remnicVersion: "1",
+        providerFreeConfirmed: true,
+      }),
+      /Unknown/
+    );
+  });
+});

--- a/packages/bench/src/benchmarks/published/locomo/retrieval-trace-runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/retrieval-trace-runner.ts
@@ -1,0 +1,512 @@
+import type {
+  BenchMemoryAdapter,
+  BenchRecallTrace,
+  BenchRecallTraceCoreCapture,
+  BenchRecallTraceSelection,
+} from "../../../adapters/types.js";
+import { canonicalJsonStringify, hashCanonicalJson, hashString } from "../../../integrity/hash-verification.js";
+import { benchmarkRecallBudgetForSessionCount } from "../../../recall-budget.js";
+import { isSecretKey } from "../../../security/secret-keys.js";
+import {
+  type LoCoMoContentDigest,
+  type LoCoMoRecallCompositionReceipt,
+  buildLoCoMoPlan,
+  loadLoCoMoDataset,
+  prioritizeLoCoMoRecallTextWithTrace,
+  sanitizeLoCoMoRecallText,
+} from "./runner.js";
+
+export const LOCOMO_RETRIEVAL_TRACE_SCHEMA_VERSION = 1 as const;
+export const LOCOMO_RETRIEVAL_TRACE_SELECTION_VERSION = 1 as const;
+export const LOCOMO_RETRIEVAL_TRACE_BUDGET_VERSION = 1 as const;
+
+export type LoCoMoRetrievalTraceProfile = "baseline" | "real";
+
+export type LoCoMoRetrievalTraceSelector =
+  | { taskIds: readonly string[]; sampleSize?: never; seed?: never }
+  | { taskIds?: never; sampleSize: number; seed: number };
+
+export interface LoCoMoRetrievalTraceSelectionManifest {
+  algorithm: "explicit-task-ids" | "sha256-seeded-sample";
+  version: typeof LOCOMO_RETRIEVAL_TRACE_SELECTION_VERSION;
+  seed?: number;
+  candidateCount: number;
+  selectedCount: number;
+  selectedTaskIds: string[];
+  selectedTaskIdsSha256: string;
+}
+
+export interface LoCoMoRetrievalTraceCoreCaptureReceipt {
+  budget: BenchRecallTraceCoreCapture["budget"];
+  filters: BenchRecallTraceCoreCapture["filters"];
+  results: Array<
+    Pick<
+      BenchRecallTraceCoreCapture["results"][number],
+      "memoryIdRef" | "servedBy" | "scoreDecomposition" | "admittedBy" | "rejectedBy" | "disclosure" | "estimatedTokens"
+    >
+  >;
+}
+
+export interface LoCoMoRetrievalTraceSelectionReceipt extends Omit<BenchRecallTraceSelection, "summary"> {
+  summary?: Omit<NonNullable<BenchRecallTraceSelection["summary"]>, "id">;
+}
+
+export interface LoCoMoRetrievalStructuralTrace extends Omit<BenchRecallTrace, "coreCapture" | "selections"> {
+  selections: LoCoMoRetrievalTraceSelectionReceipt[];
+  coreCapture?: LoCoMoRetrievalTraceCoreCaptureReceipt;
+}
+
+export interface LoCoMoRetrievalSessionReceipt {
+  session: LoCoMoContentDigest;
+  trace: LoCoMoRetrievalStructuralTrace;
+}
+
+export interface LoCoMoRetrievalTaskReceipt {
+  taskId: string;
+  question: LoCoMoContentDigest;
+  recallBudgetChars: number;
+  sessions: LoCoMoRetrievalSessionReceipt[];
+  composition: LoCoMoRecallCompositionReceipt;
+}
+
+export interface LoCoMoRetrievalTraceReceipt {
+  schemaVersion: typeof LOCOMO_RETRIEVAL_TRACE_SCHEMA_VERSION;
+  benchmarkId: "locomo";
+  captureKind: "retrieval-only";
+  artifactHash: string;
+  sensitivity: {
+    classification: "restricted";
+    contentEncoding: "sha256+length";
+    containsGold: false;
+    containsRawContent: false;
+  };
+  provenance: {
+    gitSha: string;
+    remnicVersion: string;
+    runtimeProfile: LoCoMoRetrievalTraceProfile;
+    adapterMode: "direct";
+    replayExtractionMode: "skip";
+    providerFree: true;
+    dataset: {
+      id: "locomo-10";
+      sha256: string;
+    };
+    retrievalConfigSha256: string;
+    recallBudget: {
+      algorithm: "benchmarkRecallBudgetForSessionCount";
+      version: typeof LOCOMO_RETRIEVAL_TRACE_BUDGET_VERSION;
+    };
+  };
+  selection: LoCoMoRetrievalTraceSelectionManifest;
+  tasks: LoCoMoRetrievalTaskReceipt[];
+}
+
+export interface CaptureLoCoMoRetrievalTraceOptions {
+  datasetDir: string;
+  runtimeProfile: LoCoMoRetrievalTraceProfile;
+  system: BenchMemoryAdapter;
+  retrievalConfig: Record<string, unknown>;
+  selector: LoCoMoRetrievalTraceSelector;
+  gitSha: string;
+  remnicVersion: string;
+  multiHopRecallComposition?: boolean;
+  providerFreeConfirmed: true;
+}
+
+interface SelectableTask {
+  taskId: string;
+  question: string;
+  recallSessionIds: string[];
+  planIndex: number;
+}
+
+export async function preflightLoCoMoRetrievalTraceCapture(
+  options: Omit<CaptureLoCoMoRetrievalTraceOptions, "system">
+): Promise<void> {
+  assertCaptureOptions(options);
+  assertProviderFreeRetrievalConfig(options.retrievalConfig);
+  const loaded = await loadLoCoMoDataset("full", options.datasetDir);
+  const multiHopRecallComposition = options.multiHopRecallComposition ?? true;
+  const plans = loaded.items.map((conversation) => buildLoCoMoPlan(conversation, multiHopRecallComposition));
+  const selectable = plans.flatMap((plan, planIndex) =>
+    plan.trials.map((trial) => ({ taskId: trial.taskId, planIndex }))
+  );
+  selectLoCoMoRetrievalTraceTasks(selectable, options.selector);
+}
+
+export function buildProviderFreeLoCoMoRetrievalConfig(
+  retrievalConfig: Record<string, unknown>
+): Record<string, unknown> {
+  const sanitized = sanitizeProviderFreeRetrievalConfig(retrievalConfig) as Record<string, unknown>;
+  return assertProviderFreeRetrievalConfig({
+    ...sanitized,
+    localLlmEnabled: false,
+    localLlmFastEnabled: false,
+    recallPlannerEnabled: false,
+    embeddingFallbackEnabled: false,
+    hostEmbeddingProviderEnabled: false,
+    openaiApiKey: false,
+    modelSource: "plugin",
+  });
+}
+
+export async function captureLoCoMoRetrievalTrace(
+  options: CaptureLoCoMoRetrievalTraceOptions
+): Promise<LoCoMoRetrievalTraceReceipt> {
+  assertCaptureOptions(options);
+  const retrievalConfig = assertProviderFreeRetrievalConfig(options.retrievalConfig);
+  const recallWithTrace = options.system.recallWithTrace?.bind(options.system);
+  if (!recallWithTrace) {
+    throw new Error("LoCoMo retrieval trace capture requires system.recallWithTrace().");
+  }
+
+  const loaded = await loadLoCoMoDataset("full", options.datasetDir);
+  const multiHopRecallComposition = options.multiHopRecallComposition ?? true;
+  const plans = loaded.items.map((conversation) => buildLoCoMoPlan(conversation, multiHopRecallComposition));
+  const selectable = plans.flatMap((plan, planIndex) =>
+    plan.trials.map(
+      (trial): SelectableTask => ({
+        taskId: trial.taskId,
+        question: trial.question,
+        recallSessionIds: [...trial.recallSessionIds],
+        planIndex,
+      })
+    )
+  );
+  const selection = selectLoCoMoRetrievalTraceTasks(selectable, options.selector);
+  const selectedIds = new Set(selection.selectedTaskIds);
+  const tasks: LoCoMoRetrievalTaskReceipt[] = [];
+
+  for (let planIndex = 0; planIndex < plans.length; planIndex += 1) {
+    const selected = selectable.filter((task) => task.planIndex === planIndex && selectedIds.has(task.taskId));
+    if (selected.length === 0) continue;
+    const plan = plans[planIndex];
+    if (!plan) throw new Error(`Missing LoCoMo plan at index ${planIndex}.`);
+    await options.system.reset();
+    for (const session of plan.ingestSessions) {
+      if (session.messages.length > 0) {
+        await options.system.store(session.sessionId, session.messages);
+      }
+    }
+    await options.system.drain?.();
+
+    for (const selectedTask of selected) {
+      const recallBudgetChars = benchmarkRecallBudgetForSessionCount(selectedTask.recallSessionIds.length);
+      const recalled = await Promise.all(
+        selectedTask.recallSessionIds.map(async (sessionId) => {
+          const result = await recallWithTrace(sessionId, selectedTask.question, recallBudgetChars);
+          return {
+            text: result.text,
+            receipt: {
+              session: digestContent(sessionId),
+              trace: sanitizeStructuralTrace(result.trace),
+            },
+          };
+        })
+      );
+      const rawRecalledText = recalled
+        .map((entry) => entry.text)
+        .filter(Boolean)
+        .join("\n\n");
+      const sanitized = sanitizeLoCoMoRecallText({
+        question: selectedTask.question,
+        recalledText: rawRecalledText,
+      });
+      const composition = prioritizeLoCoMoRecallTextWithTrace({
+        question: selectedTask.question,
+        recalledText: sanitized,
+        multiHopRecallComposition,
+      });
+      tasks.push({
+        taskId: selectedTask.taskId,
+        question: digestContent(selectedTask.question),
+        recallBudgetChars,
+        sessions: recalled.map((entry) => entry.receipt),
+        composition: composition.receipt,
+      });
+    }
+  }
+
+  const withoutHash = {
+    schemaVersion: LOCOMO_RETRIEVAL_TRACE_SCHEMA_VERSION,
+    benchmarkId: "locomo" as const,
+    captureKind: "retrieval-only" as const,
+    sensitivity: {
+      classification: "restricted" as const,
+      contentEncoding: "sha256+length" as const,
+      containsGold: false as const,
+      containsRawContent: false as const,
+    },
+    provenance: {
+      gitSha: options.gitSha,
+      remnicVersion: options.remnicVersion,
+      runtimeProfile: options.runtimeProfile,
+      adapterMode: "direct" as const,
+      replayExtractionMode: "skip" as const,
+      providerFree: true as const,
+      dataset: { id: "locomo-10" as const, sha256: loaded.sha256 },
+      retrievalConfigSha256: hashCanonicalJson(retrievalConfig),
+      recallBudget: {
+        algorithm: "benchmarkRecallBudgetForSessionCount" as const,
+        version: LOCOMO_RETRIEVAL_TRACE_BUDGET_VERSION,
+      },
+    },
+    selection,
+    tasks,
+  };
+  return {
+    ...withoutHash,
+    artifactHash: hashCanonicalJson(withoutHash),
+  };
+}
+
+export function selectLoCoMoRetrievalTraceTasks(
+  tasks: readonly Pick<SelectableTask, "taskId">[],
+  selector: LoCoMoRetrievalTraceSelector
+): LoCoMoRetrievalTraceSelectionManifest {
+  const allIds = tasks.map((task) => task.taskId);
+  if (new Set(allIds).size !== allIds.length) {
+    throw new Error("LoCoMo retrieval trace task ids must be unique.");
+  }
+  let selected: string[];
+  let algorithm: LoCoMoRetrievalTraceSelectionManifest["algorithm"];
+  let seed: number | undefined;
+  const hasTaskIds = "taskIds" in selector && selector.taskIds !== undefined;
+  const hasSampleSize = "sampleSize" in selector && selector.sampleSize !== undefined;
+  if (Number(hasTaskIds) + Number(hasSampleSize) !== 1) {
+    throw new Error("Choose exactly one LoCoMo retrieval trace selector.");
+  }
+  if (hasTaskIds && "seed" in selector && selector.seed !== undefined) {
+    throw new Error("LoCoMo retrieval trace seed is valid only for seeded sampling.");
+  }
+
+  if (hasTaskIds) {
+    algorithm = "explicit-task-ids";
+    const requestedTaskIds = selector.taskIds;
+    if (!requestedTaskIds) throw new Error("LoCoMo explicit task ids are required.");
+    const requested = [...requestedTaskIds];
+    if (requested.length === 0) {
+      throw new Error("LoCoMo retrieval trace explicit task selection cannot be empty.");
+    }
+    if (new Set(requested).size !== requested.length) {
+      throw new Error("LoCoMo retrieval trace explicit task ids must not contain duplicates.");
+    }
+    const available = new Set(allIds);
+    const unknown = requested.filter((taskId) => !available.has(taskId));
+    if (unknown.length > 0) {
+      throw new Error(`Unknown LoCoMo retrieval trace task id: ${unknown[0]}`);
+    }
+    const requestedSet = new Set(requested);
+    selected = allIds.filter((taskId) => requestedSet.has(taskId));
+  } else {
+    algorithm = "sha256-seeded-sample";
+    const sampleSize = selector.sampleSize;
+    seed = selector.seed;
+    if (sampleSize === undefined || seed === undefined) {
+      throw new Error("LoCoMo seeded sampling requires sampleSize and seed.");
+    }
+    if (!Number.isSafeInteger(sampleSize) || sampleSize <= 0 || sampleSize > allIds.length) {
+      throw new Error(`LoCoMo retrieval trace sampleSize must be an integer from 1 to ${allIds.length}.`);
+    }
+    if (!Number.isSafeInteger(seed) || seed < 0) {
+      throw new Error("LoCoMo retrieval trace seed must be a non-negative safe integer.");
+    }
+    const sampled = [...allIds]
+      .sort((left, right) => {
+        const leftHash = hashString(`${seed}\0${left}`);
+        const rightHash = hashString(`${seed}\0${right}`);
+        return leftHash.localeCompare(rightHash) || left.localeCompare(right);
+      })
+      .slice(0, sampleSize);
+    const sampledSet = new Set(sampled);
+    selected = allIds.filter((taskId) => sampledSet.has(taskId));
+  }
+
+  return {
+    algorithm,
+    version: LOCOMO_RETRIEVAL_TRACE_SELECTION_VERSION,
+    ...(seed === undefined ? {} : { seed }),
+    candidateCount: allIds.length,
+    selectedCount: selected.length,
+    selectedTaskIds: selected,
+    selectedTaskIdsSha256: hashCanonicalJson(selected),
+  };
+}
+
+export function serializeLoCoMoRetrievalTraceReceipt(receipt: LoCoMoRetrievalTraceReceipt): string {
+  return `${canonicalJsonStringify(receipt, 2)}\n`;
+}
+
+function sanitizeStructuralTrace(trace: BenchRecallTrace): LoCoMoRetrievalStructuralTrace {
+  return {
+    schemaVersion: trace.schemaVersion,
+    sensitivity: { ...trace.sensitivity },
+    sections: trace.sections.map((section) => ({ ...section })),
+    selections: trace.selections.map(({ summary, ...selection }) => ({
+      ...selection,
+      ...(selection.archiveRowIds === undefined ? {} : { archiveRowIds: [...selection.archiveRowIds] }),
+      ...(summary === undefined
+        ? {}
+        : { summary: { depth: summary.depth, msgStart: summary.msgStart, msgEnd: summary.msgEnd } }),
+    })),
+    lcmCandidates: trace.lcmCandidates.map((candidate) => ({ ...candidate })),
+    ...(trace.coreCapture === undefined
+      ? {}
+      : {
+          coreCapture: {
+            budget: { ...trace.coreCapture.budget },
+            filters: trace.coreCapture.filters.map((filter) => ({ ...filter })),
+            results: trace.coreCapture.results.map((result) => {
+              assertMemoryIdRef(result.memoryIdRef);
+              const score = result.scoreDecomposition;
+              return {
+                memoryIdRef: {
+                  sha256: result.memoryIdRef.sha256,
+                  length: result.memoryIdRef.length,
+                },
+                servedBy: result.servedBy,
+                scoreDecomposition: {
+                  ...(score.vector === undefined ? {} : { vector: score.vector }),
+                  ...(score.bm25 === undefined ? {} : { bm25: score.bm25 }),
+                  ...(score.importance === undefined ? {} : { importance: score.importance }),
+                  ...(score.mmrPenalty === undefined ? {} : { mmrPenalty: score.mmrPenalty }),
+                  ...(score.tierPrior === undefined ? {} : { tierPrior: score.tierPrior }),
+                  ...(score.reinforcementBoost === undefined ? {} : { reinforcementBoost: score.reinforcementBoost }),
+                  final: score.final,
+                },
+                admittedBy: [...result.admittedBy],
+                ...(result.rejectedBy === undefined ? {} : { rejectedBy: result.rejectedBy }),
+                ...(result.disclosure === undefined ? {} : { disclosure: result.disclosure }),
+                ...(result.estimatedTokens === undefined ? {} : { estimatedTokens: result.estimatedTokens }),
+              };
+            }),
+          },
+        }),
+    budget: { ...trace.budget },
+  };
+}
+
+function digestContent(value: string): LoCoMoContentDigest {
+  return {
+    sha256: hashString(value),
+    charCount: value.length,
+    lineCount: value.length === 0 ? 0 : value.split("\n").length,
+  };
+}
+
+function assertCaptureOptions(options: Omit<CaptureLoCoMoRetrievalTraceOptions, "system">): void {
+  if (!options.datasetDir.trim()) {
+    throw new Error("LoCoMo retrieval trace capture requires datasetDir.");
+  }
+  if (options.runtimeProfile !== "baseline" && options.runtimeProfile !== "real") {
+    throw new Error('LoCoMo retrieval trace runtimeProfile must be "baseline" or "real".');
+  }
+  if (
+    !options.gitSha.trim() ||
+    !options.remnicVersion.trim() ||
+    options.gitSha === "unknown" ||
+    options.remnicVersion === "unknown"
+  ) {
+    throw new Error("LoCoMo retrieval trace provenance requires gitSha and remnicVersion.");
+  }
+  if (options.providerFreeConfirmed !== true) {
+    throw new Error("LoCoMo retrieval trace capture requires explicit provider-free confirmation.");
+  }
+}
+
+function assertProviderFreeRetrievalConfig(value: Record<string, unknown>): Record<string, unknown> {
+  const config = assertJsonConfig(value) as Record<string, unknown>;
+  for (const key of [
+    "localLlmEnabled",
+    "localLlmFastEnabled",
+    "recallPlannerEnabled",
+    "embeddingFallbackEnabled",
+    "hostEmbeddingProviderEnabled",
+    "openaiApiKey",
+  ] as const) {
+    if (config[key] !== false) {
+      throw new Error(`retrievalConfig.${key} must be false for provider-free capture.`);
+    }
+  }
+  if (config.modelSource !== "plugin") {
+    throw new Error('retrievalConfig.modelSource must be "plugin" for provider-free capture.');
+  }
+  return config;
+}
+
+function assertMemoryIdRef(value: unknown): asserts value is { sha256: string; length: number } {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    !/^[0-9a-f]{64}$/u.test((value as { sha256?: unknown }).sha256 as string) ||
+    !Number.isSafeInteger((value as { length?: unknown }).length) ||
+    (value as { length: number }).length <= 0
+  ) {
+    throw new Error("LoCoMo retrieval trace requires a valid content-free memoryIdRef.");
+  }
+}
+
+function assertJsonConfig(value: unknown, path = "retrievalConfig"): unknown {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error(`${path} must contain only finite JSON numbers.`);
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry, index) => assertJsonConfig(entry, `${path}[${index}]`));
+  }
+  if (!value || typeof value !== "object") {
+    throw new Error(`${path} must be JSON-serializable and provider-free.`);
+  }
+  const output: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    const child = (value as Record<string, unknown>)[key];
+    if (key === "openaiApiKey") {
+      if (child !== false) {
+        throw new Error(`${path}.${key} must be exactly false for provider-free capture.`);
+      }
+      output[key] = false;
+      continue;
+    }
+    if (isSecretKey(key)) {
+      throw new Error(`${path}.${key} contains secret-bearing configuration.`);
+    }
+    if (child === undefined) continue;
+    if (
+      /^(?:gatewayConfig|gatewayAgentId|fastGatewayAgentId|internalProvider|llmProvider|llmModel)$/iu.test(key) ||
+      (key === "modelSource" && child !== "plugin")
+    ) {
+      throw new Error(`${path}.${key} is provider-capable configuration.`);
+    }
+    output[key] = assertJsonConfig(child, `${path}.${key}`);
+  }
+  return output;
+}
+
+function sanitizeProviderFreeRetrievalConfig(value: unknown, path = "retrievalConfig"): unknown {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error(`${path} must contain only finite JSON numbers.`);
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry, index) => sanitizeProviderFreeRetrievalConfig(entry, `${path}[${index}]`));
+  }
+  if (!value || typeof value !== "object") {
+    throw new Error(`${path} must be JSON-serializable.`);
+  }
+  const output: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    const child = (value as Record<string, unknown>)[key];
+    if (child === undefined) continue;
+    if (
+      isSecretKey(key) ||
+      /^(?:gatewayConfig|gatewayAgentId|fastGatewayAgentId|internalProvider|llmProvider|llmModel)$/iu.test(key) ||
+      key === "modelSource"
+    ) {
+      continue;
+    }
+    output[key] = sanitizeProviderFreeRetrievalConfig(child, `${path}.${key}`);
+  }
+  return output;
+}

--- a/packages/bench/src/benchmarks/published/locomo/runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.ts
@@ -8,11 +8,8 @@
  */
 
 import type { Message } from "../../../adapters/types.js";
-import {
-  type LoCoMoConversation,
-  type LoCoMoQA,
-  type LoCoMoTurn,
-} from "./fixture.js";
+import { hashString } from "../../../integrity/hash-verification.js";
+import type { LoCoMoConversation, LoCoMoQA, LoCoMoTurn } from "./fixture.js";
 import {
   LOCOMO_DATASET_FILENAMES,
   formatMissingDatasetError,
@@ -340,11 +337,12 @@ export const locomoDefinition: BenchmarkDefinition = {
 export async function runLoCoMoBenchmark(
   options: ResolvedRunBenchmarkOptions,
 ): Promise<BenchmarkResult> {
-  const conversations = await loadDataset(
+  const loaded = await loadLoCoMoDataset(
     options.mode,
     options.datasetDir,
     options.limit,
   );
+  const conversations = loaded.items;
   const trialLimit = resolveTrialLimit(options.benchmarkOptions?.trialLimit);
   const multiHopRecallComposition = resolveLoCoMoBooleanOption(
     options.benchmarkOptions?.multiHopRecallComposition,
@@ -353,7 +351,7 @@ export async function runLoCoMoBenchmark(
   );
   const plans = applyTrialLimit(
     conversations.map((conversation) =>
-      buildPlan(conversation, multiHopRecallComposition)
+      buildLoCoMoPlan(conversation, multiHopRecallComposition)
     ),
     trialLimit,
   );
@@ -437,7 +435,7 @@ function applyTrialLimit(
   return limitedPlans;
 }
 
-function buildPlan(
+export function buildLoCoMoPlan(
   conversation: LoCoMoConversation,
   multiHopRecallComposition: boolean,
 ): HarnessPlan {
@@ -491,9 +489,9 @@ function buildTrial(
     recallSessionIds: sessionIds,
     answerFormat: "short-with-specifics",
     recallTextTransform: ({ question, recalledText }) =>
-      prioritizeLoCoMoRecallText({
+      transformLoCoMoRecallText({
         question,
-        recalledText: sanitizeLoCoMoRecallText({ question, recalledText }),
+        recalledText,
         multiHopRecallComposition,
       }),
     answerFallback: ({ question, recalledText }) =>
@@ -771,7 +769,7 @@ function stripTrailingLoCoMoPunctuation(value: string): string {
   return value.replace(/[.,;:)\]]+$/g, "").trim();
 }
 
-function sanitizeLoCoMoRecallText(args: {
+export function sanitizeLoCoMoRecallText(args: {
   question: string;
   recalledText: string;
 }): string {
@@ -785,19 +783,67 @@ function sanitizeLoCoMoRecallText(args: {
     );
 }
 
-function prioritizeLoCoMoRecallText(args: {
+export interface LoCoMoContentDigest {
+  sha256: string;
+  charCount: number;
+  lineCount: number;
+}
+
+export interface LoCoMoCompositionLineReceipt {
+  inputOrdinal: number;
+  input: LoCoMoContentDigest;
+  output: LoCoMoContentDigest;
+  stage: "direct" | "linked";
+  hop?: number;
+  visible: boolean;
+  outputStart: number;
+  outputEnd: number;
+  visibleStart: number;
+  visibleEnd: number;
+}
+
+export interface LoCoMoRecallCompositionReceipt {
+  schemaVersion: 1;
+  mode: "focused" | "fallback";
+  multiHopRecallComposition: boolean;
+  input: LoCoMoContentDigest;
+  output: LoCoMoContentDigest;
+  selectedLines: LoCoMoCompositionLineReceipt[];
+}
+
+export interface LoCoMoRecallCompositionResult {
+  text: string;
+  receipt: LoCoMoRecallCompositionReceipt;
+}
+
+export function transformLoCoMoRecallText(args: {
   question: string;
   recalledText: string;
   multiHopRecallComposition: boolean;
 }): string {
-  const lines = dedupePreserveOrder(
-    args.recalledText
+  const sanitized = sanitizeLoCoMoRecallText(args);
+  return prioritizeLoCoMoRecallTextWithTrace({
+    ...args,
+    recalledText: sanitized,
+  }).text;
+}
+
+export function prioritizeLoCoMoRecallTextWithTrace(args: {
+  question: string;
+  recalledText: string;
+  multiHopRecallComposition: boolean;
+}): LoCoMoRecallCompositionResult {
+  const inputLines = args.recalledText
       .replaceAll("\r\n", "\n")
       .replaceAll("\r", "\n")
       .split("\n")
       .map((line) => line.trim())
-      .filter((line) => line.length > 0),
-  );
+      .filter((line) => line.length > 0);
+  const lines = dedupePreserveOrder(inputLines);
+  const inputOrdinalByLine = new Map<string, number>();
+  inputLines.forEach((line, index) => {
+    if (!inputOrdinalByLine.has(line)) inputOrdinalByLine.set(line, index);
+  });
   const questionTokens = expandLoCoMoQuestionTokens(
     tokenizeForLoCoMo(args.question),
   );
@@ -839,25 +885,117 @@ function prioritizeLoCoMoRecallText(args: {
     ),
   ];
   if (direct.length === 0 && linkedHops.length === 0) {
-    return truncateLoCoMoContext(
+    const { text } = truncateLoCoMoContext(
       args.recalledText,
       LOCOMO_FALLBACK_CONTEXT_MAX_CHARS,
     );
+    return {
+      text,
+      receipt: {
+        schemaVersion: 1,
+        mode: "fallback",
+        multiHopRecallComposition: args.multiHopRecallComposition,
+        input: digestLoCoMoContent(args.recalledText),
+        output: digestLoCoMoContent(text),
+        selectedLines: [],
+      },
+    };
   }
-  const sections = [
-    "## LoCoMo Question-Focused Evidence",
-    ...direct.map((entry) => truncateLoCoMoLine(entry.line)),
-  ];
+  const sections = ["## LoCoMo Question-Focused Evidence"];
+  const selectedRanges: Array<{
+    input: string;
+    output: string;
+    inputOrdinal: number;
+    stage: "direct" | "linked";
+    hop?: number;
+    outputStart: number;
+    outputEnd: number;
+  }> = [];
+  const appendSelectedLine = (
+    input: string,
+    stage: "direct" | "linked",
+    hop?: number,
+  ): void => {
+    const output = truncateLoCoMoLine(input);
+    const inputOrdinal = inputOrdinalByLine.get(input);
+    if (inputOrdinal === undefined) {
+      throw new Error("LoCoMo composition selected a line outside its normalized input.");
+    }
+    const outputStart = sections.join("\n").length + 1;
+    sections.push(output);
+    selectedRanges.push({
+      input,
+      output,
+      inputOrdinal,
+      stage,
+      ...(hop === undefined ? {} : { hop }),
+      outputStart,
+      outputEnd: outputStart + output.length,
+    });
+  };
+  for (const entry of direct) appendSelectedLine(entry.line, "direct");
   for (const hop of linkedHops) {
-    sections.push(
-      `## LoCoMo Linked Evidence (hop ${hop.hop})`,
-      ...hop.lines.map(truncateLoCoMoLine),
-    );
+    sections.push(`## LoCoMo Linked Evidence (hop ${hop.hop})`);
+    for (const line of hop.lines) appendSelectedLine(line, "linked", hop.hop);
   }
-  return truncateLoCoMoContext(
+  const truncation = truncateLoCoMoContext(
     sections.join("\n"),
     LOCOMO_FOCUSED_CONTEXT_MAX_CHARS,
   );
+  const { text, safePrefixEnd } = truncation;
+  const selectedLines = selectedRanges.map((entry) => {
+    const visibleStart = Math.min(entry.outputStart, safePrefixEnd);
+    const visibleEnd = Math.min(entry.outputEnd, safePrefixEnd);
+    const visible = visibleEnd - visibleStart === entry.output.length;
+    return buildCompositionLineReceipt(entry, visible, visibleStart, visibleEnd);
+  });
+  return {
+    text,
+    receipt: {
+      schemaVersion: 1,
+      mode: "focused",
+      multiHopRecallComposition: args.multiHopRecallComposition,
+      input: digestLoCoMoContent(args.recalledText),
+      output: digestLoCoMoContent(text),
+      selectedLines,
+    },
+  };
+}
+
+function buildCompositionLineReceipt(
+  entry: {
+    input: string;
+    output: string;
+    inputOrdinal: number;
+    stage: "direct" | "linked";
+    hop?: number;
+    outputStart: number;
+    outputEnd: number;
+  },
+  visible: boolean,
+  visibleStart: number,
+  visibleEnd: number,
+): LoCoMoCompositionLineReceipt {
+  return {
+    inputOrdinal: entry.inputOrdinal,
+    input: digestLoCoMoContent(entry.input),
+    output: digestLoCoMoContent(entry.output),
+    stage: entry.stage,
+    ...(entry.hop === undefined ? {} : { hop: entry.hop }),
+    visible,
+    outputStart: entry.outputStart,
+    outputEnd: entry.outputEnd,
+    visibleStart,
+    visibleEnd,
+  };
+}
+
+function digestLoCoMoContent(value: string): LoCoMoContentDigest {
+  return {
+    sha256: hashString(value),
+    charCount: value.length,
+    lineCount: value.length === 0 ? 0 : value.split("\n").length,
+  };
 }
 
 type LoCoMoScoredLine = {
@@ -1180,14 +1318,17 @@ function truncateLoCoMoLine(line: string): string {
     : `${line.slice(0, LOCOMO_FOCUSED_LINE_MAX_CHARS)}...`;
 }
 
-function truncateLoCoMoContext(text: string, maxChars: number): string {
+function truncateLoCoMoContext(text: string, maxChars: number): { text: string; safePrefixEnd: number } {
   if (text.length <= maxChars) {
-    return text;
+    return { text, safePrefixEnd: text.length };
   }
   const truncated = text.slice(0, maxChars);
   const lastNewline = truncated.lastIndexOf("\n");
   const safePrefix = lastNewline > 0 ? truncated.slice(0, lastNewline) : truncated;
-  return `${safePrefix}\n[LoCoMo context truncated to ${maxChars} characters]`;
+  return {
+    text: `${safePrefix}\n[LoCoMo context truncated to ${maxChars} characters]`,
+    safePrefixEnd: safePrefix.length,
+  };
 }
 
 function countHiddenEvidenceIdsInRecall(
@@ -1216,11 +1357,18 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-async function loadDataset(
+export interface LoadedLoCoMoDataset {
+  source: "dataset" | "smoke";
+  filename?: string;
+  sha256: string;
+  items: LoCoMoConversation[];
+}
+
+export async function loadLoCoMoDataset(
   mode: "full" | "quick",
   datasetDir: string | undefined,
   limit?: number,
-): Promise<LoCoMoConversation[]> {
+): Promise<LoadedLoCoMoDataset> {
   // Limit normalization happens inside `loadLoCoMo10`; do not re-validate
   // here (the shared loader's `normalizeLimit` is the single source of
   // truth).
@@ -1261,7 +1409,15 @@ async function loadDataset(
     );
   }
 
-  return loaded.items;
+  if (!loaded.sha256) {
+    throw new Error("LoCoMo dataset loader did not provide a content hash.");
+  }
+  return {
+    source: loaded.source,
+    ...(loaded.filename === undefined ? {} : { filename: loaded.filename }),
+    sha256: loaded.sha256,
+    items: loaded.items,
+  };
 }
 
 function parseDataset(

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -230,7 +230,7 @@ export type {
   CodexCreditReceiptScope,
   CodexCreditReconciliationReceipt,
 } from "./providers/codex-credit-budget.js";
-export { getRemnicVersion } from "./reporter.js";
+export { getGitSha, getRemnicVersion } from "./reporter.js";
 export {
   createProvider,
   discoverAllProviders,
@@ -418,6 +418,26 @@ export {
   renderLoComoRecallDeltaMarkdown,
   sanitizeLoComoResultReference,
 } from "./stats/locomo-recall-delta.js";
+export {
+  LOCOMO_RETRIEVAL_TRACE_BUDGET_VERSION,
+  LOCOMO_RETRIEVAL_TRACE_SCHEMA_VERSION,
+  LOCOMO_RETRIEVAL_TRACE_SELECTION_VERSION,
+  buildProviderFreeLoCoMoRetrievalConfig,
+  captureLoCoMoRetrievalTrace,
+  preflightLoCoMoRetrievalTraceCapture,
+  serializeLoCoMoRetrievalTraceReceipt,
+} from "./benchmarks/published/locomo/retrieval-trace-runner.js";
+export type {
+  CaptureLoCoMoRetrievalTraceOptions,
+  LoCoMoRetrievalSessionReceipt,
+  LoCoMoRetrievalStructuralTrace,
+  LoCoMoRetrievalTaskReceipt,
+  LoCoMoRetrievalTraceCoreCaptureReceipt,
+  LoCoMoRetrievalTraceProfile,
+  LoCoMoRetrievalTraceReceipt,
+  LoCoMoRetrievalTraceSelectionManifest,
+  LoCoMoRetrievalTraceSelector,
+} from "./benchmarks/published/locomo/retrieval-trace-runner.js";
 export type {
   DiagnoseLoComoRecallDeltaOptions,
   LoComoFinalContextRegression,

--- a/scripts/bench/capture-locomo-retrieval-trace.test.ts
+++ b/scripts/bench/capture-locomo-retrieval-trace.test.ts
@@ -1,0 +1,265 @@
+import assert from "node:assert/strict";
+import { lstat, mkdir, mkdtemp, readFile, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  main,
+  parseArgs,
+  preparePrivateOutput,
+  resolveDirectoryFdRoot,
+  writePrivateOutput,
+} from "./capture-locomo-retrieval-trace.js";
+
+async function makeDataset(root: string): Promise<string> {
+  const datasetDir = path.join(root, "dataset");
+  await mkdir(datasetDir);
+  await writeFile(
+    path.join(datasetDir, "locomo10.json"),
+    JSON.stringify([
+      {
+        sample_id: "safe-conversation",
+        conversation: {
+          speaker_a: "Maya",
+          session_1: [{ speaker: "Maya", dia_id: "D1:1", text: "Maya moved to Seattle." }],
+        },
+        qa: [{ question: "Where did Maya move?", answer: "Seattle", evidence: ["D1:1"], category: 1 }],
+      },
+    ])
+  );
+  return datasetDir;
+}
+
+test("directory-fd anchoring selects supported platform paths and fails closed otherwise", () => {
+  assert.equal(resolveDirectoryFdRoot("linux"), "/proc/self/fd");
+  assert.equal(resolveDirectoryFdRoot("darwin"), "/dev/fd");
+  assert.throws(() => resolveDirectoryFdRoot("win32"), /unsupported on platform/);
+});
+
+test("CLI path flags expand bare and slash-prefixed home tildes without expanding named users", async () => {
+  const bareHome = parseArgs([
+    "--dataset-dir",
+    "~",
+    "--runtime-profile",
+    "baseline",
+    "--remnic-config",
+    "~",
+    "--out",
+    "~",
+    "--task-ids-file",
+    "~",
+  ]);
+  assert.equal(bareHome.datasetDir, os.homedir());
+  assert.equal(bareHome.remnicConfigPath, os.homedir());
+  assert.equal(bareHome.out, os.homedir());
+  assert.equal(bareHome.taskIdsFile, os.homedir());
+
+  const expanded = parseArgs([
+    "--dataset-dir",
+    "~/datasets/locomo",
+    "--runtime-profile",
+    "baseline",
+    "--remnic-config",
+    "~/configs/remnic.json",
+    "--out",
+    "~/receipts/trace.json",
+    "--task-ids-file",
+    "~/selectors/task-ids.json",
+  ]);
+  assert.equal(expanded.datasetDir, path.join(os.homedir(), "datasets/locomo"));
+  assert.equal(expanded.remnicConfigPath, path.join(os.homedir(), "configs/remnic.json"));
+  assert.equal(expanded.out, path.join(os.homedir(), "receipts/trace.json"));
+  assert.equal(expanded.taskIdsFile, path.join(os.homedir(), "selectors/task-ids.json"));
+
+  const namedUser = parseArgs([
+    "--dataset-dir",
+    "~other/datasets/locomo",
+    "--runtime-profile",
+    "baseline",
+    "--remnic-config",
+    "~other/configs/remnic.json",
+    "--out",
+    "~other/receipts/trace.json",
+    "--task-ids-file",
+    "~other/selectors/task-ids.json",
+  ]);
+  assert.equal(namedUser.datasetDir, "~other/datasets/locomo");
+  assert.equal(namedUser.remnicConfigPath, "~other/configs/remnic.json");
+  assert.equal(namedUser.out, "~other/receipts/trace.json");
+  assert.equal(namedUser.taskIdsFile, "~other/selectors/task-ids.json");
+  await assert.rejects(preparePrivateOutput(namedUser.out), /must be located under the private root/);
+});
+
+test("pre-capture proof exercises child traversal and fails closed when traversal is unavailable", async () => {
+  let successfulProbe: string | undefined;
+  const context = await preparePrivateOutput(undefined, {
+    onChildTraversalProbe(pathname) {
+      successfulProbe = pathname;
+    },
+  });
+  assert.ok(successfulProbe?.startsWith(`${context.directoryFdRoot}/`));
+
+  let unsupportedProbeRan = false;
+  await assert.rejects(
+    preparePrivateOutput(undefined, {
+      buildAnchoredChildPath(_root, _fd, basename) {
+        return path.join(os.tmpdir(), "unsupported-directory-fd-traversal", basename);
+      },
+      onChildTraversalProbe() {
+        unsupportedProbeRan = true;
+      },
+    }),
+    /ENOENT/
+  );
+  assert.equal(unsupportedProbeRan, false);
+});
+
+test("capture CLI restricts output to the canonical private root", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-locomo-output-policy-"));
+  try {
+    const datasetDir = await makeDataset(root);
+    await assert.rejects(
+      main([
+        "--dataset-dir",
+        datasetDir,
+        "--runtime-profile",
+        "baseline",
+        "--task-id",
+        "safe-conversation-q0-single_hop",
+        "--out",
+        path.join(root, "receipt.json"),
+      ]),
+      /must be located under the private root/
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("capture CLI rejects a symlinked output parent beneath the private root before adapter creation", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-locomo-output-symlink-"));
+  const context = await preparePrivateOutput();
+  const testRoot = path.join(context.privateRoot, `symlink-test-${process.pid}-${Date.now()}`);
+  try {
+    const datasetDir = await makeDataset(root);
+    const actualOutputParent = path.join(root, "actual-output");
+    const symlinkedOutputParent = path.join(testRoot, "linked-output");
+    await mkdir(actualOutputParent);
+    await mkdir(testRoot, { recursive: true, mode: 0o700 });
+    try {
+      await symlink(actualOutputParent, symlinkedOutputParent, "dir");
+    } catch {
+      t.skip("directory symlinks are unavailable on this platform");
+      return;
+    }
+
+    await assert.rejects(
+      main([
+        "--dataset-dir",
+        datasetDir,
+        "--runtime-profile",
+        "baseline",
+        "--task-id",
+        "safe-conversation-q0-single_hop",
+        "--out",
+        path.join(symlinkedOutputParent, "receipt.json"),
+      ]),
+      /symbolic-link component/
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("anchored private writer succeeds with exclusive mode 0600", async () => {
+  const context = await preparePrivateOutput();
+  const testRoot = path.join(context.privateRoot, `writer-success-${process.pid}-${Date.now()}`);
+  const outputPath = path.join(testRoot, "receipt.json");
+  try {
+    await mkdir(testRoot, { recursive: true, mode: 0o700 });
+    await writePrivateOutput(outputPath, "safe receipt\n", context);
+    assert.equal(await readFile(outputPath, "utf8"), "safe receipt\n");
+    assert.equal((await stat(outputPath)).mode & 0o777, 0o600);
+    await assert.rejects(writePrivateOutput(outputPath, "duplicate", context), /EEXIST/);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("post-create failure removes only the created inode and permits a clean retry", async () => {
+  const context = await preparePrivateOutput();
+  const testRoot = path.join(context.privateRoot, `writer-retry-${process.pid}-${Date.now()}`);
+  const outputPath = path.join(testRoot, "receipt.json");
+  try {
+    await mkdir(testRoot, { recursive: true, mode: 0o700 });
+    await assert.rejects(
+      writePrivateOutput(outputPath, "first attempt", context, {
+        afterCreate() {
+          throw new Error("injected post-create failure");
+        },
+      }),
+      /injected post-create failure/
+    );
+    await assert.rejects(lstat(outputPath), { code: "ENOENT" });
+    await writePrivateOutput(outputPath, "retry succeeded\n", context);
+    assert.equal(await readFile(outputPath, "utf8"), "retry succeeded\n");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("anchored cleanup survives parent rename and preserves the primary failure", async () => {
+  const context = await preparePrivateOutput();
+  const testRoot = path.join(context.privateRoot, `writer-rename-${process.pid}-${Date.now()}`);
+  const movedRoot = `${testRoot}-moved`;
+  const outputPath = path.join(testRoot, "receipt.json");
+  const movedOutputPath = path.join(movedRoot, "receipt.json");
+  try {
+    await mkdir(testRoot, { recursive: true, mode: 0o700 });
+    await assert.rejects(
+      writePrivateOutput(outputPath, "first attempt", context, {
+        async afterCreate() {
+          await rename(testRoot, movedRoot);
+          throw new Error("primary write failure");
+        },
+        async closeOutputHandle(close) {
+          await close();
+          throw new Error("secondary close failure");
+        },
+      }),
+      /primary write failure/
+    );
+    await assert.rejects(lstat(movedOutputPath), { code: "ENOENT" });
+    await rename(movedRoot, testRoot);
+    await writePrivateOutput(outputPath, "retry succeeded\n", context);
+    assert.equal(await readFile(outputPath, "utf8"), "retry succeeded\n");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+    await rm(movedRoot, { recursive: true, force: true });
+  }
+});
+
+test("close failure triggers anchored cleanup and permits retry", async () => {
+  const context = await preparePrivateOutput();
+  const testRoot = path.join(context.privateRoot, `writer-close-${process.pid}-${Date.now()}`);
+  const outputPath = path.join(testRoot, "receipt.json");
+  try {
+    await mkdir(testRoot, { recursive: true, mode: 0o700 });
+    await assert.rejects(
+      writePrivateOutput(outputPath, "first attempt", context, {
+        async closeOutputHandle(close) {
+          await close();
+          throw new Error("injected close failure");
+        },
+      }),
+      /injected close failure/
+    );
+    await assert.rejects(lstat(outputPath), { code: "ENOENT" });
+    await writePrivateOutput(outputPath, "retry succeeded\n", context);
+    assert.equal(await readFile(outputPath, "utf8"), "retry succeeded\n");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/bench/capture-locomo-retrieval-trace.ts
+++ b/scripts/bench/capture-locomo-retrieval-trace.ts
@@ -1,0 +1,474 @@
+#!/usr/bin/env -S npx tsx
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { chmod, lstat, mkdir, open, readFile, realpath, stat, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+import {
+  type LoCoMoRetrievalTraceProfile,
+  type LoCoMoRetrievalTraceSelector,
+  buildProviderFreeLoCoMoRetrievalConfig,
+  captureLoCoMoRetrievalTrace,
+  createRemnicAdapter,
+  getGitSha,
+  getRemnicVersion,
+  preflightLoCoMoRetrievalTraceCapture,
+  resolveBenchRuntimeProfile,
+  serializeLoCoMoRetrievalTraceReceipt,
+} from "@remnic/bench";
+import { expandTildePath } from "@remnic/core";
+
+export interface CliOptions {
+  datasetDir: string;
+  runtimeProfile: LoCoMoRetrievalTraceProfile;
+  remnicConfigPath?: string;
+  out?: string;
+  taskIds: string[];
+  taskIdsFile?: string;
+  sampleSize?: number;
+  seed?: number;
+}
+
+export interface PrivateOutputContext {
+  privateRoot: string;
+  directoryFdRoot: string;
+  requestedOutput?: string;
+}
+
+export interface PrivateOutputPreparationOptions {
+  directoryFdRootOverride?: string;
+  onChildTraversalProbe?: (anchoredProbePath: string) => void;
+  buildAnchoredChildPath?: (directoryFdRoot: string, directoryFd: number, basename: string) => string;
+}
+
+export interface PrivateOutputTestHooks {
+  afterCreate?: () => void | Promise<void>;
+  closeOutputHandle?: (close: () => Promise<void>) => void | Promise<void>;
+}
+
+export async function main(argv: string[]): Promise<void> {
+  const options = parseArgs(argv);
+  const selector = await resolveSelector(options);
+  const runtime = await resolveBenchRuntimeProfile({
+    runtimeProfile: options.runtimeProfile,
+    ...(options.remnicConfigPath === undefined ? {} : { remnicConfigPath: options.remnicConfigPath }),
+  });
+  if (runtime.systemProvider || runtime.judgeProvider || runtime.internalProvider) {
+    throw new Error("Retrieval trace capture refuses system, judge, or internal providers.");
+  }
+  if (runtime.adapterOptions.responder || runtime.adapterOptions.judge) {
+    throw new Error("Retrieval trace capture refuses responder or judge hooks.");
+  }
+  const retrievalConfig = buildProviderFreeLoCoMoRetrievalConfig(runtime.effectiveRemnicConfig);
+  const gitSha = getGitSha();
+  const remnicVersion = await getRemnicVersion();
+  const captureOptions = {
+    datasetDir: options.datasetDir,
+    runtimeProfile: options.runtimeProfile,
+    retrievalConfig,
+    selector,
+    gitSha,
+    remnicVersion,
+    providerFreeConfirmed: true as const,
+  };
+  await preflightLoCoMoRetrievalTraceCapture(captureOptions);
+  const outputContext = await preparePrivateOutput(options.out);
+
+  const system = await createRemnicAdapter({
+    configOverrides: retrievalConfig,
+    preserveRuntimeDefaults: runtime.adapterOptions.preserveRuntimeDefaults,
+    replayExtractionMode: "skip",
+    ...(runtime.adapterOptions.drainTimeoutMs === undefined
+      ? {}
+      : { drainTimeoutMs: runtime.adapterOptions.drainTimeoutMs }),
+  });
+  try {
+    const receipt = await captureLoCoMoRetrievalTrace({
+      ...captureOptions,
+      system,
+    });
+    const outputPath = resolveOutputPath(
+      outputContext.requestedOutput,
+      receipt.artifactHash,
+      options.runtimeProfile,
+      outputContext.privateRoot
+    );
+    await mkdir(path.dirname(outputPath), { recursive: true, mode: 0o700 });
+    await writePrivateOutput(outputPath, serializeLoCoMoRetrievalTraceReceipt(receipt), outputContext);
+    process.stdout.write(`${outputPath}\n`);
+  } finally {
+    await system.destroy();
+  }
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  let datasetDir: string | undefined;
+  let runtimeProfile: LoCoMoRetrievalTraceProfile | undefined;
+  let remnicConfigPath: string | undefined;
+  let out: string | undefined;
+  const taskIds: string[] = [];
+  let taskIdsFile: string | undefined;
+  let sampleSize: number | undefined;
+  let seed: number | undefined;
+
+  const valueAfter = (index: number, flag: string): string => {
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value.`);
+    return value;
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag === undefined) continue;
+    if (flag === "--dataset-dir") {
+      datasetDir = expandTildePath(valueAfter(index, flag));
+      index += 1;
+    } else if (flag === "--runtime-profile") {
+      const value = valueAfter(index, flag);
+      if (value !== "baseline" && value !== "real") {
+        throw new Error('--runtime-profile must be "baseline" or "real".');
+      }
+      runtimeProfile = value;
+      index += 1;
+    } else if (flag === "--remnic-config") {
+      remnicConfigPath = expandTildePath(valueAfter(index, flag));
+      index += 1;
+    } else if (flag === "--out") {
+      out = expandTildePath(valueAfter(index, flag));
+      index += 1;
+    } else if (flag === "--task-id") {
+      taskIds.push(valueAfter(index, flag));
+      index += 1;
+    } else if (flag === "--task-ids-file") {
+      taskIdsFile = expandTildePath(valueAfter(index, flag));
+      index += 1;
+    } else if (flag === "--sample-size") {
+      sampleSize = parseNonNegativeInteger(valueAfter(index, flag), flag);
+      index += 1;
+    } else if (flag === "--seed") {
+      seed = parseNonNegativeInteger(valueAfter(index, flag), flag);
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument ${JSON.stringify(flag)}.`);
+    }
+  }
+  if (!datasetDir) throw new Error("--dataset-dir is required.");
+  if (!runtimeProfile) throw new Error("--runtime-profile is required.");
+  const selectorCount =
+    Number(taskIds.length > 0) + Number(taskIdsFile !== undefined) + Number(sampleSize !== undefined);
+  if (selectorCount !== 1) {
+    throw new Error("Choose exactly one selector: --task-id, --task-ids-file, or --sample-size.");
+  }
+  if (sampleSize !== undefined && sampleSize <= 0) {
+    throw new Error("--sample-size must be a positive integer.");
+  }
+  if (sampleSize !== undefined && seed === undefined) {
+    throw new Error("--seed is required with --sample-size.");
+  }
+  if (sampleSize === undefined && seed !== undefined) {
+    throw new Error("--seed is only valid with --sample-size.");
+  }
+  return {
+    datasetDir,
+    runtimeProfile,
+    ...(remnicConfigPath === undefined ? {} : { remnicConfigPath }),
+    ...(out === undefined ? {} : { out }),
+    taskIds,
+    ...(taskIdsFile === undefined ? {} : { taskIdsFile }),
+    ...(sampleSize === undefined ? {} : { sampleSize }),
+    ...(seed === undefined ? {} : { seed }),
+  };
+}
+
+async function resolveSelector(options: CliOptions): Promise<LoCoMoRetrievalTraceSelector> {
+  if (options.taskIds.length > 0) return { taskIds: options.taskIds };
+  if (options.taskIdsFile) {
+    const raw = await readFile(options.taskIdsFile, "utf8");
+    let taskIds: string[];
+    if (raw.trim().startsWith("[")) {
+      const parsed: unknown = JSON.parse(raw);
+      if (!Array.isArray(parsed) || parsed.some((entry) => typeof entry !== "string")) {
+        throw new Error("--task-ids-file JSON must be an array of strings.");
+      }
+      taskIds = parsed;
+    } else {
+      taskIds = raw
+        .split(/\r?\n/u)
+        .map((line) => line.trim())
+        .filter(Boolean);
+    }
+    return { taskIds };
+  }
+  if (options.sampleSize === undefined || options.seed === undefined) {
+    throw new Error("Seeded selection requires --sample-size and --seed.");
+  }
+  return { sampleSize: options.sampleSize, seed: options.seed };
+}
+
+function parseNonNegativeInteger(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`${flag} must be a non-negative safe integer.`);
+  }
+  return parsed;
+}
+
+function resolveOutputPath(
+  requested: string | undefined,
+  artifactHash: string,
+  profile: LoCoMoRetrievalTraceProfile,
+  privateRoot: string
+): string {
+  return path.resolve(
+    requested ?? path.join(privateRoot, "locomo-retrieval-traces", `${profile}-${artifactHash.slice(0, 16)}.json`)
+  );
+}
+
+export function resolveDirectoryFdRoot(platform = process.platform): PrivateOutputContext["directoryFdRoot"] {
+  if (platform === "linux") return "/proc/self/fd";
+  if (platform === "darwin") return "/dev/fd";
+  throw new Error(`Restricted retrieval trace output is unsupported on platform ${JSON.stringify(platform)}.`);
+}
+
+export async function preparePrivateOutput(
+  requested?: string,
+  options: PrivateOutputPreparationOptions = {}
+): Promise<PrivateOutputContext> {
+  const configuredHome = path.resolve(homedir());
+  const trustedHome = await realpath(configuredHome);
+  const privateRoot = path.join(trustedHome, ".remnic", "bench", "private");
+  await assertNoSymlinksBelow(trustedHome, privateRoot);
+  await mkdir(privateRoot, { recursive: true, mode: 0o700 });
+  await assertNoSymlinksBelow(trustedHome, privateRoot);
+  if ((await realpath(privateRoot)) !== privateRoot) {
+    throw new Error("Restricted retrieval trace private root must resolve canonically.");
+  }
+  await chmod(privateRoot, 0o700);
+  const directoryFdRoot = options.directoryFdRootOverride ?? resolveDirectoryFdRoot();
+  await verifyDirectoryFdMechanism(
+    privateRoot,
+    directoryFdRoot,
+    options.onChildTraversalProbe,
+    options.buildAnchoredChildPath
+  );
+  const requestedOutput =
+    requested === undefined
+      ? undefined
+      : canonicalizeTrustedHomePath(path.resolve(requested), configuredHome, trustedHome);
+  if (requestedOutput !== undefined) {
+    await assertSafePrivateOutputPath(requestedOutput, privateRoot);
+  }
+  return {
+    privateRoot,
+    directoryFdRoot,
+    ...(requestedOutput === undefined ? {} : { requestedOutput }),
+  };
+}
+
+function canonicalizeTrustedHomePath(candidate: string, configuredHome: string, trustedHome: string): string {
+  if (candidate === configuredHome || isWithin(configuredHome, candidate)) {
+    return path.join(trustedHome, path.relative(configuredHome, candidate));
+  }
+  return candidate;
+}
+
+async function assertSafePrivateOutputPath(outputPath: string, privateRoot: string): Promise<void> {
+  if (outputPath === privateRoot || !isWithin(privateRoot, outputPath)) {
+    throw new Error(`Restricted retrieval trace output must be located under the private root ${privateRoot}.`);
+  }
+  await assertNoSymlinksBelow(privateRoot, outputPath);
+}
+
+async function assertNoSymlinksBelow(anchor: string, candidate: string): Promise<void> {
+  const absolute = path.resolve(candidate);
+  if (absolute !== anchor && !isWithin(anchor, absolute)) {
+    throw new Error(`Restricted retrieval trace path must remain under ${anchor}.`);
+  }
+  let current = anchor;
+  for (const component of path.relative(anchor, absolute).split(path.sep).filter(Boolean)) {
+    current = path.join(current, component);
+    try {
+      if ((await lstat(current)).isSymbolicLink()) {
+        throw new Error(`Retrieval trace output path contains a symbolic-link component: ${current}`);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+  }
+}
+
+async function verifyDirectoryFdMechanism(
+  privateRoot: string,
+  directoryFdRoot: string,
+  onChildTraversalProbe?: (anchoredProbePath: string) => void,
+  buildAnchoredChildPath = defaultAnchoredChildPath
+): Promise<void> {
+  const handle = await open(privateRoot, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+  try {
+    const [opened, anchored] = await Promise.all([handle.stat(), stat(`${directoryFdRoot}/${handle.fd}`)]);
+    if (
+      !opened.isDirectory() ||
+      (opened.mode & 0o077) !== 0 ||
+      opened.dev !== anchored.dev ||
+      opened.ino !== anchored.ino
+    ) {
+      throw new Error(`Directory-fd anchoring at ${directoryFdRoot} failed its pre-capture verification.`);
+    }
+    const probeName = `.locomo-fd-probe-${process.pid}-${randomUUID()}`;
+    const requestedProbePath = path.join(privateRoot, probeName);
+    const anchoredProbePath = buildAnchoredChildPath(directoryFdRoot, handle.fd, probeName);
+    let probeIdentity: { dev: number | bigint; ino: number | bigint } | undefined;
+    let probeHandle: Awaited<ReturnType<typeof open>> | undefined;
+    let primaryError: unknown;
+    try {
+      probeHandle = await open(
+        anchoredProbePath,
+        constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+        0o600
+      );
+      const probeStats = await probeHandle.stat();
+      probeIdentity = { dev: probeStats.dev, ino: probeStats.ino };
+      const requestedStats = await lstat(requestedProbePath);
+      if (
+        !probeStats.isFile() ||
+        (probeStats.mode & 0o777) !== 0o600 ||
+        probeStats.dev !== requestedStats.dev ||
+        probeStats.ino !== requestedStats.ino
+      ) {
+        throw new Error(`Directory-fd child traversal at ${directoryFdRoot} failed inode verification.`);
+      }
+      onChildTraversalProbe?.(anchoredProbePath);
+    } catch (error) {
+      primaryError = error;
+    }
+    let closeError: unknown;
+    try {
+      await probeHandle?.close();
+    } catch (error) {
+      closeError = error;
+    }
+    let cleanupError: unknown;
+    if (probeIdentity) {
+      try {
+        await unlinkIfIdentityMatches(anchoredProbePath, probeIdentity);
+      } catch (error) {
+        cleanupError = error;
+      }
+    }
+    if (primaryError) throw primaryError;
+    if (closeError) throw closeError;
+    if (cleanupError) throw cleanupError;
+  } finally {
+    await handle.close();
+  }
+}
+
+function defaultAnchoredChildPath(directoryFdRoot: string, directoryFd: number, basename: string): string {
+  return `${directoryFdRoot}/${directoryFd}/${basename}`;
+}
+
+export async function writePrivateOutput(
+  outputPath: string,
+  content: string,
+  context: PrivateOutputContext,
+  hooks: PrivateOutputTestHooks = {}
+): Promise<void> {
+  await assertSafePrivateOutputPath(outputPath, context.privateRoot);
+  const parentPath = path.dirname(outputPath);
+  const parentHandle = await open(parentPath, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+  try {
+    const [openedParent, requestedParent] = await Promise.all([parentHandle.stat(), lstat(parentPath)]);
+    if (
+      !openedParent.isDirectory() ||
+      openedParent.dev !== requestedParent.dev ||
+      openedParent.ino !== requestedParent.ino
+    ) {
+      throw new Error("Retrieval trace output parent changed during validation.");
+    }
+    const anchoredOutputPath = `${context.directoryFdRoot}/${parentHandle.fd}/${path.basename(outputPath)}`;
+    const outputHandle = await open(
+      anchoredOutputPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600
+    );
+    let createdIdentity: { dev: number | bigint; ino: number | bigint } | undefined;
+    let primaryError: unknown;
+    try {
+      const openedStats = await outputHandle.stat();
+      createdIdentity = { dev: openedStats.dev, ino: openedStats.ino };
+      const [anchoredStats, requestedStats] = await Promise.all([
+        stat(`${context.directoryFdRoot}/${outputHandle.fd}`),
+        lstat(outputPath),
+      ]);
+      if (
+        !openedStats.isFile() ||
+        openedStats.dev !== anchoredStats.dev ||
+        openedStats.ino !== anchoredStats.ino ||
+        openedStats.dev !== requestedStats.dev ||
+        openedStats.ino !== requestedStats.ino
+      ) {
+        throw new Error("Retrieval trace output changed during secure open.");
+      }
+      await assertSafePrivateOutputPath(outputPath, context.privateRoot);
+      await hooks.afterCreate?.();
+      await outputHandle.writeFile(content, { encoding: "utf8" });
+      await outputHandle.sync();
+      await outputHandle.chmod(0o600);
+    } catch (error) {
+      primaryError = error;
+    }
+    let closeError: unknown;
+    try {
+      const close = () => outputHandle.close();
+      if (hooks.closeOutputHandle) {
+        await hooks.closeOutputHandle(close);
+      } else {
+        await close();
+      }
+    } catch (error) {
+      closeError = error;
+    }
+    let cleanupError: unknown;
+    if ((primaryError || closeError) && createdIdentity) {
+      try {
+        await unlinkIfIdentityMatches(anchoredOutputPath, createdIdentity);
+      } catch (error) {
+        cleanupError = error;
+      }
+    }
+    if (primaryError) throw primaryError;
+    if (closeError) throw closeError;
+    if (cleanupError) throw cleanupError;
+  } finally {
+    await parentHandle.close();
+  }
+}
+
+async function unlinkIfIdentityMatches(
+  outputPath: string,
+  identity: { dev: number | bigint; ino: number | bigint }
+): Promise<void> {
+  try {
+    const current = await lstat(outputPath);
+    if (current.dev === identity.dev && current.ino === identity.ino) {
+      await unlink(outputPath);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add deterministic, content-free LoCoMo retrieval-only trace receipts over the published dataset plan
- force all LLM, paid embedding, responder, judge, and replay-extraction surfaces off before adapter creation
- preserve exact selection/composition lineage while stripping raw content and nondeterministic identifiers
- write restricted receipts only beneath the canonical private benchmark root with portable descriptor-anchored, exclusive 0600 writes

## Verification
- `npm run preflight:quick`
- 41 focused LoCoMo/capture tests
- 16 focused secure-writer and cleanup regressions
- bench TypeScript and test-type baseline checks
- staged LoCoMo one-task captures were deterministic and provider-free

No provider or credit-consuming calls were made.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches benchmark data handling and filesystem security (private root, symlink checks, fd-anchored writes); retrieval config validation is fail-closed but misconfiguration could block captures.
> 
> **Overview**
> Adds **provider-free LoCoMo retrieval-only trace capture**: deterministic receipts that record structural recall/composition lineage with **sha256+length digests** instead of questions, gold answers, or raw recall text.
> 
> The shared dataset loader now attaches **`sha256`** for on-disk files and smoke fixtures. LoCoMo recall composition gains **`prioritizeLoCoMoRecallTextWithTrace`** (same output bytes as `transformLoCoMoRecallText`, plus content-free composition receipts and safer truncation visibility). **`retrieval-trace-runner`** runs ingest → `recallWithTrace` → sanitization, enforces a stripped **provider-free retrieval config** (no LLM/embedding/gateway secrets), and hashes provenance into an **`artifactHash`**.
> 
> A new **`capture-locomo-retrieval-trace`** CLI preflights selectors, blocks judge/responder providers, and writes receipts only under **`~/.remnic/bench/private`** via directory-fd–anchored **exclusive 0600** files. **`@remnic/bench`** exports the capture API and **`getGitSha`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa07c57b15527f7f3c1885f2fe92f40454899962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->