### PR TITLE
fix(coding-graph): retry pre-warm empty LSP definitions once (#1933)

### DIFF
--- a/packages/coding-graph/src/lsp/resolution.test.ts
+++ b/packages/coding-graph/src/lsp/resolution.test.ts
@@ -295,9 +295,132 @@ test("executor: definition returns empty → unresolved", async () => {
     client: mockClient,
     nodeLocator: locator,
     applyUpgrades: async () => {},
+    // Warm-up retry (issue #1933) is exercised by its own tests below;
+    // this test asserts the definitive-empty path.
+    warmupRetryDelayMs: 0,
   });
 
   assert.equal(result.upgraded, 0);
+  assert.equal(result.unresolved, 1);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Warm-up retry (issue #1933): tsserver answers pre-project-load definition
+// requests with [] instead of an error. An empty result before the server
+// has proven warm is retried once; the retry's answer is final.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("executor: warm-up retry — empty first answer retried once, retry result upgrades", async () => {
+  const requests = planLspUpgrades(
+    [makeCallSite("src/a.ts", "target", 0, "a.caller")],
+    { maxRequests: 100 },
+  ).requests;
+
+  // Stateful mock: first definition call returns [], second returns the
+  // real location (project finished loading between the two).
+  let calls = 0;
+  const client = {
+    definition: async () => {
+      calls += 1;
+      if (calls === 1) return { ok: true as const, locations: [] };
+      return {
+        ok: true as const,
+        locations: [{
+          uri: "file:///src/target.ts",
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 6 } },
+        }],
+      };
+    },
+    didOpen: () => {},
+    dispose: async () => {},
+  } as unknown as LspClient;
+
+  const applied: EdgeUpgrade[] = [];
+  const result = await executeLspResolution(requests, {
+    client,
+    nodeLocator: () => "mod.target",
+    applyUpgrades: async (upgrades) => {
+      applied.push(...upgrades);
+    },
+    warmupRetryDelayMs: 5,
+  });
+
+  assert.equal(calls, 2, "empty pre-warm answer must be retried exactly once");
+  assert.equal(result.upgraded, 1, "the retry's location produces the upgrade");
+  assert.equal(result.unresolved, 0);
+  assert.equal(applied.length, 1);
+});
+
+test("executor: warm-up retry — only ONE retry is paid; later empties are definitive", async () => {
+  const requests = planLspUpgrades(
+    [
+      makeCallSite("src/a.ts", "missing1", 0, "a.caller"),
+      makeCallSite("src/a.ts", "missing2", 10, "a.caller"),
+    ],
+    { maxRequests: 100 },
+  ).requests;
+
+  let calls = 0;
+  const client = {
+    definition: async () => {
+      calls += 1;
+      return { ok: true as const, locations: [] };
+    },
+    didOpen: () => {},
+    dispose: async () => {},
+  } as unknown as LspClient;
+
+  const result = await executeLspResolution(requests, {
+    client,
+    nodeLocator: () => null,
+    applyUpgrades: async () => {},
+    warmupRetryDelayMs: 5,
+  });
+
+  // Site 1: initial + one warm-up retry = 2 calls; the server is then
+  // considered warm. Site 2: exactly 1 call, its empty answer is final.
+  assert.equal(calls, 3, "one warm-up retry total, not one per site");
+  assert.equal(result.upgraded, 0);
+  assert.equal(result.unresolved, 2);
+});
+
+test("executor: warm-up retry — a non-empty FIRST answer marks the server warm (no retry paid)", async () => {
+  const requests = planLspUpgrades(
+    [
+      makeCallSite("src/a.ts", "target", 0, "a.caller"),
+      makeCallSite("src/a.ts", "missing", 10, "a.caller"),
+    ],
+    { maxRequests: 100 },
+  ).requests;
+
+  let calls = 0;
+  const client = {
+    definition: async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          ok: true as const,
+          locations: [{
+            uri: "file:///src/target.ts",
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 6 } },
+          }],
+        };
+      }
+      return { ok: true as const, locations: [] };
+    },
+    didOpen: () => {},
+    dispose: async () => {},
+  } as unknown as LspClient;
+
+  const result = await executeLspResolution(requests, {
+    client,
+    nodeLocator: () => "mod.target",
+    applyUpgrades: async () => {},
+    warmupRetryDelayMs: 5,
+  });
+
+  assert.equal(calls, 2, "warm server: the second site's empty answer is definitive, no retry");
+  assert.equal(result.upgraded, 1);
   assert.equal(result.unresolved, 1);
 });
 
@@ -488,6 +611,8 @@ test("executor: workspaceRoot resolves repo-relative paths to absolute URIs", as
     nodeLocator: () => null,
     applyUpgrades: async () => {},
     workspaceRoot: "/workspace",
+    // This test asserts URI shapes, not warm-up behavior (issue #1933).
+    warmupRetryDelayMs: 0,
   });
 
   assert.equal(didOpenUris.length, 1);

--- a/packages/coding-graph/src/lsp/resolution.ts
+++ b/packages/coding-graph/src/lsp/resolution.ts
@@ -210,6 +210,15 @@ export interface ResolveOptions {
   readonly client: LspClient;
   readonly nodeLocator: NodeLocator;
   /**
+   * Warm-up retry delay in ms (issue #1933). Language servers (tsserver
+   * in particular) load projects ASYNCHRONOUSLY after `didOpen`; a
+   * definition request that arrives too early returns an EMPTY location
+   * array — indistinguishable from "definitely no definition". Until the
+   * server has proven warm (any non-empty response), an empty result is
+   * retried ONCE after this delay. Default 2500. Set 0 to disable.
+   */
+  readonly warmupRetryDelayMs?: number;
+  /**
    * Apply a batch of edge upgrades atomically. Called once per file batch.
    * MUST be transactional — if it throws, zero upgrades from this batch
    * persist (rule 25). Each upgrade is an edge `{srcQualifiedName,
@@ -297,6 +306,14 @@ export async function executeLspResolution(
   let unresolved = 0;
   let degradation: LspDegradation | undefined;
 
+  // Warm-up tracking (issue #1933): false until the server returns its
+  // first NON-EMPTY definition, or until one warm-up retry has been paid.
+  // tsserver answers pre-project-load requests with [] instead of an
+  // error, so without the retry every first-run resolution silently
+  // reports unresolved and Phase B never upgrades anything.
+  let serverWarm = false;
+  const warmupRetryDelayMs = options.warmupRetryDelayMs ?? 2_500;
+
   for (const [filePath, batchReqs] of byFile) {
     // Send all definition requests for this file, collecting upgrades.
     const upgrades: EdgeUpgrade[] = [];
@@ -327,10 +344,27 @@ export async function executeLspResolution(
         break;
       }
 
-      const defResult = await client.definition({
+      let defResult = await client.definition({
         textDocument: { uri: filePathToUri(req.filePath, options.workspaceRoot) },
         position: req.position,
       });
+
+      // Warm-up retry (issue #1933): an empty result from a not-yet-warm
+      // server is indeterminate, not definitive. Pay ONE bounded delay,
+      // re-ask, and treat the server as warm from then on — whatever the
+      // retry returns is the real answer.
+      if (defResult.ok && defResult.locations.length === 0 && !serverWarm && warmupRetryDelayMs > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, warmupRetryDelayMs));
+        serverWarm = true;
+        const retryResult = await client.definition({
+          textDocument: { uri: filePathToUri(req.filePath, options.workspaceRoot) },
+          position: req.position,
+        });
+        defResult = retryResult;
+      }
+      if (defResult.ok && defResult.locations.length > 0) {
+        serverWarm = true;
+      }
 
       if (!defResult.ok) {
         // Distinguish "server problem" (stop the whole pass) from


### PR DESCRIPTION
Closes #1933.

## Problem

`executeLspResolution` sends `textDocument/definition` immediately after `didOpen`. tsserver loads projects asynchronously and answers early requests with an EMPTY location array — indistinguishable from "definitely no definition". Every first-run resolution silently reported unresolved: with #1917's wiring live on jarvis-ml, Phase B produced **zero upgrades** on a fixture whose method call typescript-language-server resolves correctly (raw-protocol proof in #1933: immediate request `[]`, identical request 3s later resolves).

## Fix

The executor tracks server warmth: an empty result before the server has proven warm (any non-empty answer) is retried ONCE after `warmupRetryDelayMs` (new `ResolveOptions` knob, default 2500ms, 0 disables). At most one bounded delay per run; the retry's answer is final either way.

## Verification (live, jarvis-ml)

Before (v9.6.38 dist): `{upgraded: 0, unresolved: 1}` on the `persist -> s.save(key)` fixture.
After (this branch built on the host, daemon restarted, full `codegraph_index` via MCP):

- `lsp: { upgraded: 1, unresolved: 0, budgetExhausted: 0 }`
- store stats: `edges: 1 (CALLS)` — the persist→Store.save member-call edge Phase A deliberately skips
- `codegraph_trace_path` from `persist` returns the callee at depth 1

## Tests

3 new executor tests (retry produces the upgrade; only one retry paid per run; a non-empty first answer marks warm with no retry). The two definitive-empty tests opt out via `warmupRetryDelayMs: 0`. LSP suite: 54/54.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LSP Phase B timing and empty-result semantics with a default 2.5s delay on the first indeterminate empty; behavior is bounded and covered by new tests but can affect index latency and first-run upgrade counts.
> 
> **Overview**
> **Phase B LSP resolution** now treats an empty `textDocument/definition` response as *possibly* “server not ready yet” instead of always “no definition,” which was causing first-run passes to upgrade **zero** edges when tsserver returned `[]` before the project finished loading.
> 
> `executeLspResolution` tracks **server warmth** for the run: until the server returns a non-empty location (or one warm-up retry has been used), an empty OK result triggers **one** re-request after `warmupRetryDelayMs` (new `ResolveOptions` field, default **2500ms**; **0** disables). Later empty answers on a warm server stay definitive, and only **one** warm-up retry is paid per run—not per call site.
> 
> Tests add three executor scenarios for this behavior and set `warmupRetryDelayMs: 0` on existing “definitive empty” / URI-shape tests so they stay fast and deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40cdc5346b0d450cd681831d2d5cc3cbc19781d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->