### PR TITLE
feat(relay): add mission evidence contract and receipt API

### DIFF
--- a/docs/remnic-relay/IMPLEMENTATION.md
+++ b/docs/remnic-relay/IMPLEMENTATION.md
@@ -58,4 +58,3 @@ work. Close every child issue only after its merged current head is verified.
 At every decision ask: “Is this OpenAI-attention and 1st place Build Week winning
 worthy?” Prefer visible product leverage, honest proof, and reliable judge
 reproduction over broad infrastructure or speculative generality.
-

--- a/docs/remnic-relay/IMPLEMENTATION.md
+++ b/docs/remnic-relay/IMPLEMENTATION.md
@@ -1,0 +1,61 @@
+# Remnic Relay implementation plan
+
+## Completion contract
+
+Relay is complete when a clean-room installation can run or replay one isolated
+mission in which a stale project decision is observed, corrected with explicit
+human approval, propagated to a cold Codex agent, and followed by a passing
+test—with a single receipt that renders the full lineage.
+
+The user owns the final Devpost submission and final recording/upload. The
+repository must contain everything else needed to do those steps reliably.
+
+## Phase 1 — Mission evidence contract and API (#1966)
+
+Deliver a host-agnostic, versioned `RelayMissionEvent` contract and append-only
+store. Add strict access operations and bounded HTTP routes for appending events
+and reading a reduced `RelayMissionSnapshot`. Include deterministic fixture
+coverage for conflicting decisions, approval, supersession, cold recall, and
+the resulting test outcome.
+
+Verification:
+
+- focused contract, store, reducer, access, and HTTP tests;
+- empty, malformed, unauthorized, missing-evidence, idempotency, corruption,
+  and backend-failure cases;
+- type checking and `npm run preflight:quick`;
+- scoped PR, current-head PR loop, and manual merge.
+
+## Phase 2 — Mission Control UI (#1967)
+
+Build a distinctive judge-facing surface around the snapshot contract. The
+screen must communicate disagreement, provenance, human approval, correction
+lineage, propagation, cold-start handoff, and outcome without narration. Keep
+the interaction model intentionally cinematic and bounded to one mission.
+
+Before implementation, write the visual system and interaction plan, critique
+generic dashboard defaults, and define the exact hero frames needed for the
+video. Verify in a real browser at desktop and presentation dimensions.
+
+## Phase 3 — Isolated Codex mission runner (#1968)
+
+Create a synthetic fixture repository and a runner that provisions fresh
+`memoryDir`, `sharedContextDir`, and `CODEX_HOME` roots. The live path uses only
+bounded Codex CLI one-shot calls with `gpt-5.6`; it rejects Sol models, enforces
+hard call/credit/time limits, and captures truthful event evidence. A signed or
+integrity-checked replay path must reproduce the same mission without network or
+model timing risk.
+
+## Phase 4 — Judge-ready hardening and story (#1969)
+
+Exercise the complete clean-room path, capture evidence and polished screenshots,
+write the measured sub-three-minute script, prepare Devpost-ready copy, and add a
+claim ledger that separates pre-existing Remnic foundations from Build Week Relay
+work. Close every child issue only after its merged current head is verified.
+
+## Continuous product gate
+
+At every decision ask: “Is this OpenAI-attention and 1st place Build Week winning
+worthy?” Prefer visible product leverage, honest proof, and reliable judge
+reproduction over broad infrastructure or speculative generality.
+

--- a/docs/remnic-relay/PROGRESS.md
+++ b/docs/remnic-relay/PROGRESS.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-17
 - [x] Deterministic bounded reducer with explicit evidence completeness.
 - [x] Namespace-authorized access operations and HTTP routes.
 - [x] Deterministic synthetic fixture and failure-path tests.
-- [ ] Focused checks and repository preflight.
+- [x] Focused checks and repository preflight.
 - [ ] PR loop reports current-head `MERGE_READY`.
 - [ ] PR manually merged and `origin/main` verified.
 

--- a/docs/remnic-relay/PROGRESS.md
+++ b/docs/remnic-relay/PROGRESS.md
@@ -14,11 +14,11 @@ Last updated: 2026-07-17
 
 ## Phase 1 checklist
 
-- [ ] Versioned strict event and snapshot schemas.
-- [ ] Symlink-safe, serialized, idempotent append-only mission store.
-- [ ] Deterministic bounded reducer with explicit evidence completeness.
-- [ ] Namespace-authorized access operations and HTTP routes.
-- [ ] Deterministic synthetic fixture and failure-path tests.
+- [x] Versioned strict event and snapshot schemas.
+- [x] Symlink-safe, serialized, idempotent append-only mission store.
+- [x] Deterministic bounded reducer with explicit evidence completeness.
+- [x] Namespace-authorized access operations and HTTP routes.
+- [x] Deterministic synthetic fixture and failure-path tests.
 - [ ] Focused checks and repository preflight.
 - [ ] PR loop reports current-head `MERGE_READY`.
 - [ ] PR manually merged and `origin/main` verified.
@@ -29,4 +29,3 @@ All Relay demo inputs and outputs must live under freshly provisioned synthetic
 roots. No production Remnic memory, shared context, or Codex home may be read or
 written. A visible receipt may claim only what a fixture event, captured model
 output, source file, memory record, recall audit, or executed test proves.
-

--- a/docs/remnic-relay/PROGRESS.md
+++ b/docs/remnic-relay/PROGRESS.md
@@ -1,0 +1,32 @@
+# Remnic Relay progress
+
+Last updated: 2026-07-17
+
+## Overall
+
+- [x] Epic and scoped child issues created (#1965–#1969).
+- [x] Persistent completion goal created with the winning-worthiness gate.
+- [x] Dedicated Relay worktree created from current `origin/main`.
+- [ ] Phase 1: mission contract and receipt API (#1966).
+- [ ] Phase 2: Mission Control UI (#1967).
+- [ ] Phase 3: isolated Codex runner and replay (#1968).
+- [ ] Phase 4: hardening, evidence, and submission package (#1969).
+
+## Phase 1 checklist
+
+- [ ] Versioned strict event and snapshot schemas.
+- [ ] Symlink-safe, serialized, idempotent append-only mission store.
+- [ ] Deterministic bounded reducer with explicit evidence completeness.
+- [ ] Namespace-authorized access operations and HTTP routes.
+- [ ] Deterministic synthetic fixture and failure-path tests.
+- [ ] Focused checks and repository preflight.
+- [ ] PR loop reports current-head `MERGE_READY`.
+- [ ] PR manually merged and `origin/main` verified.
+
+## Evidence discipline
+
+All Relay demo inputs and outputs must live under freshly provisioned synthetic
+roots. No production Remnic memory, shared context, or Codex home may be read or
+written. A visible receipt may claim only what a fixture event, captured model
+output, source file, memory record, recall audit, or executed test proves.
+

--- a/docs/remnic-relay/RESEARCH.md
+++ b/docs/remnic-relay/RESEARCH.md
@@ -1,0 +1,75 @@
+# Remnic Relay research
+
+## Product thesis
+
+Remnic Relay is a shared, inspectable, correctable mission-memory layer for a
+team of Codex agents. Its deliberately narrow promise is:
+
+> Correct once. Every Codex agent learns.
+
+The Build Week demo must make a real state change visible: two agents hold
+conflicting project beliefs, a source-grounded correction is approved, the
+stale decision is superseded, and a cold agent retrieves the replacement and
+produces a passing outcome. A receipt must connect every claim to captured
+fixture evidence.
+
+## Existing Remnic foundations
+
+Relay reuses, but does not claim as new, the following Remnic capabilities:
+
+- shared context and shared outputs;
+- recall audit and Recall X-ray evidence;
+- coding-decision memories with explicit supersession;
+- correction proposal and approval contracts;
+- graph, trace, and admin-console surfaces;
+- native Codex hooks and memory materialization.
+
+The Relay-specific work is a bounded mission read model, a dedicated Mission
+Control UI, an isolated one-shot Codex runner, deterministic replay, and the
+evidence and packaging needed for judges to reproduce the story.
+
+## Architecture findings
+
+- The Relay contract belongs in `@remnic/core`. It is host-agnostic and must not
+  import Codex, OpenClaw, or Hermes code.
+- The HTTP surface should reuse `EngramAccessService`, operation validation,
+  access tokens, namespace capabilities, and the existing surface catalog.
+- Mission events are append-only evidence. A deterministic reducer produces a
+  complete snapshot so the browser does not need to reconstruct product state.
+- An isolated mission log avoids scanning general memory or recall timelines,
+  makes bounds enforceable, and keeps the demo independent of production data.
+- A mission event can reference existing memory, recall-audit, test, source,
+  commit, correction, and agent-output evidence without pretending that a
+  historical query was captured at action time.
+- Persisted events need stable ordering, strict identifiers, idempotent append,
+  bounded reads, distinct empty/error states, cross-process serialization, and
+  symlink-safe file access.
+
+## Current technical references
+
+- Zod 3.24 supports strict objects, discriminated unions, inferred TypeScript
+  types, datetime validation, and regex-constrained identifiers. Relay uses
+  these for one versioned event envelope with a closed payload union.
+- Node.js 22 supports file-handle sync and no-follow open flags, which allows an
+  append to be durable without following a replaced symlink.
+- Remnic already provides a cross-process file-lock helper and operation-boundary
+  validation. Relay should compose those instead of introducing parallel
+  infrastructure.
+
+## Competitive and demo implications
+
+Agent-control-plane and generic memory products are crowded. Relay should not
+lead with “agents have memory.” The differentiator is a visual, falsifiable
+correction loop across independent Codex sessions with human approval and an
+auditable cold-start handoff.
+
+The winning bar for every addition is whether it improves at least one of:
+
+1. the visible correction and propagation story;
+2. judge confidence in provenance and isolation;
+3. clean-room repeatability before the three-minute deadline;
+4. product coherence as a developer tool for real Codex teams.
+
+Performance work, generic orchestration, autonomous corrections, and production
+data integration do not pass that bar for this submission.
+

--- a/docs/remnic-relay/RESEARCH.md
+++ b/docs/remnic-relay/RESEARCH.md
@@ -72,4 +72,3 @@ The winning bar for every addition is whether it improves at least one of:
 
 Performance work, generic orchestration, autonomous corrections, and production
 data integration do not pass that bar for this submission.
-

--- a/packages/remnic-core/src/access-boundary.ts
+++ b/packages/remnic-core/src/access-boundary.ts
@@ -102,6 +102,8 @@ export const OPERATION_NAMES = [
   "shared_context_write_output",
   "shared_feedback_record",
   "shared_priorities_append",
+  "relay_mission_append",
+  "relay_mission_read",
   "shared_context_cross_signals_run",
   "shared_context_curate_daily",
   "compounding_weekly_synthesize",

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -350,6 +350,12 @@ function decodeRelayMissionIdSegment(raw: string): string {
   }
 }
 
+function rejectBlankRelayNamespace(value: string | null | undefined): void {
+  if (value !== undefined && value !== null && value.trim().length === 0) {
+    throw new EngramAccessInputError("Relay namespace must not be blank when provided");
+  }
+}
+
 function codingContextFromProjectTag(projectTag: string): {
   projectId: string;
   branch: string | null;
@@ -1722,6 +1728,9 @@ export class EngramAccessHttpServer {
       ) {
         throw new EngramAccessInputError("namespace must be a string when provided");
       }
+      rejectBlankRelayNamespace(
+        typeof body.namespace === "string" ? body.namespace : undefined,
+      );
       const namespace = this.resolveNamespace(
         req,
         typeof body.namespace === "string" ? body.namespace : undefined,
@@ -1762,6 +1771,7 @@ export class EngramAccessHttpServer {
     const relayMissionMatch = /^\/engram\/v1\/relay\/missions\/([^/]+)$/.exec(pathname);
     if (req.method === "GET" && relayMissionMatch) {
       const missionId = decodeRelayMissionIdSegment(relayMissionMatch[1] ?? "");
+      rejectBlankRelayNamespace(parsed.searchParams.get("namespace"));
       const namespace = this.resolveNamespace(
         req,
         parsed.searchParams.get("namespace") ?? undefined,

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -389,7 +389,7 @@ export class EngramAccessHttpServer {
     res: ServerResponse,
     ctx: { authorized: boolean },
   ) => Promise<boolean>;
-  private readonly writeRequestTimestamps: number[] = [];
+  private readonly writeRequestSlots: Array<{ readonly recordedAt: number }> = [];
   private readonly writeRateLimitMaxRequests: number;
   private readonly writeRateLimitWindowMs: number;
   private readonly mcpServer: EngramMcpServer;
@@ -3819,30 +3819,30 @@ export class EngramAccessHttpServer {
   private ensureWriteRateLimitAvailable(): void {
     const now = Date.now();
     while (
-      this.writeRequestTimestamps.length > 0 &&
-      now - (this.writeRequestTimestamps[0] ?? 0) > this.writeRateLimitWindowMs
+      this.writeRequestSlots.length > 0 &&
+      now - (this.writeRequestSlots[0]?.recordedAt ?? 0) > this.writeRateLimitWindowMs
     ) {
-      this.writeRequestTimestamps.shift();
+      this.writeRequestSlots.shift();
     }
-    if (this.writeRequestTimestamps.length >= this.writeRateLimitMaxRequests) {
+    if (this.writeRequestSlots.length >= this.writeRateLimitMaxRequests) {
       throw new HttpError(429, "write_rate_limited", "write_rate_limited");
     }
   }
 
   private recordWriteRateLimitHit(): void {
-    this.writeRequestTimestamps.push(Date.now());
+    this.writeRequestSlots.push({ recordedAt: Date.now() });
   }
 
   private reserveWriteRateLimitSlot(): () => void {
     this.ensureWriteRateLimitAvailable();
-    const reservedAt = Date.now();
-    this.writeRequestTimestamps.push(reservedAt);
+    const slot = { recordedAt: Date.now() };
+    this.writeRequestSlots.push(slot);
     let active = true;
     return () => {
       if (!active) return;
       active = false;
-      const index = this.writeRequestTimestamps.indexOf(reservedAt);
-      if (index >= 0) this.writeRequestTimestamps.splice(index, 1);
+      const index = this.writeRequestSlots.indexOf(slot);
+      if (index >= 0) this.writeRequestSlots.splice(index, 1);
     };
   }
 

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1720,16 +1720,32 @@ export class EngramAccessHttpServer {
       if (!op) {
         throw new Error("access-boundary: operation not registered: relay_mission_append");
       }
-      const output = (await op.run(
-        { missionId, namespace, event },
-        {
-          service: this.service,
-          authenticatedPrincipal: this.resolveRequestPrincipal(req),
-          hooks: { enforceWriteQuota: () => this.ensureWriteRateLimitAvailable() },
-        },
-      )) as { result: { appended: boolean; replayed: boolean; event: unknown } };
-      if (output.result.appended) this.recordWriteRateLimitHit();
-      this.respondJson(res, output.result.appended ? 201 : 200, output.result);
+      let releaseWriteQuota: (() => void) | undefined;
+      try {
+        const output = (await op.run(
+          { missionId, namespace, event },
+          {
+            service: this.service,
+            authenticatedPrincipal: this.resolveRequestPrincipal(req),
+            hooks: {
+              enforceWriteQuota: () => {
+                releaseWriteQuota ??= this.reserveWriteRateLimitSlot();
+              },
+            },
+          },
+        )) as { result: { appended: boolean; replayed: boolean; event: unknown } };
+        if (output.result.appended) {
+          // The reservation is now the committed quota hit. Do not record a
+          // second timestamp after the append returns.
+          releaseWriteQuota = undefined;
+        }
+        this.respondJson(res, output.result.appended ? 201 : 200, output.result);
+      } finally {
+        // Replays never invoke the hook. If a future store path invokes it but
+        // does not append, or persistence throws after reservation, return the
+        // slot so a failed write cannot exhaust the rolling window.
+        releaseWriteQuota?.();
+      }
       return;
     }
 
@@ -3815,6 +3831,19 @@ export class EngramAccessHttpServer {
 
   private recordWriteRateLimitHit(): void {
     this.writeRequestTimestamps.push(Date.now());
+  }
+
+  private reserveWriteRateLimitSlot(): () => void {
+    this.ensureWriteRateLimitAvailable();
+    const reservedAt = Date.now();
+    this.writeRequestTimestamps.push(reservedAt);
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      const index = this.writeRequestTimestamps.indexOf(reservedAt);
+      if (index >= 0) this.writeRequestTimestamps.splice(index, 1);
+    };
   }
 
   private shouldCountWriteRateLimit(response: { dryRun?: boolean; idempotencyReplay?: boolean }): boolean {

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1703,6 +1703,17 @@ export class EngramAccessHttpServer {
     if (req.method === "POST" && relayEventMatch) {
       const missionId = decodeRelayMissionIdSegment(relayEventMatch[1] ?? "");
       const body = await this.readJsonBody(req);
+      const unexpectedFields = Object.keys(body).filter(
+        (key) => key !== "namespace" && key !== "event",
+      );
+      if (unexpectedFields.length > 0) {
+        throw new EngramAccessInputError(
+          `Relay append body contains unexpected field(s): ${unexpectedFields.sort().join(", ")}`,
+        );
+      }
+      if (!Object.prototype.hasOwnProperty.call(body, "event")) {
+        throw new EngramAccessInputError("Relay append body must contain an event object");
+      }
       if (
         Object.prototype.hasOwnProperty.call(body, "namespace") &&
         body.namespace !== undefined &&
@@ -1715,7 +1726,6 @@ export class EngramAccessHttpServer {
         req,
         typeof body.namespace === "string" ? body.namespace : undefined,
       );
-      const { namespace: _ignoredNamespace, ...event } = body;
       const op = getOperation("relay_mission_append");
       if (!op) {
         throw new Error("access-boundary: operation not registered: relay_mission_append");
@@ -1723,7 +1733,7 @@ export class EngramAccessHttpServer {
       let releaseWriteQuota: (() => void) | undefined;
       try {
         const output = (await op.run(
-          { missionId, namespace, event },
+          { missionId, namespace, event: body.event },
           {
             service: this.service,
             authenticatedPrincipal: this.resolveRequestPrincipal(req),

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -53,6 +53,7 @@ import { handleChatMessage, handleChatEventsSSE } from "./chat/chat-http.js";
 import { cleanupExpiredChatSessions, enforceChatSessionNamespace } from "./chat/chat-session.js";
 import { isDefaultReviewNamespace, listPairs, readPair } from "./contradiction/contradiction-review.js";
 import { isValidResolutionVerb, executeResolution } from "./contradiction/resolution.js";
+import { RelayMissionStoreError } from "./relay/mission.js";
 
 export interface AccessHttpReadinessState {
   ready: boolean;
@@ -339,6 +340,16 @@ function decodePeerIdSegment(raw: string): string {
   }
 }
 
+function decodeRelayMissionIdSegment(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    throw new EngramAccessInputError(
+      "missionId path segment is not valid percent-encoded input",
+    );
+  }
+}
+
 function codingContextFromProjectTag(projectTag: string): {
   projectId: string;
   branch: string | null;
@@ -497,6 +508,20 @@ export class EngramAccessHttpServer {
           }
           if (err instanceof CorrectionContractError) {
             this.respondJson(res, 400, { error: err.message, code: "correction_contract_error" });
+            return;
+          }
+          if (err instanceof RelayMissionStoreError) {
+            const status = err.code === "idempotency_conflict"
+              ? 409
+              : err.code === "limit_exceeded"
+                ? 413
+                : err.code === "lock_unavailable"
+                  ? 503
+                  : 500;
+            this.respondJson(res, status, {
+              error: status >= 500 ? "relay_backend_unavailable" : err.message,
+              code: `relay_${err.code}`,
+            });
             return;
           }
           if (res.headersSent) {
@@ -1667,6 +1692,73 @@ export class EngramAccessHttpServer {
     if (req.method === "GET" && pathname === "/engram/v1/lcm/status") {
       this.enforceTokenOp("lcm_status"); // boundary dispatch (issue #1525)
       this.respondJson(res, 200, await this.service.lcmStatus());
+      return;
+    }
+
+    // Remnic Relay mission receipts (issue #1966). These two routes share the
+    // access-boundary schemas and namespace-resolved storage contract. The
+    // browser receives an already-reduced snapshot; it never scans general
+    // memories, recall logs, or production state.
+    const relayEventMatch = /^\/engram\/v1\/relay\/missions\/([^/]+)\/events$/.exec(pathname);
+    if (req.method === "POST" && relayEventMatch) {
+      const missionId = decodeRelayMissionIdSegment(relayEventMatch[1] ?? "");
+      const body = await this.readJsonBody(req);
+      if (
+        Object.prototype.hasOwnProperty.call(body, "namespace") &&
+        body.namespace !== undefined &&
+        body.namespace !== null &&
+        typeof body.namespace !== "string"
+      ) {
+        throw new EngramAccessInputError("namespace must be a string when provided");
+      }
+      const namespace = this.resolveNamespace(
+        req,
+        typeof body.namespace === "string" ? body.namespace : undefined,
+      );
+      const { namespace: _ignoredNamespace, ...event } = body;
+      const op = getOperation("relay_mission_append");
+      if (!op) {
+        throw new Error("access-boundary: operation not registered: relay_mission_append");
+      }
+      const output = (await op.run(
+        { missionId, namespace, event },
+        {
+          service: this.service,
+          authenticatedPrincipal: this.resolveRequestPrincipal(req),
+          hooks: { enforceWriteQuota: () => this.ensureWriteRateLimitAvailable() },
+        },
+      )) as { result: { appended: boolean; replayed: boolean; event: unknown } };
+      if (output.result.appended) this.recordWriteRateLimitHit();
+      this.respondJson(res, output.result.appended ? 201 : 200, output.result);
+      return;
+    }
+
+    const relayMissionMatch = /^\/engram\/v1\/relay\/missions\/([^/]+)$/.exec(pathname);
+    if (req.method === "GET" && relayMissionMatch) {
+      const missionId = decodeRelayMissionIdSegment(relayMissionMatch[1] ?? "");
+      const namespace = this.resolveNamespace(
+        req,
+        parsed.searchParams.get("namespace") ?? undefined,
+      );
+      const op = getOperation("relay_mission_read");
+      if (!op) {
+        throw new Error("access-boundary: operation not registered: relay_mission_read");
+      }
+      const output = (await op.run(
+        {
+          missionId,
+          namespace,
+          since: parsed.searchParams.get("since") ?? undefined,
+          until: parsed.searchParams.get("until") ?? undefined,
+          limit: parsed.searchParams.get("limit") ?? undefined,
+        },
+        {
+          service: this.service,
+          authenticatedPrincipal: this.resolveRequestPrincipal(req),
+        },
+      )) as { result: unknown };
+      res.setHeader("cache-control", "no-store");
+      this.respondJson(res, 200, output.result);
       return;
     }
 

--- a/packages/remnic-core/src/access-mcp-cancellation.test.ts
+++ b/packages/remnic-core/src/access-mcp-cancellation.test.ts
@@ -282,7 +282,7 @@ test("MCP write quota is recorded after commit even when the client disconnects 
   });
   const serverHost = server as unknown as {
     mcpServer: EngramMcpServer;
-    writeRequestTimestamps: number[];
+    writeRequestSlots: Array<{ readonly recordedAt: number }>;
   };
   const originalHandleRequest = serverHost.mcpServer.handleRequest.bind(serverHost.mcpServer);
   serverHost.mcpServer.handleRequest = async (request, options) => {
@@ -318,7 +318,7 @@ test("MCP write quota is recorded after commit even when the client disconnects 
 
     await waitFor(operationSettled.promise);
     await new Promise<void>((resolve) => setImmediate(resolve));
-    assert.equal(serverHost.writeRequestTimestamps.length, 1);
+    assert.equal(serverHost.writeRequestSlots.length, 1);
     assert.equal(responseStarted, false, "the disconnected client must not receive the committed write response");
   } finally {
     releaseOperation.resolve();

--- a/packages/remnic-core/src/access-operations.ts
+++ b/packages/remnic-core/src/access-operations.ts
@@ -678,6 +678,8 @@ export const codegraphIngestTracesOperation = defineOperation<
 // Batch-migrated operations (issue #1525): registers all remaining
 // handlers through the boundary as a side effect of importing this module.
 import "./access-operations-batch.js";
+// Remnic Relay mission evidence operations (issue #1966).
+import "./relay/mission-access.js";
 
 export const REGISTERED_OPERATIONS = [
   memoryGetOperation.spec.name,

--- a/packages/remnic-core/src/access-surface-catalog.ts
+++ b/packages/remnic-core/src/access-surface-catalog.ts
@@ -193,6 +193,8 @@ export const HTTP_ROUTES: readonly HttpRouteEntry[] = [
   { method: "POST", pathname: "/engram/v1/lcm/compaction/flush", operation: "lcm_compaction_flush" },
   { method: "POST", pathname: "/engram/v1/lcm/compaction/record", operation: "lcm_compaction_record" },
   { method: "GET", pathname: "/engram/v1/lcm/status", operation: "lcm_status" },
+  { method: "GET", pathname: "/engram/v1/relay/missions/:id", operation: "relay_mission_read" },
+  { method: "POST", pathname: "/engram/v1/relay/missions/:id/events", operation: "relay_mission_append" },
   // Correction Contract (issue #1580) — plan/apply/pending.
   { method: "POST", pathname: "/engram/v1/correction/plan", operation: "memory_correct_plan" },
   { method: "POST", pathname: "/engram/v1/correction/apply", operation: "memory_correct_apply" },

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -387,6 +387,59 @@ export {
 } from "./access-http.js";
 export { EngramMcpServer } from "./access-mcp.js";
 
+// Remnic Relay — host-agnostic mission evidence and receipt contract.
+export {
+  RELAY_MISSION_DEFAULT_EVENT_LIMIT,
+  RELAY_MISSION_MAX_EVENT_LIMIT,
+  RELAY_MISSION_MAX_EVENTS,
+  RELAY_MISSION_MAX_FILE_BYTES,
+  RELAY_MISSION_MAX_LINE_BYTES,
+  RELAY_MISSION_SCHEMA_VERSION,
+  RelayEvidenceRefSchema,
+  RelayMissionEventInputSchema,
+  RelayMissionEventSchema,
+  RelayMissionPayloadSchema,
+  RelayMissionReadOptionsSchema,
+  RelayMissionStore,
+  RelayMissionStoreError,
+  compareRelayEvents,
+  reduceRelayMission,
+  relayMissionReceiptDigest,
+  type RelayAgentOutputSnapshot,
+  type RelayAgentSnapshot,
+  type RelayConflictSnapshot,
+  type RelayCorrectionSnapshot,
+  type RelayDecisionSnapshot,
+  type RelayEvidenceRef,
+  type RelayMissionAppendResult,
+  type RelayMissionEvent,
+  type RelayMissionEventInput,
+  type RelayMissionPayload,
+  type RelayMissionReadOptions,
+  type RelayMissionSnapshot,
+  type RelayMissionStatus,
+  type RelayMissionStoreErrorCode,
+  type RelayMissionStoreOptions,
+  type RelayPropagationSnapshot,
+  type RelayRecallSnapshot,
+  type RelayTestSnapshot,
+} from "./relay/mission.js";
+export {
+  RELAY_DEMO_MISSION_ID,
+  RELAY_DEMO_NAMESPACE,
+  createRelayMissionFixture,
+} from "./relay/mission-fixture.js";
+export {
+  appendRelayMissionEvent,
+  readRelayMission,
+  relayMissionAppendOperation,
+  relayMissionReadOperation,
+  type RelayMissionAppendAccessInput,
+  type RelayMissionAppendAccessOutput,
+  type RelayMissionReadAccessInput,
+  type RelayMissionReadAccessOutput,
+} from "./relay/mission-access.js";
+
 // agentAccessHttp.authToken SecretRef resolution (issue #757). Exposed so
 // host-specific bootstrap code (the OpenClaw plugin in `src/index.ts`, the
 // standalone server, the CLI) can resolve a SecretRef to a literal bearer

--- a/packages/remnic-core/src/relay/mission-access.test.ts
+++ b/packages/remnic-core/src/relay/mission-access.test.ts
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { EngramAccessHttpServer } from "../access-http.js";
+import { EngramAccessInputError, type EngramAccessService } from "../access-service.js";
+import type { StorageManager } from "../storage.js";
+import { createRelayMissionFixture, RELAY_DEMO_MISSION_ID, RELAY_DEMO_NAMESPACE } from "./mission-fixture.js";
+import type { RelayMissionSnapshot } from "./mission.js";
+
+async function withTempRoot(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-relay-http-"));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function fakeService(
+  root: string,
+  calls: Array<{ mode: "read" | "write"; namespace?: string; principal?: string }>
+): EngramAccessService {
+  const storage = { dir: root } as StorageManager;
+  return {
+    configRef: {
+      defaultNamespace: RELAY_DEMO_NAMESPACE,
+      namespacesEnabled: true,
+    },
+    getReadableStorageForNamespace: async (namespace?: string, principal?: string) => {
+      if (namespace === "forbidden") throw new EngramAccessInputError("namespace is not readable");
+      calls.push({ mode: "read", namespace, principal });
+      return { namespace: namespace ?? RELAY_DEMO_NAMESPACE, storage };
+    },
+    getWritableStorageForNamespace: async (namespace?: string, principal?: string) => {
+      if (namespace === "forbidden") throw new EngramAccessInputError("namespace is not writable");
+      calls.push({ mode: "write", namespace, principal });
+      return { namespace: namespace ?? RELAY_DEMO_NAMESPACE, storage };
+    },
+  } as unknown as EngramAccessService;
+}
+
+function authHeaders(token = "relay-token"): Record<string, string> {
+  return {
+    authorization: `Bearer ${token}`,
+    "content-type": "application/json",
+  };
+}
+
+test("HTTP fixture endpoint returns one complete, namespace-authorized Relay receipt", async () => {
+  await withTempRoot(async (root) => {
+    const calls: Array<{
+      mode: "read" | "write";
+      namespace?: string;
+      principal?: string;
+    }> = [];
+    const server = new EngramAccessHttpServer({
+      service: fakeService(root, calls),
+      port: 0,
+      authToken: "relay-token",
+      principal: "relay-operator",
+      adminConsoleEnabled: false,
+    });
+    const status = await server.start();
+    const base = `http://127.0.0.1:${status.port}/engram/v1/relay/missions/${RELAY_DEMO_MISSION_ID}`;
+    try {
+      const fixture = createRelayMissionFixture();
+      for (const input of fixture) {
+        const response = await fetch(`${base}/events`, {
+          method: "POST",
+          headers: authHeaders(),
+          body: JSON.stringify({ namespace: RELAY_DEMO_NAMESPACE, ...input }),
+        });
+        assert.equal(response.status, 201, await response.text());
+      }
+
+      const replay = await fetch(`${base}/events`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ namespace: RELAY_DEMO_NAMESPACE, ...fixture[0] }),
+      });
+      assert.equal(replay.status, 200);
+      assert.equal(((await replay.json()) as { replayed: boolean }).replayed, true);
+
+      const response = await fetch(`${base}?namespace=${RELAY_DEMO_NAMESPACE}&limit=20`, {
+        headers: authHeaders(),
+      });
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("cache-control"), "no-store");
+      const snapshot = (await response.json()) as RelayMissionSnapshot;
+      assert.equal(snapshot.receipt.complete, true);
+      assert.deepEqual(snapshot.receipt.activeDecisionIds, ["decision-refresh-after-expiry"]);
+      assert.deepEqual(snapshot.receipt.supersededDecisionIds, ["decision-new-token-every-request"]);
+      assert.equal(snapshot.agents.length, 3);
+      assert.equal(snapshot.tests.at(-1)?.status, "passed");
+      assert.ok(calls.every((call) => call.namespace === RELAY_DEMO_NAMESPACE));
+      assert.ok(calls.every((call) => call.principal === "relay-operator"));
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+test("HTTP Relay surface distinguishes empty, invalid, unauthorized, and backend-failed reads", async () => {
+  await withTempRoot(async (root) => {
+    const service = fakeService(root, []);
+    const server = new EngramAccessHttpServer({
+      service,
+      port: 0,
+      authTokenEntriesGetter: () => [
+        {
+          token: "read-token",
+          connector: "codex",
+          capabilities: {
+            version: 1,
+            ops: ["relay_mission_read"],
+            namespaces: [RELAY_DEMO_NAMESPACE],
+          },
+        },
+      ],
+      adminConsoleEnabled: false,
+    });
+    const status = await server.start();
+    const origin = `http://127.0.0.1:${status.port}`;
+    const emptyUrl = `${origin}/engram/v1/relay/missions/empty-mission?namespace=${RELAY_DEMO_NAMESPACE}`;
+    try {
+      const unauthenticated = await fetch(emptyUrl);
+      assert.equal(unauthenticated.status, 401);
+
+      const empty = await fetch(emptyUrl, { headers: authHeaders("read-token") });
+      assert.equal(empty.status, 200);
+      assert.deepEqual(await empty.json(), assertEmptyMissionShape());
+
+      const badLimit = await fetch(`${emptyUrl}&limit=501`, {
+        headers: authHeaders("read-token"),
+      });
+      assert.equal(badLimit.status, 400);
+
+      const traversal = await fetch(
+        `${origin}/engram/v1/relay/missions/%2E%2Eproduction?namespace=${RELAY_DEMO_NAMESPACE}`,
+        {
+          headers: authHeaders("read-token"),
+        }
+      );
+      assert.equal(traversal.status, 400);
+
+      const wrongNamespace = await fetch(`${origin}/engram/v1/relay/missions/empty-mission?namespace=forbidden`, {
+        headers: authHeaders("read-token"),
+      });
+      assert.equal(wrongNamespace.status, 403);
+
+      const deniedWrite = await fetch(`${origin}/engram/v1/relay/missions/${RELAY_DEMO_MISSION_ID}/events`, {
+        method: "POST",
+        headers: authHeaders("read-token"),
+        body: JSON.stringify({
+          namespace: RELAY_DEMO_NAMESPACE,
+          ...createRelayMissionFixture()[0],
+        }),
+      });
+      assert.equal(deniedWrite.status, 403);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  await withTempRoot(async (root) => {
+    const missingRoot = path.join(root, "missing-storage-root");
+    const server = new EngramAccessHttpServer({
+      service: fakeService(missingRoot, []),
+      port: 0,
+      authToken: "relay-token",
+      adminConsoleEnabled: false,
+    });
+    const status = await server.start();
+    try {
+      const response = await fetch(`http://127.0.0.1:${status.port}/engram/v1/relay/missions/backend-failure`, {
+        headers: authHeaders(),
+      });
+      assert.equal(response.status, 500);
+      assert.equal(((await response.json()) as { code: string }).code, "relay_unsafe_path");
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+test("HTTP Relay write quota is charged only for a real append, never an idempotent replay", async () => {
+  await withTempRoot(async (root) => {
+    const server = new EngramAccessHttpServer({
+      service: fakeService(root, []),
+      port: 0,
+      authToken: "relay-token",
+      adminConsoleEnabled: false,
+      writeRateLimitMaxRequests: 1,
+      writeRateLimitWindowMs: 60_000,
+    });
+    const status = await server.start();
+    const url = `http://127.0.0.1:${status.port}/engram/v1/relay/missions/${RELAY_DEMO_MISSION_ID}/events`;
+    const fixture = createRelayMissionFixture();
+    try {
+      const first = await fetch(url, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify(fixture[0]),
+      });
+      assert.equal(first.status, 201);
+
+      const replay = await fetch(url, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify(fixture[0]),
+      });
+      assert.equal(replay.status, 200);
+      assert.equal(((await replay.json()) as { replayed: boolean }).replayed, true);
+
+      const secondEvent = await fetch(url, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify(fixture[1]),
+      });
+      assert.equal(secondEvent.status, 429);
+      assert.equal(((await secondEvent.json()) as { code: string }).code, "write_rate_limited");
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+function assertEmptyMissionShape(): RelayMissionSnapshot {
+  return {
+    schemaVersion: "1",
+    missionId: "empty-mission",
+    namespace: RELAY_DEMO_NAMESPACE,
+    found: false,
+    readHealth: "empty",
+    status: "not_started",
+    mission: {
+      title: null,
+      objective: null,
+      runMode: null,
+      startedAt: null,
+      completedAt: null,
+    },
+    agents: [],
+    decisions: [],
+    conflicts: [],
+    corrections: [],
+    tests: [],
+    propagation: [],
+    outcome: null,
+    receipt: {
+      complete: false,
+      missingEvidence: [],
+      activeDecisionIds: [],
+      supersededDecisionIds: [],
+      coldStartVerified: false,
+      passingOutcomeVerified: false,
+    },
+    bounds: {
+      totalEvents: 0,
+      returnedEvents: 0,
+      corruptLines: 0,
+      truncated: false,
+      since: null,
+      until: null,
+    },
+    events: [],
+  };
+}

--- a/packages/remnic-core/src/relay/mission-access.test.ts
+++ b/packages/remnic-core/src/relay/mission-access.test.ts
@@ -67,6 +67,13 @@ test("HTTP fixture endpoint returns one complete, namespace-authorized Relay rec
     const base = `http://127.0.0.1:${status.port}/engram/v1/relay/missions/${RELAY_DEMO_MISSION_ID}`;
     try {
       const fixture = createRelayMissionFixture();
+      const blankNamespace = await fetch(`${base}/events`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ namespace: "", event: fixture[0] }),
+      });
+      assert.equal(blankNamespace.status, 400);
+
       const flatBody = await fetch(`${base}/events`, {
         method: "POST",
         headers: authHeaders(),
@@ -149,6 +156,11 @@ test("HTTP Relay surface distinguishes empty, invalid, unauthorized, and backend
         headers: authHeaders("read-token"),
       });
       assert.equal(badLimit.status, 400);
+
+      const blankNamespace = await fetch(`${origin}/engram/v1/relay/missions/empty-mission?namespace=`, {
+        headers: authHeaders("read-token"),
+      });
+      assert.equal(blankNamespace.status, 400);
 
       const badSince = await fetch(`${emptyUrl}&since=${encodeURIComponent("2026-01-01T00:00:00+99:99")}`, {
         headers: authHeaders("read-token"),

--- a/packages/remnic-core/src/relay/mission-access.test.ts
+++ b/packages/remnic-core/src/relay/mission-access.test.ts
@@ -150,6 +150,11 @@ test("HTTP Relay surface distinguishes empty, invalid, unauthorized, and backend
       });
       assert.equal(badLimit.status, 400);
 
+      const badSince = await fetch(`${emptyUrl}&since=${encodeURIComponent("2026-01-01T00:00:00+99:99")}`, {
+        headers: authHeaders("read-token"),
+      });
+      assert.equal(badSince.status, 400);
+
       const traversal = await fetch(
         `${origin}/engram/v1/relay/missions/%2E%2Eproduction?namespace=${RELAY_DEMO_NAMESPACE}`,
         {

--- a/packages/remnic-core/src/relay/mission-access.test.ts
+++ b/packages/remnic-core/src/relay/mission-access.test.ts
@@ -7,7 +7,7 @@ import test from "node:test";
 import { EngramAccessHttpServer } from "../access-http.js";
 import { EngramAccessInputError, type EngramAccessService } from "../access-service.js";
 import type { StorageManager } from "../storage.js";
-import { createRelayMissionFixture, RELAY_DEMO_MISSION_ID, RELAY_DEMO_NAMESPACE } from "./mission-fixture.js";
+import { RELAY_DEMO_MISSION_ID, RELAY_DEMO_NAMESPACE, createRelayMissionFixture } from "./mission-fixture.js";
 import type { RelayMissionSnapshot } from "./mission.js";
 
 async function withTempRoot(run: (root: string) => Promise<void>): Promise<void> {
@@ -222,6 +222,53 @@ test("HTTP Relay write quota is charged only for a real append, never an idempot
       });
       assert.equal(secondEvent.status, 429);
       assert.equal(((await secondEvent.json()) as { code: string }).code, "write_rate_limited");
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+test("HTTP Relay reserves global write quota across concurrent mission appends", async () => {
+  await withTempRoot(async (root) => {
+    const server = new EngramAccessHttpServer({
+      service: fakeService(root, []),
+      port: 0,
+      authToken: "relay-token",
+      adminConsoleEnabled: false,
+      writeRateLimitMaxRequests: 1,
+      writeRateLimitWindowMs: 60_000,
+    });
+    const status = await server.start();
+    const missionIds = ["concurrent-mission-a", "concurrent-mission-b"];
+    const startEvent = createRelayMissionFixture()[0];
+    assert.ok(startEvent);
+    const urls = missionIds.map(
+      (missionId) => `http://127.0.0.1:${status.port}/engram/v1/relay/missions/${missionId}/events`
+    );
+    try {
+      const responses = await Promise.all(
+        urls.map((url) =>
+          fetch(url, {
+            method: "POST",
+            headers: authHeaders(),
+            body: JSON.stringify(startEvent),
+          })
+        )
+      );
+      assert.deepEqual(
+        responses.map((response) => response.status).sort((a, b) => a - b),
+        [201, 429]
+      );
+
+      const winnerIndex = responses.findIndex((response) => response.status === 201);
+      assert.notEqual(winnerIndex, -1);
+      const replay = await fetch(urls[winnerIndex] ?? "", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify(startEvent),
+      });
+      assert.equal(replay.status, 200);
+      assert.equal(((await replay.json()) as { replayed: boolean }).replayed, true);
     } finally {
       await server.stop();
     }

--- a/packages/remnic-core/src/relay/mission-access.test.ts
+++ b/packages/remnic-core/src/relay/mission-access.test.ts
@@ -275,6 +275,38 @@ test("HTTP Relay reserves global write quota across concurrent mission appends",
   });
 });
 
+test("Relay write quota releases the exact reservation when timestamps collide", () => {
+  const server = new EngramAccessHttpServer({
+    service: {} as EngramAccessService,
+    port: 0,
+    authToken: "relay-token",
+    adminConsoleEnabled: false,
+  });
+  const internals = server as unknown as {
+    writeRequestSlots: Array<{ readonly recordedAt: number }>;
+    reserveWriteRateLimitSlot: () => () => void;
+  };
+  const originalNow = Date.now;
+  try {
+    Date.now = () => 1_754_000_000_000;
+    const releaseCommitted = internals.reserveWriteRateLimitSlot();
+    const committedSlot = internals.writeRequestSlots[0];
+    const releaseFailed = internals.reserveWriteRateLimitSlot();
+    const failedSlot = internals.writeRequestSlots[1];
+    assert.ok(committedSlot);
+    assert.ok(failedSlot);
+    assert.notEqual(committedSlot, failedSlot);
+
+    releaseFailed();
+    assert.deepEqual(internals.writeRequestSlots, [committedSlot]);
+
+    releaseCommitted();
+    assert.deepEqual(internals.writeRequestSlots, []);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
 function assertEmptyMissionShape(): RelayMissionSnapshot {
   return {
     schemaVersion: "1",

--- a/packages/remnic-core/src/relay/mission-access.test.ts
+++ b/packages/remnic-core/src/relay/mission-access.test.ts
@@ -67,11 +67,18 @@ test("HTTP fixture endpoint returns one complete, namespace-authorized Relay rec
     const base = `http://127.0.0.1:${status.port}/engram/v1/relay/missions/${RELAY_DEMO_MISSION_ID}`;
     try {
       const fixture = createRelayMissionFixture();
+      const flatBody = await fetch(`${base}/events`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify(fixture[0]),
+      });
+      assert.equal(flatBody.status, 400);
+
       for (const input of fixture) {
         const response = await fetch(`${base}/events`, {
           method: "POST",
           headers: authHeaders(),
-          body: JSON.stringify({ namespace: RELAY_DEMO_NAMESPACE, ...input }),
+          body: JSON.stringify({ namespace: RELAY_DEMO_NAMESPACE, event: input }),
         });
         assert.equal(response.status, 201, await response.text());
       }
@@ -79,7 +86,7 @@ test("HTTP fixture endpoint returns one complete, namespace-authorized Relay rec
       const replay = await fetch(`${base}/events`, {
         method: "POST",
         headers: authHeaders(),
-        body: JSON.stringify({ namespace: RELAY_DEMO_NAMESPACE, ...fixture[0] }),
+        body: JSON.stringify({ namespace: RELAY_DEMO_NAMESPACE, event: fixture[0] }),
       });
       assert.equal(replay.status, 200);
       assert.equal(((await replay.json()) as { replayed: boolean }).replayed, true);
@@ -156,7 +163,7 @@ test("HTTP Relay surface distinguishes empty, invalid, unauthorized, and backend
         headers: authHeaders("read-token"),
         body: JSON.stringify({
           namespace: RELAY_DEMO_NAMESPACE,
-          ...createRelayMissionFixture()[0],
+          event: createRelayMissionFixture()[0],
         }),
       });
       assert.equal(deniedWrite.status, 403);
@@ -203,14 +210,14 @@ test("HTTP Relay write quota is charged only for a real append, never an idempot
       const first = await fetch(url, {
         method: "POST",
         headers: authHeaders(),
-        body: JSON.stringify(fixture[0]),
+        body: JSON.stringify({ event: fixture[0] }),
       });
       assert.equal(first.status, 201);
 
       const replay = await fetch(url, {
         method: "POST",
         headers: authHeaders(),
-        body: JSON.stringify(fixture[0]),
+        body: JSON.stringify({ event: fixture[0] }),
       });
       assert.equal(replay.status, 200);
       assert.equal(((await replay.json()) as { replayed: boolean }).replayed, true);
@@ -218,7 +225,7 @@ test("HTTP Relay write quota is charged only for a real append, never an idempot
       const secondEvent = await fetch(url, {
         method: "POST",
         headers: authHeaders(),
-        body: JSON.stringify(fixture[1]),
+        body: JSON.stringify({ event: fixture[1] }),
       });
       assert.equal(secondEvent.status, 429);
       assert.equal(((await secondEvent.json()) as { code: string }).code, "write_rate_limited");
@@ -251,7 +258,7 @@ test("HTTP Relay reserves global write quota across concurrent mission appends",
           fetch(url, {
             method: "POST",
             headers: authHeaders(),
-            body: JSON.stringify(startEvent),
+            body: JSON.stringify({ event: startEvent }),
           })
         )
       );
@@ -265,7 +272,7 @@ test("HTTP Relay reserves global write quota across concurrent mission appends",
       const replay = await fetch(urls[winnerIndex] ?? "", {
         method: "POST",
         headers: authHeaders(),
-        body: JSON.stringify(startEvent),
+        body: JSON.stringify({ event: startEvent }),
       });
       assert.equal(replay.status, 200);
       assert.equal(((await replay.json()) as { replayed: boolean }).replayed, true);

--- a/packages/remnic-core/src/relay/mission-access.test.ts
+++ b/packages/remnic-core/src/relay/mission-access.test.ts
@@ -80,7 +80,12 @@ test("HTTP fixture endpoint returns one complete, namespace-authorized Relay rec
           headers: authHeaders(),
           body: JSON.stringify({ namespace: RELAY_DEMO_NAMESPACE, event: input }),
         });
-        assert.equal(response.status, 201, await response.text());
+        const responseBody = await response.text();
+        assert.equal(response.status, 201, responseBody);
+        assert.equal(
+          (JSON.parse(responseBody) as { event: { authenticatedPrincipal?: string } }).event.authenticatedPrincipal,
+          "relay-operator"
+        );
       }
 
       const replay = await fetch(`${base}/events`, {

--- a/packages/remnic-core/src/relay/mission-access.ts
+++ b/packages/remnic-core/src/relay/mission-access.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+
+import { defineOperation, type OperationContext } from "../access-boundary.js";
+import type { EngramAccessService } from "../access-service.js";
+import {
+  RELAY_MISSION_MAX_EVENT_LIMIT,
+  RelayMissionEventInputSchema,
+  RelayMissionReadOptionsSchema,
+  RelayMissionStore,
+  type RelayMissionAppendResult,
+  type RelayMissionEventInput,
+  type RelayMissionReadOptions,
+  type RelayMissionSnapshot,
+} from "./mission.js";
+
+const missionIdSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+const namespaceSchema = z.string().trim().min(1).max(128).nullable().optional();
+
+const RelayMissionAppendAccessSchema = z
+  .object({
+    missionId: missionIdSchema,
+    namespace: namespaceSchema,
+    event: RelayMissionEventInputSchema,
+  })
+  .strict();
+
+const optionalLimitSchema = z.preprocess((value) => {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string" && /^(?:0|[1-9]\d*)$/.test(value)) return Number(value);
+  return value;
+}, z.number().int().min(1).max(RELAY_MISSION_MAX_EVENT_LIMIT).optional());
+
+const RelayMissionReadAccessSchema = z
+  .object({
+    missionId: missionIdSchema,
+    namespace: namespaceSchema,
+    since: z.string().datetime({ offset: true }).optional(),
+    until: z.string().datetime({ offset: true }).optional(),
+    limit: optionalLimitSchema,
+  })
+  .strict()
+  .refine(
+    (value) =>
+      value.since === undefined || value.until === undefined || Date.parse(value.since) < Date.parse(value.until),
+    { message: "since must be earlier than until", path: ["until"] }
+  );
+
+export interface RelayMissionAppendAccessInput {
+  missionId: string;
+  namespace?: string | null;
+  event: RelayMissionEventInput;
+}
+
+export interface RelayMissionReadAccessInput extends RelayMissionReadOptions {
+  missionId: string;
+  namespace?: string | null;
+}
+
+export interface RelayMissionAppendAccessOutput {
+  result: RelayMissionAppendResult;
+}
+
+export interface RelayMissionReadAccessOutput {
+  result: RelayMissionSnapshot;
+}
+
+/**
+ * Shared service contract for transports that need to append Relay evidence.
+ * Namespace resolution stays in the existing access service so the append
+ * inherits the same tenancy and principal rules as every memory write.
+ */
+export async function appendRelayMissionEvent(
+  service: EngramAccessService,
+  input: RelayMissionAppendAccessInput,
+  authenticatedPrincipal?: string,
+  beforeAppend?: () => void | Promise<void>
+): Promise<RelayMissionAppendResult> {
+  const resolved = await service.getWritableStorageForNamespace(input.namespace ?? undefined, authenticatedPrincipal);
+  const store = new RelayMissionStore({
+    rootDir: resolved.storage.dir,
+    namespace: resolved.namespace,
+  });
+  return store.append(input.missionId, input.event, { beforeAppend });
+}
+
+/** Namespace-authorized, bounded Relay snapshot read shared by HTTP and UI. */
+export async function readRelayMission(
+  service: EngramAccessService,
+  input: RelayMissionReadAccessInput,
+  authenticatedPrincipal?: string
+): Promise<RelayMissionSnapshot> {
+  const resolved = await service.getReadableStorageForNamespace(input.namespace ?? undefined, authenticatedPrincipal);
+  const store = new RelayMissionStore({
+    rootDir: resolved.storage.dir,
+    namespace: resolved.namespace,
+  });
+  const options = RelayMissionReadOptionsSchema.parse({
+    ...(input.since === undefined ? {} : { since: input.since }),
+    ...(input.until === undefined ? {} : { until: input.until }),
+    ...(input.limit === undefined ? {} : { limit: input.limit }),
+  });
+  return store.read(input.missionId, options);
+}
+
+export const relayMissionAppendOperation = defineOperation<
+  RelayMissionAppendAccessInput,
+  RelayMissionAppendAccessOutput
+>({
+  name: "relay_mission_append",
+  description: "Append one evidence-backed event to an isolated Relay mission.",
+  schema: RelayMissionAppendAccessSchema as z.ZodType<RelayMissionAppendAccessInput>,
+  handler: async (input, ctx: OperationContext) => ({
+    result: await appendRelayMissionEvent(ctx.service, input, ctx.authenticatedPrincipal, ctx.hooks?.enforceWriteQuota),
+  }),
+});
+
+export const relayMissionReadOperation = defineOperation<RelayMissionReadAccessInput, RelayMissionReadAccessOutput>({
+  name: "relay_mission_read",
+  description: "Read one bounded, browser-ready Relay mission receipt.",
+  schema: RelayMissionReadAccessSchema as z.ZodType<RelayMissionReadAccessInput>,
+  handler: async (input, ctx: OperationContext) => ({
+    result: await readRelayMission(ctx.service, input, ctx.authenticatedPrincipal),
+  }),
+});

--- a/packages/remnic-core/src/relay/mission-access.ts
+++ b/packages/remnic-core/src/relay/mission-access.ts
@@ -80,7 +80,7 @@ export async function appendRelayMissionEvent(
     rootDir: resolved.storage.dir,
     namespace: resolved.namespace,
   });
-  return store.append(input.missionId, input.event, { beforeAppend });
+  return store.append(input.missionId, input.event, { authenticatedPrincipal, beforeAppend });
 }
 
 /** Namespace-authorized, bounded Relay snapshot read shared by HTTP and UI. */

--- a/packages/remnic-core/src/relay/mission-access.ts
+++ b/packages/remnic-core/src/relay/mission-access.ts
@@ -1,28 +1,24 @@
 import { z } from "zod";
 
-import { defineOperation, type OperationContext } from "../access-boundary.js";
+import { type OperationContext, defineOperation } from "../access-boundary.js";
 import type { EngramAccessService } from "../access-service.js";
 import {
   RELAY_MISSION_MAX_EVENT_LIMIT,
-  RelayMissionEventInputSchema,
-  RelayMissionReadOptionsSchema,
-  RelayMissionStore,
   type RelayMissionAppendResult,
   type RelayMissionEventInput,
+  RelayMissionEventInputSchema,
+  RelayMissionIdSchema,
   type RelayMissionReadOptions,
+  RelayMissionReadOptionsSchema,
   type RelayMissionSnapshot,
+  RelayMissionStore,
 } from "./mission.js";
 
-const missionIdSchema = z
-  .string()
-  .min(1)
-  .max(64)
-  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
 const namespaceSchema = z.string().trim().min(1).max(128).nullable().optional();
 
 const RelayMissionAppendAccessSchema = z
   .object({
-    missionId: missionIdSchema,
+    missionId: RelayMissionIdSchema,
     namespace: namespaceSchema,
     event: RelayMissionEventInputSchema,
   })
@@ -36,7 +32,7 @@ const optionalLimitSchema = z.preprocess((value) => {
 
 const RelayMissionReadAccessSchema = z
   .object({
-    missionId: missionIdSchema,
+    missionId: RelayMissionIdSchema,
     namespace: namespaceSchema,
     since: z.string().datetime({ offset: true }).optional(),
     until: z.string().datetime({ offset: true }).optional(),

--- a/packages/remnic-core/src/relay/mission-access.ts
+++ b/packages/remnic-core/src/relay/mission-access.ts
@@ -4,6 +4,7 @@ import { type OperationContext, defineOperation } from "../access-boundary.js";
 import type { EngramAccessService } from "../access-service.js";
 import {
   RELAY_MISSION_MAX_EVENT_LIMIT,
+  RelayIsoDateTimeSchema,
   type RelayMissionAppendResult,
   type RelayMissionEventInput,
   RelayMissionEventInputSchema,
@@ -34,8 +35,8 @@ const RelayMissionReadAccessSchema = z
   .object({
     missionId: RelayMissionIdSchema,
     namespace: namespaceSchema,
-    since: z.string().datetime({ offset: true }).optional(),
-    until: z.string().datetime({ offset: true }).optional(),
+    since: RelayIsoDateTimeSchema.optional(),
+    until: RelayIsoDateTimeSchema.optional(),
     limit: optionalLimitSchema,
   })
   .strict()

--- a/packages/remnic-core/src/relay/mission-fixture.ts
+++ b/packages/remnic-core/src/relay/mission-fixture.ts
@@ -27,6 +27,14 @@ const approvalEvidence = {
   capture: "fixture" as const,
 };
 
+const correctionEvidence = {
+  kind: "correction" as const,
+  id: "correction-token-refresh",
+  label: "Applied Remnic correction",
+  locator: "fixture://remnic/corrections/correction-token-refresh.json",
+  capture: "fixture" as const,
+};
+
 function at(second: number): string {
   return `2026-07-17T18:00:${String(second).padStart(2, "0")}.000Z`;
 }
@@ -171,6 +179,7 @@ export function createRelayMissionFixture(): RelayMissionEventInput[] {
       payload: {
         kind: "test_result",
         testId: "test-before-correction",
+        decisionId: "decision-new-token-every-request",
         command: "npm test -- token-policy.test.ts",
         status: "failed",
         summary: "Retry minted a second token instead of reusing the session token.",
@@ -216,15 +225,7 @@ export function createRelayMissionFixture(): RelayMissionEventInput[] {
         decisionId: "decision-new-token-every-request",
         replacementDecisionId: "decision-refresh-after-expiry",
         correctionId: "correction-token-refresh",
-        evidence: [
-          {
-            kind: "correction",
-            id: "correction-token-refresh",
-            label: "Applied Remnic correction",
-            locator: "fixture://remnic/corrections/correction-token-refresh.json",
-            capture: "fixture",
-          },
-        ],
+        evidence: [correctionEvidence],
       },
     },
     {
@@ -277,11 +278,13 @@ export function createRelayMissionFixture(): RelayMissionEventInput[] {
       payload: {
         kind: "test_result",
         testId: "test-after-correction",
+        decisionId: "decision-refresh-after-expiry",
+        correctionId: "correction-token-refresh",
         command: "npm test -- token-policy.test.ts",
         status: "passed",
         summary: "The cold agent reused the session token and the integration contract passed.",
         durationMs: 391,
-        evidence: [testEvidence],
+        evidence: [testEvidence, correctionEvidence],
       },
     },
     {

--- a/packages/remnic-core/src/relay/mission-fixture.ts
+++ b/packages/remnic-core/src/relay/mission-fixture.ts
@@ -1,0 +1,298 @@
+import type { RelayMissionEventInput } from "./mission.js";
+
+export const RELAY_DEMO_MISSION_ID = "checkout-token-recovery";
+export const RELAY_DEMO_NAMESPACE = "relay-build-week";
+
+const sourceEvidence = {
+  kind: "source" as const,
+  id: "source-checkout-contract",
+  label: "Checkout token contract",
+  locator: "fixture://checkout-service/src/token-policy.ts",
+  capture: "fixture" as const,
+};
+
+const testEvidence = {
+  kind: "test" as const,
+  id: "test-checkout-contract",
+  label: "Checkout integration contract",
+  locator: "fixture://checkout-service/test/token-policy.test.ts",
+  capture: "fixture" as const,
+};
+
+const approvalEvidence = {
+  kind: "approval" as const,
+  id: "approval-build-week-operator",
+  label: "Human approval receipt",
+  locator: "fixture://relay/approvals/correction-token-refresh.json",
+  capture: "fixture" as const,
+};
+
+function at(second: number): string {
+  return `2026-07-17T18:00:${String(second).padStart(2, "0")}.000Z`;
+}
+
+/**
+ * Deterministic evidence stream shared by contract tests, replay, and the
+ * judge-facing fixture mode. Every event has a stable idempotency key and
+ * source reference so the resulting receipt is complete without fabricated
+ * runtime evidence.
+ */
+export function createRelayMissionFixture(): RelayMissionEventInput[] {
+  return [
+    {
+      occurredAt: at(0),
+      idempotencyKey: "fixture-001",
+      payload: {
+        kind: "mission_started",
+        title: "The checkout token split",
+        objective: "Resolve a conflicting token refresh policy and prove a cold agent acts on it.",
+        runMode: "fixture",
+        evidence: [sourceEvidence],
+      },
+    },
+    {
+      occurredAt: at(2),
+      idempotencyKey: "fixture-002",
+      payload: {
+        kind: "agent_status",
+        agentId: "agent-atlas",
+        sessionId: "session-atlas",
+        label: "Atlas",
+        role: "Checkout implementation",
+        status: "working",
+        evidence: [sourceEvidence],
+      },
+    },
+    {
+      occurredAt: at(3),
+      idempotencyKey: "fixture-003",
+      payload: {
+        kind: "agent_status",
+        agentId: "agent-nova",
+        sessionId: "session-nova",
+        label: "Nova",
+        role: "Integration verification",
+        status: "working",
+        evidence: [testEvidence],
+      },
+    },
+    {
+      occurredAt: at(6),
+      idempotencyKey: "fixture-004",
+      payload: {
+        kind: "agent_output",
+        agentId: "agent-atlas",
+        sessionId: "session-atlas",
+        outputId: "output-atlas-policy",
+        summary: "Implemented a new token for every checkout retry.",
+        evidence: [
+          {
+            kind: "agent_output",
+            id: "output-atlas-policy",
+            label: "Atlas one-shot output",
+            locator: "fixture://codex/atlas/final-output.txt",
+            capture: "fixture",
+          },
+        ],
+      },
+    },
+    {
+      occurredAt: at(7),
+      idempotencyKey: "fixture-005",
+      payload: {
+        kind: "belief_observed",
+        agentId: "agent-atlas",
+        sessionId: "session-atlas",
+        beliefId: "belief-new-token-every-request",
+        decisionId: "decision-new-token-every-request",
+        statement: "Mint a new checkout token for every request and retry.",
+        confidence: 0.91,
+        evidence: [
+          {
+            kind: "memory",
+            id: "memory-stale-token-policy",
+            label: "Stale project decision",
+            locator: "fixture://remnic/memories/memory-stale-token-policy.md",
+            capture: "fixture",
+          },
+        ],
+      },
+    },
+    {
+      occurredAt: at(9),
+      idempotencyKey: "fixture-006",
+      payload: {
+        kind: "agent_output",
+        agentId: "agent-nova",
+        sessionId: "session-nova",
+        outputId: "output-nova-policy",
+        summary: "The contract requires one token per checkout session, refreshed only after expiry.",
+        evidence: [
+          {
+            kind: "agent_output",
+            id: "output-nova-policy",
+            label: "Nova one-shot output",
+            locator: "fixture://codex/nova/final-output.txt",
+            capture: "fixture",
+          },
+          sourceEvidence,
+        ],
+      },
+    },
+    {
+      occurredAt: at(10),
+      idempotencyKey: "fixture-007",
+      payload: {
+        kind: "belief_observed",
+        agentId: "agent-nova",
+        sessionId: "session-nova",
+        beliefId: "belief-refresh-after-expiry",
+        decisionId: "decision-refresh-after-expiry",
+        statement: "Reuse the checkout-session token and refresh it only after expiry.",
+        confidence: 0.98,
+        evidence: [sourceEvidence],
+      },
+    },
+    {
+      occurredAt: at(12),
+      idempotencyKey: "fixture-008",
+      payload: {
+        kind: "conflict_detected",
+        conflictId: "conflict-token-lifecycle",
+        decisionIds: ["decision-refresh-after-expiry", "decision-new-token-every-request"],
+        agentIds: ["agent-nova", "agent-atlas"],
+        summary: "The agents disagree on whether retries reuse or rotate the checkout token.",
+        evidence: [sourceEvidence, testEvidence],
+      },
+    },
+    {
+      occurredAt: at(14),
+      idempotencyKey: "fixture-009",
+      payload: {
+        kind: "test_result",
+        testId: "test-before-correction",
+        command: "npm test -- token-policy.test.ts",
+        status: "failed",
+        summary: "Retry minted a second token instead of reusing the session token.",
+        durationMs: 418,
+        evidence: [testEvidence],
+      },
+    },
+    {
+      occurredAt: at(18),
+      idempotencyKey: "fixture-010",
+      payload: {
+        kind: "correction_proposed",
+        correctionId: "correction-token-refresh",
+        conflictId: "conflict-token-lifecycle",
+        proposedDecisionId: "decision-refresh-after-expiry",
+        supersedesDecisionIds: ["decision-new-token-every-request"],
+        statement: "Reuse the checkout-session token and refresh it only after expiry.",
+        rationale: "The implementation contract and failing integration test agree on session reuse.",
+        proposedBy: "agent-resolver",
+        evidence: [sourceEvidence, testEvidence],
+      },
+    },
+    {
+      occurredAt: at(21),
+      idempotencyKey: "fixture-011",
+      payload: {
+        kind: "correction_approved",
+        correctionId: "correction-token-refresh",
+        approvedBy: {
+          kind: "human",
+          id: "operator-build-week",
+          label: "Build Week operator",
+        },
+        note: "Approve the source-grounded policy and retire the stale decision.",
+        evidence: [approvalEvidence],
+      },
+    },
+    {
+      occurredAt: at(23),
+      idempotencyKey: "fixture-012",
+      payload: {
+        kind: "decision_superseded",
+        decisionId: "decision-new-token-every-request",
+        replacementDecisionId: "decision-refresh-after-expiry",
+        correctionId: "correction-token-refresh",
+        evidence: [
+          {
+            kind: "correction",
+            id: "correction-token-refresh",
+            label: "Applied Remnic correction",
+            locator: "fixture://remnic/corrections/correction-token-refresh.json",
+            capture: "fixture",
+          },
+        ],
+      },
+    },
+    {
+      occurredAt: at(27),
+      idempotencyKey: "fixture-013",
+      payload: {
+        kind: "recall_observed",
+        agentId: "agent-orbit",
+        sessionId: "session-orbit-cold",
+        recallReceiptId: "recall-orbit-cold",
+        decisionId: "decision-refresh-after-expiry",
+        query: "What token lifecycle must checkout retries follow?",
+        capturedAtAction: true,
+        evidence: [
+          {
+            kind: "recall_audit",
+            id: "recall-orbit-cold",
+            label: "Cold-start recall audit",
+            locator: "fixture://remnic/recall-audit/recall-orbit-cold.json",
+            capture: "fixture",
+          },
+        ],
+      },
+    },
+    {
+      occurredAt: at(29),
+      idempotencyKey: "fixture-014",
+      payload: {
+        kind: "propagation_verified",
+        agentId: "agent-orbit",
+        sessionId: "session-orbit-cold",
+        correctionId: "correction-token-refresh",
+        decisionId: "decision-refresh-after-expiry",
+        recallReceiptId: "recall-orbit-cold",
+        staleDecisionAbsent: true,
+        evidence: [
+          {
+            kind: "recall_audit",
+            id: "recall-orbit-cold",
+            label: "Cold-start recall audit",
+            locator: "fixture://remnic/recall-audit/recall-orbit-cold.json",
+            capture: "fixture",
+          },
+        ],
+      },
+    },
+    {
+      occurredAt: at(34),
+      idempotencyKey: "fixture-015",
+      payload: {
+        kind: "test_result",
+        testId: "test-after-correction",
+        command: "npm test -- token-policy.test.ts",
+        status: "passed",
+        summary: "The cold agent reused the session token and the integration contract passed.",
+        durationMs: 391,
+        evidence: [testEvidence],
+      },
+    },
+    {
+      occurredAt: at(36),
+      idempotencyKey: "fixture-016",
+      payload: {
+        kind: "mission_completed",
+        outcome: "recovered",
+        summary: "One approved correction reached a cold agent and changed the observable outcome.",
+        evidence: [testEvidence, approvalEvidence],
+      },
+    },
+  ];
+}

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -50,6 +50,12 @@ function fixtureEvents(): RelayMissionEvent[] {
   );
 }
 
+function firstFixtureInput() {
+  const [first] = createRelayMissionFixture();
+  if (!first) throw new Error("Relay mission fixture must contain a start event");
+  return first;
+}
+
 test("fixture reduces to a complete correction and cold-start receipt", async () => {
   await withTempRoot(async (root) => {
     const store = deterministicStore(root);
@@ -112,7 +118,7 @@ test("idempotent append replays matching input and rejects conflicting input", a
 test("a rejected append hook does not poison the mission mutation chain", async () => {
   await withTempRoot(async (root) => {
     const store = deterministicStore(root);
-    const first = createRelayMissionFixture()[0]!;
+    const first = firstFixtureInput();
     await assert.rejects(
       store.append(RELAY_DEMO_MISSION_ID, first, {
         beforeAppend: () => {
@@ -213,7 +219,7 @@ test("reducer sorts equal-time events with a stable event-id tie break", () => {
     namespace: RELAY_DEMO_NAMESPACE,
     recordedAt: "2026-07-17T18:00:00.000Z",
     occurredAt: "2026-07-17T18:00:00.000Z",
-    payload: createRelayMissionFixture()[0]!.payload,
+    payload: firstFixtureInput().payload,
   };
   const events: RelayMissionEvent[] = [
     { ...base, eventId: "event-b" },
@@ -236,7 +242,7 @@ test("reducer sorts offset timestamps by instant before applying state transitio
     missionId: RELAY_DEMO_MISSION_ID,
     namespace: RELAY_DEMO_NAMESPACE,
     recordedAt: "2026-07-17T16:00:00.000Z",
-    payload: createRelayMissionFixture()[0]!.payload,
+    payload: firstFixtureInput().payload,
   };
   const events: RelayMissionEvent[] = [
     { ...base, eventId: "event-later", occurredAt: "2026-07-17T10:00:00.000-05:00" },
@@ -286,9 +292,105 @@ test("receipt requires an observed, decision-linked conflict and coherent missio
       event.payload.kind === "mission_started" ? { ...event, occurredAt: "2026-07-17T18:00:40.000Z" } : event
     ),
   });
-  assert.equal(lateStart.status, "completed");
+  assert.equal(lateStart.status, "active");
   assert.equal(lateStart.receipt.complete, false);
   assert.ok(lateStart.receipt.missingEvidence.includes("mission:lifecycle-order"));
+  assert.ok(lateStart.receipt.missingEvidence.some((item) => item.startsWith("mission:event-before-start:")));
+  assert.deepEqual(lateStart.decisions, []);
+  assert.equal(lateStart.outcome, null);
+
+  const [start, firstEvidence, ...remainingEvents] = fixtureEvents();
+  assert.ok(start && firstEvidence);
+  const appendedBeforeStart = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: [firstEvidence, start, ...remainingEvents],
+  });
+  assert.equal(appendedBeforeStart.receipt.complete, false);
+  assert.ok(
+    appendedBeforeStart.receipt.missingEvidence.includes(`mission:event-before-start:${firstEvidence.eventId}`)
+  );
+});
+
+test("a correction must account for every decision in its observed conflict", () => {
+  const events = fixtureEvents();
+  const belief = events.find((event) => event.payload.kind === "belief_observed");
+  assert.ok(belief && belief.payload.kind === "belief_observed");
+  const thirdDecision: RelayMissionEvent = RelayMissionEventSchema.parse({
+    ...belief,
+    eventId: "fixture-event-third-conflict",
+    recordedAt: "2026-07-17T18:00:11.000Z",
+    occurredAt: "2026-07-17T18:00:11.000Z",
+    payload: {
+      ...belief.payload,
+      beliefId: "belief-static-token",
+      decisionId: "decision-use-static-token",
+      statement: "Reuse one static token indefinitely.",
+    },
+  });
+  const incompleteConflict = events.map((event) =>
+    event.payload.kind === "conflict_detected"
+      ? {
+          ...event,
+          payload: {
+            ...event.payload,
+            decisionIds: [...event.payload.decisionIds, "decision-use-static-token"],
+          },
+        }
+      : event
+  );
+  const snapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: [...incompleteConflict, thirdDecision],
+  });
+
+  assert.equal(snapshot.receipt.complete, false);
+  assert.deepEqual(snapshot.receipt.supersededDecisionIds, []);
+  assert.equal(snapshot.conflicts[0]?.status, "open");
+  assert.equal(snapshot.corrections[0]?.status, "approved");
+  assert.ok(snapshot.receipt.missingEvidence.includes("conflict:conflict-token-lifecycle:decision-link"));
+});
+
+test("events after completion cannot rewrite the terminal mission snapshot", () => {
+  const events = fixtureEvents();
+  const proposal = events.find((event) => event.payload.kind === "correction_proposed");
+  assert.ok(proposal && proposal.payload.kind === "correction_proposed");
+  const postCompletionProposal: RelayMissionEvent = RelayMissionEventSchema.parse({
+    ...proposal,
+    eventId: "fixture-event-after-completion",
+    recordedAt: "2026-07-17T18:00:40.000Z",
+    occurredAt: "2026-07-17T18:00:40.000Z",
+    payload: {
+      ...proposal.payload,
+      correctionId: "correction-after-completion",
+    },
+  });
+  const backdatedPostCompletionProposal: RelayMissionEvent = RelayMissionEventSchema.parse({
+    ...proposal,
+    eventId: "fixture-event-backdated-after-completion",
+    recordedAt: "2026-07-17T18:00:41.000Z",
+    occurredAt: "2026-07-17T18:00:20.000Z",
+    payload: {
+      ...proposal.payload,
+      correctionId: "correction-backdated-after-completion",
+    },
+  });
+  const snapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: [...events, postCompletionProposal, backdatedPostCompletionProposal],
+  });
+
+  assert.equal(snapshot.status, "completed");
+  assert.equal(snapshot.outcome?.result, "recovered");
+  assert.equal(snapshot.corrections.length, 1);
+  assert.equal(snapshot.corrections[0]?.status, "propagated");
+  assert.equal(snapshot.receipt.complete, false);
+  assert.ok(snapshot.receipt.missingEvidence.includes("mission:event-after-completion:fixture-event-after-completion"));
+  assert.ok(
+    snapshot.receipt.missingEvidence.includes("mission:event-after-completion:fixture-event-backdated-after-completion")
+  );
 });
 
 test("propagation requires a matching post-application recall from a cold agent session", () => {
@@ -380,14 +482,15 @@ test("receipt requires human approval and a passing test after verified propagat
 });
 
 test("missing evidence is explicit rather than conflated with a complete receipt", () => {
-  const input = createRelayMissionFixture()[0]!;
+  const input = firstFixtureInput();
+  assert.ok(input.occurredAt);
   const event: RelayMissionEvent = {
     schemaVersion: "1",
     eventId: "event-no-evidence",
     missionId: RELAY_DEMO_MISSION_ID,
     namespace: RELAY_DEMO_NAMESPACE,
-    recordedAt: input.occurredAt!,
-    occurredAt: input.occurredAt!,
+    recordedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
     payload: { ...input.payload, evidence: [] },
   };
   const snapshot = reduceRelayMission({
@@ -416,10 +519,11 @@ test("store rejects a symlinked Relay directory and event-count overflow", async
 
   await withTempRoot(async (root) => {
     const bounded = deterministicStore(root, { maxEvents: 1 });
-    const fixture = createRelayMissionFixture();
-    await bounded.append(RELAY_DEMO_MISSION_ID, fixture[0]!);
+    const [first, second] = createRelayMissionFixture();
+    assert.ok(first && second);
+    await bounded.append(RELAY_DEMO_MISSION_ID, first);
     await assert.rejects(
-      bounded.append(RELAY_DEMO_MISSION_ID, fixture[1]!),
+      bounded.append(RELAY_DEMO_MISSION_ID, second),
       (error: unknown) => error instanceof RelayMissionStoreError && error.code === "limit_exceeded"
     );
   });
@@ -429,6 +533,6 @@ test("mission identifiers cannot traverse the storage root", async () => {
   await withTempRoot(async (root) => {
     const store = deterministicStore(root);
     await assert.rejects(store.read("../production"));
-    await assert.rejects(store.append("bad/id", createRelayMissionFixture()[0]!));
+    await assert.rejects(store.append("bad/id", firstFixtureInput()));
   });
 });

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  RelayMissionEventInputSchema,
+  RelayMissionStore,
+  RelayMissionStoreError,
+  reduceRelayMission,
+  relayMissionReceiptDigest,
+  type RelayMissionEvent,
+} from "./mission.js";
+import { createRelayMissionFixture, RELAY_DEMO_MISSION_ID, RELAY_DEMO_NAMESPACE } from "./mission-fixture.js";
+
+async function withTempRoot(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-relay-"));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function deterministicStore(root: string, options: { maxEvents?: number } = {}): RelayMissionStore {
+  let nextId = 0;
+  return new RelayMissionStore({
+    rootDir: root,
+    namespace: RELAY_DEMO_NAMESPACE,
+    now: () => new Date("2026-07-17T19:00:00.000Z"),
+    createEventId: () => `event-${String(++nextId).padStart(3, "0")}`,
+    ...options,
+  });
+}
+
+test("fixture reduces to a complete correction and cold-start receipt", async () => {
+  await withTempRoot(async (root) => {
+    const store = deterministicStore(root);
+    for (const input of createRelayMissionFixture()) {
+      const result = await store.append(RELAY_DEMO_MISSION_ID, input);
+      assert.equal(result.appended, true);
+      assert.equal(result.replayed, false);
+    }
+
+    const snapshot = await store.read(RELAY_DEMO_MISSION_ID);
+    assert.equal(snapshot.found, true);
+    assert.equal(snapshot.readHealth, "ok");
+    assert.equal(snapshot.status, "completed");
+    assert.equal(snapshot.events.length, 16);
+    assert.deepEqual(snapshot.receipt.activeDecisionIds, ["decision-refresh-after-expiry"]);
+    assert.deepEqual(snapshot.receipt.supersededDecisionIds, ["decision-new-token-every-request"]);
+    assert.equal(snapshot.receipt.coldStartVerified, true);
+    assert.equal(snapshot.receipt.passingOutcomeVerified, true);
+    assert.deepEqual(snapshot.receipt.missingEvidence, []);
+    assert.equal(snapshot.receipt.complete, true);
+    assert.equal(snapshot.corrections[0]?.status, "propagated");
+    assert.equal(
+      snapshot.decisions.find((item) => item.status === "superseded")?.supersededBy,
+      "decision-refresh-after-expiry"
+    );
+
+    const digest = relayMissionReceiptDigest(snapshot);
+    assert.match(digest, /^[a-f0-9]{64}$/);
+    assert.equal(digest, relayMissionReceiptDigest(await store.read(RELAY_DEMO_MISSION_ID)));
+
+    const mode = await readFile(path.join(root, "state", "relay", "missions", `${RELAY_DEMO_MISSION_ID}.jsonl`));
+    assert.ok(mode.length > 0);
+  });
+});
+
+test("idempotent append replays matching input and rejects conflicting input", async () => {
+  await withTempRoot(async (root) => {
+    const store = deterministicStore(root);
+    const [first] = createRelayMissionFixture();
+    assert.ok(first);
+    assert.equal(first.payload.kind, "mission_started");
+    if (first.payload.kind !== "mission_started") throw new Error("fixture contract drift");
+    const initial = await store.append(RELAY_DEMO_MISSION_ID, first);
+    const replay = await store.append(RELAY_DEMO_MISSION_ID, first);
+    assert.equal(replay.replayed, true);
+    assert.equal(replay.event.eventId, initial.event.eventId);
+
+    await assert.rejects(
+      store.append(RELAY_DEMO_MISSION_ID, {
+        ...first,
+        payload: { ...first.payload, title: "Different mission" },
+      }),
+      (error: unknown) => error instanceof RelayMissionStoreError && error.code === "idempotency_conflict"
+    );
+  });
+});
+
+test("empty, partial, and bounded reads remain distinct and deterministic", async () => {
+  await withTempRoot(async (root) => {
+    const store = deterministicStore(root);
+    const empty = await store.read(RELAY_DEMO_MISSION_ID);
+    assert.equal(empty.found, false);
+    assert.equal(empty.readHealth, "empty");
+    assert.equal(empty.status, "not_started");
+
+    for (const input of createRelayMissionFixture().slice(0, 3)) {
+      await store.append(RELAY_DEMO_MISSION_ID, input);
+    }
+    const file = path.join(root, "state", "relay", "missions", `${RELAY_DEMO_MISSION_ID}.jsonl`);
+    await writeFile(file, `${await readFile(file, "utf8")}not-json\n`, { mode: 0o600 });
+
+    const partial = await store.read(RELAY_DEMO_MISSION_ID, {
+      since: "2026-07-17T18:00:02.000Z",
+      until: "2026-07-17T18:00:03.000Z",
+      limit: 1,
+    });
+    assert.equal(partial.readHealth, "partial");
+    assert.equal(partial.bounds.corruptLines, 1);
+    assert.equal(partial.bounds.totalEvents, 1);
+    assert.equal(partial.events[0]?.payload.kind, "agent_status");
+    assert.equal(partial.events[0]?.occurredAt, "2026-07-17T18:00:02.000Z");
+  });
+});
+
+test("event contract rejects invalid identifiers, self-supersession, and mislabeled recall", () => {
+  const fixture = createRelayMissionFixture();
+  assert.throws(() => new RelayMissionStore({ rootDir: "/tmp", namespace: "" }));
+  assert.equal(
+    RelayMissionEventInputSchema.safeParse({
+      occurredAt: "2026-07-17T18:00:00.000Z",
+      payload: {
+        kind: "decision_superseded",
+        decisionId: "same",
+        replacementDecisionId: "same",
+        correctionId: "correction",
+        evidence: [],
+      },
+    }).success,
+    false
+  );
+  const recall = fixture.find((item) => item.payload.kind === "recall_observed");
+  assert.ok(recall && recall.payload.kind === "recall_observed");
+  assert.equal(
+    RelayMissionEventInputSchema.safeParse({
+      ...recall,
+      payload: {
+        ...recall.payload,
+        evidence: recall.payload.evidence.map((item) => ({
+          ...item,
+          capture: "historical_lookup" as const,
+        })),
+      },
+    }).success,
+    false
+  );
+});
+
+test("reducer sorts equal-time events with a stable event-id tie break", () => {
+  const base = {
+    schemaVersion: "1" as const,
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    recordedAt: "2026-07-17T18:00:00.000Z",
+    occurredAt: "2026-07-17T18:00:00.000Z",
+    payload: createRelayMissionFixture()[0]!.payload,
+  };
+  const events: RelayMissionEvent[] = [
+    { ...base, eventId: "event-b" },
+    { ...base, eventId: "event-a" },
+  ];
+  const snapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events,
+  });
+  assert.deepEqual(
+    snapshot.events.map((event) => event.eventId),
+    ["event-a", "event-b"]
+  );
+});
+
+test("missing evidence is explicit rather than conflated with a complete receipt", () => {
+  const input = createRelayMissionFixture()[0]!;
+  const event: RelayMissionEvent = {
+    schemaVersion: "1",
+    eventId: "event-no-evidence",
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    recordedAt: input.occurredAt!,
+    occurredAt: input.occurredAt!,
+    payload: { ...input.payload, evidence: [] },
+  };
+  const snapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: [event],
+  });
+  assert.equal(snapshot.receipt.complete, false);
+  assert.deepEqual(snapshot.receipt.missingEvidence, ["event:event-no-evidence:evidence"]);
+});
+
+test("store rejects a symlinked Relay directory and event-count overflow", async () => {
+  await withTempRoot(async (root) => {
+    const outside = await mkdtemp(path.join(os.tmpdir(), "remnic-relay-outside-"));
+    try {
+      await symlink(outside, path.join(root, "state"));
+      const unsafe = deterministicStore(root);
+      await assert.rejects(
+        unsafe.read(RELAY_DEMO_MISSION_ID),
+        (error: unknown) => error instanceof RelayMissionStoreError && error.code === "unsafe_path"
+      );
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  await withTempRoot(async (root) => {
+    const bounded = deterministicStore(root, { maxEvents: 1 });
+    const fixture = createRelayMissionFixture();
+    await bounded.append(RELAY_DEMO_MISSION_ID, fixture[0]!);
+    await assert.rejects(
+      bounded.append(RELAY_DEMO_MISSION_ID, fixture[1]!),
+      (error: unknown) => error instanceof RelayMissionStoreError && error.code === "limit_exceeded"
+    );
+  });
+});
+
+test("mission identifiers cannot traverse the storage root", async () => {
+  await withTempRoot(async (root) => {
+    const store = deterministicStore(root);
+    await assert.rejects(store.read("../production"));
+    await assert.rejects(store.append("bad/id", createRelayMissionFixture()[0]!));
+  });
+});

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -560,6 +560,25 @@ test("receipt requires human approval and a passing test after verified propagat
   });
   assert.equal(ungroundedPassSnapshot.receipt.passingOutcomeVerified, false);
   assert.ok(ungroundedPassSnapshot.receipt.missingEvidence.includes("outcome:passing-test"));
+
+  const noTestArtifact = fixtureEvents().map((event) =>
+    event.payload.kind === "test_result" && event.payload.status === "passed"
+      ? {
+          ...event,
+          payload: {
+            ...event.payload,
+            evidence: event.payload.evidence.filter((item) => item.kind !== "test"),
+          },
+        }
+      : event
+  );
+  const noTestArtifactSnapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: noTestArtifact,
+  });
+  assert.equal(noTestArtifactSnapshot.receipt.passingOutcomeVerified, false);
+  assert.ok(noTestArtifactSnapshot.receipt.missingEvidence.includes("outcome:passing-test"));
 });
 
 test("missing evidence is explicit rather than conflated with a complete receipt", () => {
@@ -607,6 +626,32 @@ test("store rejects a symlinked Relay directory and event-count overflow", async
       bounded.append(RELAY_DEMO_MISSION_ID, second),
       (error: unknown) => error instanceof RelayMissionStoreError && error.code === "limit_exceeded"
     );
+  });
+});
+
+test("append remains pinned inside the Relay root when the missions pathname is swapped", async () => {
+  await withTempRoot(async (root) => {
+    const outside = await mkdtemp(path.join(os.tmpdir(), "remnic-relay-swap-outside-"));
+    const missionDir = path.join(root, "state", "relay", "missions");
+    const pinnedDir = path.join(root, "state", "relay", "missions-pinned");
+    const missionFileName = `${RELAY_DEMO_MISSION_ID}.jsonl`;
+    try {
+      const store = deterministicStore(root);
+      await store.append(RELAY_DEMO_MISSION_ID, firstFixtureInput(), {
+        beforeAppend: async () => {
+          await rename(missionDir, pinnedDir);
+          await symlink(outside, missionDir);
+        },
+      });
+
+      assert.match(await readFile(path.join(pinnedDir, missionFileName), "utf8"), /mission_started/);
+      await assert.rejects(
+        readFile(path.join(outside, missionFileName), "utf8"),
+        (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT"
+      );
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -352,6 +352,53 @@ test("a correction must account for every decision in its observed conflict", ()
   assert.ok(snapshot.receipt.missingEvidence.includes("conflict:conflict-token-lifecycle:decision-link"));
 });
 
+test("a recovered correction must share source evidence with its observed conflict", () => {
+  const withoutSources = fixtureEvents().map((event) =>
+    RelayMissionEventSchema.parse({
+      ...event,
+      payload: {
+        ...event.payload,
+        evidence: event.payload.evidence.map((item) =>
+          item.kind === "source" ? { ...item, kind: "test" as const } : item
+        ),
+      },
+    })
+  );
+  const ungrounded = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: withoutSources,
+  });
+
+  assert.equal(ungrounded.receipt.complete, false);
+  assert.deepEqual(ungrounded.receipt.supersededDecisionIds, []);
+  assert.equal(ungrounded.conflicts[0]?.status, "open");
+  assert.ok(ungrounded.receipt.missingEvidence.includes("conflict:conflict-token-lifecycle:source"));
+  assert.ok(ungrounded.receipt.missingEvidence.includes("correction:correction-token-refresh:source"));
+  assert.ok(ungrounded.receipt.missingEvidence.includes("correction:correction-token-refresh:source-link"));
+
+  const mismatchedSource = fixtureEvents().map((event) =>
+    event.payload.kind === "correction_proposed"
+      ? RelayMissionEventSchema.parse({
+          ...event,
+          payload: {
+            ...event.payload,
+            evidence: event.payload.evidence.map((item) =>
+              item.kind === "source" ? { ...item, id: "source-unrelated-contract" } : item
+            ),
+          },
+        })
+      : event
+  );
+  const unlinked = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: mismatchedSource,
+  });
+  assert.equal(unlinked.receipt.complete, false);
+  assert.ok(unlinked.receipt.missingEvidence.includes("correction:correction-token-refresh:source-link"));
+});
+
 test("events after completion cannot rewrite the terminal mission snapshot", () => {
   const events = fixtureEvents();
   const proposal = events.find((event) => event.payload.kind === "correction_proposed");

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -526,6 +526,38 @@ test("receipt requires human approval and a passing test after verified propagat
   assert.equal(earlyPassSnapshot.receipt.complete, false);
   assert.equal(earlyPassSnapshot.receipt.passingOutcomeVerified, false);
   assert.ok(earlyPassSnapshot.receipt.missingEvidence.includes("outcome:passing-test"));
+
+  const unrelatedPass = fixtureEvents().map((event) =>
+    event.payload.kind === "test_result" && event.payload.status === "passed"
+      ? { ...event, payload: { ...event.payload, decisionId: "decision-unrelated" } }
+      : event
+  );
+  const unrelatedPassSnapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: unrelatedPass,
+  });
+  assert.equal(unrelatedPassSnapshot.receipt.passingOutcomeVerified, false);
+  assert.ok(unrelatedPassSnapshot.receipt.missingEvidence.includes("outcome:passing-test"));
+
+  const ungroundedPass = fixtureEvents().map((event) =>
+    event.payload.kind === "test_result" && event.payload.status === "passed"
+      ? {
+          ...event,
+          payload: {
+            ...event.payload,
+            evidence: event.payload.evidence.filter((item) => item.kind !== "correction"),
+          },
+        }
+      : event
+  );
+  const ungroundedPassSnapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: ungroundedPass,
+  });
+  assert.equal(ungroundedPassSnapshot.receipt.passingOutcomeVerified, false);
+  assert.ok(ungroundedPassSnapshot.receipt.missingEvidence.includes("outcome:passing-test"));
 });
 
 test("missing evidence is explicit rather than conflated with a complete receipt", () => {

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -140,7 +140,7 @@ test("empty, partial, and bounded reads remain distinct and deterministic", asyn
     assert.equal(empty.readHealth, "empty");
     assert.equal(empty.status, "not_started");
 
-    for (const input of createRelayMissionFixture().slice(0, 3)) {
+    for (const input of createRelayMissionFixture()) {
       await store.append(RELAY_DEMO_MISSION_ID, input);
     }
     const file = path.join(root, "state", "relay", "missions", `${RELAY_DEMO_MISSION_ID}.jsonl`);
@@ -156,6 +156,8 @@ test("empty, partial, and bounded reads remain distinct and deterministic", asyn
     assert.equal(partial.bounds.totalEvents, 1);
     assert.equal(partial.events[0]?.payload.kind, "agent_status");
     assert.equal(partial.events[0]?.occurredAt, "2026-07-17T18:00:02.000Z");
+    assert.equal(partial.receipt.complete, false);
+    assert.ok(partial.receipt.missingEvidence.includes("mission:corrupt-events"));
 
     const outsideWindow = await store.read(RELAY_DEMO_MISSION_ID, {
       since: "2026-07-17T19:00:00.000Z",

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, readdir, rename, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -186,6 +186,7 @@ test("empty, partial, and bounded reads remain distinct and deterministic", asyn
     assert.equal(empty.found, false);
     assert.equal(empty.readHealth, "empty");
     assert.equal(empty.status, "not_started");
+    assert.deepEqual(await readdir(root), []);
 
     for (const input of createRelayMissionFixture()) {
       await store.append(RELAY_DEMO_MISSION_ID, input);
@@ -212,6 +213,29 @@ test("empty, partial, and bounded reads remain distinct and deterministic", asyn
     });
     assert.equal(outsideWindow.found, true, "a known mission remains found outside the selected window");
     assert.equal(outsideWindow.bounds.totalEvents, 0);
+  });
+});
+
+test("read serves an existing receipt without mutating a read-only mission directory", async () => {
+  await withTempRoot(async (root) => {
+    const store = deterministicStore(root);
+    for (const input of createRelayMissionFixture()) {
+      await store.append(RELAY_DEMO_MISSION_ID, input);
+    }
+    const missionDir = path.join(root, "state", "relay", "missions");
+    const missionFile = path.join(missionDir, `${RELAY_DEMO_MISSION_ID}.jsonl`);
+    const entriesBefore = (await readdir(missionDir)).sort();
+
+    await chmod(missionFile, 0o400);
+    await chmod(missionDir, 0o555);
+    try {
+      const snapshot = await store.read(RELAY_DEMO_MISSION_ID);
+      assert.equal(snapshot.receipt.complete, true);
+      assert.deepEqual((await readdir(missionDir)).sort(), entriesBefore);
+    } finally {
+      await chmod(missionDir, 0o700);
+      await chmod(missionFile, 0o600);
+    }
   });
 });
 

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -70,6 +70,21 @@ function firstFixtureInput() {
   return first;
 }
 
+function moveEventBefore(
+  events: RelayMissionEvent[],
+  select: (event: RelayMissionEvent) => boolean,
+  before: (event: RelayMissionEvent) => boolean
+): RelayMissionEvent[] {
+  const movingIndex = events.findIndex(select);
+  assert.notEqual(movingIndex, -1, "moving event must exist");
+  const moving = events[movingIndex];
+  assert.ok(moving);
+  const remaining = events.filter((_, index) => index !== movingIndex);
+  const anchorIndex = remaining.findIndex(before);
+  assert.notEqual(anchorIndex, -1, "anchor event must exist");
+  return [...remaining.slice(0, anchorIndex), moving, ...remaining.slice(anchorIndex)];
+}
+
 test("fixture reduces to a complete correction and cold-start receipt", async () => {
   await withTempRoot(async (root) => {
     const store = deterministicStore(root);
@@ -583,6 +598,66 @@ test("receipt cannot apply or propagate a correction without prior approval", ()
   );
   assert.equal(snapshot.corrections[0]?.status, "proposed");
   assert.ok(snapshot.receipt.missingEvidence.includes("correction:correction-token-refresh:approval"));
+});
+
+test("receipt binds the full correction proof chain to server append order", () => {
+  const scenarios = [
+    {
+      name: "conflict appended before its beliefs",
+      events: moveEventBefore(
+        fixtureEvents(),
+        (event) => event.payload.kind === "conflict_detected",
+        (event) => event.payload.kind === "belief_observed"
+      ),
+      missing: "conflict:conflict-token-lifecycle:decision:decision-new-token-every-request:append-order",
+    },
+    {
+      name: "proposal appended before conflict",
+      events: moveEventBefore(
+        fixtureEvents(),
+        (event) => event.payload.kind === "correction_proposed",
+        (event) => event.payload.kind === "conflict_detected"
+      ),
+      missing: "correction:correction-token-refresh:conflict-append-order",
+    },
+    {
+      name: "approval appended after supersession",
+      events: moveEventBefore(
+        fixtureEvents(),
+        (event) => event.payload.kind === "decision_superseded",
+        (event) => event.payload.kind === "correction_approved"
+      ),
+      missing: "correction:correction-token-refresh:approval-append-order",
+    },
+    {
+      name: "recall appended after propagation",
+      events: moveEventBefore(
+        fixtureEvents(),
+        (event) => event.payload.kind === "propagation_verified",
+        (event) => event.payload.kind === "recall_observed"
+      ),
+      missing: "recall:recall-orbit-cold:propagation-append-order",
+    },
+    {
+      name: "passing test appended before propagation",
+      events: moveEventBefore(
+        fixtureEvents(),
+        (event) => event.payload.kind === "test_result" && event.payload.status === "passed",
+        (event) => event.payload.kind === "propagation_verified"
+      ),
+      missing: "outcome:passing-test",
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const snapshot = reduceRelayMission({
+      missionId: RELAY_DEMO_MISSION_ID,
+      namespace: RELAY_DEMO_NAMESPACE,
+      events: scenario.events,
+    });
+    assert.equal(snapshot.receipt.complete, false, scenario.name);
+    assert.ok(snapshot.receipt.missingEvidence.includes(scenario.missing), scenario.name);
+  }
 });
 
 test("receipt requires human approval and a passing test after verified propagation", () => {

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -93,6 +93,29 @@ test("fixture reduces to a complete correction and cold-start receipt", async ()
   });
 });
 
+test("live receipts reject fixture-captured evidence", () => {
+  const forgedLiveEvents = fixtureEvents().map((event) =>
+    event.payload.kind === "mission_started"
+      ? {
+          ...event,
+          payload: { ...event.payload, runMode: "live" as const },
+        }
+      : event
+  );
+
+  const snapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: forgedLiveEvents,
+  });
+
+  assert.equal(snapshot.mission.runMode, "live");
+  assert.equal(snapshot.receipt.complete, false);
+  assert.equal(snapshot.receipt.coldStartVerified, false);
+  assert.equal(snapshot.receipt.passingOutcomeVerified, false);
+  assert.ok(snapshot.receipt.missingEvidence.includes("mission:live-fixture-evidence:fixture-event-001"));
+});
+
 test("idempotent append replays matching input and rejects conflicting input", async () => {
   await withTempRoot(async (root) => {
     const store = deterministicStore(root);

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -71,6 +71,8 @@ test("fixture reduces to a complete correction and cold-start receipt", async ()
     assert.deepEqual(snapshot.receipt.missingEvidence, []);
     assert.equal(snapshot.receipt.complete, true);
     assert.equal(snapshot.corrections[0]?.status, "propagated");
+    assert.equal(snapshot.corrections[0]?.appliedAt, "2026-07-17T18:00:23.000Z");
+    assert.equal(snapshot.agents.find((agent) => agent.agentId === "agent-orbit")?.recalls[0]?.coldStart, true);
     assert.equal(
       snapshot.decisions.find((item) => item.status === "superseded")?.supersededBy,
       "decision-refresh-after-expiry"
@@ -189,6 +191,19 @@ test("event contract rejects invalid identifiers, self-supersession, and mislabe
     }).success,
     false
   );
+  assert.equal(
+    RelayMissionEventInputSchema.safeParse({
+      ...recall,
+      payload: {
+        ...recall.payload,
+        evidence: recall.payload.evidence.map((item) => ({
+          ...item,
+          id: "different-recall-receipt",
+        })),
+      },
+    }).success,
+    false
+  );
 });
 
 test("reducer sorts equal-time events with a stable event-id tie break", () => {
@@ -252,6 +267,60 @@ test("time windows filter the event feed without rewriting authoritative receipt
   assert.equal(snapshot.bounds.totalEvents, 0);
   assert.equal(snapshot.bounds.returnedEvents, 0);
   assert.deepEqual(snapshot.events, []);
+});
+
+test("receipt requires an observed, decision-linked conflict and coherent mission lifecycle", () => {
+  const withoutConflict = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: fixtureEvents().filter((event) => event.payload.kind !== "conflict_detected"),
+  });
+  assert.equal(withoutConflict.receipt.complete, false);
+  assert.deepEqual(withoutConflict.conflicts, []);
+  assert.ok(withoutConflict.receipt.missingEvidence.includes("conflict:conflict-token-lifecycle:observation"));
+
+  const lateStart = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: fixtureEvents().map((event) =>
+      event.payload.kind === "mission_started" ? { ...event, occurredAt: "2026-07-17T18:00:40.000Z" } : event
+    ),
+  });
+  assert.equal(lateStart.status, "completed");
+  assert.equal(lateStart.receipt.complete, false);
+  assert.ok(lateStart.receipt.missingEvidence.includes("mission:lifecycle-order"));
+});
+
+test("propagation requires a matching post-application recall from a cold agent session", () => {
+  const recallBeforeApplication = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: fixtureEvents().map((event) =>
+      event.payload.kind === "recall_observed" ? { ...event, occurredAt: "2026-07-17T18:00:22.000Z" } : event
+    ),
+  });
+  assert.equal(recallBeforeApplication.receipt.complete, false);
+  assert.equal(recallBeforeApplication.receipt.coldStartVerified, false);
+  assert.ok(recallBeforeApplication.receipt.missingEvidence.includes("recall:recall-orbit-cold:post-application"));
+
+  const warmAgent = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: fixtureEvents().map((event) => {
+      if (event.payload.kind !== "recall_observed" && event.payload.kind !== "propagation_verified") return event;
+      return {
+        ...event,
+        payload: {
+          ...event.payload,
+          agentId: "agent-atlas",
+          sessionId: "session-atlas",
+        },
+      };
+    }),
+  });
+  assert.equal(warmAgent.receipt.complete, false);
+  assert.equal(warmAgent.receipt.coldStartVerified, false);
+  assert.ok(warmAgent.receipt.missingEvidence.includes("recall:recall-orbit-cold:cold-start"));
 });
 
 test("receipt cannot apply or propagate a correction without prior approval", () => {

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -421,6 +421,32 @@ test("conflict participants must hold distinct conflicting decisions at detectio
   );
 });
 
+test("conflict decisions must contain genuinely distinct normalized statements", () => {
+  const identicalPolicies = fixtureEvents().map((event) =>
+    event.payload.kind === "belief_observed" && event.payload.decisionId === "decision-refresh-after-expiry"
+      ? {
+          ...event,
+          payload: {
+            ...event.payload,
+            statement: "  MINT a new checkout token for every request and retry!!!  ",
+          },
+        }
+      : event
+  );
+  const snapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: identicalPolicies,
+  });
+
+  assert.equal(snapshot.receipt.complete, false);
+  assert.deepEqual(snapshot.receipt.supersededDecisionIds, []);
+  assert.equal(snapshot.conflicts[0]?.status, "open");
+  assert.ok(
+    snapshot.receipt.missingEvidence.includes("conflict:conflict-token-lifecycle:distinct-decision-statements")
+  );
+});
+
 test("a correction must account for every decision in its observed conflict", () => {
   const events = fixtureEvents();
   const belief = events.find((event) => event.payload.kind === "belief_observed");
@@ -682,10 +708,21 @@ test("receipt requires human approval and a passing test after verified propagat
     agentApprovedSnapshot.receipt.missingEvidence.includes("correction:correction-token-refresh:human-approval")
   );
 
+  const forgedHumanEvents = liveFixtureEvents("agent-runner");
+  const forgedApprovalIndex = forgedHumanEvents.findIndex((event) => event.payload.kind === "correction_approved");
+  assert.notEqual(forgedApprovalIndex, -1);
+  const forgedApprovalSnapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: forgedHumanEvents.slice(0, forgedApprovalIndex + 1),
+  });
+  assert.equal(forgedApprovalSnapshot.status, "awaiting_approval");
+  assert.equal(forgedApprovalSnapshot.corrections[0]?.status, "proposed");
+
   const forgedHumanSnapshot = reduceRelayMission({
     missionId: RELAY_DEMO_MISSION_ID,
     namespace: RELAY_DEMO_NAMESPACE,
-    events: liveFixtureEvents("agent-runner"),
+    events: forgedHumanEvents,
   });
   assert.equal(forgedHumanSnapshot.receipt.complete, false);
   assert.ok(

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -91,6 +91,23 @@ test("idempotent append replays matching input and rejects conflicting input", a
   });
 });
 
+test("a rejected append hook does not poison the mission mutation chain", async () => {
+  await withTempRoot(async (root) => {
+    const store = deterministicStore(root);
+    const first = createRelayMissionFixture()[0]!;
+    await assert.rejects(
+      store.append(RELAY_DEMO_MISSION_ID, first, {
+        beforeAppend: () => {
+          throw new Error("quota rejected");
+        },
+      }),
+      /quota rejected/
+    );
+    const recovered = await store.append(RELAY_DEMO_MISSION_ID, first);
+    assert.equal(recovered.appended, true);
+  });
+});
+
 test("empty, partial, and bounded reads remain distinct and deterministic", async () => {
   await withTempRoot(async (root) => {
     const store = deterministicStore(root);
@@ -115,6 +132,13 @@ test("empty, partial, and bounded reads remain distinct and deterministic", asyn
     assert.equal(partial.bounds.totalEvents, 1);
     assert.equal(partial.events[0]?.payload.kind, "agent_status");
     assert.equal(partial.events[0]?.occurredAt, "2026-07-17T18:00:02.000Z");
+
+    const outsideWindow = await store.read(RELAY_DEMO_MISSION_ID, {
+      since: "2026-07-17T19:00:00.000Z",
+      limit: 1,
+    });
+    assert.equal(outsideWindow.found, true, "a known mission remains found outside the selected window");
+    assert.equal(outsideWindow.bounds.totalEvents, 0);
   });
 });
 

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -447,6 +447,61 @@ test("conflict decisions must contain genuinely distinct normalized statements",
   );
 });
 
+test("decision identity remains bound to one normalized statement across beliefs and corrections", () => {
+  const events = fixtureEvents();
+  const replacementBeliefIndex = events.findIndex(
+    (event) => event.payload.kind === "belief_observed" && event.payload.decisionId === "decision-refresh-after-expiry"
+  );
+  assert.notEqual(replacementBeliefIndex, -1);
+  const replacementBelief = events[replacementBeliefIndex];
+  assert.ok(replacementBelief?.payload.kind === "belief_observed");
+  const reboundBelief = RelayMissionEventSchema.parse({
+    ...replacementBelief,
+    eventId: "fixture-event-rebound-policy",
+    payload: {
+      ...replacementBelief.payload,
+      beliefId: "belief-rebound-policy",
+      statement: "Mint a new checkout token for every request and retry.",
+    },
+  });
+  const reboundSnapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: [
+      ...events.slice(0, replacementBeliefIndex + 1),
+      reboundBelief,
+      ...events.slice(replacementBeliefIndex + 1),
+    ],
+  });
+  assert.equal(reboundSnapshot.receipt.complete, false);
+  assert.ok(
+    reboundSnapshot.receipt.missingEvidence.includes("decision:decision-refresh-after-expiry:statement-consistency")
+  );
+
+  const contradictoryCorrection = events.map((event) =>
+    event.payload.kind === "correction_proposed"
+      ? {
+          ...event,
+          payload: {
+            ...event.payload,
+            statement: "Mint a new checkout token for every request and retry.",
+          },
+        }
+      : event
+  );
+  const correctionSnapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: contradictoryCorrection,
+  });
+  assert.equal(correctionSnapshot.receipt.complete, false);
+  assert.deepEqual(correctionSnapshot.receipt.supersededDecisionIds, []);
+  assert.equal(correctionSnapshot.conflicts[0]?.status, "open");
+  assert.ok(
+    correctionSnapshot.receipt.missingEvidence.includes("correction:correction-token-refresh:replacement-statement")
+  );
+});
+
 test("a correction must account for every decision in its observed conflict", () => {
   const events = fixtureEvents();
   const belief = events.find((event) => event.payload.kind === "belief_observed");

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -238,6 +238,22 @@ test("reducer sorts offset timestamps by instant before applying state transitio
   );
 });
 
+test("time windows filter the event feed without rewriting authoritative receipt state", () => {
+  const snapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: fixtureEvents(),
+    options: { since: "2026-07-17T19:00:00.000Z", limit: 1 },
+  });
+
+  assert.equal(snapshot.found, true);
+  assert.equal(snapshot.status, "completed");
+  assert.equal(snapshot.receipt.complete, true);
+  assert.equal(snapshot.bounds.totalEvents, 0);
+  assert.equal(snapshot.bounds.returnedEvents, 0);
+  assert.deepEqual(snapshot.events, []);
+});
+
 test("receipt cannot apply or propagate a correction without prior approval", () => {
   const events = fixtureEvents().filter((event) => event.payload.kind !== "correction_approved");
   const snapshot = reduceRelayMission({

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -4,15 +4,16 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { RELAY_DEMO_MISSION_ID, RELAY_DEMO_NAMESPACE, createRelayMissionFixture } from "./mission-fixture.js";
 import {
+  type RelayMissionEvent,
   RelayMissionEventInputSchema,
+  RelayMissionEventSchema,
   RelayMissionStore,
   RelayMissionStoreError,
   reduceRelayMission,
   relayMissionReceiptDigest,
-  type RelayMissionEvent,
 } from "./mission.js";
-import { createRelayMissionFixture, RELAY_DEMO_MISSION_ID, RELAY_DEMO_NAMESPACE } from "./mission-fixture.js";
 
 async function withTempRoot(run: (root: string) => Promise<void>): Promise<void> {
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-relay-"));
@@ -32,6 +33,21 @@ function deterministicStore(root: string, options: { maxEvents?: number } = {}):
     createEventId: () => `event-${String(++nextId).padStart(3, "0")}`,
     ...options,
   });
+}
+
+function fixtureEvents(): RelayMissionEvent[] {
+  return createRelayMissionFixture().map((input, index) =>
+    RelayMissionEventSchema.parse({
+      schemaVersion: "1",
+      eventId: `fixture-event-${String(index + 1).padStart(3, "0")}`,
+      missionId: RELAY_DEMO_MISSION_ID,
+      namespace: RELAY_DEMO_NAMESPACE,
+      recordedAt: input.occurredAt,
+      occurredAt: input.occurredAt,
+      ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
+      payload: input.payload,
+    })
+  );
 }
 
 test("fixture reduces to a complete correction and cold-start receipt", async () => {
@@ -197,6 +213,85 @@ test("reducer sorts equal-time events with a stable event-id tie break", () => {
     snapshot.events.map((event) => event.eventId),
     ["event-a", "event-b"]
   );
+});
+
+test("reducer sorts offset timestamps by instant before applying state transitions", () => {
+  const base = {
+    schemaVersion: "1" as const,
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    recordedAt: "2026-07-17T16:00:00.000Z",
+    payload: createRelayMissionFixture()[0]!.payload,
+  };
+  const events: RelayMissionEvent[] = [
+    { ...base, eventId: "event-later", occurredAt: "2026-07-17T10:00:00.000-05:00" },
+    { ...base, eventId: "event-earlier", occurredAt: "2026-07-17T14:00:00.000Z" },
+  ];
+  const snapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events,
+  });
+  assert.deepEqual(
+    snapshot.events.map((event) => event.eventId),
+    ["event-earlier", "event-later"]
+  );
+});
+
+test("receipt cannot apply or propagate a correction without prior approval", () => {
+  const events = fixtureEvents().filter((event) => event.payload.kind !== "correction_approved");
+  const snapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events,
+  });
+
+  assert.equal(snapshot.receipt.complete, false);
+  assert.equal(snapshot.receipt.coldStartVerified, false);
+  assert.deepEqual(snapshot.receipt.supersededDecisionIds, []);
+  assert.equal(
+    snapshot.decisions.find((decision) => decision.decisionId === "decision-new-token-every-request")?.status,
+    "active"
+  );
+  assert.equal(snapshot.corrections[0]?.status, "proposed");
+  assert.ok(snapshot.receipt.missingEvidence.includes("correction:correction-token-refresh:approval"));
+});
+
+test("receipt requires human approval and a passing test after verified propagation", () => {
+  const agentApproved = fixtureEvents().map((event) =>
+    event.payload.kind === "correction_approved"
+      ? {
+          ...event,
+          payload: {
+            ...event.payload,
+            approvedBy: { kind: "agent" as const, id: "policy-agent", label: "Policy agent" },
+          },
+        }
+      : event
+  );
+  const agentApprovedSnapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: agentApproved,
+  });
+  assert.equal(agentApprovedSnapshot.receipt.complete, false);
+  assert.ok(
+    agentApprovedSnapshot.receipt.missingEvidence.includes("correction:correction-token-refresh:human-approval")
+  );
+
+  const passBeforePropagation = fixtureEvents().map((event) =>
+    event.payload.kind === "test_result" && event.payload.status === "passed"
+      ? { ...event, occurredAt: "2026-07-17T18:00:11.500Z" }
+      : event
+  );
+  const earlyPassSnapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: passBeforePropagation,
+  });
+  assert.equal(earlyPassSnapshot.receipt.complete, false);
+  assert.equal(earlyPassSnapshot.receipt.passingOutcomeVerified, false);
+  assert.ok(earlyPassSnapshot.receipt.missingEvidence.includes("outcome:passing-test"));
 });
 
 test("missing evidence is explicit rather than conflated with a complete receipt", () => {

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, readFile, readdir, rename, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, link, mkdtemp, readFile, readdir, rename, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -839,6 +839,27 @@ test("append remains pinned inside the Relay root when the missions pathname is 
     } finally {
       await rm(outside, { recursive: true, force: true });
     }
+  });
+});
+
+test("mission files reject hard links before append and read", async () => {
+  await withTempRoot(async (root) => {
+    const store = deterministicStore(root);
+    const outsideFile = path.join(root, "outside-mission.jsonl");
+    const missionFile = path.join(root, "state", "relay", "missions", `${RELAY_DEMO_MISSION_ID}.jsonl`);
+    await writeFile(outsideFile, "outside remains unchanged\n", { mode: 0o600 });
+
+    await assert.rejects(
+      store.append(RELAY_DEMO_MISSION_ID, firstFixtureInput(), {
+        beforeAppend: () => link(outsideFile, missionFile),
+      }),
+      (error: unknown) => error instanceof RelayMissionStoreError && error.code === "unsafe_path"
+    );
+    assert.equal(await readFile(outsideFile, "utf8"), "outside remains unchanged\n");
+    await assert.rejects(
+      store.read(RELAY_DEMO_MISSION_ID),
+      (error: unknown) => error instanceof RelayMissionStoreError && error.code === "unsafe_path"
+    );
   });
 });
 

--- a/packages/remnic-core/src/relay/mission.test.ts
+++ b/packages/remnic-core/src/relay/mission.test.ts
@@ -50,6 +50,20 @@ function fixtureEvents(): RelayMissionEvent[] {
   );
 }
 
+function liveFixtureEvents(authenticatedPrincipal: string): RelayMissionEvent[] {
+  return fixtureEvents().map((event) =>
+    RelayMissionEventSchema.parse({
+      ...event,
+      authenticatedPrincipal,
+      payload: {
+        ...event.payload,
+        ...(event.payload.kind === "mission_started" ? { runMode: "live" } : {}),
+        evidence: event.payload.evidence.map((item) => ({ ...item, capture: "at_action" })),
+      },
+    })
+  );
+}
+
 function firstFixtureInput() {
   const [first] = createRelayMissionFixture();
   if (!first) throw new Error("Relay mission fixture must contain a start event");
@@ -123,10 +137,20 @@ test("idempotent append replays matching input and rejects conflicting input", a
     assert.ok(first);
     assert.equal(first.payload.kind, "mission_started");
     if (first.payload.kind !== "mission_started") throw new Error("fixture contract drift");
-    const initial = await store.append(RELAY_DEMO_MISSION_ID, first);
-    const replay = await store.append(RELAY_DEMO_MISSION_ID, first);
+    const initial = await store.append(RELAY_DEMO_MISSION_ID, first, {
+      authenticatedPrincipal: "relay-operator",
+    });
+    const replay = await store.append(RELAY_DEMO_MISSION_ID, first, {
+      authenticatedPrincipal: "relay-operator",
+    });
     assert.equal(replay.replayed, true);
     assert.equal(replay.event.eventId, initial.event.eventId);
+    assert.equal(initial.event.authenticatedPrincipal, "relay-operator");
+
+    await assert.rejects(
+      store.append(RELAY_DEMO_MISSION_ID, first, { authenticatedPrincipal: "different-operator" }),
+      (error: unknown) => error instanceof RelayMissionStoreError && error.code === "idempotency_conflict"
+    );
 
     await assert.rejects(
       store.append(RELAY_DEMO_MISSION_ID, {
@@ -337,6 +361,27 @@ test("receipt requires an observed, decision-linked conflict and coherent missio
   );
 });
 
+test("conflict participants must hold distinct conflicting decisions at detection time", () => {
+  const singleHolder = fixtureEvents().map((event) =>
+    event.payload.kind === "belief_observed" && event.payload.decisionId === "decision-refresh-after-expiry"
+      ? {
+          ...event,
+          payload: { ...event.payload, agentId: "agent-atlas" },
+        }
+      : event
+  );
+  const snapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: singleHolder,
+  });
+
+  assert.equal(snapshot.receipt.complete, false);
+  assert.ok(
+    snapshot.receipt.missingEvidence.includes("conflict:conflict-token-lifecycle:participant:agent-nova:decision-link")
+  );
+});
+
 test("a correction must account for every decision in its observed conflict", () => {
   const events = fixtureEvents();
   const belief = events.find((event) => event.payload.kind === "belief_observed");
@@ -537,6 +582,26 @@ test("receipt requires human approval and a passing test after verified propagat
   assert.ok(
     agentApprovedSnapshot.receipt.missingEvidence.includes("correction:correction-token-refresh:human-approval")
   );
+
+  const forgedHumanSnapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: liveFixtureEvents("agent-runner"),
+  });
+  assert.equal(forgedHumanSnapshot.receipt.complete, false);
+  assert.ok(
+    forgedHumanSnapshot.receipt.missingEvidence.includes(
+      "correction:correction-token-refresh:authenticated-human-approval"
+    )
+  );
+
+  const authenticatedHumanSnapshot = reduceRelayMission({
+    missionId: RELAY_DEMO_MISSION_ID,
+    namespace: RELAY_DEMO_NAMESPACE,
+    events: liveFixtureEvents("operator-build-week"),
+  });
+  assert.equal(authenticatedHumanSnapshot.receipt.complete, true);
+  assert.equal(authenticatedHumanSnapshot.corrections[0]?.approvalPrincipal, "operator-build-week");
 
   const passBeforePropagation = fixtureEvents().map((event) =>
     event.payload.kind === "test_result" && event.payload.status === "passed"

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -663,12 +663,11 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   const corruptLines = input.corruptLines ?? 0;
   const sinceMs = options.since ? Date.parse(options.since) : undefined;
   const untilMs = options.until ? Date.parse(options.until) : undefined;
-  const filtered = input.events
-    .filter((event) => {
-      const occurredAt = Date.parse(event.occurredAt);
-      return (sinceMs === undefined || occurredAt >= sinceMs) && (untilMs === undefined || occurredAt < untilMs);
-    })
-    .sort(compareRelayEvents);
+  const orderedEvents = [...input.events].sort(compareRelayEvents);
+  const filteredEvents = orderedEvents.filter((event) => {
+    const occurredAt = Date.parse(event.occurredAt);
+    return (sinceMs === undefined || occurredAt >= sinceMs) && (untilMs === undefined || occurredAt < untilMs);
+  });
 
   const agents = new Map<string, RelayAgentSnapshot>();
   const decisions = new Map<string, RelayDecisionSnapshot>();
@@ -706,7 +705,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
     return created;
   };
 
-  for (const event of filtered) {
+  for (const event of orderedEvents) {
     const payload = event.payload;
     switch (payload.kind) {
       case "mission_started":
@@ -1010,7 +1009,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
     missingEvidence.add("outcome:cold-start-propagation");
   }
 
-  const eventWindow = filtered.slice(Math.max(0, filtered.length - options.limit));
+  const eventWindow = filteredEvents.slice(Math.max(0, filteredEvents.length - options.limit));
   // `found` describes whether the mission has any valid persisted evidence,
   // not whether the caller's optional time window happened to select an
   // event. A known mission with an empty [since, until) window is distinct
@@ -1059,10 +1058,10 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       passingOutcomeVerified,
     },
     bounds: {
-      totalEvents: filtered.length,
+      totalEvents: filteredEvents.length,
       returnedEvents: eventWindow.length,
       corruptLines,
-      truncated: filtered.length > eventWindow.length,
+      truncated: filteredEvents.length > eventWindow.length,
       since: options.since ?? null,
       until: options.until ?? null,
     },

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -1,0 +1,1169 @@
+import { createHash, randomUUID } from "node:crypto";
+import { constants as fsConstants, promises as fs } from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+
+import { serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
+
+export const RELAY_MISSION_SCHEMA_VERSION = "1" as const;
+export const RELAY_MISSION_MAX_FILE_BYTES = 4 * 1024 * 1024;
+export const RELAY_MISSION_MAX_LINE_BYTES = 64 * 1024;
+export const RELAY_MISSION_MAX_EVENTS = 2_000;
+export const RELAY_MISSION_DEFAULT_EVENT_LIMIT = 200;
+export const RELAY_MISSION_MAX_EVENT_LIMIT = 500;
+
+const missionIdSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/, {
+    message: "must contain only lowercase letters, numbers, and single hyphens",
+  });
+
+const identifierSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9](?:[A-Za-z0-9._:@-]{0,126}[A-Za-z0-9])?$/, {
+    message: "must be a bounded identifier",
+  });
+
+const namespaceSchema = z.string().trim().min(1).max(128);
+const shortTextSchema = z.string().trim().min(1).max(240);
+const statementSchema = z.string().trim().min(1).max(4_000);
+
+const isoDateTimeSchema = z
+  .string()
+  .datetime({ offset: true })
+  .refine((value) => Number.isFinite(Date.parse(value)), "must be a representable timestamp");
+
+export const RelayEvidenceRefSchema = z
+  .object({
+    kind: z.enum(["memory", "recall_audit", "source", "test", "commit", "correction", "agent_output", "approval"]),
+    id: identifierSchema,
+    label: shortTextSchema,
+    locator: z.string().trim().min(1).max(2_048).optional(),
+    capture: z.enum(["at_action", "historical_lookup", "fixture"]),
+  })
+  .strict();
+
+export type RelayEvidenceRef = z.infer<typeof RelayEvidenceRefSchema>;
+
+const evidenceListSchema = z.array(RelayEvidenceRefSchema).max(16);
+const agentIdentityFields = {
+  agentId: identifierSchema,
+  sessionId: identifierSchema,
+} as const;
+
+const RelayMissionPayloadUnionSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("mission_started"),
+      title: shortTextSchema,
+      objective: statementSchema,
+      runMode: z.enum(["live", "replay", "fixture"]),
+      evidence: evidenceListSchema.default([]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("agent_status"),
+      ...agentIdentityFields,
+      label: shortTextSchema,
+      role: shortTextSchema,
+      status: z.enum(["idle", "working", "blocked", "complete", "failed"]),
+      detail: statementSchema.optional(),
+      evidence: evidenceListSchema.default([]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("agent_output"),
+      ...agentIdentityFields,
+      outputId: identifierSchema,
+      summary: statementSchema,
+      evidence: evidenceListSchema.default([]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("belief_observed"),
+      ...agentIdentityFields,
+      beliefId: identifierSchema,
+      decisionId: identifierSchema,
+      statement: statementSchema,
+      confidence: z.number().finite().min(0).max(1).optional(),
+      evidence: evidenceListSchema.default([]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("conflict_detected"),
+      conflictId: identifierSchema,
+      decisionIds: z.array(identifierSchema).min(2).max(8),
+      agentIds: z.array(identifierSchema).min(2).max(16),
+      summary: statementSchema,
+      evidence: evidenceListSchema.default([]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("test_result"),
+      testId: identifierSchema,
+      command: z.string().trim().min(1).max(1_000),
+      status: z.enum(["passed", "failed", "error"]),
+      summary: statementSchema,
+      durationMs: z.number().int().nonnegative().max(3_600_000).optional(),
+      evidence: evidenceListSchema.default([]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("correction_proposed"),
+      correctionId: identifierSchema,
+      conflictId: identifierSchema,
+      proposedDecisionId: identifierSchema,
+      supersedesDecisionIds: z.array(identifierSchema).min(1).max(8),
+      statement: statementSchema,
+      rationale: statementSchema,
+      proposedBy: identifierSchema,
+      evidence: evidenceListSchema.default([]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("correction_approved"),
+      correctionId: identifierSchema,
+      approvedBy: z
+        .object({
+          kind: z.enum(["human", "agent"]),
+          id: identifierSchema,
+          label: shortTextSchema,
+        })
+        .strict(),
+      note: statementSchema.optional(),
+      evidence: evidenceListSchema.default([]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("decision_superseded"),
+      decisionId: identifierSchema,
+      replacementDecisionId: identifierSchema,
+      correctionId: identifierSchema,
+      evidence: evidenceListSchema.default([]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("recall_observed"),
+      ...agentIdentityFields,
+      recallReceiptId: identifierSchema,
+      decisionId: identifierSchema,
+      query: statementSchema,
+      capturedAtAction: z.boolean(),
+      evidence: evidenceListSchema.default([]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("propagation_verified"),
+      ...agentIdentityFields,
+      correctionId: identifierSchema,
+      decisionId: identifierSchema,
+      recallReceiptId: identifierSchema,
+      staleDecisionAbsent: z.boolean(),
+      evidence: evidenceListSchema.default([]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("mission_completed"),
+      outcome: z.enum(["recovered", "failed", "inconclusive"]),
+      summary: statementSchema,
+      evidence: evidenceListSchema.default([]),
+    })
+    .strict(),
+]);
+
+export const RelayMissionPayloadSchema = RelayMissionPayloadUnionSchema.superRefine((value, ctx) => {
+  if (value.kind === "decision_superseded" && value.decisionId === value.replacementDecisionId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "a decision cannot supersede itself",
+      path: ["replacementDecisionId"],
+    });
+  }
+  if (value.kind !== "recall_observed") return;
+  for (const [index, evidence] of value.evidence.entries()) {
+    if (evidence.kind !== "recall_audit") continue;
+    const expectedCapture = value.capturedAtAction ? "at_action" : "historical_lookup";
+    if (evidence.capture !== expectedCapture && evidence.capture !== "fixture") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `recall evidence must be labeled ${expectedCapture}`,
+        path: ["evidence", index, "capture"],
+      });
+    }
+  }
+});
+
+export type RelayMissionPayload = z.infer<typeof RelayMissionPayloadSchema>;
+
+export const RelayMissionEventInputSchema = z
+  .object({
+    occurredAt: isoDateTimeSchema.optional(),
+    idempotencyKey: identifierSchema.optional(),
+    payload: RelayMissionPayloadSchema,
+  })
+  .strict();
+
+export type RelayMissionEventInput = z.infer<typeof RelayMissionEventInputSchema>;
+
+export const RelayMissionEventSchema = z
+  .object({
+    schemaVersion: z.literal(RELAY_MISSION_SCHEMA_VERSION),
+    eventId: identifierSchema,
+    missionId: missionIdSchema,
+    namespace: namespaceSchema,
+    recordedAt: isoDateTimeSchema,
+    occurredAt: isoDateTimeSchema,
+    idempotencyKey: identifierSchema.optional(),
+    payload: RelayMissionPayloadSchema,
+  })
+  .strict();
+
+export type RelayMissionEvent = z.infer<typeof RelayMissionEventSchema>;
+
+export const RelayMissionReadOptionsSchema = z
+  .object({
+    since: isoDateTimeSchema.optional(),
+    until: isoDateTimeSchema.optional(),
+    limit: z.number().int().min(1).max(RELAY_MISSION_MAX_EVENT_LIMIT).default(RELAY_MISSION_DEFAULT_EVENT_LIMIT),
+  })
+  .strict()
+  .refine(
+    (value) =>
+      value.since === undefined || value.until === undefined || Date.parse(value.since) < Date.parse(value.until),
+    { message: "since must be earlier than until", path: ["until"] }
+  );
+
+export type RelayMissionReadOptions = z.input<typeof RelayMissionReadOptionsSchema>;
+
+export type RelayMissionStatus =
+  | "not_started"
+  | "active"
+  | "awaiting_approval"
+  | "correcting"
+  | "verified"
+  | "completed"
+  | "failed";
+
+export interface RelayAgentOutputSnapshot {
+  outputId: string;
+  summary: string;
+  occurredAt: string;
+  evidence: RelayEvidenceRef[];
+}
+
+export interface RelayRecallSnapshot {
+  recallReceiptId: string;
+  decisionId: string;
+  query: string;
+  capturedAtAction: boolean;
+  occurredAt: string;
+  evidence: RelayEvidenceRef[];
+}
+
+export interface RelayAgentSnapshot {
+  agentId: string;
+  label: string;
+  role: string;
+  status: "idle" | "working" | "blocked" | "complete" | "failed";
+  sessionIds: string[];
+  outputs: RelayAgentOutputSnapshot[];
+  recalls: RelayRecallSnapshot[];
+  lastSeenAt: string;
+}
+
+export interface RelayDecisionSnapshot {
+  decisionId: string;
+  statement: string;
+  status: "active" | "superseded" | "proposed";
+  heldByAgentIds: string[];
+  beliefIds: string[];
+  evidence: RelayEvidenceRef[];
+  firstObservedAt: string;
+  supersededAt?: string;
+  supersededBy?: string;
+  correctionId?: string;
+}
+
+export interface RelayConflictSnapshot {
+  conflictId: string;
+  decisionIds: string[];
+  agentIds: string[];
+  summary: string;
+  status: "open" | "proposed" | "resolved";
+  correctionId?: string;
+  occurredAt: string;
+  evidence: RelayEvidenceRef[];
+}
+
+export interface RelayCorrectionSnapshot {
+  correctionId: string;
+  conflictId: string;
+  proposedDecisionId: string;
+  supersedesDecisionIds: string[];
+  statement: string;
+  rationale: string;
+  proposedBy: string;
+  status: "proposed" | "approved" | "applied" | "propagated";
+  proposedAt: string;
+  approvedAt?: string;
+  approvedBy?: { kind: "human" | "agent"; id: string; label: string };
+  approvalNote?: string;
+  propagatedAt?: string;
+  evidence: RelayEvidenceRef[];
+}
+
+export interface RelayTestSnapshot {
+  testId: string;
+  command: string;
+  status: "passed" | "failed" | "error";
+  summary: string;
+  durationMs?: number;
+  occurredAt: string;
+  evidence: RelayEvidenceRef[];
+}
+
+export interface RelayPropagationSnapshot {
+  correctionId: string;
+  agentId: string;
+  sessionId: string;
+  decisionId: string;
+  recallReceiptId: string;
+  staleDecisionAbsent: boolean;
+  occurredAt: string;
+  evidence: RelayEvidenceRef[];
+}
+
+export interface RelayMissionSnapshot {
+  schemaVersion: typeof RELAY_MISSION_SCHEMA_VERSION;
+  missionId: string;
+  namespace: string;
+  found: boolean;
+  readHealth: "empty" | "ok" | "partial";
+  status: RelayMissionStatus;
+  mission: {
+    title: string | null;
+    objective: string | null;
+    runMode: "live" | "replay" | "fixture" | null;
+    startedAt: string | null;
+    completedAt: string | null;
+  };
+  agents: RelayAgentSnapshot[];
+  decisions: RelayDecisionSnapshot[];
+  conflicts: RelayConflictSnapshot[];
+  corrections: RelayCorrectionSnapshot[];
+  tests: RelayTestSnapshot[];
+  propagation: RelayPropagationSnapshot[];
+  outcome: {
+    result: "recovered" | "failed" | "inconclusive";
+    summary: string;
+    occurredAt: string;
+    evidence: RelayEvidenceRef[];
+  } | null;
+  receipt: {
+    complete: boolean;
+    missingEvidence: string[];
+    activeDecisionIds: string[];
+    supersededDecisionIds: string[];
+    coldStartVerified: boolean;
+    passingOutcomeVerified: boolean;
+  };
+  bounds: {
+    totalEvents: number;
+    returnedEvents: number;
+    corruptLines: number;
+    truncated: boolean;
+    since: string | null;
+    until: string | null;
+  };
+  events: RelayMissionEvent[];
+}
+
+export type RelayMissionStoreErrorCode =
+  | "idempotency_conflict"
+  | "limit_exceeded"
+  | "lock_unavailable"
+  | "read_failed"
+  | "unsafe_path"
+  | "write_failed";
+
+export class RelayMissionStoreError extends Error {
+  constructor(
+    public readonly code: RelayMissionStoreErrorCode,
+    message: string,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+    this.name = "RelayMissionStoreError";
+  }
+}
+
+export interface RelayMissionStoreOptions {
+  rootDir: string;
+  namespace: string;
+  now?: () => Date;
+  createEventId?: () => string;
+  maxFileBytes?: number;
+  maxEvents?: number;
+  lockMaxWaitMs?: number;
+}
+
+interface MissionFileRead {
+  exists: boolean;
+  events: RelayMissionEvent[];
+  corruptLines: number;
+  rawBytes: number;
+}
+
+export interface RelayMissionAppendResult {
+  appended: boolean;
+  replayed: boolean;
+  event: RelayMissionEvent;
+}
+
+export class RelayMissionStore {
+  private readonly rootDir: string;
+  private readonly namespace: string;
+  private readonly now: () => Date;
+  private readonly createEventId: () => string;
+  private readonly maxFileBytes: number;
+  private readonly maxEvents: number;
+  private readonly lockMaxWaitMs: number;
+
+  constructor(options: RelayMissionStoreOptions) {
+    if (typeof options.rootDir !== "string" || options.rootDir.trim().length === 0) {
+      throw new TypeError("RelayMissionStore rootDir must be a non-empty string");
+    }
+    this.rootDir = path.resolve(options.rootDir);
+    this.namespace = namespaceSchema.parse(options.namespace);
+    this.now = options.now ?? (() => new Date());
+    this.createEventId = options.createEventId ?? (() => `relay-${randomUUID()}`);
+    this.maxFileBytes = positiveIntegerOption(options.maxFileBytes, "maxFileBytes", RELAY_MISSION_MAX_FILE_BYTES);
+    this.maxEvents = positiveIntegerOption(options.maxEvents, "maxEvents", RELAY_MISSION_MAX_EVENTS);
+    this.lockMaxWaitMs = positiveIntegerOption(options.lockMaxWaitMs, "lockMaxWaitMs", 5_000);
+  }
+
+  async append(missionIdValue: string, inputValue: RelayMissionEventInput): Promise<RelayMissionAppendResult> {
+    const missionId = missionIdSchema.parse(missionIdValue);
+    const input = RelayMissionEventInputSchema.parse(inputValue);
+    const missionDir = await this.ensureMissionDirectory();
+    const filePath = path.join(missionDir, `${missionId}.jsonl`);
+    const lockPath = `${filePath}.lock`;
+
+    return serializeMutations(`relay-mission:${filePath}`, () =>
+      withHeldFileLock(
+        lockPath,
+        { staleMs: 30_000, maxWaitMs: this.lockMaxWaitMs, heartbeatMs: 10_000 },
+        async (acquired) => {
+          if (!acquired) {
+            throw new RelayMissionStoreError("lock_unavailable", "could not acquire Relay mission lock");
+          }
+
+          const existing = await this.readFile(filePath, missionId);
+          if (input.idempotencyKey) {
+            const replay = existing.events.find((event) => event.idempotencyKey === input.idempotencyKey);
+            if (replay) {
+              if (!sameIdempotentInput(replay, input)) {
+                throw new RelayMissionStoreError(
+                  "idempotency_conflict",
+                  `idempotency key ${input.idempotencyKey} was already used for different input`
+                );
+              }
+              return { appended: false, replayed: true, event: replay };
+            }
+          }
+
+          if (existing.events.length >= this.maxEvents) {
+            throw new RelayMissionStoreError(
+              "limit_exceeded",
+              `mission ${missionId} reached the ${this.maxEvents}-event limit`
+            );
+          }
+
+          const recordedAt = validNow(this.now);
+          const event = RelayMissionEventSchema.parse({
+            schemaVersion: RELAY_MISSION_SCHEMA_VERSION,
+            eventId: this.createEventId(),
+            missionId,
+            namespace: this.namespace,
+            recordedAt,
+            occurredAt: input.occurredAt ?? recordedAt,
+            ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
+            payload: input.payload,
+          });
+          const line = `${JSON.stringify(event)}\n`;
+          const lineBytes = Buffer.byteLength(line, "utf8");
+          if (lineBytes > RELAY_MISSION_MAX_LINE_BYTES) {
+            throw new RelayMissionStoreError(
+              "limit_exceeded",
+              `Relay mission event exceeds ${RELAY_MISSION_MAX_LINE_BYTES} bytes`
+            );
+          }
+          if (existing.rawBytes + lineBytes > this.maxFileBytes) {
+            throw new RelayMissionStoreError(
+              "limit_exceeded",
+              `mission ${missionId} would exceed the ${this.maxFileBytes}-byte limit`
+            );
+          }
+
+          await this.appendFile(filePath, line);
+          return { appended: true, replayed: false, event };
+        }
+      )
+    );
+  }
+
+  async read(missionIdValue: string, readOptions: RelayMissionReadOptions = {}): Promise<RelayMissionSnapshot> {
+    const missionId = missionIdSchema.parse(missionIdValue);
+    const options = RelayMissionReadOptionsSchema.parse(readOptions);
+    const missionDir = await this.ensureMissionDirectory();
+    const filePath = path.join(missionDir, `${missionId}.jsonl`);
+    const lockPath = `${filePath}.lock`;
+
+    return serializeMutations(`relay-mission:${filePath}`, () =>
+      withHeldFileLock(
+        lockPath,
+        { staleMs: 30_000, maxWaitMs: this.lockMaxWaitMs, heartbeatMs: 10_000 },
+        async (acquired) => {
+          if (!acquired) {
+            throw new RelayMissionStoreError("lock_unavailable", "could not acquire Relay mission read lock");
+          }
+          const read = await this.readFile(filePath, missionId);
+          return reduceRelayMission({
+            missionId,
+            namespace: this.namespace,
+            events: read.events,
+            corruptLines: read.corruptLines,
+            fileExists: read.exists,
+            options,
+          });
+        }
+      )
+    );
+  }
+
+  private async ensureMissionDirectory(): Promise<string> {
+    try {
+      await assertExistingSafeDirectory(this.rootDir);
+      let current = this.rootDir;
+      for (const segment of ["state", "relay", "missions"]) {
+        current = path.join(current, segment);
+        await ensureSafeChildDirectory(current);
+      }
+      return current;
+    } catch (error) {
+      if (error instanceof RelayMissionStoreError) throw error;
+      throw new RelayMissionStoreError("unsafe_path", "Relay mission directory is unavailable or unsafe", {
+        cause: error,
+      });
+    }
+  }
+
+  private async readFile(filePath: string, missionId: string): Promise<MissionFileRead> {
+    let handle: import("node:fs/promises").FileHandle | undefined;
+    try {
+      await assertParentDirectoryStable(filePath);
+      handle = await fs.open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+      const info = await handle.stat();
+      if (!info.isFile()) {
+        throw new RelayMissionStoreError("unsafe_path", "Relay mission path is not a file");
+      }
+      if (info.size > this.maxFileBytes) {
+        throw new RelayMissionStoreError(
+          "limit_exceeded",
+          `mission ${missionId} exceeds the ${this.maxFileBytes}-byte read limit`
+        );
+      }
+      const raw = await handle.readFile("utf8");
+      const parsed = parseMissionJsonl(raw, missionId, this.namespace, this.maxEvents);
+      return { exists: true, rawBytes: Buffer.byteLength(raw, "utf8"), ...parsed };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { exists: false, events: [], corruptLines: 0, rawBytes: 0 };
+      }
+      if (error instanceof RelayMissionStoreError) throw error;
+      throw new RelayMissionStoreError("read_failed", "failed to read Relay mission", {
+        cause: error,
+      });
+    } finally {
+      await handle?.close().catch(() => undefined);
+    }
+  }
+
+  private async appendFile(filePath: string, line: string): Promise<void> {
+    let handle: import("node:fs/promises").FileHandle | undefined;
+    try {
+      await assertParentDirectoryStable(filePath);
+      handle = await fs.open(
+        filePath,
+        fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_APPEND | fsConstants.O_NOFOLLOW,
+        0o600
+      );
+      const info = await handle.stat();
+      if (!info.isFile()) {
+        throw new RelayMissionStoreError("unsafe_path", "Relay mission path is not a file");
+      }
+      await handle.chmod(0o600);
+      await handle.writeFile(line, "utf8");
+      await handle.sync();
+    } catch (error) {
+      if (error instanceof RelayMissionStoreError) throw error;
+      if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+        throw new RelayMissionStoreError("unsafe_path", "Relay mission symlink is rejected", {
+          cause: error,
+        });
+      }
+      throw new RelayMissionStoreError("write_failed", "failed to append Relay mission", {
+        cause: error,
+      });
+    } finally {
+      await handle?.close().catch(() => undefined);
+    }
+  }
+}
+
+interface ReduceRelayMissionInput {
+  missionId: string;
+  namespace: string;
+  events: RelayMissionEvent[];
+  corruptLines?: number;
+  fileExists?: boolean;
+  options?: RelayMissionReadOptions;
+}
+
+export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMissionSnapshot {
+  const missionId = missionIdSchema.parse(input.missionId);
+  const namespace = namespaceSchema.parse(input.namespace);
+  const options = RelayMissionReadOptionsSchema.parse(input.options ?? {});
+  const corruptLines = input.corruptLines ?? 0;
+  const sinceMs = options.since ? Date.parse(options.since) : undefined;
+  const untilMs = options.until ? Date.parse(options.until) : undefined;
+  const filtered = input.events
+    .filter((event) => {
+      const occurredAt = Date.parse(event.occurredAt);
+      return (sinceMs === undefined || occurredAt >= sinceMs) && (untilMs === undefined || occurredAt < untilMs);
+    })
+    .sort(compareRelayEvents);
+
+  const agents = new Map<string, RelayAgentSnapshot>();
+  const decisions = new Map<string, RelayDecisionSnapshot>();
+  const conflicts = new Map<string, RelayConflictSnapshot>();
+  const corrections = new Map<string, RelayCorrectionSnapshot>();
+  const tests: RelayTestSnapshot[] = [];
+  const propagation: RelayPropagationSnapshot[] = [];
+  const missingEvidence = new Set<string>();
+  let title: string | null = null;
+  let objective: string | null = null;
+  let runMode: "live" | "replay" | "fixture" | null = null;
+  let startedAt: string | null = null;
+  let completedAt: string | null = null;
+  let status: RelayMissionStatus = "not_started";
+  let outcome: RelayMissionSnapshot["outcome"] = null;
+
+  const ensureAgent = (agentId: string, sessionId: string, occurredAt: string): RelayAgentSnapshot => {
+    const existing = agents.get(agentId);
+    if (existing) {
+      if (!existing.sessionIds.includes(sessionId)) existing.sessionIds.push(sessionId);
+      existing.lastSeenAt = occurredAt;
+      return existing;
+    }
+    const created: RelayAgentSnapshot = {
+      agentId,
+      label: agentId,
+      role: "Codex agent",
+      status: "working",
+      sessionIds: [sessionId],
+      outputs: [],
+      recalls: [],
+      lastSeenAt: occurredAt,
+    };
+    agents.set(agentId, created);
+    return created;
+  };
+
+  for (const event of filtered) {
+    const payload = event.payload;
+    switch (payload.kind) {
+      case "mission_started":
+        title = payload.title;
+        objective = payload.objective;
+        runMode = payload.runMode;
+        startedAt = event.occurredAt;
+        status = "active";
+        collectMissingEvidence(missingEvidence, event, payload.evidence);
+        break;
+      case "agent_status": {
+        const agent = ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
+        agent.label = payload.label;
+        agent.role = payload.role;
+        agent.status = payload.status;
+        collectMissingEvidence(missingEvidence, event, payload.evidence);
+        break;
+      }
+      case "agent_output": {
+        const agent = ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
+        agent.outputs.push({
+          outputId: payload.outputId,
+          summary: payload.summary,
+          occurredAt: event.occurredAt,
+          evidence: payload.evidence,
+        });
+        collectMissingEvidence(missingEvidence, event, payload.evidence);
+        break;
+      }
+      case "belief_observed": {
+        ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
+        const existing = decisions.get(payload.decisionId);
+        if (existing) {
+          if (!existing.heldByAgentIds.includes(payload.agentId)) {
+            existing.heldByAgentIds.push(payload.agentId);
+          }
+          if (!existing.beliefIds.includes(payload.beliefId)) existing.beliefIds.push(payload.beliefId);
+          existing.evidence.push(...payload.evidence);
+        } else {
+          decisions.set(payload.decisionId, {
+            decisionId: payload.decisionId,
+            statement: payload.statement,
+            status: "active",
+            heldByAgentIds: [payload.agentId],
+            beliefIds: [payload.beliefId],
+            evidence: [...payload.evidence],
+            firstObservedAt: event.occurredAt,
+          });
+        }
+        collectMissingEvidence(missingEvidence, event, payload.evidence);
+        break;
+      }
+      case "conflict_detected":
+        conflicts.set(payload.conflictId, {
+          conflictId: payload.conflictId,
+          decisionIds: uniqueSorted(payload.decisionIds),
+          agentIds: uniqueSorted(payload.agentIds),
+          summary: payload.summary,
+          status: "open",
+          occurredAt: event.occurredAt,
+          evidence: payload.evidence,
+        });
+        collectMissingEvidence(missingEvidence, event, payload.evidence);
+        break;
+      case "test_result":
+        tests.push({
+          testId: payload.testId,
+          command: payload.command,
+          status: payload.status,
+          summary: payload.summary,
+          ...(payload.durationMs === undefined ? {} : { durationMs: payload.durationMs }),
+          occurredAt: event.occurredAt,
+          evidence: payload.evidence,
+        });
+        collectMissingEvidence(missingEvidence, event, payload.evidence);
+        break;
+      case "correction_proposed": {
+        corrections.set(payload.correctionId, {
+          correctionId: payload.correctionId,
+          conflictId: payload.conflictId,
+          proposedDecisionId: payload.proposedDecisionId,
+          supersedesDecisionIds: uniqueSorted(payload.supersedesDecisionIds),
+          statement: payload.statement,
+          rationale: payload.rationale,
+          proposedBy: payload.proposedBy,
+          status: "proposed",
+          proposedAt: event.occurredAt,
+          evidence: [...payload.evidence],
+        });
+        if (!decisions.has(payload.proposedDecisionId)) {
+          decisions.set(payload.proposedDecisionId, {
+            decisionId: payload.proposedDecisionId,
+            statement: payload.statement,
+            status: "proposed",
+            heldByAgentIds: [],
+            beliefIds: [],
+            evidence: [...payload.evidence],
+            firstObservedAt: event.occurredAt,
+          });
+        }
+        const conflict = conflicts.get(payload.conflictId);
+        if (conflict) {
+          conflict.status = "proposed";
+          conflict.correctionId = payload.correctionId;
+        }
+        status = "awaiting_approval";
+        collectMissingEvidence(missingEvidence, event, payload.evidence);
+        break;
+      }
+      case "correction_approved": {
+        const correction = corrections.get(payload.correctionId);
+        if (correction) {
+          correction.status = "approved";
+          correction.approvedAt = event.occurredAt;
+          correction.approvedBy = payload.approvedBy;
+          correction.approvalNote = payload.note;
+          correction.evidence.push(...payload.evidence);
+        } else {
+          missingEvidence.add(`correction:${payload.correctionId}:proposal`);
+        }
+        status = "correcting";
+        collectMissingEvidence(missingEvidence, event, payload.evidence);
+        break;
+      }
+      case "decision_superseded": {
+        const stale = decisions.get(payload.decisionId);
+        const replacement = decisions.get(payload.replacementDecisionId);
+        if (stale) {
+          stale.status = "superseded";
+          stale.supersededAt = event.occurredAt;
+          stale.supersededBy = payload.replacementDecisionId;
+          stale.correctionId = payload.correctionId;
+          stale.evidence.push(...payload.evidence);
+        } else {
+          missingEvidence.add(`decision:${payload.decisionId}:observation`);
+        }
+        if (replacement) {
+          replacement.status = "active";
+          replacement.evidence.push(...payload.evidence);
+        } else {
+          missingEvidence.add(`decision:${payload.replacementDecisionId}:replacement`);
+        }
+        const correction = corrections.get(payload.correctionId);
+        if (correction) {
+          correction.status = "applied";
+          correction.evidence.push(...payload.evidence);
+          const conflict = conflicts.get(correction.conflictId);
+          if (conflict) conflict.status = "resolved";
+        } else {
+          missingEvidence.add(`correction:${payload.correctionId}:proposal`);
+        }
+        collectMissingEvidence(missingEvidence, event, payload.evidence);
+        break;
+      }
+      case "recall_observed": {
+        const agent = ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
+        agent.recalls.push({
+          recallReceiptId: payload.recallReceiptId,
+          decisionId: payload.decisionId,
+          query: payload.query,
+          capturedAtAction: payload.capturedAtAction,
+          occurredAt: event.occurredAt,
+          evidence: payload.evidence,
+        });
+        const decision = decisions.get(payload.decisionId);
+        if (decision && !decision.heldByAgentIds.includes(payload.agentId)) {
+          decision.heldByAgentIds.push(payload.agentId);
+        }
+        if (!decision) missingEvidence.add(`decision:${payload.decisionId}:recall-target`);
+        collectMissingEvidence(missingEvidence, event, payload.evidence);
+        break;
+      }
+      case "propagation_verified": {
+        ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
+        propagation.push({
+          correctionId: payload.correctionId,
+          agentId: payload.agentId,
+          sessionId: payload.sessionId,
+          decisionId: payload.decisionId,
+          recallReceiptId: payload.recallReceiptId,
+          staleDecisionAbsent: payload.staleDecisionAbsent,
+          occurredAt: event.occurredAt,
+          evidence: payload.evidence,
+        });
+        const correction = corrections.get(payload.correctionId);
+        if (correction) {
+          correction.status = "propagated";
+          correction.propagatedAt = event.occurredAt;
+          correction.evidence.push(...payload.evidence);
+        } else {
+          missingEvidence.add(`correction:${payload.correctionId}:proposal`);
+        }
+        const recalled = agents
+          .get(payload.agentId)
+          ?.recalls.some((recall) => recall.recallReceiptId === payload.recallReceiptId);
+        if (!recalled) missingEvidence.add(`recall:${payload.recallReceiptId}:observation`);
+        status = payload.staleDecisionAbsent ? "verified" : "correcting";
+        collectMissingEvidence(missingEvidence, event, payload.evidence);
+        break;
+      }
+      case "mission_completed":
+        outcome = {
+          result: payload.outcome,
+          summary: payload.summary,
+          occurredAt: event.occurredAt,
+          evidence: payload.evidence,
+        };
+        completedAt = event.occurredAt;
+        status = payload.outcome === "failed" ? "failed" : "completed";
+        collectMissingEvidence(missingEvidence, event, payload.evidence);
+        break;
+    }
+  }
+
+  for (const conflict of conflicts.values()) {
+    for (const decisionId of conflict.decisionIds) {
+      if (!decisions.has(decisionId)) missingEvidence.add(`decision:${decisionId}:conflict-target`);
+    }
+  }
+  for (const correction of corrections.values()) {
+    if (correction.status === "proposed") {
+      missingEvidence.add(`correction:${correction.correctionId}:approval`);
+    }
+    if (correction.status === "approved") {
+      missingEvidence.add(`correction:${correction.correctionId}:supersession`);
+    }
+    if (correction.status === "applied") {
+      missingEvidence.add(`correction:${correction.correctionId}:propagation`);
+    }
+  }
+
+  const sortedDecisions = [...decisions.values()]
+    .map((decision) => ({
+      ...decision,
+      heldByAgentIds: uniqueSorted(decision.heldByAgentIds),
+      beliefIds: uniqueSorted(decision.beliefIds),
+      evidence: uniqueEvidence(decision.evidence),
+    }))
+    .sort((a, b) => compareText(a.decisionId, b.decisionId));
+  const passingOutcomeVerified = outcome?.result === "recovered" && tests.some((test) => test.status === "passed");
+  const coldStartVerified = propagation.some((item) => item.staleDecisionAbsent);
+  if (outcome && !passingOutcomeVerified) missingEvidence.add("outcome:passing-test");
+  if (outcome?.result === "recovered" && !coldStartVerified) {
+    missingEvidence.add("outcome:cold-start-propagation");
+  }
+
+  const eventWindow = filtered.slice(Math.max(0, filtered.length - options.limit));
+  const found = filtered.length > 0;
+  return {
+    schemaVersion: RELAY_MISSION_SCHEMA_VERSION,
+    missionId,
+    namespace,
+    found,
+    readHealth: corruptLines > 0 ? "partial" : found || input.fileExists ? "ok" : "empty",
+    status,
+    mission: { title, objective, runMode, startedAt, completedAt },
+    agents: [...agents.values()]
+      .map((agent) => ({
+        ...agent,
+        sessionIds: uniqueSorted(agent.sessionIds),
+        outputs: agent.outputs.sort((a, b) => compareTimedIds(a, b, "outputId")),
+        recalls: agent.recalls.sort((a, b) => compareTimedIds(a, b, "recallReceiptId")),
+      }))
+      .sort((a, b) => compareText(a.agentId, b.agentId)),
+    decisions: sortedDecisions,
+    conflicts: [...conflicts.values()].sort((a, b) => compareText(a.conflictId, b.conflictId)),
+    corrections: [...corrections.values()]
+      .map((correction) => ({ ...correction, evidence: uniqueEvidence(correction.evidence) }))
+      .sort((a, b) => compareText(a.correctionId, b.correctionId)),
+    tests: tests.sort((a, b) => compareTimedIds(a, b, "testId")),
+    propagation: propagation.sort((a, b) => {
+      const byTime = compareText(a.occurredAt, b.occurredAt);
+      if (byTime !== 0) return byTime;
+      const byAgent = compareText(a.agentId, b.agentId);
+      return byAgent !== 0 ? byAgent : compareText(a.recallReceiptId, b.recallReceiptId);
+    }),
+    outcome,
+    receipt: {
+      complete:
+        outcome?.result === "recovered" && passingOutcomeVerified && coldStartVerified && missingEvidence.size === 0,
+      missingEvidence: [...missingEvidence].sort(compareText),
+      activeDecisionIds: sortedDecisions
+        .filter((decision) => decision.status === "active")
+        .map((decision) => decision.decisionId),
+      supersededDecisionIds: sortedDecisions
+        .filter((decision) => decision.status === "superseded")
+        .map((decision) => decision.decisionId),
+      coldStartVerified,
+      passingOutcomeVerified,
+    },
+    bounds: {
+      totalEvents: filtered.length,
+      returnedEvents: eventWindow.length,
+      corruptLines,
+      truncated: filtered.length > eventWindow.length,
+      since: options.since ?? null,
+      until: options.until ?? null,
+    },
+    events: eventWindow,
+  };
+}
+
+export function compareRelayEvents(a: RelayMissionEvent, b: RelayMissionEvent): number {
+  const byOccurrence = compareText(a.occurredAt, b.occurredAt);
+  if (byOccurrence !== 0) return byOccurrence;
+  const byRecord = compareText(a.recordedAt, b.recordedAt);
+  if (byRecord !== 0) return byRecord;
+  return compareText(a.eventId, b.eventId);
+}
+
+function parseMissionJsonl(
+  raw: string,
+  missionId: string,
+  namespace: string,
+  maxEvents: number
+): Pick<MissionFileRead, "events" | "corruptLines"> {
+  const events: RelayMissionEvent[] = [];
+  let corruptLines = 0;
+  for (const line of raw.split("\n")) {
+    if (line.trim().length === 0) continue;
+    if (Buffer.byteLength(line, "utf8") > RELAY_MISSION_MAX_LINE_BYTES) {
+      corruptLines += 1;
+      continue;
+    }
+    let candidate: unknown;
+    try {
+      candidate = JSON.parse(line);
+    } catch {
+      corruptLines += 1;
+      continue;
+    }
+    const parsed = RelayMissionEventSchema.safeParse(candidate);
+    if (!parsed.success || parsed.data.missionId !== missionId || parsed.data.namespace !== namespace) {
+      corruptLines += 1;
+      continue;
+    }
+    if (events.length >= maxEvents) {
+      throw new RelayMissionStoreError(
+        "limit_exceeded",
+        `mission ${missionId} exceeds the ${maxEvents}-event read limit`
+      );
+    }
+    events.push(parsed.data);
+  }
+  return { events, corruptLines };
+}
+
+function collectMissingEvidence(missing: Set<string>, event: RelayMissionEvent, evidence: RelayEvidenceRef[]): void {
+  if (evidence.length === 0) missing.add(`event:${event.eventId}:evidence`);
+}
+
+function sameIdempotentInput(event: RelayMissionEvent, input: z.infer<typeof RelayMissionEventInputSchema>): boolean {
+  if (input.occurredAt !== undefined && event.occurredAt !== input.occurredAt) return false;
+  return stableJson(event.payload) === stableJson(input.payload);
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => compareText(a, b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stableJson(child)}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function uniqueEvidence(evidence: RelayEvidenceRef[]): RelayEvidenceRef[] {
+  const byKey = new Map<string, RelayEvidenceRef>();
+  for (const item of evidence) byKey.set(`${item.kind}\0${item.id}`, item);
+  return [...byKey.values()].sort((a, b) => {
+    const byKind = compareText(a.kind, b.kind);
+    return byKind !== 0 ? byKind : compareText(a.id, b.id);
+  });
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort(compareText);
+}
+
+function compareText(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function compareTimedIds<T extends { occurredAt: string }, K extends keyof T>(a: T, b: T, idKey: K): number {
+  const byTime = compareText(a.occurredAt, b.occurredAt);
+  if (byTime !== 0) return byTime;
+  return compareText(String(a[idKey]), String(b[idKey]));
+}
+
+function positiveIntegerOption(value: number | undefined, name: string, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new TypeError(`RelayMissionStore ${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function validNow(now: () => Date): string {
+  const value = now();
+  if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+    throw new TypeError("RelayMissionStore now() must return a valid Date");
+  }
+  return value.toISOString();
+}
+
+async function assertExistingSafeDirectory(directory: string): Promise<void> {
+  const info = await fs.lstat(directory);
+  if (info.isSymbolicLink() || !info.isDirectory()) {
+    throw new RelayMissionStoreError("unsafe_path", "Relay root must be a real directory");
+  }
+}
+
+async function ensureSafeChildDirectory(directory: string): Promise<void> {
+  try {
+    await fs.mkdir(directory, { mode: 0o700 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  }
+  const info = await fs.lstat(directory);
+  if (info.isSymbolicLink() || !info.isDirectory()) {
+    throw new RelayMissionStoreError("unsafe_path", "Relay directory symlinks are rejected");
+  }
+  const handle = await fs.open(directory, fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW);
+  try {
+    const openInfo = await handle.stat();
+    const pathInfo = await fs.lstat(directory);
+    if (openInfo.dev !== pathInfo.dev || openInfo.ino !== pathInfo.ino) {
+      throw new RelayMissionStoreError("unsafe_path", "Relay directory changed during validation");
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+async function assertParentDirectoryStable(filePath: string): Promise<void> {
+  const parent = path.dirname(filePath);
+  const handle = await fs.open(parent, fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW);
+  try {
+    const openInfo = await handle.stat();
+    const pathInfo = await fs.lstat(parent);
+    if (
+      pathInfo.isSymbolicLink() ||
+      !pathInfo.isDirectory() ||
+      openInfo.dev !== pathInfo.dev ||
+      openInfo.ino !== pathInfo.ino
+    ) {
+      throw new RelayMissionStoreError("unsafe_path", "Relay mission parent is unsafe");
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+export function relayMissionReceiptDigest(snapshot: RelayMissionSnapshot): string {
+  const receipt = {
+    schemaVersion: snapshot.schemaVersion,
+    missionId: snapshot.missionId,
+    namespace: snapshot.namespace,
+    status: snapshot.status,
+    decisions: snapshot.decisions,
+    corrections: snapshot.corrections,
+    propagation: snapshot.propagation,
+    tests: snapshot.tests,
+    outcome: snapshot.outcome,
+    receipt: snapshot.receipt,
+  };
+  return createHash("sha256").update(stableJson(receipt)).digest("hex");
+}

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -31,6 +31,12 @@ const identifierSchema = z
 const namespaceSchema = z.string().trim().min(1).max(128);
 const shortTextSchema = z.string().trim().min(1).max(240);
 const statementSchema = z.string().trim().min(1).max(4_000);
+const uniqueIdentifierListSchema = (minimum: number, maximum: number) =>
+  z
+    .array(identifierSchema)
+    .min(minimum)
+    .max(maximum)
+    .refine((values) => new Set(values).size === values.length, "must not contain duplicate identifiers");
 
 const isoDateTimeSchema = z
   .string()
@@ -100,8 +106,8 @@ const RelayMissionPayloadUnionSchema = z.discriminatedUnion("kind", [
     .object({
       kind: z.literal("conflict_detected"),
       conflictId: identifierSchema,
-      decisionIds: z.array(identifierSchema).min(2).max(8),
-      agentIds: z.array(identifierSchema).min(2).max(16),
+      decisionIds: uniqueIdentifierListSchema(2, 8),
+      agentIds: uniqueIdentifierListSchema(2, 16),
       summary: statementSchema,
       evidence: evidenceListSchema.default([]),
     })
@@ -123,7 +129,7 @@ const RelayMissionPayloadUnionSchema = z.discriminatedUnion("kind", [
       correctionId: identifierSchema,
       conflictId: identifierSchema,
       proposedDecisionId: identifierSchema,
-      supersedesDecisionIds: z.array(identifierSchema).min(1).max(8),
+      supersedesDecisionIds: uniqueIdentifierListSchema(1, 8),
       statement: statementSchema,
       rationale: statementSchema,
       proposedBy: identifierSchema,
@@ -692,7 +698,13 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   const corruptLines = input.corruptLines ?? 0;
   const sinceMs = options.since ? Date.parse(options.since) : undefined;
   const untilMs = options.until ? Date.parse(options.until) : undefined;
+  const appendPositions = new Map(input.events.map((event, index) => [event, index] as const));
   const orderedEvents = [...input.events].sort(compareRelayEvents);
+  const firstStartEvent = input.events.find((event) => event.payload.kind === "mission_started");
+  const firstCompletionEvent = input.events.find((event) => event.payload.kind === "mission_completed");
+  const firstStartPosition = firstStartEvent === undefined ? -1 : (appendPositions.get(firstStartEvent) ?? -1);
+  const firstCompletionPosition =
+    firstCompletionEvent === undefined ? -1 : (appendPositions.get(firstCompletionEvent) ?? -1);
   const filteredEvents = orderedEvents.filter((event) => {
     const occurredAt = Date.parse(event.occurredAt);
     return (sinceMs === undefined || occurredAt >= sinceMs) && (untilMs === undefined || occurredAt < untilMs);
@@ -743,8 +755,24 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
 
   for (const event of orderedEvents) {
     const payload = event.payload;
-    if (outcome !== null && payload.kind !== "mission_completed") {
+    const appendPosition = appendPositions.get(event) ?? -1;
+    if (
+      payload.kind !== "mission_started" &&
+      firstStartEvent !== undefined &&
+      (appendPosition < firstStartPosition || compareRelayEvents(event, firstStartEvent) < 0)
+    ) {
+      missingEvidence.add(`mission:event-before-start:${event.eventId}`);
+      collectMissingEvidence(missingEvidence, event, payload.evidence);
+      continue;
+    }
+    if (
+      payload.kind !== "mission_completed" &&
+      (outcome !== null || (firstCompletionPosition >= 0 && appendPosition > firstCompletionPosition))
+    ) {
       missingEvidence.add(`mission:event-after-completion:${event.eventId}`);
+      if (payload.kind === "mission_started") missingEvidence.add("mission:lifecycle-order");
+      collectMissingEvidence(missingEvidence, event, payload.evidence);
+      continue;
     }
     switch (payload.kind) {
       case "mission_started":
@@ -842,7 +870,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           break;
         }
         substantiveAgentIds.add(payload.proposedBy);
-        corrections.set(payload.correctionId, {
+        const correction: RelayCorrectionSnapshot = {
           correctionId: payload.correctionId,
           conflictId: payload.conflictId,
           proposedDecisionId: payload.proposedDecisionId,
@@ -853,7 +881,8 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           status: "proposed",
           proposedAt: event.occurredAt,
           evidence: [...payload.evidence],
-        });
+        };
+        corrections.set(payload.correctionId, correction);
         if (!decisions.has(payload.proposedDecisionId)) {
           decisions.set(payload.proposedDecisionId, {
             decisionId: payload.proposedDecisionId,
@@ -867,12 +896,12 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         }
         const conflict = conflicts.get(payload.conflictId);
         if (conflict) {
-          const requiredDecisionIds = [payload.proposedDecisionId, ...payload.supersedesDecisionIds];
-          if (!requiredDecisionIds.every((decisionId) => conflict.decisionIds.includes(decisionId))) {
+          if (!correctionCoversConflict(correction, conflict)) {
             missingEvidence.add(`conflict:${payload.conflictId}:decision-link`);
+          } else {
+            conflict.status = "proposed";
+            conflict.correctionId = payload.correctionId;
           }
-          conflict.status = "proposed";
-          conflict.correctionId = payload.correctionId;
         } else {
           missingEvidence.add(`conflict:${payload.conflictId}:observation`);
         }
@@ -912,6 +941,12 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           collectMissingEvidence(missingEvidence, event, payload.evidence);
           break;
         }
+        const conflict = conflicts.get(correction.conflictId);
+        if (!conflict || !correctionCoversConflict(correction, conflict)) {
+          missingEvidence.add(`conflict:${correction.conflictId}:decision-link`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
         if (
           !correction.supersedesDecisionIds.includes(payload.decisionId) ||
           correction.proposedDecisionId !== payload.replacementDecisionId
@@ -941,8 +976,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         if (correctionSupersessionComplete(correction, decisions)) {
           correction.appliedAt ??= event.occurredAt;
           if (correction.status !== "propagated") correction.status = "applied";
-          const conflict = conflicts.get(correction.conflictId);
-          if (conflict) conflict.status = "resolved";
+          conflict.status = "resolved";
         }
         collectMissingEvidence(missingEvidence, event, payload.evidence);
         break;
@@ -1110,6 +1144,13 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   }
   if (input.events.length > 0 && startedAt === null) missingEvidence.add("mission:start");
   if (startedAt !== null && completedAt !== null && compareInstants(startedAt, completedAt) >= 0) {
+    missingEvidence.add("mission:lifecycle-order");
+  }
+  if (
+    firstStartEvent !== undefined &&
+    firstCompletionEvent !== undefined &&
+    (firstStartPosition >= firstCompletionPosition || compareRelayEvents(firstStartEvent, firstCompletionEvent) >= 0)
+  ) {
     missingEvidence.add("mission:lifecycle-order");
   }
 
@@ -1287,6 +1328,20 @@ function correctionSupersessionComplete(
       decision.correctionId === correction.correctionId
     );
   });
+}
+
+function correctionCoversConflict(
+  correction: Pick<RelayCorrectionSnapshot, "proposedDecisionId" | "supersedesDecisionIds">,
+  conflict: Pick<RelayConflictSnapshot, "decisionIds">
+): boolean {
+  const expectedSuperseded = uniqueSorted(
+    conflict.decisionIds.filter((decisionId) => decisionId !== correction.proposedDecisionId)
+  );
+  const declaredSuperseded = uniqueSorted(correction.supersedesDecisionIds);
+  return (
+    expectedSuperseded.length === declaredSuperseded.length &&
+    expectedSuperseded.every((decisionId, index) => decisionId === declaredSuperseded[index])
+  );
 }
 
 function positiveIntegerOption(value: number | undefined, name: string, fallback: number): number {

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { constants as fsConstants, promises as fs } from "node:fs";
+import { promises as fs, constants as fsConstants } from "node:fs";
 import path from "node:path";
 import { z } from "zod";
 
@@ -268,6 +268,7 @@ export interface RelayAgentOutputSnapshot {
 
 export interface RelayRecallSnapshot {
   recallReceiptId: string;
+  sessionId: string;
   decisionId: string;
   query: string;
   capturedAtAction: boolean;
@@ -818,10 +819,12 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       case "correction_approved": {
         const correction = corrections.get(payload.correctionId);
         if (correction) {
-          correction.status = "approved";
-          correction.approvedAt = event.occurredAt;
-          correction.approvedBy = payload.approvedBy;
-          correction.approvalNote = payload.note;
+          if (correction.approvedAt === undefined) {
+            correction.approvedAt = event.occurredAt;
+            correction.approvedBy = payload.approvedBy;
+            correction.approvalNote = payload.note;
+            if (correction.status === "proposed") correction.status = "approved";
+          }
           correction.evidence.push(...payload.evidence);
         } else {
           missingEvidence.add(`correction:${payload.correctionId}:proposal`);
@@ -831,31 +834,47 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         break;
       }
       case "decision_superseded": {
+        const correction = corrections.get(payload.correctionId);
+        if (!correction) {
+          missingEvidence.add(`correction:${payload.correctionId}:proposal`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        if (correction.approvedAt === undefined || correction.approvedBy === undefined) {
+          missingEvidence.add(`correction:${payload.correctionId}:approval`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        if (
+          !correction.supersedesDecisionIds.includes(payload.decisionId) ||
+          correction.proposedDecisionId !== payload.replacementDecisionId
+        ) {
+          missingEvidence.add(`correction:${payload.correctionId}:supersession-link`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+
         const stale = decisions.get(payload.decisionId);
         const replacement = decisions.get(payload.replacementDecisionId);
-        if (stale) {
-          stale.status = "superseded";
-          stale.supersededAt = event.occurredAt;
-          stale.supersededBy = payload.replacementDecisionId;
-          stale.correctionId = payload.correctionId;
-          stale.evidence.push(...payload.evidence);
-        } else {
-          missingEvidence.add(`decision:${payload.decisionId}:observation`);
+        if (!stale) missingEvidence.add(`decision:${payload.decisionId}:observation`);
+        if (!replacement) missingEvidence.add(`decision:${payload.replacementDecisionId}:replacement`);
+        if (!stale || !replacement) {
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
         }
-        if (replacement) {
-          replacement.status = "active";
-          replacement.evidence.push(...payload.evidence);
-        } else {
-          missingEvidence.add(`decision:${payload.replacementDecisionId}:replacement`);
-        }
-        const correction = corrections.get(payload.correctionId);
-        if (correction) {
-          correction.status = "applied";
-          correction.evidence.push(...payload.evidence);
+
+        stale.status = "superseded";
+        stale.supersededAt = event.occurredAt;
+        stale.supersededBy = payload.replacementDecisionId;
+        stale.correctionId = payload.correctionId;
+        stale.evidence.push(...payload.evidence);
+        replacement.status = "active";
+        replacement.evidence.push(...payload.evidence);
+        correction.evidence.push(...payload.evidence);
+        if (correctionSupersessionComplete(correction, decisions)) {
+          if (correction.status !== "propagated") correction.status = "applied";
           const conflict = conflicts.get(correction.conflictId);
           if (conflict) conflict.status = "resolved";
-        } else {
-          missingEvidence.add(`correction:${payload.correctionId}:proposal`);
         }
         collectMissingEvidence(missingEvidence, event, payload.evidence);
         break;
@@ -864,6 +883,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         const agent = ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
         agent.recalls.push({
           recallReceiptId: payload.recallReceiptId,
+          sessionId: payload.sessionId,
           decisionId: payload.decisionId,
           query: payload.query,
           capturedAtAction: payload.capturedAtAction,
@@ -879,7 +899,43 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         break;
       }
       case "propagation_verified": {
-        ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
+        const agent = ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
+        const correction = corrections.get(payload.correctionId);
+        if (!correction) {
+          missingEvidence.add(`correction:${payload.correctionId}:proposal`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        if (correction.approvedAt === undefined || correction.approvedBy === undefined) {
+          missingEvidence.add(`correction:${payload.correctionId}:approval`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        if (
+          (correction.status !== "applied" && correction.status !== "propagated") ||
+          correction.proposedDecisionId !== payload.decisionId
+        ) {
+          missingEvidence.add(`correction:${payload.correctionId}:supersession`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        const recalled = agent.recalls.find(
+          (recall) =>
+            recall.recallReceiptId === payload.recallReceiptId &&
+            recall.sessionId === payload.sessionId &&
+            recall.decisionId === payload.decisionId
+        );
+        if (!recalled) {
+          missingEvidence.add(`recall:${payload.recallReceiptId}:observation`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        if (!recalled.capturedAtAction) {
+          missingEvidence.add(`recall:${payload.recallReceiptId}:at-action`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+
         propagation.push({
           correctionId: payload.correctionId,
           agentId: payload.agentId,
@@ -890,18 +946,11 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           occurredAt: event.occurredAt,
           evidence: payload.evidence,
         });
-        const correction = corrections.get(payload.correctionId);
-        if (correction) {
+        correction.evidence.push(...payload.evidence);
+        if (payload.staleDecisionAbsent) {
           correction.status = "propagated";
           correction.propagatedAt = event.occurredAt;
-          correction.evidence.push(...payload.evidence);
-        } else {
-          missingEvidence.add(`correction:${payload.correctionId}:proposal`);
         }
-        const recalled = agents
-          .get(payload.agentId)
-          ?.recalls.some((recall) => recall.recallReceiptId === payload.recallReceiptId);
-        if (!recalled) missingEvidence.add(`recall:${payload.recallReceiptId}:observation`);
         status = payload.staleDecisionAbsent ? "verified" : "correcting";
         collectMissingEvidence(missingEvidence, event, payload.evidence);
         break;
@@ -926,10 +975,12 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
     }
   }
   for (const correction of corrections.values()) {
-    if (correction.status === "proposed") {
+    if (correction.approvedAt === undefined || correction.approvedBy === undefined) {
       missingEvidence.add(`correction:${correction.correctionId}:approval`);
+    } else if (correction.approvedBy.kind !== "human") {
+      missingEvidence.add(`correction:${correction.correctionId}:human-approval`);
     }
-    if (correction.status === "approved") {
+    if (correction.status === "approved" || correction.status === "proposed") {
       missingEvidence.add(`correction:${correction.correctionId}:supersession`);
     }
     if (correction.status === "applied") {
@@ -945,8 +996,15 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       evidence: uniqueEvidence(decision.evidence),
     }))
     .sort((a, b) => compareText(a.decisionId, b.decisionId));
-  const passingOutcomeVerified = outcome?.result === "recovered" && tests.some((test) => test.status === "passed");
   const coldStartVerified = propagation.some((item) => item.staleDecisionAbsent);
+  const passingOutcomeVerified =
+    outcome?.result === "recovered" &&
+    tests.some(
+      (test) =>
+        test.status === "passed" &&
+        compareInstants(test.occurredAt, outcome.occurredAt) < 0 &&
+        propagation.some((item) => item.staleDecisionAbsent && compareInstants(item.occurredAt, test.occurredAt) < 0)
+    );
   if (outcome && !passingOutcomeVerified) missingEvidence.add("outcome:passing-test");
   if (outcome?.result === "recovered" && !coldStartVerified) {
     missingEvidence.add("outcome:cold-start-propagation");
@@ -981,7 +1039,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       .sort((a, b) => compareText(a.correctionId, b.correctionId)),
     tests: tests.sort((a, b) => compareTimedIds(a, b, "testId")),
     propagation: propagation.sort((a, b) => {
-      const byTime = compareText(a.occurredAt, b.occurredAt);
+      const byTime = compareInstants(a.occurredAt, b.occurredAt);
       if (byTime !== 0) return byTime;
       const byAgent = compareText(a.agentId, b.agentId);
       return byAgent !== 0 ? byAgent : compareText(a.recallReceiptId, b.recallReceiptId);
@@ -1013,9 +1071,9 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
 }
 
 export function compareRelayEvents(a: RelayMissionEvent, b: RelayMissionEvent): number {
-  const byOccurrence = compareText(a.occurredAt, b.occurredAt);
+  const byOccurrence = compareInstants(a.occurredAt, b.occurredAt);
   if (byOccurrence !== 0) return byOccurrence;
-  const byRecord = compareText(a.recordedAt, b.recordedAt);
+  const byRecord = compareInstants(a.recordedAt, b.recordedAt);
   if (byRecord !== 0) return byRecord;
   return compareText(a.eventId, b.eventId);
 }
@@ -1096,10 +1154,32 @@ function compareText(a: string, b: string): number {
   return 0;
 }
 
+function compareInstants(a: string, b: string): number {
+  const aMs = Date.parse(a);
+  const bMs = Date.parse(b);
+  if (aMs < bMs) return -1;
+  if (aMs > bMs) return 1;
+  return 0;
+}
+
 function compareTimedIds<T extends { occurredAt: string }, K extends keyof T>(a: T, b: T, idKey: K): number {
-  const byTime = compareText(a.occurredAt, b.occurredAt);
+  const byTime = compareInstants(a.occurredAt, b.occurredAt);
   if (byTime !== 0) return byTime;
   return compareText(String(a[idKey]), String(b[idKey]));
+}
+
+function correctionSupersessionComplete(
+  correction: RelayCorrectionSnapshot,
+  decisions: ReadonlyMap<string, RelayDecisionSnapshot>
+): boolean {
+  return correction.supersedesDecisionIds.every((decisionId) => {
+    const decision = decisions.get(decisionId);
+    return (
+      decision?.status === "superseded" &&
+      decision.supersededBy === correction.proposedDecisionId &&
+      decision.correctionId === correction.correctionId
+    );
+  });
 }
 
 function positiveIntegerOption(value: number | undefined, name: string, fallback: number): number {

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -29,6 +29,7 @@ const identifierSchema = z
   });
 
 const namespaceSchema = z.string().trim().min(1).max(128);
+const authenticatedPrincipalSchema = z.string().trim().min(1).max(256);
 const shortTextSchema = z.string().trim().min(1).max(240);
 const statementSchema = z.string().trim().min(1).max(4_000);
 const uniqueIdentifierListSchema = (minimum: number, maximum: number) =>
@@ -261,6 +262,7 @@ export const RelayMissionEventSchema = z
     eventId: identifierSchema,
     missionId: RelayMissionIdSchema,
     namespace: namespaceSchema,
+    authenticatedPrincipal: authenticatedPrincipalSchema.optional(),
     recordedAt: isoDateTimeSchema,
     occurredAt: isoDateTimeSchema,
     idempotencyKey: identifierSchema.optional(),
@@ -360,6 +362,7 @@ export interface RelayCorrectionSnapshot {
   approvedAt?: string;
   approvedBy?: { kind: "human" | "agent"; id: string; label: string };
   approvalNote?: string;
+  approvalPrincipal?: string;
   appliedAt?: string;
   propagatedAt?: string;
   evidence: RelayEvidenceRef[];
@@ -506,10 +509,14 @@ export class RelayMissionStore {
   async append(
     missionIdValue: string,
     inputValue: RelayMissionEventInput,
-    hooks: { beforeAppend?: () => void | Promise<void> } = {}
+    hooks: { authenticatedPrincipal?: string; beforeAppend?: () => void | Promise<void> } = {}
   ): Promise<RelayMissionAppendResult> {
     const missionId = RelayMissionIdSchema.parse(missionIdValue);
     const input = RelayMissionEventInputSchema.parse(inputValue);
+    const authenticatedPrincipal =
+      hooks.authenticatedPrincipal === undefined
+        ? undefined
+        : authenticatedPrincipalSchema.parse(hooks.authenticatedPrincipal);
     const missionDir = await this.openMissionDirectory();
     const filePath = path.join(missionDir.accessPath, `${missionId}.jsonl`);
     const logicalFilePath = path.join(missionDir.logicalPath, `${missionId}.jsonl`);
@@ -529,7 +536,7 @@ export class RelayMissionStore {
             if (input.idempotencyKey) {
               const replay = existing.events.find((event) => event.idempotencyKey === input.idempotencyKey);
               if (replay) {
-                if (!sameIdempotentInput(replay, input)) {
+                if (!sameIdempotentInput(replay, input, authenticatedPrincipal)) {
                   throw new RelayMissionStoreError(
                     "idempotency_conflict",
                     `idempotency key ${input.idempotencyKey} was already used for different input`
@@ -558,6 +565,7 @@ export class RelayMissionStore {
               eventId: this.createEventId(),
               missionId,
               namespace: this.namespace,
+              ...(authenticatedPrincipal === undefined ? {} : { authenticatedPrincipal }),
               recordedAt,
               occurredAt: input.occurredAt ?? recordedAt,
               ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
@@ -862,6 +870,28 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         break;
       }
       case "conflict_detected": {
+        const participantHoldings = payload.agentIds.map((agentId) => ({
+          agentId,
+          decisionIds: uniqueSorted(
+            payload.decisionIds.filter((decisionId) => decisions.get(decisionId)?.heldByAgentIds.includes(agentId))
+          ),
+        }));
+        for (const participant of participantHoldings) {
+          if (participant.decisionIds.length === 0) {
+            missingEvidence.add(`conflict:${payload.conflictId}:participant:${participant.agentId}:decision-link`);
+          }
+        }
+        for (const decisionId of payload.decisionIds) {
+          if (!participantHoldings.some((participant) => participant.decisionIds.includes(decisionId))) {
+            missingEvidence.add(`conflict:${payload.conflictId}:decision:${decisionId}:participant-link`);
+          }
+        }
+        if (
+          participantHoldings.every((participant) => participant.decisionIds.length > 0) &&
+          new Set(participantHoldings.map((participant) => participant.decisionIds.join("\0"))).size < 2
+        ) {
+          missingEvidence.add(`conflict:${payload.conflictId}:distinct-participant-beliefs`);
+        }
         if (conflicts.has(payload.conflictId)) {
           missingEvidence.add(`conflict:${payload.conflictId}:duplicate`);
         } else {
@@ -956,10 +986,19 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         if (payload.approvedBy.kind === "agent") substantiveAgentIds.add(payload.approvedBy.id);
         const correction = corrections.get(payload.correctionId);
         if (correction) {
-          if (correction.approvedAt === undefined) {
+          const authenticatedHumanApproval =
+            payload.approvedBy.kind !== "human" ||
+            runMode !== "live" ||
+            event.authenticatedPrincipal === payload.approvedBy.id;
+          if (!authenticatedHumanApproval) {
+            missingEvidence.add(`correction:${payload.correctionId}:authenticated-human-approval`);
+          } else if (correction.approvedAt === undefined) {
             correction.approvedAt = event.occurredAt;
             correction.approvedBy = payload.approvedBy;
             correction.approvalNote = payload.note;
+            if (event.authenticatedPrincipal !== undefined) {
+              correction.approvalPrincipal = event.authenticatedPrincipal;
+            }
             if (correction.status === "proposed") correction.status = "approved";
           } else {
             missingEvidence.add(`correction:${payload.correctionId}:duplicate-approval`);
@@ -1166,6 +1205,8 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       missingEvidence.add(`correction:${correction.correctionId}:approval`);
     } else if (correction.approvedBy.kind !== "human") {
       missingEvidence.add(`correction:${correction.correctionId}:human-approval`);
+    } else if (runMode === "live" && correction.approvalPrincipal !== correction.approvedBy.id) {
+      missingEvidence.add(`correction:${correction.correctionId}:authenticated-human-approval`);
     }
     if (correction.status === "approved" || correction.status === "proposed") {
       missingEvidence.add(`correction:${correction.correctionId}:supersession`);
@@ -1352,7 +1393,12 @@ function collectMissingEvidence(missing: Set<string>, event: RelayMissionEvent, 
   if (evidence.length === 0) missing.add(`event:${event.eventId}:evidence`);
 }
 
-function sameIdempotentInput(event: RelayMissionEvent, input: z.infer<typeof RelayMissionEventInputSchema>): boolean {
+function sameIdempotentInput(
+  event: RelayMissionEvent,
+  input: z.infer<typeof RelayMissionEventInputSchema>,
+  authenticatedPrincipal: string | undefined
+): boolean {
+  if (event.authenticatedPrincipal !== authenticatedPrincipal) return false;
   if (input.occurredAt !== undefined && event.occurredAt !== input.occurredAt) return false;
   return stableJson(event.payload) === stableJson(input.payload);
 }

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -682,6 +682,9 @@ export class RelayMissionStore {
       if (!info.isFile()) {
         throw new RelayMissionStoreError("unsafe_path", "Relay mission path is not a file");
       }
+      if (info.nlink !== 1) {
+        throw new RelayMissionStoreError("unsafe_path", "Relay mission hard links are rejected");
+      }
       if (info.size > this.maxFileBytes) {
         throw new RelayMissionStoreError(
           "limit_exceeded",
@@ -715,6 +718,9 @@ export class RelayMissionStore {
       const info = await handle.stat();
       if (!info.isFile()) {
         throw new RelayMissionStoreError("unsafe_path", "Relay mission path is not a file");
+      }
+      if (info.nlink !== 1) {
+        throw new RelayMissionStoreError("unsafe_path", "Relay mission hard links are rejected");
       }
       await handle.chmod(0o600);
       await handle.writeFile(line, "utf8");

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -1175,6 +1175,17 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
     }
   }
 
+  const liveFixtureEvidenceEventIds =
+    runMode === "live"
+      ? orderedEvents
+          .filter((event) => event.payload.evidence.some((item) => item.capture === "fixture"))
+          .map((event) => event.eventId)
+      : [];
+  for (const eventId of liveFixtureEvidenceEventIds) {
+    missingEvidence.add(`mission:live-fixture-evidence:${eventId}`);
+  }
+  const captureTrustValid = liveFixtureEvidenceEventIds.length === 0;
+
   const sortedDecisions = [...decisions.values()]
     .map((decision) => ({
       ...decision,
@@ -1183,8 +1194,9 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       evidence: uniqueEvidence(decision.evidence),
     }))
     .sort((a, b) => compareText(a.decisionId, b.decisionId));
-  const coldStartVerified = propagation.some((item) => item.staleDecisionAbsent);
+  const coldStartVerified = captureTrustValid && propagation.some((item) => item.staleDecisionAbsent);
   const passingOutcomeVerified =
+    captureTrustValid &&
     outcome?.result === "recovered" &&
     tests.some((test) => {
       if (

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -769,6 +769,14 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   const corrections = new Map<string, RelayCorrectionSnapshot>();
   const tests: RelayTestSnapshot[] = [];
   const propagation: RelayPropagationSnapshot[] = [];
+  const beliefAppendPositions = new Map<string, number>();
+  const conflictAppendPositions = new Map<string, number>();
+  const correctionProposalAppendPositions = new Map<string, number>();
+  const correctionApprovalAppendPositions = new Map<string, number>();
+  const correctionAppliedAppendPositions = new Map<string, number>();
+  const recallAppendPositions = new Map<RelayRecallSnapshot, number>();
+  const propagationAppendPositions = new Map<RelayPropagationSnapshot, number>();
+  const testAppendPositions = new Map<RelayTestSnapshot, number>();
   const missingEvidence = new Set<string>();
   if (corruptLines > 0) missingEvidence.add("mission:corrupt-events");
   const substantiveAgentIds = new Set<string>();
@@ -867,6 +875,11 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       case "belief_observed": {
         ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
         markSubstantiveParticipation(payload.agentId, payload.sessionId);
+        recordEarliestAppendPosition(
+          beliefAppendPositions,
+          beliefAppendPositionKey(payload.agentId, payload.decisionId),
+          appendPosition
+        );
         const existing = decisions.get(payload.decisionId);
         if (existing) {
           if (!existing.heldByAgentIds.includes(payload.agentId)) {
@@ -889,6 +902,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         break;
       }
       case "conflict_detected": {
+        recordEarliestAppendPosition(conflictAppendPositions, payload.conflictId, appendPosition);
         const participantHoldings = payload.agentIds.map((agentId) => ({
           agentId,
           decisionIds: uniqueSorted(
@@ -903,6 +917,26 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         for (const decisionId of payload.decisionIds) {
           if (!participantHoldings.some((participant) => participant.decisionIds.includes(decisionId))) {
             missingEvidence.add(`conflict:${payload.conflictId}:decision:${decisionId}:participant-link`);
+          }
+          if (
+            !payload.agentIds.some(
+              (agentId) =>
+                (beliefAppendPositions.get(beliefAppendPositionKey(agentId, decisionId)) ?? Number.POSITIVE_INFINITY) <
+                appendPosition
+            )
+          ) {
+            missingEvidence.add(`conflict:${payload.conflictId}:decision:${decisionId}:append-order`);
+          }
+        }
+        for (const agentId of payload.agentIds) {
+          if (
+            !payload.decisionIds.some(
+              (decisionId) =>
+                (beliefAppendPositions.get(beliefAppendPositionKey(agentId, decisionId)) ?? Number.POSITIVE_INFINITY) <
+                appendPosition
+            )
+          ) {
+            missingEvidence.add(`conflict:${payload.conflictId}:participant:${agentId}:append-order`);
           }
         }
         if (
@@ -928,8 +962,8 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         collectMissingEvidence(missingEvidence, event, payload.evidence);
         break;
       }
-      case "test_result":
-        tests.push({
+      case "test_result": {
+        const testSnapshot: RelayTestSnapshot = {
           testId: payload.testId,
           decisionId: payload.decisionId,
           ...(payload.correctionId === undefined ? {} : { correctionId: payload.correctionId }),
@@ -939,9 +973,12 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           ...(payload.durationMs === undefined ? {} : { durationMs: payload.durationMs }),
           occurredAt: event.occurredAt,
           evidence: payload.evidence,
-        });
+        };
+        tests.push(testSnapshot);
+        testAppendPositions.set(testSnapshot, appendPosition);
         collectMissingEvidence(missingEvidence, event, payload.evidence);
         break;
+      }
       case "correction_proposed": {
         if (corrections.has(payload.correctionId)) {
           missingEvidence.add(`correction:${payload.correctionId}:duplicate-proposal`);
@@ -962,6 +999,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           evidence: [...payload.evidence],
         };
         corrections.set(payload.correctionId, correction);
+        correctionProposalAppendPositions.set(payload.correctionId, appendPosition);
         if (!decisions.has(payload.proposedDecisionId)) {
           decisions.set(payload.proposedDecisionId, {
             decisionId: payload.proposedDecisionId,
@@ -974,6 +1012,12 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           });
         }
         const conflict = conflicts.get(payload.conflictId);
+        const conflictAppendPosition = conflictAppendPositions.get(payload.conflictId);
+        const conflictPredatesProposal =
+          conflictAppendPosition !== undefined && conflictAppendPosition < appendPosition;
+        if (!conflictPredatesProposal) {
+          missingEvidence.add(`correction:${payload.correctionId}:conflict-append-order`);
+        }
         const correctionSourceIds = sourceEvidenceIds(payload.evidence);
         if (correctionSourceIds.size === 0) {
           missingEvidence.add(`correction:${payload.correctionId}:source`);
@@ -989,7 +1033,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           }
           if (!correctionCoversConflict(correction, conflict)) {
             missingEvidence.add(`conflict:${payload.conflictId}:decision-link`);
-          } else if (sourceLinked) {
+          } else if (sourceLinked && conflictPredatesProposal) {
             groundedCorrectionIds.add(payload.correctionId);
             conflict.status = "proposed";
             conflict.correctionId = payload.correctionId;
@@ -1005,11 +1049,16 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         if (payload.approvedBy.kind === "agent") substantiveAgentIds.add(payload.approvedBy.id);
         const correction = corrections.get(payload.correctionId);
         if (correction) {
+          const proposalAppendPosition = correctionProposalAppendPositions.get(payload.correctionId);
+          const proposalPredatesApproval =
+            proposalAppendPosition !== undefined && proposalAppendPosition < appendPosition;
           const authenticatedHumanApproval =
             payload.approvedBy.kind !== "human" ||
             runMode !== "live" ||
             event.authenticatedPrincipal === payload.approvedBy.id;
-          if (!authenticatedHumanApproval) {
+          if (!proposalPredatesApproval) {
+            missingEvidence.add(`correction:${payload.correctionId}:approval-append-order`);
+          } else if (!authenticatedHumanApproval) {
             missingEvidence.add(`correction:${payload.correctionId}:authenticated-human-approval`);
           } else if (correction.approvedAt === undefined) {
             correction.approvedAt = event.occurredAt;
@@ -1018,6 +1067,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
             if (event.authenticatedPrincipal !== undefined) {
               correction.approvalPrincipal = event.authenticatedPrincipal;
             }
+            correctionApprovalAppendPositions.set(payload.correctionId, appendPosition);
             if (correction.status === "proposed") correction.status = "approved";
           } else {
             missingEvidence.add(`correction:${payload.correctionId}:duplicate-approval`);
@@ -1039,6 +1089,12 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         }
         if (correction.approvedAt === undefined || correction.approvedBy === undefined) {
           missingEvidence.add(`correction:${payload.correctionId}:approval`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        const approvalAppendPosition = correctionApprovalAppendPositions.get(payload.correctionId);
+        if (approvalAppendPosition === undefined || approvalAppendPosition >= appendPosition) {
+          missingEvidence.add(`correction:${payload.correctionId}:approval-append-order`);
           collectMissingEvidence(missingEvidence, event, payload.evidence);
           break;
         }
@@ -1081,6 +1137,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         correction.evidence.push(...payload.evidence);
         if (correctionSupersessionComplete(correction, decisions)) {
           correction.appliedAt ??= event.occurredAt;
+          recordEarliestAppendPosition(correctionAppliedAppendPositions, payload.correctionId, appendPosition);
           if (correction.status !== "propagated") correction.status = "applied";
           conflict.status = "resolved";
         }
@@ -1093,7 +1150,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           !substantiveAgentIds.has(payload.agentId) &&
           !substantiveSessionIds.has(payload.sessionId) &&
           agent.recalls.length === 0;
-        agent.recalls.push({
+        const recallSnapshot: RelayRecallSnapshot = {
           recallReceiptId: payload.recallReceiptId,
           sessionId: payload.sessionId,
           decisionId: payload.decisionId,
@@ -1102,7 +1159,9 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           coldStart,
           occurredAt: event.occurredAt,
           evidence: payload.evidence,
-        });
+        };
+        agent.recalls.push(recallSnapshot);
+        recallAppendPositions.set(recallSnapshot, appendPosition);
         markSubstantiveParticipation(payload.agentId, payload.sessionId);
         const decision = decisions.get(payload.decisionId);
         if (decision && !decision.heldByAgentIds.includes(payload.agentId)) {
@@ -1145,6 +1204,22 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           collectMissingEvidence(missingEvidence, event, payload.evidence);
           break;
         }
+        const appliedAppendPosition = correctionAppliedAppendPositions.get(payload.correctionId);
+        const recallAppendPosition = recallAppendPositions.get(recalled);
+        if (
+          appliedAppendPosition === undefined ||
+          recallAppendPosition === undefined ||
+          appliedAppendPosition >= recallAppendPosition
+        ) {
+          missingEvidence.add(`recall:${payload.recallReceiptId}:post-application-append-order`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        if (recallAppendPosition >= appendPosition) {
+          missingEvidence.add(`recall:${payload.recallReceiptId}:propagation-append-order`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
         if (!recalled.capturedAtAction) {
           missingEvidence.add(`recall:${payload.recallReceiptId}:at-action`);
           collectMissingEvidence(missingEvidence, event, payload.evidence);
@@ -1166,7 +1241,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           break;
         }
 
-        propagation.push({
+        const propagationSnapshot: RelayPropagationSnapshot = {
           correctionId: payload.correctionId,
           agentId: payload.agentId,
           sessionId: payload.sessionId,
@@ -1175,7 +1250,9 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           staleDecisionAbsent: payload.staleDecisionAbsent,
           occurredAt: event.occurredAt,
           evidence: payload.evidence,
-        });
+        };
+        propagation.push(propagationSnapshot);
+        propagationAppendPositions.set(propagationSnapshot, appendPosition);
         correction.evidence.push(...payload.evidence);
         if (payload.staleDecisionAbsent) {
           correction.status = "propagated";
@@ -1259,9 +1336,13 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
     captureTrustValid &&
     outcome?.result === "recovered" &&
     tests.some((test) => {
+      const testAppendPosition = testAppendPositions.get(test);
       if (
         test.status !== "passed" ||
         test.correctionId === undefined ||
+        testAppendPosition === undefined ||
+        firstCompletionPosition < 0 ||
+        testAppendPosition >= firstCompletionPosition ||
         compareInstants(test.occurredAt, outcome.occurredAt) >= 0
       ) {
         return false;
@@ -1275,13 +1356,17 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       ) {
         return false;
       }
-      return propagation.some(
-        (item) =>
+      return propagation.some((item) => {
+        const propagationAppendPosition = propagationAppendPositions.get(item);
+        return (
           item.staleDecisionAbsent &&
           item.correctionId === correction.correctionId &&
           item.decisionId === test.decisionId &&
+          propagationAppendPosition !== undefined &&
+          propagationAppendPosition < testAppendPosition &&
           compareInstants(item.occurredAt, test.occurredAt) < 0
-      );
+        );
+      });
     });
   if (outcome && !passingOutcomeVerified) missingEvidence.add("outcome:passing-test");
   if (outcome?.result === "recovered" && !coldStartVerified) {
@@ -1464,6 +1549,15 @@ function compareTimedIds<T extends { occurredAt: string }, K extends keyof T>(a:
   const byTime = compareInstants(a.occurredAt, b.occurredAt);
   if (byTime !== 0) return byTime;
   return compareText(String(a[idKey]), String(b[idKey]));
+}
+
+function beliefAppendPositionKey(agentId: string, decisionId: string): string {
+  return `${agentId}\0${decisionId}`;
+}
+
+function recordEarliestAppendPosition(positions: Map<string, number>, key: string, position: number): void {
+  const current = positions.get(key);
+  if (current === undefined || position < current) positions.set(key, position);
 }
 
 function correctionSupersessionComplete(

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -787,6 +787,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   if (corruptLines > 0) missingEvidence.add("mission:corrupt-events");
   const substantiveAgentIds = new Set<string>();
   const substantiveSessionIds = new Set<string>();
+  const conflictDisagreementIds = new Set<string>();
   const groundedCorrectionIds = new Set<string>();
   let title: string | null = null;
   let objective: string | null = null;
@@ -909,6 +910,18 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       }
       case "conflict_detected": {
         recordEarliestAppendPosition(conflictAppendPositions, payload.conflictId, appendPosition);
+        const normalizedDecisionStatements = payload.decisionIds
+          .map((decisionId) => decisions.get(decisionId)?.statement)
+          .filter((statement): statement is string => statement !== undefined)
+          .map(normalizeDecisionStatement);
+        if (
+          normalizedDecisionStatements.length !== payload.decisionIds.length ||
+          new Set(normalizedDecisionStatements).size < 2
+        ) {
+          missingEvidence.add(`conflict:${payload.conflictId}:distinct-decision-statements`);
+        } else {
+          conflictDisagreementIds.add(payload.conflictId);
+        }
         const participantHoldings = payload.agentIds.map((agentId) => ({
           agentId,
           decisionIds: uniqueSorted(
@@ -1039,7 +1052,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           }
           if (!correctionCoversConflict(correction, conflict)) {
             missingEvidence.add(`conflict:${payload.conflictId}:decision-link`);
-          } else if (sourceLinked && conflictPredatesProposal) {
+          } else if (sourceLinked && conflictPredatesProposal && conflictDisagreementIds.has(payload.conflictId)) {
             groundedCorrectionIds.add(payload.correctionId);
             conflict.status = "proposed";
             conflict.correctionId = payload.correctionId;
@@ -1075,6 +1088,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
             }
             correctionApprovalAppendPositions.set(payload.correctionId, appendPosition);
             if (correction.status === "proposed") correction.status = "approved";
+            status = "correcting";
           } else {
             missingEvidence.add(`correction:${payload.correctionId}:duplicate-approval`);
           }
@@ -1082,7 +1096,6 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         } else {
           missingEvidence.add(`correction:${payload.correctionId}:proposal`);
         }
-        status = "correcting";
         collectMissingEvidence(missingEvidence, event, payload.evidence);
         break;
       }
@@ -1559,6 +1572,15 @@ function compareTimedIds<T extends { occurredAt: string }, K extends keyof T>(a:
 
 function beliefAppendPositionKey(agentId: string, decisionId: string): string {
   return `${agentId}\0${decisionId}`;
+}
+
+function normalizeDecisionStatement(statement: string): string {
+  return statement
+    .normalize("NFKC")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/[.!?]+$/, "");
 }
 
 function recordEarliestAppendPosition(positions: Map<string, number>, key: string, position: number): void {

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -721,6 +721,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   const tests: RelayTestSnapshot[] = [];
   const propagation: RelayPropagationSnapshot[] = [];
   const missingEvidence = new Set<string>();
+  if (corruptLines > 0) missingEvidence.add("mission:corrupt-events");
   const substantiveAgentIds = new Set<string>();
   const substantiveSessionIds = new Set<string>();
   const groundedCorrectionIds = new Set<string>();

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -517,7 +517,7 @@ export class RelayMissionStore {
       hooks.authenticatedPrincipal === undefined
         ? undefined
         : authenticatedPrincipalSchema.parse(hooks.authenticatedPrincipal);
-    const missionDir = await this.openMissionDirectory();
+    const missionDir = await this.openMissionDirectory(true);
     const filePath = path.join(missionDir.accessPath, `${missionId}.jsonl`);
     const logicalFilePath = path.join(missionDir.logicalPath, `${missionId}.jsonl`);
     const lockPath = `${filePath}.lock`;
@@ -599,44 +599,63 @@ export class RelayMissionStore {
   async read(missionIdValue: string, readOptions: RelayMissionReadOptions = {}): Promise<RelayMissionSnapshot> {
     const missionId = RelayMissionIdSchema.parse(missionIdValue);
     const options = RelayMissionReadOptionsSchema.parse(readOptions);
-    const missionDir = await this.openMissionDirectory();
+    const missionDir = await this.openMissionDirectory(false);
+    if (missionDir === null) {
+      return reduceRelayMission({
+        missionId,
+        namespace: this.namespace,
+        events: [],
+        fileExists: false,
+        options,
+      });
+    }
     const filePath = path.join(missionDir.accessPath, `${missionId}.jsonl`);
     const logicalFilePath = path.join(missionDir.logicalPath, `${missionId}.jsonl`);
-    const lockPath = `${filePath}.lock`;
 
     try {
-      return await serializeMutations(`relay-mission:${logicalFilePath}`, () =>
-        withHeldFileLock(
-          lockPath,
-          { staleMs: 30_000, maxWaitMs: this.lockMaxWaitMs, heartbeatMs: 10_000 },
-          async (acquired) => {
-            if (!acquired) {
-              throw new RelayMissionStoreError("lock_unavailable", "could not acquire Relay mission read lock");
-            }
-            const read = await this.readFile(filePath, missionId);
-            return reduceRelayMission({
-              missionId,
-              namespace: this.namespace,
-              events: read.events,
-              corruptLines: read.corruptLines,
-              fileExists: read.exists,
-              options,
-            });
-          }
-        )
-      );
+      // Coordinate with writers in this process without creating a lock file.
+      // Cross-process appends are single bounded O_APPEND records; a torn or
+      // malformed record remains explicit partial evidence rather than being
+      // silently accepted.
+      return await serializeMutations(`relay-mission:${logicalFilePath}`, async () => {
+        const read = await this.readFile(filePath, missionId);
+        return reduceRelayMission({
+          missionId,
+          namespace: this.namespace,
+          events: read.events,
+          corruptLines: read.corruptLines,
+          fileExists: read.exists,
+          options,
+        });
+      });
     } finally {
       await missionDir.handle.close().catch(() => undefined);
     }
   }
 
-  private async openMissionDirectory(): Promise<PinnedMissionDirectory> {
+  private async openMissionDirectory(create: true): Promise<PinnedMissionDirectory>;
+  private async openMissionDirectory(create: false): Promise<PinnedMissionDirectory | null>;
+  private async openMissionDirectory(create: boolean): Promise<PinnedMissionDirectory | null> {
     let currentHandle: import("node:fs/promises").FileHandle | undefined;
     try {
       currentHandle = await openVerifiedDirectory(this.rootDir, "Relay root must be a real directory");
       let logicalPath = this.rootDir;
       for (const segment of ["state", "relay", "missions"]) {
-        const childHandle = await openOrCreatePinnedChildDirectory(currentHandle, segment);
+        let childHandle: import("node:fs/promises").FileHandle;
+        try {
+          childHandle = create
+            ? await openOrCreatePinnedChildDirectory(currentHandle, segment)
+            : await openVerifiedDirectory(
+                path.join(pinnedDirectoryPath(currentHandle), segment),
+                "Relay directory symlinks are rejected"
+              );
+        } catch (error) {
+          if (!create && (error as NodeJS.ErrnoException).code === "ENOENT") {
+            await currentHandle.close();
+            return null;
+          }
+          throw error;
+        }
         await currentHandle.close();
         currentHandle = childHandle;
         logicalPath = path.join(logicalPath, segment);

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -16,7 +16,7 @@ const missionIdSchema = z
   .string()
   .min(1)
   .max(64)
-  .regex(/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/, {
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
     message: "must contain only lowercase letters, numbers, and single hyphens",
   });
 
@@ -457,7 +457,11 @@ export class RelayMissionStore {
     this.lockMaxWaitMs = positiveIntegerOption(options.lockMaxWaitMs, "lockMaxWaitMs", 5_000);
   }
 
-  async append(missionIdValue: string, inputValue: RelayMissionEventInput): Promise<RelayMissionAppendResult> {
+  async append(
+    missionIdValue: string,
+    inputValue: RelayMissionEventInput,
+    hooks: { beforeAppend?: () => void | Promise<void> } = {}
+  ): Promise<RelayMissionAppendResult> {
     const missionId = missionIdSchema.parse(missionIdValue);
     const input = RelayMissionEventInputSchema.parse(inputValue);
     const missionDir = await this.ensureMissionDirectory();
@@ -493,6 +497,12 @@ export class RelayMissionStore {
               `mission ${missionId} reached the ${this.maxEvents}-event limit`
             );
           }
+
+          // Transport quotas run only after idempotency replay detection and
+          // while this mission's mutation lock is held. A response-lost retry
+          // remains replayable even when the original append used the final
+          // quota slot.
+          await hooks.beforeAppend?.();
 
           const recordedAt = validNow(this.now);
           const event = RelayMissionEventSchema.parse({
@@ -943,7 +953,11 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   }
 
   const eventWindow = filtered.slice(Math.max(0, filtered.length - options.limit));
-  const found = filtered.length > 0;
+  // `found` describes whether the mission has any valid persisted evidence,
+  // not whether the caller's optional time window happened to select an
+  // event. A known mission with an empty [since, until) window is distinct
+  // from a mission that has never existed.
+  const found = input.events.length > 0;
   return {
     schemaVersion: RELAY_MISSION_SCHEMA_VERSION,
     missionId,

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -116,6 +116,8 @@ const RelayMissionPayloadUnionSchema = z.discriminatedUnion("kind", [
     .object({
       kind: z.literal("test_result"),
       testId: identifierSchema,
+      decisionId: identifierSchema,
+      correctionId: identifierSchema.optional(),
       command: z.string().trim().min(1).max(1_000),
       status: z.enum(["passed", "failed", "error"]),
       summary: statementSchema,
@@ -365,6 +367,8 @@ export interface RelayCorrectionSnapshot {
 
 export interface RelayTestSnapshot {
   testId: string;
+  decisionId: string;
+  correctionId?: string;
   command: string;
   status: "passed" | "failed" | "error";
   summary: string;
@@ -855,6 +859,8 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       case "test_result":
         tests.push({
           testId: payload.testId,
+          decisionId: payload.decisionId,
+          ...(payload.correctionId === undefined ? {} : { correctionId: payload.correctionId }),
           command: payload.command,
           status: payload.status,
           summary: payload.summary,
@@ -1157,12 +1163,30 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   const coldStartVerified = propagation.some((item) => item.staleDecisionAbsent);
   const passingOutcomeVerified =
     outcome?.result === "recovered" &&
-    tests.some(
-      (test) =>
-        test.status === "passed" &&
-        compareInstants(test.occurredAt, outcome.occurredAt) < 0 &&
-        propagation.some((item) => item.staleDecisionAbsent && compareInstants(item.occurredAt, test.occurredAt) < 0)
-    );
+    tests.some((test) => {
+      if (
+        test.status !== "passed" ||
+        test.correctionId === undefined ||
+        compareInstants(test.occurredAt, outcome.occurredAt) >= 0
+      ) {
+        return false;
+      }
+      const correction = corrections.get(test.correctionId);
+      if (
+        correction?.status !== "propagated" ||
+        correction.proposedDecisionId !== test.decisionId ||
+        !test.evidence.some((item) => item.kind === "correction" && item.id === correction.correctionId)
+      ) {
+        return false;
+      }
+      return propagation.some(
+        (item) =>
+          item.staleDecisionAbsent &&
+          item.correctionId === correction.correctionId &&
+          item.decisionId === test.decisionId &&
+          compareInstants(item.occurredAt, test.occurredAt) < 0
+      );
+    });
   if (outcome && !passingOutcomeVerified) missingEvidence.add("outcome:passing-test");
   if (outcome?.result === "recovered" && !coldStartVerified) {
     missingEvidence.add("outcome:cold-start-propagation");

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -719,6 +719,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   const missingEvidence = new Set<string>();
   const substantiveAgentIds = new Set<string>();
   const substantiveSessionIds = new Set<string>();
+  const groundedCorrectionIds = new Set<string>();
   let title: string | null = null;
   let objective: string | null = null;
   let runMode: "live" | "replay" | "fixture" | null = null;
@@ -895,10 +896,23 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           });
         }
         const conflict = conflicts.get(payload.conflictId);
+        const correctionSourceIds = sourceEvidenceIds(payload.evidence);
+        if (correctionSourceIds.size === 0) {
+          missingEvidence.add(`correction:${payload.correctionId}:source`);
+        }
         if (conflict) {
+          const conflictSourceIds = sourceEvidenceIds(conflict.evidence);
+          if (conflictSourceIds.size === 0) {
+            missingEvidence.add(`conflict:${payload.conflictId}:source`);
+          }
+          const sourceLinked = [...correctionSourceIds].some((sourceId) => conflictSourceIds.has(sourceId));
+          if (!sourceLinked) {
+            missingEvidence.add(`correction:${payload.correctionId}:source-link`);
+          }
           if (!correctionCoversConflict(correction, conflict)) {
             missingEvidence.add(`conflict:${payload.conflictId}:decision-link`);
-          } else {
+          } else if (sourceLinked) {
+            groundedCorrectionIds.add(payload.correctionId);
             conflict.status = "proposed";
             conflict.correctionId = payload.correctionId;
           }
@@ -944,6 +958,11 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         const conflict = conflicts.get(correction.conflictId);
         if (!conflict || !correctionCoversConflict(correction, conflict)) {
           missingEvidence.add(`conflict:${correction.conflictId}:decision-link`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        if (!groundedCorrectionIds.has(payload.correctionId)) {
+          missingEvidence.add(`correction:${payload.correctionId}:source-link`);
           collectMissingEvidence(missingEvidence, event, payload.evidence);
           break;
         }
@@ -1100,6 +1119,9 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   }
 
   for (const conflict of conflicts.values()) {
+    if (sourceEvidenceIds(conflict.evidence).size === 0) {
+      missingEvidence.add(`conflict:${conflict.conflictId}:source`);
+    }
     for (const decisionId of conflict.decisionIds) {
       if (!decisions.has(decisionId)) missingEvidence.add(`decision:${decisionId}:conflict-target`);
     }
@@ -1108,6 +1130,9 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
     }
   }
   for (const correction of corrections.values()) {
+    if (sourceEvidenceIds(correction.evidence).size === 0) {
+      missingEvidence.add(`correction:${correction.correctionId}:source`);
+    }
     if (correction.approvedAt === undefined || correction.approvedBy === undefined) {
       missingEvidence.add(`correction:${correction.correctionId}:approval`);
     } else if (correction.approvedBy.kind !== "human") {
@@ -1342,6 +1367,10 @@ function correctionCoversConflict(
     expectedSuperseded.length === declaredSuperseded.length &&
     expectedSuperseded.every((decisionId, index) => decisionId === declaredSuperseded[index])
   );
+}
+
+function sourceEvidenceIds(evidence: readonly RelayEvidenceRef[]): Set<string> {
+  return new Set(evidence.filter((item) => item.kind === "source").map((item) => item.id));
 }
 
 function positiveIntegerOption(value: number | undefined, name: string, fallback: number): number {

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -889,6 +889,9 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         );
         const existing = decisions.get(payload.decisionId);
         if (existing) {
+          if (!decisionStatementsMatch(existing.statement, payload.statement)) {
+            missingEvidence.add(`decision:${payload.decisionId}:statement-consistency`);
+          }
           if (!existing.heldByAgentIds.includes(payload.agentId)) {
             existing.heldByAgentIds.push(payload.agentId);
           }
@@ -1019,7 +1022,14 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         };
         corrections.set(payload.correctionId, correction);
         correctionProposalAppendPositions.set(payload.correctionId, appendPosition);
-        if (!decisions.has(payload.proposedDecisionId)) {
+        const existingProposedDecision = decisions.get(payload.proposedDecisionId);
+        const replacementStatementMatches =
+          existingProposedDecision === undefined ||
+          decisionStatementsMatch(existingProposedDecision.statement, payload.statement);
+        if (!replacementStatementMatches) {
+          missingEvidence.add(`correction:${payload.correctionId}:replacement-statement`);
+        }
+        if (existingProposedDecision === undefined) {
           decisions.set(payload.proposedDecisionId, {
             decisionId: payload.proposedDecisionId,
             statement: payload.statement,
@@ -1052,7 +1062,12 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
           }
           if (!correctionCoversConflict(correction, conflict)) {
             missingEvidence.add(`conflict:${payload.conflictId}:decision-link`);
-          } else if (sourceLinked && conflictPredatesProposal && conflictDisagreementIds.has(payload.conflictId)) {
+          } else if (
+            sourceLinked &&
+            conflictPredatesProposal &&
+            conflictDisagreementIds.has(payload.conflictId) &&
+            replacementStatementMatches
+          ) {
             groundedCorrectionIds.add(payload.correctionId);
             conflict.status = "proposed";
             conflict.correctionId = payload.correctionId;
@@ -1581,6 +1596,10 @@ function normalizeDecisionStatement(statement: string): string {
     .toLowerCase()
     .replace(/\s+/g, " ")
     .replace(/[.!?]+$/, "");
+}
+
+function decisionStatementsMatch(left: string, right: string): boolean {
+  return normalizeDecisionStatement(left) === normalizeDecisionStatement(right);
 }
 
 function recordEarliestAppendPosition(positions: Map<string, number>, key: string, position: number): void {

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -39,7 +39,7 @@ const uniqueIdentifierListSchema = (minimum: number, maximum: number) =>
     .max(maximum)
     .refine((values) => new Set(values).size === values.length, "must not contain duplicate identifiers");
 
-const isoDateTimeSchema = z
+export const RelayIsoDateTimeSchema = z
   .string()
   .datetime({ offset: true })
   .refine((value) => Number.isFinite(Date.parse(value)), "must be a representable timestamp");
@@ -248,7 +248,7 @@ export type RelayMissionPayload = z.infer<typeof RelayMissionPayloadSchema>;
 
 export const RelayMissionEventInputSchema = z
   .object({
-    occurredAt: isoDateTimeSchema.optional(),
+    occurredAt: RelayIsoDateTimeSchema.optional(),
     idempotencyKey: identifierSchema.optional(),
     payload: RelayMissionPayloadSchema,
   })
@@ -263,8 +263,8 @@ export const RelayMissionEventSchema = z
     missionId: RelayMissionIdSchema,
     namespace: namespaceSchema,
     authenticatedPrincipal: authenticatedPrincipalSchema.optional(),
-    recordedAt: isoDateTimeSchema,
-    occurredAt: isoDateTimeSchema,
+    recordedAt: RelayIsoDateTimeSchema,
+    occurredAt: RelayIsoDateTimeSchema,
     idempotencyKey: identifierSchema.optional(),
     payload: RelayMissionPayloadSchema,
   })
@@ -274,8 +274,8 @@ export type RelayMissionEvent = z.infer<typeof RelayMissionEventSchema>;
 
 export const RelayMissionReadOptionsSchema = z
   .object({
-    since: isoDateTimeSchema.optional(),
-    until: isoDateTimeSchema.optional(),
+    since: RelayIsoDateTimeSchema.optional(),
+    until: RelayIsoDateTimeSchema.optional(),
     limit: z.number().int().min(1).max(RELAY_MISSION_MAX_EVENT_LIMIT).default(RELAY_MISSION_DEFAULT_EVENT_LIMIT),
   })
   .strict()

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -469,6 +469,12 @@ interface MissionFileRead {
   rawBytes: number;
 }
 
+interface PinnedMissionDirectory {
+  logicalPath: string;
+  accessPath: string;
+  handle: import("node:fs/promises").FileHandle;
+}
+
 export interface RelayMissionAppendResult {
   appended: boolean;
   replayed: boolean;
@@ -504,118 +510,136 @@ export class RelayMissionStore {
   ): Promise<RelayMissionAppendResult> {
     const missionId = RelayMissionIdSchema.parse(missionIdValue);
     const input = RelayMissionEventInputSchema.parse(inputValue);
-    const missionDir = await this.ensureMissionDirectory();
-    const filePath = path.join(missionDir, `${missionId}.jsonl`);
+    const missionDir = await this.openMissionDirectory();
+    const filePath = path.join(missionDir.accessPath, `${missionId}.jsonl`);
+    const logicalFilePath = path.join(missionDir.logicalPath, `${missionId}.jsonl`);
     const lockPath = `${filePath}.lock`;
 
-    return serializeMutations(`relay-mission:${filePath}`, () =>
-      withHeldFileLock(
-        lockPath,
-        { staleMs: 30_000, maxWaitMs: this.lockMaxWaitMs, heartbeatMs: 10_000 },
-        async (acquired) => {
-          if (!acquired) {
-            throw new RelayMissionStoreError("lock_unavailable", "could not acquire Relay mission lock");
-          }
-
-          const existing = await this.readFile(filePath, missionId);
-          if (input.idempotencyKey) {
-            const replay = existing.events.find((event) => event.idempotencyKey === input.idempotencyKey);
-            if (replay) {
-              if (!sameIdempotentInput(replay, input)) {
-                throw new RelayMissionStoreError(
-                  "idempotency_conflict",
-                  `idempotency key ${input.idempotencyKey} was already used for different input`
-                );
-              }
-              return { appended: false, replayed: true, event: replay };
+    try {
+      return await serializeMutations(`relay-mission:${logicalFilePath}`, () =>
+        withHeldFileLock(
+          lockPath,
+          { staleMs: 30_000, maxWaitMs: this.lockMaxWaitMs, heartbeatMs: 10_000 },
+          async (acquired) => {
+            if (!acquired) {
+              throw new RelayMissionStoreError("lock_unavailable", "could not acquire Relay mission lock");
             }
-          }
 
-          if (existing.events.length >= this.maxEvents) {
-            throw new RelayMissionStoreError(
-              "limit_exceeded",
-              `mission ${missionId} reached the ${this.maxEvents}-event limit`
-            );
-          }
+            const existing = await this.readFile(filePath, missionId);
+            if (input.idempotencyKey) {
+              const replay = existing.events.find((event) => event.idempotencyKey === input.idempotencyKey);
+              if (replay) {
+                if (!sameIdempotentInput(replay, input)) {
+                  throw new RelayMissionStoreError(
+                    "idempotency_conflict",
+                    `idempotency key ${input.idempotencyKey} was already used for different input`
+                  );
+                }
+                return { appended: false, replayed: true, event: replay };
+              }
+            }
 
-          // Transport quotas run only after idempotency replay detection and
-          // while this mission's mutation lock is held. A response-lost retry
-          // remains replayable even when the original append used the final
-          // quota slot.
-          await hooks.beforeAppend?.();
+            if (existing.events.length >= this.maxEvents) {
+              throw new RelayMissionStoreError(
+                "limit_exceeded",
+                `mission ${missionId} reached the ${this.maxEvents}-event limit`
+              );
+            }
 
-          const recordedAt = validNow(this.now);
-          const event = RelayMissionEventSchema.parse({
-            schemaVersion: RELAY_MISSION_SCHEMA_VERSION,
-            eventId: this.createEventId(),
-            missionId,
-            namespace: this.namespace,
-            recordedAt,
-            occurredAt: input.occurredAt ?? recordedAt,
-            ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
-            payload: input.payload,
-          });
-          const line = `${JSON.stringify(event)}\n`;
-          const lineBytes = Buffer.byteLength(line, "utf8");
-          if (lineBytes > RELAY_MISSION_MAX_LINE_BYTES) {
-            throw new RelayMissionStoreError(
-              "limit_exceeded",
-              `Relay mission event exceeds ${RELAY_MISSION_MAX_LINE_BYTES} bytes`
-            );
-          }
-          if (existing.rawBytes + lineBytes > this.maxFileBytes) {
-            throw new RelayMissionStoreError(
-              "limit_exceeded",
-              `mission ${missionId} would exceed the ${this.maxFileBytes}-byte limit`
-            );
-          }
+            // Transport quotas run only after idempotency replay detection and
+            // while this mission's mutation lock is held. A response-lost retry
+            // remains replayable even when the original append used the final
+            // quota slot.
+            await hooks.beforeAppend?.();
 
-          await this.appendFile(filePath, line);
-          return { appended: true, replayed: false, event };
-        }
-      )
-    );
+            const recordedAt = validNow(this.now);
+            const event = RelayMissionEventSchema.parse({
+              schemaVersion: RELAY_MISSION_SCHEMA_VERSION,
+              eventId: this.createEventId(),
+              missionId,
+              namespace: this.namespace,
+              recordedAt,
+              occurredAt: input.occurredAt ?? recordedAt,
+              ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
+              payload: input.payload,
+            });
+            const line = `${JSON.stringify(event)}\n`;
+            const lineBytes = Buffer.byteLength(line, "utf8");
+            if (lineBytes > RELAY_MISSION_MAX_LINE_BYTES) {
+              throw new RelayMissionStoreError(
+                "limit_exceeded",
+                `Relay mission event exceeds ${RELAY_MISSION_MAX_LINE_BYTES} bytes`
+              );
+            }
+            if (existing.rawBytes + lineBytes > this.maxFileBytes) {
+              throw new RelayMissionStoreError(
+                "limit_exceeded",
+                `mission ${missionId} would exceed the ${this.maxFileBytes}-byte limit`
+              );
+            }
+
+            await this.appendFile(filePath, line);
+            return { appended: true, replayed: false, event };
+          }
+        )
+      );
+    } finally {
+      await missionDir.handle.close().catch(() => undefined);
+    }
   }
 
   async read(missionIdValue: string, readOptions: RelayMissionReadOptions = {}): Promise<RelayMissionSnapshot> {
     const missionId = RelayMissionIdSchema.parse(missionIdValue);
     const options = RelayMissionReadOptionsSchema.parse(readOptions);
-    const missionDir = await this.ensureMissionDirectory();
-    const filePath = path.join(missionDir, `${missionId}.jsonl`);
+    const missionDir = await this.openMissionDirectory();
+    const filePath = path.join(missionDir.accessPath, `${missionId}.jsonl`);
+    const logicalFilePath = path.join(missionDir.logicalPath, `${missionId}.jsonl`);
     const lockPath = `${filePath}.lock`;
 
-    return serializeMutations(`relay-mission:${filePath}`, () =>
-      withHeldFileLock(
-        lockPath,
-        { staleMs: 30_000, maxWaitMs: this.lockMaxWaitMs, heartbeatMs: 10_000 },
-        async (acquired) => {
-          if (!acquired) {
-            throw new RelayMissionStoreError("lock_unavailable", "could not acquire Relay mission read lock");
+    try {
+      return await serializeMutations(`relay-mission:${logicalFilePath}`, () =>
+        withHeldFileLock(
+          lockPath,
+          { staleMs: 30_000, maxWaitMs: this.lockMaxWaitMs, heartbeatMs: 10_000 },
+          async (acquired) => {
+            if (!acquired) {
+              throw new RelayMissionStoreError("lock_unavailable", "could not acquire Relay mission read lock");
+            }
+            const read = await this.readFile(filePath, missionId);
+            return reduceRelayMission({
+              missionId,
+              namespace: this.namespace,
+              events: read.events,
+              corruptLines: read.corruptLines,
+              fileExists: read.exists,
+              options,
+            });
           }
-          const read = await this.readFile(filePath, missionId);
-          return reduceRelayMission({
-            missionId,
-            namespace: this.namespace,
-            events: read.events,
-            corruptLines: read.corruptLines,
-            fileExists: read.exists,
-            options,
-          });
-        }
-      )
-    );
+        )
+      );
+    } finally {
+      await missionDir.handle.close().catch(() => undefined);
+    }
   }
 
-  private async ensureMissionDirectory(): Promise<string> {
+  private async openMissionDirectory(): Promise<PinnedMissionDirectory> {
+    let currentHandle: import("node:fs/promises").FileHandle | undefined;
     try {
-      await assertExistingSafeDirectory(this.rootDir);
-      let current = this.rootDir;
+      currentHandle = await openVerifiedDirectory(this.rootDir, "Relay root must be a real directory");
+      let logicalPath = this.rootDir;
       for (const segment of ["state", "relay", "missions"]) {
-        current = path.join(current, segment);
-        await ensureSafeChildDirectory(current);
+        const childHandle = await openOrCreatePinnedChildDirectory(currentHandle, segment);
+        await currentHandle.close();
+        currentHandle = childHandle;
+        logicalPath = path.join(logicalPath, segment);
       }
-      return current;
+      return {
+        logicalPath,
+        accessPath: pinnedDirectoryPath(currentHandle),
+        handle: currentHandle,
+      };
     } catch (error) {
+      await currentHandle?.close().catch(() => undefined);
       if (error instanceof RelayMissionStoreError) throw error;
       throw new RelayMissionStoreError("unsafe_path", "Relay mission directory is unavailable or unsafe", {
         cause: error,
@@ -626,7 +650,6 @@ export class RelayMissionStore {
   private async readFile(filePath: string, missionId: string): Promise<MissionFileRead> {
     let handle: import("node:fs/promises").FileHandle | undefined;
     try {
-      await assertParentDirectoryStable(filePath);
       handle = await fs.open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
       const info = await handle.stat();
       if (!info.isFile()) {
@@ -657,7 +680,6 @@ export class RelayMissionStore {
   private async appendFile(filePath: string, line: string): Promise<void> {
     let handle: import("node:fs/promises").FileHandle | undefined;
     try {
-      await assertParentDirectoryStable(filePath);
       handle = await fs.open(
         filePath,
         fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_APPEND | fsConstants.O_NOFOLLOW,
@@ -1176,7 +1198,8 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       if (
         correction?.status !== "propagated" ||
         correction.proposedDecisionId !== test.decisionId ||
-        !test.evidence.some((item) => item.kind === "correction" && item.id === correction.correctionId)
+        !test.evidence.some((item) => item.kind === "correction" && item.id === correction.correctionId) ||
+        !test.evidence.some((item) => item.kind === "test")
       ) {
         return false;
       }
@@ -1414,52 +1437,57 @@ function validNow(now: () => Date): string {
   return value.toISOString();
 }
 
-async function assertExistingSafeDirectory(directory: string): Promise<void> {
-  const info = await fs.lstat(directory);
-  if (info.isSymbolicLink() || !info.isDirectory()) {
-    throw new RelayMissionStoreError("unsafe_path", "Relay root must be a real directory");
-  }
-}
-
-async function ensureSafeChildDirectory(directory: string): Promise<void> {
+async function openOrCreatePinnedChildDirectory(
+  parentHandle: import("node:fs/promises").FileHandle,
+  segment: string
+): Promise<import("node:fs/promises").FileHandle> {
+  const directory = path.join(pinnedDirectoryPath(parentHandle), segment);
   try {
     await fs.mkdir(directory, { mode: 0o700 });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
   }
-  const info = await fs.lstat(directory);
-  if (info.isSymbolicLink() || !info.isDirectory()) {
-    throw new RelayMissionStoreError("unsafe_path", "Relay directory symlinks are rejected");
+  return openVerifiedDirectory(directory, "Relay directory symlinks are rejected");
+}
+
+async function openVerifiedDirectory(
+  directory: string,
+  unsafeMessage: string
+): Promise<import("node:fs/promises").FileHandle> {
+  const before = await fs.lstat(directory);
+  if (before.isSymbolicLink() || !before.isDirectory()) {
+    throw new RelayMissionStoreError("unsafe_path", unsafeMessage);
   }
   const handle = await fs.open(directory, fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW);
   try {
     const openInfo = await handle.stat();
-    const pathInfo = await fs.lstat(directory);
-    if (openInfo.dev !== pathInfo.dev || openInfo.ino !== pathInfo.ino) {
+    const after = await fs.lstat(directory);
+    if (
+      after.isSymbolicLink() ||
+      !after.isDirectory() ||
+      before.dev !== openInfo.dev ||
+      before.ino !== openInfo.ino ||
+      after.dev !== openInfo.dev ||
+      after.ino !== openInfo.ino
+    ) {
       throw new RelayMissionStoreError("unsafe_path", "Relay directory changed during validation");
     }
-  } finally {
-    await handle.close();
+    return handle;
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    throw error;
   }
 }
 
-async function assertParentDirectoryStable(filePath: string): Promise<void> {
-  const parent = path.dirname(filePath);
-  const handle = await fs.open(parent, fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW);
-  try {
-    const openInfo = await handle.stat();
-    const pathInfo = await fs.lstat(parent);
-    if (
-      pathInfo.isSymbolicLink() ||
-      !pathInfo.isDirectory() ||
-      openInfo.dev !== pathInfo.dev ||
-      openInfo.ino !== pathInfo.ino
-    ) {
-      throw new RelayMissionStoreError("unsafe_path", "Relay mission parent is unsafe");
-    }
-  } finally {
-    await handle.close();
+function pinnedDirectoryPath(handle: import("node:fs/promises").FileHandle): string {
+  if (process.platform === "linux") return `/proc/self/fd/${handle.fd}`;
+  if (process.platform === "darwin" || process.platform === "freebsd" || process.platform === "openbsd") {
+    return `/dev/fd/${handle.fd}`;
   }
+  throw new RelayMissionStoreError(
+    "unsafe_path",
+    `Relay pinned directory access is unsupported on ${process.platform}`
+  );
 }
 
 export function relayMissionReceiptDigest(snapshot: RelayMissionSnapshot): string {

--- a/packages/remnic-core/src/relay/mission.ts
+++ b/packages/remnic-core/src/relay/mission.ts
@@ -12,7 +12,7 @@ export const RELAY_MISSION_MAX_EVENTS = 2_000;
 export const RELAY_MISSION_DEFAULT_EVENT_LIMIT = 200;
 export const RELAY_MISSION_MAX_EVENT_LIMIT = 500;
 
-const missionIdSchema = z
+export const RelayMissionIdSchema = z
   .string()
   .min(1)
   .max(64)
@@ -194,15 +194,42 @@ export const RelayMissionPayloadSchema = RelayMissionPayloadUnionSchema.superRef
       path: ["replacementDecisionId"],
     });
   }
-  if (value.kind !== "recall_observed") return;
-  for (const [index, evidence] of value.evidence.entries()) {
-    if (evidence.kind !== "recall_audit") continue;
+  if (value.kind === "correction_approved" && !value.evidence.some((item) => item.kind === "approval")) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "correction approval requires approval evidence",
+      path: ["evidence"],
+    });
+  }
+  if (
+    value.kind === "decision_superseded" &&
+    !value.evidence.some((item) => item.kind === "correction" && item.id === value.correctionId)
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "decision supersession requires matching correction evidence",
+      path: ["evidence"],
+    });
+  }
+  if (value.kind !== "recall_observed" && value.kind !== "propagation_verified") return;
+  const matchingRecallEvidence = value.evidence.find(
+    (item) => item.kind === "recall_audit" && item.id === value.recallReceiptId
+  );
+  if (!matchingRecallEvidence) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "recall proof requires a matching recall-audit reference",
+      path: ["evidence"],
+    });
+    return;
+  }
+  if (value.kind === "recall_observed") {
     const expectedCapture = value.capturedAtAction ? "at_action" : "historical_lookup";
-    if (evidence.capture !== expectedCapture && evidence.capture !== "fixture") {
+    if (matchingRecallEvidence.capture !== expectedCapture && matchingRecallEvidence.capture !== "fixture") {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: `recall evidence must be labeled ${expectedCapture}`,
-        path: ["evidence", index, "capture"],
+        path: ["evidence", value.evidence.indexOf(matchingRecallEvidence), "capture"],
       });
     }
   }
@@ -224,7 +251,7 @@ export const RelayMissionEventSchema = z
   .object({
     schemaVersion: z.literal(RELAY_MISSION_SCHEMA_VERSION),
     eventId: identifierSchema,
-    missionId: missionIdSchema,
+    missionId: RelayMissionIdSchema,
     namespace: namespaceSchema,
     recordedAt: isoDateTimeSchema,
     occurredAt: isoDateTimeSchema,
@@ -272,6 +299,7 @@ export interface RelayRecallSnapshot {
   decisionId: string;
   query: string;
   capturedAtAction: boolean;
+  coldStart: boolean;
   occurredAt: string;
   evidence: RelayEvidenceRef[];
 }
@@ -324,6 +352,7 @@ export interface RelayCorrectionSnapshot {
   approvedAt?: string;
   approvedBy?: { kind: "human" | "agent"; id: string; label: string };
   approvalNote?: string;
+  appliedAt?: string;
   propagatedAt?: string;
   evidence: RelayEvidenceRef[];
 }
@@ -463,7 +492,7 @@ export class RelayMissionStore {
     inputValue: RelayMissionEventInput,
     hooks: { beforeAppend?: () => void | Promise<void> } = {}
   ): Promise<RelayMissionAppendResult> {
-    const missionId = missionIdSchema.parse(missionIdValue);
+    const missionId = RelayMissionIdSchema.parse(missionIdValue);
     const input = RelayMissionEventInputSchema.parse(inputValue);
     const missionDir = await this.ensureMissionDirectory();
     const filePath = path.join(missionDir, `${missionId}.jsonl`);
@@ -539,7 +568,7 @@ export class RelayMissionStore {
   }
 
   async read(missionIdValue: string, readOptions: RelayMissionReadOptions = {}): Promise<RelayMissionSnapshot> {
-    const missionId = missionIdSchema.parse(missionIdValue);
+    const missionId = RelayMissionIdSchema.parse(missionIdValue);
     const options = RelayMissionReadOptionsSchema.parse(readOptions);
     const missionDir = await this.ensureMissionDirectory();
     const filePath = path.join(missionDir, `${missionId}.jsonl`);
@@ -657,7 +686,7 @@ interface ReduceRelayMissionInput {
 }
 
 export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMissionSnapshot {
-  const missionId = missionIdSchema.parse(input.missionId);
+  const missionId = RelayMissionIdSchema.parse(input.missionId);
   const namespace = namespaceSchema.parse(input.namespace);
   const options = RelayMissionReadOptionsSchema.parse(input.options ?? {});
   const corruptLines = input.corruptLines ?? 0;
@@ -676,6 +705,8 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   const tests: RelayTestSnapshot[] = [];
   const propagation: RelayPropagationSnapshot[] = [];
   const missingEvidence = new Set<string>();
+  const substantiveAgentIds = new Set<string>();
+  const substantiveSessionIds = new Set<string>();
   let title: string | null = null;
   let objective: string | null = null;
   let runMode: "live" | "replay" | "fixture" | null = null;
@@ -705,19 +736,33 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
     return created;
   };
 
+  const markSubstantiveParticipation = (agentId: string, sessionId?: string): void => {
+    substantiveAgentIds.add(agentId);
+    if (sessionId) substantiveSessionIds.add(sessionId);
+  };
+
   for (const event of orderedEvents) {
     const payload = event.payload;
+    if (outcome !== null && payload.kind !== "mission_completed") {
+      missingEvidence.add(`mission:event-after-completion:${event.eventId}`);
+    }
     switch (payload.kind) {
       case "mission_started":
+        if (startedAt !== null) {
+          missingEvidence.add("mission:duplicate-start");
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
         title = payload.title;
         objective = payload.objective;
         runMode = payload.runMode;
         startedAt = event.occurredAt;
-        status = "active";
+        if (outcome === null) status = "active";
         collectMissingEvidence(missingEvidence, event, payload.evidence);
         break;
       case "agent_status": {
         const agent = ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
+        markSubstantiveParticipation(payload.agentId, payload.sessionId);
         agent.label = payload.label;
         agent.role = payload.role;
         agent.status = payload.status;
@@ -726,6 +771,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       }
       case "agent_output": {
         const agent = ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
+        markSubstantiveParticipation(payload.agentId, payload.sessionId);
         agent.outputs.push({
           outputId: payload.outputId,
           summary: payload.summary,
@@ -737,6 +783,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       }
       case "belief_observed": {
         ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
+        markSubstantiveParticipation(payload.agentId, payload.sessionId);
         const existing = decisions.get(payload.decisionId);
         if (existing) {
           if (!existing.heldByAgentIds.includes(payload.agentId)) {
@@ -758,18 +805,24 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         collectMissingEvidence(missingEvidence, event, payload.evidence);
         break;
       }
-      case "conflict_detected":
-        conflicts.set(payload.conflictId, {
-          conflictId: payload.conflictId,
-          decisionIds: uniqueSorted(payload.decisionIds),
-          agentIds: uniqueSorted(payload.agentIds),
-          summary: payload.summary,
-          status: "open",
-          occurredAt: event.occurredAt,
-          evidence: payload.evidence,
-        });
+      case "conflict_detected": {
+        if (conflicts.has(payload.conflictId)) {
+          missingEvidence.add(`conflict:${payload.conflictId}:duplicate`);
+        } else {
+          conflicts.set(payload.conflictId, {
+            conflictId: payload.conflictId,
+            decisionIds: uniqueSorted(payload.decisionIds),
+            agentIds: uniqueSorted(payload.agentIds),
+            summary: payload.summary,
+            status: "open",
+            occurredAt: event.occurredAt,
+            evidence: payload.evidence,
+          });
+        }
+        for (const agentId of payload.agentIds) substantiveAgentIds.add(agentId);
         collectMissingEvidence(missingEvidence, event, payload.evidence);
         break;
+      }
       case "test_result":
         tests.push({
           testId: payload.testId,
@@ -783,6 +836,12 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         collectMissingEvidence(missingEvidence, event, payload.evidence);
         break;
       case "correction_proposed": {
+        if (corrections.has(payload.correctionId)) {
+          missingEvidence.add(`correction:${payload.correctionId}:duplicate-proposal`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        substantiveAgentIds.add(payload.proposedBy);
         corrections.set(payload.correctionId, {
           correctionId: payload.correctionId,
           conflictId: payload.conflictId,
@@ -808,14 +867,21 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         }
         const conflict = conflicts.get(payload.conflictId);
         if (conflict) {
+          const requiredDecisionIds = [payload.proposedDecisionId, ...payload.supersedesDecisionIds];
+          if (!requiredDecisionIds.every((decisionId) => conflict.decisionIds.includes(decisionId))) {
+            missingEvidence.add(`conflict:${payload.conflictId}:decision-link`);
+          }
           conflict.status = "proposed";
           conflict.correctionId = payload.correctionId;
+        } else {
+          missingEvidence.add(`conflict:${payload.conflictId}:observation`);
         }
         status = "awaiting_approval";
         collectMissingEvidence(missingEvidence, event, payload.evidence);
         break;
       }
       case "correction_approved": {
+        if (payload.approvedBy.kind === "agent") substantiveAgentIds.add(payload.approvedBy.id);
         const correction = corrections.get(payload.correctionId);
         if (correction) {
           if (correction.approvedAt === undefined) {
@@ -823,6 +889,8 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
             correction.approvedBy = payload.approvedBy;
             correction.approvalNote = payload.note;
             if (correction.status === "proposed") correction.status = "approved";
+          } else {
+            missingEvidence.add(`correction:${payload.correctionId}:duplicate-approval`);
           }
           correction.evidence.push(...payload.evidence);
         } else {
@@ -871,6 +939,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         replacement.evidence.push(...payload.evidence);
         correction.evidence.push(...payload.evidence);
         if (correctionSupersessionComplete(correction, decisions)) {
+          correction.appliedAt ??= event.occurredAt;
           if (correction.status !== "propagated") correction.status = "applied";
           const conflict = conflicts.get(correction.conflictId);
           if (conflict) conflict.status = "resolved";
@@ -880,15 +949,21 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
       }
       case "recall_observed": {
         const agent = ensureAgent(payload.agentId, payload.sessionId, event.occurredAt);
+        const coldStart =
+          !substantiveAgentIds.has(payload.agentId) &&
+          !substantiveSessionIds.has(payload.sessionId) &&
+          agent.recalls.length === 0;
         agent.recalls.push({
           recallReceiptId: payload.recallReceiptId,
           sessionId: payload.sessionId,
           decisionId: payload.decisionId,
           query: payload.query,
           capturedAtAction: payload.capturedAtAction,
+          coldStart,
           occurredAt: event.occurredAt,
           evidence: payload.evidence,
         });
+        markSubstantiveParticipation(payload.agentId, payload.sessionId);
         const decision = decisions.get(payload.decisionId);
         if (decision && !decision.heldByAgentIds.includes(payload.agentId)) {
           decision.heldByAgentIds.push(payload.agentId);
@@ -912,6 +987,7 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         }
         if (
           (correction.status !== "applied" && correction.status !== "propagated") ||
+          correction.appliedAt === undefined ||
           correction.proposedDecisionId !== payload.decisionId
         ) {
           missingEvidence.add(`correction:${payload.correctionId}:supersession`);
@@ -931,6 +1007,21 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         }
         if (!recalled.capturedAtAction) {
           missingEvidence.add(`recall:${payload.recallReceiptId}:at-action`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        if (!recalled.coldStart) {
+          missingEvidence.add(`recall:${payload.recallReceiptId}:cold-start`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        if (compareInstants(correction.appliedAt, recalled.occurredAt) >= 0) {
+          missingEvidence.add(`recall:${payload.recallReceiptId}:post-application`);
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        if (compareInstants(recalled.occurredAt, event.occurredAt) >= 0) {
+          missingEvidence.add(`recall:${payload.recallReceiptId}:propagation-order`);
           collectMissingEvidence(missingEvidence, event, payload.evidence);
           break;
         }
@@ -955,6 +1046,12 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
         break;
       }
       case "mission_completed":
+        if (outcome !== null) {
+          missingEvidence.add("mission:duplicate-completion");
+          collectMissingEvidence(missingEvidence, event, payload.evidence);
+          break;
+        }
+        if (startedAt === null) missingEvidence.add("mission:start");
         outcome = {
           result: payload.outcome,
           summary: payload.summary,
@@ -971,6 +1068,9 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   for (const conflict of conflicts.values()) {
     for (const decisionId of conflict.decisionIds) {
       if (!decisions.has(decisionId)) missingEvidence.add(`decision:${decisionId}:conflict-target`);
+    }
+    for (const agentId of conflict.agentIds) {
+      if (!agents.has(agentId)) missingEvidence.add(`agent:${agentId}:conflict-participant`);
     }
   }
   for (const correction of corrections.values()) {
@@ -1007,6 +1107,10 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
   if (outcome && !passingOutcomeVerified) missingEvidence.add("outcome:passing-test");
   if (outcome?.result === "recovered" && !coldStartVerified) {
     missingEvidence.add("outcome:cold-start-propagation");
+  }
+  if (input.events.length > 0 && startedAt === null) missingEvidence.add("mission:start");
+  if (startedAt !== null && completedAt !== null && compareInstants(startedAt, completedAt) >= 0) {
+    missingEvidence.add("mission:lifecycle-order");
   }
 
   const eventWindow = filteredEvents.slice(Math.max(0, filteredEvents.length - options.limit));
@@ -1046,7 +1150,11 @@ export function reduceRelayMission(input: ReduceRelayMissionInput): RelayMission
     outcome,
     receipt: {
       complete:
-        outcome?.result === "recovered" && passingOutcomeVerified && coldStartVerified && missingEvidence.size === 0,
+        status === "completed" &&
+        outcome?.result === "recovered" &&
+        passingOutcomeVerified &&
+        coldStartVerified &&
+        missingEvidence.size === 0,
       missingEvidence: [...missingEvidence].sort(compareText),
       activeDecisionIds: sortedDecisions
         .filter((decision) => decision.status === "active")


### PR DESCRIPTION
## What changed

- add a strict, versioned Relay mission event contract and deterministic snapshot/receipt reducer
- persist append-only mission evidence with stable ordering, idempotency, cross-process serialization, symlink defenses, and hard read/write bounds
- expose namespace-authorized append/read operations through the shared access boundary and HTTP catalog
- include a deterministic checkout-token recovery fixture that proves conflict, human approval, supersession, cold-agent recall, propagation, and recovered tests
- document the Build Week product thesis, implementation phases, and evidence discipline

## Why this matters

Relay's core promise is **Correct once. Every Codex agent learns.** This PR creates the falsifiable evidence layer behind that promise: a receipt is complete only when a source-grounded correction is approved, the stale decision is superseded, a cold agent recalls the replacement, propagation is verified, and the mission test recovers.

This is host-agnostic core infrastructure. It does not read production Remnic data, invoke Codex, or depend on OpenClaw/Hermes.

## Verification

- `pnpm --filter @remnic/core exec tsx --test src/relay/mission.test.ts src/relay/mission-access.test.ts src/access-surface-catalog.test.ts` — 25 passed
- `pnpm --filter @remnic/core check-types` — passed
- `npm run preflight:quick` — passed on rebased v9.7.9 head
- `git diff --check origin/main...HEAD` — passed

Closes #1966

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New HTTP write paths and persistence touch namespace auth and global write rate limits; the reducer enforces strict evidence rules, so contract mistakes would surface as incomplete receipts rather than silent success.
> 
> **Overview**
> Introduces **Remnic Relay** Phase 1 (#1966): a host-agnostic mission evidence layer in `@remnic/core` so clients append events and read a pre-reduced **receipt snapshot** without scanning general memory.
> 
> **Core contract and persistence:** Strict Zod schemas for `RelayMissionEvent` / `RelayMissionSnapshot`, an append-only JSONL `RelayMissionStore` (idempotency, file locks, bounds, symlink/hard-link defenses), and `reduceRelayMission` that marks a receipt **complete** only when conflict → human-approved correction → supersession → cold recall → propagation → passing test are provably ordered and evidenced. A deterministic checkout-token fixture and receipt digest support demos and tests.
> 
> **Access surface:** New `relay_mission_append` / `relay_mission_read` operations, HTTP routes under `/engram/v1/relay/missions/…`, catalog entries, exports from `index.ts`, and mapped `RelayMissionStoreError` HTTP statuses. Relay appends use **reservable** global write-rate-limit slots so idempotent replays and failed writes do not consume quota incorrectly.
> 
> **Docs:** `docs/remnic-relay/` captures product thesis, phased plan, and progress for Build Week.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cd5c30f92dd70fa518731d1865f7b422a14a18b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->