### PR TITLE
feat(bench): diagnose paired LoCoMo retrieval traces

### DIFF
--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -419,6 +419,19 @@ export {
   sanitizeLoComoResultReference,
 } from "./stats/locomo-recall-delta.js";
 export {
+  LOCOMO_RETRIEVAL_TRACE_DELTA_SCHEMA_VERSION,
+  diagnoseLoCoMoRetrievalTraceDelta,
+  serializeLoCoMoRetrievalTraceDelta,
+} from "./stats/locomo-retrieval-trace-delta.js";
+export type {
+  LoCoMoCategory,
+  LoCoMoRetrievalMechanism,
+  LoCoMoRetrievalMechanismSummary,
+  LoCoMoRetrievalTaskDelta,
+  LoCoMoRetrievalTraceDeltaReport,
+  LoCoMoStructuralMultisetDelta,
+} from "./stats/locomo-retrieval-trace-delta.js";
+export {
   LOCOMO_RETRIEVAL_TRACE_BUDGET_VERSION,
   LOCOMO_RETRIEVAL_TRACE_SCHEMA_VERSION,
   LOCOMO_RETRIEVAL_TRACE_SELECTION_VERSION,

--- a/packages/bench/src/stats/locomo-retrieval-trace-delta.test.ts
+++ b/packages/bench/src/stats/locomo-retrieval-trace-delta.test.ts
@@ -1,0 +1,373 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  LoCoMoRetrievalTaskReceipt,
+  LoCoMoRetrievalTraceReceipt,
+} from "../benchmarks/published/locomo/retrieval-trace-runner.js";
+import { prioritizeLoCoMoRecallTextWithTrace } from "../benchmarks/published/locomo/runner.js";
+import { hashCanonicalJson, hashString } from "../integrity/hash-verification.js";
+import {
+  diagnoseLoCoMoRetrievalTraceDelta,
+  serializeLoCoMoRetrievalTraceDelta,
+} from "./locomo-retrieval-trace-delta.js";
+
+const DATASET_HASH = hashString("dataset");
+
+function digest(value: string) {
+  return { sha256: hashString(value), charCount: value.length, lineCount: 1 };
+}
+
+function task(
+  id: string,
+  options: {
+    sectionCopies?: number;
+    sectionChars?: number;
+    coreChars?: number;
+    coreScore?: number;
+    compositionMode?: "focused" | "fallback";
+    truncated?: boolean;
+    lineageStatus?: "exact" | "unavailable";
+  } = {}
+): LoCoMoRetrievalTaskReceipt {
+  const sectionCopies = options.sectionCopies ?? 1;
+  const sectionChars = options.sectionChars ?? 20;
+  const coreScore = options.coreScore ?? 1;
+  const coreChars = options.coreChars ?? 0;
+  const lineageStatus = options.lineageStatus ?? "exact";
+  return {
+    taskId: id,
+    question: digest(`question:${id}`),
+    recallBudgetChars: 100,
+    sessions: [
+      {
+        session: digest(`session:${id}`),
+        trace: {
+          schemaVersion: 1,
+          sensitivity: { classification: "restricted", contentEncoding: "sha256+length", containsGold: false },
+          sections: [
+            ...Array.from({ length: sectionCopies }, (_, index) => ({
+              id: `section-${index}`,
+              source: "lcm-summary" as const,
+              separatorStart: index * sectionChars,
+              contentStart: index * sectionChars,
+              contentEnd: (index + 1) * sectionChars,
+              composedStart: index * sectionChars,
+              composedEnd: (index + 1) * sectionChars,
+              visibleStart: index * sectionChars,
+              visibleEnd: (index + 1) * sectionChars,
+              visibleChars: sectionChars,
+            })),
+            ...(coreChars === 0
+              ? []
+              : [
+                  {
+                    id: "core-section",
+                    source: "core" as const,
+                    separatorStart: 0,
+                    contentStart: 0,
+                    contentEnd: coreChars,
+                    composedStart: 0,
+                    composedEnd: coreChars,
+                    visibleStart: 0,
+                    visibleEnd: coreChars,
+                    visibleChars: coreChars,
+                  },
+                ]),
+          ],
+          selections: [
+            {
+              sectionId: "section-0",
+              kind: "lcm-summary",
+              lineageStatus,
+              ...(lineageStatus === "exact" ? { archiveRowIds: [7] } : {}),
+              summary: { depth: 1, msgStart: 0, msgEnd: 1 },
+              composedStart: 0,
+              composedEnd: sectionChars,
+              visibleStart: 0,
+              visibleEnd: sectionChars,
+            },
+          ],
+          lcmCandidates: [{ rank: 0, archiveRowId: 7, turnIndex: 2, role: "user", score: sectionChars, lineageStatus }],
+          coreCapture: {
+            budget: { chars: 100, used: 10 },
+            filters: [{ name: "admission", considered: 1, admitted: 1 }],
+            results: [
+              {
+                memoryIdRef: { sha256: hashString("private-core-memory-id"), length: 22 },
+                servedBy: "hot",
+                scoreDecomposition: { final: coreScore },
+                admittedBy: ["budget"],
+              },
+            ],
+          },
+          budget: {
+            requestedChars: 100,
+            composedChars: 20,
+            returnedChars: options.truncated ? 10 : 20,
+            truncated: options.truncated ?? false,
+          },
+        },
+      },
+    ],
+    composition: {
+      schemaVersion: 1,
+      mode: options.compositionMode ?? "focused",
+      multiHopRecallComposition: true,
+      input: digest("composition-input"),
+      output: digest(options.compositionMode ?? "focused"),
+      selectedLines: [],
+    },
+  };
+}
+
+function receipt(
+  profile: "baseline" | "real",
+  tasks: LoCoMoRetrievalTaskReceipt[],
+  config = profile
+): LoCoMoRetrievalTraceReceipt {
+  const selectedTaskIds = tasks.map((entry) => entry.taskId);
+  const withoutHash = {
+    schemaVersion: 1 as const,
+    benchmarkId: "locomo" as const,
+    captureKind: "retrieval-only" as const,
+    sensitivity: {
+      classification: "restricted" as const,
+      contentEncoding: "sha256+length" as const,
+      containsGold: false as const,
+      containsRawContent: false as const,
+    },
+    provenance: {
+      gitSha: "abc123",
+      remnicVersion: "9.6.32",
+      runtimeProfile: profile,
+      adapterMode: "direct" as const,
+      replayExtractionMode: "skip" as const,
+      providerFree: true as const,
+      dataset: { id: "locomo-10" as const, sha256: DATASET_HASH },
+      retrievalConfigSha256: hashString(config),
+      recallBudget: { algorithm: "benchmarkRecallBudgetForSessionCount" as const, version: 1 as const },
+    },
+    selection: {
+      algorithm: "explicit-task-ids" as const,
+      version: 1 as const,
+      candidateCount: tasks.length,
+      selectedCount: tasks.length,
+      selectedTaskIds,
+      selectedTaskIdsSha256: hashCanonicalJson(selectedTaskIds),
+    },
+    tasks,
+  };
+  return { ...withoutHash, artifactHash: hashCanonicalJson(withoutHash) };
+}
+
+function reseal(value: LoCoMoRetrievalTraceReceipt): LoCoMoRetrievalTraceReceipt {
+  const { artifactHash: _artifactHash, ...withoutHash } = value;
+  return { ...withoutHash, artifactHash: hashCanonicalJson(withoutHash) };
+}
+
+test("pairs deterministic receipts and reports core-visible LCM displacement without raw identifiers", () => {
+  const ids = ["private-alpha-q0-multi_hop", "private-alpha-q1-multi_hop", "private-alpha-q2-multi_hop"];
+  const baseline = receipt(
+    "baseline",
+    ids.map((id) => task(id))
+  );
+  const real = receipt(
+    "real",
+    ids.map((id) => task(id, { sectionChars: 19, coreChars: 10, coreScore: 0.5 }))
+  );
+  const first = diagnoseLoCoMoRetrievalTraceDelta(baseline, real);
+  const second = diagnoseLoCoMoRetrievalTraceDelta(baseline, real);
+
+  assert.deepEqual(first, second);
+  assert.equal(first.overall.mechanisms["real-core-visible-lcm-displacement"], 3);
+  assert.deepEqual(first.dominantMultiHopMechanism, {
+    status: "supported",
+    mechanism: "real-core-visible-lcm-displacement",
+    count: 3,
+    taskCount: 3,
+    rule: "strict-majority-and-at-least-two",
+  });
+  const serialized = serializeLoCoMoRetrievalTraceDelta(first);
+  assert.equal(serialized.includes("private-alpha"), false);
+  assert.equal(serialized.includes("private-core-memory-id"), false);
+  assert.doesNotMatch(serialized, /"(?:taskId|sessionId|memoryId|archiveRowId|path|excerpt|timestamp)"/u);
+  const { artifactHash, ...withoutHash } = first;
+  assert.equal(artifactHash, hashCanonicalJson(withoutHash));
+});
+
+test("uses true multiset subtraction and labels composition and budget changes", () => {
+  const baselineTasks = [
+    task("fixture-q0-single_hop", { sectionCopies: 2 }),
+    task("fixture-q1-temporal"),
+    task("fixture-q2-adversarial"),
+  ];
+  const realTasks = [
+    task("fixture-q0-single_hop", { sectionCopies: 1 }),
+    task("fixture-q1-temporal", { compositionMode: "fallback" }),
+    task("fixture-q2-adversarial", { truncated: true }),
+  ];
+  const report = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", baselineTasks), receipt("real", realTasks));
+
+  assert.deepEqual(report.tasks[0]?.dimensions.sectionVisibleChars, {
+    baselineCount: 2,
+    realCount: 1,
+    sharedCount: 1,
+    baselineOnlyCount: 1,
+    realOnlyCount: 0,
+    changed: true,
+  });
+  assert.equal(report.tasks[0]?.mechanism, "lcm-selection-change");
+  assert.equal(report.tasks[1]?.mechanism, "composition-filter-displacement");
+  assert.equal(report.tasks[1]?.dimensions.compositionPolicy.changed, true);
+  assert.equal(report.tasks[1]?.dimensions.compositionDigests.changed, true);
+  assert.equal(report.tasks[2]?.mechanism, "budget-truncation-change");
+});
+
+test("preserves equal-total section source and layout changes as structural signals", () => {
+  const sourceBaseline = task("fixture-q0-single_hop", { sectionChars: 10 });
+  const sourceReal = task("fixture-q0-single_hop", { sectionChars: 10 });
+  const baselineSection = sourceBaseline.sessions[0]?.trace.sections[0];
+  const realSection = sourceReal.sessions[0]?.trace.sections[0];
+  assert.ok(baselineSection);
+  assert.ok(realSection);
+  baselineSection.source = "derived";
+  realSection.source = "evidence-pack";
+  const sourceDelta = diagnoseLoCoMoRetrievalTraceDelta(
+    receipt("baseline", [sourceBaseline]),
+    receipt("real", [sourceReal])
+  ).tasks[0];
+  assert.equal(sourceDelta?.dimensions.sectionVisibleChars.changed, true);
+  assert.equal(sourceDelta?.mechanism, "mixed");
+
+  const layoutDelta = diagnoseLoCoMoRetrievalTraceDelta(
+    receipt("baseline", [task("fixture-q1-multi_hop", { sectionCopies: 2, sectionChars: 5 })]),
+    receipt("real", [task("fixture-q1-multi_hop", { sectionCopies: 1, sectionChars: 10 })])
+  ).tasks[0];
+  assert.equal(layoutDelta?.dimensions.sectionVisibleChars.changed, true);
+  assert.equal(layoutDelta?.mechanism, "lcm-selection-change");
+});
+
+test("attributes upstream displacement before downstream composition digest drift", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id);
+  const realTask = task(id, { sectionChars: 19, coreChars: 10, coreScore: 0.5 });
+  baselineTask.composition = prioritizeLoCoMoRecallTextWithTrace({
+    question: "Where does Alice live?",
+    recalledText: "Alice lives in Rome.",
+    multiHopRecallComposition: true,
+  }).receipt;
+  realTask.composition = prioritizeLoCoMoRecallTextWithTrace({
+    question: "Where does Alice live?",
+    recalledText: "Alice lives in Paris.",
+    multiHopRecallComposition: true,
+  }).receipt;
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.dimensions.compositionPolicy.changed, false);
+  assert.equal(delta?.dimensions.compositionDigests.changed, true);
+  assert.equal(delta?.mechanism, "real-core-visible-lcm-displacement");
+});
+
+test("fails closed on tampering, pairing drift, equal config hashes, and unavailable lineage", () => {
+  const baseline = receipt("baseline", [task("fixture-q0-multi_hop")]);
+  const real = receipt("real", [task("fixture-q0-multi_hop", { lineageStatus: "unavailable" })]);
+  assert.equal(diagnoseLoCoMoRetrievalTraceDelta(baseline, real).tasks[0]?.mechanism, "insufficient-exact-lineage");
+
+  const tampered = structuredClone(real);
+  const tamperedTask = tampered.tasks[0];
+  assert.ok(tamperedTask);
+  tamperedTask.recallBudgetChars += 1;
+  assert.throws(() => diagnoseLoCoMoRetrievalTraceDelta(baseline, tampered), /hash verification failed/);
+
+  const mismatched = receipt("real", [task("different-q0-multi_hop")]);
+  assert.throws(
+    () => diagnoseLoCoMoRetrievalTraceDelta(baseline, mismatched),
+    /provenance does not match|task mismatch/
+  );
+
+  const equalConfig = receipt("real", [task("fixture-q0-multi_hop")], "baseline");
+  assert.throws(() => diagnoseLoCoMoRetrievalTraceDelta(baseline, equalConfig), /different baseline and real/);
+
+  const changedQuestion = structuredClone(real);
+  const changedQuestionTask = changedQuestion.tasks[0];
+  assert.ok(changedQuestionTask);
+  changedQuestionTask.question = digest("different question");
+  assert.throws(() => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(changedQuestion)), /task mismatch/);
+
+  const changedSession = structuredClone(real);
+  const changedSessionReceipt = changedSession.tasks[0]?.sessions[0];
+  assert.ok(changedSessionReceipt);
+  changedSessionReceipt.session = digest("different session");
+  assert.throws(() => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(changedSession)), /session mismatch/);
+
+  const changedBudget = structuredClone(real);
+  const changedBudgetSession = changedBudget.tasks[0]?.sessions[0];
+  assert.ok(changedBudgetSession);
+  changedBudgetSession.trace.budget.requestedChars += 1;
+  assert.throws(() => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(changedBudget)), /budget mismatch/);
+
+  for (const missingLineage of ["selection-missing", "selection-empty", "candidate-missing"] as const) {
+    const incomplete = receipt("real", [task("fixture-q0-multi_hop")]);
+    const trace = incomplete.tasks[0]?.sessions[0]?.trace;
+    assert.ok(trace);
+    if (missingLineage === "selection-missing" && trace.selections[0]) {
+      const { archiveRowIds: _archiveRowIds, ...withoutArchiveRows } = trace.selections[0];
+      trace.selections[0] = withoutArchiveRows;
+    }
+    if (missingLineage === "selection-empty" && trace.selections[0]) trace.selections[0].archiveRowIds = [];
+    if (missingLineage === "candidate-missing" && trace.lcmCandidates[0]) {
+      const { archiveRowId: _archiveRowId, ...withoutArchiveRow } = trace.lcmCandidates[0];
+      trace.lcmCandidates[0] = withoutArchiveRow;
+    }
+    assert.equal(
+      diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(incomplete)).tasks[0]?.mechanism,
+      "insufficient-exact-lineage"
+    );
+  }
+});
+
+test("rejects duplicate task identities and impossible selection counts", () => {
+  const duplicate = receipt("baseline", [task("fixture-q0-multi_hop"), task("fixture-q0-multi_hop")]);
+  const real = receipt("real", [task("fixture-q0-multi_hop"), task("fixture-q0-multi_hop")]);
+  assert.throws(() => diagnoseLoCoMoRetrievalTraceDelta(duplicate, real), /restricted provider-free contract/);
+
+  const impossible = receipt("baseline", [task("fixture-q0-multi_hop")]);
+  impossible.selection.candidateCount = 0;
+  assert.throws(
+    () => diagnoseLoCoMoRetrievalTraceDelta(reseal(impossible), receipt("real", [task("fixture-q0-multi_hop")])),
+    /restricted provider-free contract/
+  );
+});
+
+test("requires a strict majority and at least two multi-hop observations", () => {
+  const ids = Array.from({ length: 4 }, (_, index) => `fixture-q${index}-multi_hop`);
+  const baseline = receipt(
+    "baseline",
+    ids.map((id) => task(id))
+  );
+  const realTwoOfFour = receipt(
+    "real",
+    ids.map((id, index) => task(id, index < 2 ? { sectionChars: 21 } : {}))
+  );
+  assert.equal(
+    diagnoseLoCoMoRetrievalTraceDelta(baseline, realTwoOfFour).dominantMultiHopMechanism.status,
+    "not-supported"
+  );
+
+  const threeIds = ids.slice(0, 3);
+  const realTwoOfThree = receipt(
+    "real",
+    threeIds.map((id, index) => task(id, index < 2 ? { sectionChars: 21 } : {}))
+  );
+  const supported = diagnoseLoCoMoRetrievalTraceDelta(
+    receipt(
+      "baseline",
+      threeIds.map((id) => task(id))
+    ),
+    realTwoOfThree
+  ).dominantMultiHopMechanism;
+  assert.equal(supported.status, "supported");
+  assert.equal(supported.count, 2);
+});

--- a/packages/bench/src/stats/locomo-retrieval-trace-delta.test.ts
+++ b/packages/bench/src/stats/locomo-retrieval-trace-delta.test.ts
@@ -75,20 +75,31 @@ function task(
                   },
                 ]),
           ],
-          selections: [
+          selections: Array.from(
+            { length: sectionCopies },
+            (_, index) =>
+              ({
+                sectionId: `section-${index}`,
+                kind: "lcm-summary",
+                lineageStatus,
+                ...(lineageStatus === "exact" ? { archiveRowIds: [7 + index] } : {}),
+                summary: { depth: 1, msgStart: index, msgEnd: index + 1 },
+                composedStart: index * sectionChars,
+                composedEnd: (index + 1) * sectionChars,
+                visibleStart: index * sectionChars,
+                visibleEnd: (index + 1) * sectionChars,
+              }) as LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["selections"][number]
+          ),
+          lcmCandidates: [
             {
-              sectionId: "section-0",
-              kind: "lcm-summary",
+              rank: 0,
+              ...(lineageStatus === "exact" ? { archiveRowId: 7 } : {}),
+              turnIndex: 2,
+              role: "user",
+              score: sectionChars,
               lineageStatus,
-              ...(lineageStatus === "exact" ? { archiveRowIds: [7] } : {}),
-              summary: { depth: 1, msgStart: 0, msgEnd: 1 },
-              composedStart: 0,
-              composedEnd: sectionChars,
-              visibleStart: 0,
-              visibleEnd: sectionChars,
             },
           ],
-          lcmCandidates: [{ rank: 0, archiveRowId: 7, turnIndex: 2, role: "user", score: sectionChars, lineageStatus }],
           coreCapture: {
             budget: { chars: 100, used: 10 },
             filters: [{ name: "admission", considered: 1, admitted: 1 }],
@@ -233,6 +244,12 @@ test("preserves equal-total section source and layout changes as structural sign
   assert.ok(realSection);
   baselineSection.source = "derived";
   realSection.source = "evidence-pack";
+  for (const entry of [sourceBaseline, sourceReal]) {
+    const selection = entry.sessions[0]?.trace.selections[0];
+    assert.ok(selection);
+    selection.kind = "evidence-block";
+    delete selection.summary;
+  }
   const sourceDelta = diagnoseLoCoMoRetrievalTraceDelta(
     receipt("baseline", [sourceBaseline]),
     receipt("real", [sourceReal])
@@ -246,6 +263,100 @@ test("preserves equal-total section source and layout changes as structural sign
   ).tasks[0];
   assert.equal(layoutDelta?.dimensions.sectionVisibleChars.changed, true);
   assert.equal(layoutDelta?.mechanism, "lcm-selection-change");
+});
+
+test("preserves equal-length section identity and ordering changes", () => {
+  const reorderedId = "fixture-q0-multi_hop";
+  const reorderedBaseline = task(reorderedId, { sectionCopies: 2 });
+  const reorderedReal = task(reorderedId, { sectionCopies: 2 });
+  const reorderedTrace = reorderedReal.sessions[0]?.trace;
+  assert.ok(reorderedTrace?.sections[0]);
+  assert.ok(reorderedTrace.sections[1]);
+  assert.ok(reorderedTrace.selections[0]);
+  assert.ok(reorderedTrace.selections[1]);
+  [reorderedTrace.sections[0].id, reorderedTrace.sections[1].id] = [
+    reorderedTrace.sections[1].id,
+    reorderedTrace.sections[0].id,
+  ];
+  [reorderedTrace.selections[0].sectionId, reorderedTrace.selections[1].sectionId] = [
+    reorderedTrace.selections[1].sectionId,
+    reorderedTrace.selections[0].sectionId,
+  ];
+  const reorderedDelta = diagnoseLoCoMoRetrievalTraceDelta(
+    receipt("baseline", [reorderedBaseline]),
+    receipt("real", [reorderedReal])
+  ).tasks[0];
+  assert.equal(reorderedDelta?.dimensions.sectionVisibleChars.changed, true);
+  assert.equal(reorderedDelta?.dimensions.selections.changed, false);
+  assert.equal(reorderedDelta?.mechanism, "lcm-selection-change");
+
+  const replacedId = "fixture-q1-multi_hop";
+  const replacedBaseline = task(replacedId);
+  const replacedReal = task(replacedId);
+  const replacedTrace = replacedReal.sessions[0]?.trace;
+  const replacedSection = replacedTrace?.sections[0];
+  const replacedSelection = replacedTrace?.selections[0];
+  assert.ok(replacedSection);
+  assert.ok(replacedSelection);
+  replacedSection.id = "replacement-section";
+  replacedSelection.sectionId = "replacement-section";
+  const replacedDelta = diagnoseLoCoMoRetrievalTraceDelta(
+    receipt("baseline", [replacedBaseline]),
+    receipt("real", [replacedReal])
+  ).tasks[0];
+  assert.equal(replacedDelta?.dimensions.sectionVisibleChars.changed, true);
+  assert.equal(replacedDelta?.dimensions.selections.changed, false);
+  assert.equal(replacedDelta?.mechanism, "lcm-selection-change");
+});
+
+test("binds summary and raw-row lineage identities to rendered positions", () => {
+  const summaryId = "fixture-q0-multi_hop";
+  const summaryBaseline = task(summaryId, { sectionCopies: 2 });
+  const summaryReal = task(summaryId, { sectionCopies: 2 });
+  const summarySelections = summaryReal.sessions[0]?.trace.selections;
+  assert.ok(summarySelections?.[0]?.summary);
+  assert.ok(summarySelections[1]?.summary);
+  [summarySelections[0].summary, summarySelections[1].summary] = [
+    summarySelections[1].summary,
+    summarySelections[0].summary,
+  ];
+  const summaryDelta = diagnoseLoCoMoRetrievalTraceDelta(
+    receipt("baseline", [summaryBaseline]),
+    receipt("real", [summaryReal])
+  ).tasks[0];
+  assert.equal(summaryDelta?.dimensions.sectionVisibleChars.changed, false);
+  assert.equal(summaryDelta?.dimensions.selections.changed, true);
+  assert.equal(summaryDelta?.mechanism, "lcm-selection-change");
+
+  const rawRowId = "fixture-q1-multi_hop";
+  const rawRowBaseline = task(rawRowId, { sectionCopies: 2 });
+  const rawRowReal = task(rawRowId, { sectionCopies: 2 });
+  for (const entry of [rawRowBaseline, rawRowReal]) {
+    const trace = entry.sessions[0]?.trace;
+    assert.ok(trace);
+    trace.sections.forEach((section) => {
+      section.source = "raw-row";
+    });
+    trace.selections = trace.selections.map((selection) => {
+      const { summary: _summary, ...rawRowSelection } = selection;
+      return { ...rawRowSelection, kind: "raw-row" };
+    });
+  }
+  const rawSelections = rawRowReal.sessions[0]?.trace.selections;
+  assert.ok(rawSelections?.[0]?.archiveRowIds);
+  assert.ok(rawSelections[1]?.archiveRowIds);
+  [rawSelections[0].archiveRowIds, rawSelections[1].archiveRowIds] = [
+    rawSelections[1].archiveRowIds,
+    rawSelections[0].archiveRowIds,
+  ];
+  const rawRowDelta = diagnoseLoCoMoRetrievalTraceDelta(
+    receipt("baseline", [rawRowBaseline]),
+    receipt("real", [rawRowReal])
+  ).tasks[0];
+  assert.equal(rawRowDelta?.dimensions.sectionVisibleChars.changed, false);
+  assert.equal(rawRowDelta?.dimensions.archiveRows.changed, false);
+  assert.equal(rawRowDelta?.dimensions.selections.changed, true);
+  assert.equal(rawRowDelta?.mechanism, "lcm-selection-change");
 });
 
 test("attributes upstream displacement before downstream composition digest drift", () => {
@@ -268,6 +379,330 @@ test("attributes upstream displacement before downstream composition digest drif
   assert.equal(delta?.dimensions.compositionPolicy.changed, false);
   assert.equal(delta?.dimensions.compositionDigests.changed, true);
   assert.equal(delta?.mechanism, "real-core-visible-lcm-displacement");
+});
+
+test("does not classify rendered character counts as recall-budget changes", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id);
+  const realTask = task(id, { sectionChars: 19, coreChars: 10, coreScore: 0.5 });
+  const realBudget = realTask.sessions[0]?.trace.budget;
+  assert.ok(realBudget);
+  realBudget.composedChars = 29;
+  realBudget.returnedChars = 29;
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.dimensions.recallBudget.changed, false);
+  assert.equal(delta?.mechanism, "real-core-visible-lcm-displacement");
+});
+
+test("labels composition-digest-only changes without claiming no structural delta", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id);
+  const realTask = task(id);
+  realTask.composition.output = digest("different composition output");
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.dimensions.compositionDigests.changed, true);
+  assert.equal(delta?.mechanism, "composition-digest-change");
+});
+
+test("accepts exact compressed-summary lineage without archive row ids", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id);
+  const realTask = task(id);
+  for (const entry of [baselineTask, realTask]) {
+    const trace = entry.sessions[0]?.trace;
+    const selection = trace?.selections[0];
+    assert.ok(trace);
+    assert.ok(selection);
+    delete selection.archiveRowIds;
+    if (selection.summary) selection.summary.msgEnd = selection.summary.msgStart;
+    trace.lcmCandidates = [];
+  }
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.mechanism, "no-structural-delta");
+});
+
+test("treats LCM-free tasks and exact raw-row fallback as complete lineage", () => {
+  const coreOnlyId = "fixture-q0-multi_hop";
+  const coreOnlyBaseline = task(coreOnlyId, { coreChars: 10 });
+  const coreOnlyReal = task(coreOnlyId, { coreChars: 10 });
+  for (const entry of [coreOnlyBaseline, coreOnlyReal]) {
+    const trace = entry.sessions[0]?.trace;
+    assert.ok(trace);
+    trace.sections = trace.sections.filter((section) => section.source === "core");
+    trace.selections = [];
+    trace.lcmCandidates = [];
+  }
+  assert.equal(
+    diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [coreOnlyBaseline]), receipt("real", [coreOnlyReal])).tasks[0]
+      ?.mechanism,
+    "no-structural-delta"
+  );
+
+  const rawRowId = "fixture-q1-multi_hop";
+  const rawRowBaseline = task(rawRowId);
+  const rawRowReal = task(rawRowId);
+  for (const entry of [rawRowBaseline, rawRowReal]) {
+    const trace = entry.sessions[0]?.trace;
+    const section = trace?.sections[0];
+    const selection = trace?.selections[0];
+    assert.ok(trace);
+    assert.ok(section);
+    assert.ok(selection);
+    section.source = "raw-row";
+    const { summary: _summary, ...rawRowSelection } = selection;
+    trace.selections[0] = { ...rawRowSelection, kind: "raw-row" };
+    trace.lcmCandidates = [];
+  }
+  assert.equal(
+    diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [rawRowBaseline]), receipt("real", [rawRowReal])).tasks[0]
+      ?.mechanism,
+    "no-structural-delta"
+  );
+});
+
+test("ignores unavailable candidates when rendered LCM lineage is exact", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id);
+  const realTask = task(id);
+  const baselineCandidate = baselineTask.sessions[0]?.trace.lcmCandidates[0];
+  const baselineTrace = baselineTask.sessions[0]?.trace;
+  const realTrace = realTask.sessions[0]?.trace;
+  assert.ok(baselineCandidate);
+  assert.ok(baselineTrace);
+  assert.ok(realTrace);
+  const { archiveRowId: _baselineArchiveRowId, ...baselineCandidateWithoutRow } = baselineCandidate;
+  baselineTrace.lcmCandidates[0] = { ...baselineCandidateWithoutRow, lineageStatus: "unavailable" };
+  realTrace.lcmCandidates = [];
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.dimensions.lcmCandidates.changed, false);
+  assert.equal(delta?.mechanism, "no-structural-delta");
+
+  const candidateOnly = task(id);
+  const candidateOnlyTrace = candidateOnly.sessions[0]?.trace;
+  const candidateOnlyCandidate = candidateOnlyTrace?.lcmCandidates[0];
+  assert.ok(candidateOnlyTrace);
+  assert.ok(candidateOnlyCandidate);
+  candidateOnlyTrace.sections = [];
+  candidateOnlyTrace.selections = [];
+  const { archiveRowId: _candidateOnlyArchiveRowId, ...candidateOnlyWithoutRow } = candidateOnlyCandidate;
+  candidateOnlyTrace.lcmCandidates[0] = { ...candidateOnlyWithoutRow, lineageStatus: "unavailable" };
+  assert.equal(
+    diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [task(id)]), receipt("real", [candidateOnly])).tasks[0]
+      ?.mechanism,
+    "insufficient-exact-lineage"
+  );
+});
+
+test("ignores unavailable non-LCM selections for exact attribution", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id);
+  const realTask = task(id);
+  for (const entry of [baselineTask, realTask]) {
+    const trace = entry.sessions[0]?.trace;
+    assert.ok(trace);
+    trace.sections.push({
+      id: "evidence-section",
+      source: "evidence-pack",
+      separatorStart: 20,
+      contentStart: 22,
+      contentEnd: 30,
+      composedStart: 20,
+      composedEnd: 30,
+      visibleStart: 20,
+      visibleEnd: 30,
+      visibleChars: 10,
+    });
+    trace.budget.composedChars = 30;
+    trace.budget.returnedChars = 30;
+  }
+  const baselineTrace = baselineTask.sessions[0]?.trace;
+  assert.ok(baselineTrace);
+  baselineTrace.selections.push({
+    sectionId: "evidence-section",
+    kind: "evidence-block",
+    lineageStatus: "unavailable",
+    composedStart: 22,
+    composedEnd: 30,
+    visibleStart: 22,
+    visibleEnd: 30,
+  });
+  baselineTrace.selections.push({
+    sectionId: "evidence-section",
+    kind: "trajectory-line",
+    lineageStatus: "unavailable",
+    archiveRowIds: [99],
+    composedStart: 22,
+    composedEnd: 30,
+    visibleStart: 22,
+    visibleEnd: 30,
+  });
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.dimensions.sectionVisibleChars.changed, false);
+  assert.equal(delta?.dimensions.selections.changed, false);
+  assert.equal(delta?.dimensions.archiveRows.changed, false);
+  assert.equal(delta?.mechanism, "no-structural-delta");
+});
+
+test("keeps exact auxiliary selection changes out of LCM attribution", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id);
+  const realTask = task(id);
+  for (const [index, entry] of [baselineTask, realTask].entries()) {
+    const trace = entry.sessions[0]?.trace;
+    assert.ok(trace);
+    trace.sections.push({
+      id: "evidence-section",
+      source: "evidence-pack",
+      separatorStart: 20,
+      contentStart: 22,
+      contentEnd: 30,
+      composedStart: 20,
+      composedEnd: 30,
+      visibleStart: 20,
+      visibleEnd: 30,
+      visibleChars: 10,
+    });
+    trace.selections.push({
+      sectionId: "evidence-section",
+      kind: "evidence-block",
+      lineageStatus: "exact",
+      archiveRowIds: [101 + index],
+      composedStart: 22,
+      composedEnd: 30,
+      visibleStart: 22,
+      visibleEnd: 30,
+    });
+    trace.budget.composedChars = 30;
+    trace.budget.returnedChars = 30;
+  }
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.dimensions.sectionVisibleChars.changed, false);
+  assert.equal(delta?.dimensions.selections.changed, true);
+  assert.equal(delta?.dimensions.archiveRows.changed, true);
+  assert.equal(delta?.dimensions.lcmCandidates.changed, false);
+  assert.equal(delta?.mechanism, "mixed");
+});
+
+test("analyzes core-capture budget presence as a structural delta", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id);
+  const realTask = task(id);
+  const baselineTrace = baselineTask.sessions[0]?.trace;
+  assert.ok(baselineTrace);
+  const { coreCapture: _coreCapture, ...withoutCoreCapture } = baselineTrace;
+  const baselineSession = baselineTask.sessions[0];
+  assert.ok(baselineSession);
+  baselineSession.trace = withoutCoreCapture;
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.dimensions.coreBudget.changed, true);
+  assert.equal(delta?.dimensions.coreResults.changed, true);
+});
+
+test("preserves ranked core-result ordering as a structural signal", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id, { coreChars: 10 });
+  const realTask = task(id, { coreChars: 10 });
+  for (const entry of [baselineTask, realTask]) {
+    const results = entry.sessions[0]?.trace.coreCapture?.results;
+    const first = results?.[0];
+    assert.ok(results);
+    assert.ok(first);
+    results.push({
+      ...structuredClone(first),
+      memoryIdRef: { sha256: hashString("second-private-core-memory-id"), length: 29 },
+      scoreDecomposition: { ...first.scoreDecomposition, final: 0.5 },
+    });
+  }
+  const realResults = realTask.sessions[0]?.trace.coreCapture?.results;
+  assert.ok(realResults);
+  realResults.reverse();
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.dimensions.sectionVisibleChars.changed, false);
+  assert.equal(delta?.dimensions.coreBudget.changed, false);
+  assert.equal(delta?.dimensions.coreFilters.changed, false);
+  assert.deepEqual(delta?.dimensions.coreResults, {
+    baselineCount: 2,
+    realCount: 2,
+    sharedCount: 0,
+    baselineOnlyCount: 2,
+    realOnlyCount: 2,
+    changed: true,
+  });
+  assert.equal(delta?.dimensions.recallBudget.changed, false);
+  assert.equal(delta?.dimensions.compositionPolicy.changed, false);
+  assert.equal(delta?.dimensions.compositionDigests.changed, false);
+  assert.equal(delta?.mechanism, "mixed");
+});
+
+test("requires an LCM-specific lineage carrier for LCM-bearing sections", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id);
+  const realTask = task(id);
+  for (const entry of [baselineTask, realTask]) {
+    const trace = entry.sessions[0]?.trace;
+    const selection = trace?.selections[0];
+    assert.ok(trace);
+    assert.ok(selection);
+    selection.kind = "evidence-block";
+    delete selection.summary;
+    trace.lcmCandidates = [];
+  }
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.mechanism, "insufficient-exact-lineage");
+});
+
+test("binds exact LCM lineage to every rendered LCM section", () => {
+  const id = "fixture-q0-multi_hop";
+  const orphaned = task(id);
+  const orphanedSelection = orphaned.sessions[0]?.trace.selections[0];
+  assert.ok(orphanedSelection);
+  orphanedSelection.sectionId = "missing-section";
+  assert.throws(
+    () => diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [task(id)]), receipt("real", [orphaned])),
+    /selection structure is invalid/
+  );
+
+  const baselineTask = task(id);
+  const realTask = task(id);
+  for (const entry of [baselineTask, realTask]) {
+    const trace = entry.sessions[0]?.trace;
+    assert.ok(trace);
+    trace.sections.push({
+      id: "raw-row-section",
+      source: "raw-row",
+      separatorStart: 20,
+      contentStart: 20,
+      contentEnd: 30,
+      composedStart: 20,
+      composedEnd: 30,
+      visibleStart: 20,
+      visibleEnd: 30,
+      visibleChars: 10,
+    });
+  }
+  assert.equal(
+    diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask])).tasks[0]
+      ?.mechanism,
+    "insufficient-exact-lineage"
+  );
 });
 
 test("fails closed on tampering, pairing drift, equal config hashes, and unavailable lineage", () => {
@@ -303,15 +738,34 @@ test("fails closed on tampering, pairing drift, equal config hashes, and unavail
   assert.throws(() => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(changedSession)), /session mismatch/);
 
   const changedBudget = structuredClone(real);
+  const changedBudgetTask = changedBudget.tasks[0];
   const changedBudgetSession = changedBudget.tasks[0]?.sessions[0];
+  assert.ok(changedBudgetTask);
   assert.ok(changedBudgetSession);
+  changedBudgetTask.recallBudgetChars += 1;
   changedBudgetSession.trace.budget.requestedChars += 1;
-  assert.throws(() => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(changedBudget)), /budget mismatch/);
+  assert.throws(() => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(changedBudget)), /task mismatch/);
+
+  const inconsistentBudget = receipt("real", [task("fixture-q0-multi_hop")]);
+  const inconsistentTrace = inconsistentBudget.tasks[0]?.sessions[0]?.trace;
+  assert.ok(inconsistentTrace);
+  inconsistentTrace.budget.returnedChars = inconsistentTrace.budget.composedChars - 1;
+  assert.throws(
+    () => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(inconsistentBudget)),
+    /session structure is invalid/
+  );
 
   for (const missingLineage of ["selection-missing", "selection-empty", "candidate-missing"] as const) {
     const incomplete = receipt("real", [task("fixture-q0-multi_hop")]);
     const trace = incomplete.tasks[0]?.sessions[0]?.trace;
     assert.ok(trace);
+    if ((missingLineage === "selection-missing" || missingLineage === "selection-empty") && trace.selections[0]) {
+      trace.selections[0].kind = "raw-row";
+      delete trace.selections[0].summary;
+      const section = trace.sections.find((entry) => entry.id === trace.selections[0]?.sectionId);
+      assert.ok(section);
+      section.source = "raw-row";
+    }
     if (missingLineage === "selection-missing" && trace.selections[0]) {
       const { archiveRowIds: _archiveRowIds, ...withoutArchiveRows } = trace.selections[0];
       trace.selections[0] = withoutArchiveRows;
@@ -321,11 +775,88 @@ test("fails closed on tampering, pairing drift, equal config hashes, and unavail
       const { archiveRowId: _archiveRowId, ...withoutArchiveRow } = trace.lcmCandidates[0];
       trace.lcmCandidates[0] = withoutArchiveRow;
     }
-    assert.equal(
-      diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(incomplete)).tasks[0]?.mechanism,
-      "insufficient-exact-lineage"
+    if (missingLineage === "candidate-missing") {
+      assert.throws(
+        () => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(incomplete)),
+        /candidate structure is invalid/
+      );
+    } else {
+      assert.equal(
+        diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(incomplete)).tasks[0]?.mechanism,
+        "insufficient-exact-lineage"
+      );
+    }
+  }
+
+  const emptyLineage = receipt("real", [task("fixture-q0-multi_hop", { sectionChars: 19 })]);
+  const emptyTrace = emptyLineage.tasks[0]?.sessions[0]?.trace;
+  assert.ok(emptyTrace);
+  emptyTrace.selections = [];
+  emptyTrace.lcmCandidates = [];
+  assert.equal(
+    diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(emptyLineage)).tasks[0]?.mechanism,
+    "insufficient-exact-lineage"
+  );
+
+  const sessionIncompleteBaseline = task("fixture-q0-multi_hop");
+  const sessionIncompleteReal = task("fixture-q0-multi_hop");
+  const completeSecondSession = structuredClone(sessionIncompleteBaseline.sessions[0]);
+  const emptySecondSession = structuredClone(sessionIncompleteReal.sessions[0]);
+  assert.ok(completeSecondSession);
+  assert.ok(emptySecondSession);
+  sessionIncompleteBaseline.sessions.push(completeSecondSession);
+  emptySecondSession.trace.selections = [];
+  emptySecondSession.trace.lcmCandidates = [];
+  sessionIncompleteReal.sessions.push(emptySecondSession);
+  assert.equal(
+    diagnoseLoCoMoRetrievalTraceDelta(
+      receipt("baseline", [sessionIncompleteBaseline]),
+      receipt("real", [sessionIncompleteReal])
+    ).tasks[0]?.mechanism,
+    "insufficient-exact-lineage"
+  );
+
+  const futureField = receipt("real", [task("fixture-q0-multi_hop")]);
+  const futureCandidate = futureField.tasks[0]?.sessions[0]?.trace.lcmCandidates[0] as
+    | (LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["lcmCandidates"][number] & {
+        futureRaw?: string;
+      })
+    | undefined;
+  assert.ok(futureCandidate);
+  futureCandidate.futureRaw = "must-not-influence-attribution";
+  assert.throws(() => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(futureField)), /unsupported field/);
+
+  for (const invalidSelection of [
+    { algorithm: "bogus", seed: undefined },
+    { algorithm: "explicit-task-ids", seed: 7 },
+    { algorithm: "sha256-seeded-sample", seed: undefined },
+  ] as const) {
+    const invalid = receipt("real", [task("fixture-q0-multi_hop")]);
+    invalid.selection.algorithm = invalidSelection.algorithm as typeof invalid.selection.algorithm;
+    if (invalidSelection.seed === undefined) delete invalid.selection.seed;
+    else invalid.selection.seed = invalidSelection.seed;
+    assert.throws(
+      () => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(invalid)),
+      /restricted provider-free contract/
     );
   }
+
+  const missingFinal = receipt("real", [task("fixture-q0-multi_hop")]);
+  const score = missingFinal.tasks[0]?.sessions[0]?.trace.coreCapture?.results[0]?.scoreDecomposition as
+    | Record<string, unknown>
+    | undefined;
+  assert.ok(score);
+  delete score.final;
+  assert.throws(
+    () => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(missingFinal)),
+    /core result structure is invalid/
+  );
+
+  const noSessions = receipt("real", [task("fixture-q0-multi_hop")]);
+  const noSessionsTask = noSessions.tasks[0];
+  assert.ok(noSessionsTask);
+  noSessionsTask.sessions = [];
+  assert.throws(() => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(noSessions)), /task structure is invalid/);
 });
 
 test("rejects duplicate task identities and impossible selection counts", () => {

--- a/packages/bench/src/stats/locomo-retrieval-trace-delta.test.ts
+++ b/packages/bench/src/stats/locomo-retrieval-trace-delta.test.ts
@@ -381,6 +381,24 @@ test("attributes upstream displacement before downstream composition digest drif
   assert.equal(delta?.mechanism, "real-core-visible-lcm-displacement");
 });
 
+test("does not claim core-visible LCM displacement across composition policy changes", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id);
+  const realTask = task(id, {
+    sectionChars: 19,
+    coreChars: 10,
+    coreScore: 0.5,
+    compositionMode: "fallback",
+  });
+  realTask.composition.output = baselineTask.composition.output;
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.dimensions.compositionPolicy.changed, true);
+  assert.equal(delta?.dimensions.compositionDigests.changed, false);
+  assert.equal(delta?.mechanism, "mixed");
+});
+
 test("does not classify rendered character counts as recall-budget changes", () => {
   const id = "fixture-q0-multi_hop";
   const baselineTask = task(id);

--- a/packages/bench/src/stats/locomo-retrieval-trace-delta.test.ts
+++ b/packages/bench/src/stats/locomo-retrieval-trace-delta.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { createBenchRecallTraceRecorder } from "../adapters/remnic-recall-trace.js";
 import type {
   LoCoMoRetrievalTaskReceipt,
   LoCoMoRetrievalTraceReceipt,
@@ -26,7 +27,6 @@ function task(
     coreChars?: number;
     coreScore?: number;
     compositionMode?: "focused" | "fallback";
-    truncated?: boolean;
     lineageStatus?: "exact" | "unavailable";
   } = {}
 ): LoCoMoRetrievalTaskReceipt {
@@ -35,6 +35,57 @@ function task(
   const coreScore = options.coreScore ?? 1;
   const coreChars = options.coreChars ?? 0;
   const lineageStatus = options.lineageStatus ?? "exact";
+  const sections: LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["sections"] = [];
+  const selections: LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["selections"] = [];
+  let composedChars = 0;
+  for (let index = 0; index < sectionCopies; index += 1) {
+    const separatorStart = composedChars;
+    const contentStart = separatorStart + (sections.length === 0 ? 0 : 2);
+    const contentEnd = contentStart + sectionChars;
+    sections.push({
+      id: `section-${index}`,
+      source: "lcm-summary",
+      separatorStart,
+      contentStart,
+      contentEnd,
+      composedStart: separatorStart,
+      composedEnd: contentEnd,
+      visibleStart: separatorStart,
+      visibleEnd: contentEnd,
+      visibleChars: contentEnd - separatorStart,
+    });
+    selections.push({
+      sectionId: `section-${index}`,
+      kind: "lcm-summary",
+      lineageStatus,
+      ...(lineageStatus === "exact" ? { archiveRowIds: [7 + index] } : {}),
+      summary: { depth: 1, msgStart: index, msgEnd: index + 1 },
+      composedStart: contentStart,
+      composedEnd: contentEnd,
+      visibleStart: contentStart,
+      visibleEnd: contentEnd,
+    });
+    composedChars = contentEnd;
+  }
+  if (coreChars > 0) {
+    const separatorStart = composedChars;
+    const contentStart = separatorStart + (sections.length === 0 ? 0 : 2);
+    const contentEnd = contentStart + coreChars;
+    sections.push({
+      id: "core-section",
+      source: "core",
+      separatorStart,
+      contentStart,
+      contentEnd,
+      composedStart: separatorStart,
+      composedEnd: contentEnd,
+      visibleStart: separatorStart,
+      visibleEnd: contentEnd,
+      visibleChars: contentEnd - separatorStart,
+    });
+    composedChars = contentEnd;
+  }
+  const returnedChars = composedChars;
   return {
     taskId: id,
     question: digest(`question:${id}`),
@@ -45,51 +96,8 @@ function task(
         trace: {
           schemaVersion: 1,
           sensitivity: { classification: "restricted", contentEncoding: "sha256+length", containsGold: false },
-          sections: [
-            ...Array.from({ length: sectionCopies }, (_, index) => ({
-              id: `section-${index}`,
-              source: "lcm-summary" as const,
-              separatorStart: index * sectionChars,
-              contentStart: index * sectionChars,
-              contentEnd: (index + 1) * sectionChars,
-              composedStart: index * sectionChars,
-              composedEnd: (index + 1) * sectionChars,
-              visibleStart: index * sectionChars,
-              visibleEnd: (index + 1) * sectionChars,
-              visibleChars: sectionChars,
-            })),
-            ...(coreChars === 0
-              ? []
-              : [
-                  {
-                    id: "core-section",
-                    source: "core" as const,
-                    separatorStart: 0,
-                    contentStart: 0,
-                    contentEnd: coreChars,
-                    composedStart: 0,
-                    composedEnd: coreChars,
-                    visibleStart: 0,
-                    visibleEnd: coreChars,
-                    visibleChars: coreChars,
-                  },
-                ]),
-          ],
-          selections: Array.from(
-            { length: sectionCopies },
-            (_, index) =>
-              ({
-                sectionId: `section-${index}`,
-                kind: "lcm-summary",
-                lineageStatus,
-                ...(lineageStatus === "exact" ? { archiveRowIds: [7 + index] } : {}),
-                summary: { depth: 1, msgStart: index, msgEnd: index + 1 },
-                composedStart: index * sectionChars,
-                composedEnd: (index + 1) * sectionChars,
-                visibleStart: index * sectionChars,
-                visibleEnd: (index + 1) * sectionChars,
-              }) as LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["selections"][number]
-          ),
+          sections,
+          selections,
           lcmCandidates: [
             {
               rank: 0,
@@ -114,9 +122,9 @@ function task(
           },
           budget: {
             requestedChars: 100,
-            composedChars: 20,
-            returnedChars: options.truncated ? 10 : 20,
-            truncated: options.truncated ?? false,
+            composedChars,
+            returnedChars,
+            truncated: false,
           },
         },
       },
@@ -177,6 +185,42 @@ function reseal(value: LoCoMoRetrievalTraceReceipt): LoCoMoRetrievalTraceReceipt
   return { ...withoutHash, artifactHash: hashCanonicalJson(withoutHash) };
 }
 
+function recorderTask(id: string, sectionChars: number): LoCoMoRetrievalTaskReceipt {
+  const requestedChars = 20;
+  const taskReceipt = task(id);
+  const recorder = createBenchRecallTraceRecorder(requestedChars);
+  recorder.appendSection("section-0", "lcm-summary", sectionChars);
+  recorder.recordSummarySelections("section-0", [
+    { id: "summary-0", depth: 1, msgStart: 0, msgEnd: 1, entryStart: 0, entryEnd: 10 },
+  ]);
+  recorder.recordLcmCandidate({
+    rank: 0,
+    archiveRowId: 7,
+    turnIndex: 2,
+    role: "user",
+    score: 0.5,
+    lineageStatus: "exact",
+  });
+  const trace = recorder.finalize(Math.min(requestedChars, sectionChars));
+  const coreCapture = taskReceipt.sessions[0]?.trace.coreCapture;
+  const session = taskReceipt.sessions[0];
+  assert.ok(session);
+  session.trace = {
+    ...trace,
+    selections: trace.selections.map(({ summary, ...selection }) => ({
+      ...selection,
+      ...(summary === undefined
+        ? {}
+        : { summary: { depth: summary.depth, msgStart: summary.msgStart, msgEnd: summary.msgEnd } }),
+    })),
+    ...(coreCapture === undefined ? {} : { coreCapture }),
+  };
+  taskReceipt.recallBudgetChars = requestedChars;
+  taskReceipt.composition.input = digest(`recall-prefix-${Math.min(requestedChars, sectionChars)}`);
+  taskReceipt.composition.output = digest("stable composition output");
+  return taskReceipt;
+}
+
 test("pairs deterministic receipts and reports core-visible LCM displacement without raw identifiers", () => {
   const ids = ["private-alpha-q0-multi_hop", "private-alpha-q1-multi_hop", "private-alpha-q2-multi_hop"];
   const baseline = receipt(
@@ -211,12 +255,12 @@ test("uses true multiset subtraction and labels composition and budget changes",
   const baselineTasks = [
     task("fixture-q0-single_hop", { sectionCopies: 2 }),
     task("fixture-q1-temporal"),
-    task("fixture-q2-adversarial"),
+    recorderTask("fixture-q2-adversarial", 15),
   ];
   const realTasks = [
     task("fixture-q0-single_hop", { sectionCopies: 1 }),
     task("fixture-q1-temporal", { compositionMode: "fallback" }),
-    task("fixture-q2-adversarial", { truncated: true }),
+    recorderTask("fixture-q2-adversarial", 25),
   ];
   const report = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", baselineTasks), receipt("real", realTasks));
 
@@ -242,7 +286,7 @@ test("preserves equal-total section source and layout changes as structural sign
   const realSection = sourceReal.sessions[0]?.trace.sections[0];
   assert.ok(baselineSection);
   assert.ok(realSection);
-  baselineSection.source = "derived";
+  baselineSection.source = "explicit-cue";
   realSection.source = "evidence-pack";
   for (const entry of [sourceBaseline, sourceReal]) {
     const selection = entry.sessions[0]?.trace.selections[0];
@@ -287,7 +331,7 @@ test("preserves equal-length section identity and ordering changes", () => {
     receipt("real", [reorderedReal])
   ).tasks[0];
   assert.equal(reorderedDelta?.dimensions.sectionVisibleChars.changed, true);
-  assert.equal(reorderedDelta?.dimensions.selections.changed, false);
+  assert.equal(reorderedDelta?.dimensions.selections.changed, true);
   assert.equal(reorderedDelta?.mechanism, "lcm-selection-change");
 
   const replacedId = "fixture-q1-multi_hop";
@@ -305,8 +349,26 @@ test("preserves equal-length section identity and ordering changes", () => {
     receipt("real", [replacedReal])
   ).tasks[0];
   assert.equal(replacedDelta?.dimensions.sectionVisibleChars.changed, true);
-  assert.equal(replacedDelta?.dimensions.selections.changed, false);
+  assert.equal(replacedDelta?.dimensions.selections.changed, true);
   assert.equal(replacedDelta?.mechanism, "lcm-selection-change");
+});
+
+test("binds selection lineage to its section identity", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id, { sectionCopies: 2 });
+  const realTask = task(id, { sectionCopies: 2 });
+  const realSelections = realTask.sessions[0]?.trace.selections;
+  assert.ok(realSelections?.[0]);
+  assert.ok(realSelections[1]);
+  [realSelections[0].sectionId, realSelections[1].sectionId] = [
+    realSelections[1].sectionId,
+    realSelections[0].sectionId,
+  ];
+
+  assert.throws(
+    () => diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask])),
+    /selection structure is invalid/
+  );
 });
 
 test("binds summary and raw-row lineage identities to rendered positions", () => {
@@ -370,7 +432,7 @@ test("attributes upstream displacement before downstream composition digest drif
   }).receipt;
   realTask.composition = prioritizeLoCoMoRecallTextWithTrace({
     question: "Where does Alice live?",
-    recalledText: "Alice lives in Paris.",
+    recalledText: "Alice lives in Lima.",
     multiHopRecallComposition: true,
   }).receipt;
 
@@ -403,15 +465,214 @@ test("does not classify rendered character counts as recall-budget changes", () 
   const id = "fixture-q0-multi_hop";
   const baselineTask = task(id);
   const realTask = task(id, { sectionChars: 19, coreChars: 10, coreScore: 0.5 });
-  const realBudget = realTask.sessions[0]?.trace.budget;
-  assert.ok(realBudget);
-  realBudget.composedChars = 29;
-  realBudget.returnedChars = 29;
 
   const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
     .tasks[0];
   assert.equal(delta?.dimensions.recallBudget.changed, false);
   assert.equal(delta?.mechanism, "real-core-visible-lcm-displacement");
+});
+
+test("reports recorder-built fixed-budget tail-geometry transitions", () => {
+  const baselineTask = recorderTask("fixture-q0-multi_hop", 15);
+  const realTask = recorderTask("fixture-q0-multi_hop", 25);
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.dimensions.recallBudget.changed, true);
+  assert.equal(delta?.dimensions.sectionVisibleChars.changed, true);
+  assert.equal(delta?.dimensions.selections.changed, false);
+  assert.equal(delta?.dimensions.compositionDigests.changed, true);
+  assert.equal(delta?.dimensions.compositionPolicy.changed, false);
+  assert.equal(delta?.mechanism, "budget-truncation-change");
+
+  const reverse = diagnoseLoCoMoRetrievalTraceDelta(
+    receipt("baseline", [recorderTask("fixture-q1-multi_hop", 25)]),
+    receipt("real", [recorderTask("fixture-q1-multi_hop", 15)])
+  ).tasks[0];
+  assert.equal(reverse?.mechanism, "budget-truncation-change");
+});
+
+test("keeps policy and pre-truncation retrieval changes out of budget tail attribution", () => {
+  const cases: Array<{
+    name: string;
+    mutate: (baselineTask: LoCoMoRetrievalTaskReceipt, realTask: LoCoMoRetrievalTaskReceipt) => void;
+  }> = [
+    {
+      name: "composition policy",
+      mutate: (_baselineTask, realTask) => {
+        realTask.composition.mode = "fallback";
+      },
+    },
+    {
+      name: "composed section layout",
+      mutate: (baselineTask, realTask) => {
+        for (const entry of [baselineTask, realTask]) {
+          const trace = entry.sessions[0]?.trace;
+          assert.ok(trace);
+          const separatorStart = trace.budget.composedChars;
+          const contentStart = separatorStart + 2;
+          trace.sections.push({
+            id: "derived-tail",
+            source: "derived",
+            separatorStart,
+            contentStart,
+            contentEnd: contentStart,
+            composedStart: separatorStart,
+            composedEnd: contentStart,
+            visibleStart: Math.min(separatorStart, trace.budget.requestedChars),
+            visibleEnd: Math.min(contentStart, trace.budget.requestedChars),
+            visibleChars:
+              Math.min(contentStart, trace.budget.requestedChars) -
+              Math.min(separatorStart, trace.budget.requestedChars),
+          });
+          trace.budget.composedChars = contentStart;
+          trace.budget.returnedChars = Math.min(trace.budget.requestedChars, contentStart);
+          trace.budget.truncated = trace.budget.returnedChars < contentStart;
+        }
+      },
+    },
+    {
+      name: "selection lineage",
+      mutate: (_baselineTask, realTask) => {
+        const summary = realTask.sessions[0]?.trace.selections[0]?.summary;
+        assert.ok(summary);
+        summary.msgEnd += 1;
+      },
+    },
+    {
+      name: "candidate identity",
+      mutate: (_baselineTask, realTask) => {
+        const candidate = realTask.sessions[0]?.trace.lcmCandidates[0];
+        assert.ok(candidate);
+        candidate.archiveRowId = 8;
+      },
+    },
+    {
+      name: "unavailable candidate structure",
+      mutate: (baselineTask, realTask) => {
+        for (const entry of [baselineTask, realTask]) {
+          const trace = entry.sessions[0]?.trace;
+          const candidate = trace?.lcmCandidates[0];
+          assert.ok(trace);
+          assert.ok(candidate);
+          const { archiveRowId: _archiveRowId, ...withoutArchiveRowId } = candidate;
+          trace.lcmCandidates[0] = { ...withoutArchiveRowId, lineageStatus: "unavailable" };
+        }
+        const realCandidate = realTask.sessions[0]?.trace.lcmCandidates[0];
+        assert.ok(realCandidate);
+        realCandidate.role = "assistant";
+      },
+    },
+    {
+      name: "composition output",
+      mutate: (_baselineTask, realTask) => {
+        realTask.composition.output = digest("different composition output");
+      },
+    },
+    {
+      name: "composition selected-line digest",
+      mutate: (baselineTask, realTask) => {
+        const composition = prioritizeLoCoMoRecallTextWithTrace({
+          question: "Where does Alice live and work?",
+          recalledText: "Alice lives in Rome.\nAlice works at Acme.",
+          multiHopRecallComposition: true,
+        }).receipt;
+        baselineTask.composition = structuredClone(composition);
+        realTask.composition = structuredClone(composition);
+        const selectedLine = realTask.composition.selectedLines[0];
+        assert.ok(selectedLine);
+        selectedLine.output = digest("Alice lives in Lima.");
+      },
+    },
+    {
+      name: "composition selected-line geometry",
+      mutate: (baselineTask, realTask) => {
+        const composition = prioritizeLoCoMoRecallTextWithTrace({
+          question: "Where does Alice live and work?",
+          recalledText: "Alice lives in Rome.\nAlice works at Acme.",
+          multiHopRecallComposition: true,
+        }).receipt;
+        baselineTask.composition = structuredClone(composition);
+        realTask.composition = structuredClone(composition);
+        const selectedLine = realTask.composition.selectedLines[0];
+        assert.ok(selectedLine);
+        selectedLine.outputStart += 1;
+        selectedLine.outputEnd += 1;
+        selectedLine.visibleStart += 1;
+        selectedLine.visibleEnd += 1;
+      },
+    },
+  ];
+
+  for (const testCase of cases) {
+    const baselineTask = recorderTask(`fixture-${testCase.name}-q0-multi_hop`, 15);
+    const realTask = recorderTask(`fixture-${testCase.name}-q0-multi_hop`, 25);
+    testCase.mutate(baselineTask, realTask);
+    const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+      .tasks[0];
+    assert.equal(delta?.mechanism, "mixed", testCase.name);
+  }
+});
+
+test("keeps core and auxiliary changes out of budget tail attribution", () => {
+  const cases: Array<{
+    name: string;
+    mutate: (realTask: LoCoMoRetrievalTaskReceipt) => void;
+  }> = [
+    {
+      name: "core result",
+      mutate: (realTask) => {
+        const result = realTask.sessions[0]?.trace.coreCapture?.results[0];
+        assert.ok(result);
+        result.scoreDecomposition.final = 0.5;
+      },
+    },
+    {
+      name: "core filter",
+      mutate: (realTask) => {
+        const filter = realTask.sessions[0]?.trace.coreCapture?.filters[0];
+        assert.ok(filter);
+        filter.admitted = 0;
+      },
+    },
+    {
+      name: "core allocation",
+      mutate: (realTask) => {
+        const budget = realTask.sessions[0]?.trace.coreCapture?.budget;
+        assert.ok(budget);
+        budget.used += 1;
+      },
+    },
+    {
+      name: "auxiliary structure",
+      mutate: (realTask) => {
+        const trace = realTask.sessions[0]?.trace;
+        assert.ok(trace);
+        trace.sections.push({
+          id: "evidence-section",
+          source: "evidence-pack",
+          separatorStart: 25,
+          contentStart: 27,
+          contentEnd: 35,
+          composedStart: 25,
+          composedEnd: 35,
+          visibleStart: 20,
+          visibleEnd: 20,
+          visibleChars: 0,
+        });
+        trace.budget.composedChars = 35;
+      },
+    },
+  ];
+
+  for (const testCase of cases) {
+    const baselineTask = recorderTask(`fixture-${testCase.name}-q0-multi_hop`, 15);
+    const realTask = recorderTask(`fixture-${testCase.name}-q0-multi_hop`, 25);
+    testCase.mutate(realTask);
+    const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+      .tasks[0];
+    assert.equal(delta?.mechanism, "mixed", testCase.name);
+  }
 });
 
 test("labels composition-digest-only changes without claiming no structural delta", () => {
@@ -447,12 +708,11 @@ test("accepts exact compressed-summary lineage without archive row ids", () => {
 
 test("treats LCM-free tasks and exact raw-row fallback as complete lineage", () => {
   const coreOnlyId = "fixture-q0-multi_hop";
-  const coreOnlyBaseline = task(coreOnlyId, { coreChars: 10 });
-  const coreOnlyReal = task(coreOnlyId, { coreChars: 10 });
+  const coreOnlyBaseline = task(coreOnlyId, { sectionCopies: 0, coreChars: 10 });
+  const coreOnlyReal = task(coreOnlyId, { sectionCopies: 0, coreChars: 10 });
   for (const entry of [coreOnlyBaseline, coreOnlyReal]) {
     const trace = entry.sessions[0]?.trace;
     assert.ok(trace);
-    trace.sections = trace.sections.filter((section) => section.source === "core");
     trace.selections = [];
     trace.lcmCandidates = [];
   }
@@ -503,13 +763,11 @@ test("ignores unavailable candidates when rendered LCM lineage is exact", () => 
   assert.equal(delta?.dimensions.lcmCandidates.changed, false);
   assert.equal(delta?.mechanism, "no-structural-delta");
 
-  const candidateOnly = task(id);
+  const candidateOnly = task(id, { sectionCopies: 0 });
   const candidateOnlyTrace = candidateOnly.sessions[0]?.trace;
   const candidateOnlyCandidate = candidateOnlyTrace?.lcmCandidates[0];
   assert.ok(candidateOnlyTrace);
   assert.ok(candidateOnlyCandidate);
-  candidateOnlyTrace.sections = [];
-  candidateOnlyTrace.selections = [];
   const { archiveRowId: _candidateOnlyArchiveRowId, ...candidateOnlyWithoutRow } = candidateOnlyCandidate;
   candidateOnlyTrace.lcmCandidates[0] = { ...candidateOnlyWithoutRow, lineageStatus: "unavailable" };
   assert.equal(
@@ -552,17 +810,6 @@ test("ignores unavailable non-LCM selections for exact attribution", () => {
     visibleStart: 22,
     visibleEnd: 30,
   });
-  baselineTrace.selections.push({
-    sectionId: "evidence-section",
-    kind: "trajectory-line",
-    lineageStatus: "unavailable",
-    archiveRowIds: [99],
-    composedStart: 22,
-    composedEnd: 30,
-    visibleStart: 22,
-    visibleEnd: 30,
-  });
-
   const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
     .tasks[0];
   assert.equal(delta?.dimensions.sectionVisibleChars.changed, false);
@@ -674,11 +921,8 @@ test("requires an LCM-specific lineage carrier for LCM-bearing sections", () => 
   const realTask = task(id);
   for (const entry of [baselineTask, realTask]) {
     const trace = entry.sessions[0]?.trace;
-    const selection = trace?.selections[0];
     assert.ok(trace);
-    assert.ok(selection);
-    selection.kind = "evidence-block";
-    delete selection.summary;
+    trace.selections = [];
     trace.lcmCandidates = [];
   }
 
@@ -707,7 +951,7 @@ test("binds exact LCM lineage to every rendered LCM section", () => {
       id: "raw-row-section",
       source: "raw-row",
       separatorStart: 20,
-      contentStart: 20,
+      contentStart: 22,
       contentEnd: 30,
       composedStart: 20,
       composedEnd: 30,
@@ -715,6 +959,8 @@ test("binds exact LCM lineage to every rendered LCM section", () => {
       visibleEnd: 30,
       visibleChars: 10,
     });
+    trace.budget.composedChars = 30;
+    trace.budget.returnedChars = 30;
   }
   assert.equal(
     diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask])).tasks[0]
@@ -771,6 +1017,71 @@ test("fails closed on tampering, pairing drift, equal config hashes, and unavail
   assert.throws(
     () => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(inconsistentBudget)),
     /session structure is invalid/
+  );
+
+  const malformedCompanionBaseline = recorderTask("fixture-q1-multi_hop", 15);
+  const malformedCompanionReal = recorderTask("fixture-q1-multi_hop", 25);
+  const malformedCompanion = structuredClone(malformedCompanionBaseline.sessions[0]);
+  assert.ok(malformedCompanion);
+  malformedCompanion.trace.budget.composedChars = 30;
+  malformedCompanion.trace.budget.returnedChars = 20;
+  malformedCompanion.trace.budget.truncated = true;
+  malformedCompanionBaseline.sessions.push(structuredClone(malformedCompanion));
+  malformedCompanionReal.sessions.push(structuredClone(malformedCompanion));
+  assert.throws(
+    () =>
+      diagnoseLoCoMoRetrievalTraceDelta(
+        receipt("baseline", [malformedCompanionBaseline]),
+        receipt("real", [malformedCompanionReal])
+      ),
+    /session structure is invalid/
+  );
+
+  const inconsistentSectionVisibility = receipt("real", [task("fixture-q0-multi_hop")]);
+  const invalidSection = inconsistentSectionVisibility.tasks[0]?.sessions[0]?.trace.sections[0];
+  assert.ok(invalidSection);
+  invalidSection.visibleEnd -= 1;
+  invalidSection.visibleChars -= 1;
+  assert.throws(
+    () => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(inconsistentSectionVisibility)),
+    /section structure is invalid/
+  );
+
+  const malformedSectionLayout = receipt("real", [task("fixture-q0-multi_hop", { sectionCopies: 2 })]);
+  const malformedSecondSection = malformedSectionLayout.tasks[0]?.sessions[0]?.trace.sections[1];
+  assert.ok(malformedSecondSection);
+  malformedSecondSection.separatorStart += 1;
+  malformedSecondSection.contentStart += 1;
+  malformedSecondSection.composedStart += 1;
+  assert.throws(
+    () => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(malformedSectionLayout)),
+    /section structure is invalid/
+  );
+
+  const outOfSectionSelection = receipt("real", [task("fixture-q0-multi_hop")]);
+  const invalidSelection = outOfSectionSelection.tasks[0]?.sessions[0]?.trace.selections[0];
+  assert.ok(invalidSelection);
+  invalidSelection.composedEnd += 1;
+  invalidSelection.visibleEnd += 1;
+  assert.throws(
+    () => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(outOfSectionSelection)),
+    /selection structure is invalid/
+  );
+
+  const invalidComposition = receipt("real", [task("fixture-q0-multi_hop")]);
+  const invalidCompositionTask = invalidComposition.tasks[0];
+  assert.ok(invalidCompositionTask);
+  invalidCompositionTask.composition = prioritizeLoCoMoRecallTextWithTrace({
+    question: "Where does Alice live?",
+    recalledText: "Alice lives in Rome.",
+    multiHopRecallComposition: true,
+  }).receipt;
+  const invalidCompositionLine = invalidCompositionTask.composition.selectedLines[0];
+  assert.ok(invalidCompositionLine);
+  invalidCompositionLine.visible = !invalidCompositionLine.visible;
+  assert.throws(
+    () => diagnoseLoCoMoRetrievalTraceDelta(baseline, reseal(invalidComposition)),
+    /composition line structure is invalid/
   );
 
   for (const missingLineage of ["selection-missing", "selection-empty", "candidate-missing"] as const) {

--- a/packages/bench/src/stats/locomo-retrieval-trace-delta.test.ts
+++ b/packages/bench/src/stats/locomo-retrieval-trace-delta.test.ts
@@ -461,6 +461,20 @@ test("does not claim core-visible LCM displacement across composition policy cha
   assert.equal(delta?.mechanism, "mixed");
 });
 
+test("does not claim LCM selection change across composition policy changes", () => {
+  const id = "fixture-q0-multi_hop";
+  const baselineTask = task(id);
+  const realTask = task(id, { sectionChars: 19, compositionMode: "fallback" });
+  realTask.composition.output = baselineTask.composition.output;
+
+  const delta = diagnoseLoCoMoRetrievalTraceDelta(receipt("baseline", [baselineTask]), receipt("real", [realTask]))
+    .tasks[0];
+  assert.equal(delta?.dimensions.sectionVisibleChars.changed, true);
+  assert.equal(delta?.dimensions.compositionPolicy.changed, true);
+  assert.equal(delta?.dimensions.compositionDigests.changed, false);
+  assert.equal(delta?.mechanism, "mixed");
+});
+
 test("does not classify rendered character counts as recall-budget changes", () => {
   const id = "fixture-q0-multi_hop";
   const baselineTask = task(id);

--- a/packages/bench/src/stats/locomo-retrieval-trace-delta.ts
+++ b/packages/bench/src/stats/locomo-retrieval-trace-delta.ts
@@ -242,7 +242,8 @@ function compareTask(baseline: LoCoMoRetrievalTaskReceipt, real: LoCoMoRetrieval
     realVisible.core > baselineVisible.core &&
     realVisible.lcm < baselineVisible.lcm &&
     !other &&
-    !budget;
+    !budget &&
+    !compositionPolicy;
   let mechanism: LoCoMoRetrievalMechanism;
   if (!exact) mechanism = "insufficient-exact-lineage";
   else if (coreVisibleLcmDisplacement) mechanism = "real-core-visible-lcm-displacement";

--- a/packages/bench/src/stats/locomo-retrieval-trace-delta.ts
+++ b/packages/bench/src/stats/locomo-retrieval-trace-delta.ts
@@ -11,6 +11,7 @@ const MECHANISMS = [
   "real-core-visible-lcm-displacement",
   "lcm-selection-change",
   "composition-filter-displacement",
+  "composition-digest-change",
   "budget-truncation-change",
   "mixed",
   "no-structural-delta",
@@ -167,40 +168,91 @@ function compareTask(baseline: LoCoMoRetrievalTaskReceipt, real: LoCoMoRetrieval
     compositionPolicy: delta(signatures(baseline, "compositionPolicy"), signatures(real, "compositionPolicy")),
     compositionDigests: delta(signatures(baseline, "compositionDigests"), signatures(real, "compositionDigests")),
   };
-  const exact = [...baseline.sessions, ...real.sessions].every(
-    (session) =>
-      session.trace.selections.every(hasExactSelectionLineage) &&
-      session.trace.lcmCandidates.every(hasExactCandidateLineage) &&
-      (session.trace.coreCapture?.results.every(
-        (result) => isSha256Hex(result.memoryIdRef.sha256) && result.memoryIdRef.length > 0
-      ) ??
-        true)
-  );
+  const hasCompleteExactLineage = (task: LoCoMoRetrievalTaskReceipt): boolean => {
+    return task.sessions.every((session) => {
+      const renderedSections = session.trace.sections.filter(
+        (section) => section.source === "lcm-summary" || section.source === "raw-row"
+      );
+      const lcmSelections = session.trace.selections.filter(
+        (selection) => selection.kind === "lcm-summary" || selection.kind === "raw-row"
+      );
+      const selectionMatchesSection = (selection: (typeof session.trace.selections)[number]): boolean =>
+        renderedSections.some((section) => section.id === selection.sectionId && section.source === selection.kind);
+      const renderedLineageComplete = renderedSections.every((section) =>
+        lcmSelections.some(
+          (selection) =>
+            selection.sectionId === section.id &&
+            selection.kind === section.source &&
+            hasExactSelectionLineage(selection)
+        )
+      );
+      const candidateLineageComplete = session.trace.lcmCandidates.every(hasExactCandidateLineage);
+      const hasCarrier =
+        (renderedSections.length > 0 && renderedLineageComplete) ||
+        (renderedSections.length === 0 &&
+          lcmSelections.length === 0 &&
+          session.trace.lcmCandidates.length > 0 &&
+          candidateLineageComplete);
+      const hasLcmEvidence =
+        renderedSections.length > 0 || lcmSelections.length > 0 || session.trace.lcmCandidates.length > 0;
+      return (
+        (!hasLcmEvidence || hasCarrier) &&
+        lcmSelections.every(selectionMatchesSection) &&
+        lcmSelections.every(hasExactSelectionLineage) &&
+        (renderedSections.length > 0 || candidateLineageComplete) &&
+        (session.trace.coreCapture?.results.every(
+          (result) => isSha256Hex(result.memoryIdRef.sha256) && result.memoryIdRef.length > 0
+        ) ??
+          true)
+      );
+    });
+  };
+  const exact = hasCompleteExactLineage(baseline) && hasCompleteExactLineage(real);
+  const lcmSelectionsChanged = delta(
+    exactSelectionSignatures(baseline, "lcm"),
+    exactSelectionSignatures(real, "lcm")
+  ).changed;
+  const lcmArchiveRowsChanged = delta(
+    exactArchiveRowSignatures(baseline, "lcm"),
+    exactArchiveRowSignatures(real, "lcm")
+  ).changed;
+  const auxiliarySelectionsChanged = delta(
+    exactSelectionSignatures(baseline, "auxiliary"),
+    exactSelectionSignatures(real, "auxiliary")
+  ).changed;
+  const auxiliaryArchiveRowsChanged = delta(
+    exactArchiveRowSignatures(baseline, "auxiliary"),
+    exactArchiveRowSignatures(real, "auxiliary")
+  ).changed;
   const core = dimensions.coreResults.changed || dimensions.coreFilters.changed || dimensions.coreBudget.changed;
   const baselineVisible = visibleCharsByGroup(baseline);
   const realVisible = visibleCharsByGroup(real);
   const coreSections = sectionGroupChanged(baseline, real, "core");
   const lcmSections = sectionGroupChanged(baseline, real, "lcm");
   const otherSections = sectionGroupChanged(baseline, real, "other");
-  const lcm =
-    lcmSections || dimensions.selections.changed || dimensions.archiveRows.changed || dimensions.lcmCandidates.changed;
+  const lcm = lcmSections || lcmSelectionsChanged || lcmArchiveRowsChanged || dimensions.lcmCandidates.changed;
+  const auxiliary = auxiliarySelectionsChanged || auxiliaryArchiveRowsChanged;
+  const other = otherSections || auxiliary;
   const compositionPolicy = dimensions.compositionPolicy.changed;
+  const compositionDigests = dimensions.compositionDigests.changed;
   const budget = dimensions.recallBudget.changed;
   const coreVisibleLcmDisplacement =
     core &&
     lcm &&
     realVisible.core > baselineVisible.core &&
     realVisible.lcm < baselineVisible.lcm &&
-    !otherSections &&
+    !other &&
     !budget;
   let mechanism: LoCoMoRetrievalMechanism;
   if (!exact) mechanism = "insufficient-exact-lineage";
   else if (coreVisibleLcmDisplacement) mechanism = "real-core-visible-lcm-displacement";
-  else if (lcm && !core && !coreSections && !otherSections && !budget) mechanism = "lcm-selection-change";
-  else if (budget && !core && !coreSections && !lcm && !otherSections) mechanism = "budget-truncation-change";
-  else if (compositionPolicy && !core && !coreSections && !lcm && !otherSections && !budget)
+  else if (lcm && !core && !coreSections && !other && !budget) mechanism = "lcm-selection-change";
+  else if (budget && !core && !coreSections && !lcm && !other) mechanism = "budget-truncation-change";
+  else if (compositionPolicy && !core && !coreSections && !lcm && !other && !budget)
     mechanism = "composition-filter-displacement";
-  else if (!core && !coreSections && !lcm && !otherSections && !budget && !compositionPolicy)
+  else if (compositionDigests && !compositionPolicy && !core && !coreSections && !lcm && !other && !budget)
+    mechanism = "composition-digest-change";
+  else if (!core && !coreSections && !lcm && !other && !budget && !compositionPolicy && !compositionDigests)
     mechanism = "no-structural-delta";
   else mechanism = "mixed";
   return { taskRef: digestIdentifier(baseline.taskId), category, mechanism, dimensions };
@@ -232,13 +284,11 @@ function sectionGroupChanged(
   const signaturesFor = (task: LoCoMoRetrievalTaskReceipt): string[] => {
     const output: string[] = [];
     task.sessions.forEach((session, sessionOrdinal) => {
-      for (const section of session.trace.sections) {
+      session.trace.sections.forEach((section, sectionOrdinal) => {
         if (sectionGroup(section.source) === group) {
-          output.push(
-            hashCanonicalJson({ sessionOrdinal, source: section.source, visibleChars: section.visibleChars })
-          );
+          output.push(structuralSectionSignature(section, sessionOrdinal, sectionOrdinal));
         }
-      }
+      });
     });
     return output;
   };
@@ -253,13 +303,93 @@ function sectionGroup(
   return "other";
 }
 
+function structuralSectionSignature(
+  section: LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["sections"][number],
+  sessionOrdinal: number,
+  sectionOrdinal: number
+): string {
+  return hashCanonicalJson({
+    sessionOrdinal,
+    sectionOrdinal,
+    sectionIdRef: digestIdentifier(section.id),
+    source: section.source,
+    separatorStart: section.separatorStart,
+    contentStart: section.contentStart,
+    contentEnd: section.contentEnd,
+    composedStart: section.composedStart,
+    composedEnd: section.composedEnd,
+    visibleStart: section.visibleStart,
+    visibleEnd: section.visibleEnd,
+    visibleChars: section.visibleChars,
+  });
+}
+
 type Dimension = keyof LoCoMoRetrievalTaskDelta["dimensions"];
+type SelectionScope = "all" | "lcm" | "auxiliary";
+
+function selectionInScope(
+  selection: LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["selections"][number],
+  scope: SelectionScope
+): boolean {
+  const isLcm = selection.kind === "lcm-summary" || selection.kind === "raw-row";
+  return scope === "all" || (scope === "lcm" ? isLcm : !isLcm);
+}
+
+function exactSelectionSignatures(task: LoCoMoRetrievalTaskReceipt, scope: SelectionScope): string[] {
+  const output: string[] = [];
+  task.sessions.forEach((session, sessionOrdinal) => {
+    for (const value of session.trace.selections) {
+      if (!selectionInScope(value, scope) || !hasExactSelectionLineage(value)) continue;
+      output.push(
+        hashCanonicalJson({
+          sessionOrdinal,
+          kind: value.kind,
+          lineageStatus: value.lineageStatus,
+          turnIndex: value.turnIndex,
+          role: value.role,
+          score: value.score,
+          summary: value.summary,
+          archiveRowIds: value.archiveRowIds,
+          composedStart: value.composedStart,
+          composedEnd: value.composedEnd,
+          visibleStart: value.visibleStart,
+          visibleEnd: value.visibleEnd,
+        })
+      );
+    }
+  });
+  return output;
+}
+
+function exactArchiveRowSignatures(task: LoCoMoRetrievalTaskReceipt, scope: SelectionScope): string[] {
+  const output: string[] = [];
+  task.sessions.forEach((session, sessionOrdinal) => {
+    for (const value of session.trace.selections) {
+      if (!selectionInScope(value, scope) || !hasExactSelectionLineage(value)) continue;
+      for (const archiveRowId of value.archiveRowIds ?? []) {
+        output.push(hashCanonicalJson({ sessionOrdinal, archiveRowId }));
+      }
+    }
+  });
+  return output;
+}
 
 function hasExactSelectionLineage(
   selection: LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["selections"][number]
 ): boolean {
+  if (selection.lineageStatus !== "exact") return false;
+  if (selection.kind === "lcm-summary") {
+    return (
+      selection.summary !== undefined &&
+      Number.isSafeInteger(selection.summary.depth) &&
+      selection.summary.depth >= 0 &&
+      Number.isSafeInteger(selection.summary.msgStart) &&
+      selection.summary.msgStart >= 0 &&
+      Number.isSafeInteger(selection.summary.msgEnd) &&
+      selection.summary.msgEnd >= selection.summary.msgStart
+    );
+  }
   return (
-    selection.lineageStatus === "exact" &&
     Array.isArray(selection.archiveRowIds) &&
     selection.archiveRowIds.length > 0 &&
     selection.archiveRowIds.every((id) => Number.isSafeInteger(id) && id > 0)
@@ -277,11 +407,16 @@ function hasExactCandidateLineage(
 }
 
 function signatures(task: LoCoMoRetrievalTaskReceipt, dimension: Dimension): string[] {
+  if (dimension === "selections") return exactSelectionSignatures(task, "all");
+  if (dimension === "archiveRows") return exactArchiveRowSignatures(task, "all");
   if (dimension === "recallBudget") {
     return [
       hashCanonicalJson({
         recallBudgetChars: task.recallBudgetChars,
-        budgets: task.sessions.map((s) => s.trace.budget),
+        budgets: task.sessions.map((session) => ({
+          requestedChars: session.trace.budget.requestedChars,
+          truncated: session.trace.budget.truncated,
+        })),
       }),
     ];
   }
@@ -312,33 +447,49 @@ function signatures(task: LoCoMoRetrievalTaskReceipt, dimension: Dimension): str
   task.sessions.forEach((session, sessionOrdinal) => {
     const trace = session.trace;
     if (dimension === "sectionVisibleChars") {
-      for (const value of trace.sections)
-        output.push(hashCanonicalJson({ sessionOrdinal, source: value.source, visibleChars: value.visibleChars }));
-    } else if (dimension === "selections") {
-      for (const value of trace.selections)
+      trace.sections.forEach((value, sectionOrdinal) => {
+        output.push(structuralSectionSignature(value, sessionOrdinal, sectionOrdinal));
+      });
+    } else if (dimension === "lcmCandidates") {
+      for (const value of trace.lcmCandidates) {
+        if (!hasExactCandidateLineage(value)) continue;
         output.push(
           hashCanonicalJson({
             sessionOrdinal,
-            kind: value.kind,
-            lineageStatus: value.lineageStatus,
+            rank: value.rank,
+            archiveRowId: value.archiveRowId,
             turnIndex: value.turnIndex,
             role: value.role,
             score: value.score,
-            summary: value.summary,
+            lineageStatus: value.lineageStatus,
           })
         );
-    } else if (dimension === "archiveRows") {
-      for (const value of trace.selections)
-        for (const archiveRowId of value.archiveRowIds ?? [])
-          output.push(hashCanonicalJson({ sessionOrdinal, archiveRowId }));
-    } else if (dimension === "lcmCandidates") {
-      for (const value of trace.lcmCandidates) output.push(hashCanonicalJson({ sessionOrdinal, ...value }));
+      }
     } else if (dimension === "coreResults") {
-      for (const value of trace.coreCapture?.results ?? [])
-        output.push(hashCanonicalJson({ sessionOrdinal, ...value }));
+      for (const [resultOrdinal, value] of (trace.coreCapture?.results ?? []).entries())
+        output.push(
+          hashCanonicalJson({
+            sessionOrdinal,
+            resultOrdinal,
+            memoryIdRef: value.memoryIdRef,
+            servedBy: value.servedBy,
+            scoreDecomposition: value.scoreDecomposition,
+            admittedBy: value.admittedBy,
+            rejectedBy: value.rejectedBy,
+            disclosure: value.disclosure,
+            estimatedTokens: value.estimatedTokens,
+          })
+        );
     } else if (dimension === "coreFilters") {
       for (const value of trace.coreCapture?.filters ?? [])
-        output.push(hashCanonicalJson({ sessionOrdinal, ...value }));
+        output.push(
+          hashCanonicalJson({
+            sessionOrdinal,
+            name: value.name,
+            considered: value.considered,
+            admitted: value.admitted,
+          })
+        );
     } else if (dimension === "coreBudget") {
       if (trace.coreCapture) output.push(hashCanonicalJson({ sessionOrdinal, ...trace.coreCapture.budget }));
     }
@@ -394,6 +545,42 @@ function categoryOf(taskId: string): LoCoMoCategory {
 function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): void {
   if (!receipt || typeof receipt !== "object") throw new Error(`${label} receipt must be an object.`);
   assertFiniteJson(receipt, `${label} receipt`);
+  assertExactKeys(
+    receipt,
+    ["schemaVersion", "benchmarkId", "captureKind", "artifactHash", "sensitivity", "provenance", "selection", "tasks"],
+    `${label} receipt`
+  );
+  assertExactKeys(
+    receipt.sensitivity,
+    ["classification", "contentEncoding", "containsGold", "containsRawContent"],
+    `${label} receipt.sensitivity`
+  );
+  assertExactKeys(
+    receipt.provenance,
+    [
+      "gitSha",
+      "remnicVersion",
+      "runtimeProfile",
+      "adapterMode",
+      "replayExtractionMode",
+      "providerFree",
+      "dataset",
+      "retrievalConfigSha256",
+      "recallBudget",
+    ],
+    `${label} receipt.provenance`
+  );
+  assertExactKeys(receipt.provenance.dataset, ["id", "sha256"], `${label} receipt.provenance.dataset`);
+  assertExactKeys(
+    receipt.provenance.recallBudget,
+    ["algorithm", "version"],
+    `${label} receipt.provenance.recallBudget`
+  );
+  assertExactKeys(
+    receipt.selection,
+    ["algorithm", "version", "seed", "candidateCount", "selectedCount", "selectedTaskIds", "selectedTaskIdsSha256"],
+    `${label} receipt.selection`
+  );
   const { artifactHash, ...withoutHash } = receipt;
   if (!isSha256Hex(artifactHash) || hashCanonicalJson(withoutHash) !== artifactHash) {
     throw new Error(`${label} retrieval trace artifact hash verification failed.`);
@@ -417,7 +604,11 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
     typeof receipt.provenance.remnicVersion !== "string" ||
     receipt.provenance.remnicVersion.length === 0 ||
     receipt.selection.version !== 1 ||
+    (receipt.selection.algorithm !== "explicit-task-ids" && receipt.selection.algorithm !== "sha256-seeded-sample") ||
+    (receipt.selection.algorithm === "explicit-task-ids" && receipt.selection.seed !== undefined) ||
+    (receipt.selection.algorithm === "sha256-seeded-sample" && !isNonNegativeSafeInteger(receipt.selection.seed)) ||
     !Array.isArray(receipt.selection.selectedTaskIds) ||
+    receipt.selection.selectedTaskIds.some((taskId) => typeof taskId !== "string" || taskId.length === 0) ||
     !Array.isArray(receipt.tasks) ||
     !Number.isSafeInteger(receipt.selection.candidateCount) ||
     !Number.isSafeInteger(receipt.selection.selectedCount) ||
@@ -437,10 +628,16 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
     throw new Error(`${label} retrieval trace receipt contains invalid provenance hashes.`);
   }
   for (const task of receipt.tasks) {
+    assertExactKeys(
+      task,
+      ["taskId", "question", "recallBudgetChars", "sessions", "composition"],
+      `${label} retrieval trace task`
+    );
     if (
       typeof task.taskId !== "string" ||
       task.taskId.length === 0 ||
       !Array.isArray(task.sessions) ||
+      task.sessions.length === 0 ||
       !isDigest(task.question) ||
       !Number.isSafeInteger(task.recallBudgetChars) ||
       task.recallBudgetChars < 0
@@ -450,7 +647,23 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
     categoryOf(task.taskId);
     assertComposition(task.composition, label);
     for (const session of task.sessions) {
+      assertExactKeys(session, ["session", "trace"], `${label} retrieval trace session`);
       const trace = session.trace;
+      assertExactKeys(
+        trace,
+        ["schemaVersion", "sensitivity", "sections", "selections", "lcmCandidates", "coreCapture", "budget"],
+        `${label} retrieval structural trace`
+      );
+      assertExactKeys(
+        trace.sensitivity,
+        ["classification", "contentEncoding", "containsGold"],
+        `${label} retrieval trace sensitivity`
+      );
+      assertExactKeys(
+        trace.budget,
+        ["requestedChars", "composedChars", "returnedChars", "truncated"],
+        `${label} retrieval trace budget`
+      );
       if (
         !isDigest(session.session) ||
         !trace ||
@@ -461,11 +674,31 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
         !Array.isArray(trace.sections) ||
         !Array.isArray(trace.selections) ||
         !Array.isArray(trace.lcmCandidates) ||
-        !isTraceBudget(trace.budget)
+        new Set(trace.sections.map((section) => section.id)).size !== trace.sections.length ||
+        !isTraceBudget(trace.budget) ||
+        trace.budget.requestedChars !== task.recallBudgetChars ||
+        trace.budget.returnedChars > trace.budget.composedChars ||
+        trace.budget.truncated !== trace.budget.returnedChars < trace.budget.composedChars
       ) {
         throw new Error(`${label} retrieval trace session structure is invalid.`);
       }
       for (const section of trace.sections) {
+        assertExactKeys(
+          section,
+          [
+            "id",
+            "source",
+            "separatorStart",
+            "contentStart",
+            "contentEnd",
+            "composedStart",
+            "composedEnd",
+            "visibleStart",
+            "visibleEnd",
+            "visibleChars",
+          ],
+          `${label} retrieval trace section`
+        );
         if (
           ![
             "derived",
@@ -476,6 +709,10 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
             "lcm-summary",
             "raw-row",
           ].includes(section.source) ||
+          typeof section.id !== "string" ||
+          section.id.length === 0 ||
+          !isTraceRange(section) ||
+          ![section.separatorStart, section.contentStart, section.contentEnd].every(isNonNegativeSafeInteger) ||
           !Number.isSafeInteger(section.visibleChars) ||
           section.visibleChars < 0
         ) {
@@ -483,9 +720,48 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
         }
       }
       for (const selection of trace.selections) {
+        assertExactKeys(
+          selection,
+          [
+            "sectionId",
+            "kind",
+            "lineageStatus",
+            "archiveRowIds",
+            "turnIndex",
+            "role",
+            "score",
+            "summary",
+            "composedStart",
+            "composedEnd",
+            "visibleStart",
+            "visibleEnd",
+          ],
+          `${label} retrieval trace selection`
+        );
+        if (selection.summary !== undefined) {
+          assertExactKeys(
+            selection.summary,
+            ["depth", "msgStart", "msgEnd"],
+            `${label} retrieval trace selection summary`
+          );
+        }
+        const selectedSection = trace.sections.find((section) => section.id === selection.sectionId);
         if (
           !["evidence-block", "trajectory-line", "lcm-summary", "raw-row"].includes(selection.kind) ||
+          typeof selection.sectionId !== "string" ||
+          selection.sectionId.length === 0 ||
+          selectedSection === undefined ||
+          (selection.kind === "lcm-summary" && selectedSection.source !== "lcm-summary") ||
+          (selection.kind === "raw-row" && selectedSection.source !== "raw-row") ||
+          !isTraceRange(selection) ||
           (selection.lineageStatus !== "exact" && selection.lineageStatus !== "unavailable") ||
+          (selection.turnIndex !== undefined && !isNonNegativeSafeInteger(selection.turnIndex)) ||
+          (selection.role !== undefined && typeof selection.role !== "string") ||
+          (selection.score !== undefined && !Number.isFinite(selection.score)) ||
+          (selection.summary !== undefined &&
+            ![selection.summary.depth, selection.summary.msgStart, selection.summary.msgEnd].every(
+              isNonNegativeSafeInteger
+            )) ||
           (selection.archiveRowIds !== undefined &&
             (!Array.isArray(selection.archiveRowIds) ||
               selection.archiveRowIds.some((id) => !Number.isSafeInteger(id) || id <= 0)))
@@ -494,10 +770,20 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
         }
       }
       for (const candidate of trace.lcmCandidates) {
+        assertExactKeys(
+          candidate,
+          ["rank", "archiveRowId", "turnIndex", "role", "score", "lineageStatus"],
+          `${label} retrieval trace LCM candidate`
+        );
         if (
           (candidate.lineageStatus !== "exact" && candidate.lineageStatus !== "unavailable") ||
           !Number.isSafeInteger(candidate.rank) ||
           candidate.rank < 0 ||
+          !isNonNegativeSafeInteger(candidate.turnIndex) ||
+          typeof candidate.role !== "string" ||
+          (candidate.score !== undefined && !Number.isFinite(candidate.score)) ||
+          (candidate.lineageStatus === "exact" && candidate.archiveRowId === undefined) ||
+          (candidate.lineageStatus === "unavailable" && candidate.archiveRowId !== undefined) ||
           (candidate.archiveRowId !== undefined &&
             (!Number.isSafeInteger(candidate.archiveRowId) || candidate.archiveRowId <= 0))
         ) {
@@ -505,6 +791,52 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
         }
       }
       if (trace.coreCapture) {
+        assertExactKeys(trace.coreCapture, ["budget", "filters", "results"], `${label} retrieval trace core capture`);
+        assertExactKeys(trace.coreCapture.budget, ["chars", "used"], `${label} retrieval trace core budget`);
+        for (const filter of trace.coreCapture.filters) {
+          assertExactKeys(filter, ["name", "considered", "admitted"], `${label} retrieval trace core filter`);
+          if (
+            typeof filter.name !== "string" ||
+            !isNonNegativeSafeInteger(filter.considered) ||
+            !isNonNegativeSafeInteger(filter.admitted) ||
+            filter.admitted > filter.considered
+          ) {
+            throw new Error(`${label} retrieval trace core filter structure is invalid.`);
+          }
+        }
+        for (const result of trace.coreCapture.results) {
+          assertExactKeys(
+            result,
+            [
+              "memoryIdRef",
+              "servedBy",
+              "scoreDecomposition",
+              "admittedBy",
+              "rejectedBy",
+              "disclosure",
+              "estimatedTokens",
+            ],
+            `${label} retrieval trace core result`
+          );
+          assertExactKeys(result.memoryIdRef, ["sha256", "length"], `${label} retrieval trace core memory reference`);
+          assertExactKeys(
+            result.scoreDecomposition,
+            ["vector", "bm25", "importance", "mmrPenalty", "tierPrior", "reinforcementBoost", "final"],
+            `${label} retrieval trace score decomposition`
+          );
+          if (
+            typeof result.servedBy !== "string" ||
+            !Number.isFinite(result.scoreDecomposition.final) ||
+            !Object.values(result.scoreDecomposition).every((score) => score === undefined || Number.isFinite(score)) ||
+            !Array.isArray(result.admittedBy) ||
+            result.admittedBy.some((reason) => typeof reason !== "string") ||
+            (result.rejectedBy !== undefined && typeof result.rejectedBy !== "string") ||
+            (result.disclosure !== undefined && !["chunk", "section", "raw"].includes(result.disclosure)) ||
+            (result.estimatedTokens !== undefined && !isNonNegativeSafeInteger(result.estimatedTokens))
+          ) {
+            throw new Error(`${label} retrieval trace core result structure is invalid.`);
+          }
+        }
         if (
           !isCountBudget(trace.coreCapture.budget) ||
           !Array.isArray(trace.coreCapture.filters) ||
@@ -524,6 +856,11 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
 }
 
 function assertComposition(composition: LoCoMoRetrievalTaskReceipt["composition"], label: string): void {
+  assertExactKeys(
+    composition,
+    ["schemaVersion", "mode", "multiHopRecallComposition", "input", "output", "selectedLines"],
+    `${label} retrieval trace composition`
+  );
   if (
     !composition ||
     composition.schemaVersion !== 1 ||
@@ -535,6 +872,58 @@ function assertComposition(composition: LoCoMoRetrievalTaskReceipt["composition"
   ) {
     throw new Error(`${label} retrieval trace composition structure is invalid.`);
   }
+  for (const line of composition.selectedLines) {
+    assertExactKeys(
+      line,
+      [
+        "inputOrdinal",
+        "input",
+        "output",
+        "stage",
+        "hop",
+        "visible",
+        "outputStart",
+        "outputEnd",
+        "visibleStart",
+        "visibleEnd",
+      ],
+      `${label} retrieval trace composition line`
+    );
+    if (
+      !isNonNegativeSafeInteger(line.inputOrdinal) ||
+      !isDigest(line.input) ||
+      !isDigest(line.output) ||
+      (line.stage !== "direct" && line.stage !== "linked") ||
+      (line.hop !== undefined && !isNonNegativeSafeInteger(line.hop)) ||
+      typeof line.visible !== "boolean" ||
+      ![line.outputStart, line.outputEnd, line.visibleStart, line.visibleEnd].every(isNonNegativeSafeInteger)
+    ) {
+      throw new Error(`${label} retrieval trace composition line structure is invalid.`);
+    }
+  }
+}
+
+function assertExactKeys(value: unknown, allowed: readonly string[], label: string): void {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  const allowedKeys = new Set(allowed);
+  if (Object.keys(value).some((key) => !allowedKeys.has(key))) {
+    throw new Error(`${label} contains an unsupported field.`);
+  }
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function isTraceRange(value: {
+  composedStart?: unknown;
+  composedEnd?: unknown;
+  visibleStart?: unknown;
+  visibleEnd?: unknown;
+}): boolean {
+  return [value.composedStart, value.composedEnd, value.visibleStart, value.visibleEnd].every(isNonNegativeSafeInteger);
 }
 
 function isTraceBudget(value: unknown): boolean {
@@ -612,10 +1001,7 @@ function assertComparable(baseline: LoCoMoRetrievalTraceReceipt, real: LoCoMoRet
       if (!other || canonicalJsonStringify(session.session) !== canonicalJsonStringify(other.session)) {
         throw new Error(`Paired retrieval trace session mismatch at task ${index}, session ${sessionIndex}.`);
       }
-      if (
-        session.trace.budget.requestedChars !== other.trace.budget.requestedChars ||
-        session.trace.coreCapture?.budget.chars !== other.trace.coreCapture?.budget.chars
-      ) {
+      if (session.trace.budget.requestedChars !== other.trace.budget.requestedChars) {
         throw new Error(`Paired retrieval trace budget mismatch at task ${index}, session ${sessionIndex}.`);
       }
     });
@@ -624,6 +1010,7 @@ function assertComparable(baseline: LoCoMoRetrievalTraceReceipt, real: LoCoMoRet
 
 function isDigest(value: unknown): value is { sha256: string; charCount: number; lineCount: number } {
   if (!value || typeof value !== "object") return false;
+  if (Object.keys(value).some((key) => !["sha256", "charCount", "lineCount"].includes(key))) return false;
   const digest = value as { sha256?: unknown; charCount?: unknown; lineCount?: unknown };
   return (
     isSha256Hex(digest.sha256) &&

--- a/packages/bench/src/stats/locomo-retrieval-trace-delta.ts
+++ b/packages/bench/src/stats/locomo-retrieval-trace-delta.ts
@@ -1,0 +1,635 @@
+import type {
+  LoCoMoRetrievalTaskReceipt,
+  LoCoMoRetrievalTraceReceipt,
+} from "../benchmarks/published/locomo/retrieval-trace-runner.js";
+import { canonicalJsonStringify, hashCanonicalJson, hashString, isSha256Hex } from "../integrity/hash-verification.js";
+
+export const LOCOMO_RETRIEVAL_TRACE_DELTA_SCHEMA_VERSION = 1 as const;
+
+const CATEGORIES = ["single_hop", "multi_hop", "temporal", "open_domain", "adversarial"] as const;
+const MECHANISMS = [
+  "real-core-visible-lcm-displacement",
+  "lcm-selection-change",
+  "composition-filter-displacement",
+  "budget-truncation-change",
+  "mixed",
+  "no-structural-delta",
+  "insufficient-exact-lineage",
+] as const;
+
+export type LoCoMoRetrievalMechanism = (typeof MECHANISMS)[number];
+export type LoCoMoCategory = (typeof CATEGORIES)[number];
+
+export interface LoCoMoStructuralMultisetDelta {
+  baselineCount: number;
+  realCount: number;
+  sharedCount: number;
+  baselineOnlyCount: number;
+  realOnlyCount: number;
+  changed: boolean;
+}
+
+export interface LoCoMoRetrievalTaskDelta {
+  taskRef: { sha256: string; length: number };
+  category: LoCoMoCategory;
+  mechanism: LoCoMoRetrievalMechanism;
+  dimensions: {
+    sectionVisibleChars: LoCoMoStructuralMultisetDelta;
+    selections: LoCoMoStructuralMultisetDelta;
+    archiveRows: LoCoMoStructuralMultisetDelta;
+    lcmCandidates: LoCoMoStructuralMultisetDelta;
+    coreResults: LoCoMoStructuralMultisetDelta;
+    coreFilters: LoCoMoStructuralMultisetDelta;
+    coreBudget: LoCoMoStructuralMultisetDelta;
+    recallBudget: LoCoMoStructuralMultisetDelta;
+    compositionPolicy: LoCoMoStructuralMultisetDelta;
+    compositionDigests: LoCoMoStructuralMultisetDelta;
+  };
+}
+
+export interface LoCoMoRetrievalMechanismSummary {
+  taskCount: number;
+  mechanisms: Record<LoCoMoRetrievalMechanism, number>;
+}
+
+export interface LoCoMoRetrievalTraceDeltaReport {
+  schemaVersion: typeof LOCOMO_RETRIEVAL_TRACE_DELTA_SCHEMA_VERSION;
+  benchmarkId: "locomo";
+  analysisKind: "paired-retrieval-structural-delta";
+  artifactHash: string;
+  sensitivity: {
+    classification: "restricted";
+    contentEncoding: "sha256+length";
+    containsGold: false;
+    containsRawContent: false;
+    containsRawIdentifiers: false;
+  };
+  comparison: {
+    baselineArtifactHash: string;
+    realArtifactHash: string;
+    retrievalConfigHashesDiffer: true;
+    taskOrderSha256: string;
+  };
+  overall: LoCoMoRetrievalMechanismSummary;
+  categories: Array<LoCoMoRetrievalMechanismSummary & { category: LoCoMoCategory }>;
+  dominantMultiHopMechanism: {
+    status: "supported" | "not-supported";
+    mechanism?: LoCoMoRetrievalMechanism;
+    count: number;
+    taskCount: number;
+    rule: "strict-majority-and-at-least-two";
+  };
+  tasks: LoCoMoRetrievalTaskDelta[];
+  evidenceBoundary: {
+    attribution: "observed-structural-mechanism-only";
+    causalClaim: false;
+    exactLineageRequired: true;
+    explanation: string;
+  };
+}
+
+export function diagnoseLoCoMoRetrievalTraceDelta(
+  baseline: LoCoMoRetrievalTraceReceipt,
+  real: LoCoMoRetrievalTraceReceipt
+): LoCoMoRetrievalTraceDeltaReport {
+  assertReceipt(baseline, "baseline");
+  assertReceipt(real, "real");
+  assertComparable(baseline, real);
+
+  const tasks = baseline.tasks.map((baselineTask, index) =>
+    compareTask(baselineTask, real.tasks[index] as LoCoMoRetrievalTaskReceipt)
+  );
+  const overall = summarize(tasks);
+  const categories = CATEGORIES.filter((category) => tasks.some((task) => task.category === category)).map(
+    (category) => ({ category, ...summarize(tasks.filter((task) => task.category === category)) })
+  );
+  const multiHop = tasks.filter((task) => task.category === "multi_hop");
+  const candidates = MECHANISMS.filter(
+    (mechanism) => mechanism !== "no-structural-delta" && mechanism !== "insufficient-exact-lineage"
+  ).map((mechanism) => ({ mechanism, count: multiHop.filter((task) => task.mechanism === mechanism).length }));
+  candidates.sort((left, right) => right.count - left.count || left.mechanism.localeCompare(right.mechanism));
+  const dominant = candidates[0];
+  const supported = dominant !== undefined && dominant.count >= 2 && dominant.count * 2 > multiHop.length;
+
+  const withoutHash = {
+    schemaVersion: LOCOMO_RETRIEVAL_TRACE_DELTA_SCHEMA_VERSION,
+    benchmarkId: "locomo" as const,
+    analysisKind: "paired-retrieval-structural-delta" as const,
+    sensitivity: {
+      classification: "restricted" as const,
+      contentEncoding: "sha256+length" as const,
+      containsGold: false as const,
+      containsRawContent: false as const,
+      containsRawIdentifiers: false as const,
+    },
+    comparison: {
+      baselineArtifactHash: baseline.artifactHash,
+      realArtifactHash: real.artifactHash,
+      retrievalConfigHashesDiffer: true as const,
+      taskOrderSha256: hashCanonicalJson(baseline.tasks.map((task) => digestIdentifier(task.taskId))),
+    },
+    overall,
+    categories,
+    dominantMultiHopMechanism: {
+      status: supported ? ("supported" as const) : ("not-supported" as const),
+      ...(supported && dominant ? { mechanism: dominant.mechanism } : {}),
+      count: dominant?.count ?? 0,
+      taskCount: multiHop.length,
+      rule: "strict-majority-and-at-least-two" as const,
+    },
+    tasks,
+    evidenceBoundary: {
+      attribution: "observed-structural-mechanism-only" as const,
+      causalClaim: false as const,
+      exactLineageRequired: true as const,
+      explanation:
+        "Labels summarize paired, content-free structural differences. They do not prove that a retrieval mechanism caused an answer or score change.",
+    },
+  };
+  return { ...withoutHash, artifactHash: hashCanonicalJson(withoutHash) };
+}
+
+export function serializeLoCoMoRetrievalTraceDelta(report: LoCoMoRetrievalTraceDeltaReport): string {
+  return `${canonicalJsonStringify(report, 2)}\n`;
+}
+
+function compareTask(baseline: LoCoMoRetrievalTaskReceipt, real: LoCoMoRetrievalTaskReceipt): LoCoMoRetrievalTaskDelta {
+  const category = categoryOf(baseline.taskId);
+  const dimensions = {
+    sectionVisibleChars: delta(signatures(baseline, "sectionVisibleChars"), signatures(real, "sectionVisibleChars")),
+    selections: delta(signatures(baseline, "selections"), signatures(real, "selections")),
+    archiveRows: delta(signatures(baseline, "archiveRows"), signatures(real, "archiveRows")),
+    lcmCandidates: delta(signatures(baseline, "lcmCandidates"), signatures(real, "lcmCandidates")),
+    coreResults: delta(signatures(baseline, "coreResults"), signatures(real, "coreResults")),
+    coreFilters: delta(signatures(baseline, "coreFilters"), signatures(real, "coreFilters")),
+    coreBudget: delta(signatures(baseline, "coreBudget"), signatures(real, "coreBudget")),
+    recallBudget: delta(signatures(baseline, "recallBudget"), signatures(real, "recallBudget")),
+    compositionPolicy: delta(signatures(baseline, "compositionPolicy"), signatures(real, "compositionPolicy")),
+    compositionDigests: delta(signatures(baseline, "compositionDigests"), signatures(real, "compositionDigests")),
+  };
+  const exact = [...baseline.sessions, ...real.sessions].every(
+    (session) =>
+      session.trace.selections.every(hasExactSelectionLineage) &&
+      session.trace.lcmCandidates.every(hasExactCandidateLineage) &&
+      (session.trace.coreCapture?.results.every(
+        (result) => isSha256Hex(result.memoryIdRef.sha256) && result.memoryIdRef.length > 0
+      ) ??
+        true)
+  );
+  const core = dimensions.coreResults.changed || dimensions.coreFilters.changed || dimensions.coreBudget.changed;
+  const baselineVisible = visibleCharsByGroup(baseline);
+  const realVisible = visibleCharsByGroup(real);
+  const coreSections = sectionGroupChanged(baseline, real, "core");
+  const lcmSections = sectionGroupChanged(baseline, real, "lcm");
+  const otherSections = sectionGroupChanged(baseline, real, "other");
+  const lcm =
+    lcmSections || dimensions.selections.changed || dimensions.archiveRows.changed || dimensions.lcmCandidates.changed;
+  const compositionPolicy = dimensions.compositionPolicy.changed;
+  const budget = dimensions.recallBudget.changed;
+  const coreVisibleLcmDisplacement =
+    core &&
+    lcm &&
+    realVisible.core > baselineVisible.core &&
+    realVisible.lcm < baselineVisible.lcm &&
+    !otherSections &&
+    !budget;
+  let mechanism: LoCoMoRetrievalMechanism;
+  if (!exact) mechanism = "insufficient-exact-lineage";
+  else if (coreVisibleLcmDisplacement) mechanism = "real-core-visible-lcm-displacement";
+  else if (lcm && !core && !coreSections && !otherSections && !budget) mechanism = "lcm-selection-change";
+  else if (budget && !core && !coreSections && !lcm && !otherSections) mechanism = "budget-truncation-change";
+  else if (compositionPolicy && !core && !coreSections && !lcm && !otherSections && !budget)
+    mechanism = "composition-filter-displacement";
+  else if (!core && !coreSections && !lcm && !otherSections && !budget && !compositionPolicy)
+    mechanism = "no-structural-delta";
+  else mechanism = "mixed";
+  return { taskRef: digestIdentifier(baseline.taskId), category, mechanism, dimensions };
+}
+
+function visibleCharsByGroup(task: LoCoMoRetrievalTaskReceipt): { core: number; lcm: number; other: number } {
+  const output = { core: 0, lcm: 0, other: 0 };
+  for (const session of task.sessions) {
+    for (const section of session.trace.sections) {
+      if (section.source === "core") {
+        output.core += section.visibleChars;
+      } else if (section.source === "lcm-summary" || section.source === "raw-row") {
+        output.lcm += section.visibleChars;
+      } else {
+        output.other += section.visibleChars;
+      }
+    }
+  }
+  return output;
+}
+
+type SectionGroup = "core" | "lcm" | "other";
+
+function sectionGroupChanged(
+  baseline: LoCoMoRetrievalTaskReceipt,
+  real: LoCoMoRetrievalTaskReceipt,
+  group: SectionGroup
+): boolean {
+  const signaturesFor = (task: LoCoMoRetrievalTaskReceipt): string[] => {
+    const output: string[] = [];
+    task.sessions.forEach((session, sessionOrdinal) => {
+      for (const section of session.trace.sections) {
+        if (sectionGroup(section.source) === group) {
+          output.push(
+            hashCanonicalJson({ sessionOrdinal, source: section.source, visibleChars: section.visibleChars })
+          );
+        }
+      }
+    });
+    return output;
+  };
+  return delta(signaturesFor(baseline), signaturesFor(real)).changed;
+}
+
+function sectionGroup(
+  source: LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["sections"][number]["source"]
+): SectionGroup {
+  if (source === "core") return "core";
+  if (source === "lcm-summary" || source === "raw-row") return "lcm";
+  return "other";
+}
+
+type Dimension = keyof LoCoMoRetrievalTaskDelta["dimensions"];
+
+function hasExactSelectionLineage(
+  selection: LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["selections"][number]
+): boolean {
+  return (
+    selection.lineageStatus === "exact" &&
+    Array.isArray(selection.archiveRowIds) &&
+    selection.archiveRowIds.length > 0 &&
+    selection.archiveRowIds.every((id) => Number.isSafeInteger(id) && id > 0)
+  );
+}
+
+function hasExactCandidateLineage(
+  candidate: LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["lcmCandidates"][number]
+): boolean {
+  return (
+    candidate.lineageStatus === "exact" &&
+    Number.isSafeInteger(candidate.archiveRowId) &&
+    (candidate.archiveRowId as number) > 0
+  );
+}
+
+function signatures(task: LoCoMoRetrievalTaskReceipt, dimension: Dimension): string[] {
+  if (dimension === "recallBudget") {
+    return [
+      hashCanonicalJson({
+        recallBudgetChars: task.recallBudgetChars,
+        budgets: task.sessions.map((s) => s.trace.budget),
+      }),
+    ];
+  }
+  if (dimension === "compositionPolicy") {
+    return [
+      hashCanonicalJson({
+        mode: task.composition.mode,
+        multiHopRecallComposition: task.composition.multiHopRecallComposition,
+        selectedLines: task.composition.selectedLines.map((line) => ({
+          inputOrdinal: line.inputOrdinal,
+          stage: line.stage,
+          hop: line.hop,
+          visible: line.visible,
+        })),
+      }),
+    ];
+  }
+  if (dimension === "compositionDigests") {
+    return [
+      hashCanonicalJson({
+        input: task.composition.input,
+        output: task.composition.output,
+        selectedLines: task.composition.selectedLines.map((line) => ({ input: line.input, output: line.output })),
+      }),
+    ];
+  }
+  const output: string[] = [];
+  task.sessions.forEach((session, sessionOrdinal) => {
+    const trace = session.trace;
+    if (dimension === "sectionVisibleChars") {
+      for (const value of trace.sections)
+        output.push(hashCanonicalJson({ sessionOrdinal, source: value.source, visibleChars: value.visibleChars }));
+    } else if (dimension === "selections") {
+      for (const value of trace.selections)
+        output.push(
+          hashCanonicalJson({
+            sessionOrdinal,
+            kind: value.kind,
+            lineageStatus: value.lineageStatus,
+            turnIndex: value.turnIndex,
+            role: value.role,
+            score: value.score,
+            summary: value.summary,
+          })
+        );
+    } else if (dimension === "archiveRows") {
+      for (const value of trace.selections)
+        for (const archiveRowId of value.archiveRowIds ?? [])
+          output.push(hashCanonicalJson({ sessionOrdinal, archiveRowId }));
+    } else if (dimension === "lcmCandidates") {
+      for (const value of trace.lcmCandidates) output.push(hashCanonicalJson({ sessionOrdinal, ...value }));
+    } else if (dimension === "coreResults") {
+      for (const value of trace.coreCapture?.results ?? [])
+        output.push(hashCanonicalJson({ sessionOrdinal, ...value }));
+    } else if (dimension === "coreFilters") {
+      for (const value of trace.coreCapture?.filters ?? [])
+        output.push(hashCanonicalJson({ sessionOrdinal, ...value }));
+    } else if (dimension === "coreBudget") {
+      if (trace.coreCapture) output.push(hashCanonicalJson({ sessionOrdinal, ...trace.coreCapture.budget }));
+    }
+  });
+  return output;
+}
+
+function delta(baseline: string[], real: string[]): LoCoMoStructuralMultisetDelta {
+  const realCounts = counts(real);
+  let sharedCount = 0;
+  for (const entry of baseline) {
+    const available = realCounts.get(entry) ?? 0;
+    if (available > 0) {
+      sharedCount += 1;
+      realCounts.set(entry, available - 1);
+    }
+  }
+  return {
+    baselineCount: baseline.length,
+    realCount: real.length,
+    sharedCount,
+    baselineOnlyCount: baseline.length - sharedCount,
+    realOnlyCount: real.length - sharedCount,
+    changed: sharedCount !== baseline.length || sharedCount !== real.length,
+  };
+}
+
+function counts(values: string[]): Map<string, number> {
+  const output = new Map<string, number>();
+  for (const value of values) output.set(value, (output.get(value) ?? 0) + 1);
+  return output;
+}
+
+function summarize(tasks: LoCoMoRetrievalTaskDelta[]): LoCoMoRetrievalMechanismSummary {
+  const mechanisms = Object.fromEntries(MECHANISMS.map((mechanism) => [mechanism, 0])) as Record<
+    LoCoMoRetrievalMechanism,
+    number
+  >;
+  for (const task of tasks) mechanisms[task.mechanism] += 1;
+  return { taskCount: tasks.length, mechanisms };
+}
+
+function digestIdentifier(value: string): { sha256: string; length: number } {
+  return { sha256: hashString(value), length: value.length };
+}
+
+function categoryOf(taskId: string): LoCoMoCategory {
+  const category = CATEGORIES.find((candidate) => taskId.endsWith(`-${candidate}`));
+  if (!category) throw new Error("LoCoMo retrieval trace task id has an unsupported category.");
+  return category;
+}
+
+function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): void {
+  if (!receipt || typeof receipt !== "object") throw new Error(`${label} receipt must be an object.`);
+  assertFiniteJson(receipt, `${label} receipt`);
+  const { artifactHash, ...withoutHash } = receipt;
+  if (!isSha256Hex(artifactHash) || hashCanonicalJson(withoutHash) !== artifactHash) {
+    throw new Error(`${label} retrieval trace artifact hash verification failed.`);
+  }
+  if (
+    receipt.schemaVersion !== 1 ||
+    receipt.benchmarkId !== "locomo" ||
+    receipt.captureKind !== "retrieval-only" ||
+    receipt.sensitivity.classification !== "restricted" ||
+    receipt.sensitivity.contentEncoding !== "sha256+length" ||
+    receipt.sensitivity.containsGold !== false ||
+    receipt.sensitivity.containsRawContent !== false ||
+    receipt.provenance.providerFree !== true ||
+    receipt.provenance.adapterMode !== "direct" ||
+    receipt.provenance.replayExtractionMode !== "skip" ||
+    receipt.provenance.dataset.id !== "locomo-10" ||
+    receipt.provenance.recallBudget.algorithm !== "benchmarkRecallBudgetForSessionCount" ||
+    receipt.provenance.recallBudget.version !== 1 ||
+    typeof receipt.provenance.gitSha !== "string" ||
+    receipt.provenance.gitSha.length === 0 ||
+    typeof receipt.provenance.remnicVersion !== "string" ||
+    receipt.provenance.remnicVersion.length === 0 ||
+    receipt.selection.version !== 1 ||
+    !Array.isArray(receipt.selection.selectedTaskIds) ||
+    !Array.isArray(receipt.tasks) ||
+    !Number.isSafeInteger(receipt.selection.candidateCount) ||
+    !Number.isSafeInteger(receipt.selection.selectedCount) ||
+    receipt.selection.selectedCount <= 0 ||
+    receipt.selection.candidateCount < receipt.selection.selectedCount ||
+    receipt.selection.selectedCount !== receipt.tasks.length ||
+    receipt.selection.selectedTaskIds.length !== receipt.tasks.length ||
+    new Set(receipt.selection.selectedTaskIds).size !== receipt.selection.selectedTaskIds.length ||
+    new Set(receipt.tasks.map((task) => task.taskId)).size !== receipt.tasks.length ||
+    receipt.selection.selectedTaskIdsSha256 !== hashCanonicalJson(receipt.selection.selectedTaskIds) ||
+    receipt.selection.selectedTaskIds.some((taskId, index) => taskId !== receipt.tasks[index]?.taskId) ||
+    receipt.tasks.length === 0
+  ) {
+    throw new Error(`${label} retrieval trace receipt violates the restricted provider-free contract.`);
+  }
+  if (!isSha256Hex(receipt.provenance.dataset.sha256) || !isSha256Hex(receipt.provenance.retrievalConfigSha256)) {
+    throw new Error(`${label} retrieval trace receipt contains invalid provenance hashes.`);
+  }
+  for (const task of receipt.tasks) {
+    if (
+      typeof task.taskId !== "string" ||
+      task.taskId.length === 0 ||
+      !Array.isArray(task.sessions) ||
+      !isDigest(task.question) ||
+      !Number.isSafeInteger(task.recallBudgetChars) ||
+      task.recallBudgetChars < 0
+    ) {
+      throw new Error(`${label} retrieval trace task structure is invalid.`);
+    }
+    categoryOf(task.taskId);
+    assertComposition(task.composition, label);
+    for (const session of task.sessions) {
+      const trace = session.trace;
+      if (
+        !isDigest(session.session) ||
+        !trace ||
+        trace.schemaVersion !== 1 ||
+        trace.sensitivity.classification !== "restricted" ||
+        trace.sensitivity.contentEncoding !== "sha256+length" ||
+        trace.sensitivity.containsGold !== false ||
+        !Array.isArray(trace.sections) ||
+        !Array.isArray(trace.selections) ||
+        !Array.isArray(trace.lcmCandidates) ||
+        !isTraceBudget(trace.budget)
+      ) {
+        throw new Error(`${label} retrieval trace session structure is invalid.`);
+      }
+      for (const section of trace.sections) {
+        if (
+          ![
+            "derived",
+            "explicit-cue",
+            "trajectory-analysis",
+            "core",
+            "evidence-pack",
+            "lcm-summary",
+            "raw-row",
+          ].includes(section.source) ||
+          !Number.isSafeInteger(section.visibleChars) ||
+          section.visibleChars < 0
+        ) {
+          throw new Error(`${label} retrieval trace section structure is invalid.`);
+        }
+      }
+      for (const selection of trace.selections) {
+        if (
+          !["evidence-block", "trajectory-line", "lcm-summary", "raw-row"].includes(selection.kind) ||
+          (selection.lineageStatus !== "exact" && selection.lineageStatus !== "unavailable") ||
+          (selection.archiveRowIds !== undefined &&
+            (!Array.isArray(selection.archiveRowIds) ||
+              selection.archiveRowIds.some((id) => !Number.isSafeInteger(id) || id <= 0)))
+        ) {
+          throw new Error(`${label} retrieval trace selection structure is invalid.`);
+        }
+      }
+      for (const candidate of trace.lcmCandidates) {
+        if (
+          (candidate.lineageStatus !== "exact" && candidate.lineageStatus !== "unavailable") ||
+          !Number.isSafeInteger(candidate.rank) ||
+          candidate.rank < 0 ||
+          (candidate.archiveRowId !== undefined &&
+            (!Number.isSafeInteger(candidate.archiveRowId) || candidate.archiveRowId <= 0))
+        ) {
+          throw new Error(`${label} retrieval trace LCM candidate structure is invalid.`);
+        }
+      }
+      if (trace.coreCapture) {
+        if (
+          !isCountBudget(trace.coreCapture.budget) ||
+          !Array.isArray(trace.coreCapture.filters) ||
+          !Array.isArray(trace.coreCapture.results) ||
+          trace.coreCapture.results.some(
+            (result) =>
+              !isSha256Hex(result.memoryIdRef?.sha256) ||
+              !Number.isSafeInteger(result.memoryIdRef?.length) ||
+              result.memoryIdRef.length <= 0
+          )
+        ) {
+          throw new Error(`${label} retrieval trace core capture structure is invalid.`);
+        }
+      }
+    }
+  }
+}
+
+function assertComposition(composition: LoCoMoRetrievalTaskReceipt["composition"], label: string): void {
+  if (
+    !composition ||
+    composition.schemaVersion !== 1 ||
+    (composition.mode !== "focused" && composition.mode !== "fallback") ||
+    typeof composition.multiHopRecallComposition !== "boolean" ||
+    !isDigest(composition.input) ||
+    !isDigest(composition.output) ||
+    !Array.isArray(composition.selectedLines)
+  ) {
+    throw new Error(`${label} retrieval trace composition structure is invalid.`);
+  }
+}
+
+function isTraceBudget(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const budget = value as {
+    requestedChars?: unknown;
+    composedChars?: unknown;
+    returnedChars?: unknown;
+    truncated?: unknown;
+  };
+  return (
+    [budget.requestedChars, budget.composedChars, budget.returnedChars].every(
+      (entry) => Number.isSafeInteger(entry) && (entry as number) >= 0
+    ) && typeof budget.truncated === "boolean"
+  );
+}
+
+function isCountBudget(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const budget = value as { chars?: unknown; used?: unknown };
+  return [budget.chars, budget.used].every((entry) => Number.isSafeInteger(entry) && (entry as number) >= 0);
+}
+
+function assertFiniteJson(value: unknown, label: string): void {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error(`${label} contains a non-finite number.`);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertFiniteJson(entry, `${label}[${index}]`));
+    return;
+  }
+  if (!value || typeof value !== "object") throw new Error(`${label} is not canonical JSON.`);
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry === undefined) throw new Error(`${label}.${key} is undefined.`);
+    assertFiniteJson(entry, `${label}.${key}`);
+  }
+}
+
+function assertComparable(baseline: LoCoMoRetrievalTraceReceipt, real: LoCoMoRetrievalTraceReceipt): void {
+  if (baseline.provenance.runtimeProfile !== "baseline" || real.provenance.runtimeProfile !== "real") {
+    throw new Error("Paired retrieval traces require baseline and real runtime profiles in that order.");
+  }
+  const matching = [
+    [baseline.schemaVersion, real.schemaVersion],
+    [baseline.benchmarkId, real.benchmarkId],
+    [baseline.provenance.gitSha, real.provenance.gitSha],
+    [baseline.provenance.remnicVersion, real.provenance.remnicVersion],
+    [baseline.provenance.dataset.sha256, real.provenance.dataset.sha256],
+    [baseline.provenance.recallBudget.version, real.provenance.recallBudget.version],
+    [baseline.selection.selectedTaskIdsSha256, real.selection.selectedTaskIdsSha256],
+    [canonicalJsonStringify(baseline.selection), canonicalJsonStringify(real.selection)],
+    [baseline.tasks.length, real.tasks.length],
+  ];
+  if (matching.some(([left, right]) => left !== right))
+    throw new Error("Paired retrieval trace provenance does not match.");
+  if (baseline.provenance.retrievalConfigSha256 === real.provenance.retrievalConfigSha256) {
+    throw new Error("Paired retrieval traces must use different baseline and real retrieval configuration hashes.");
+  }
+  baseline.tasks.forEach((left, index) => {
+    const right = real.tasks[index];
+    if (
+      !right ||
+      left.taskId !== right.taskId ||
+      canonicalJsonStringify(left.question) !== canonicalJsonStringify(right.question) ||
+      left.recallBudgetChars !== right.recallBudgetChars ||
+      left.sessions.length !== right.sessions.length ||
+      left.composition.multiHopRecallComposition !== right.composition.multiHopRecallComposition
+    ) {
+      throw new Error(`Paired retrieval trace task mismatch at index ${index}.`);
+    }
+    left.sessions.forEach((session, sessionIndex) => {
+      const other = right.sessions[sessionIndex];
+      if (!other || canonicalJsonStringify(session.session) !== canonicalJsonStringify(other.session)) {
+        throw new Error(`Paired retrieval trace session mismatch at task ${index}, session ${sessionIndex}.`);
+      }
+      if (
+        session.trace.budget.requestedChars !== other.trace.budget.requestedChars ||
+        session.trace.coreCapture?.budget.chars !== other.trace.coreCapture?.budget.chars
+      ) {
+        throw new Error(`Paired retrieval trace budget mismatch at task ${index}, session ${sessionIndex}.`);
+      }
+    });
+  });
+}
+
+function isDigest(value: unknown): value is { sha256: string; charCount: number; lineCount: number } {
+  if (!value || typeof value !== "object") return false;
+  const digest = value as { sha256?: unknown; charCount?: unknown; lineCount?: unknown };
+  return (
+    isSha256Hex(digest.sha256) &&
+    Number.isSafeInteger(digest.charCount) &&
+    (digest.charCount as number) >= 0 &&
+    Number.isSafeInteger(digest.lineCount) &&
+    (digest.lineCount as number) >= 0
+  );
+}

--- a/packages/bench/src/stats/locomo-retrieval-trace-delta.ts
+++ b/packages/bench/src/stats/locomo-retrieval-trace-delta.ts
@@ -144,7 +144,7 @@ export function diagnoseLoCoMoRetrievalTraceDelta(
       causalClaim: false as const,
       exactLineageRequired: true as const,
       explanation:
-        "Labels summarize paired, content-free structural differences. They do not prove that a retrieval mechanism caused an answer or score change.",
+        "Labels summarize paired, content-free structural differences. The budget-truncation label denotes a fixed-budget tail-geometry transition with a stable recorded composition outcome; it does not prove identical prefix content. No label proves that a retrieval mechanism caused an answer or score change.",
     },
   };
   return { ...withoutHash, artifactHash: hashCanonicalJson(withoutHash) };
@@ -209,16 +209,16 @@ function compareTask(baseline: LoCoMoRetrievalTaskReceipt, real: LoCoMoRetrieval
   };
   const exact = hasCompleteExactLineage(baseline) && hasCompleteExactLineage(real);
   const lcmSelectionsChanged = delta(
-    exactSelectionSignatures(baseline, "lcm"),
-    exactSelectionSignatures(real, "lcm")
+    exactSelectionSignatures(baseline, "lcm", "emitted"),
+    exactSelectionSignatures(real, "lcm", "emitted")
   ).changed;
   const lcmArchiveRowsChanged = delta(
     exactArchiveRowSignatures(baseline, "lcm"),
     exactArchiveRowSignatures(real, "lcm")
   ).changed;
   const auxiliarySelectionsChanged = delta(
-    exactSelectionSignatures(baseline, "auxiliary"),
-    exactSelectionSignatures(real, "auxiliary")
+    exactSelectionSignatures(baseline, "auxiliary", "emitted"),
+    exactSelectionSignatures(real, "auxiliary", "emitted")
   ).changed;
   const auxiliaryArchiveRowsChanged = delta(
     exactArchiveRowSignatures(baseline, "auxiliary"),
@@ -227,14 +227,20 @@ function compareTask(baseline: LoCoMoRetrievalTaskReceipt, real: LoCoMoRetrieval
   const core = dimensions.coreResults.changed || dimensions.coreFilters.changed || dimensions.coreBudget.changed;
   const baselineVisible = visibleCharsByGroup(baseline);
   const realVisible = visibleCharsByGroup(real);
-  const coreSections = sectionGroupChanged(baseline, real, "core");
-  const lcmSections = sectionGroupChanged(baseline, real, "lcm");
-  const otherSections = sectionGroupChanged(baseline, real, "other");
+  const coreSections = sectionGroupChanged(baseline, real, "core", "emitted");
+  const lcmSections = sectionGroupChanged(baseline, real, "lcm", "emitted");
+  const otherSections = sectionGroupChanged(baseline, real, "other", "emitted");
   const lcm = lcmSections || lcmSelectionsChanged || lcmArchiveRowsChanged || dimensions.lcmCandidates.changed;
   const auxiliary = auxiliarySelectionsChanged || auxiliaryArchiveRowsChanged;
   const other = otherSections || auxiliary;
+  const composedSelectionsChanged = delta(
+    structuralSelectionSignatures(baseline, "all", "composed", false),
+    structuralSelectionSignatures(real, "all", "composed", false)
+  ).changed;
+  const allCandidatesChanged = delta(candidateSignatures(baseline, false), candidateSignatures(real, false)).changed;
   const compositionPolicy = dimensions.compositionPolicy.changed;
   const compositionDigests = dimensions.compositionDigests.changed;
+  const compositionOutcomeChanged = compositionOutcomeSignature(baseline) !== compositionOutcomeSignature(real);
   const budget = dimensions.recallBudget.changed;
   const coreVisibleLcmDisplacement =
     core &&
@@ -244,11 +250,19 @@ function compareTask(baseline: LoCoMoRetrievalTaskReceipt, real: LoCoMoRetrieval
     !other &&
     !budget &&
     !compositionPolicy;
+  const budgetTailGeometryTransition =
+    budget &&
+    hasFixedBudgetTailGeometryTransition(baseline, real) &&
+    !core &&
+    !composedSelectionsChanged &&
+    !allCandidatesChanged &&
+    !compositionPolicy &&
+    !compositionOutcomeChanged;
   let mechanism: LoCoMoRetrievalMechanism;
   if (!exact) mechanism = "insufficient-exact-lineage";
   else if (coreVisibleLcmDisplacement) mechanism = "real-core-visible-lcm-displacement";
   else if (lcm && !core && !coreSections && !other && !budget) mechanism = "lcm-selection-change";
-  else if (budget && !core && !coreSections && !lcm && !other) mechanism = "budget-truncation-change";
+  else if (budgetTailGeometryTransition) mechanism = "budget-truncation-change";
   else if (compositionPolicy && !core && !coreSections && !lcm && !other && !budget)
     mechanism = "composition-filter-displacement";
   else if (compositionDigests && !compositionPolicy && !core && !coreSections && !lcm && !other && !budget)
@@ -280,14 +294,15 @@ type SectionGroup = "core" | "lcm" | "other";
 function sectionGroupChanged(
   baseline: LoCoMoRetrievalTaskReceipt,
   real: LoCoMoRetrievalTaskReceipt,
-  group: SectionGroup
+  group: SectionGroup,
+  projection: StructuralProjection
 ): boolean {
   const signaturesFor = (task: LoCoMoRetrievalTaskReceipt): string[] => {
     const output: string[] = [];
     task.sessions.forEach((session, sessionOrdinal) => {
       session.trace.sections.forEach((section, sectionOrdinal) => {
         if (sectionGroup(section.source) === group) {
-          output.push(structuralSectionSignature(section, sessionOrdinal, sectionOrdinal));
+          output.push(structuralSectionSignature(section, sessionOrdinal, sectionOrdinal, projection));
         }
       });
     });
@@ -307,7 +322,8 @@ function sectionGroup(
 function structuralSectionSignature(
   section: LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["sections"][number],
   sessionOrdinal: number,
-  sectionOrdinal: number
+  sectionOrdinal: number,
+  projection: StructuralProjection
 ): string {
   return hashCanonicalJson({
     sessionOrdinal,
@@ -319,14 +335,19 @@ function structuralSectionSignature(
     contentEnd: section.contentEnd,
     composedStart: section.composedStart,
     composedEnd: section.composedEnd,
-    visibleStart: section.visibleStart,
-    visibleEnd: section.visibleEnd,
-    visibleChars: section.visibleChars,
+    ...(projection === "emitted"
+      ? {
+          visibleStart: section.visibleStart,
+          visibleEnd: section.visibleEnd,
+          visibleChars: section.visibleChars,
+        }
+      : {}),
   });
 }
 
 type Dimension = keyof LoCoMoRetrievalTaskDelta["dimensions"];
 type SelectionScope = "all" | "lcm" | "auxiliary";
+type StructuralProjection = "emitted" | "composed";
 
 function selectionInScope(
   selection: LoCoMoRetrievalTaskReceipt["sessions"][number]["trace"]["selections"][number],
@@ -336,14 +357,28 @@ function selectionInScope(
   return scope === "all" || (scope === "lcm" ? isLcm : !isLcm);
 }
 
-function exactSelectionSignatures(task: LoCoMoRetrievalTaskReceipt, scope: SelectionScope): string[] {
+function exactSelectionSignatures(
+  task: LoCoMoRetrievalTaskReceipt,
+  scope: SelectionScope,
+  projection: StructuralProjection
+): string[] {
+  return structuralSelectionSignatures(task, scope, projection, true);
+}
+
+function structuralSelectionSignatures(
+  task: LoCoMoRetrievalTaskReceipt,
+  scope: SelectionScope,
+  projection: StructuralProjection,
+  exactOnly: boolean
+): string[] {
   const output: string[] = [];
   task.sessions.forEach((session, sessionOrdinal) => {
     for (const value of session.trace.selections) {
-      if (!selectionInScope(value, scope) || !hasExactSelectionLineage(value)) continue;
+      if (!selectionInScope(value, scope) || (exactOnly && !hasExactSelectionLineage(value))) continue;
       output.push(
         hashCanonicalJson({
           sessionOrdinal,
+          sectionIdRef: digestIdentifier(value.sectionId),
           kind: value.kind,
           lineageStatus: value.lineageStatus,
           turnIndex: value.turnIndex,
@@ -353,8 +388,12 @@ function exactSelectionSignatures(task: LoCoMoRetrievalTaskReceipt, scope: Selec
           archiveRowIds: value.archiveRowIds,
           composedStart: value.composedStart,
           composedEnd: value.composedEnd,
-          visibleStart: value.visibleStart,
-          visibleEnd: value.visibleEnd,
+          ...(projection === "emitted"
+            ? {
+                visibleStart: value.visibleStart,
+                visibleEnd: value.visibleEnd,
+              }
+            : {}),
         })
       );
     }
@@ -407,9 +446,31 @@ function hasExactCandidateLineage(
   );
 }
 
+function candidateSignatures(task: LoCoMoRetrievalTaskReceipt, exactOnly: boolean): string[] {
+  const output: string[] = [];
+  task.sessions.forEach((session, sessionOrdinal) => {
+    for (const value of session.trace.lcmCandidates) {
+      if (exactOnly && !hasExactCandidateLineage(value)) continue;
+      output.push(
+        hashCanonicalJson({
+          sessionOrdinal,
+          rank: value.rank,
+          archiveRowId: value.archiveRowId,
+          turnIndex: value.turnIndex,
+          role: value.role,
+          score: value.score,
+          lineageStatus: value.lineageStatus,
+        })
+      );
+    }
+  });
+  return output;
+}
+
 function signatures(task: LoCoMoRetrievalTaskReceipt, dimension: Dimension): string[] {
-  if (dimension === "selections") return exactSelectionSignatures(task, "all");
+  if (dimension === "selections") return exactSelectionSignatures(task, "all", "emitted");
   if (dimension === "archiveRows") return exactArchiveRowSignatures(task, "all");
+  if (dimension === "lcmCandidates") return candidateSignatures(task, true);
   if (dimension === "recallBudget") {
     return [
       hashCanonicalJson({
@@ -431,6 +492,10 @@ function signatures(task: LoCoMoRetrievalTaskReceipt, dimension: Dimension): str
           stage: line.stage,
           hop: line.hop,
           visible: line.visible,
+          outputStart: line.outputStart,
+          outputEnd: line.outputEnd,
+          visibleStart: line.visibleStart,
+          visibleEnd: line.visibleEnd,
         })),
       }),
     ];
@@ -449,23 +514,8 @@ function signatures(task: LoCoMoRetrievalTaskReceipt, dimension: Dimension): str
     const trace = session.trace;
     if (dimension === "sectionVisibleChars") {
       trace.sections.forEach((value, sectionOrdinal) => {
-        output.push(structuralSectionSignature(value, sessionOrdinal, sectionOrdinal));
+        output.push(structuralSectionSignature(value, sessionOrdinal, sectionOrdinal, "emitted"));
       });
-    } else if (dimension === "lcmCandidates") {
-      for (const value of trace.lcmCandidates) {
-        if (!hasExactCandidateLineage(value)) continue;
-        output.push(
-          hashCanonicalJson({
-            sessionOrdinal,
-            rank: value.rank,
-            archiveRowId: value.archiveRowId,
-            turnIndex: value.turnIndex,
-            role: value.role,
-            score: value.score,
-            lineageStatus: value.lineageStatus,
-          })
-        );
-      }
     } else if (dimension === "coreResults") {
       for (const [resultOrdinal, value] of (trace.coreCapture?.results ?? []).entries())
         output.push(
@@ -496,6 +546,110 @@ function signatures(task: LoCoMoRetrievalTaskReceipt, dimension: Dimension): str
     }
   });
   return output;
+}
+
+function compositionOutcomeSignature(task: LoCoMoRetrievalTaskReceipt): string {
+  return hashCanonicalJson({
+    output: task.composition.output,
+    selectedLines: task.composition.selectedLines.map((line) => ({ input: line.input, output: line.output })),
+  });
+}
+
+function hasFixedBudgetTailGeometryTransition(
+  baseline: LoCoMoRetrievalTaskReceipt,
+  real: LoCoMoRetrievalTaskReceipt
+): boolean {
+  let sawTransition = false;
+  for (let index = 0; index < baseline.sessions.length; index += 1) {
+    const baselineSession = baseline.sessions[index];
+    const realSession = real.sessions[index];
+    const baselineTrace = baselineSession?.trace;
+    const realTrace = realSession?.trace;
+    if (
+      !baselineSession ||
+      !realSession ||
+      !baselineTrace ||
+      !realTrace ||
+      baselineTrace.budget.requestedChars !== realTrace.budget.requestedChars
+    ) {
+      return false;
+    }
+    if (baselineTrace.budget.truncated === realTrace.budget.truncated) {
+      if (
+        baselineTrace.budget.composedChars !== realTrace.budget.composedChars ||
+        baselineTrace.budget.returnedChars !== realTrace.budget.returnedChars ||
+        sectionGroupChanged(
+          { ...baseline, sessions: [baselineSession] },
+          { ...real, sessions: [realSession] },
+          "core",
+          "composed"
+        ) ||
+        sectionGroupChanged(
+          { ...baseline, sessions: [baselineSession] },
+          { ...real, sessions: [realSession] },
+          "lcm",
+          "composed"
+        ) ||
+        sectionGroupChanged(
+          { ...baseline, sessions: [baselineSession] },
+          { ...real, sessions: [realSession] },
+          "other",
+          "composed"
+        )
+      ) {
+        return false;
+      }
+      continue;
+    }
+    const shorter = baselineTrace.budget.truncated ? realTrace : baselineTrace;
+    const longer = baselineTrace.budget.truncated ? baselineTrace : realTrace;
+    const requested = shorter.budget.requestedChars;
+    if (
+      shorter.budget.truncated ||
+      !longer.budget.truncated ||
+      shorter.budget.composedChars > requested ||
+      longer.budget.composedChars <= requested ||
+      shorter.budget.returnedChars !== shorter.budget.composedChars ||
+      longer.budget.returnedChars !== requested ||
+      shorter.sections.length === 0 ||
+      shorter.sections.length !== longer.sections.length
+    ) {
+      return false;
+    }
+    const finalIndex = shorter.sections.length - 1;
+    for (let sectionIndex = 0; sectionIndex < finalIndex; sectionIndex += 1) {
+      const shortSection = shorter.sections[sectionIndex];
+      const longSection = longer.sections[sectionIndex];
+      if (!shortSection || !longSection) return false;
+      if (
+        structuralSectionSignature(shortSection, 0, sectionIndex, "composed") !==
+        structuralSectionSignature(longSection, 0, sectionIndex, "composed")
+      ) {
+        return false;
+      }
+    }
+    const shortFinal = shorter.sections[finalIndex];
+    const longFinal = longer.sections[finalIndex];
+    if (!shortFinal || !longFinal) return false;
+    const extension = longFinal.composedEnd - shortFinal.composedEnd;
+    if (
+      shortFinal.id !== longFinal.id ||
+      shortFinal.source !== longFinal.source ||
+      shortFinal.separatorStart !== longFinal.separatorStart ||
+      shortFinal.contentStart !== longFinal.contentStart ||
+      shortFinal.composedStart !== longFinal.composedStart ||
+      shortFinal.contentEnd !== shortFinal.composedEnd ||
+      longFinal.contentEnd !== longFinal.composedEnd ||
+      shortFinal.composedEnd !== shorter.budget.composedChars ||
+      longFinal.composedEnd !== longer.budget.composedChars ||
+      extension <= 0 ||
+      longFinal.contentEnd - shortFinal.contentEnd !== extension
+    ) {
+      return false;
+    }
+    sawTransition = true;
+  }
+  return sawTransition;
 }
 
 function delta(baseline: string[], real: string[]): LoCoMoStructuralMultisetDelta {
@@ -650,6 +804,9 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
     for (const session of task.sessions) {
       assertExactKeys(session, ["session", "trace"], `${label} retrieval trace session`);
       const trace = session.trace;
+      const expectedComposedChars = Array.isArray(trace.sections)
+        ? trace.sections.reduce((maximum, section) => Math.max(maximum, section.composedEnd), 0)
+        : -1;
       assertExactKeys(
         trace,
         ["schemaVersion", "sensitivity", "sections", "selections", "lcmCandidates", "coreCapture", "budget"],
@@ -678,12 +835,15 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
         new Set(trace.sections.map((section) => section.id)).size !== trace.sections.length ||
         !isTraceBudget(trace.budget) ||
         trace.budget.requestedChars !== task.recallBudgetChars ||
+        trace.budget.composedChars !== expectedComposedChars ||
+        trace.budget.returnedChars !== Math.min(trace.budget.requestedChars, trace.budget.composedChars) ||
         trace.budget.returnedChars > trace.budget.composedChars ||
         trace.budget.truncated !== trace.budget.returnedChars < trace.budget.composedChars
       ) {
         throw new Error(`${label} retrieval trace session structure is invalid.`);
       }
-      for (const section of trace.sections) {
+      let previousContentEnd = 0;
+      for (const [sectionIndex, section] of trace.sections.entries()) {
         assertExactKeys(
           section,
           [
@@ -700,6 +860,13 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
           ],
           `${label} retrieval trace section`
         );
+        const expectedVisibleStart = Math.min(section.composedStart, trace.budget.returnedChars);
+        const expectedVisibleEnd = Math.max(
+          expectedVisibleStart,
+          Math.min(section.composedEnd, trace.budget.returnedChars)
+        );
+        const expectedSeparatorStart = sectionIndex === 0 ? 0 : previousContentEnd;
+        const expectedContentStart = expectedSeparatorStart + (sectionIndex === 0 ? 0 : 2);
         if (
           ![
             "derived",
@@ -714,11 +881,20 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
           section.id.length === 0 ||
           !isTraceRange(section) ||
           ![section.separatorStart, section.contentStart, section.contentEnd].every(isNonNegativeSafeInteger) ||
+          section.separatorStart !== expectedSeparatorStart ||
+          section.contentStart !== expectedContentStart ||
+          section.contentEnd < section.contentStart ||
+          section.composedStart !== section.separatorStart ||
+          section.composedEnd !== section.contentEnd ||
           !Number.isSafeInteger(section.visibleChars) ||
-          section.visibleChars < 0
+          section.visibleChars < 0 ||
+          section.visibleStart !== expectedVisibleStart ||
+          section.visibleEnd !== expectedVisibleEnd ||
+          section.visibleChars !== expectedVisibleEnd - expectedVisibleStart
         ) {
           throw new Error(`${label} retrieval trace section structure is invalid.`);
         }
+        previousContentEnd = section.contentEnd;
       }
       for (const selection of trace.selections) {
         assertExactKeys(
@@ -747,6 +923,11 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
           );
         }
         const selectedSection = trace.sections.find((section) => section.id === selection.sectionId);
+        const expectedVisibleStart = Math.min(selection.composedStart, trace.budget.returnedChars);
+        const expectedVisibleEnd = Math.max(
+          expectedVisibleStart,
+          Math.min(selection.composedEnd, trace.budget.returnedChars)
+        );
         if (
           !["evidence-block", "trajectory-line", "lcm-summary", "raw-row"].includes(selection.kind) ||
           typeof selection.sectionId !== "string" ||
@@ -754,7 +935,15 @@ function assertReceipt(receipt: LoCoMoRetrievalTraceReceipt, label: string): voi
           selectedSection === undefined ||
           (selection.kind === "lcm-summary" && selectedSection.source !== "lcm-summary") ||
           (selection.kind === "raw-row" && selectedSection.source !== "raw-row") ||
+          (selection.kind === "evidence-block" &&
+            selectedSection.source !== "explicit-cue" &&
+            selectedSection.source !== "evidence-pack") ||
+          (selection.kind === "trajectory-line" && selectedSection.source !== "trajectory-analysis") ||
           !isTraceRange(selection) ||
+          selection.composedStart < selectedSection.contentStart ||
+          selection.composedEnd > selectedSection.contentEnd ||
+          selection.visibleStart !== expectedVisibleStart ||
+          selection.visibleEnd !== expectedVisibleEnd ||
           (selection.lineageStatus !== "exact" && selection.lineageStatus !== "unavailable") ||
           (selection.turnIndex !== undefined && !isNonNegativeSafeInteger(selection.turnIndex)) ||
           (selection.role !== undefined && typeof selection.role !== "string") ||
@@ -873,6 +1062,7 @@ function assertComposition(composition: LoCoMoRetrievalTaskReceipt["composition"
   ) {
     throw new Error(`${label} retrieval trace composition structure is invalid.`);
   }
+  let previousOutputEnd = -1;
   for (const line of composition.selectedLines) {
     assertExactKeys(
       line,
@@ -897,10 +1087,20 @@ function assertComposition(composition: LoCoMoRetrievalTaskReceipt["composition"
       (line.stage !== "direct" && line.stage !== "linked") ||
       (line.hop !== undefined && !isNonNegativeSafeInteger(line.hop)) ||
       typeof line.visible !== "boolean" ||
-      ![line.outputStart, line.outputEnd, line.visibleStart, line.visibleEnd].every(isNonNegativeSafeInteger)
+      ![line.outputStart, line.outputEnd, line.visibleStart, line.visibleEnd].every(isNonNegativeSafeInteger) ||
+      line.outputStart < previousOutputEnd ||
+      line.outputEnd < line.outputStart ||
+      line.outputEnd - line.outputStart !== line.output.charCount ||
+      line.visibleEnd < line.visibleStart ||
+      line.visibleStart > line.outputStart ||
+      line.visibleEnd > line.outputEnd ||
+      line.visibleEnd > composition.output.charCount ||
+      (line.visibleStart < line.outputStart && line.visibleStart !== line.visibleEnd) ||
+      line.visible !== (line.visibleStart === line.outputStart && line.visibleEnd === line.outputEnd)
     ) {
       throw new Error(`${label} retrieval trace composition line structure is invalid.`);
     }
+    previousOutputEnd = line.outputEnd;
   }
 }
 
@@ -924,7 +1124,11 @@ function isTraceRange(value: {
   visibleStart?: unknown;
   visibleEnd?: unknown;
 }): boolean {
-  return [value.composedStart, value.composedEnd, value.visibleStart, value.visibleEnd].every(isNonNegativeSafeInteger);
+  return (
+    [value.composedStart, value.composedEnd, value.visibleStart, value.visibleEnd].every(isNonNegativeSafeInteger) &&
+    (value.composedEnd as number) >= (value.composedStart as number) &&
+    (value.visibleEnd as number) >= (value.visibleStart as number)
+  );
 }
 
 function isTraceBudget(value: unknown): boolean {

--- a/packages/bench/src/stats/locomo-retrieval-trace-delta.ts
+++ b/packages/bench/src/stats/locomo-retrieval-trace-delta.ts
@@ -261,7 +261,8 @@ function compareTask(baseline: LoCoMoRetrievalTaskReceipt, real: LoCoMoRetrieval
   let mechanism: LoCoMoRetrievalMechanism;
   if (!exact) mechanism = "insufficient-exact-lineage";
   else if (coreVisibleLcmDisplacement) mechanism = "real-core-visible-lcm-displacement";
-  else if (lcm && !core && !coreSections && !other && !budget) mechanism = "lcm-selection-change";
+  else if (lcm && !core && !coreSections && !other && !budget && !compositionPolicy)
+    mechanism = "lcm-selection-change";
   else if (budgetTailGeometryTransition) mechanism = "budget-truncation-change";
   else if (compositionPolicy && !core && !coreSections && !lcm && !other && !budget)
     mechanism = "composition-filter-displacement";

--- a/scripts/bench/diagnose-locomo-retrieval-trace-delta.test.ts
+++ b/scripts/bench/diagnose-locomo-retrieval-trace-delta.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
+import { tmpdir } from "node:os";
 import test from "node:test";
 
-import { parseArgs } from "./diagnose-locomo-retrieval-trace-delta.js";
+import { formatOperatorError, main, parseArgs, runCli } from "./diagnose-locomo-retrieval-trace-delta.js";
 
 test("expands tilde paths for both inputs and the private output", () => {
   assert.deepEqual(parseArgs(["~/baseline.json", "~/real.json", "--out", "~/delta.json"]), {
@@ -18,4 +20,58 @@ test("does not expand unsupported named-user prefixes", () => {
     baselinePath: "~someone/baseline.json",
     realPath: "real.json",
   });
+});
+
+test("does not expose raw filesystem paths in operator errors", async () => {
+  const sentinel = "/private/benchmark/secret-baseline.json";
+  await assert.rejects(main([sentinel, "/private/benchmark/secret-real.json"]), (error: unknown) => {
+    assert.ok(error instanceof Error);
+    assert.doesNotMatch(error.message, /\/private\/benchmark/u);
+    assert.match(error.message, /Unable to read (?:baseline|real) retrieval trace JSON: Error \(ENOENT\)/u);
+    return true;
+  });
+  assert.equal(formatOperatorError(new Error(`failed at ${sentinel}`)), "Error");
+
+  let stderr = "";
+  const exitCode = await runCli([sentinel, "/private/benchmark/secret-real.json"], {
+    write(chunk) {
+      stderr += chunk;
+    },
+  });
+  assert.equal(exitCode, 1);
+  assert.match(stderr, /Unable to read (?:baseline|real) retrieval trace JSON: Error \(ENOENT\)/u);
+  assert.doesNotMatch(stderr, /\/private\/benchmark/u);
+
+  stderr = "";
+  const invalidArgExitCode = await runCli(["baseline.json", "real.json", "/private/benchmark/secret-output.json"], {
+    write(chunk) {
+      stderr += chunk;
+    },
+  });
+  assert.equal(invalidArgExitCode, 1);
+  assert.equal(stderr, "Invalid command-line arguments.\n");
+  assert.doesNotMatch(stderr, /\/private\/benchmark/u);
+});
+
+test("reports trusted top-level JSON type errors without exposing paths", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "remnic-trace-delta-"));
+  const baselinePath = path.join(directory, "private-baseline.json");
+  const realPath = path.join(directory, "private-real.json");
+  try {
+    await writeFile(realPath, "{}\n", { mode: 0o600 });
+    for (const invalidJson of ["null\n", "[]\n"]) {
+      await writeFile(baselinePath, invalidJson, { mode: 0o600 });
+      let stderr = "";
+      const exitCode = await runCli([baselinePath, realPath], {
+        write(chunk) {
+          stderr += chunk;
+        },
+      });
+      assert.equal(exitCode, 1);
+      assert.equal(stderr, "baseline retrieval trace JSON must contain an object.\n");
+      assert.doesNotMatch(stderr, /private-baseline|remnic-trace-delta/u);
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });

--- a/scripts/bench/diagnose-locomo-retrieval-trace-delta.test.ts
+++ b/scripts/bench/diagnose-locomo-retrieval-trace-delta.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { parseArgs } from "./diagnose-locomo-retrieval-trace-delta.js";
+
+test("expands tilde paths for both inputs and the private output", () => {
+  assert.deepEqual(parseArgs(["~/baseline.json", "~/real.json", "--out", "~/delta.json"]), {
+    baselinePath: path.join(homedir(), "baseline.json"),
+    realPath: path.join(homedir(), "real.json"),
+    out: path.join(homedir(), "delta.json"),
+  });
+});
+
+test("does not expand unsupported named-user prefixes", () => {
+  assert.deepEqual(parseArgs(["~someone/baseline.json", "real.json"]), {
+    baselinePath: "~someone/baseline.json",
+    realPath: "real.json",
+  });
+});

--- a/scripts/bench/diagnose-locomo-retrieval-trace-delta.ts
+++ b/scripts/bench/diagnose-locomo-retrieval-trace-delta.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env -S npx tsx
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+import {
+  type LoCoMoRetrievalTraceReceipt,
+  diagnoseLoCoMoRetrievalTraceDelta,
+  serializeLoCoMoRetrievalTraceDelta,
+} from "@remnic/bench";
+import { expandTildePath } from "@remnic/core";
+
+import { preparePrivateOutput, writePrivateOutput } from "./capture-locomo-retrieval-trace.js";
+
+export interface CliOptions {
+  baselinePath: string;
+  realPath: string;
+  out?: string;
+}
+
+export async function main(argv: string[]): Promise<string> {
+  const options = parseArgs(argv);
+  const [baseline, real] = await Promise.all([
+    loadReceipt(options.baselinePath, "baseline"),
+    loadReceipt(options.realPath, "real"),
+  ]);
+  const report = diagnoseLoCoMoRetrievalTraceDelta(baseline, real);
+  const outputContext = await preparePrivateOutput(options.out);
+  const outputPath = path.resolve(
+    outputContext.requestedOutput ??
+      path.join(
+        outputContext.privateRoot,
+        "locomo-retrieval-trace-deltas",
+        `paired-${report.artifactHash.slice(0, 16)}.json`
+      )
+  );
+  await mkdir(path.dirname(outputPath), { recursive: true, mode: 0o700 });
+  await writePrivateOutput(outputPath, serializeLoCoMoRetrievalTraceDelta(report), outputContext);
+  process.stdout.write(`${outputPath}\n`);
+  return outputPath;
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  if (argv.length < 2) {
+    throw new Error(
+      "usage: diagnose-locomo-retrieval-trace-delta.ts <baseline-trace> <real-trace> [--out private-path]"
+    );
+  }
+  const [baselinePath, realPath, ...flags] = argv;
+  if (!baselinePath || !realPath || baselinePath.startsWith("--") || realPath.startsWith("--")) {
+    throw new Error("Both baseline and real retrieval trace paths are required.");
+  }
+  let out: string | undefined;
+  for (let index = 0; index < flags.length; index += 1) {
+    const flag = flags[index];
+    if (flag === "--out") {
+      const value = flags[index + 1];
+      if (!value || value.startsWith("--")) throw new Error("--out requires a value.");
+      if (out !== undefined) throw new Error("--out may be specified only once.");
+      out = value;
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument ${JSON.stringify(flag)}.`);
+    }
+  }
+  return {
+    baselinePath: expandTildePath(baselinePath),
+    realPath: expandTildePath(realPath),
+    ...(out === undefined ? {} : { out: expandTildePath(out) }),
+  };
+}
+
+async function loadReceipt(pathname: string, label: string): Promise<LoCoMoRetrievalTraceReceipt> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(pathname, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Unable to read ${label} retrieval trace JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${label} retrieval trace JSON must contain an object.`);
+  }
+  return parsed as LoCoMoRetrievalTraceReceipt;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/bench/diagnose-locomo-retrieval-trace-delta.ts
+++ b/scripts/bench/diagnose-locomo-retrieval-trace-delta.ts
@@ -10,6 +10,7 @@ import {
   serializeLoCoMoRetrievalTraceDelta,
 } from "@remnic/bench";
 import { expandTildePath } from "@remnic/core";
+import { displayErrorDetail } from "@remnic/core/runtime/better-sqlite";
 
 import { preparePrivateOutput, writePrivateOutput } from "./capture-locomo-retrieval-trace.js";
 
@@ -19,13 +20,29 @@ export interface CliOptions {
   out?: string;
 }
 
+interface TextSink {
+  write(chunk: string): unknown;
+}
+
+class OperatorFacingError extends Error {}
+
 export async function main(argv: string[]): Promise<string> {
-  const options = parseArgs(argv);
+  let options: CliOptions;
+  try {
+    options = parseArgs(argv);
+  } catch {
+    throw new OperatorFacingError("Invalid command-line arguments.");
+  }
   const [baseline, real] = await Promise.all([
     loadReceipt(options.baselinePath, "baseline"),
     loadReceipt(options.realPath, "real"),
   ]);
-  const report = diagnoseLoCoMoRetrievalTraceDelta(baseline, real);
+  let report;
+  try {
+    report = diagnoseLoCoMoRetrievalTraceDelta(baseline, real);
+  } catch (error) {
+    throw trustedOperatorError(error, "Unable to diagnose paired retrieval traces.");
+  }
   const outputContext = await preparePrivateOutput(options.out);
   const outputPath = path.resolve(
     outputContext.requestedOutput ??
@@ -76,19 +93,35 @@ async function loadReceipt(pathname: string, label: string): Promise<LoCoMoRetri
   try {
     parsed = JSON.parse(await readFile(pathname, "utf8"));
   } catch (error) {
-    throw new Error(
-      `Unable to read ${label} retrieval trace JSON: ${error instanceof Error ? error.message : String(error)}`
-    );
+    throw new OperatorFacingError(`Unable to read ${label} retrieval trace JSON: ${formatOperatorError(error)}`);
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(`${label} retrieval trace JSON must contain an object.`);
+    throw new OperatorFacingError(`${label} retrieval trace JSON must contain an object.`);
   }
   return parsed as LoCoMoRetrievalTraceReceipt;
 }
 
+export function formatOperatorError(error: unknown): string {
+  if (error instanceof OperatorFacingError) return error.message;
+  return displayErrorDetail(error) || "Error";
+}
+
+function trustedOperatorError(error: unknown, fallback: string): OperatorFacingError {
+  return new OperatorFacingError(error instanceof Error && error.message.length > 0 ? error.message : fallback);
+}
+
+export async function runCli(argv: string[], stderr: TextSink = process.stderr): Promise<number> {
+  try {
+    await main(argv);
+    return 0;
+  } catch (error) {
+    stderr.write(`${formatOperatorError(error)}\n`);
+    return 1;
+  }
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main(process.argv.slice(2)).catch((error) => {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-    process.exitCode = 1;
+  runCli(process.argv.slice(2)).then((exitCode) => {
+    process.exitCode = exitCode;
   });
 }


### PR DESCRIPTION
## Summary

- pair baseline and real provider-free LoCoMo retrieval receipts with strict artifact, dataset, selector, and lineage validation
- compute deterministic content-free structural deltas for candidate, selected, section, budget, and composition stages
- classify dominant retrieval mechanisms without exposing raw questions, answers, memory IDs, paths, or timestamps
- add a private-output CLI and focused regression coverage

## Verification

- focused analyzer and CLI tests: 9/9 pass
- bench TypeScript check: pass
- changed-file Biome and git diff check: pass
- npm run preflight:quick: pass

Part of #1879.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New bench diagnostics and a private-output CLI; no production retrieval or auth paths. Large validation surface is covered by extensive unit tests.
> 
> **Overview**
> Adds **paired structural delta analysis** for provider-free LoCoMo retrieval trace receipts: baseline vs real runs are validated (artifact hashes, provenance, task order, differing retrieval configs), then compared on content-free dimensions (sections, selections, core capture, recall budget, composition) using multiset diffs and hashed task refs only.
> 
> Per-task **mechanism labels** (e.g. core-visible LCM displacement, LCM selection change, budget tail truncation, composition filter/digest changes, mixed, insufficient lineage) drive overall and per-category counts, plus a **dominant multi-hop mechanism** when a strict majority (≥2 tasks) agrees. Reports are sealed with `artifactHash` and serialized without raw identifiers.
> 
> **`@remnic/bench`** exports `diagnoseLoCoMoRetrievalTraceDelta` and `serializeLoCoMoRetrievalTraceDelta`. A **`diagnose-locomo-retrieval-trace-delta`** CLI loads two JSON receipts, writes a private delta artifact (optional `--out`), and uses operator-safe errors that omit filesystem paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61c6c11d171bbac7c9586101c3ad552998c2c09a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->