### PR TITLE
fix(plugin-hermes): inject profile context when count is 0 and make prefetch wait configurable (#1929)

### DIFF
--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -15,6 +15,7 @@ Canonical upstream references:
 - [Why MemoryProvider](#why-memoryprovider)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
+- [How Hermes discovers the provider](#how-hermes-discovers-the-provider)
 - [Configuration reference](#configuration-reference)
 - [Environment variable overrides](#environment-variable-overrides)
 - [Token bootstrap](#token-bootstrap)
@@ -36,7 +37,7 @@ Remnic registers as a Hermes **memory provider** (`plugin.yaml` declares `kind: 
 
 The manifest declares Hermes-supported capability metadata with `provides_tools` and `provides_hooks`. It does not declare or register a context engine.
 
-**Remnic does not, and should not, register as a Hermes `context_engine`.** Hermes' `context_engine` slot replaces the built-in `ContextCompressor` — it controls how Hermes compresses *its own outgoing conversation history* before sending to the LLM. That is a different concern from external memory recall. Remnic delivers all of the following through the `memory_provider` hook chain (`pre_llm_call` → recall envelope), with no `context_engine` registration involved:
+**Remnic does not, and should not, register as a Hermes `context_engine`.** Hermes' `context_engine` slot replaces the built-in `ContextCompressor` — it controls how Hermes compresses *its own outgoing conversation history* before sending to the LLM. That is a different concern from external memory recall. Remnic delivers all of the following through the MemoryProvider protocol (`prefetch()` → recall envelope), with no `context_engine` registration involved:
 
 - Recalled memories from the Remnic store
 - Lossless Context Management (LCM) compressed-history sections, when the Remnic daemon has `lcmEnabled: true`
@@ -88,7 +89,7 @@ remnic connectors install hermes
 pip install --upgrade remnic-hermes
 ```
 
-Then add the config block manually — see [Configuration reference](#configuration-reference).
+Then add the config block manually and create the memory-provider shim — see [Configuration reference](#configuration-reference) and [How Hermes discovers the provider](#how-hermes-discovers-the-provider).
 
 ### Option C: editable install from source
 
@@ -97,17 +98,46 @@ cd packages/plugin-hermes
 pip install -e ".[dev]"
 ```
 
+### How Hermes discovers the provider
+
+Hermes memory providers are discovered by directory scan, not by pip metadata. Upstream (`plugins/memory/__init__.py`, verified against `NousResearch/hermes-agent` commit `53adb3f`, 2026-07-16) scans:
+
+1. Bundled providers: `<hermes-repo>/plugins/memory/<name>/`
+2. User-installed providers: `$HERMES_HOME/plugins/<name>/` (default `~/.hermes/plugins/<name>/`)
+
+A pip install of `remnic-hermes` into site-packages is **not** scanned, so the package alone does not register with Hermes. You need a small shim directory whose `__init__.py` bridges to the pip package:
+
+```python
+# $HERMES_HOME/plugins/remnic/__init__.py
+"""Remnic memory provider shim. Calls collector.register_memory_provider()."""
+
+from remnic_hermes import register  # register() handles config loading itself
+```
+
+Hermes' discovery heuristic requires the literal text `register_memory_provider` or `MemoryProvider` to appear in the shim's `__init__.py` source (cheap text scan before import), which the docstring above satisfies. Hermes calls the module's `register(collector)`; the collector exposes `register_memory_provider()` but carries **no** `.config` attribute, so `remnic_hermes.register()` falls back to reading the Hermes host config via `hermes_cli.config.load_config_readonly()` (added in `remnic-hermes` 1.0.5, issue #1929).
+
+Then select the provider in `config.yaml`:
+
+```yaml
+memory:
+  provider: remnic
+  memory_enabled: true
+```
+
+Only one memory provider can be active at a time (`kind: exclusive`).
+
 ---
 
 ## Configuration reference
 
-The plugin entry point is `register(ctx)` in `remnic_hermes/__init__.py`. It reads configuration from `ctx.config["remnic"]`, falling back to `ctx.config["engram"]` if the `remnic` key is absent. The extracted dict is passed directly to `RemnicMemoryProvider`.
+The plugin entry point is `register(ctx)` in `remnic_hermes/__init__.py`. It reads configuration from `ctx.config["remnic"]`, falling back to `ctx.config["engram"]` if the `remnic` key is absent. When the context carries no `config` attribute at all (Hermes' memory-provider discovery collector), the Hermes host config is loaded directly via `hermes_cli.config.load_config_readonly()`. The extracted dict is passed to `RemnicMemoryProvider`.
 
-In Hermes `config.yaml`, the config block sits at the **top level** under a `remnic:` key (or `engram:` for legacy configs), alongside the `plugins:` list:
+In Hermes `config.yaml`, the config block sits at the **top level** under a `remnic:` key (or `engram:` for legacy configs), alongside the `memory:` block that selects the provider:
 
 ```yaml
-plugins:
-  - remnic_hermes
+memory:
+  provider: remnic        # must match the shim directory name under $HERMES_HOME/plugins/
+  memory_enabled: true
 
 remnic:
   host: "127.0.0.1"
@@ -115,6 +145,7 @@ remnic:
   token: ""
   session_key: ""
   timeout: 30.0
+  prefetch_wait_timeout: 2.0
 ```
 
 ### Field reference
@@ -126,6 +157,7 @@ remnic:
 | `token` | string | `""` | Auth token for the daemon. If empty, auto-loaded from the token store (see [Token bootstrap](#token-bootstrap)). |
 | `session_key` | string | `""` | Session identifier passed on every recall/observe call. If empty, auto-generated as `hermes-<12 random hex chars>` at startup. |
 | `timeout` | float | `30.0` | HTTP request timeout in seconds applied to all daemon calls. |
+| `prefetch_wait_timeout` | float | `2.0` | Maximum seconds `prefetch()` blocks the turn waiting for a first-fetch recall (always additionally capped by `timeout`). Set `0` for pure fire-and-forget: prefetch only ever returns cached results and never waits. Invalid values (negative, non-numeric, NaN/inf) are rejected at load. Added in 1.0.5 (issue #1929). |
 
 No other fields are read. Fields documented elsewhere (such as `namespace`, `recall_top_k`, `recall_mode`, or `token_env`) do not exist in this implementation.
 
@@ -198,15 +230,21 @@ Called when the plugin loads. Creates an `httpx.AsyncClient` pointed at `http://
 
 Note: the HTTP base path currently uses `/engram/v1` because the Remnic daemon exposes a legacy surface during the v1.x compat window. This will change to `/remnic/v1` once the daemon ships the dual-path rollout.
 
+### `prefetch` / `queue_prefetch` — the Hermes injection path
+
+**This is how memory reaches the model in Hermes.** Verified against upstream `NousResearch/hermes-agent` commit `53adb3f` (2026-07-16): `agent/turn_context.py` calls `MemoryManager.prefetch_all()` → `provider.prefetch(query, session_id=...)` **synchronously** on the turn hot path, and the returned text is injected into the current turn's user message. Hermes imposes no timeout of its own on `prefetch()`, so the provider is responsible for bounding its own latency. After each completed turn, Hermes calls `queue_prefetch()` and `sync_turn()` on a background executor.
+
+`prefetch()` behavior:
+
+1. **Skips recall entirely** if the query is absent or fewer than 3 words (whitespace-split). This avoids triggering recall on very short acknowledgments like "ok" or "thanks".
+2. Serves from a per-session in-memory cache (60s TTL, invalidated by `sync_turn` and session switches) when possible.
+3. On a cache miss, starts `POST /recall` (query, `sessionKey`, `topK: 8`) on a background event loop and waits up to `prefetch_wait_timeout` seconds (default 2.0, capped by `timeout`) for the result. If the recall is still in flight when the wait expires, `prefetch()` returns `""` for this turn and the completed result populates the cache for the next turn.
+4. A non-empty `context` in the daemon response is wrapped in a `<remnic-memory count="N">` block. **`count` may be `0` with a populated `context`** — the daemon returns profile and knowledge-index sections even when no specific memory IDs matched the query. The block is injected either way; only an empty `context` yields `""` (fixed in 1.0.5, issue #1929).
+5. Exceptions are swallowed (logged at DEBUG on the `remnic_hermes.provider` logger); returns `""` on any error so the LLM call proceeds normally.
+
 ### `pre_llm_call`
 
-Called before every LLM request. Behavior:
-
-1. Scans `messages` in reverse to find the last message with `role: "user"`.
-2. **Skips recall entirely** if the user message is absent or fewer than 3 words (whitespace-split). This avoids triggering recall on very short acknowledgments like "ok" or "thanks".
-3. Issues `POST /recall` with the user message as the query, `sessionKey`, and `topK: 8`. The plugin leaves recall mode unset so the daemon default can include LCM compressed-history sections when `lcmEnabled: true`.
-4. If the response has a non-empty `context` field and `count > 0`, returns a `<remnic-memory count="N">` block that Hermes injects into the system prompt.
-5. Exceptions are swallowed; returns `""` on any error so the LLM call proceeds normally.
+Retained for hosts that embed the provider directly, but **Hermes never calls `pre_llm_call` on memory providers** — the `pre_llm_call` hook exists only in Hermes' general plugin system (`hermes_cli.plugins`), a separate registration path from the MemoryProvider protocol. Do not describe `pre_llm_call` as the Hermes injection path; that is `prefetch()` above. `pre_llm_call(messages)` performs the same recall as `prefetch()` (last user message as query, same 3-word gate, same `<remnic-memory>` block) without the cache/wait machinery.
 
 ### `sync_turn`
 
@@ -431,6 +469,8 @@ Install into the correct environment: `<path-to-hermes-python> -m pip install --
 2. Confirm the query is at least 3 words — `pre_llm_call` skips recall for shorter messages.
 3. Confirm the token is valid: a 401 is swallowed silently, so daemon health does not catch it.
 4. Use the explicit tool to test the round-trip: call `remnic_recall` with a query. If it returns `{"error": "Not connected to Remnic"}`, `initialize` never completed successfully.
+5. Enable debug logging for the provider's critical path (added in 1.0.5): configure Python logging so the `remnic_hermes.provider` logger emits DEBUG. It reports prefetch wait expiries, background recall failures, and recalls that returned no context (with `count` and `sourcesUsed`).
+6. If your daemon is slow (e.g. Docker with a bind-mounted memory dir), recall can exceed the prefetch wait. Raise `prefetch_wait_timeout` (trades turn latency for first-turn injection) — the background recall still completes and feeds the cache for the next turn either way.
 
 ### Memories from a previous session are not recalled
 

--- a/llms.txt
+++ b/llms.txt
@@ -236,7 +236,17 @@ CONNECTING OTHER AGENTS
   remnic connectors install claude-code
   remnic connectors install codex-cli
   remnic connectors install replit
-  pip install remnic-hermes
+  pip install remnic-hermes && remnic connectors install hermes
+
+Hermes discovers memory providers by scanning $HERMES_HOME/plugins/<name>/,
+not pip metadata: the pip package must be bridged by a shim
+(~/.hermes/plugins/remnic/__init__.py re-exporting remnic_hermes.register)
+and selected via memory.provider in Hermes config.yaml. Memory is injected
+through the provider's synchronous prefetch() (bounded by the
+prefetch_wait_timeout config, default 2.0s); Hermes never calls
+pre_llm_call on memory providers. The daemon's /recall returns profile and
+knowledge-index context even when count == 0; the plugin injects it either
+way. See docs/plugins/hermes.md.
 
 Built-in connector ids: claude-code, codex-cli, cursor, cline,
 github-copilot, roo-code, windsurf, amp, pi, omp, replit, generic-mcp,

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -12,16 +12,16 @@ MCP tools give an agent the ability to call memory functions, but only when the 
 |--------|----------|---------------|
 | Recall | Agent must call `remnic_recall` | Automatic on every turn |
 | Observe | Agent must call `remnic_store` | Automatic after every response |
-| Latency | Tool call overhead | Pre-fetched, non-blocking |
+| Latency | Tool call overhead | Bounded synchronous wait on first fetch (`prefetch_wait_timeout`, default 2.0s), cached and non-blocking on subsequent turns |
 | Reliability | Agent may forget to call | Structural — cannot be skipped |
 
 ## Which Hermes plugin slot does Remnic use?
 
 Remnic ships as a Hermes memory provider plugin (declared in `plugin.yaml` as `kind: exclusive`, the Hermes manifest kind used for provider plugins selected through `memory.provider`).
 
-**Remnic does not use, and does not need to use, Hermes' `context_engine` slot.** That slot replaces the built-in `ContextCompressor` — it is for *compressing the agent's own outgoing conversation history*. Remnic delivers external memory recall (and, when enabled daemon-side, Lossless Context Management archive content) through the `memory_provider` hook (`pre_llm_call`), which is the correct slot for this concern.
+**Remnic does not use, and does not need to use, Hermes' `context_engine` slot.** That slot replaces the built-in `ContextCompressor` — it is for *compressing the agent's own outgoing conversation history*. Remnic delivers external memory recall (and, when enabled daemon-side, Lossless Context Management archive content) through the MemoryProvider protocol's `prefetch()` hot path, which is the correct slot for this concern.
 
-If you have read documentation or third-party reviews suggesting Remnic must register as a `context_engine` to enable LCM in Hermes, that is incorrect. LCM runs on the Remnic daemon and arrives in Hermes through the recall envelope returned by the memory_provider — no `context_engine` registration is involved. The two slots are orthogonal: a future Remnic-backed `ContextEngine` plugin would be a separate, additive feature for replacing Hermes' local compressor, not a prerequisite for memory or LCM.
+If you have read documentation or third-party reviews suggesting Remnic must register as a `context_engine` to enable LCM in Hermes, that is incorrect. LCM runs on the Remnic daemon and arrives in Hermes through the recall envelope returned by the memory provider's `prefetch()` — no `context_engine` registration is involved. The two slots are orthogonal: a future Remnic-backed `ContextEngine` plugin would be a separate, additive feature for replacing Hermes' local compressor, not a prerequisite for memory or LCM.
 
 ## Prerequisites
 
@@ -41,9 +41,23 @@ If you have read documentation or third-party reviews suggesting Remnic must reg
    remnic connectors install hermes
    ```
 
-3. Restart Hermes so it picks up the new config entry.
+3. Create the memory-provider shim and select the provider (Hermes discovers memory providers by scanning `$HERMES_HOME/plugins/<name>/`, not pip metadata):
+   ```python
+   # ~/.hermes/plugins/remnic/__init__.py
+   """Remnic memory provider shim. Calls collector.register_memory_provider()."""
 
-4. Verify the connection:
+   from remnic_hermes import register  # register() handles config loading itself
+   ```
+   ```yaml
+   # config.yaml
+   memory:
+     provider: remnic
+     memory_enabled: true
+   ```
+
+4. Restart Hermes so it picks up the new config entry.
+
+5. Verify the connection:
    ```bash
    hermes --version && pip show remnic-hermes
    ```
@@ -54,8 +68,9 @@ Your agent should now have structural memory on every turn plus explicit tools s
 If you prefer not to use `remnic connectors install`, add the following to your Hermes `config.yaml` directly:
 
 ```yaml
-plugins:
-  - remnic_hermes
+memory:
+  provider: remnic       # matches the shim directory name under $HERMES_HOME/plugins/
+  memory_enabled: true
 
 remnic:
   host: "127.0.0.1"      # Remnic daemon host. Default: 127.0.0.1
@@ -63,6 +78,7 @@ remnic:
   token: ""              # Auth token. Leave empty to auto-load from ~/.remnic/tokens.json.
   session_key: ""        # Session identifier. Auto-generated as hermes-<12hex> if not set.
   timeout: 30.0          # HTTP request timeout in seconds. Default: 30.0
+  prefetch_wait_timeout: 2.0  # Max seconds prefetch() blocks a turn on a first-fetch recall. 0 = never wait (cache-only). Default: 2.0
 ```
 
 A legacy `engram:` config block is also accepted during the Engram to Remnic transition. The plugin reads `remnic:` first and falls back to `engram:` when the `remnic:` key is absent, so existing configs continue working without edits.
@@ -108,7 +124,9 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | Method | Trigger | Behavior |
 |--------|---------|----------|
 | `initialize` | Plugin loads | Opens an HTTP client to the Remnic daemon and pings `/health`. A failed health check is non-fatal — the daemon may start later. |
-| `pre_llm_call` | Before every LLM call | Recalls up to 8 memories using the last user message as the query. Skipped if the user message is fewer than 3 words. Injects a `<remnic-memory>` block into the system prompt when results are found. |
+| `prefetch` | Before every LLM call (synchronous, Hermes hot path) | Recalls up to 8 memories using the user message as the query (skipped under 3 words). Serves from a per-session cache when warm; on a cache miss waits up to `prefetch_wait_timeout` (default 2.0s) for the recall, else returns `""` and lets the completed recall warm the cache for the next turn. Injects a `<remnic-memory count="N">` block — including when `count` is `0` but the daemon returned profile/knowledge-index context. |
+| `queue_prefetch` | After every turn (background) | Warms the prefetch cache for the next turn. |
+| `pre_llm_call` | Not called by Hermes | Compatibility method for hosts that embed the provider directly; Hermes injects via `prefetch`, not `pre_llm_call`. |
 | `sync_turn` | After every response | Sends the last 2 messages (user + assistant) to the Remnic daemon for real-time observation. |
 | `extract_memories` | Session ends | Sends the full session transcript to the daemon for deep structured extraction. |
 | `on_session_switch` / `on_session_reset` | Hermes session boundary | Keeps generated session keys aligned with the active Hermes session while preserving configured stable keys. |
@@ -234,6 +252,8 @@ Memories are only injected when the last user message is 3 or more words and the
 ```bash
 remnic daemon status
 ```
+
+If recall works via the tool but nothing is injected automatically, enable DEBUG logging on the `remnic_hermes.provider` logger — it reports prefetch wait expiries, background recall failures, and recalls that returned no context. On slow daemons (e.g. Docker bind mounts), raise `prefetch_wait_timeout` so the first fetch can complete within the turn.
 
 ## Uninstall
 

--- a/packages/plugin-hermes/plugin.yaml
+++ b/packages/plugin-hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: remnic
-version: 1.0.4
+version: 1.0.5
 description: Universal memory for AI agents — Remnic MemoryProvider integration for Hermes
 author: Joshua Warren
 homepage: https://github.com/joshuaswarren/remnic

--- a/packages/plugin-hermes/pyproject.toml
+++ b/packages/plugin-hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "remnic-hermes"
-version = "1.0.4"
+version = "1.0.5"
 description = "Remnic MemoryProvider plugin for Hermes Agent"
 readme = "README.md"
 license = "MIT"

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -334,11 +334,22 @@ def _load_hermes_host_config() -> dict:  # type: ignore[type-arg]
     the host config here lets a `$HERMES_HOME/plugins/<name>/` directory shim
     simply re-export this ``register`` instead of duplicating config loading
     (issue #1929).
+
+    Prefers ``load_config_readonly()`` (fast, no deepcopy) and falls back to
+    ``load_config()`` on older Hermes releases (v0.7.0+ supported floor) that
+    predate the readonly helper.
     """
     try:
-        from hermes_cli.config import load_config_readonly
-
-        loaded = load_config_readonly()
+        from hermes_cli import config as hermes_config
+    except Exception:
+        return {}
+    loader = getattr(hermes_config, "load_config_readonly", None)
+    if not callable(loader):
+        loader = getattr(hermes_config, "load_config", None)
+    if not callable(loader):
+        return {}
+    try:
+        loaded = loader()
         return loaded if isinstance(loaded, dict) else {}
     except Exception:
         return {}

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -325,11 +325,33 @@ def _register_issue_815_hooks(ctx, provider: RemnicMemoryProvider):  # type: ign
     register_hook("on_session_reset", _on_session_reset)
 
 
+def _load_hermes_host_config() -> dict:  # type: ignore[type-arg]
+    """Load Hermes config.yaml when the registration context carries no config.
+
+    Hermes' memory-provider discovery (`plugins/memory/__init__.py`) invokes
+    ``register()`` with a bare collector that exposes
+    ``register_memory_provider()`` but has NO ``.config`` attribute. Reading
+    the host config here lets a `$HERMES_HOME/plugins/<name>/` directory shim
+    simply re-export this ``register`` instead of duplicating config loading
+    (issue #1929).
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        loaded = load_config_readonly()
+        return loaded if isinstance(loaded, dict) else {}
+    except Exception:
+        return {}
+
+
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
-    config = ctx.config.get("remnic")
+    raw_config = getattr(ctx, "config", None)
+    if not isinstance(raw_config, dict):
+        raw_config = _load_hermes_host_config()
+    config = raw_config.get("remnic")
     if not isinstance(config, dict):
-        config = ctx.config.get("engram", {})
+        config = raw_config.get("engram", {})
 
     provider = RemnicMemoryProvider(config)
     ctx.register_memory_provider(provider)

--- a/packages/plugin-hermes/remnic_hermes/config.py
+++ b/packages/plugin-hermes/remnic_hermes/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 from dataclasses import dataclass
 
@@ -16,6 +17,7 @@ class RemnicHermesConfig:
     token: str = ""
     session_key: str = ""
     timeout: float = 30.0
+    prefetch_wait_timeout: float = 2.0
 
     @classmethod
     def from_hermes_config(cls, config: dict[str, object]) -> RemnicHermesConfig:
@@ -44,11 +46,26 @@ class RemnicHermesConfig:
             token=token,
             session_key=str(section.get("session_key", "")),
             timeout=float(section.get("timeout", 30.0)),
+            prefetch_wait_timeout=_parse_prefetch_wait_timeout(section.get("prefetch_wait_timeout", 2.0)),
         )
 
 
 # Legacy class alias — import path compat for pre-rename consumers.
 EngramHermesConfig = RemnicHermesConfig
+
+
+def _parse_prefetch_wait_timeout(raw: object) -> float:
+    """Parse and validate prefetch_wait_timeout: a finite float >= 0.
+
+    0 disables synchronous waiting entirely (prefetch becomes fire-and-forget:
+    it queues the recall and only ever returns cached results).
+    """
+    value = float(raw)  # type: ignore[arg-type]
+    if not math.isfinite(value) or value < 0:
+        raise ValueError(
+            f"remnic prefetch_wait_timeout must be a finite number >= 0, got {raw!r}"
+        )
+    return value
 
 
 def _read_compat_env(primary: str, legacy: str, default: str) -> str:

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import threading
 import uuid
 from collections import OrderedDict
@@ -18,6 +19,8 @@ try:  # Hermes Agent is present when loaded as an installed memory provider.
     from agent.memory_provider import MemoryProvider as HermesMemoryProvider
 except Exception:  # pragma: no cover - keeps package importable outside Hermes.
     HermesMemoryProvider = object
+
+_log = logging.getLogger("remnic_hermes.provider")
 
 
 _NAMESPACE = {"type": "string"}
@@ -145,7 +148,10 @@ class RemnicMemoryProvider(HermesMemoryProvider):  # type: ignore[misc]
         self._prefetch_cache: OrderedDict[str, tuple[str, float]] = OrderedDict()
         self._prefetch_inflight: set[str] = set()
         self._prefetch_lock = threading.Lock()
-        self._prefetch_wait_timeout = min(cfg.timeout, 0.1)
+        # Cap the synchronous prefetch wait by the overall HTTP timeout.
+        # Default 2.0s: local daemons routinely take 250-500ms per recall
+        # (issue #1929); the old 100ms cap made prefetch always return "".
+        self._prefetch_wait_timeout = min(cfg.timeout, cfg.prefetch_wait_timeout)
         self._prefetch_cache_ttl = 60.0
         self._prefetch_cache_max_entries = 128
 
@@ -175,7 +181,10 @@ class RemnicMemoryProvider(HermesMemoryProvider):  # type: ignore[misc]
         try:
             await self._client.health()
         except Exception:
-            pass  # Non-fatal — daemon might start later.
+            # Non-fatal — daemon might start later.
+            _log.debug(
+                "initialize: daemon health check failed (%s:%s)", self._host, self._port, exc_info=True
+            )
 
     def system_prompt_block(self) -> str:
         return ""
@@ -200,8 +209,15 @@ class RemnicMemoryProvider(HermesMemoryProvider):  # type: ignore[misc]
             try:
                 return future.result(timeout=self._prefetch_wait_timeout) or ""
             except FutureTimeoutError:
+                _log.debug(
+                    "prefetch: recall still in flight after %.2fs wait (session=%s); "
+                    "result will populate the cache for the next turn",
+                    self._prefetch_wait_timeout,
+                    session_key,
+                )
                 return ""
             except Exception:
+                _log.debug("prefetch: recall failed (session=%s)", session_key, exc_info=True)
                 return ""
 
         return ""
@@ -289,6 +305,9 @@ class RemnicMemoryProvider(HermesMemoryProvider):  # type: ignore[misc]
                     self._set_prefetch_cache_locked(cache_key, block)
             return block
         except Exception:
+            _log.debug(
+                "prefetch: background recall failed (session=%s)", session_key, exc_info=True
+            )
             return ""
         finally:
             with self._prefetch_lock:
@@ -306,8 +325,17 @@ class RemnicMemoryProvider(HermesMemoryProvider):  # type: ignore[misc]
         )
         context = result.get("context", "")
         count = result.get("count", 0)
-        if context and count > 0:
+        # The daemon returns useful context (profile, knowledge index) even when
+        # count == 0, i.e. no specific memory IDs matched. Gate on context only
+        # (issue #1929 bug 1) — count stays in the tag as daemon-reported truth.
+        if context:
             return f"<remnic-memory count=\"{count}\">\n{context}\n</remnic-memory>"
+        _log.debug(
+            "recall returned no context (session=%s, count=%s, sources=%s)",
+            session_key,
+            count,
+            result.get("sourcesUsed"),
+        )
         return ""
 
     async def pre_llm_call(self, messages: list[dict[str, str]]) -> str:
@@ -323,6 +351,9 @@ class RemnicMemoryProvider(HermesMemoryProvider):  # type: ignore[misc]
         try:
             return await self._recall_block(query=query, session_key=self._session_key)
         except Exception:
+            _log.debug(
+                "pre_llm_call: recall failed (session=%s)", self._session_key, exc_info=True
+            )
             return ""
 
     def sync_turn(

--- a/packages/plugin-hermes/tests/test_config.py
+++ b/packages/plugin-hermes/tests/test_config.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from remnic_hermes import EngramHermesConfig
 from remnic_hermes.config import RemnicHermesConfig, _load_token_from_file
 
@@ -13,6 +15,7 @@ def test_default_config():
     assert config.port == 4318
     assert config.token == ""
     assert config.timeout == 30.0
+    assert config.prefetch_wait_timeout == 2.0
 
 
 def test_custom_config():
@@ -27,6 +30,26 @@ def test_from_hermes_config_empty():
     config = RemnicHermesConfig.from_hermes_config({})
     assert config.host == "127.0.0.1"
     assert config.port == 4318
+    assert config.prefetch_wait_timeout == 2.0
+
+
+def test_from_hermes_config_parses_prefetch_wait_timeout():
+    """prefetch_wait_timeout accepts numeric and string-typed values (issue #1929)."""
+    config = RemnicHermesConfig.from_hermes_config({"remnic": {"prefetch_wait_timeout": 0.5}})
+    assert config.prefetch_wait_timeout == 0.5
+
+    coerced = RemnicHermesConfig.from_hermes_config({"remnic": {"prefetch_wait_timeout": "1.25"}})
+    assert coerced.prefetch_wait_timeout == 1.25
+
+    disabled = RemnicHermesConfig.from_hermes_config({"remnic": {"prefetch_wait_timeout": 0}})
+    assert disabled.prefetch_wait_timeout == 0.0
+
+
+@pytest.mark.parametrize("invalid", [-1, -0.5, float("nan"), float("inf"), "abc"])
+def test_from_hermes_config_rejects_invalid_prefetch_wait_timeout(invalid):
+    """Invalid prefetch_wait_timeout values must be rejected, not silently defaulted."""
+    with pytest.raises(ValueError):
+        RemnicHermesConfig.from_hermes_config({"remnic": {"prefetch_wait_timeout": invalid}})
 
 
 def test_from_hermes_config_prefers_remnic_section():

--- a/packages/plugin-hermes/tests/test_provider.py
+++ b/packages/plugin-hermes/tests/test_provider.py
@@ -201,11 +201,36 @@ class TestPrefetch:
             top_k=8,
         )
 
-    def test_prefetch_does_not_block_on_slow_daemon_recall(self, provider):
+    def test_prefetch_waits_out_a_moderately_slow_daemon_recall(self, provider):
+        """Issue #1929 bug 2: local daemons take 250-500ms per recall; the
+        default synchronous wait (2.0s) must cover that so the FIRST prefetch
+        already returns memory instead of always returning ""."""
         client = AsyncMock()
 
         async def slow_recall(**kwargs):
             await asyncio.sleep(0.25)
+            return {"context": "late prior", "count": 1}
+
+        client.recall = AsyncMock(side_effect=slow_recall)
+        provider._client = client
+
+        result = provider.prefetch("what did we decide last week")
+        assert result.startswith('<remnic-memory count="1">')
+        assert "late prior" in result
+
+    def test_prefetch_does_not_block_past_configured_wait_timeout(self):
+        provider = RemnicMemoryProvider(
+            {
+                "host": "127.0.0.1",
+                "port": 4318,
+                "token": "test-token",
+                "prefetch_wait_timeout": 0.05,
+            }
+        )
+        client = AsyncMock()
+
+        async def slow_recall(**kwargs):
+            await asyncio.sleep(0.5)
             return {"context": "late prior", "count": 1}
 
         client.recall = AsyncMock(side_effect=slow_recall)
@@ -216,8 +241,34 @@ class TestPrefetch:
         elapsed = time.monotonic() - started
 
         assert result == ""
-        assert elapsed < 0.15
+        assert elapsed < 0.4
         _wait_for_await(client.recall)
+
+    def test_prefetch_wait_timeout_defaults_capped_by_request_timeout(self):
+        default_provider = RemnicMemoryProvider({"token": "test-token"})
+        assert default_provider._prefetch_wait_timeout == 2.0
+
+        capped_provider = RemnicMemoryProvider({"token": "test-token", "timeout": 1.5})
+        assert capped_provider._prefetch_wait_timeout == 1.5
+
+    def test_prefetch_returns_profile_context_when_count_is_zero(self, provider):
+        """Issue #1929 bug 1: the daemon returns profile/knowledge-index context
+        even when no specific memory IDs matched (count == 0). That context must
+        still be injected."""
+        client = AsyncMock()
+        client.recall = AsyncMock(
+            return_value={
+                "context": "## User Profile\n\n# Behavioral Profile",
+                "count": 0,
+                "memoryIds": [],
+                "sourcesUsed": ["profile", "knowledge-index"],
+            }
+        )
+        provider._client = client
+
+        result = provider.prefetch("what did we decide last week")
+        assert result.startswith('<remnic-memory count="0">')
+        assert "Behavioral Profile" in result
 
     def test_prefetch_does_not_cache_transient_failures_as_empty(self, provider):
         client = AsyncMock()

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -225,3 +225,41 @@ def test_register_without_config_and_without_hermes_cli_uses_empty_config():
         register(ctx)
 
     mock_provider.assert_called_once_with({})
+
+
+def _fake_hermes_cli(config_module):
+    """Install a fake hermes_cli/hermes_cli.config into sys.modules."""
+    import sys
+    from types import ModuleType
+
+    pkg = ModuleType("hermes_cli")
+    pkg.config = config_module
+    return patch.dict(sys.modules, {"hermes_cli": pkg, "hermes_cli.config": config_module})
+
+
+def test_load_hermes_host_config_prefers_readonly_loader():
+    from types import ModuleType
+
+    from remnic_hermes import _load_hermes_host_config
+
+    mod = ModuleType("hermes_cli.config")
+    mod.load_config_readonly = lambda: {"remnic": {"token": "ro"}}
+    mod.load_config = lambda: {"remnic": {"token": "full"}}
+
+    with _fake_hermes_cli(mod):
+        assert _load_hermes_host_config() == {"remnic": {"token": "ro"}}
+
+
+def test_load_hermes_host_config_falls_back_to_load_config_on_older_hermes():
+    """Hermes releases in the supported floor (v0.7.0+) expose load_config()
+    but not load_config_readonly(); the loader must fall back rather than
+    silently returning {} (issue #1929 review)."""
+    from types import ModuleType
+
+    from remnic_hermes import _load_hermes_host_config
+
+    mod = ModuleType("hermes_cli.config")
+    mod.load_config = lambda: {"remnic": {"token": "full", "host": "10.0.0.8"}}
+
+    with _fake_hermes_cli(mod):
+        assert _load_hermes_host_config() == {"remnic": {"token": "full", "host": "10.0.0.8"}}

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -190,3 +190,38 @@ def test_register_falls_back_to_engram_config_key():
     mock_provider.assert_called_once_with(
         {"token": "legacy-token", "host": "127.0.0.1"},
     )
+
+
+def test_register_handles_collector_without_config():
+    """Hermes memory-provider discovery passes a bare collector with no
+    .config attribute (issue #1929); register() must fall back to loading the
+    Hermes host config instead of crashing."""
+    ctx = SimpleNamespace(
+        register_memory_provider=lambda provider: None,
+        register_tool=lambda name, schema, handler: None,
+    )
+
+    with patch("remnic_hermes.RemnicMemoryProvider") as mock_provider:
+        _populate_provider_mock(mock_provider.return_value)
+        with patch(
+            "remnic_hermes._load_hermes_host_config",
+            return_value={"remnic": {"token": "host-token", "host": "10.0.0.7"}},
+        ):
+            register(ctx)
+
+    mock_provider.assert_called_once_with({"token": "host-token", "host": "10.0.0.7"})
+
+
+def test_register_without_config_and_without_hermes_cli_uses_empty_config():
+    """Outside a Hermes runtime (no hermes_cli importable), a config-less
+    context still registers a provider built from defaults."""
+    ctx = SimpleNamespace(
+        register_memory_provider=lambda provider: None,
+        register_tool=lambda name, schema, handler: None,
+    )
+
+    with patch("remnic_hermes.RemnicMemoryProvider") as mock_provider:
+        _populate_provider_mock(mock_provider.return_value)
+        register(ctx)
+
+    mock_provider.assert_called_once_with({})


### PR DESCRIPTION
Fixes the two bugs and two of the four architecture concerns from #1929, verified still present on current main.

## Bug 1 — `_recall_block` dropped profile context when `count == 0`
The daemon's `/engram/v1/recall` returns populated `context` (profile + knowledge index) even when no specific memory IDs matched (`count: 0`). The `context and count > 0` gate dropped all of it, so nothing was ever injected. Gate is now on non-empty `context` only; `count` stays in the tag as daemon-reported truth.

## Bug 2 — prefetch wait hardcoded to 100ms
`prefetch()` waited at most `min(timeout, 0.1)` seconds for the background recall; local daemons routinely take 250–500ms, so prefetch always returned `""`. Now `min(timeout, prefetch_wait_timeout)` with a **2.0s default**, configurable via a new `prefetch_wait_timeout` config field (`0` = cache-only fire-and-forget; invalid values rejected at load).

Upstream context (verified against `NousResearch/hermes-agent` @ `53adb3f`): Hermes calls `prefetch()` synchronously on the turn hot path with no timeout of its own, so the provider must bound its own wait — hence a config knob rather than an unbounded wait. `queue_prefetch`/`sync_turn` run on Hermes' background executor and keep the cache warm for subsequent turns.

## Architecture concern 4 — no logging in the critical path
Added DEBUG logging on the `remnic_hermes.provider` logger: prefetch wait expiry, background recall failure, empty-context recalls (with `count`/`sourcesUsed`), health-check failure, `pre_llm_call` failure.

## Architecture concerns 1 & 3 — registration shim / `pre_llm_call`
- `register(ctx)` now tolerates Hermes' memory-provider discovery collector (which has **no** `.config` attribute) by falling back to `hermes_cli.config.load_config_readonly()`, so a one-line `$HERMES_HOME/plugins/remnic/__init__.py` shim suffices. (Automating shim creation in `remnic connectors install hermes` lands as a separate PR.)
- Docs corrected: Hermes **never** calls `pre_llm_call` on memory providers — injection goes through `prefetch()`. `docs/plugins/hermes.md`, the package README, and `llms.txt` now document the real injection path, the shim requirement, `memory.provider` selection, count==0 semantics, and the new knob.

## Version
`remnic-hermes` 1.0.4 → 1.0.5 (pyproject + plugin.yaml).

## Verification
- `mypy remnic_hermes/ --ignore-missing-imports` OK
- `ruff check remnic_hermes/ tests/` OK
- `pytest tests/` — 98 passed (new: count==0 injection, default/configured/capped wait timeout, invalid-value rejection, bare-collector registration)
- `npm run preflight:quick` OK

Part of #1929

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes synchronous turn-path prefetch latency and what gets injected into the model; behavior is bounded and covered by new tests, but mis-tuned `prefetch_wait_timeout` can add per-turn delay or skip first-turn injection.
> 
> **Overview**
> **`remnic-hermes` 1.0.5** fixes Hermes memory injection (#1929): recall context is injected whenever the daemon returns non-empty `context`, including **`count == 0`** profile/knowledge-index payloads that were previously dropped.
> 
> **`prefetch()`** no longer caps synchronous wait at 100ms (which made first-turn recall almost always empty). It uses a new **`prefetch_wait_timeout`** config (default **2.0s**, capped by `timeout`; **`0`** = cache-only). Invalid values fail at config load. DEBUG logging on **`remnic_hermes.provider`** covers wait expiry, recall failures, and empty context.
> 
> **`register()`** loads Hermes **`config.yaml`** via **`hermes_cli`** when the memory-provider discovery collector has no **`.config`**, so a **`$HERMES_HOME/plugins/remnic/`** shim can re-export **`register`** alone.
> 
> Docs (**`docs/plugins/hermes.md`**, package README, **`llms.txt`**) now describe **`prefetch()`** as the Hermes injection path (not **`pre_llm_call`**), the pip + shim + **`memory.provider`** setup, and troubleshooting for slow daemons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b82189077988be3aca8f1f40ca85a773c741d31d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->