### PR TITLE
docs(build-week): refresh judge-ready package path

### DIFF
--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -155,6 +155,13 @@ and HTML export succeeded; the report was 15,144 bytes; and the test ended in
 `PACKAGED_SANDBOX_OK`. This verifies the current source package set on Linux
 x64. It does not claim that version 9.6.33 is published or that a model ran.
 
+On July 16, merged head `2b98fbff` also passed the cold package test at
+version 9.6.34. Separately, an exact registry install of
+`@remnic/cli@9.6.34` and `@remnic/bench@9.6.34` into a clean Linux x86_64
+prefix completed the keyless MCP MemCorrect smoke, run listing, and HTML
+export. The registry-installed report was 15,128 bytes. No judge or provider
+ran. This is the current judge install path below.
+
 Codex `/feedback` session ID for the core functionality:
 **PENDING OPERATOR INPUT.** Run `/feedback` in the primary Codex session and
 paste the real session ID here before submission.
@@ -272,7 +279,7 @@ queued internal work can finish after the last scored task.
 After the npm packages are installed, no datasets, API keys, or network:
 
 ```bash
-npm install -g @remnic/cli@9.6.24 @remnic/bench@9.6.24
+npm install -g @remnic/cli@9.6.34 @remnic/bench@9.6.34
 remnic bench run --quick memcorrect-v1 --adapter mcp --mcp-demo
 remnic bench runs list
 remnic bench export <run-id> --format html --output ./memcorrect-report.html
@@ -311,7 +318,7 @@ in `docs/paper/repro-appendix.md`.
 | Environment | Build Week support statement |
 |---|---|
 | Node.js | 22.12 or newer |
-| Linux | Source-checkout and version 9.6.24 packed-tarball global-prefix paths verified on Linux x64 |
+| Linux | Source-checkout, packed-tarball, and version 9.6.34 registry-install paths verified on Linux x64 |
 | macOS | Supported by the Node CLI; final global-install receipt pending |
 | Windows | Use WSL2 for the claimed path; native Windows is not claimed as verified |
 | MCP transport | stdio and Streamable HTTP |
@@ -321,7 +328,8 @@ Both `@remnic/cli` and `@remnic/bench` are published at 9.6.24. This receipt
 does not claim a macOS or native Windows verification. The version 9.6.33
 source package set also passed the same Linux x64 cold global-prefix test on
 July 16; that newer receipt is a source-package check, not a publication
-claim.
+claim. Version 9.6.34 of both judge-facing packages is now published, and the
+exact registry install plus keyless flow is verified on Linux x86_64.
 
 ## Honest framing of the novelty claim
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,50 @@ See [docs/importers.md](docs/importers.md) for input formats, provenance metadat
 - [Shared context](docs/shared-context.md) — cross-agent shared intelligence for multi-agent teams.
 - [Coding-agent memory](docs/coding-agent.md) — repo conventions, review behavior, and ask-before rules for coding tools.
 
+## OpenAI Build Week: MemCorrect
+
+MemCorrect is Remnic's Developer Tools entry for OpenAI Build Week 2026. It
+benchmarks the memory system behind an AI agent through a generic MCP adapter,
+then writes a provenance-locked result and offline HTML report. The keyless
+test path takes about two minutes and needs no dataset, API key, or model call:
+
+```bash
+npm install -g @remnic/cli@9.6.34 @remnic/bench@9.6.34
+remnic bench run --quick memcorrect-v1 --adapter mcp --mcp-demo
+remnic bench runs list
+remnic bench export <run-id> --format html --output ./memcorrect-report.html
+```
+
+That exact 9.6.34 registry install and run passed in a clean Linux x86_64
+prefix. The Node CLI also supports macOS; the submission does not claim a
+final macOS global-install receipt. On Windows, use WSL2; native Windows is not
+claimed. The MCP adapter supports stdio and Streamable HTTP.
+
+Codex accelerated three concrete in-window decisions: it shaped the generic
+MCP tool/argument mapping and backend safety checks, implemented the sealed
+structured-output judge and fail-closed provider semantics, and built the
+single-file report/provenance flow plus the isolated one-shot Codex CLI credit
+guard. GPT-5.6 is integrated as the opt-in Responses API judge under model id
+`gpt-5.6`. The separate ChatGPT-backed benchmark path uses
+`gpt-5.6-luna` for bulk work and `gpt-5.6-terra` for quality-critical judging;
+`gpt-5.6-sol` is outside the bounded plan. We do not claim a GPT-5.6 score
+until a successful artifact and manifest are committed.
+
+To exercise the optional API judge, provide your own key and add the judge
+flags to the same smoke command:
+
+```bash
+export OPENAI_API_KEY=...
+remnic bench run --quick memcorrect-v1 --adapter mcp --mcp-demo \
+  --judge-provider openai --judge-model gpt-5.6
+```
+
+Remnic and the original benchmark package predate Build Week. The
+[submission evidence ledger](HACKATHON.md) draws the prior-work boundary
+commit by commit, while the [demo script](docs/hackathon/demo-script.md) and
+[Devpost draft](docs/hackathon/devpost-description.md) keep model and package
+claims tied to reproducible receipts.
+
 ## Privacy and your data
 
 Local-first is a trust feature, not a tagline.

--- a/docs/benchmarks/memcorrect.md
+++ b/docs/benchmarks/memcorrect.md
@@ -39,7 +39,7 @@ stdio MCP demo backend, scores the generic MCP adapter against it, and writes
 an offline HTML report:
 
 ```bash
-npm install -g @remnic/cli@9.6.24 @remnic/bench@9.6.24
+npm install -g @remnic/cli@9.6.34 @remnic/bench@9.6.34
 remnic bench run --quick memcorrect-v1 --adapter mcp --mcp-demo
 remnic bench runs list
 remnic bench export <run-id> --format html --output ./memcorrect-report.html
@@ -47,9 +47,9 @@ remnic bench export <run-id> --format html --output ./memcorrect-report.html
 
 The test asks three questions: did recall find the right fact, did the memory
 accept a correction, and did the stale fact stay gone? We verified this exact
-flow against the 9.6.24 packed tarballs from a clean global prefix on Linux
-x86_64 with Node 22.23.1; newer releases work the same way without the version
-pins.
+flow against the published 9.6.34 packages from a clean global prefix on Linux
+x86_64; the registry-installed run produced its result, manifest, run-listing
+entry, and offline HTML report without a provider call.
 
 ## OpenAI Build Week 2026 provenance
 

--- a/docs/hackathon/demo-script.md
+++ b/docs/hackathon/demo-script.md
@@ -3,8 +3,8 @@
 Target duration: 2 minutes 40 seconds. Hard limit: 3 minutes.
 
 Operator gate before recording: replace every bracketed placeholder used in the
-video with real evidence. The version 9.6.24 packed-tarball path is verified on
-Linux x86_64. The Codex `/feedback` session ID is still required. If the GPT-5.6
+video with real evidence. The version 9.6.34 registry-install path is verified
+on Linux x86_64. The Codex `/feedback` session ID is still required. If the GPT-5.6
 frontier artifact does not land, omit that result and its URL. Do not substitute
 another model or turn a bounded trial into a full-run claim.
 
@@ -41,7 +41,7 @@ HTML report.
 
 Voiceover: "These are separate checks. Uptake asks whether the next answer
 uses the correction. Non-resurrection asks whether the old fact returns later.
-In the verified version 9.6.24 packaged run, uptake was 1. Non-resurrection was
+In the verified version 9.6.34 packaged run, uptake was 1. Non-resurrection was
 0: the correction appeared at once, but the stale fact returned later.
 MemCorrect catches both behaviors instead of hiding them in one score."
 
@@ -120,7 +120,7 @@ database."
 - [ ] Runtime is under 3 minutes and audio is present.
 - [ ] Audio explicitly explains both Codex and GPT-5.6 usage.
 - [ ] Commands shown match the released packages or the disclosed source path.
-- [ ] The keyless package receipt identifies version 9.6.24 and does not imply
+- [ ] The keyless package receipt identifies version 9.6.34 and does not imply
   a paid-model run.
 - [ ] No API key, token, personal data, or private terminal history is visible.
 - [ ] Every narrated score appears in the recorded artifact.

--- a/docs/hackathon/devpost-description.md
+++ b/docs/hackathon/devpost-description.md
@@ -8,6 +8,9 @@ mode before each revision ships.
 
 Project name: MemCorrect: benchmark an AI agent's memory.
 
+Category: Developer Tools. MemCorrect is infrastructure for developers to test
+and compare an agent's memory backend, not an end-user memory assistant.
+
 Tagline: Agent memory without evals is vibes with a database. MemCorrect
 scores Remnic or another conforming memory backend with one command. It checks
 recall quality, correction handling, and stale-memory harm. GPT-5.6 can grade
@@ -113,19 +116,19 @@ honestly. This is a protocol claim, not a "first to think of it" claim.
 
 ## Try it (judges)
 
-Version 9.6.24 of both packages is published. After installation, the smoke
+Version 9.6.34 of both packages is published. After installation, the smoke
 path needs no dataset, API key, or network:
 
 ```bash
-npm install -g @remnic/cli@9.6.24 @remnic/bench@9.6.24
+npm install -g @remnic/cli@9.6.34 @remnic/bench@9.6.34
 remnic bench run --quick memcorrect-v1 --adapter mcp --mcp-demo
 remnic bench runs list
 remnic bench export <run-id> --format html --output ./memcorrect-report.html
 ```
 
-The quick run uses a packaged stdio MCP server. The corresponding 9.6.24
-packed-tarball path passed in a clean Linux x86_64 global prefix with Node
-22.23.1 and produced a 15,144-byte offline report. The run itself needs no
+The quick run uses a packaged stdio MCP server. The exact 9.6.34 registry
+install passed in a clean Linux x86_64 global prefix and produced a
+15,128-byte offline report. The run itself needs no
 dataset, key, or network, and it exercises the real adapter. To add GPT-5.6
 judging, export `OPENAI_API_KEY` and append `--judge-provider openai
 --judge-model gpt-5.6`. Reproduction paths live in


### PR DESCRIPTION
## Summary
- add the competition-required README coverage for MemCorrect setup, supported platforms, Codex contributions, GPT-5.6 integration, and the prior-work boundary
- update judge-facing commands to the exact published 9.6.34 packages and record the clean registry-install receipt
- add the Developer Tools category rationale to the Devpost draft and keep demo/package claims aligned

## Evidence
- exact registry install: `@remnic/cli@9.6.34` + `@remnic/bench@9.6.34`
- keyless MCP MemCorrect run completed with no judge/provider/model call
- run listing and export succeeded; offline report size was 15,128 bytes
- current source packed-sandbox verification ended in `PACKAGED_SANDBOX_OK`

## Verification
- `git diff --check`
- `npm run check:docs-parity`
- `npm run preflight:quick`
- independent read-only submission claim audit: no P1/P2 findings

No GPT-5.6 score is claimed; the successful model artifact remains an explicit operator-gated item.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only submission and documentation changes; no runtime, auth, or package code modified.
> 
> **Overview**
> Documentation updates align OpenAI Build Week / MemCorrect judge materials with **published `@remnic/cli@9.6.34` and `@remnic/bench@9.6.34`**, and record a **clean Linux x86_64 registry-install receipt** (keyless MCP smoke, run list, HTML export; **15,128-byte** report; no judge/provider).
> 
> **`README.md`** gains a new **OpenAI Build Week: MemCorrect** section: two-minute keyless commands, platform notes (Linux verified, macOS/WSL2 framing), how **Codex** and **GPT-5.6** fit the submission, optional judge flags, and links to `HACKATHON.md` / hackathon docs.
> 
> **`HACKATHON.md`** adds the 9.6.34 cold-package and registry-install evidence, bumps the five-minute and support-table copy to 9.6.34 as the current judge path, and extends Linux verification to include registry install (older 9.6.24/9.6.33 receipts stay as history).
> 
> **`docs/benchmarks/memcorrect.md`**, **`docs/hackathon/demo-script.md`**, and **`docs/hackathon/devpost-description.md`** pin install/run examples and narrated metrics to **9.6.34**; Devpost draft adds **Developer Tools** category rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24df6fa87d3a4e06cd12bc0b60ba7ab44b7cc53e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->