### PR TITLE
bench: add hash-pinned LoCoMo scored selectors

### DIFF
--- a/packages/bench/src/benchmarks/published/locomo/retrieval-trace-runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/retrieval-trace-runner.ts
@@ -15,26 +15,23 @@ import {
   prioritizeLoCoMoRecallTextWithTrace,
   sanitizeLoCoMoRecallText,
 } from "./runner.js";
+import {
+  LOCOMO_TASK_SELECTION_VERSION,
+  type LoCoMoTaskSelectionManifest,
+  type LoCoMoTaskSelector,
+  selectLoCoMoTasks,
+} from "./task-selection.js";
 
 export const LOCOMO_RETRIEVAL_TRACE_SCHEMA_VERSION = 1 as const;
-export const LOCOMO_RETRIEVAL_TRACE_SELECTION_VERSION = 1 as const;
+export const LOCOMO_RETRIEVAL_TRACE_SELECTION_VERSION =
+  LOCOMO_TASK_SELECTION_VERSION;
 export const LOCOMO_RETRIEVAL_TRACE_BUDGET_VERSION = 1 as const;
 
 export type LoCoMoRetrievalTraceProfile = "baseline" | "real";
 
-export type LoCoMoRetrievalTraceSelector =
-  | { taskIds: readonly string[]; sampleSize?: never; seed?: never }
-  | { taskIds?: never; sampleSize: number; seed: number };
-
-export interface LoCoMoRetrievalTraceSelectionManifest {
-  algorithm: "explicit-task-ids" | "sha256-seeded-sample";
-  version: typeof LOCOMO_RETRIEVAL_TRACE_SELECTION_VERSION;
-  seed?: number;
-  candidateCount: number;
-  selectedCount: number;
-  selectedTaskIds: string[];
-  selectedTaskIdsSha256: string;
-}
+export type LoCoMoRetrievalTraceSelector = LoCoMoTaskSelector;
+export type LoCoMoRetrievalTraceSelectionManifest =
+  LoCoMoTaskSelectionManifest;
 
 export interface LoCoMoRetrievalTraceCoreCaptureReceipt {
   budget: BenchRecallTraceCoreCapture["budget"];
@@ -264,73 +261,7 @@ export function selectLoCoMoRetrievalTraceTasks(
   tasks: readonly Pick<SelectableTask, "taskId">[],
   selector: LoCoMoRetrievalTraceSelector
 ): LoCoMoRetrievalTraceSelectionManifest {
-  const allIds = tasks.map((task) => task.taskId);
-  if (new Set(allIds).size !== allIds.length) {
-    throw new Error("LoCoMo retrieval trace task ids must be unique.");
-  }
-  let selected: string[];
-  let algorithm: LoCoMoRetrievalTraceSelectionManifest["algorithm"];
-  let seed: number | undefined;
-  const hasTaskIds = "taskIds" in selector && selector.taskIds !== undefined;
-  const hasSampleSize = "sampleSize" in selector && selector.sampleSize !== undefined;
-  if (Number(hasTaskIds) + Number(hasSampleSize) !== 1) {
-    throw new Error("Choose exactly one LoCoMo retrieval trace selector.");
-  }
-  if (hasTaskIds && "seed" in selector && selector.seed !== undefined) {
-    throw new Error("LoCoMo retrieval trace seed is valid only for seeded sampling.");
-  }
-
-  if (hasTaskIds) {
-    algorithm = "explicit-task-ids";
-    const requestedTaskIds = selector.taskIds;
-    if (!requestedTaskIds) throw new Error("LoCoMo explicit task ids are required.");
-    const requested = [...requestedTaskIds];
-    if (requested.length === 0) {
-      throw new Error("LoCoMo retrieval trace explicit task selection cannot be empty.");
-    }
-    if (new Set(requested).size !== requested.length) {
-      throw new Error("LoCoMo retrieval trace explicit task ids must not contain duplicates.");
-    }
-    const available = new Set(allIds);
-    const unknown = requested.filter((taskId) => !available.has(taskId));
-    if (unknown.length > 0) {
-      throw new Error(`Unknown LoCoMo retrieval trace task id: ${unknown[0]}`);
-    }
-    const requestedSet = new Set(requested);
-    selected = allIds.filter((taskId) => requestedSet.has(taskId));
-  } else {
-    algorithm = "sha256-seeded-sample";
-    const sampleSize = selector.sampleSize;
-    seed = selector.seed;
-    if (sampleSize === undefined || seed === undefined) {
-      throw new Error("LoCoMo seeded sampling requires sampleSize and seed.");
-    }
-    if (!Number.isSafeInteger(sampleSize) || sampleSize <= 0 || sampleSize > allIds.length) {
-      throw new Error(`LoCoMo retrieval trace sampleSize must be an integer from 1 to ${allIds.length}.`);
-    }
-    if (!Number.isSafeInteger(seed) || seed < 0) {
-      throw new Error("LoCoMo retrieval trace seed must be a non-negative safe integer.");
-    }
-    const sampled = [...allIds]
-      .sort((left, right) => {
-        const leftHash = hashString(`${seed}\0${left}`);
-        const rightHash = hashString(`${seed}\0${right}`);
-        return leftHash.localeCompare(rightHash) || left.localeCompare(right);
-      })
-      .slice(0, sampleSize);
-    const sampledSet = new Set(sampled);
-    selected = allIds.filter((taskId) => sampledSet.has(taskId));
-  }
-
-  return {
-    algorithm,
-    version: LOCOMO_RETRIEVAL_TRACE_SELECTION_VERSION,
-    ...(seed === undefined ? {} : { seed }),
-    candidateCount: allIds.length,
-    selectedCount: selected.length,
-    selectedTaskIds: selected,
-    selectedTaskIdsSha256: hashCanonicalJson(selected),
-  };
+  return selectLoCoMoTasks(tasks, selector);
 }
 
 export function serializeLoCoMoRetrievalTraceReceipt(receipt: LoCoMoRetrievalTraceReceipt): string {

--- a/packages/bench/src/benchmarks/published/locomo/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.test.ts
@@ -3,9 +3,9 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-
 import type { Message } from "../../../adapters/types.js";
 import { locomoDefinition, runLoCoMoBenchmark } from "./runner.ts";
+import { selectLoCoMoTasks } from "./task-selection.js";
 
 test("LoCoMo normalizes numeric answers and adversarial-answer fallbacks from the official dataset", async () => {
   const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-locomo-"));
@@ -972,6 +972,279 @@ test("LoCoMo applies benchmarkOptions.trialLimit across scored QA trials", async
       storedMessages[1]?.content ?? "",
       /relative_time: session date 8 May 2023; yesterday = 7 May 2023/,
     );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("LoCoMo task selection scores canonical dataset order while retaining complete selected-conversation ingest", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-locomo-selected-"));
+  const datasetPath = path.join(tempDir, "locomo10.json");
+  const calls: string[] = [];
+  const candidateTaskIds = [
+    "conversation-a-q0-single_hop",
+    "conversation-a-q1-multi_hop",
+    "conversation-b-q0-multi_hop",
+    "conversation-unused-q0-single_hop",
+  ];
+  const selection = selectLoCoMoTasks(
+    candidateTaskIds.map((taskId) => ({ taskId })),
+    {
+      taskIds: [
+        "conversation-b-q0-multi_hop",
+        "conversation-a-q1-multi_hop",
+      ],
+    },
+  );
+
+  try {
+    await writeFile(
+      datasetPath,
+      JSON.stringify([
+        {
+          sample_id: "conversation-a",
+          conversation: {
+            speaker_a: "Maya",
+            session_1: [
+              { speaker: "Maya", dia_id: "D1:1", text: "Alpha context." },
+            ],
+            session_2: [
+              { speaker: "Maya", dia_id: "D2:1", text: "Beta context." },
+            ],
+          },
+          qa: [
+            {
+              question: "What is alpha?",
+              answer: "alpha",
+              evidence: ["D1:1"],
+              category: 1,
+            },
+            {
+              question: "What is beta?",
+              answer: "beta",
+              evidence: ["D2:1"],
+              category: 2,
+            },
+          ],
+        },
+        {
+          sample_id: "conversation-b",
+          conversation: {
+            speaker_a: "Noah",
+            session_1: [
+              { speaker: "Noah", dia_id: "D3:1", text: "Gamma context." },
+            ],
+          },
+          qa: [
+            {
+              question: "What is gamma?",
+              answer: "gamma",
+              evidence: ["D3:1"],
+              category: 2,
+            },
+          ],
+        },
+        {
+          sample_id: "conversation-unused",
+          conversation: {
+            speaker_a: "Unused",
+            session_1: [
+              { speaker: "Unused", dia_id: "D4:1", text: "Unused context." },
+            ],
+          },
+          qa: [
+            {
+              question: "What is unused?",
+              answer: "unused",
+              evidence: ["D4:1"],
+              category: 1,
+            },
+          ],
+        },
+      ]),
+      "utf8",
+    );
+
+    const result = await runLoCoMoBenchmark({
+      benchmark: locomoDefinition,
+      mode: "full",
+      datasetDir: tempDir,
+      benchmarkOptions: {
+        taskSelector: {
+          kind: "explicit-task-ids",
+          taskIds: [
+            "conversation-b-q0-multi_hop",
+            "conversation-a-q1-multi_hop",
+          ],
+          expectedSelectedTaskIdsSha256: selection.selectedTaskIdsSha256,
+        },
+      },
+      system: {
+        async reset() {
+          calls.push("reset");
+        },
+        async store(sessionId) {
+          calls.push(`store:${sessionId}`);
+        },
+        async recall(_sessionId, question) {
+          return `${question} alpha beta gamma`;
+        },
+        async search() {
+          return [];
+        },
+        async destroy() {},
+        async getStats() {
+          return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+        },
+        responder: {
+          async respond(question) {
+            return {
+              text: question.includes("beta") ? "beta" : "gamma",
+              tokens: { input: 1, output: 1 },
+              latencyMs: 1,
+              model: "selector-test-responder",
+            };
+          },
+        },
+        judge: {
+          async score() {
+            return 1;
+          },
+        },
+      },
+    });
+
+    assert.deepEqual(
+      result.results.tasks.map((task) => task.taskId),
+      ["conversation-a-q1-multi_hop", "conversation-b-q0-multi_hop"],
+    );
+    assert.deepEqual(calls, [
+      "reset",
+      "store:conversation-a-session_1",
+      "store:conversation-a-session_2",
+      "reset",
+      "store:conversation-b-session_1",
+    ]);
+    assert.deepEqual(result.config.benchmarkOptions?.taskSelection, selection);
+    assert.equal(result.config.benchmarkOptions?.taskSelector, undefined);
+    assert.match(result.meta.datasetHash ?? "", /^[0-9a-f]{64}$/u);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("LoCoMo task selection fails before adapter side effects on invalid or incompatible selectors", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-locomo-selector-invalid-"));
+  const datasetPath = path.join(tempDir, "locomo10.json");
+  let sideEffects = 0;
+  const taskId = "selector-validation-q0-multi_hop";
+  const validHash = selectLoCoMoTasks([{ taskId }], { taskIds: [taskId] })
+    .selectedTaskIdsSha256;
+  const system = {
+    async reset() {
+      sideEffects += 1;
+    },
+    async store() {
+      sideEffects += 1;
+    },
+    async recall() {
+      sideEffects += 1;
+      return "";
+    },
+    async search() {
+      return [];
+    },
+    async destroy() {},
+    async getStats() {
+      return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+    },
+  };
+
+  try {
+    await writeFile(
+      datasetPath,
+      JSON.stringify([
+        {
+          sample_id: "selector-validation",
+          conversation: {
+            speaker_a: "Maya",
+            session_1: [
+              { speaker: "Maya", dia_id: "D1:1", text: "Selector context." },
+            ],
+          },
+          qa: [
+            {
+              question: "Which selector?",
+              answer: "selector",
+              evidence: ["D1:1"],
+              category: 2,
+            },
+          ],
+        },
+      ]),
+      "utf8",
+    );
+
+    const selector = {
+      kind: "explicit-task-ids",
+      taskIds: [taskId],
+      expectedSelectedTaskIdsSha256: validHash,
+    };
+    const base = {
+      benchmark: locomoDefinition,
+      mode: "full" as const,
+      datasetDir: tempDir,
+      system,
+    };
+    await assert.rejects(
+      runLoCoMoBenchmark({
+        ...base,
+        benchmarkOptions: {
+          taskSelector: {
+            ...selector,
+            expectedSelectedTaskIdsSha256: "0".repeat(64),
+          },
+        },
+      }),
+      /selected task-id hash does not match/,
+    );
+    await assert.rejects(
+      runLoCoMoBenchmark({
+        ...base,
+        benchmarkOptions: {
+          taskSelector: { ...selector, taskIds: ["unknown"] },
+        },
+      }),
+      /Unknown/,
+    );
+    await assert.rejects(
+      runLoCoMoBenchmark({
+        ...base,
+        benchmarkOptions: {
+          taskSelector: { ...selector, taskIds: [taskId, taskId] },
+        },
+      }),
+      /duplicates/,
+    );
+    for (const incompatible of [
+      { ...base, mode: "quick" as const, benchmarkOptions: { taskSelector: selector } },
+      { ...base, limit: 1, benchmarkOptions: { taskSelector: selector } },
+      { ...base, benchmarkOptions: { taskSelector: selector, trialLimit: 1 } },
+      {
+        ...base,
+        benchmarkOptions: { taskSelector: selector, trialConcurrency: 2 },
+      },
+    ]) {
+      await assert.rejects(runLoCoMoBenchmark(incompatible), /task selection/);
+    }
+    await assert.rejects(
+      runLoCoMoBenchmark({
+        ...base,
+        benchmarkOptions: { taskSelection: { selectedCount: 1 } },
+      }),
+      /runner-owned/,
+    );
+    assert.equal(sideEffects, 0);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/packages/bench/src/benchmarks/published/locomo/runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.ts
@@ -26,6 +26,11 @@ import type {
   BenchmarkResult,
   ResolvedRunBenchmarkOptions,
 } from "../../../types.js";
+import {
+  type LoCoMoPinnedTaskSelector,
+  type LoCoMoTaskSelectionManifest,
+  selectLoCoMoTasks,
+} from "./task-selection.js";
 
 const CATEGORY_NAMES: Record<number, string> = {
   1: "single_hop",
@@ -337,31 +342,54 @@ export const locomoDefinition: BenchmarkDefinition = {
 export async function runLoCoMoBenchmark(
   options: ResolvedRunBenchmarkOptions,
 ): Promise<BenchmarkResult> {
+  const rawBenchmarkOptions = options.benchmarkOptions ?? {};
+  if (rawBenchmarkOptions.taskSelection !== undefined) {
+    throw new Error(
+      "LoCoMo benchmarkOptions.taskSelection is runner-owned and cannot be supplied by callers.",
+    );
+  }
+  const taskSelector = resolvePinnedTaskSelector(
+    rawBenchmarkOptions.taskSelector,
+  );
+  if (taskSelector !== undefined) {
+    assertTaskSelectorCompatibility(options, rawBenchmarkOptions);
+  }
   const loaded = await loadLoCoMoDataset(
     options.mode,
     options.datasetDir,
     options.limit,
   );
   const conversations = loaded.items;
-  const trialLimit = resolveTrialLimit(options.benchmarkOptions?.trialLimit);
+  const trialLimit = resolveTrialLimit(rawBenchmarkOptions.trialLimit);
   const multiHopRecallComposition = resolveLoCoMoBooleanOption(
-    options.benchmarkOptions?.multiHopRecallComposition,
+    rawBenchmarkOptions.multiHopRecallComposition,
     "multiHopRecallComposition",
     true,
   );
-  const plans = applyTrialLimit(
-    conversations.map((conversation) =>
-      buildLoCoMoPlan(conversation, multiHopRecallComposition)
-    ),
-    trialLimit,
+  const allPlans = conversations.map((conversation) =>
+    buildLoCoMoPlan(conversation, multiHopRecallComposition)
   );
+  const selected = taskSelector === undefined
+    ? undefined
+    : applyTaskSelection(allPlans, taskSelector);
+  const plans = selected === undefined
+    ? applyTrialLimit(allPlans, trialLimit)
+    : selected.plans;
+  const {
+    taskSelector: _taskSelector,
+    taskSelection: _taskSelection,
+    ...callerBenchmarkOptions
+  } = rawBenchmarkOptions;
   const benchmarkOptions = {
-    ...(options.benchmarkOptions ?? {}),
+    ...callerBenchmarkOptions,
     ...(trialLimit === undefined ? {} : { trialLimit }),
+    ...(selected === undefined
+      ? {}
+      : { taskSelection: selected.manifest }),
     multiHopRecallComposition,
   };
 
-  return runPublishedHarness({
+  const result = await runPublishedHarness({
     options: { ...options, benchmarkOptions },
     metricsSpec: {
       metrics: ["f1", "contains_answer", "rouge_l", "llm_judge"],
@@ -369,6 +397,111 @@ export async function runLoCoMoBenchmark(
     plans,
     totalCount: plans.reduce((sum, plan) => sum + plan.trials.length, 0),
   });
+  result.meta.datasetHash = loaded.sha256;
+  return result;
+}
+
+function resolvePinnedTaskSelector(
+  raw: unknown,
+): LoCoMoPinnedTaskSelector | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("LoCoMo benchmarkOptions.taskSelector must be an object.");
+  }
+  const record = raw as Record<string, unknown>;
+  const allowedKeys = new Set([
+    "kind",
+    "taskIds",
+    "expectedSelectedTaskIdsSha256",
+  ]);
+  const unknownKey = Object.keys(record).find((key) => !allowedKeys.has(key));
+  if (unknownKey !== undefined) {
+    throw new Error(
+      `LoCoMo benchmarkOptions.taskSelector contains unknown field ${unknownKey}.`,
+    );
+  }
+  if (record.kind !== "explicit-task-ids") {
+    throw new Error(
+      'LoCoMo benchmarkOptions.taskSelector.kind must be "explicit-task-ids".',
+    );
+  }
+  if (
+    !Array.isArray(record.taskIds) ||
+    record.taskIds.some(
+      (taskId) => typeof taskId !== "string" || taskId.length === 0,
+    )
+  ) {
+    throw new Error(
+      "LoCoMo benchmarkOptions.taskSelector.taskIds must contain non-empty strings.",
+    );
+  }
+  if (
+    typeof record.expectedSelectedTaskIdsSha256 !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(record.expectedSelectedTaskIdsSha256)
+  ) {
+    throw new Error(
+      "LoCoMo benchmarkOptions.taskSelector.expectedSelectedTaskIdsSha256 must be 64 lowercase hexadecimal characters.",
+    );
+  }
+  return {
+    kind: "explicit-task-ids",
+    taskIds: [...record.taskIds] as string[],
+    expectedSelectedTaskIdsSha256:
+      record.expectedSelectedTaskIdsSha256,
+  };
+}
+
+function assertTaskSelectorCompatibility(
+  options: ResolvedRunBenchmarkOptions,
+  benchmarkOptions: Record<string, unknown>,
+): void {
+  if (options.mode !== "full") {
+    throw new Error("LoCoMo task selection requires full benchmark mode.");
+  }
+  if (options.limit !== undefined) {
+    throw new Error("LoCoMo task selection cannot be combined with limit.");
+  }
+  if (benchmarkOptions.trialLimit !== undefined) {
+    throw new Error(
+      "LoCoMo task selection cannot be combined with benchmarkOptions.trialLimit.",
+    );
+  }
+  if (
+    benchmarkOptions.trialConcurrency !== undefined &&
+    Number(benchmarkOptions.trialConcurrency) !== 1
+  ) {
+    throw new Error(
+      "LoCoMo task selection requires benchmarkOptions.trialConcurrency to be 1.",
+    );
+  }
+}
+
+function applyTaskSelection(
+  plans: HarnessPlan[],
+  selector: LoCoMoPinnedTaskSelector,
+): { plans: HarnessPlan[]; manifest: LoCoMoTaskSelectionManifest } {
+  const candidateTrials = plans.flatMap((plan) => plan.trials);
+  const manifest = selectLoCoMoTasks(candidateTrials, {
+    taskIds: selector.taskIds,
+  });
+  if (
+    manifest.selectedTaskIdsSha256 !==
+    selector.expectedSelectedTaskIdsSha256
+  ) {
+    throw new Error(
+      "LoCoMo selected task-id hash does not match benchmarkOptions.taskSelector.expectedSelectedTaskIdsSha256.",
+    );
+  }
+  const selectedTaskIds = new Set(manifest.selectedTaskIds);
+  const selectedPlans = plans.flatMap((plan) => {
+    const trials = plan.trials.filter((trial) =>
+      selectedTaskIds.has(trial.taskId)
+    );
+    return trials.length === 0 ? [] : [{ ...plan, trials }];
+  });
+  return { plans: selectedPlans, manifest };
 }
 
 function resolveLoCoMoBooleanOption(

--- a/packages/bench/src/benchmarks/published/locomo/task-selection.test.ts
+++ b/packages/bench/src/benchmarks/published/locomo/task-selection.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LOCOMO_TASK_SELECTION_VERSION,
+  parseLoCoMoTaskSelectionManifest,
+  selectLoCoMoTasks,
+} from "./task-selection.js";
+
+test("explicit LoCoMo selection canonicalizes requested ids into dataset order", () => {
+  const tasks = ["task-c", "task-a", "task-b"].map((taskId) => ({ taskId }));
+  const selection = selectLoCoMoTasks(tasks, {
+    taskIds: ["task-b", "task-c"],
+  });
+
+  assert.deepEqual(selection, {
+    algorithm: "explicit-task-ids",
+    version: LOCOMO_TASK_SELECTION_VERSION,
+    candidateCount: 3,
+    selectedCount: 2,
+    selectedTaskIds: ["task-c", "task-b"],
+    selectedTaskIdsSha256:
+      "c93eb02d11571fd2c219957db9928383c4b727b03b6b3bef4e1fec0ad74877d0",
+  });
+});
+
+test("seeded LoCoMo selection has stable membership and dataset-order output", () => {
+  const tasks = ["task-c", "task-a", "task-b"].map((taskId) => ({ taskId }));
+  const first = selectLoCoMoTasks(tasks, { sampleSize: 2, seed: 42 });
+  const reversed = selectLoCoMoTasks([...tasks].reverse(), {
+    sampleSize: 2,
+    seed: 42,
+  });
+
+  assert.deepEqual(new Set(first.selectedTaskIds), new Set(reversed.selectedTaskIds));
+  assert.deepEqual(
+    first.selectedTaskIds,
+    tasks
+      .map((task) => task.taskId)
+      .filter((taskId) => first.selectedTaskIds.includes(taskId)),
+  );
+});
+
+test("LoCoMo task selectors reject malformed, duplicate, and unknown ids", () => {
+  const tasks = ["task-a", "task-b"].map((taskId) => ({ taskId }));
+  assert.throws(
+    () => selectLoCoMoTasks(tasks, { taskIds: [] }),
+    /cannot be empty/,
+  );
+  assert.throws(
+    () => selectLoCoMoTasks(tasks, { taskIds: ["task-a", "task-a"] }),
+    /duplicates/,
+  );
+  assert.throws(
+    () => selectLoCoMoTasks(tasks, { taskIds: ["unknown"] }),
+    /Unknown/,
+  );
+  assert.throws(
+    () => selectLoCoMoTasks(tasks, { sampleSize: 0, seed: 1 }),
+    /sampleSize/,
+  );
+  assert.throws(
+    () =>
+      selectLoCoMoTasks(tasks, {
+        taskIds: ["task-a"],
+        sampleSize: 1,
+        seed: 1,
+      } as never),
+    /exactly one/,
+  );
+  assert.throws(
+    () => selectLoCoMoTasks([{ taskId: "task-a" }, { taskId: "task-a" }], {
+      taskIds: ["task-a"],
+    }),
+    /candidate task ids must be unique/,
+  );
+});
+
+test("persisted LoCoMo selection parser verifies schema, counts, order hash, and clones ids", () => {
+  const source = selectLoCoMoTasks(
+    [{ taskId: "task-a" }, { taskId: "task-b" }],
+    { taskIds: ["task-b"] },
+  );
+  const parsed = parseLoCoMoTaskSelectionManifest(source);
+  assert.deepEqual(parsed, source);
+  assert.notEqual(parsed.selectedTaskIds, source.selectedTaskIds);
+
+  assert.throws(
+    () => parseLoCoMoTaskSelectionManifest({ ...source, selectedCount: 2 }),
+    /selectedCount must equal/,
+  );
+  assert.throws(
+    () =>
+      parseLoCoMoTaskSelectionManifest({
+        ...source,
+        selectedTaskIdsSha256: "0".repeat(64),
+      }),
+    /does not match/,
+  );
+  assert.throws(
+    () => parseLoCoMoTaskSelectionManifest({ ...source, future: true }),
+    /unknown field/,
+  );
+});

--- a/packages/bench/src/benchmarks/published/locomo/task-selection.ts
+++ b/packages/bench/src/benchmarks/published/locomo/task-selection.ts
@@ -1,0 +1,227 @@
+import {
+  hashCanonicalJson,
+  hashString,
+} from "../../../integrity/hash-verification.js";
+
+export const LOCOMO_TASK_SELECTION_VERSION = 1 as const;
+
+export type LoCoMoTaskSelector =
+  | { taskIds: readonly string[]; sampleSize?: never; seed?: never }
+  | { taskIds?: never; sampleSize: number; seed: number };
+
+export interface LoCoMoPinnedTaskSelector {
+  kind: "explicit-task-ids";
+  taskIds: readonly string[];
+  expectedSelectedTaskIdsSha256: string;
+}
+
+export interface LoCoMoTaskSelectionManifest {
+  algorithm: "explicit-task-ids" | "sha256-seeded-sample";
+  version: typeof LOCOMO_TASK_SELECTION_VERSION;
+  seed?: number;
+  candidateCount: number;
+  selectedCount: number;
+  selectedTaskIds: string[];
+  selectedTaskIdsSha256: string;
+}
+
+export function parseLoCoMoTaskSelectionManifest(
+  value: unknown,
+  label = "LoCoMo task selection",
+): LoCoMoTaskSelectionManifest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  const record = value as Record<string, unknown>;
+  const allowedKeys = new Set([
+    "algorithm",
+    "version",
+    "seed",
+    "candidateCount",
+    "selectedCount",
+    "selectedTaskIds",
+    "selectedTaskIdsSha256",
+  ]);
+  const unknownKey = Object.keys(record).find((key) => !allowedKeys.has(key));
+  if (unknownKey !== undefined) {
+    throw new Error(`${label} contains unknown field ${unknownKey}.`);
+  }
+  if (
+    record.algorithm !== "explicit-task-ids" &&
+    record.algorithm !== "sha256-seeded-sample"
+  ) {
+    throw new Error(`${label}.algorithm is invalid.`);
+  }
+  if (record.version !== LOCOMO_TASK_SELECTION_VERSION) {
+    throw new Error(
+      `${label}.version must be ${LOCOMO_TASK_SELECTION_VERSION}.`,
+    );
+  }
+  const candidateCountRaw = record.candidateCount;
+  const selectedCountRaw = record.selectedCount;
+  if (
+    typeof candidateCountRaw !== "number" ||
+    !Number.isSafeInteger(candidateCountRaw) ||
+    candidateCountRaw <= 0
+  ) {
+    throw new Error(`${label}.candidateCount must be a positive safe integer.`);
+  }
+  if (
+    typeof selectedCountRaw !== "number" ||
+    !Number.isSafeInteger(selectedCountRaw) ||
+    selectedCountRaw <= 0
+  ) {
+    throw new Error(`${label}.selectedCount must be a positive safe integer.`);
+  }
+  const candidateCount = candidateCountRaw;
+  const selectedCount = selectedCountRaw;
+  if (selectedCount > candidateCount) {
+    throw new Error(`${label}.selectedCount cannot exceed candidateCount.`);
+  }
+  if (
+    !Array.isArray(record.selectedTaskIds) ||
+    record.selectedTaskIds.some(
+      (taskId) => typeof taskId !== "string" || taskId.length === 0,
+    )
+  ) {
+    throw new Error(`${label}.selectedTaskIds must contain non-empty strings.`);
+  }
+  const selectedTaskIds = [...record.selectedTaskIds] as string[];
+  if (new Set(selectedTaskIds).size !== selectedTaskIds.length) {
+    throw new Error(`${label}.selectedTaskIds must not contain duplicates.`);
+  }
+  if (selectedTaskIds.length !== selectedCount) {
+    throw new Error(
+      `${label}.selectedCount must equal selectedTaskIds.length.`,
+    );
+  }
+  const selectedTaskIdsSha256 = record.selectedTaskIdsSha256;
+  if (
+    typeof selectedTaskIdsSha256 !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(selectedTaskIdsSha256) ||
+    selectedTaskIdsSha256 !== hashCanonicalJson(selectedTaskIds)
+  ) {
+    throw new Error(`${label}.selectedTaskIdsSha256 does not match selectedTaskIds.`);
+  }
+  const seed = record.seed;
+  if (record.algorithm === "explicit-task-ids") {
+    if (seed !== undefined) {
+      throw new Error(`${label}.seed is invalid for explicit task ids.`);
+    }
+  } else if (!Number.isSafeInteger(seed) || (seed as number) < 0) {
+    throw new Error(`${label}.seed must be a non-negative safe integer.`);
+  }
+
+  return {
+    algorithm: record.algorithm,
+    version: LOCOMO_TASK_SELECTION_VERSION,
+    ...(seed === undefined ? {} : { seed: seed as number }),
+    candidateCount,
+    selectedCount,
+    selectedTaskIds,
+    selectedTaskIdsSha256,
+  };
+}
+
+/**
+ * Resolve a LoCoMo task selector into canonical dataset order.
+ *
+ * Explicit selector order never controls execution order. This keeps paired
+ * runs byte-stable even when two equivalent selector files list ids in a
+ * different order. Seeded sampling chooses membership by hash and then also
+ * restores dataset order before producing the manifest.
+ */
+export function selectLoCoMoTasks(
+  tasks: readonly { taskId: string }[],
+  selector: LoCoMoTaskSelector,
+): LoCoMoTaskSelectionManifest {
+  const allIds = tasks.map((task) => task.taskId);
+  if (allIds.some((taskId) => typeof taskId !== "string" || taskId.length === 0)) {
+    throw new Error("LoCoMo candidate task ids must be non-empty strings.");
+  }
+  if (new Set(allIds).size !== allIds.length) {
+    throw new Error("LoCoMo candidate task ids must be unique.");
+  }
+
+  const hasTaskIds = "taskIds" in selector && selector.taskIds !== undefined;
+  const hasSampleSize =
+    "sampleSize" in selector && selector.sampleSize !== undefined;
+  if (Number(hasTaskIds) + Number(hasSampleSize) !== 1) {
+    throw new Error("Choose exactly one LoCoMo task selector.");
+  }
+  if (hasTaskIds && "seed" in selector && selector.seed !== undefined) {
+    throw new Error("LoCoMo task-selection seed is valid only for seeded sampling.");
+  }
+
+  let selected: string[];
+  let algorithm: LoCoMoTaskSelectionManifest["algorithm"];
+  let seed: number | undefined;
+  if (hasTaskIds) {
+    algorithm = "explicit-task-ids";
+    const requestedTaskIds = selector.taskIds;
+    if (!requestedTaskIds) {
+      throw new Error("LoCoMo explicit task ids are required.");
+    }
+    const requested = [...requestedTaskIds];
+    if (requested.length === 0) {
+      throw new Error("LoCoMo explicit task selection cannot be empty.");
+    }
+    if (
+      requested.some(
+        (taskId) => typeof taskId !== "string" || taskId.length === 0,
+      )
+    ) {
+      throw new Error("LoCoMo explicit task ids must be non-empty strings.");
+    }
+    if (new Set(requested).size !== requested.length) {
+      throw new Error("LoCoMo explicit task ids must not contain duplicates.");
+    }
+    const available = new Set(allIds);
+    const unknown = requested.find((taskId) => !available.has(taskId));
+    if (unknown !== undefined) {
+      throw new Error(`Unknown LoCoMo task id: ${unknown}`);
+    }
+    const requestedSet = new Set(requested);
+    selected = allIds.filter((taskId) => requestedSet.has(taskId));
+  } else {
+    algorithm = "sha256-seeded-sample";
+    const sampleSize = selector.sampleSize;
+    seed = selector.seed;
+    if (sampleSize === undefined || seed === undefined) {
+      throw new Error("LoCoMo seeded sampling requires sampleSize and seed.");
+    }
+    if (
+      !Number.isSafeInteger(sampleSize) ||
+      sampleSize <= 0 ||
+      sampleSize > allIds.length
+    ) {
+      throw new Error(
+        `LoCoMo task-selection sampleSize must be an integer from 1 to ${allIds.length}.`,
+      );
+    }
+    if (!Number.isSafeInteger(seed) || seed < 0) {
+      throw new Error(
+        "LoCoMo task-selection seed must be a non-negative safe integer.",
+      );
+    }
+    const sampled = [...allIds]
+      .sort((left, right) => {
+        const leftHash = hashString(`${seed}\0${left}`);
+        const rightHash = hashString(`${seed}\0${right}`);
+        return leftHash.localeCompare(rightHash) || left.localeCompare(right);
+      })
+      .slice(0, sampleSize);
+    const sampledSet = new Set(sampled);
+    selected = allIds.filter((taskId) => sampledSet.has(taskId));
+  }
+
+  return {
+    algorithm,
+    version: LOCOMO_TASK_SELECTION_VERSION,
+    ...(seed === undefined ? {} : { seed }),
+    candidateCount: allIds.length,
+    selectedCount: selected.length,
+    selectedTaskIds: selected,
+    selectedTaskIdsSha256: hashCanonicalJson(selected),
+  };
+}

--- a/packages/bench/src/stats/locomo-recall-delta.test.ts
+++ b/packages/bench/src/stats/locomo-recall-delta.test.ts
@@ -4,6 +4,10 @@ import test from "node:test";
 
 import type { BenchmarkResult, TaskResult } from "../types.js";
 import {
+  selectLoCoMoTasks,
+  type LoCoMoTaskSelectionManifest,
+} from "../benchmarks/published/locomo/task-selection.js";
+import {
   LOCOMO_FULL_TASK_COUNT,
   diagnoseLoComoRecallDelta,
   renderLoComoRecallDeltaMarkdown,
@@ -42,15 +46,7 @@ function result(
   overrides: Partial<BenchmarkResult> = {}
 ): BenchmarkResult {
   const complete = completeTasks(tasks);
-  const aggregates = Object.fromEntries(
-    Object.keys(complete[0]?.scores ?? {}).map((metric) => {
-      const values = complete
-        .map((entry) => entry.scores[metric])
-        .filter((value): value is number => Number.isFinite(value));
-      const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
-      return [metric, { mean, median: mean, stdDev: 0, min: Math.min(...values), max: Math.max(...values) }];
-    })
-  );
+  const aggregates = aggregatesFor(complete);
   const value: BenchmarkResult = {
     meta: {
       id: `${profile}-id`,
@@ -84,6 +80,47 @@ function result(
     environment: { os: "linux", nodeVersion: "v22" },
   };
   return { ...value, ...overrides };
+}
+
+function aggregatesFor(tasks: TaskResult[]): BenchmarkResult["results"]["aggregates"] {
+  return Object.fromEntries(
+    Object.keys(tasks[0]?.scores ?? {}).map((metric) => {
+      const values = tasks
+        .map((entry) => entry.scores[metric])
+        .filter((value): value is number => Number.isFinite(value));
+      const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+      return [metric, { mean, median: mean, stdDev: 0, min: Math.min(...values), max: Math.max(...values) }];
+    })
+  );
+}
+
+function selectedResult(
+  profile: "baseline" | "real",
+  tasks: TaskResult[],
+  selectionOverride?: LoCoMoTaskSelectionManifest
+): BenchmarkResult {
+  const base = result(profile, tasks);
+  const candidates = [
+    ...tasks.map((entry) => ({ taskId: entry.taskId })),
+    ...Array.from(
+      { length: LOCOMO_FULL_TASK_COUNT - tasks.length },
+      (_, index) => ({ taskId: `selection-candidate-${index}` })
+    ),
+  ];
+  const taskSelection =
+    selectionOverride ??
+    selectLoCoMoTasks(candidates, { taskIds: tasks.map((entry) => entry.taskId) });
+  return {
+    ...base,
+    config: {
+      ...base.config,
+      benchmarkOptions: { taskSelection },
+    },
+    results: {
+      tasks,
+      aggregates: aggregatesFor(tasks),
+    },
+  };
 }
 
 function completeTasks(tasks: TaskResult[]): TaskResult[] {
@@ -243,6 +280,104 @@ test("rejects partial, limited, failed, wrong-profile, or wrong-sized results", 
   assert.throws(
     () => diagnose({ ...baseline, results: { ...baseline.results, tasks: [] } }, real),
     /exactly 1986 tasks/
+  );
+});
+
+test("accepts paired selected results only with identical canonical taskSelection provenance", () => {
+  const baselineTasks = [
+    task({ id: "conv-1-q0-single_hop", score: 1, recall: "needle answer" }),
+    task({ id: "conv-1-q1-multi_hop", score: 0, recall: "other evidence" }),
+  ];
+  const realTasks = [
+    task({ id: "conv-1-q0-single_hop", score: 0, recall: "unknown" }),
+    task({ id: "conv-1-q1-multi_hop", score: 1, recall: "other evidence" }),
+  ];
+  const baseline = selectedResult("baseline", baselineTasks);
+  const manifest = baseline.config.benchmarkOptions?.taskSelection as LoCoMoTaskSelectionManifest;
+  const real = selectedResult("real", realTasks, manifest);
+
+  const report = diagnoseLoComoRecallDelta({
+    baseline: evidence(baseline, "selected-b"),
+    real: evidence(real, "selected-r"),
+  });
+
+  assert.equal(report.taskCount, 2);
+  assert.deepEqual(report.comparison.baseline.taskSelection, manifest);
+  assert.deepEqual(report.comparison.real.taskSelection, manifest);
+});
+
+test("rejects missing, mismatched, malformed, or non-canonical selected provenance", () => {
+  const selectedTasks = [
+    task({ id: "conv-1-q0-single_hop", score: 1, recall: "needle answer" }),
+    task({ id: "conv-1-q1-multi_hop", score: 0, recall: "other evidence" }),
+  ];
+  const baseline = selectedResult("baseline", selectedTasks);
+  const manifest = baseline.config.benchmarkOptions?.taskSelection as LoCoMoTaskSelectionManifest;
+  const real = selectedResult("real", selectedTasks, manifest);
+  const diagnose = (left: BenchmarkResult, right: BenchmarkResult) =>
+    diagnoseLoComoRecallDelta({
+      baseline: evidence(left, "selected-b"),
+      real: evidence(right, "selected-r"),
+    });
+
+  assert.throws(
+    () => diagnose(baseline, result("real", selectedTasks)),
+    /taskSelection differs/
+  );
+  const differentSelectionTasks = [
+    selectedTasks[0]!,
+    task({ id: "conv-1-q2-temporal", score: 0, recall: "different evidence" }),
+  ];
+  assert.throws(
+    () => diagnose(baseline, selectedResult("real", differentSelectionTasks)),
+    /taskSelection differs/
+  );
+  assert.throws(
+    () => diagnose(
+      baseline,
+      selectedResult("real", selectedTasks, { ...manifest, candidateCount: 1_985 })
+    ),
+    /candidateCount must be 1986/
+  );
+  assert.throws(
+    () => diagnose(
+      baseline,
+      {
+        ...real,
+        config: {
+          ...real.config,
+          benchmarkOptions: {
+            taskSelection: { ...manifest, selectedCount: manifest.selectedCount + 1 },
+          },
+        },
+      }
+    ),
+    /selectedCount must equal selectedTaskIds.length/
+  );
+  assert.throws(
+    () => diagnose(
+      baseline,
+      {
+        ...real,
+        config: {
+          ...real.config,
+          benchmarkOptions: {
+            taskSelection: { ...manifest, selectedTaskIdsSha256: "0".repeat(64) },
+          },
+        },
+      }
+    ),
+    /selectedTaskIdsSha256 does not match selectedTaskIds/
+  );
+  assert.throws(
+    () => diagnose(
+      baseline,
+      {
+        ...real,
+        results: { ...real.results, tasks: [...real.results.tasks].reverse() },
+      }
+    ),
+    /exactly match taskSelection.selectedTaskIds in canonical order/
   );
 });
 

--- a/packages/bench/src/stats/locomo-recall-delta.ts
+++ b/packages/bench/src/stats/locomo-recall-delta.ts
@@ -2,6 +2,10 @@ import { createHash } from "node:crypto";
 import { basename } from "node:path";
 
 import type { BenchmarkResult, ProviderConfig, TaskResult } from "../types.js";
+import {
+  parseLoCoMoTaskSelectionManifest,
+  type LoCoMoTaskSelectionManifest,
+} from "../benchmarks/published/locomo/task-selection.js";
 
 export const LOCOMO_FULL_TASK_COUNT = 1_986;
 export const LOCOMO_RECALL_EXCERPT_CHARS = 240;
@@ -92,6 +96,7 @@ export interface LoComoRecallResultProvenance {
   judgeModel: string;
   seeds: number[];
   taskPayloadSha256: string;
+  taskSelection?: LoCoMoTaskSelectionManifest;
 }
 
 export interface LoComoRecallDeltaReport {
@@ -149,9 +154,14 @@ export function diagnoseLoComoRecallDelta(options: DiagnoseLoComoRecallDeltaOpti
 
   assertEvidenceEnvelope(options.baseline, "baseline");
   assertEvidenceEnvelope(options.real, "real");
-  assertCompleteResult(options.baseline.result, "baseline");
-  assertCompleteResult(options.real.result, "real");
-  assertComparableResults(options.baseline.result, options.real.result);
+  const baselineSelection = assertCompleteResult(options.baseline.result, "baseline");
+  const realSelection = assertCompleteResult(options.real.result, "real");
+  assertComparableResults(
+    options.baseline.result,
+    options.real.result,
+    baselineSelection,
+    realSelection
+  );
 
   const joined = joinTasks(options.baseline.result, options.real.result);
   assertMetricSets(joined, primaryMetric);
@@ -177,8 +187,8 @@ export function diagnoseLoComoRecallDelta(options: DiagnoseLoComoRecallDeltaOpti
     schemaVersion: 1,
     benchmarkId: "locomo",
     comparison: {
-      baseline: buildProvenance(options.baseline, "baseline", joined, "baseline"),
-      real: buildProvenance(options.real, "real", joined, "real"),
+      baseline: buildProvenance(options.baseline, "baseline", joined, "baseline", baselineSelection),
+      real: buildProvenance(options.real, "real", joined, "real", realSelection),
     },
     taskCount: joined.length,
     primaryMetric,
@@ -278,7 +288,10 @@ function assertEvidenceEnvelope(evidence: LoComoRawResultEvidence, label: "basel
   }
 }
 
-function assertCompleteResult(result: BenchmarkResult, label: "baseline" | "real"): void {
+function assertCompleteResult(
+  result: BenchmarkResult,
+  label: "baseline" | "real"
+): LoCoMoTaskSelectionManifest | undefined {
   if (result.meta.benchmark !== "locomo") {
     throw new Error(`${label} result must be a locomo benchmark result.`);
   }
@@ -293,10 +306,34 @@ function assertCompleteResult(result: BenchmarkResult, label: "baseline" | "real
   if (limit !== undefined || trialLimit !== undefined) {
     throw new Error(`${label} result is limited and cannot be used as complete evidence.`);
   }
-  if (result.results.tasks.length !== LOCOMO_FULL_TASK_COUNT) {
+  const benchmarkOptions = result.config.benchmarkOptions;
+  const hasTaskSelection =
+    benchmarkOptions !== null &&
+    typeof benchmarkOptions === "object" &&
+    Object.prototype.hasOwnProperty.call(benchmarkOptions, "taskSelection");
+  const taskSelection = hasTaskSelection
+    ? parseLoCoMoTaskSelectionManifest(
+        benchmarkOptions.taskSelection,
+        `${label} result taskSelection`
+      )
+    : undefined;
+  if (!taskSelection && result.results.tasks.length !== LOCOMO_FULL_TASK_COUNT) {
     throw new Error(
       `${label} result must contain exactly ${LOCOMO_FULL_TASK_COUNT} tasks; got ${result.results.tasks.length}.`
     );
+  }
+  if (taskSelection) {
+    if (taskSelection.candidateCount !== LOCOMO_FULL_TASK_COUNT) {
+      throw new Error(
+        `${label} result taskSelection.candidateCount must be ${LOCOMO_FULL_TASK_COUNT}.`
+      );
+    }
+    const resultTaskIds = result.results.tasks.map((task) => task.taskId);
+    if (stableJson(resultTaskIds) !== stableJson(taskSelection.selectedTaskIds)) {
+      throw new Error(
+        `${label} result task ids must exactly match taskSelection.selectedTaskIds in canonical order.`
+      );
+    }
   }
   for (const task of result.results.tasks) {
     const details = asRecord(task.details);
@@ -306,14 +343,26 @@ function assertCompleteResult(result: BenchmarkResult, label: "baseline" | "real
       throw new Error(`${label} result contains failed task ${JSON.stringify(task.taskId)}.`);
     }
   }
+  return taskSelection;
 }
 
-function assertComparableResults(baseline: BenchmarkResult, real: BenchmarkResult): void {
+function assertComparableResults(
+  baseline: BenchmarkResult,
+  real: BenchmarkResult,
+  baselineSelection: LoCoMoTaskSelectionManifest | undefined,
+  realSelection: LoCoMoTaskSelectionManifest | undefined
+): void {
   if (baseline.config.runtimeProfile !== "baseline") {
     throw new Error('baseline result runtimeProfile must be "baseline".');
   }
   if (real.config.runtimeProfile !== "real") {
     throw new Error('real result runtimeProfile must be "real".');
+  }
+  if (stableJson(baselineSelection ?? null) !== stableJson(realSelection ?? null)) {
+    throw new Error(
+      "Results are not comparable: config.benchmarkOptions.taskSelection differs " +
+        `(${stableJson(baselineSelection ?? null)} vs ${stableJson(realSelection ?? null)}).`
+    );
   }
   const checks: Array<[string, unknown, unknown]> = [
     ["meta.version", baseline.meta.version, real.meta.version],
@@ -468,7 +517,8 @@ function buildProvenance(
   evidence: LoComoRawResultEvidence,
   profile: "baseline" | "real",
   joined: JoinedTask[],
-  side: "baseline" | "real"
+  side: "baseline" | "real",
+  taskSelection: LoCoMoTaskSelectionManifest | undefined
 ): LoComoRecallResultProvenance {
   const system = requireProvider(evidence.result.config.systemProvider, profile, "system");
   const judge = requireProvider(evidence.result.config.judgeProvider, profile, "judge");
@@ -491,6 +541,7 @@ function buildProvenance(
     judgeModel: judge.model,
     seeds: [...evidence.result.meta.seeds],
     taskPayloadSha256: sha256(stableJson(payload)),
+    ...(taskSelection ? { taskSelection } : {}),
   };
 }
 

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -463,6 +463,80 @@ test("parseBenchArgs accepts --trial-limit for bench run locomo", () => {
   assert.equal(parsed.publishedTrialLimit, 3);
 });
 
+test("parseBenchArgs accepts hash-pinned task selection for one full LoCoMo run", () => {
+  const digest = "a".repeat(64);
+  const parsed = parseBenchArgs([
+    "run",
+    "locomo",
+    "--task-ids-file",
+    "./private/task-ids.json",
+    "--expected-task-id-list-sha256",
+    digest,
+  ]);
+
+  assert.equal(parsed.taskIdsFile, path.resolve("private/task-ids.json"));
+  assert.equal(parsed.expectedTaskIdListSha256, digest);
+});
+
+test("parseBenchArgs requires both hash-pinned task-selection flags", () => {
+  assert.throws(
+    () => parseBenchArgs(["run", "locomo", "--task-ids-file", "task-ids.json"]),
+    /must be supplied together/,
+  );
+  assert.throws(
+    () => parseBenchArgs([
+      "run",
+      "locomo",
+      "--expected-task-id-list-sha256",
+      "a".repeat(64),
+    ]),
+    /must be supplied together/,
+  );
+});
+
+test("parseBenchArgs rejects invalid task-selection hashes", () => {
+  assert.throws(
+    () => parseBenchArgs([
+      "run",
+      "locomo",
+      "--task-ids-file",
+      "task-ids.json",
+      "--expected-task-id-list-sha256",
+      "ABC",
+    ]),
+    /--expected-task-id-list-sha256 must be a lowercase SHA-256 hex digest/,
+  );
+});
+
+test("parseBenchArgs scopes explicit task selection to an uncapped full LoCoMo run", () => {
+  const selectorFlags = [
+    "--task-ids-file",
+    "task-ids.json",
+    "--expected-task-id-list-sha256",
+    "a".repeat(64),
+  ];
+
+  for (const argv of [
+    ["run", "longmemeval", ...selectorFlags],
+    ["run", "locomo", "longmemeval", ...selectorFlags],
+    ["run", "--all", ...selectorFlags],
+  ]) {
+    assert.throws(() => parseBenchArgs(argv), /only for a single LoCoMo run/);
+  }
+  assert.throws(
+    () => parseBenchArgs(["run", "locomo", "--quick", ...selectorFlags]),
+    /requires a full LoCoMo run/,
+  );
+  assert.throws(
+    () => parseBenchArgs(["run", "locomo", "--limit", "10", ...selectorFlags]),
+    /cannot be combined with --limit or --trial-limit/,
+  );
+  assert.throws(
+    () => parseBenchArgs(["run", "locomo", "--trial-limit", "10", ...selectorFlags]),
+    /cannot be combined with --limit or --trial-limit/,
+  );
+});
+
 test("parseBenchArgs accepts --trial-limit for bench run memoryagentbench", () => {
   const parsed = parseBenchArgs(["run", "memoryagentbench", "--trial-limit", "2"]);
 

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -94,6 +94,8 @@ export interface ParsedBenchArgs {
   sourceResultId?: string;
   expectedAnswerSetSha256?: string;
   expectedQuestionIdListSha256?: string;
+  taskIdsFile?: string;
+  expectedTaskIdListSha256?: string;
   drainTimeout?: number;
   /** Max wall-clock time (ms) to keep retrying 429 rate-limit responses. */
   max429WaitMs?: number;
@@ -472,6 +474,8 @@ const BENCH_VALUE_FLAGS = Object.freeze([
   "--source-result-id",
   "--expected-answer-set-sha256",
   "--expected-question-id-list-sha256",
+  "--task-ids-file",
+  "--expected-task-id-list-sha256",
   "--drain-timeout",
   "--max-429-wait",
   "--ama-bench-judge-protocol",
@@ -563,6 +567,8 @@ const RUN_VALUE_FLAGS = Object.freeze([
   "--calibration-dir",
   "--calibration-local-config-sha256",
   "--calibration-frontier-config-sha256",
+  "--task-ids-file",
+  "--expected-task-id-list-sha256",
   "--drain-timeout",
   "--max-429-wait",
   "--ama-bench-judge-protocol",
@@ -918,6 +924,8 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const sourceResultId = readBenchOptionValue(args, "--source-result-id");
   const expectedAnswerSetSha256 = readBenchOptionValue(args, "--expected-answer-set-sha256");
   const expectedQuestionIdListSha256 = readBenchOptionValue(args, "--expected-question-id-list-sha256");
+  const taskIdsFileRaw = readBenchOptionValue(args, "--task-ids-file");
+  const expectedTaskIdListSha256 = readBenchOptionValue(args, "--expected-task-id-list-sha256");
   const drainTimeoutRaw = readBenchOptionValue(args, "--drain-timeout");
   // Issue #1573 PR1: judge-result cache directory override. `parseBenchArgs`
   // resolves tildes + relative paths identically to other filesystem flags
@@ -1139,6 +1147,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   for (const [flag, digest] of [
     ["--expected-answer-set-sha256", expectedAnswerSetSha256],
     ["--expected-question-id-list-sha256", expectedQuestionIdListSha256],
+    ["--expected-task-id-list-sha256", expectedTaskIdListSha256],
     ["--calibration-local-config-sha256", calibrationLocalConfigSha256],
     ["--calibration-frontier-config-sha256", calibrationFrontierConfigSha256],
   ] as const) {
@@ -1283,6 +1292,33 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     );
   if (publishedTrialLimit !== undefined && !trialLimitTargetsSupportedBenchmark) {
     throw new Error("ERROR: --trial-limit is currently supported only for LoCoMo and MemoryAgentBench.");
+  }
+
+  const hasTaskIdsFile = taskIdsFileRaw !== undefined;
+  const hasExpectedTaskIdListSha256 = expectedTaskIdListSha256 !== undefined;
+  if (hasTaskIdsFile !== hasExpectedTaskIdListSha256) {
+    throw new Error(
+      "ERROR: --task-ids-file and --expected-task-id-list-sha256 must be supplied together.",
+    );
+  }
+  if (hasTaskIdsFile) {
+    const targetsSingleLoCoMo = action === "published"
+      ? publishedName === "locomo" && benchmarks.length === 0
+      : action === "run" && !args.includes("--all") &&
+        benchmarks.length === 1 && benchmarks[0] === "locomo";
+    if (!targetsSingleLoCoMo) {
+      throw new Error(
+        "ERROR: --task-ids-file is supported only for a single LoCoMo run.",
+      );
+    }
+    if (args.includes("--quick")) {
+      throw new Error("ERROR: --task-ids-file requires a full LoCoMo run; remove --quick.");
+    }
+    if (publishedLimit !== undefined || publishedTrialLimit !== undefined) {
+      throw new Error(
+        "ERROR: --task-ids-file cannot be combined with --limit or --trial-limit.",
+      );
+    }
   }
 
   let publishedTrialConcurrency: number | undefined;
@@ -1606,6 +1642,10 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     sourceResultId,
     expectedAnswerSetSha256,
     expectedQuestionIdListSha256,
+    taskIdsFile: taskIdsFileRaw
+      ? path.resolve(expandTilde(taskIdsFileRaw))
+      : undefined,
+    expectedTaskIdListSha256,
     drainTimeout,
     // Issue #1573 PR1: surface judge-cache flags into the runner options.
     noJudgeCache: args.includes("--no-judge-cache"),

--- a/packages/remnic-cli/src/bench-task-selector.test.ts
+++ b/packages/remnic-cli/src/bench-task-selector.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { __benchDatasetTestHooks } from "./index.js";
+import { runCli } from "./run-cli.js";
 
 const DIGEST = "a".repeat(64);
 
@@ -80,4 +81,110 @@ test("CLI redacts the selector file path from persisted repro argv", () => {
       DIGEST,
     ],
   );
+});
+
+test("LoCoMo published dry-run validates a pinned selector through the runner", async () => {
+  const selector = {
+    kind: "explicit-task-ids" as const,
+    taskIds: ["unknown-task"],
+    expectedSelectedTaskIdsSha256: DIGEST,
+  };
+  let capturedOptions: Record<string, unknown> | undefined;
+  const benchModule = {
+    async runBenchmark(_id: string, options: Record<string, unknown>) {
+      capturedOptions = options;
+      throw new Error("Unknown LoCoMo task id: unknown-task");
+    },
+  };
+
+  await assert.rejects(
+    __benchDatasetTestHooks.validatePinnedLoCoMoPublishedDryRunSelectorWithModuleForTest(
+      benchModule,
+      "full",
+      "/tmp/locomo",
+      undefined,
+      42,
+      { taskSelector: selector },
+      selector,
+    ),
+    /Unknown LoCoMo task id: unknown-task/,
+  );
+  assert.deepEqual(capturedOptions?.benchmarkOptions, { taskSelector: selector });
+});
+
+test("LoCoMo published dry-run does not invoke the runner without a pinned selector", async () => {
+  let invoked = false;
+  await __benchDatasetTestHooks.validatePinnedLoCoMoPublishedDryRunSelectorWithModuleForTest(
+    {
+      async runBenchmark() {
+        invoked = true;
+      },
+    },
+    "full",
+    "/tmp/locomo",
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  );
+  assert.equal(invoked, false);
+});
+
+test("bench published LoCoMo dry-run rejects an unknown pinned task id", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-task-selector-cli-"));
+  const selectorPath = path.join(dir, "task-ids.json");
+  fs.writeFileSync(selectorPath, JSON.stringify(["unknown-task"]));
+  fs.writeFileSync(
+    path.join(dir, "locomo10.json"),
+    JSON.stringify([
+      {
+        sample_id: "selector-dry-run",
+        conversation: {
+          speaker_a: "Maya",
+          speaker_b: "Assistant",
+          session_1: [
+            { speaker: "Maya", dia_id: "D1:1", text: "I moved to Austin." },
+          ],
+        },
+        qa: [
+          {
+            question: "Where did Maya move?",
+            answer: "Austin",
+            evidence: ["D1:1"],
+            category: 1,
+          },
+        ],
+      },
+    ]),
+  );
+
+  try {
+    const result = await runCli(
+      [
+        "bench",
+        "published",
+        "--name",
+        "locomo",
+        "--dataset",
+        dir,
+        "--model",
+        "gpt-5.6-luna",
+        "--provider",
+        "codex-cli",
+        "--task-ids-file",
+        selectorPath,
+        "--expected-task-id-list-sha256",
+        DIGEST,
+        "--trial-concurrency",
+        "1",
+        "--dry-run",
+      ],
+      { cwd: path.resolve(import.meta.dirname, "../../..") },
+    );
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stdout, /\[dry-run\] locomo: source=dataset/);
+    assert.match(result.stderr, /Unknown LoCoMo task id: unknown-task/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-cli/src/bench-task-selector.test.ts
+++ b/packages/remnic-cli/src/bench-task-selector.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { __benchDatasetTestHooks } from "./index.js";
+
+const DIGEST = "a".repeat(64);
+
+test("CLI loads an explicit LoCoMo selector and forwards no local path", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-task-selector-"));
+  const selectorPath = path.join(dir, "task-ids.json");
+  fs.writeFileSync(selectorPath, JSON.stringify(["task-b", "task-a"]));
+  try {
+    const selector = __benchDatasetTestHooks.loadPinnedLoCoMoTaskSelectorForTest({
+      taskIdsFile: selectorPath,
+      expectedTaskIdListSha256: DIGEST,
+    });
+    assert.deepEqual(selector, {
+      kind: "explicit-task-ids",
+      taskIds: ["task-b", "task-a"],
+      expectedSelectedTaskIdsSha256: DIGEST,
+    });
+
+    const options = __benchDatasetTestHooks.buildPublishedBenchmarkOptionsForTest(
+      "locomo",
+      {},
+      selector,
+    );
+    assert.deepEqual(options?.taskSelector, selector);
+    assert.equal(JSON.stringify(options).includes(selectorPath), false);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI rejects malformed or duplicate explicit LoCoMo selectors", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-task-selector-"));
+  try {
+    for (const [value, expected] of [
+      [{ task: "task-a" }, /non-empty array of strings/],
+      [[], /non-empty array of strings/],
+      [["task-a", ""], /only non-empty strings/],
+      [["task-a", "task-a"], /must not contain duplicate task IDs/],
+    ] as const) {
+      const selectorPath = path.join(dir, `${Math.random()}.json`);
+      fs.writeFileSync(selectorPath, JSON.stringify(value));
+      assert.throws(
+        () => __benchDatasetTestHooks.loadPinnedLoCoMoTaskSelectorForTest({
+          taskIdsFile: selectorPath,
+          expectedTaskIdListSha256: DIGEST,
+        }),
+        expected,
+      );
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI redacts the selector file path from persisted repro argv", () => {
+  assert.deepEqual(
+    __benchDatasetTestHooks.redactBenchTaskIdsFilePathForTest([
+      "bench",
+      "run",
+      "locomo",
+      "--task-ids-file",
+      "/private/host/path/task-ids.json",
+      "--expected-task-id-list-sha256",
+      DIGEST,
+    ]),
+    [
+      "bench",
+      "run",
+      "locomo",
+      "--task-ids-file",
+      "<task-ids-file>",
+      "--expected-task-id-list-sha256",
+      DIGEST,
+    ],
+  );
+});

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1997,6 +1997,25 @@ export const __benchDatasetTestHooks = {
       benchmarkOptions,
     );
   },
+  validatePinnedLoCoMoPublishedDryRunSelectorWithModuleForTest(
+    benchModule: unknown,
+    mode: "quick" | "full",
+    datasetDir: string | undefined,
+    limit: number | undefined,
+    seed: number | undefined,
+    benchmarkOptions: Record<string, unknown> | undefined,
+    taskSelector: PackageBenchTaskSelector | undefined,
+  ) {
+    return validatePinnedLoCoMoPublishedDryRunSelector(
+      benchModule as PackageBenchModule,
+      mode,
+      datasetDir,
+      limit,
+      seed,
+      benchmarkOptions,
+      taskSelector,
+    );
+  },
   printBenchStatusLineForTest: printBenchStatusLine,
 };
 
@@ -3031,6 +3050,24 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
       );
       process.exit(1);
     }
+    if (benchmarkId === "locomo") {
+      try {
+        await validatePinnedLoCoMoPublishedDryRunSelector(
+          benchModule,
+          mode,
+          parsed.datasetDir,
+          effectiveLimit,
+          parsed.publishedSeed,
+          benchmarkOptions,
+          taskSelector,
+        );
+      } catch (error) {
+        console.error(
+          `ERROR: [dry-run] ${benchmarkId}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exit(1);
+      }
+    }
     return;
   }
 
@@ -3257,6 +3294,29 @@ async function validateRunnerManagedPublishedDryRunDataset(
     }
     throw error;
   }
+}
+
+async function validatePinnedLoCoMoPublishedDryRunSelector(
+  benchModule: PackageBenchModule,
+  mode: "quick" | "full",
+  datasetDir: string | undefined,
+  limit: number | undefined,
+  seed: number | undefined,
+  benchmarkOptions: Record<string, unknown> | undefined,
+  taskSelector: PackageBenchTaskSelector | undefined,
+): Promise<void> {
+  if (taskSelector === undefined) {
+    return;
+  }
+  await validateRunnerManagedPublishedDryRunDataset(
+    benchModule,
+    "locomo",
+    mode,
+    datasetDir,
+    limit,
+    seed,
+    benchmarkOptions,
+  );
 }
 
 async function validateRunnerManagedPublishedDryRunDatasetForTest(

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -495,6 +495,12 @@ type PackageBenchProviderConfig = {
   reasoningEffort?: "low" | "medium" | "high" | "xhigh";
 };
 
+type PackageBenchTaskSelector = {
+  kind: "explicit-task-ids";
+  taskIds: string[];
+  expectedSelectedTaskIdsSha256: string;
+};
+
 type PackageBenchModule = {
   getBenchmark?: (id: string) => {
     runnerAvailable?: boolean;
@@ -1067,6 +1073,9 @@ Options:
                            Path to a local-lab manifest JSON file (required for --runtime-profile local-lab)
   --threshold <value>      Regression threshold for compare (default: 0.05)
   --trial-limit <n>        Cap scored LoCoMo or MemoryAgentBench QA trials for staged published runs
+  --task-ids-file <path>   Select an explicit JSON array of LoCoMo task IDs
+  --expected-task-id-list-sha256 <sha256>
+                           Pin the selected LoCoMo task-ID list
   --task-filter <pattern>  BEAM diagnostic filter; match task id, ability, or question text
   --detail                 Include per-task details for bench results
   --format <json|csv|html> Output format for bench export
@@ -1323,6 +1332,11 @@ async function runBenchViaFallback(
   benchmarkId: string,
   runtimeProfile: BenchRuntimeProfile,
 ): Promise<string> {
+  if (parsed.taskIdsFile) {
+    throw new Error(
+      "Fallback benchmark runner does not support hash-pinned LoCoMo task selection. Build/install @remnic/bench to use --task-ids-file.",
+    );
+  }
   if (runtimeProfile === "real" && parsed.remnicConfigPath) {
     resolveExistingBenchRemnicConfigPath(parsed.remnicConfigPath);
   }
@@ -1957,9 +1971,12 @@ export const __benchDatasetTestHooks = {
       publishedTrialConcurrency?: number;
       publishedTaskFilter?: string;
     },
+    taskSelector?: PackageBenchTaskSelector,
   ) {
-    return buildPublishedBenchmarkOptions(benchmarkId, args);
+    return buildPublishedBenchmarkOptions(benchmarkId, args, taskSelector);
   },
+  loadPinnedLoCoMoTaskSelectorForTest: loadPinnedLoCoMoTaskSelector,
+  redactBenchTaskIdsFilePathForTest: redactBenchTaskIdsFilePath,
   validateRunnerManagedPublishedDryRunDatasetForTest,
   validateRunnerManagedPublishedDryRunDatasetWithModuleForTest(
     benchModule: unknown,
@@ -2894,6 +2911,7 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
     );
     process.exit(1);
   }
+  const taskSelector = loadPinnedLoCoMoTaskSelector(parsed);
 
   // Dry-run: validate config and load the dataset, but never touch the
   // model. Useful for pre-flight checking a long run. Prints a single
@@ -2920,6 +2938,7 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
     const benchmarkOptions = buildPublishedBenchmarkOptions(
       benchmarkId,
       parsed,
+      taskSelector,
     );
     let itemCount: number | undefined;
     // Codex P2 review on PR #603: when the loader returns
@@ -3031,6 +3050,8 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
       parsed,
       benchmarkId,
       runtimeProfile,
+      undefined,
+      taskSelector,
     );
     if (!result.ok) {
       console.error(
@@ -3117,6 +3138,7 @@ function buildPublishedBenchmarkOptions(
     publishedTaskFilter?: string;
     memcorrectAdapter?: "remnic" | "prompt-only";
   },
+  taskSelector?: PackageBenchTaskSelector,
 ): Record<string, unknown> | undefined {
   const trialLimitOptions =
     args.publishedTrialLimit !== undefined
@@ -3131,6 +3153,7 @@ function buildPublishedBenchmarkOptions(
       ...(trialLimitOptions ?? {}),
       ...(trialConcurrencyOptions ?? {}),
       replayExtractionMode: "skip",
+      ...(taskSelector ? { taskSelector } : {}),
     };
   }
   if (benchmarkId === "ama-bench") {
@@ -3146,6 +3169,53 @@ function buildPublishedBenchmarkOptions(
     return { adapter: args.memcorrectAdapter };
   }
   return undefined;
+}
+
+function loadPinnedLoCoMoTaskSelector(
+  parsed: Pick<ParsedBenchArgs, "taskIdsFile" | "expectedTaskIdListSha256">,
+): PackageBenchTaskSelector | undefined {
+  if (!parsed.taskIdsFile) return undefined;
+  if (!parsed.expectedTaskIdListSha256) {
+    throw new Error(
+      "--task-ids-file requires --expected-task-id-list-sha256.",
+    );
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(fs.readFileSync(parsed.taskIdsFile, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Unable to read --task-ids-file ${parsed.taskIdsFile}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!Array.isArray(decoded) || decoded.length === 0) {
+    throw new Error("--task-ids-file JSON must be a non-empty array of strings.");
+  }
+  if (decoded.some((taskId) => typeof taskId !== "string" || taskId.length === 0)) {
+    throw new Error("--task-ids-file JSON must contain only non-empty strings.");
+  }
+  const taskIds = decoded as string[];
+  if (new Set(taskIds).size !== taskIds.length) {
+    throw new Error("--task-ids-file must not contain duplicate task IDs.");
+  }
+
+  return {
+    kind: "explicit-task-ids",
+    taskIds,
+    expectedSelectedTaskIdsSha256: parsed.expectedTaskIdListSha256,
+  };
+}
+
+function redactBenchTaskIdsFilePath(argv: readonly string[]): string[] {
+  const redacted = [...argv];
+  for (let index = 0; index < redacted.length; index += 1) {
+    if (redacted[index] === "--task-ids-file" && index + 1 < redacted.length) {
+      redacted[index + 1] = "<task-ids-file>";
+      index += 1;
+    }
+  }
+  return redacted;
 }
 
 async function validateRunnerManagedPublishedDryRunDataset(
@@ -3360,6 +3430,7 @@ async function runBenchViaPackage(
   benchmarkId: string,
   runtimeProfile: BenchRuntimeProfile,
   benchStatusPath?: string,
+  taskSelector?: PackageBenchTaskSelector,
 ): Promise<{ ok: boolean; writtenPath?: string }> {
   const loaded = await tryLoadBenchModule();
   if (!loaded) return { ok: false };
@@ -3429,7 +3500,11 @@ async function runBenchViaPackage(
   // parsed but dropped, and the harness recorded `ctx.options.seed ?? 0`
   // instead of the user-specified seed, breaking reproducibility.
   const effectiveSeed = parsed.publishedSeed;
-  let benchmarkOptions = buildPublishedBenchmarkOptions(benchmarkId, parsed);
+  let benchmarkOptions = buildPublishedBenchmarkOptions(
+    benchmarkId,
+    parsed,
+    taskSelector,
+  );
 
   try {
     const amaBenchProtocol = buildAmaBenchProtocolOptions(
@@ -4068,7 +4143,7 @@ async function writeBenchReproManifestForPackageRun(args: {
       datasetDirs: resolveBenchReproDatasetDirs(args.parsed, args.benchmarkIds),
       command: {
         cwd: process.cwd(),
-        argv: process.argv.slice(2),
+        argv: redactBenchTaskIdsFilePath(process.argv.slice(2)),
         env: process.env,
         envKeys: resolveBenchReproEnvKeys(),
       },
@@ -10721,6 +10796,7 @@ async function cmdBench(rest: string[]): Promise<void> {
     process.exit(1);
   }
 
+  const taskSelector = loadPinnedLoCoMoTaskSelector(parsed);
   const runtimeProfiles = resolveBenchRunProfiles(parsed);
   let selectedWorkItems = createBenchWorkItems(selectedBenchmarks, runtimeProfiles);
 
@@ -10816,6 +10892,7 @@ async function cmdBench(rest: string[]): Promise<void> {
             benchmarkId,
             runtimeProfile,
             benchStatusPath,
+            taskSelector,
           );
           if (handledByPackage.ok) {
             if (handledByPackage.writtenPath) {

--- a/scripts/bench/build-artifact-from-result.ts
+++ b/scripts/bench/build-artifact-from-result.ts
@@ -198,8 +198,9 @@ export function parseArgs(argv: string[]): ArgParseResult {
 /**
  * Validate a parsed result for promotion to a publishable artifact. Publish-
  * safety guards (issue #1712): reject unpublished benchmark ids, partial /
- * quick-mode runs, and runs persisted with a `benchmarkOptions.limit` or
- * `trialLimit` — only complete full runs may be published. Structural
+ * quick-mode runs, and runs persisted with a `benchmarkOptions.limit`,
+ * `trialLimit`, or `taskSelection` — only complete full-dataset runs may be
+ * published. Structural
  * validation of the inner task/aggregate shape is delegated to
  * `buildBenchmarkArtifact`, which throws with a per-field diagnostic.
  */
@@ -278,6 +279,13 @@ export function validateResultForPromotion(result: unknown): ValidationResult {
         ok: false,
         message:
           "refusing to promote a limited run (config.benchmarkOptions.limit/trialLimit set); only full runs may be published.",
+      };
+    }
+    if (Object.prototype.hasOwnProperty.call(benchmarkOptions, "taskSelection")) {
+      return {
+        ok: false,
+        message:
+          "refusing to promote selected coverage (config.benchmarkOptions.taskSelection set); only full-dataset runs may be published.",
       };
     }
   }

--- a/scripts/bench/verify-public-matrix.ts
+++ b/scripts/bench/verify-public-matrix.ts
@@ -553,8 +553,8 @@ function validateFullDatasetRunOptions(
     }
   }
   const disallowedKeys = allowBoundedTrial
-    ? (["taskFilter"] as const)
-    : ([...boundedKeys, "taskFilter"] as const);
+    ? (["taskFilter", "taskSelection"] as const)
+    : ([...boundedKeys, "taskFilter", "taskSelection"] as const);
   for (const key of disallowedKeys) {
     if (Object.prototype.hasOwnProperty.call(benchmarkOptions, key)) {
       addIssue(

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -298,10 +298,10 @@ tests/bench-openai-provider.test.ts(86,30): TS2722
 tests/bench-openai-provider.test.ts(86,30): TS18048
 tests/bench-public-matrix-verifier.test.ts(412,7): TS2740
 tests/bench-public-matrix-verifier.test.ts(416,7): TS2739
-tests/bench-public-matrix-verifier.test.ts(989,7): TS2740
-tests/bench-public-matrix-verifier.test.ts(992,7): TS2739
-tests/bench-public-matrix-verifier.test.ts(1059,7): TS2740
-tests/bench-public-matrix-verifier.test.ts(1142,7): TS2739
+tests/bench-public-matrix-verifier.test.ts(1027,7): TS2740
+tests/bench-public-matrix-verifier.test.ts(1030,7): TS2739
+tests/bench-public-matrix-verifier.test.ts(1097,7): TS2740
+tests/bench-public-matrix-verifier.test.ts(1180,7): TS2739
 tests/bench-remnic-deterministic-runners.test.ts(221,37): TS2339
 tests/bench-ui-assistant.test.ts(21,9): TS2741
 tests/bench-ui-results.test.ts(20,8): TS6142

--- a/tests/bench-build-artifact-helper.test.ts
+++ b/tests/bench-build-artifact-helper.test.ts
@@ -276,6 +276,23 @@ test("validateResultForPromotion rejects a limited run via benchmarkOptions.tria
   assert.match(!r.ok && r.message, /refusing to promote a limited run/);
 });
 
+test("validateResultForPromotion rejects selected task coverage", () => {
+  const r = validateResultForPromotion(makeResult({
+    benchmarkOptions: {
+      taskSelection: {
+        algorithm: "explicit-task-ids",
+        version: 1,
+        candidateCount: 1_986,
+        selectedCount: 1,
+        selectedTaskIds: ["locomo-task-1"],
+        selectedTaskIdsSha256: "a".repeat(64),
+      },
+    },
+  }));
+  assert.equal(r.ok, false);
+  assert.match(!r.ok && r.message, /refusing to promote selected coverage.*taskSelection/);
+});
+
 test("validateResultForPromotion treats a null benchmarkOptions as absent (typeof null === object footgun)", () => {
   // JSON `null` must not crash the limit check (typeof null === "object").
   const r = validateResultForPromotion(makeResult({ benchmarkOptions: null as unknown as Record<string, unknown> }));

--- a/tests/bench-public-matrix-verifier.test.ts
+++ b/tests/bench-public-matrix-verifier.test.ts
@@ -727,6 +727,44 @@ test("accepts a manifest whose artifact hash binds a Codex credit receipt", asyn
   assert.equal(limitedIssues.length, 1, JSON.stringify(filteredTrial.issues, null, 2));
   assert.match(limitedIssues[0]!.message, /taskFilter/);
 
+  result.config.benchmarkOptions = {
+    limit: 1,
+    taskSelection: {
+      algorithm: "explicit-task-ids",
+      version: 1,
+      candidateCount: 1_986,
+      selectedCount: 1,
+      selectedTaskIds: [result.results.tasks[0]!.taskId],
+      selectedTaskIdsSha256: "a".repeat(64),
+    },
+  };
+  await writeResult(resultsDir, result);
+  await writeManifest(
+    resultsDir,
+    [benchmark],
+    "abc123",
+    1,
+    "test-public-matrix-run",
+    validCodexCreditReceipt(),
+  );
+  const selectedTrial = await verifyPublicMatrixEvidence({
+    resultsDir,
+    benchmarks: [benchmark],
+    expectedGitSha: "abc123",
+    expectedSystemModel: "gpt-5.6-luna",
+    expectedJudgeModel: "gpt-5.6-terra",
+    expectedInternalModel: "gpt-5.6-luna",
+    expectedSystemReasoningEffort: "medium",
+    expectedJudgeReasoningEffort: "high",
+    expectedInternalReasoningEffort: "medium",
+    expectedServiceTier: "default",
+    requireCodexCreditReceipt: true,
+    allowBoundedTrial: true,
+  });
+  const selectedIssues = selectedTrial.issues.filter((issue) => issue.code === "limited-result");
+  assert.equal(selectedIssues.length, 1, JSON.stringify(selectedTrial.issues, null, 2));
+  assert.match(selectedIssues[0]!.message, /taskSelection/);
+
   result.config.benchmarkOptions = { limit: 1 };
   await writeResult(resultsDir, result);
   await writeManifest(


### PR DESCRIPTION
## Summary
- add a shared, deterministic LoCoMo task selector used by scored and retrieval-trace runs
- expose hash-pinned selector files through the CLI without persisting private paths
- require canonical paired selection provenance in the recall delta analyzer
- reject selected diagnostics from full-artifact promotion and the public full matrix

## Why
Issue #1879 needs a current-head paired scored rerun over the exact 321 multi-hop tasks (selector SHA-256 `bbc56610faefc0a65704f713c6c7aa8ce5a7f71ca060a1e3d218c57a514f21b9`). Existing `--limit` and `--trial-limit` cannot select those tasks across all ten conversations while retaining complete conversation ingest.

## Verification
- 147 focused tests pass
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/cli check-types`
- `npm run preflight:quick`

## Evidence safety
Selected runs remain full-mode but partial-coverage diagnostics. Their canonical task IDs and hash are persisted; the private selector path is redacted; promotion/public-matrix guards reject them.

Refs #1879 #1880

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark run semantics, CLI flags, and evidence gates for LoCoMo; mistakes could affect reproducibility or incorrectly allow/block publication, but scope is bench/CLI with heavy test coverage and fail-fast validation.
> 
> **Overview**
> Adds **shared, deterministic LoCoMo task selection** so scored runs, retrieval-trace capture, and recall-delta analysis all agree on which tasks ran and in what canonical order.
> 
> A new `task-selection` module centralizes explicit ID lists and SHA-256–seeded sampling; retrieval-trace selection delegates to it instead of duplicating logic. The LoCoMo runner accepts an optional **hash-pinned** `taskSelector`, filters trials while keeping **full conversation ingest** for selected conversations, persists a runner-owned `taskSelection` manifest (and drops the caller’s selector from stored config), and rejects incompatible modes (`quick`, `limit`, `trialLimit`, `trialConcurrency` ≠ 1).
> 
> The CLI adds **`--task-ids-file`** and **`--expected-task-id-list-sha256`** for single full LoCoMo runs, validates them in published dry-run, redacts the file path from repro argv, and blocks the fallback runner from using them. **Recall delta** diagnostics require matching `taskSelection` provenance for partial runs and validate manifests against result task order. **Promotion and public-matrix** checks now reject results that carry `taskSelection`, marking them as partial-coverage diagnostics rather than publishable full-dataset evidence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd5d7cae6b8e4fda4adc85d4b3a48f2ecd13fa20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->