### PR TITLE
docs(bench): record current LoCoMo trace evidence

### DIFF
--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -130,6 +130,13 @@ Additional in-window receipts:
   [`ab849733`](https://github.com/joshuaswarren/remnic/commit/ab84973365935418f938fd0ed9510d3b4a95e1c7)
   add the LoCoMo diagnosis tool, pin staged dataset paths, add safe credit
   recovery, and let judge calibration resume after a stop.
+- [`30de78ea`](https://github.com/joshuaswarren/remnic/commit/30de78ea924af066c72f64768a017fc88518af78)
+  and
+  [`7d885e2e`](https://github.com/joshuaswarren/remnic/commit/7d885e2e1fcecdceee056aa4a3ac3419cb5a650a)
+  add provider-free LoCoMo recall receipts and a strict paired structural
+  analyzer. The July 16 current-main capture covered all 321 historical
+  multi-hop tasks and found no baseline/real retrieval-structure delta. This
+  is negative diagnostic evidence, not a scored benchmark lift.
 
 On July 15, merged head `ab849733` passed the cold package test:
 `node scripts/verify-build-week-sandbox.mjs --keep`. The test put version 9.6.24
@@ -139,6 +146,14 @@ or provider ran. It scored `uptake_at_next=1` and `non_resurrection=0`. It also
 wrote a 15,144-byte offline HTML report. The focused results-store test passed
 20 of 20 tests. This receipt proves the packaged keyless path and report
 export. It is not a paid-model result.
+
+On July 16, merged head `7d885e2e` repeated the cold package test from the
+source checkout at version 9.6.33. A clean global prefix installed the packed
+core, server, Pi plugin, coding graph, bench, and CLI packages. The keyless
+one-task LongMemEval smoke and MCP MemCorrect run both completed; run listing
+and HTML export succeeded; the report was 15,144 bytes; and the test ended in
+`PACKAGED_SANDBOX_OK`. This verifies the current source package set on Linux
+x64. It does not claim that version 9.6.33 is published or that a model ran.
 
 Codex `/feedback` session ID for the core functionality:
 **PENDING OPERATOR INPUT.** Run `/feedback` in the primary Codex session and
@@ -303,7 +318,10 @@ in `docs/paper/repro-appendix.md`.
 
 The version 9.6.24 packed-tarball cold-install receipt is complete on Linux.
 Both `@remnic/cli` and `@remnic/bench` are published at 9.6.24. This receipt
-does not claim a macOS or native Windows verification.
+does not claim a macOS or native Windows verification. The version 9.6.33
+source package set also passed the same Linux x64 cold global-prefix test on
+July 16; that newer receipt is a source-package check, not a publication
+claim.
 
 ## Honest framing of the novelty claim
 

--- a/docs/benchmarks/locomo-profile-diagnosis.md
+++ b/docs/benchmarks/locomo-profile-diagnosis.md
@@ -11,16 +11,19 @@ and has a −0.104 F1 delta.
 
 This establishes the affected slice, not the recall-side mechanism. The
 published score artifacts contain per-task scores but no answer payloads or
-recall X-ray receipts. No paired baseline/real recall receipts are available
-in the repository or local result store, so claims that QMD, entity retrieval,
-verified recall, or Memory Boxes displaced LCM evidence remain hypotheses.
+recall X-ray receipts. The later private paired capture described below tests
+the current runtime rather than reconstructing the July 14 runtime. Claims
+that QMD, entity retrieval, verified recall, or Memory Boxes caused the
+historical regression therefore remain hypotheses.
 
-For benchmark operators, the evidence supports a narrow provisional rule:
-use `--runtime-profile baseline` for LoCoMo runs that deliberately use
-`replayExtractionMode: "skip"` when the objective is the best score from this
-validated configuration. Do not generalize that recommendation to production
-agents, LongMemEval, extraction-enabled LoCoMo runs, or other workloads. No
-shipped default changes on this evidence.
+For benchmark operators, that historical pair supported a narrow provisional
+rule: use `--runtime-profile baseline` for LoCoMo runs that deliberately use
+`replayExtractionMode: "skip"` when reproducing the July 14 configuration.
+A July 16 current-main capture described below no longer reproduces a
+retrieval-structure difference, so this is historical reproduction guidance,
+not current-main profile guidance. Do not generalize it to production agents,
+LongMemEval, extraction-enabled LoCoMo runs, or other workloads. No shipped
+default changes on this evidence.
 
 ## Multi-hop accounts for most of the headline judge delta
 
@@ -96,27 +99,58 @@ pnpm exec tsx scripts/bench/diagnose-locomo-profile-delta.ts \
   --metric f1 --format json
 ```
 
-## Acceptance remains blocked on paired recall evidence
+## Current main does not reproduce the retrieval-structure divergence
 
-The baseline score artifact is recoverable from git history, but the operator
-baseline replay state, answer-level traces, and paired recall X-ray receipts
-are not available. The committed real artifact alone cannot prove recall
-interference. Issue #1879's root-cause acceptance criterion therefore remains
-open until an operator captures baseline and real receipts for the same ranked
-regression task ids.
+On July 16, 2026, merged main `7d885e2e` captured paired, provider-free recall
+receipts for all 321 multi-hop tasks from the historical comparison. Both
+captures used LoCoMo-10 dataset SHA-256
+`79fa87e90f04081343b8c8debecb80a9a6842b76a7aa537dc9fdf651ea698ff4`,
+the same ordered selector (`selectedTaskIdsSha256`
+`bbc56610faefc0a65704f713c6c7aa8ce5a7f71ca060a1e3d218c57a514f21b9`),
+the same recall-budget algorithm, and skip-extraction replay. Their retrieval
+configuration hashes differ as intended:
 
-The deterministic tool prints those task ids. The next run should preserve,
-for each profile and task: served recall tiers, ordered evidence and scores,
-token-budget truncation/displacement, final responder answer, and the exact
-profile/config hash. Compare multi-hop regressions first, retain a few
-single-hop improvements as negative controls, and only then choose between a
-recall-composition fix and permanent benchmark-profile guidance.
+- baseline: `bec4199d39a1c706276a1cca99cb100a7aa2d588ebc64fcdd1aa3f8fe2f30e88`
+- real: `2a87cae27581fe0534e4316888f2a000bf85ce13bcc646f9e99abe1bb41e2bd3`
+
+The strict paired analyzer classified all 321 tasks as
+`no-structural-delta`. Every displacement, selection, composition, budget,
+mixed, and insufficient-lineage count was zero. The report therefore marks
+the dominant multi-hop mechanism `not-supported` (0 of 321). Safe artifact
+identities are:
+
+- baseline receipt: `a9ce89899ba7baa22d272b5b774ae661f3f49bcb2eccbd18efb45bd824edf661`
+- real receipt: `5d83561b24b8a8530e0f95ee357d138626460f0c24368fe773fe1fb2276bc716`
+- paired report: `719ddd7a32c3afca9f0c8f522ee5d57fd2571a35581c929a42294829ef948f47`
+
+The receipts and full report remain in the operator's private benchmark store.
+They contain no gold answers or raw content, but are classified restricted and
+are not committed. This negative result rules out the proposed current-main
+core/LCM structural-displacement explanation on the affected slice. It does
+not identify the July 14 historical cause, prove that answer scores are now
+equal, or show that a responder would treat identical context identically.
+
+## Acceptance remains blocked on paired scored evidence
+
+The retrieval capture now exists, but it finds no structural divergence on
+current main. Issue #1879's acceptance criterion therefore remains open until
+a same-selector scored baseline/real rerun either establishes parity or names
+a different mechanism with bounded evidence. That rerun must use identical
+responder, judge, seed, dataset, task order, and recall budget. It should start
+with a credit-metered smoke and expand only if the reconciled Codex-credit
+ledger can cover the selected slice while preserving its reserve.
+
+Do not treat the current negative trace as a benchmark lift. It made no model
+calls and captured no answers or judge scores. Likewise, do not promote the
+historical baseline recommendation into permanent workload guidance unless a
+new scored comparison justifies it.
 
 ## Further questions
 
 - Does the multi-hop regression reproduce when the responder answers are
   judged by the same calibrated frontier judge?
-- Which recall tier first diverges between profiles on the ranked task ids?
+- If scored answers still diverge, which post-retrieval or responder behavior
+  explains the difference despite structurally identical recalled context?
 - Is the effect caused by evidence omission, ordering, token-budget pressure,
   or responder distraction despite retaining the same evidence?
 - Does enabling extraction for LoCoMo reverse the result, making the current


### PR DESCRIPTION
## Summary
- record the provider-free paired retrieval capture for all 321 historical LoCoMo multi-hop tasks
- document the negative result honestly: current main shows no baseline/real structural retrieval delta, but scored parity and the historical cause remain unproven
- refresh the Build Week package receipt with the successful 9.6.33 cold global-prefix test

## Evidence
- capture/analyzer artifacts validate with matching dataset, selector, git, and config provenance
- all 321 tasks classify `no-structural-delta`; every other mechanism count is zero
- private artifacts remain restricted and uncommitted; only safe content hashes are documented
- `node scripts/verify-build-week-sandbox.mjs --keep` ended in `PACKAGED_SANDBOX_OK` and produced a 15,144-byte report

## Verification
- `git diff --check`
- `npm run check:docs-parity`
- `npm run preflight:quick`
- independent read-only evidence/claim audit: no P1/P2 findings

Related: #1879

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes to benchmark and hackathon documentation; no runtime, auth, or data-path code is modified.
> 
> **Overview**
> Documentation-only update that records **July 16** provider-free paired LoCoMo recall work and tightens how operators should read the July 14 profile regression.
> 
> **`docs/benchmarks/locomo-profile-diagnosis.md`** now documents a current-main capture on merged head `7d885e2e`: all **321** historical multi-hop tasks got paired baseline/real recall receipts with matching dataset/selector provenance but different retrieval config hashes. The strict analyzer classified every task as **`no-structural-delta`**, with safe content hashes only (full artifacts stay private). The doc reframes the old “use baseline for skip-extraction LoCoMo” note as **historical reproduction** guidance, not current-main profile advice, and shifts **#1879** acceptance to needing a **paired scored** rerun—not retrieval receipts alone.
> 
> **`HACKATHON.md`** adds the same in-window commits as negative diagnostic evidence (not a benchmark lift) and logs a **9.6.33** Linux x64 cold global-prefix `PACKAGED_SANDBOX_OK` receipt as a source-package check, without claiming npm publish or model runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5136ef492eeb4de505b5a52739f1950286b4176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->