### PR TITLE
perf(core): bound the namespace catalog touch path (#1903)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3262,6 +3262,29 @@
           ]
         }
       },
+      "namespacesCatalogCompactBytes": {
+        "type": "number",
+        "default": 16777216,
+        "minimum": 0,
+        "description": "Size (bytes) at which a namespace-catalog touch auto-compacts <memoryDir>/state/namespaces.jsonl (issue #1903). The append-only log is folded (last-record-wins; every namespace row preserved) and atomically rewritten once it exceeds this size. Default 16777216 (16 MB); 0 disables auto-compaction."
+      },
+      "namespacesCatalogReadTouchCoalesceMs": {
+        "type": "number",
+        "default": 60000,
+        "minimum": 0,
+        "description": "Coalescing window (ms) for repeated pure-timestamp read touches on an already-known namespace (issue #1903). Buffered per (namespace, kind) and flushed once per window; observable touches (first sight, provenance/field change) always flush immediately. Default 60000; 0 disables read coalescing."
+      },
+      "namespacesCatalogTouchStateWrites": {
+        "type": "boolean",
+        "default": false,
+        "description": "Whether pure state-file writes (state/buffer.json, ledgers, indexes) touch the namespace catalog (issue #1903). State files are not namespace memory data, so by default their writes do not record a catalog touch. Set true to restore the pre-#1903 behavior. Default false."
+      },
+      "namespacesCatalogWriteTouchCoalesceMs": {
+        "type": "number",
+        "default": 1000,
+        "minimum": 0,
+        "description": "Coalescing window (ms) for repeated pure-timestamp write touches on an already-known namespace (issue #1903). Mirrors namespacesCatalogReadTouchCoalesceMs for markWrite/lastWriteAt. Default 1000; 0 disables write coalescing."
+      },
       "namespacesEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3262,6 +3262,29 @@
           ]
         }
       },
+      "namespacesCatalogCompactBytes": {
+        "type": "number",
+        "default": 16777216,
+        "minimum": 0,
+        "description": "Size (bytes) at which a namespace-catalog touch auto-compacts <memoryDir>/state/namespaces.jsonl (issue #1903). The append-only log is folded (last-record-wins; every namespace row preserved) and atomically rewritten once it exceeds this size. Default 16777216 (16 MB); 0 disables auto-compaction."
+      },
+      "namespacesCatalogReadTouchCoalesceMs": {
+        "type": "number",
+        "default": 60000,
+        "minimum": 0,
+        "description": "Coalescing window (ms) for repeated pure-timestamp read touches on an already-known namespace (issue #1903). Buffered per (namespace, kind) and flushed once per window; observable touches (first sight, provenance/field change) always flush immediately. Default 60000; 0 disables read coalescing."
+      },
+      "namespacesCatalogTouchStateWrites": {
+        "type": "boolean",
+        "default": false,
+        "description": "Whether pure state-file writes (state/buffer.json, ledgers, indexes) touch the namespace catalog (issue #1903). State files are not namespace memory data, so by default their writes do not record a catalog touch. Set true to restore the pre-#1903 behavior. Default false."
+      },
+      "namespacesCatalogWriteTouchCoalesceMs": {
+        "type": "number",
+        "default": 1000,
+        "minimum": 0,
+        "description": "Coalescing window (ms) for repeated pure-timestamp write touches on an already-known namespace (issue #1903). Mirrors namespacesCatalogReadTouchCoalesceMs for markWrite/lastWriteAt. Default 1000; 0 disables write coalescing."
+      },
       "namespacesEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -2161,3 +2161,47 @@ test("parseConfig rejects non-positive extraction retry/breaker numerics and fal
   assert.equal(c.extractionBreakerAuthCooldownMs, 1_800_000, "non-positive auth cooldown -> default");
   assert.deepEqual(c.extractionRetryScheduleMs, [60_000, 300_000, 1_800_000, 7_200_000], "schedule with non-positive entry -> default");
 });
+
+test("parseConfig namespace-catalog touch-path knobs: defaults, 0-accepting numerics, and validation (#1903)", () => {
+  // Documented defaults when absent.
+  const d = parseConfig({});
+  assert.equal(d.namespacesCatalogCompactBytes, 16 * 1024 * 1024, "compactBytes default 16 MB");
+  assert.equal(d.namespacesCatalogReadTouchCoalesceMs, 60_000, "read coalesce default 60000ms");
+  assert.equal(d.namespacesCatalogWriteTouchCoalesceMs, 1_000, "write coalesce default 1000ms");
+  assert.equal(d.namespacesCatalogTouchStateWrites, false, "state-write touch default false");
+
+  // 0 is an accepted disable switch for every numeric (resolveNonNegativeIntegerConfig).
+  assert.equal(parseConfig({ namespacesCatalogCompactBytes: 0 }).namespacesCatalogCompactBytes, 0);
+  assert.equal(parseConfig({ namespacesCatalogReadTouchCoalesceMs: 0 }).namespacesCatalogReadTouchCoalesceMs, 0);
+  assert.equal(parseConfig({ namespacesCatalogWriteTouchCoalesceMs: 0 }).namespacesCatalogWriteTouchCoalesceMs, 0);
+
+  // Positive integers pass through; CLI/env numeric strings coerce.
+  assert.equal(parseConfig({ namespacesCatalogCompactBytes: 4096 }).namespacesCatalogCompactBytes, 4096);
+  assert.equal(parseConfig({ namespacesCatalogReadTouchCoalesceMs: "30000" }).namespacesCatalogReadTouchCoalesceMs, 30_000);
+
+  // Boolean-like coercion for the state-write toggle (gotcha #36).
+  assert.equal(parseConfig({ namespacesCatalogTouchStateWrites: true }).namespacesCatalogTouchStateWrites, true);
+  assert.equal(parseConfig({ namespacesCatalogTouchStateWrites: "true" }).namespacesCatalogTouchStateWrites, true);
+  assert.equal(parseConfig({ namespacesCatalogTouchStateWrites: "off" }).namespacesCatalogTouchStateWrites, false);
+
+  // Negative and non-integer numerics are rejected with the documented message.
+  for (const key of [
+    "namespacesCatalogCompactBytes",
+    "namespacesCatalogReadTouchCoalesceMs",
+    "namespacesCatalogWriteTouchCoalesceMs",
+  ]) {
+    for (const bad of [-1, 1.5, "1.5", "abc", Number.NaN, Infinity]) {
+      assert.throws(
+        () => parseConfig({ [key]: bad }),
+        new RegExp(`${key} must be a non-negative integer`),
+        `${key}=${JSON.stringify(bad)} should throw`,
+      );
+    }
+  }
+
+  // A present-but-malformed boolean toggle fails fast (gotcha #51).
+  assert.throws(
+    () => parseConfig({ namespacesCatalogTouchStateWrites: "maybe" }),
+    /namespacesCatalogTouchStateWrites must be a boolean-like value/,
+  );
+});

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -435,6 +435,26 @@ function resolvePositiveIntegerConfig(
   return coerced;
 }
 
+function resolveNonNegativeIntegerConfig(
+  value: unknown,
+  defaultValue: number,
+  keyName: string,
+): number {
+  if (value === undefined || value === null) return defaultValue;
+  const coerced = coerceNumber(value);
+  if (
+    coerced === undefined ||
+    !Number.isFinite(coerced) ||
+    !Number.isInteger(coerced) ||
+    coerced < 0
+  ) {
+    throw new Error(
+      `${keyName} must be a non-negative integer; got ${JSON.stringify(value)}`,
+    );
+  }
+  return coerced;
+}
+
 export function isOpenaiApiKeyDisabled(value: unknown): boolean {
   return value === false || (typeof value === "string" && value.trim().toLowerCase() === "false");
 }
@@ -2934,6 +2954,29 @@ export function parseConfig(
     // silently defaulting to enabled (CLAUDE.md rule #51); default to enabled
     // only when the value is absent.
     namespaceCatalogEnabled: resolveNamespaceCatalogEnabled(cfg.namespaceCatalogEnabled, rawOperatorConfig, runtimeSet),
+    // Namespace catalog touch-path performance knobs (issue #1903). Numerics use
+    // resolveNonNegativeIntegerConfig so 0 is an accepted disable switch; a
+    // present-but-invalid value (negative/non-integer) is REJECTED (rule #51).
+    namespacesCatalogCompactBytes: resolveNonNegativeIntegerConfig(
+      cfg.namespacesCatalogCompactBytes,
+      16 * 1024 * 1024,
+      "namespacesCatalogCompactBytes",
+    ),
+    namespacesCatalogReadTouchCoalesceMs: resolveNonNegativeIntegerConfig(
+      cfg.namespacesCatalogReadTouchCoalesceMs,
+      60_000,
+      "namespacesCatalogReadTouchCoalesceMs",
+    ),
+    namespacesCatalogWriteTouchCoalesceMs: resolveNonNegativeIntegerConfig(
+      cfg.namespacesCatalogWriteTouchCoalesceMs,
+      1_000,
+      "namespacesCatalogWriteTouchCoalesceMs",
+    ),
+    namespacesCatalogTouchStateWrites: resolveBooleanConfig(
+      cfg.namespacesCatalogTouchStateWrites,
+      false,
+      "namespacesCatalogTouchStateWrites",
+    ),
     // NOTE: namespace identifiers are intentionally NOT sanitized here — the
     // codebase rejects unsafe namespaces at the point of use (see
     // codex-materialize-runner and NamespaceStorageRouter / resolveNamespaceDir),

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -3694,3 +3694,261 @@ test("router resolve-hook serializer recovers after a prior hook rejects (issue 
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Issue #1903: touch-path performance (auto-compaction, coalescing, streaming) ──
+
+async function countCatalogLines(memoryDir: string): Promise<number> {
+  const raw = await readFile(path.join(memoryDir, "state", "namespaces.jsonl"), "utf8").catch(() => "");
+  return raw.split("\n").filter((line) => line.trim().length > 0).length;
+}
+
+// 1. Warm cache: with coalescing OFF every touch appends, but a warm cache means
+// none of them re-parses the JSONL after the initial warm-up parse.
+test("#1903 warm cache: repeated touches never re-parse the log (coalescing off)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new CountingNamespaceCatalog(
+      makeConfig(memoryDir, {
+        namespacesCatalogReadTouchCoalesceMs: 0,
+        namespacesCatalogWriteTouchCoalesceMs: 0,
+      }),
+    );
+    // Warm the cache: the first write creates the file; a read then performs the
+    // one-time full parse and warms the in-process cache.
+    await catalog.markWrite("alpha", { discoveredBy: "write" });
+    await catalog.listNamespaces();
+    const warm = catalog.catalogReadCount;
+    assert.ok(warm >= 1, "the warm-up performed at least one full parse");
+    for (let i = 0; i < 25; i++) {
+      await catalog.markWrite("alpha", { discoveredBy: "write" });
+      await catalog.markRead("alpha", { discoveredBy: "read" });
+    }
+    assert.equal(
+      catalog.catalogReadCount,
+      warm,
+      "every subsequent touch is served from the warm cache without a re-parse",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// 2. Write-touch coalescing collapses many in-window writes into a single append,
+// and the newest buffered timestamp wins on flush.
+test("#1903 write-touch coalescing collapses 50 in-window writes to one append", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(
+      makeConfig(memoryDir, { namespacesCatalogWriteTouchCoalesceMs: 60_000 }),
+    );
+    // Seed the record, then read it back so the in-process cache is warm — the
+    // following writes are then pure-timestamp refreshes on a known record and
+    // are deferred (a cold cache would force the first one to flush immediately).
+    await catalog.markWrite("alpha", { discoveredBy: "write" });
+    await catalog.getNamespaceRecord("alpha");
+    const linesAfterSeed = await countCatalogLines(memoryDir);
+    let newest = new Date();
+    for (let i = 0; i < 50; i++) {
+      newest = new Date(Date.now() + (i + 1) * 1000);
+      await catalog.markWrite("alpha", { discoveredBy: "write", at: newest });
+    }
+    assert.equal(
+      await countCatalogLines(memoryDir),
+      linesAfterSeed,
+      "coalesced writes stay buffered — no per-touch append",
+    );
+    await catalog.flushPendingTouches();
+    assert.equal(
+      await countCatalogLines(memoryDir),
+      linesAfterSeed + 1,
+      "the 50 buffered writes collapse into exactly one append on flush",
+    );
+    const record = await catalog.getNamespaceRecord("alpha");
+    assert.equal(
+      record?.lastWriteAt,
+      newest.toISOString(),
+      "the newest in-window write timestamp wins",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// 3. Read-touch coalescing collapses in-window reads and keeps the latest freshness.
+test("#1903 read-touch coalescing keeps the latest in-window lastReadAt", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(
+      makeConfig(memoryDir, { namespacesCatalogReadTouchCoalesceMs: 60_000 }),
+    );
+    // Seed the read field, then warm the cache so the following reads defer.
+    await catalog.markRead("alpha", { discoveredBy: "read" });
+    await catalog.getNamespaceRecord("alpha");
+    const linesAfterSeed = await countCatalogLines(memoryDir);
+    let newest = new Date();
+    for (let i = 0; i < 30; i++) {
+      newest = new Date(Date.now() + (i + 1) * 1000);
+      await catalog.markRead("alpha", { discoveredBy: "read", at: newest });
+    }
+    assert.equal(
+      await countCatalogLines(memoryDir),
+      linesAfterSeed,
+      "coalesced reads stay buffered — no per-touch append",
+    );
+    await catalog.flushPendingTouches();
+    assert.equal(await countCatalogLines(memoryDir), linesAfterSeed + 1);
+    const record = await catalog.getNamespaceRecord("alpha");
+    assert.equal(
+      record?.lastReadAt,
+      newest.toISOString(),
+      "the newest in-window read timestamp wins",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// 4. Provenance upgrade under coalescing: a config pre-registration followed by a
+// write must read back "write" WITHOUT an explicit flush (immediate-flush rule).
+test("#1903 markWrite upgrades config→write under coalescing without an explicit flush", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(
+      makeConfig(memoryDir, {
+        namespacesCatalogReadTouchCoalesceMs: 60_000,
+        namespacesCatalogWriteTouchCoalesceMs: 60_000,
+      }),
+    );
+    const ns = "project-origin-prov";
+    const storageDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await catalog.registerResolved(ns, storageDir);
+    assert.equal(
+      (await catalog.getNamespaceRecord(ns))?.discoveredBy,
+      "config",
+      "pre-registration is discovered by config",
+    );
+    // A real write must upgrade the provenance immediately even with coalescing on.
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir });
+    assert.equal(
+      (await catalog.getNamespaceRecord(ns))?.discoveredBy,
+      "write",
+      "the config→write upgrade flushes immediately (not coalesced away)",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// 5. Zero-limit semantics: CompactBytes=0 never rewrites and CoalesceMs=0 appends
+// one line per touch (line count == touch count) — the pre-#1903 behavior.
+test("#1903 zero knobs restore append-per-touch with no compaction", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(
+      makeConfig(memoryDir, {
+        namespacesCatalogCompactBytes: 0,
+        namespacesCatalogReadTouchCoalesceMs: 0,
+        namespacesCatalogWriteTouchCoalesceMs: 0,
+      }),
+    );
+    const touches = 12;
+    for (let i = 0; i < touches; i++) {
+      await catalog.markWrite("alpha", { discoveredBy: "write" });
+    }
+    assert.equal(
+      await countCatalogLines(memoryDir),
+      touches,
+      "no coalescing and no compaction → exactly one append per touch",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// 6. Auto-compaction bounds the log to one row per namespace and preserves every
+// namespace with its newest fields. A tiny limit forces compaction on each touch.
+test("#1903 auto-compaction bounds the log to one row per namespace and preserves all", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(
+      makeConfig(memoryDir, {
+        namespacesCatalogCompactBytes: 100,
+        namespacesCatalogReadTouchCoalesceMs: 0,
+        namespacesCatalogWriteTouchCoalesceMs: 0,
+      }),
+    );
+    const namespaces = [
+      "project-origin-a",
+      "project-origin-b",
+      "project-origin-c",
+      "project-origin-d",
+      "project-origin-e",
+    ];
+    const newest = new Map<string, string>();
+    for (let round = 0; round < 20; round++) {
+      for (const ns of namespaces) {
+        const at = new Date(Date.now() + (round * namespaces.length + namespaces.indexOf(ns)) * 1000);
+        newest.set(ns, at.toISOString());
+        await catalog.markWrite(ns, { discoveredBy: "write", at });
+      }
+    }
+    assert.equal(
+      await countCatalogLines(memoryDir),
+      namespaces.length,
+      "the log is bounded to exactly one row per namespace after compaction",
+    );
+    const list = await catalog.listNamespaces();
+    for (const ns of namespaces) {
+      const record = list.find((r) => r.namespace === ns);
+      assert.ok(record, `namespace ${ns} survives compaction`);
+      assert.equal(
+        record?.lastWriteAt,
+        newest.get(ns),
+        `namespace ${ns} keeps its newest write timestamp through compaction`,
+      );
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// 7. Cross-process cache-coherence: compaction on one instance must never drop
+// another instance's rows (mirrors the rebuild-race tests). A third fresh
+// instance must read back every namespace touched by either.
+test("#1903 cross-instance compaction never drops another instance's rows", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const cfg = () =>
+      makeConfig(memoryDir, {
+        namespacesCatalogCompactBytes: 100,
+        namespacesCatalogReadTouchCoalesceMs: 0,
+        namespacesCatalogWriteTouchCoalesceMs: 0,
+      });
+    // Separate instances behave like separate processes (own lock owner id).
+    const a = new NamespaceCatalog(cfg());
+    const b = new NamespaceCatalog(cfg());
+    const written = new Set<string>();
+    for (let round = 0; round < 8; round++) {
+      const nsA = `project-origin-a${round}`;
+      const nsB = `project-origin-b${round}`;
+      written.add(nsA);
+      written.add(nsB);
+      // Interleave: A appends a fresh namespace while B triggers a compaction of
+      // the shared log. The cross-process lock serializes the two.
+      await Promise.all([
+        a.markWrite(nsA, { discoveredBy: "write" }),
+        b.markWrite(nsB, { discoveredBy: "write" }),
+      ]);
+    }
+    const fresh = new NamespaceCatalog(makeConfig(memoryDir));
+    const list = await fresh.listNamespaces();
+    for (const ns of written) {
+      assert.ok(
+        list.some((r) => r.namespace === ns),
+        `namespace ${ns} must survive cross-instance interleaved compaction`,
+      );
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -741,11 +741,21 @@ export class NamespaceCatalog {
       await this.touch(namespace, kind, metadata);
       return;
     }
-    // Pure timestamp refresh on a known record → defer/coalesce.
+    // Pure timestamp refresh on a known record → coalesce within a FIXED window.
     const key = `${kind}:${ns}`;
     const at = metadata?.at ?? new Date();
     const existing = this.pendingTouches.get(key);
-    if (existing) clearTimeout(existing.timer);
+    if (existing) {
+      // Keep the ORIGINAL timer and only refresh the buffered payload (#1903,
+      // Codex). Re-arming on every touch would make this a debounce that never
+      // flushes under continuous traffic (e.g. a sustained import), leaving
+      // lastWriteAt stale and writtenSince/maintenance consumers blind to an
+      // actively-written namespace. With a fixed window, each window flushes on
+      // schedule carrying the newest buffered timestamp.
+      existing.metadata = metadata;
+      existing.at = at;
+      return;
+    }
     // Cap at Node's maximum setTimeout delay (2^31-1 ms ≈ 24.8 days). Values
     // above that are clamped by Node to 1ms, which would append almost every
     // touch and recreate the churn this coalescing exists to prevent (#1903, Codex).

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -505,6 +505,12 @@ export class NamespaceCatalog {
   private readonly compactBytesLimit: number;
   private readonly readCoalesceMs: number;
   private readonly writeCoalesceMs: number;
+  // Size after the most recent auto-compaction (0 = none yet). Hysteresis for
+  // maybeAutoCompact: a folded catalog that is itself above the limit (many
+  // distinct namespaces) would otherwise be re-folded + re-rewritten on every
+  // touch. We only compact again once the log has grown by >= one limit-worth
+  // since the last compaction (#1903, Codex).
+  private lastCompactedSize = 0;
 
   // Issue #1903 — per-(namespace, kind) coalescing buffer. Keyed `${kind}:${ns}`.
   // Holds the latest buffered timestamp/metadata for a pure-timestamp touch on
@@ -1452,8 +1458,15 @@ export class NamespaceCatalog {
       // next touch re-warms and re-checks.
       const size = this.compactedCache?.identity.size;
       if (size === undefined || size <= limit) return;
+      // Hysteresis (issue #1903, Codex): a folded catalog whose deduped state is
+      // itself above the limit (many distinct namespaces) would otherwise be
+      // re-folded + re-rewritten on EVERY touch — O(catalog) per touch. Only
+      // compact again once the log has grown by >= one limit-worth since the last
+      // compaction; by then the new appends are duplicates the fold can collapse.
+      if (this.lastCompactedSize > 0 && size - this.lastCompactedSize < limit) return;
       const folded = await this.loadCompacted();
       await this.rewriteUnchained([...folded.values()]);
+      this.lastCompactedSize = this.compactedCache?.identity.size ?? size;
     } catch {
       // Fail-open: compaction is best-effort maintenance on already-durable data.
     }

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -746,9 +746,13 @@ export class NamespaceCatalog {
     const at = metadata?.at ?? new Date();
     const existing = this.pendingTouches.get(key);
     if (existing) clearTimeout(existing.timer);
+    // Cap at Node's maximum setTimeout delay (2^31-1 ms ≈ 24.8 days). Values
+    // above that are clamped by Node to 1ms, which would append almost every
+    // touch and recreate the churn this coalescing exists to prevent (#1903, Codex).
+    const safeWindow = Math.min(window, 2_147_483_647);
     const timer = setTimeout(() => {
       void this.flushPendingTouch(key);
-    }, window);
+    }, safeWindow);
     timer.unref();
     this.pendingTouches.set(key, { namespace: ns, kind, metadata, at, timer });
   }
@@ -778,6 +782,9 @@ export class NamespaceCatalog {
     if (metadata.parentNamespace !== undefined && metadata.parentNamespace !== cached.parentNamespace) {
       return true;
     }
+    // A changed storageDir repoints routing/containment for this namespace —
+    // must be observable at once, not held stale by the coalesce window (#1903, Cursor).
+    if (metadata.storageDir !== undefined && metadata.storageDir !== cached.storageDir) return true;
     return false;
   }
 

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -12,6 +12,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
+import { StringDecoder } from "node:string_decoder";
 import type { PluginConfig } from "../types.js";
 import {
   MutationSerializer,
@@ -497,12 +498,40 @@ export class NamespaceCatalog {
   // against this normalized form everywhere instead.
   private readonly defaultNamespaceIdentity: string;
 
+  // Issue #1903 — touch-path performance knobs, resolved with the documented
+  // defaults when an externally-built PluginConfig omits them (so a partial
+  // config object still yields the production behavior). `0` is a real disable
+  // switch for each and is preserved by `??` (0 is not null/undefined).
+  private readonly compactBytesLimit: number;
+  private readonly readCoalesceMs: number;
+  private readonly writeCoalesceMs: number;
+
+  // Issue #1903 — per-(namespace, kind) coalescing buffer. Keyed `${kind}:${ns}`.
+  // Holds the latest buffered timestamp/metadata for a pure-timestamp touch on
+  // an already-known record; a `.unref()`'d timer flushes it once per window so
+  // the append-only log does not grow one line per repeat touch. Semantically
+  // observable touches (first sight, provenance/field change) bypass this buffer
+  // and flush immediately (see `coalesceTouch`).
+  private readonly pendingTouches = new Map<
+    string,
+    {
+      namespace: string;
+      kind: "read" | "write";
+      metadata?: NamespaceTouchMetadata;
+      at: Date;
+      timer: NodeJS.Timeout;
+    }
+  >();
+
   constructor(private readonly config: PluginConfig) {
     this.memoryDir = config.memoryDir;
     this.stateDir = path.join(this.memoryDir, STATE_DIR);
     this.catalogPath = path.join(this.stateDir, CATALOG_FILE);
     this.rebuildLockPath = path.join(this.stateDir, REBUILD_LOCK_FILE);
     this.defaultNamespaceIdentity = normalizeNamespaceIdentity(config.defaultNamespace);
+    this.compactBytesLimit = config.namespacesCatalogCompactBytes ?? 16 * 1024 * 1024;
+    this.readCoalesceMs = config.namespacesCatalogReadTouchCoalesceMs ?? 60_000;
+    this.writeCoalesceMs = config.namespacesCatalogWriteTouchCoalesceMs ?? 1_000;
   }
 
   /** Whether the catalog is active (namespaces enabled and catalog not opted out). */
@@ -663,11 +692,120 @@ export class NamespaceCatalog {
   // ── Touch API (cheap, failure-tolerant) ─────────────────────────────────
 
   async markRead(namespace: string, metadata?: NamespaceTouchMetadata): Promise<void> {
-    await this.touch(namespace, "read", metadata);
+    await this.coalesceTouch(namespace, "read", metadata);
   }
 
   async markWrite(namespace: string, metadata?: NamespaceTouchMetadata): Promise<void> {
-    await this.touch(namespace, "write", metadata);
+    await this.coalesceTouch(namespace, "write", metadata);
+  }
+
+  /**
+   * Route a read/write touch through the per-(namespace, kind) coalescing buffer
+   * (issue #1903). A touch flushes IMMEDIATELY (bypassing the buffer) whenever it
+   * is semantically observable to an in-process reader — first sight of the
+   * namespace, a `config`→`write` provenance upgrade, the first time a touch
+   * field is set (so `listNamespaces({ writtenSince })` and record presence stay
+   * correct), or a change to `kind`/`principal`/`projectId`/`branch`/
+   * `parentNamespace`. A pure timestamp refresh on an already-known record is
+   * DEFERRED and coalesced: the newest buffered `at`/metadata wins and a single
+   * `touch` runs when the window elapses (or on `flushPendingTouches`). Window
+   * `0` skips the buffer entirely (the pre-#1903 immediate-append behavior).
+   * Best-effort: coalescing decisions read only the warm `compactedCache`, never
+   * forcing a disk parse; a cold cache flushes immediately (and re-warms it).
+   */
+  private async coalesceTouch(
+    namespace: string,
+    kind: "read" | "write",
+    metadata?: NamespaceTouchMetadata,
+  ): Promise<void> {
+    if (!this.enabled) return;
+    const window = kind === "read" ? this.readCoalesceMs : this.writeCoalesceMs;
+    if (window <= 0) {
+      await this.touch(namespace, kind, metadata);
+      return;
+    }
+    // Validate up front so an unsafe namespace rejects deterministically, exactly
+    // as the immediate-append path does (touch validates too).
+    const ns = this.validateNamespace(namespace);
+    const cached = this.compactedCache?.records.get(ns);
+    if (cached === undefined || this.touchMustFlushImmediately(kind, metadata, cached)) {
+      // Semantically observable in-process → flush now (also warms the cache).
+      // Any older buffered touch for this key is now redundant (this newer touch
+      // updates the same field with a newer timestamp): drop it so its stale
+      // timer cannot regress the timestamp after this flush.
+      const stale = this.pendingTouches.get(`${kind}:${ns}`);
+      if (stale) {
+        clearTimeout(stale.timer);
+        this.pendingTouches.delete(`${kind}:${ns}`);
+      }
+      await this.touch(namespace, kind, metadata);
+      return;
+    }
+    // Pure timestamp refresh on a known record → defer/coalesce.
+    const key = `${kind}:${ns}`;
+    const at = metadata?.at ?? new Date();
+    const existing = this.pendingTouches.get(key);
+    if (existing) clearTimeout(existing.timer);
+    const timer = setTimeout(() => {
+      void this.flushPendingTouch(key);
+    }, window);
+    timer.unref();
+    this.pendingTouches.set(key, { namespace: ns, kind, metadata, at, timer });
+  }
+
+  /**
+   * Whether a read/write touch on an EXISTING cached record must flush
+   * immediately rather than coalesce. Only pure timestamp refreshes (the value
+   * returns false) are safe to defer.
+   */
+  private touchMustFlushImmediately(
+    kind: "read" | "write",
+    metadata: NamespaceTouchMetadata | undefined,
+    cached: NamespaceRecord,
+  ): boolean {
+    // A write upgrading a config pre-registration to "write" changes the
+    // discoveredBy filter result — must be observable at once (~:1261).
+    if (kind === "write" && cached.discoveredBy === "config") return true;
+    // The first time a touch field is set makes the namespace newly match
+    // presence/`writtenSince` reads, so it must not be deferred.
+    if (kind === "write" && cached.lastWriteAt === undefined) return true;
+    if (kind === "read" && cached.lastReadAt === undefined) return true;
+    if (!metadata) return false;
+    if (metadata.kind !== undefined && metadata.kind !== cached.kind) return true;
+    if (metadata.principal !== undefined && metadata.principal !== cached.principal) return true;
+    if (metadata.projectId !== undefined && metadata.projectId !== cached.projectId) return true;
+    if (metadata.branch !== undefined && metadata.branch !== cached.branch) return true;
+    if (metadata.parentNamespace !== undefined && metadata.parentNamespace !== cached.parentNamespace) {
+      return true;
+    }
+    return false;
+  }
+
+  /** Fire a single buffered touch when its coalescing window elapses. */
+  private async flushPendingTouch(key: string): Promise<void> {
+    const pending = this.pendingTouches.get(key);
+    if (!pending) return;
+    this.pendingTouches.delete(key);
+    clearTimeout(pending.timer);
+    await this.touch(pending.namespace, pending.kind, { ...pending.metadata, at: pending.at }).catch(
+      () => undefined,
+    );
+  }
+
+  /**
+   * Flush every buffered coalesced touch now (issue #1903). Called from the
+   * router/orchestrator shutdown hook so a long-lived host does not drop
+   * buffered read/write timestamps on teardown, and by tests to make coalesced
+   * touches deterministically observable. Best-effort: a failed flush never
+   * throws (each touch is `.catch()`-guarded).
+   */
+  async flushPendingTouches(): Promise<void> {
+    const pending = [...this.pendingTouches.values()];
+    this.pendingTouches.clear();
+    for (const p of pending) {
+      clearTimeout(p.timer);
+      await this.touch(p.namespace, p.kind, { ...p.metadata, at: p.at }).catch(() => undefined);
+    }
   }
 
   async markMaintenance(namespace: string, jobName: string, at?: Date): Promise<void> {
@@ -1269,9 +1407,39 @@ export class NamespaceCatalog {
         }
 
         await this.appendUnchained(record);
+        // Size-triggered auto-compaction (issue #1903), still inside the held
+        // cross-process lock + queueCritical turn so the fold→rename is atomic
+        // against concurrent touches and cross-process rebuilds.
+        await this.maybeAutoCompact();
         return true;
       }),
     );
+  }
+
+  /**
+   * Fold-and-rewrite the JSONL log when it exceeds `compactBytesLimit`
+   * (issue #1903). MUST be called only from inside `touch`'s held-lock +
+   * `queueCritical` critical section — it reuses `loadCompacted` (last-record-
+   * wins fold; every namespace row survives) and `rewriteUnchained` (atomic
+   * temp-file + rename), so the collapse is cross-process safe and never
+   * invokes the disk-scan purge in `finishRebuild`. Best-effort and fail-open
+   * (rule #40): the append already succeeded and is durable, so a failed
+   * compaction must not fail the touch — the next over-limit touch retries.
+   */
+  private async maybeAutoCompact(): Promise<void> {
+    try {
+      const limit = this.compactBytesLimit; // 0 => auto-compaction disabled
+      if (limit <= 0) return;
+      // Exact post-append size when the cache is warm; skip this touch's check
+      // when the cache is cold (a cross-process append invalidated it) — the
+      // next touch re-warms and re-checks.
+      const size = this.compactedCache?.identity.size;
+      if (size === undefined || size <= limit) return;
+      const folded = await this.loadCompacted();
+      await this.rewriteUnchained([...folded.values()]);
+    } catch {
+      // Fail-open: compaction is best-effort maintenance on already-durable data.
+    }
   }
 
   // ── Rebuild from disk ────────────────────────────────────────────────────
@@ -1957,25 +2125,52 @@ export class NamespaceCatalog {
 
     try {
       this.onCatalogReadForTest?.();
-      const raw = await handle.readFile("utf8");
-      for (const line of raw.split("\n")) {
+      // Streaming chunked parse (issue #1903): the log can reach 100+ MB in
+      // production, so read it in bounded chunks and yield to the event loop
+      // every ~5000 lines instead of buffering the whole file and blocking on a
+      // single giant `split("\n")`. The fold is unchanged (last-record-wins with
+      // field-level touch merge across cross-process full-snapshot appends).
+      const CHUNK_BYTES = 1 << 16; // 64 KiB
+      const YIELD_EVERY_LINES = 5000;
+      const chunk = Buffer.allocUnsafe(CHUNK_BYTES);
+      // StringDecoder buffers partial multi-byte UTF-8 sequences that straddle a
+      // chunk boundary, so a namespace/principal with non-ASCII bytes never
+      // corrupts at the seam.
+      const decoder = new StringDecoder("utf8");
+      let leftover = "";
+      let linesSinceYield = 0;
+      const foldLine = (line: string): void => {
         const trimmed = line.trim();
-        if (trimmed.length === 0) continue;
+        if (trimmed.length === 0) return;
         let parsed: unknown;
         try {
           parsed = JSON.parse(trimmed);
         } catch {
           // Skip corrupt lines (CLAUDE.md rule #18 robustness).
-          continue;
+          return;
         }
         const record = coerceRecord(parsed);
-        if (!record) continue;
-        // Preserve each touch field across cross-process full-snapshot appends.
-        // Field-level touch merge preserves the newest value for every touch
-        // field when full-snapshot appends from separate processes interleave.
+        if (!record) return;
         const prior = records.get(record.namespace);
         records.set(record.namespace, prior ? mergeNewerTouchFields(record, prior) : record);
+      };
+      for (;;) {
+        const { bytesRead } = await handle.read(chunk, 0, CHUNK_BYTES, null);
+        if (bytesRead === 0) break;
+        leftover += decoder.write(chunk.subarray(0, bytesRead));
+        let newlineIndex = leftover.indexOf("\n");
+        while (newlineIndex !== -1) {
+          foldLine(leftover.slice(0, newlineIndex));
+          leftover = leftover.slice(newlineIndex + 1);
+          if (++linesSinceYield >= YIELD_EVERY_LINES) {
+            linesSinceYield = 0;
+            await new Promise<void>((resolve) => setImmediate(resolve));
+          }
+          newlineIndex = leftover.indexOf("\n");
+        }
       }
+      leftover += decoder.end();
+      foldLine(leftover);
     } catch {
       this.compactedCache = undefined;
       return new Map();

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -509,6 +509,11 @@ export class NamespaceStorageRouter {
    * moved should await this instead of racing a timer.
    */
   async whenWriteTouchesSettled(): Promise<void> {
+    // Flush any coalesced (buffered) touches first so their appends join the
+    // pending set below — otherwise this could resolve while a buffered touch's
+    // lastWriteAt is still unwritten on disk (#1903, Cursor). No-op when
+    // coalescing is disabled (window 0) or the catalog is inert.
+    await this.catalog?.flushPendingTouches().catch(() => undefined);
     while (this.pendingWriteTouches.size > 0) {
       await Promise.allSettled([...this.pendingWriteTouches]);
     }

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -414,6 +414,10 @@ export class NamespaceStorageRouter {
    * default-namespace storage (`this.storage`) that bypasses the router.
    */
   bindCatalogWriteHook(sm: StorageManager, namespace: string): void {
+    // Issue #1903: pure state-file writes only touch the catalog when explicitly
+    // opted in. Router-created storages (storageFor) and the legacy default
+    // storage both flow through here, so this is the single wiring point.
+    sm.touchStateWrites = this.config.namespacesCatalogTouchStateWrites === true;
     sm.onCatalogWrite = () => this.touchCatalogWrite(namespace, sm.dir);
   }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -948,6 +948,9 @@ export class Orchestrator {
     }
     this.maintenanceScheduler.dispose();
     await drainRecallWrites(this);
+    // Issue #1903: flush any coalesced namespace-catalog touches before teardown
+    // so a long-lived host does not drop buffered read/write timestamps.
+    await this.namespaceCatalog.flushPendingTouches().catch(() => undefined);
     await this.namespaceSearchRouter.dispose();
     await (this.qmd as { dispose?: () => void | Promise<void> }).dispose?.();
     if (this.conversationQmd && this.conversationQmd !== this.qmd) {

--- a/packages/remnic-core/src/storage-catalog-touch-gating.test.ts
+++ b/packages/remnic-core/src/storage-catalog-touch-gating.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Issue #1903 — state-file writes must not touch the namespace catalog.
+ *
+ * The post-write catalog hook (`onCatalogWrite`) fires on every successful
+ * secure-file write. Pure state files (`state/buffer.json`, ledgers, indexes)
+ * are NOT namespace memory data, so by default their writes must be excluded
+ * from the catalog touch path (they were the dominant source of catalog churn
+ * that grew `state/namespaces.jsonl` unbounded). Namespace data writes
+ * (`facts/`, ...) still touch. The `touchStateWrites` opt-in restores the
+ * pre-#1903 behavior where every write touched.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { StorageManager } from "./storage.js";
+import type { BufferState } from "./types.js";
+
+async function mkDir(): Promise<string> {
+  return await mkdtemp(path.join(os.tmpdir(), "remnic-touch-gate-"));
+}
+
+function emptyBuffer(): BufferState {
+  return { turns: [], lastExtractionAt: null, extractionCount: 0 };
+}
+
+test("#1903 state-file writes do not touch the catalog by default; data writes do", async () => {
+  const dir = await mkDir();
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    let touches = 0;
+    storage.onCatalogWrite = () => {
+      touches += 1;
+    };
+
+    // A pure state-file write (state/buffer.json) must NOT touch the catalog.
+    await storage.saveBuffer(emptyBuffer());
+    assert.equal(touches, 0, "saving buffer.json (a state file) records no catalog touch");
+
+    // A namespace-data write (facts/) MUST touch exactly once. The lifecycle
+    // ledger append it also performs is a state write and stays excluded.
+    touches = 0;
+    await storage.writeMemory("fact", "The database is PostgreSQL.", { confidence: 0.9 });
+    assert.equal(touches, 1, "writing a fact records exactly one catalog touch");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("#1903 touchStateWrites=true restores the state-file catalog touch", async () => {
+  const dir = await mkDir();
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    storage.touchStateWrites = true;
+    let touches = 0;
+    storage.onCatalogWrite = () => {
+      touches += 1;
+    };
+
+    await storage.saveBuffer(emptyBuffer());
+    assert.ok(touches >= 1, "with touchStateWrites enabled, saving buffer.json touches the catalog");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2447,6 +2447,32 @@ export class StorageManager {
     }
   }
 
+  /**
+   * Whether pure state-file writes touch the namespace catalog (issue #1903).
+   * Set by `NamespaceStorageRouter.bindCatalogWriteHook` from
+   * `namespacesCatalogTouchStateWrites` (default false). State files
+   * (`state/buffer.json`, ledgers, indexes) are not namespace memory data, so by
+   * default their writes do NOT record a catalog touch.
+   */
+  touchStateWrites = false;
+
+  /**
+   * Post-write catalog hook, gated by file path (issue #1903). Namespace data
+   * (`facts/`, `cold/`, `entities/`, `artifacts/`, `profile.md`, ...) lives
+   * OUTSIDE `stateDir`, so a data write always touches; a write under `stateDir`
+   * is a pure state write and is skipped unless `touchStateWrites` is enabled.
+   */
+  private notifyCatalogWriteForPath(filePath: string): void {
+    if (!this.touchStateWrites && this.isStateFilePath(filePath)) return;
+    this.notifyCatalogWrite();
+  }
+
+  /** Whether `filePath` resolves to `stateDir` itself or a path contained in it. */
+  private isStateFilePath(filePath: string): boolean {
+    const rel = path.relative(this.stateDir, path.resolve(filePath));
+    return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+  }
+
   // ── Tombstone store (issue #1579) ───────────────────────────────────────
   // Instance-scoped (rule 11) + namespace-scoped (rule 42) tombstone index.
   // Lazily loaded from <stateDir>/tombstones.jsonl; invalidated together with
@@ -3083,12 +3109,12 @@ export class StorageManager {
   }
   private writeStorageSecureFile(filePath: string, content: string | Buffer): Promise<void> {
     return writeMaybeEncryptedFile(filePath, content, this.resolveWriteKey(), {}, this.baseDir).then(() =>
-      this.notifyCatalogWrite()
+      this.notifyCatalogWriteForPath(filePath)
     );
   }
   private writeStorageSecureFileChunks(filePath: string, chunks: AsyncIterable<Buffer>): Promise<void> {
     return writeMaybeEncryptedFileFromChunks(filePath, chunks, this.resolveWriteKey(), {}, this.baseDir).then(() =>
-      this.notifyCatalogWrite()
+      this.notifyCatalogWriteForPath(filePath)
     );
   }
 
@@ -3340,14 +3366,14 @@ export class StorageManager {
         if (isEncryptedFile(await readFile(filePath))) {
           const existing = await this.readStorageSecureFile(filePath);
           await writeMaybeEncryptedFile(filePath, `${existing}${content}`, null, {}, this.baseDir);
-          this.notifyCatalogWrite();
+          this.notifyCatalogWriteForPath(filePath);
           return;
         }
       } catch (err) {
         if (!isErrnoCode(err, "ENOENT")) throw err;
       }
       await appendFile(filePath, content, "utf-8");
-      this.notifyCatalogWrite();
+      this.notifyCatalogWriteForPath(filePath);
       return;
     }
 
@@ -3358,7 +3384,7 @@ export class StorageManager {
       if (!isErrnoCode(err, "ENOENT")) throw err;
     }
     await writeMaybeEncryptedFile(filePath, `${existing}${content}`, writeKey, {}, this.baseDir);
-    this.notifyCatalogWrite();
+    this.notifyCatalogWriteForPath(filePath);
   }
   private get stateDir(): string {
     return path.join(this.baseDir, "state");

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1690,6 +1690,40 @@ export interface PluginConfig {
    * existing single-namespace behavior is unchanged. Default on.
    */
   namespaceCatalogEnabled: boolean;
+  /**
+   * Size (bytes) at which a namespace-catalog touch triggers an in-lock
+   * auto-compaction of `state/namespaces.jsonl` (issue #1903). The append-only
+   * log grows one line per touch; once it exceeds this many bytes the next
+   * touch folds it (last-record-wins, every namespace row preserved) and
+   * atomically rewrites it. Default `16 * 1024 * 1024` (16 MB). `0` disables
+   * auto-compaction (restores the pre-#1903 unbounded-append behavior).
+   */
+  namespacesCatalogCompactBytes: number;
+  /**
+   * Coalescing window (ms) for pure-timestamp READ touches on an
+   * already-known namespace record (issue #1903). Repeated `markRead` touches
+   * that only refresh `lastReadAt` are buffered per (namespace, kind) and
+   * flushed once per window instead of appending a line each time.
+   * Semantically-observable touches (first sight, provenance/field changes)
+   * always flush immediately. Default `60000`. `0` disables read coalescing
+   * (each touch appends immediately, the pre-#1903 behavior).
+   */
+  namespacesCatalogReadTouchCoalesceMs: number;
+  /**
+   * Coalescing window (ms) for pure-timestamp WRITE touches on an
+   * already-known namespace record (issue #1903). Mirrors
+   * `namespacesCatalogReadTouchCoalesceMs` for `markWrite`/`lastWriteAt`.
+   * Default `1000`. `0` disables write coalescing.
+   */
+  namespacesCatalogWriteTouchCoalesceMs: number;
+  /**
+   * Whether pure state-file writes (`state/buffer.json`, ledgers, indexes)
+   * touch the namespace catalog (issue #1903). State files are not namespace
+   * memory data, so by default their writes do NOT record a catalog touch.
+   * Set `true` to restore the pre-#1903 behavior where every secure-file
+   * write touched the catalog. Default `false`.
+   */
+  namespacesCatalogTouchStateWrites: boolean;
   defaultNamespace: string;
   sharedNamespace: string;
   principalFromSessionKeyMode: PrincipalFromSessionKeyMode;

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,11 +4,11 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 3965,
+      "packages/remnic-core/src/orchestrator.ts": 3964,
       "packages/remnic-core/src/cli.ts": 9429,
       "packages/remnic-core/src/access-service.ts": 5905,
-      "packages/remnic-core/src/storage.ts": 6937,
-      "packages/remnic-core/src/config.ts": 4491
+      "packages/remnic-core/src/storage.ts": 6963,
+      "packages/remnic-core/src/config.ts": 4534
     },
     "oversizedFileCount": 11,
     "scatteredConfigFlagReads": 6,

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -19,6 +19,9 @@ test("shared-namespace promotion updates the shared namespace lastWriteAt in the
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-promo-catalog-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -93,6 +96,9 @@ test("persistExtraction shared promotion records a shared-namespace catalog writ
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-promo-integ-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -156,6 +162,9 @@ test("scope profile shared reads do not imply automatic shared promotion", async
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-scope-profile-promo-gate-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -236,6 +245,9 @@ test("scope profile auto-promotion does not require legacy global promotion", as
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-scope-profile-promo-enabled-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -319,6 +331,9 @@ test("shared promotion records catalog write after shared temporal supersession"
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-promo-order-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -433,6 +448,9 @@ test("shared hash-dedup supersession-only update records a shared-namespace cata
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-dedup-catalog-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -546,6 +564,9 @@ test("no_recall recall does not record catalog read touches", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-no-recall-catalog-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -588,6 +609,9 @@ test("zero recall result limit (topK:0) records no catalog read touches", async 
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-zero-limit-catalog-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -636,6 +660,9 @@ test("storageDirNamespace preserves a token-shaped literal raw namespace name", 
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-ns-from-dir-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -687,6 +714,9 @@ test("storageDirNamespace preserves a CONFIGURED namespace named like a canonica
     const literalTokenName = tokenize("alpha"); // "ns-616c706861" — decodes to "alpha"
 
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -704,6 +734,9 @@ test("storageDirNamespace preserves a CONFIGURED namespace named like a canonica
 
     // Control: the identical byte-shape, but NOT configured, still decodes.
     const otherConfig = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -732,6 +765,9 @@ test("storageDirNamespace preserves a CATALOGED dynamic namespace named like a c
     await mkdir(path.join(rawDir, "facts"), { recursive: true });
 
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -788,6 +824,9 @@ test("storageDirNamespace ignores catalog hints whose storageDir belongs to anot
     );
 
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -843,6 +882,9 @@ test("storageDirNamespace compacts catalog hints before choosing token-root owne
     );
 
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -874,6 +916,9 @@ test("persistExtraction records non-fact catalog touch when a later non-fact wri
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-nonfact-finally-catalog-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -951,6 +996,9 @@ test("an already-aborted recall records no catalog read touches", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-aborted-recall-catalog-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -1003,6 +1051,9 @@ test("autoConsolidateIdentity records a catalog write for a dynamic namespace wh
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-identity-consolidate-catalog-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -1085,6 +1136,9 @@ test("semantic consolidation records a catalog write when archival fails after c
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-semantic-partial-catalog-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -1188,6 +1242,9 @@ test("persistExtraction records non-chunked source catalog touch after graph and
   let cleanup: (() => Promise<void>) | undefined;
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -1275,6 +1332,9 @@ test("maintenanceNamespaces skips absent catalog-only read rows but includes exi
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-maintenance-catalog-read-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),
@@ -1330,6 +1390,9 @@ test("maintenanceNamespaces skips catalog write rows whose storage root was dele
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-maintenance-deleted-write-"));
   try {
     const config = parseConfig({
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
       openaiApiKey: "sk-test",
       memoryDir,
       workspaceDir: path.join(memoryDir, "workspace"),

--- a/tests/storage-contract/helpers.ts
+++ b/tests/storage-contract/helpers.ts
@@ -55,6 +55,14 @@ export function makeStorageTestConfig(
     extractionMinUserTurns: 1,
     consolidateEveryN: 50,
     initGateTimeoutMs: 1000,
+    // #1903: run storage-contract chokepoint tests with the catalog touch path
+    // in its immediate/wired mode (no coalescing, state-file writes DO touch) so
+    // they keep verifying the post-write hook WIRING for every entry point. The
+    // new coalescing + state-gating behaviors are covered by the dedicated
+    // catalog.test.ts / storage-catalog-touch-gating.test.ts suites.
+    namespacesCatalogWriteTouchCoalesceMs: 0,
+    namespacesCatalogReadTouchCoalesceMs: 0,
+    namespacesCatalogTouchStateWrites: true,
     ...overrides,
   });
 }


### PR DESCRIPTION
Part of #1903.

Implements the catalog touch-path perf fix per the issue spec:

1. **Config knobs** (`config.ts` + `types.ts`): `namespacesCatalogCompactBytes` (16 MB default, `0` disables), `...ReadTouchCoalesceMs` (60000), `...WriteTouchCoalesceMs` (1000), `namespacesCatalogTouchStateWrites` (`false`). Uses a new `resolveNonNegativeIntegerConfig` (permits 0, rejects negatives/non-integers).
2. **Size-triggered auto-compaction** (`catalog.ts`): `maybeAutoCompact()` fires after `appendUnchained` inside the held lock when the post-append size exceeds the threshold — folds the log last-record-wins via `loadCompacted` and atomically rewrites via the existing `rewriteUnchained` (temp+rename). Never invokes the `finishRebuild` disk-scan purge; preserves every namespace row; fail-open.
3. **Per-(namespace,kind) touch coalescing** (`catalog.ts`): `pendingTouches` defers pure-timestamp refreshes; immediate-flush on first-sight, `config`→`write` provenance upgrade, and provenance/field change (so `listNamespaces`/`getNamespaceRecord` observability is preserved). `.unref()` timers; `0` window bypasses (current behavior). `flushPendingTouches()` wired into `orchestrator.destroy()`.
4. **State-file exclusion** (`storage.ts`): `notifyCatalogWriteForPath` gates the touch on `stateDir` containment (so `buffer.json`/ledgers/maintenance status no longer fire namespace write-touches by default); `touchStateWrites=true` restores the old behavior. Real namespace data (`facts/`, `cold/`, `entities/`, etc.) is never under `stateDir`, so its touches are unaffected.
5. **Streaming-parse floor** (`catalog.ts`): `loadCompacted`'s cache-miss path now reads in 64 KiB chunks with a `StringDecoder`, yielding to the event loop every ~5000 lines instead of one multi-second `readFile`+`split` macrotask.

Guardrails honored: touches stay best-effort/fail-open; appends + rewrites stay under `withHeldCatalogLock`; the `compactedCache` identity check remains the sole cross-process-append authority; compaction is a duplicate-line collapse (no purge); `0`/`false` knobs restore prior behavior; atomic temp+rename.

Existing catalog-write chokepoint + shared-promotion suites updated to run in immediate-touch mode (they test the wiring; the new behaviors are covered by the dedicated suites).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path catalog semantics (`writtenSince`, maintenance fanout) via coalescing and default state-write exclusion, though observable touches still flush immediately and knobs can restore prior behavior. Compaction and cross-process locking add complexity but stay fail-open and lock-serialized.
> 
> **Overview**
> **Bounds namespace catalog touch churn** so `state/namespaces.jsonl` no longer grows unbounded from high-frequency reads/writes and state-file activity (issue #1903).
> 
> Adds four config knobs (plugin schema + `parseConfig`): **auto-compaction** when the log exceeds a byte threshold (default 16 MB), **read/write touch coalescing** windows (defaults 60s / 1s), and **`namespacesCatalogTouchStateWrites`** (default `false`) to stop `state/` writes from touching the catalog. `0` on numerics and `true` on the state toggle restore pre-#1903 behavior.
> 
> **`NamespaceCatalog`** routes `markRead`/`markWrite` through coalescing (immediate flush on first sight, provenance upgrades, and metadata changes), runs **size-triggered fold+rewrite** inside the existing lock after appends, parses the JSONL **in streamed chunks** instead of one giant read, and exposes **`flushPendingTouches()`** on orchestrator destroy and `whenWriteTouchesSettled()`.
> 
> **`StorageManager`** gates catalog hooks by path: namespace data under `facts/` etc. still touches; writes under `stateDir` skip unless opted in. Existing catalog-wiring tests are pinned to immediate-touch mode; new suites cover coalescing, compaction, cross-process safety, and state-file gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e0cfe3a6cf28a36e288ad98d3040152aa3421b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->