### PR TITLE
fix(qmd): auto-create the default namespace's flat-root collection (#1929)

### DIFF
--- a/.changeset/fix-1929-qmd-default-namespace-collection.md
+++ b/.changeset/fix-1929-qmd-default-namespace-collection.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Fix QMD recall returning 0 results for a configured default namespace whose data lives at the flat memory root (#1929). The default-namespace record derived the base QMD collection on both the index and search sides but skipped auto-creating it, so a fresh namespace-enabled install with any flat-root default (custom like `geek` or the unset default) left maintenance running with no collection and empty recall. The base ("broad root") collection is now auto-created for the legacy-default-root case; `filterNamespaceSubtreeResults` still strips the nested `namespaces/` subtree from default-namespace results, so index and search stay symmetric and nested data does not leak into default recall. Legacy installs that already have the base collection are unaffected (auto-create is a no-op when present).

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -90,6 +90,15 @@ Security rules:
 
 When namespaces are enabled, QMD needs entries for namespace-specific collections in `~/.config/qmd/index.yml`. The collection names follow the pattern `<qmdCollection>--ns--<namespace>`, where `<qmdCollection>` is the base collection name from your Remnic config (default: `openclaw-engram`, an intentional compatibility name). This matches the runtime logic in `namespaceCollectionName()` (`src/namespaces/search.ts`). Check the gateway log for the exact names — Remnic logs `QMD collection "..." not found` with the expected name when entries are missing.
 
+> **Auto-creation (#1929):** When Remnic runs QMD in daemon-managed mode it now
+> auto-creates every namespace collection it needs on startup and during
+> maintenance — including the base collection that serves the default namespace
+> at the flat `memoryDir` root. The manual `index.yml` entries below are only
+> required when you run QMD yourself (self-managed indexes). Earlier builds
+> skipped auto-creating the default-namespace base collection, so a configured
+> default namespace (e.g. `geek`) whose data lived at the flat root returned 0
+> recall results until the entry was added by hand.
+
 ```yaml
 # Base collection (default namespace root)
 openclaw-engram:

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -90,14 +90,16 @@ Security rules:
 
 When namespaces are enabled, QMD needs entries for namespace-specific collections in `~/.config/qmd/index.yml`. The collection names follow the pattern `<qmdCollection>--ns--<namespace>`, where `<qmdCollection>` is the base collection name from your Remnic config (default: `openclaw-engram`, an intentional compatibility name). This matches the runtime logic in `namespaceCollectionName()` (`src/namespaces/search.ts`). Check the gateway log for the exact names — Remnic logs `QMD collection "..." not found` with the expected name when entries are missing.
 
-> **Auto-creation (#1929):** When Remnic runs QMD in daemon-managed mode it now
-> auto-creates every namespace collection it needs on startup and during
-> maintenance — including the base collection that serves the default namespace
-> at the flat `memoryDir` root. The manual `index.yml` entries below are only
-> required when you run QMD yourself (self-managed indexes). Earlier builds
-> skipped auto-creating the default-namespace base collection, so a configured
-> default namespace (e.g. `geek`) whose data lived at the flat root returned 0
-> recall results until the entry was added by hand.
+> **Auto-creation (#1929):** Whenever Remnic manages the QMD index (daemon mode
+> AND the subprocess/CLI path — `QmdClient.ensureCollection` runs
+> `qmd collection add` in both), it now auto-creates every namespace collection
+> it needs on startup and during maintenance — including the base collection
+> that serves the default namespace at the flat `memoryDir` root. The manual
+> `index.yml` entries below are only required for indexes you maintain entirely
+> outside Remnic. Earlier builds skipped auto-creating the default-namespace
+> base collection, so a configured default namespace (e.g. `geek`) whose data
+> lived at the flat root returned 0 recall results until the entry was added by
+> hand.
 
 ```yaml
 # Base collection (default namespace root)

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -461,7 +461,7 @@ test("ensureNamespaceCollection forwards abort signals to backend collection che
   assert.deepEqual(backend.ensureCollections, ["openclaw-engram--ns-6d61696e"]);
 });
 
-test("legacy default namespace root checks collection without auto-creating broad root", async () => {
+test("legacy default namespace root auto-creates its base collection (broad root, #1929)", async () => {
   const backend = new FakeBackend(false);
   const router = new NamespaceSearchRouter(
     config(),
@@ -474,14 +474,17 @@ test("legacy default namespace root checks collection without auto-creating broa
     signal: controller.signal,
   });
 
+  // The default namespace at the flat root targets the BASE collection (not a
+  // tokenized name) on both index and search sides, and that collection is now
+  // auto-created so recall has something to read. Skipping creation left a
+  // configured default namespace with maintenance "ran" but 0 results (#1929).
   assert.equal(state, "present");
-  assert.deepEqual(backend.checkSignals, [controller.signal]);
-  assert.deepEqual(backend.checkCollections, ["openclaw-engram"]);
-  assert.deepEqual(backend.ensureCollections, []);
+  assert.deepEqual(backend.ensureSignals, [controller.signal]);
+  assert.deepEqual(backend.ensureCollections, ["openclaw-engram"]);
 });
 
-test("legacy default namespace root fail-opens missing guarded collections", async () => {
-  const backend = new FakeBackend(false, [], { check: "missing" });
+test("legacy default namespace root auto-creates a missing base collection (#1929)", async () => {
+  const backend = new FakeBackend(false, [], { check: "missing", ensure: "present" });
   const router = new NamespaceSearchRouter(
     config(),
     { storageFor: async () => ({ dir: "/tmp/remnic" }) },
@@ -490,9 +493,71 @@ test("legacy default namespace root fail-opens missing guarded collections", asy
 
   const state = await router.ensureNamespaceCollection("main");
 
-  assert.equal(state, "unknown");
-  assert.deepEqual(backend.checkCollections, ["openclaw-engram"]);
-  assert.deepEqual(backend.ensureCollections, []);
+  // A missing base collection is no longer left missing (the old fail-open path);
+  // it is created so a fresh install with a flat-root default namespace gets a
+  // working QMD collection instead of silently returning 0 results.
+  assert.equal(state, "present");
+  assert.deepEqual(backend.ensureCollections, ["openclaw-engram"]);
+});
+
+test("configured non-legacy default namespace still recalls from its flat-root base collection (#1929)", async () => {
+  // Reporter's config: defaultNamespace "geek", data at the flat root. The
+  // default record must search the SAME base collection the index side creates,
+  // so recall returns results instead of 0.
+  const geekConfig = { ...config(), defaultNamespace: "geek" } as PluginConfig;
+  const created: FakeBackend[] = [];
+  const router = new NamespaceSearchRouter(
+    geekConfig,
+    { storageFor: async () => ({ dir: "/tmp/remnic" }) },
+    () => {
+      const backend = new FakeBackend(false, [
+        { docid: "1", path: "facts/geek-fact.md", snippet: "geek", score: 1 },
+      ]);
+      created.push(backend);
+      return backend;
+    },
+  );
+
+  const ensured = await router.ensureNamespaceCollection("geek");
+  assert.equal(ensured, "present");
+  assert.deepEqual(created[0]?.ensureCollections, ["openclaw-engram"]);
+
+  const results = await router.searchAcrossNamespaces({
+    query: "geek",
+    namespaces: ["geek"],
+    maxResults: 10,
+  });
+
+  assert.deepEqual(
+    created.flatMap((backend) => backend.calls.map((call) => call.collection)),
+    ["openclaw-engram"],
+  );
+  assert.equal(results.length, 1);
+  assert.equal(results[0]?.snippet, "geek");
+});
+
+test("configured non-legacy default namespace filters nested namespace files from its base collection (#1929)", async () => {
+  // The broad-root base collection also indexes nested `namespaces/` files; the
+  // default namespace search must strip them so auto-creation does not leak
+  // cross-namespace data into the default recall path.
+  const geekConfig = { ...config(), defaultNamespace: "geek" } as PluginConfig;
+  const backend = new FakeBackend(false, [
+    { docid: "1", path: "facts/geek-fact.md", snippet: "geek", score: 2 },
+    { docid: "2", path: "namespaces/ns-736861726564/facts/shared.md", snippet: "shared", score: 1 },
+  ]);
+  const router = new NamespaceSearchRouter(
+    geekConfig,
+    { storageFor: async () => ({ dir: "/tmp/remnic" }) },
+    () => backend,
+  );
+
+  const results = await router.searchAcrossNamespaces({
+    query: "geek",
+    namespaces: ["geek"],
+    maxResults: 10,
+  });
+
+  assert.deepEqual(results.map((result) => result.snippet), ["geek"]);
 });
 
 test("healthForNamespace checks namespace collection without auto-creating or caching state", async () => {

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -379,10 +379,20 @@ export class NamespaceSearchRouter {
       });
       const collectionState = available
         ? await awaitWithAbort(
+          // The legacy default namespace at the flat root (`filtersNestedNamespaces`)
+          // shares its `memoryDir` with the `namespaces/` container, so its base
+          // collection is a "broad root" that also indexes nested-namespace files.
+          // We STILL auto-create it (issue #1929): the search side already targets
+          // this exact base collection and `filterNamespaceSubtreeResults` strips
+          // the nested `namespaces/` subtree out of its results, so index and
+          // search stay symmetric. Skipping creation left a configured default
+          // namespace (e.g. `geek`) with maintenance "ran" but no collection and 0
+          // recall results. `ensureCollection` is a no-op when the collection is
+          // already present, so legacy installs that pre-created the broad root are
+          // unaffected.
           this.collectionStateForBackend(backend, storage.dir, scopedConfig.qmdCollection, {
             autoCreate: options.autoCreateCollection,
             failOpenMissingGuardedCollection: options.failOpenMissingGuardedCollection,
-            skipAutoCreate: filtersNestedNamespaces,
             execution,
           }),
           execution?.signal,
@@ -417,11 +427,10 @@ export class NamespaceSearchRouter {
     options: {
       autoCreate: boolean;
       failOpenMissingGuardedCollection: boolean;
-      skipAutoCreate: boolean;
       execution?: SearchExecutionOptions;
     },
   ): Promise<CollectionState> {
-    if (!options.autoCreate || options.skipAutoCreate) {
+    if (!options.autoCreate) {
       if (!backend.checkCollection) return "unknown";
       const collectionState = await backend
         .checkCollection(collection, options.execution)


### PR DESCRIPTION
Fixes Bug 3 from #1929: on namespace-enabled installs whose default namespace stores at the flat memory root (any configured default, e.g. `defaultNamespace: "geek"`, or the unset default), QMD recall consistently returned 0 results (`primaryResultCount: 0`, `hybridResultCount: 0`) while profile/knowledge-index/transcript recall worked.

## Root cause
`namespaces/search.ts:createBackendRecordFor` reused `filtersNestedNamespaces` as `skipAutoCreate`. The flag correctly drives search-side stripping of the nested `namespaces/` subtree from broad-root results, but reusing it for auto-creation meant the default namespace's base collection was only ever *checked*, never created (`ensureCollection` was skipped, and the missing collection failed open to `"unknown"`). Search then targeted a nonexistent collection → 0 results. Legacy installs were masked because their base collection predated namespaces. Introduced by `79498bcd`.

The reporter's "maintenance ran for ns-6765656b" observation is the namespace-planner status keyed by identity token — orthogonal to collection existence, which is why it looked healthy.

## Fix
Decouple auto-creation from nested-filtering: drop the `skipAutoCreate` override (and the now-dead parameter) so the legacy-default-root case auto-creates its base ("broad root") collection, symmetric with the search side. `filtersNestedNamespaces` still strips nested-namespace files from default-namespace results, so isolation is unchanged. `ensureCollection` is a no-op when the collection exists, so legacy installs are unaffected; non-default namespaces never hit this path.

## User impact
Affected installs self-heal on the next daemon start (startup search sync ensures + updates all namespace collections) or on the next QMD maintenance cycle — no manual migration; symlinking into `namespaces/ns-<hex>/` was never the right shape because the default namespace searches the BASE collection.

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/namespaces/search.test.ts` — 21 pass (4 new #1929 regression tests; with the fix reverted, 3 of them fail)
- Adjacent suites (namespaces catalog/migrate/identity, orchestration maintenance, access health) — 120 pass
- `npm run test:entity-hardening` — 246 pass
- `npm run preflight:quick` OK

Part of #1929

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes namespace QMD collection lifecycle on a core recall path, but behavior is covered by new regression tests and existing installs with the collection already present are unaffected (ensure is a no-op).
> 
> **Overview**
> Fixes **empty QMD recall** on namespace-enabled installs whose default namespace stores memories at the flat `memoryDir` root (including custom `defaultNamespace` values like `geek`).
> 
> Previously, `NamespaceSearchRouter` tied **auto-creation** to the same flag used for **search-side filtering** of nested `namespaces/` paths (`filtersNestedNamespaces`). Index/search both targeted the **base** QMD collection for that case, but maintenance only **checked** the collection and skipped `ensureCollection`, so fresh installs could run maintenance with **no collection** and get **0 recall results**. The router now **always auto-creates** that base (“broad root”) collection when auto-create is enabled; **`filterNamespaceSubtreeResults` is unchanged**, so nested-namespace hits are still stripped from default-namespace recall.
> 
> Docs note that Remnic-managed QMD indexes auto-create the default-namespace base collection on startup/maintenance. Tests cover ensure-on-flat-root, missing-base creation, recall for a non-legacy default name, and nested-path filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27410955aa21803233093af278c8e11f69f7f495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->