### PR TITLE
fix(evals): redact local dataset paths

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -84,7 +84,7 @@ Results are stored as versioned JSON in `evals/results/`:
 ama-bench-v9.0.0-2026-03-15T14-30-00.json
 ```
 
-Each result includes: engram version, git SHA, timestamp, per-task scores, aggregate metrics, adapter mode, and config snapshot.
+Each result includes: engram version, git SHA, timestamp, per-task scores, aggregate metrics, adapter mode, and config snapshot. Dataset locations inside the repository are stored as portable repo-relative paths; external dataset overrides are recorded as `<external>` so result artifacts do not expose machine-local paths.
 
 ## Dataset Download
 

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -212,7 +212,7 @@ A prior experiment with multi-hop graph traversal and confidence gating showed n
 
 **Datasets:** All downloaded from official sources (HuggingFace, GitHub) using `evals/scripts/download-datasets.sh`. Formats match the published dataset schemas exactly.
 
-**Reproducibility:** Run with `tsx evals/run.ts --benchmark <name>`. Results are stored as versioned JSON in `evals/results/`.
+**Reproducibility:** Run with `tsx evals/run.ts --benchmark <name>`. Results are stored as versioned JSON in `evals/results/`. Historical dataset locations were normalized to portable repo-relative paths without changing scores or run metadata.
 
 ---
 

--- a/evals/reporter.ts
+++ b/evals/reporter.ts
@@ -2,17 +2,49 @@
  * Results reporter — writes versioned JSON and prints console summary.
  */
 
-import { writeFile, mkdir } from "node:fs/promises";
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { BenchmarkResult } from "./adapter/types.js";
 
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+
+/**
+ * Keep persisted benchmark artifacts portable and free of developer-local
+ * directory names. Paths inside the repository are recorded repo-relative;
+ * external overrides are intentionally represented without their host path.
+ */
+export function portableDatasetDir(datasetDir: string, repoRoot = REPO_ROOT): string {
+  if (!path.isAbsolute(datasetDir)) {
+    return datasetDir;
+  }
+
+  const relative = path.relative(repoRoot, datasetDir);
+  const isInsideRepo =
+    relative !== "" && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+
+  return isInsideRepo ? relative.split(path.sep).join("/") : "<external>";
+}
+
+export function resultForPersistence(result: BenchmarkResult): BenchmarkResult {
+  const datasetDir = result.config.datasetDir;
+  if (typeof datasetDir !== "string") {
+    return result;
+  }
+
+  return {
+    ...result,
+    config: {
+      ...result.config,
+      datasetDir: portableDatasetDir(datasetDir),
+    },
+  };
+}
+
 function getEngramVersion(): string {
   try {
-    const pkg = JSON.parse(
-      readFileSync(path.resolve(import.meta.dirname, "../package.json"), "utf-8"),
-    );
+    const pkg = JSON.parse(readFileSync(path.resolve(import.meta.dirname, "../package.json"), "utf-8"));
     return typeof pkg.version === "string" ? pkg.version : "unknown";
   } catch {
     return "unknown";
@@ -36,24 +68,21 @@ export function enrichResult(result: BenchmarkResult): BenchmarkResult {
   };
 }
 
-export async function writeResult(
-  result: BenchmarkResult,
-  outputDir: string,
-): Promise<string> {
+export async function writeResult(result: BenchmarkResult, outputDir: string): Promise<string> {
   await mkdir(outputDir, { recursive: true });
 
   const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
   const filename = `${result.meta.name}-v${result.engramVersion}-${ts}.json`;
   const filePath = path.join(outputDir, filename);
 
-  await writeFile(filePath, JSON.stringify(result, null, 2) + "\n");
+  await writeFile(filePath, `${JSON.stringify(resultForPersistence(result), null, 2)}\n`);
   return filePath;
 }
 
 export function printSummary(result: BenchmarkResult): void {
   const { meta, aggregate, taskCount, durationMs, adapterMode } = result;
 
-  console.log("\n" + "=".repeat(60));
+  console.log(`\n${"=".repeat(60)}`);
   console.log(`Benchmark: ${meta.name} (${meta.category})`);
   console.log(`Adapter:   ${adapterMode}`);
   console.log(`Tasks:     ${taskCount}`);
@@ -71,5 +100,5 @@ export function printSummary(result: BenchmarkResult): void {
     }
   }
 
-  console.log("=".repeat(60) + "\n");
+  console.log(`${"=".repeat(60)}\n`);
 }

--- a/evals/results/ama-bench-v9.0.0-2026-03-15T18-55-07.json
+++ b/evals/results/ama-bench-v9.0.0-2026-03-15T18-55-07.json
@@ -4354,7 +4354,7 @@
   },
   "config": {
     "limit": 20,
-    "datasetDir": "/Users/joshuawarren/src/openclaw-engram/evals/datasets/ama-bench",
+    "datasetDir": "evals/datasets/ama-bench",
     "episodes_run": 20
   },
   "durationMs": 37069

--- a/evals/results/amemgym-v9.0.0-2026-03-15T19-07-44.json
+++ b/evals/results/amemgym-v9.0.0-2026-03-15T19-07-44.json
@@ -3822,7 +3822,7 @@
     "contains_answer_max": 0
   },
   "config": {
-    "datasetDir": "/Users/joshuawarren/src/openclaw-engram/evals/datasets/amemgym",
+    "datasetDir": "evals/datasets/amemgym",
     "profiles_run": 20
   },
   "durationMs": 31514

--- a/evals/results/amemgym-v9.0.0-2026-03-15T20-23-01.json
+++ b/evals/results/amemgym-v9.0.0-2026-03-15T20-23-01.json
@@ -3822,7 +3822,7 @@
     "contains_answer_max": 0
   },
   "config": {
-    "datasetDir": "/Users/joshuawarren/src/openclaw-engram/evals/datasets/amemgym",
+    "datasetDir": "evals/datasets/amemgym",
     "profiles_run": 20
   },
   "durationMs": 26016

--- a/evals/results/locomo-v9.0.0-2026-03-15T19-02-51.json
+++ b/evals/results/locomo-v9.0.0-2026-03-15T19-02-51.json
@@ -40141,7 +40141,7 @@
     "adversarial_count": 446
   },
   "config": {
-    "datasetDir": "/Users/joshuawarren/src/openclaw-engram/evals/datasets/locomo",
+    "datasetDir": "evals/datasets/locomo",
     "conversations_run": 10
   },
   "durationMs": 501326

--- a/evals/results/locomo-v9.0.0-2026-03-15T20-43-32.json
+++ b/evals/results/locomo-v9.0.0-2026-03-15T20-43-32.json
@@ -40141,7 +40141,7 @@
     "adversarial_count": 446
   },
   "config": {
-    "datasetDir": "/Users/joshuawarren/src/openclaw-engram/evals/datasets/locomo",
+    "datasetDir": "evals/datasets/locomo",
     "conversations_run": 10
   },
   "durationMs": 1257099

--- a/evals/results/longmemeval-v9.0.0-2026-03-15T19-01-03.json
+++ b/evals/results/longmemeval-v9.0.0-2026-03-15T19-01-03.json
@@ -10497,7 +10497,7 @@
     "single-session-user_count": 70
   },
   "config": {
-    "datasetDir": "/Users/joshuawarren/src/openclaw-engram/evals/datasets/longmemeval"
+    "datasetDir": "evals/datasets/longmemeval"
   },
   "durationMs": 393889
 }

--- a/evals/results/longmemeval-v9.0.0-2026-03-15T20-29-47.json
+++ b/evals/results/longmemeval-v9.0.0-2026-03-15T20-29-47.json
@@ -10497,7 +10497,7 @@
     "single-session-user_count": 70
   },
   "config": {
-    "datasetDir": "/Users/joshuawarren/src/openclaw-engram/evals/datasets/longmemeval"
+    "datasetDir": "evals/datasets/longmemeval"
   },
   "durationMs": 431745
 }

--- a/evals/results/memory-arena-v9.0.0-2026-03-15T19-17-34.json
+++ b/evals/results/memory-arena-v9.0.0-2026-03-15T19-17-34.json
@@ -78537,7 +78537,7 @@
     "progressive_search_count": 1641
   },
   "config": {
-    "datasetDir": "/Users/joshuawarren/src/openclaw-engram/evals/datasets/memory-arena",
+    "datasetDir": "evals/datasets/memory-arena",
     "domains_run": [
       "bundled_shopping",
       "formal_reasoning_math",

--- a/tests/evals-reporter.test.ts
+++ b/tests/evals-reporter.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { BenchmarkResult } from "../evals/adapter/types.js";
+import { portableDatasetDir, resultForPersistence, writeResult } from "../evals/reporter.js";
+
+function benchmarkResult(datasetDir: string): BenchmarkResult {
+  return {
+    meta: {
+      name: "locomo",
+      version: "1",
+      description: "fixture",
+      category: "conversational",
+    },
+    engramVersion: "test",
+    gitSha: "test",
+    timestamp: "2026-07-16T00:00:00.000Z",
+    adapterMode: "direct",
+    taskCount: 1,
+    scores: [],
+    aggregate: { accuracy: 1 },
+    config: { datasetDir },
+    durationMs: 1,
+  };
+}
+
+test("portableDatasetDir makes repository datasets portable", () => {
+  const repoRoot = path.resolve(os.tmpdir(), "remnic-repo");
+  const datasetDir = path.join(repoRoot, "evals", "datasets", "locomo");
+
+  assert.equal(portableDatasetDir(datasetDir, repoRoot), "evals/datasets/locomo");
+  assert.equal(portableDatasetDir("evals/datasets/locomo", repoRoot), "evals/datasets/locomo");
+});
+
+test("portableDatasetDir redacts external host paths", () => {
+  const repoRoot = path.resolve(os.tmpdir(), "remnic-repo");
+  const externalDir = path.resolve(os.tmpdir(), "private-user", "locomo");
+
+  assert.equal(portableDatasetDir(externalDir, repoRoot), "<external>");
+});
+
+test("resultForPersistence preserves config without mutating the result", () => {
+  const result = benchmarkResult(path.resolve("evals/datasets/locomo"));
+  result.config.limit = 5;
+  const persisted = resultForPersistence(result);
+
+  assert.equal(persisted.config.datasetDir, "evals/datasets/locomo");
+  assert.equal(persisted.config.limit, 5);
+  assert.equal(result.config.datasetDir, path.resolve("evals/datasets/locomo"));
+});
+
+test("writeResult omits developer-local dataset paths", async () => {
+  const outputDir = await mkdtemp(path.join(os.tmpdir(), "remnic-eval-result-"));
+  try {
+    const result = benchmarkResult(path.resolve(os.tmpdir(), "private-user", "locomo"));
+    const filePath = await writeResult(result, outputDir);
+    const persisted = JSON.parse(await readFile(filePath, "utf8")) as BenchmarkResult;
+
+    assert.equal(persisted.config.datasetDir, "<external>");
+    assert.equal(result.config.datasetDir, path.resolve(os.tmpdir(), "private-user", "locomo"));
+  } finally {
+    await rm(outputDir, { recursive: true, force: true });
+  }
+});
+
+test("committed legacy results contain no developer-local dataset paths", async () => {
+  const resultsDir = path.resolve(import.meta.dirname, "../evals/results");
+  const files = (await readdir(resultsDir)).filter((name) => name.endsWith(".json"));
+  assert.ok(files.length > 0, "expected committed legacy result fixtures");
+
+  for (const name of files) {
+    const content = await readFile(path.join(resultsDir, name), "utf8");
+    const result = JSON.parse(content) as BenchmarkResult;
+    const datasetDir = result.config?.datasetDir;
+    if (typeof datasetDir === "string") {
+      const isAbsolute = path.isAbsolute(datasetDir) || /^[A-Za-z]:[\\/]/.test(datasetDir);
+      assert.equal(isAbsolute, false, `${name} contains an absolute datasetDir`);
+      assert.doesNotMatch(datasetDir, /openclaw-engram/i, `${name} contains a legacy local repo path`);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- persist in-repository legacy eval dataset paths as portable repo-relative references
- redact external dataset override paths at the result-writing boundary without mutating runtime results
- normalize eight historical result files and add regression coverage plus documentation

## Verification
- `pnpm exec tsx --test tests/evals-reporter.test.ts`
- `npm run preflight:quick`
- `pnpm exec biome check --diagnostic-level=error --files-ignore-unknown=true evals/reporter.ts tests/evals-reporter.test.ts`

The historical files have no application-level artifact hash or signature; scores and run metadata are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to how dataset paths are serialized in eval artifacts and documentation; benchmark scoring and runtime behavior are unchanged.
> 
> **Overview**
> Eval result JSON no longer records absolute developer machine paths in `config.datasetDir`. **Persistence** now runs through `portableDatasetDir` / `resultForPersistence` in `evals/reporter.ts`: in-repo datasets are stored as portable paths like `evals/datasets/locomo`, and paths outside the repo are written as `<external>` without mutating the in-memory run result.
> 
> **Committed history** is cleaned up the same way—eight existing files under `evals/results/` only change `datasetDir` (scores and other metadata unchanged). Docs in `evals/README.md` and `evals/RESULTS.md` describe the policy; `tests/evals-reporter.test.ts` covers normalization, redaction, non-mutation, and asserts legacy result files stay free of absolute paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e3d1c8baa132de9b122a0cc10aba2c2efcec3e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->