### PR TITLE
fix(local-llm): Ollama backend thinking suppression via reasoning_effort

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3002,6 +3002,19 @@
         "default": "local-model",
         "description": "Model name for local LLM requests"
       },
+      "localLlmReasoningEffort": {
+        "type": "string",
+        "enum": [
+          "",
+          "none",
+          "low",
+          "medium",
+          "high",
+          "max"
+        ],
+        "default": "none",
+        "description": "Ollama-backend thinking suppression: reasoning_effort injected for thinking-suppressed operations (Ollama ignores chat_template_kwargs). Empty string disables injection."
+      },
       "localLlmRetry5xxCount": {
         "type": "number",
         "default": 1,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3002,6 +3002,19 @@
         "default": "local-model",
         "description": "Model name for local LLM requests"
       },
+      "localLlmReasoningEffort": {
+        "type": "string",
+        "enum": [
+          "",
+          "none",
+          "low",
+          "medium",
+          "high",
+          "max"
+        ],
+        "default": "none",
+        "description": "Ollama-backend thinking suppression: reasoning_effort injected for thinking-suppressed operations (Ollama ignores chat_template_kwargs). Empty string disables injection."
+      },
       "localLlmRetry5xxCount": {
         "type": "number",
         "default": 1,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2870,6 +2870,15 @@ export function parseConfig(
       typeof cfg.localLlm400TripThreshold === "number" ? cfg.localLlm400TripThreshold : 5,
     localLlm400CooldownMs:
       typeof cfg.localLlm400CooldownMs === "number" ? cfg.localLlm400CooldownMs : 120_000,
+    // Ollama thinking suppression dialect (issue #1996): reasoning_effort value
+    // for THINKING_SUPPRESSED_OPERATIONS on the ollama backend. Default "none"
+    // (think off). "" disables injection. Invalid values fall back to "none"
+    // rather than reaching Ollama, which 400s on unknown efforts.
+    localLlmReasoningEffort:
+      typeof cfg.localLlmReasoningEffort === "string" &&
+      ["", "none", "low", "medium", "high", "max"].includes(cfg.localLlmReasoningEffort)
+        ? cfg.localLlmReasoningEffort
+        : "none",
     // Extraction retry/backoff + circuit breaker (extraction hot-loop hardening)
     extractionRetryEnabled: coerceBooleanLike(cfg.extractionRetryEnabled) ?? true,
     extractionRetryScheduleMs:

--- a/packages/remnic-core/src/local-llm-thinking.test.ts
+++ b/packages/remnic-core/src/local-llm-thinking.test.ts
@@ -18,6 +18,7 @@ function createConfig(): PluginConfig {
     localLlm400TripThreshold: 3,
     localLlm400CooldownMs: 60_000,
     debug: false,
+    localLlmReasoningEffort: "none",
     slowLogEnabled: false,
     slowLogThresholdMs: 1_000,
   } as unknown as PluginConfig;
@@ -255,7 +256,7 @@ test("disableThinking fails open for generic backend — no kwarg sent (#548 Cod
   );
 });
 
-test("disableThinking fails open for ollama backend — no kwarg sent", async () => {
+test("ollama backend: suppression injects reasoning_effort, never chat_template_kwargs (#1996)", async () => {
   const client = new LocalLlmClient(createConfig());
   primeClient(client, { thinking: true, detected: "ollama" });
   const { restore, bodies } = captureFetchBodies();
@@ -265,6 +266,59 @@ test("disableThinking fails open for ollama backend — no kwarg sent", async ()
     restore();
   }
   assert.equal("chat_template_kwargs" in (bodies[0] ?? {}), false);
+  assert.equal(bodies[0]?.reasoning_effort, "none");
+});
+
+test("ollama backend: non-suppressed operation gets no reasoning_effort (#1996)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "ollama" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client, "consolidation");
+  } finally {
+    restore();
+  }
+  assert.equal("reasoning_effort" in (bodies[0] ?? {}), false);
+});
+
+test("ollama backend: empty localLlmReasoningEffort disables injection (#1996)", async () => {
+  const config = { ...createConfig(), localLlmReasoningEffort: "" } as PluginConfig;
+  const client = new LocalLlmClient(config);
+  primeClient(client, { thinking: true, detected: "ollama" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client);
+  } finally {
+    restore();
+  }
+  assert.equal("reasoning_effort" in (bodies[0] ?? {}), false);
+  assert.equal("chat_template_kwargs" in (bodies[0] ?? {}), false);
+});
+
+test("ollama backend: configured effort value is passed through (#1996)", async () => {
+  const config = { ...createConfig(), localLlmReasoningEffort: "low" } as PluginConfig;
+  const client = new LocalLlmClient(config);
+  primeClient(client, { thinking: true, detected: "ollama" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client);
+  } finally {
+    restore();
+  }
+  assert.equal(bodies[0]?.reasoning_effort, "low");
+});
+
+test("lmstudio backend never receives reasoning_effort (#1996)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "lmstudio" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client);
+  } finally {
+    restore();
+  }
+  assert.equal("reasoning_effort" in (bodies[0] ?? {}), false);
+  assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
 });
 
 test("disableThinking fails open when backend is undetected (null)", async () => {

--- a/packages/remnic-core/src/local-llm.ts
+++ b/packages/remnic-core/src/local-llm.ts
@@ -999,6 +999,20 @@ export class LocalLlmClient {
         THINKING_COMPATIBLE_BACKENDS.has(this.detectedType)
       ) {
         requestBody.chat_template_kwargs = { enable_thinking: false };
+      } else if (shouldSuppressThinking && this.detectedType === "ollama") {
+        // Ollama's /v1 endpoint silently drops `chat_template_kwargs` AND
+        // `enable_thinking` — the ONLY field it maps to think-off is
+        // `reasoning_effort` ("none" → ThinkValue{false} in openai.go;
+        // verified against Ollama 0.32.0 source and live probes,
+        // issue #1996). Without this, thinking-capable models (Gemma 4,
+        // Qwen 3.5+) burn 1,700-2,000 reasoning tokens per extraction on
+        // Ollama, exceed the client timeout, and retry forever. The effort
+        // is configurable via `localLlmReasoningEffort` (default "none");
+        // an empty value disables injection (pre-#1996 behavior).
+        const effort = this.config.localLlmReasoningEffort;
+        if (effort) {
+          requestBody.reasoning_effort = effort;
+        }
       }
 
       // Normalize URL (use 127.0.0.1 instead of localhost)

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1595,6 +1595,12 @@ export interface PluginConfig {
   localLlmRetryBackoffMs: number;
   localLlm400TripThreshold: number;
   localLlm400CooldownMs: number;
+  /** Ollama-backend thinking suppression: `reasoning_effort` value injected on
+   *  `/v1/chat/completions` for THINKING_SUPPRESSED_OPERATIONS ("none" | "low" |
+   *  "medium" | "high" | "max"; "" disables injection). Ollama ignores
+   *  `chat_template_kwargs`, so this is the only think-off dialect it honors.
+   *  Issue #1996. */
+  localLlmReasoningEffort: string;
   // Extraction retry/backoff + circuit breaker (extraction hot-loop hardening)
   /** Master gate. When false, restores pre-change behavior (extractor called on every triggered observe; no gate). */
   extractionRetryEnabled: boolean;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -3002,6 +3002,19 @@
         "default": "local-model",
         "description": "Model name for local LLM requests"
       },
+      "localLlmReasoningEffort": {
+        "type": "string",
+        "enum": [
+          "",
+          "none",
+          "low",
+          "medium",
+          "high",
+          "max"
+        ],
+        "default": "none",
+        "description": "Ollama-backend thinking suppression: reasoning_effort injected for thinking-suppressed operations (Ollama ignores chat_template_kwargs). Empty string disables injection."
+      },
       "localLlmRetry5xxCount": {
         "type": "number",
         "default": 1,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -8,7 +8,7 @@
       "packages/remnic-core/src/cli.ts": 9429,
       "packages/remnic-core/src/access-service.ts": 5905,
       "packages/remnic-core/src/storage.ts": 6963,
-      "packages/remnic-core/src/config.ts": 4534
+      "packages/remnic-core/src/config.ts": 4543
     },
     "oversizedFileCount": 11,
     "scatteredConfigFlagReads": 6,


### PR DESCRIPTION
Fixes #1996.

## Problem

`LocalLlmClient` suppresses thinking for `THINKING_SUPPRESSED_OPERATIONS` via `chat_template_kwargs: { enable_thinking: false }`, gated to `THINKING_COMPATIBLE_BACKENDS` (lmstudio/vllm/llamacpp) per #548. Ollama was deliberately excluded (400 risk) — so on Ollama, **thinking suppression never fires**. Ollama's `/v1/chat/completions` silently drops both `chat_template_kwargs` and `enable_thinking`; the only think-off field it maps is `reasoning_effort` (`openai.go`: `"none"` → `ThinkValue{false}`; verified against Ollama 0.32.0 source and live probes).

Production impact, measured 2026-07-17: gemma4-31b extraction turns burned 1,700–2,000 reasoning tokens, exceeded the ~2-min client timeout every time on M1 Max-class hardware, and sat in a permanent retry loop (500 @ 1m59s every ~2 min) that saturated the serving lane. A/B with the verbatim production prompt over 4 real transcripts: no-think = 100% precision, 4/4 valid JSON, full dense-content coverage (homelab-infra `docs/remnic-extraction-thinking-ab-2026-07-17.md`). Length-aware thinking (the sparse-transcript quality win) is follow-up #1997.

## Change

- `local-llm.ts`: when suppression applies (same operation gating as today) and `detectedType === "ollama"`, inject `reasoning_effort` from config. lmstudio/vllm/llamacpp keep the existing kwargs path; mlx/generic/null still fail open. Behavior for non-suppressed operations (consolidation) unchanged.
- `types.ts`/`config.ts`: new `localLlmReasoningEffort: string`, **default `"none"`**, validated against Ollama's accepted set (`none|low|medium|high|max`); `""` disables injection entirely (pre-change behavior). Invalid values fall back to `"none"` rather than reaching Ollama (which 400s on unknown efforts → would trip the `localLlm400*` cooldown).
- Schema entry added to all three `openclaw.plugin.json` manifests (config-contract gate).

## Verification

- `local-llm-thinking.test.ts`: 5 new cases — ollama+extraction injects `reasoning_effort:"none"` and never `chat_template_kwargs`; non-suppressed op gets nothing; `""` disables; configured value passes through; lmstudio never receives `reasoning_effort`. 19/19 pass.
- `config.test.ts` 157/157; `@remnic/core` build clean.
- `npm run preflight:quick` → OK; `npm run test:entity-hardening` → 246/246 (config.ts touched).

## Ratchet note

`config.ts` 4534 → 4543 (+9: the parse entry for the new key). Baseline updated per the #1939 precedent (`writeRateLimit*` config keys, baseline 4467 → 4477) — a new config key structurally requires a parse entry; no other growth.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the local LLM request path for a specific backend during high-volume extraction operations; misconfiguration could re-enable heavy reasoning or trigger Ollama 400s, though validation and backend gating limit blast radius.
> 
> **Overview**
> **Ollama** backends now get think-off behavior for the same **thinking-suppressed operations** (extraction, judges, summarization, etc.) that already use `chat_template_kwargs` on lmstudio/vllm/llamacpp. Ollama’s OpenAI-compatible API ignores those kwargs, so suppressed calls inject **`reasoning_effort`** instead (default **`"none"`**).
> 
> New plugin/config key **`localLlmReasoningEffort`**: `none|low|medium|high|max`, or **`""`** to skip injection (pre-fix behavior). Invalid values coerce to **`none`** so Ollama doesn’t 400 on unknown efforts. Non-Ollama backends are unchanged; non-suppressed ops (e.g. consolidation) still get no extra fields.
> 
> Tests cover Ollama injection, opt-out, pass-through, and lmstudio isolation; plugin JSON schemas and a **`config.ts`** ratchet baseline bump are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9808bfa0502862f774f117a18a42c790a9d60cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->