### PR TITLE
fix(bench): normalize legacy ledger drift

### DIFF
--- a/packages/bench/src/providers/codex-credit-budget.test.ts
+++ b/packages/bench/src/providers/codex-credit-budget.test.ts
@@ -715,6 +715,98 @@ test("v1 migration rejects sub-nanounit values and accepts the exact nanounit bo
   }
 });
 
+test("v1 migration normalizes accumulated aggregate float drift from exact entry nanounits", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-credit-v1-float-drift-"));
+  const ledgerPath = path.join(directory, "ledger.json");
+  const config = { budgetCredits: 2_473, reserveCredits: 473, ledgerPath, allowSol: false };
+  const entryCount = 2_677;
+  const totalCachedInputTokens = 200_181_025;
+  const tokensPerEntry = Math.floor(totalCachedInputTokens / entryCount);
+  const entriesWithExtraToken = totalCachedInputTokens % entryCount;
+  const entries = Array.from({ length: entryCount }, (_, index) => {
+    const inputTokens = tokensPerEntry + (index < entriesWithExtraToken ? 1 : 0);
+    const entryUsage = {
+      inputTokens,
+      cachedInputTokens: inputTokens,
+      outputTokens: 0,
+      reasoningOutputTokens: 0,
+    };
+    return {
+      at: "2026-07-15T00:00:00.000Z",
+      model: "gpt-5.6-luna",
+      runId: "drifted-v1-run",
+      credits: calculateCodexBudgetUnits("gpt-5.6-luna", entryUsage),
+      ...entryUsage,
+    };
+  });
+  __codexCreditBudgetTestHooks.resetQueue();
+  try {
+    await writeFile(
+      ledgerPath,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        budgetCredits: 2_473,
+        reserveCredits: 473,
+        spentCredits: 500.45256250000057,
+        entries,
+        blockedReason: "missing terminal usage after accumulated float accounting",
+      })}\n`,
+      { mode: 0o600 }
+    );
+
+    const before = await readFile(ledgerPath);
+    const initialReceipt = await buildCodexCreditReceipt(ledgerPath, "drifted-v1-run");
+    assert.equal(initialReceipt.totalSpentUnits, 500.4525625);
+    assert.equal(initialReceipt.cumulative.calls, entryCount);
+
+    const reconciliation = await reconcileCodexCreditLedger({
+      ledgerPath,
+      priorLedgerSha256: createHash("sha256").update(before).digest("hex"),
+      beforeAccountBalance: "2500.1250000000",
+      afterAccountBalance: "2500.1250000000",
+      affectedRunId: "drifted-v1-run",
+      sameAccountConfirmed: true,
+      snapshotsBracketBlockedEventConfirmed: true,
+      balanceSettledConfirmed: true,
+      noCreditsAddedOrRefundedConfirmed: true,
+    });
+    assert.equal(reconciliation.priorRecordedSpentUnits, 500.4525625);
+    assert.equal(reconciliation.totalSpentUnits, 500.4525625);
+    const migratedLedger = JSON.parse(await readFile(ledgerPath, "utf8")) as {
+      spentUnits: number;
+      migrationWitnessV1: { source: string };
+    };
+    assert.equal(migratedLedger.spentUnits, 500.4525625);
+    assert.equal(migratedLedger.migrationWitnessV1.source, before.toString("utf8"));
+    assert.equal((await buildCodexCreditReceipt(ledgerPath)).totalSpentUnits, 500.4525625);
+
+    assert.equal(
+      await runWithinCodexCreditBudget({
+        config,
+        model: "gpt-5.6-luna",
+        run: async () => ({ value: "continued after drift migration", usage }),
+      }),
+      "continued after drift migration"
+    );
+    assert.equal((await buildCodexCreditReceipt(ledgerPath)).totalSpentUnits, 504.0025625);
+
+    await writeFile(
+      ledgerPath,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        budgetCredits: 2_473,
+        reserveCredits: 473,
+        spentCredits: 500.452562502,
+        entries,
+      })}\n`,
+      { mode: 0o600 }
+    );
+    await assert.rejects(buildCodexCreditReceipt(ledgerPath), /ledger schema is invalid/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("unknown charged usage blocks the ledger until manual reconciliation", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-credit-blocked-"));
   const ledgerPath = path.join(directory, "ledger.json");

--- a/packages/bench/src/providers/codex-credit-budget.ts
+++ b/packages/bench/src/providers/codex-credit-budget.ts
@@ -161,6 +161,7 @@ export interface CodexCreditReceipt {
 // Conservative upper bound for one supported text-model turn. GPT-5.6 Terra's
 // full 1.05M-token context plus 128K output costs well under this amount.
 const MAX_BOUNDED_CALL_CREDITS = 300;
+const LEGACY_LEDGER_FLOAT_DRIFT_TOLERANCE = 1e-9;
 const SOL_MODEL = /^gpt-5\.6-sol$/i;
 const CREDIT_RATES: ReadonlyArray<[RegExp, CodexCreditRate]> = [
   [/^gpt-5\.6-sol$/i, { input: 125, cachedInput: 12.5, output: 750 }],
@@ -861,17 +862,12 @@ function isLedgerV1(value: unknown): value is CodexCreditLedgerV1 {
     isSupportedBudgetUnits(candidate.reserveCredits) &&
     candidate.reserveCredits < candidate.budgetCredits &&
     isNonNegativeFinite(candidate.spentCredits) &&
-    isSupportedBudgetUnits(candidate.spentCredits) &&
     Array.isArray(entries) &&
     entries.every(isLedgerEntryV1) &&
     (reconciliations === undefined ||
       (Array.isArray(reconciliations) &&
         reconciliations.every((item) => isLedgerReconciliationWithinBudgetV1(item, candidate.budgetCredits)))) &&
-    Math.abs(
-      entries.reduce((sum, entry) => sum + entry.credits, 0) +
-        (reconciliations ?? []).reduce((sum, item) => sum + item.credits, 0) -
-        candidate.spentCredits
-    ) <= 1e-9 &&
+    isLedgerV1SpentConsistent(candidate as CodexCreditLedgerV1) &&
     (candidate.blockedReason === undefined ||
       (typeof candidate.blockedReason === "string" && candidate.blockedReason.length > 0))
   );
@@ -879,11 +875,12 @@ function isLedgerV1(value: unknown): value is CodexCreditLedgerV1 {
 
 function migrateLedgerV1(ledger: CodexCreditLedgerV1, sourceContents?: string | Uint8Array): CodexCreditLedger {
   const source = sourceContents ? Buffer.from(sourceContents).toString("utf8") : `${JSON.stringify(ledger)}\n`;
+  const spentUnits = nanounitsToBudgetUnits(ledgerV1SpentNanounits(ledger));
   return {
     schemaVersion: 2,
     budgetUnits: ledger.budgetCredits,
     reserveUnits: ledger.reserveCredits,
-    spentUnits: ledger.spentCredits,
+    spentUnits,
     entries: ledger.entries.map(({ credits, ...entry }) => ({ ...entry, budgetUnits: credits })),
     ...(ledger.reconciliations?.length ? { legacyReconciliations: ledger.reconciliations } : {}),
     migratedFromV1Sha256: sha256(source),
@@ -1061,7 +1058,7 @@ function isDirectV1PredecessorResolution(ledger: CodexCreditLedger, resolution: 
     isLedgerV1(predecessor) &&
     resolution.priorEntryCount === predecessor.entries.length &&
     resolution.priorLedgerSha256 === ledger.migratedFromV1Sha256 &&
-    budgetUnitsToNanounits(resolution.priorRecordedSpentUnits) === budgetUnitsToNanounits(predecessor.spentCredits) &&
+    budgetUnitsToNanounits(resolution.priorRecordedSpentUnits) === ledgerV1SpentNanounits(predecessor) &&
     predecessor.blockedReason === resolution.affectedBlockedEvent.reason
   );
 }
@@ -1348,6 +1345,24 @@ function nanounitsToBudgetUnits(value: bigint): number {
 
 function sumBudgetUnitNanounits(values: number[]): bigint {
   return values.reduce((sum, value) => sum + budgetUnitsToNanounits(value), 0n);
+}
+
+function ledgerV1SpentNanounits(ledger: CodexCreditLedgerV1): bigint {
+  return (
+    sumBudgetUnitNanounits(ledger.entries.map((entry) => entry.credits)) +
+    sumBudgetUnitNanounits((ledger.reconciliations ?? []).map((reconciliation) => reconciliation.credits))
+  );
+}
+
+function isLedgerV1SpentConsistent(ledger: CodexCreditLedgerV1): boolean {
+  try {
+    const exactSpentNanounits = ledgerV1SpentNanounits(ledger);
+    if (exactSpentNanounits > BigInt(Number.MAX_SAFE_INTEGER)) return false;
+    const exactSpentUnits = nanounitsToBudgetUnits(exactSpentNanounits);
+    return Math.abs(exactSpentUnits - ledger.spentCredits) <= LEGACY_LEDGER_FLOAT_DRIFT_TOLERANCE;
+  } catch {
+    return false;
+  }
 }
 
 function ledgerSpentNanounits(ledger: CodexCreditLedger): bigint {


### PR DESCRIPTION
## Summary

- preserve exact nanounit validation for every legacy charge
- tolerate only the existing <=1e-9 aggregate floating-point drift in schema-v1 `spentCredits`
- derive migrated v2 totals from exact entry and reconciliation nanounits
- preserve the original v1 source-byte migration witness

## Why

The Build Week ledger has 2,677 individually valid charges whose historical floating-point accumulation differs from their exact sum by ~5.7e-13. PR #1941 correctly rejected sub-nanounit charges but also rejected this provable aggregate drift, preventing safe reconciliation. This follow-up normalizes only the aggregate after validating all detailed values and their strict consistency.

## Verification

- focused ledger tests: 34/34
- `npm run preflight:quick`
- bench typecheck
- test-type baseline
- read-only receipt validation against the private historical ledger (no mutation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Codex credit ledger validation and v1 migration paths used for manual reconciliation; incorrect tolerance could admit bad totals or block legitimate ledgers.
> 
> **Overview**
> **Schema v1 Codex credit ledgers** now accept aggregate `spentCredits` that only diverges from the exact nanounit sum of entries and reconciliations by up to **1e-9**, while per-entry charges stay strictly validated.
> 
> **v1 → v2 migration** sets `spentUnits` from that exact nanounit total instead of copying `spentCredits`, and **v1 predecessor reconciliation** compares against the same computed total. Drift beyond the tolerance still fails validation.
> 
> A **regression test** simulates ~2,677 charges with historical float accumulation (~5.7e-13 drift): receipt, reconciliation, migration witness preservation, continued budgeted runs, and rejection when drift exceeds tolerance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2249e8326f89ffb32a8bdec41973c9cbac5ac3f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->