### PR TITLE
perf(#1905): O(candidates) Memory-Worth/TrustScore stage, event-invalidated, deadline-bound

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4339,6 +4339,11 @@
         "default": true,
         "description": "When true, recall multiplies candidate scores by the Memory Worth factor (mw_success / mw_fail counters, see issue #560). Memories with a history of failed sessions sink; neutral/uninstrumented memories are untouched. PR 5 bench: +0.60 precision@5 vs baseline on all 50 seeded cases. Operators can opt out with false."
       },
+      "recallTrustStageCorpusFallbackEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true (default), the Memory-Worth/TrustScore recall rerank stage probes a per-namespace corpus counter/signal map for candidates whose frontmatter was NOT already loaded on the hot path (cold-tier / embedding-fallback / archive rows). The map is version-keyed (invalidated on corpus mutation) and age-bounded for trust signals, so it hits in steady state without the old 30s-TTL permanent-miss. Set false to disable the corpus fallback entirely (only preloaded-candidate + direct-read paths run) — max performance when every candidate is hot, at the cost of neutral treatment for cold candidates."
+      },
       "hotMemoriesCacheEnabled": {
         "type": "boolean",
         "default": true,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -4339,6 +4339,11 @@
         "default": true,
         "description": "When true, recall multiplies candidate scores by the Memory Worth factor (mw_success / mw_fail counters, see issue #560). Memories with a history of failed sessions sink; neutral/uninstrumented memories are untouched. PR 5 bench: +0.60 precision@5 vs baseline on all 50 seeded cases. Operators can opt out with false."
       },
+      "recallTrustStageCorpusFallbackEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true (default), the Memory-Worth/TrustScore recall rerank stage probes a per-namespace corpus counter/signal map for candidates whose frontmatter was NOT already loaded on the hot path (cold-tier / embedding-fallback / archive rows). The map is version-keyed (invalidated on corpus mutation) and age-bounded for trust signals, so it hits in steady state without the old 30s-TTL permanent-miss. Set false to disable the corpus fallback entirely (only preloaded-candidate + direct-read paths run) — max performance when every candidate is hot, at the cost of neutral treatment for cold candidates."
+      },
       "hotMemoriesCacheEnabled": {
         "type": "boolean",
         "default": true,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2126,6 +2126,15 @@ export function parseConfig(
     // opt out with recallMemoryWorthFilterEnabled=false.
     recallMemoryWorthFilterEnabled:
       coerceBool(cfg.recallMemoryWorthFilterEnabled) ?? true,
+    // Trust/Memory-Worth recall stage corpus-level fallback (issue #1905).
+    // Default true: when a candidate is missing from the frontmatter already
+    // loaded on the hot recall path, the stage may fall back to a per-namespace
+    // corpus counter/signal map (version-keyed, so it hits in steady state).
+    // Set false to disable that O(corpus) fallback entirely — the stage then
+    // uses only the preloaded frontmatter plus a bounded-parallel per-candidate
+    // direct read (fully O(candidates)). coerceBool handles "false"/"0" forms.
+    recallTrustStageCorpusFallbackEnabled:
+      coerceBool(cfg.recallTrustStageCorpusFallbackEnabled) ?? true,
     // Hot-memories result cache (issue #1902). Default on: readAllMemories()
     // serves from the version-keyed in-process corpus cache. coerceBool
     // handles "false"/"0" string forms; set false to force disk scans.

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -4356,6 +4356,13 @@ export class RecallInternalCoordinator {
         // its next loop boundary instead of burning I/O after recall returned,
         // and the metric records the truth (#1905, Codex/Kilo).
         const trustAbort = new AbortController();
+        // Also honor the caller's abort (e.g. a disconnected request) while the
+        // stage runs: compose the deadline controller with the request signal so
+        // EITHER cancels the cooperative reads. AbortSignal.any manages the
+        // listener lifecycle internally — no manual disposal (#1905, Codex).
+        const trustSignal = options.abortSignal
+          ? AbortSignal.any([options.abortSignal, trustAbort.signal])
+          : trustAbort.signal;
         const trustFallback = { results: memoryResults, trustByPath: recallTrustByPath };
         const trustOutcome = await awaitAssemblyStep(
           "trustStage",
@@ -4366,7 +4373,7 @@ export class RecallInternalCoordinator {
               caps,
               "hot-qmd",
               qmdBoostInput.memoryByPath,
-              trustAbort.signal,
+              trustSignal,
             ),
           trustFallback,
         );
@@ -4564,6 +4571,11 @@ export class RecallInternalCoordinator {
           // semantics (rule 41 parity).
           const trustT0 = Date.now();
           const trustAbort = new AbortController();
+          // Compose with the caller's signal so a disconnected request also
+          // cancels the cooperative reads (#1905, Codex).
+          const trustSignal = options.abortSignal
+            ? AbortSignal.any([options.abortSignal, trustAbort.signal])
+            : trustAbort.signal;
           const trustFallback = { results: scoped, trustByPath: recallTrustByPath };
           const trustOutcome = await awaitAssemblyStep(
             "trustStage",
@@ -4574,7 +4586,7 @@ export class RecallInternalCoordinator {
                 caps,
                 "embedding-fallback",
                 undefined,
-                trustAbort.signal,
+                trustSignal,
               ),
             trustFallback,
           );
@@ -4764,6 +4776,11 @@ export class RecallInternalCoordinator {
           // Deadline-bound (issue #1905); no preloaded map on this branch.
           const trustT0 = Date.now();
           const trustAbort = new AbortController();
+          // Compose with the caller's signal so a disconnected request also
+          // cancels the cooperative reads (#1905, Codex).
+          const trustSignal = options.abortSignal
+            ? AbortSignal.any([options.abortSignal, trustAbort.signal])
+            : trustAbort.signal;
           const trustFallback = { results: scoped, trustByPath: recallTrustByPath };
           const trustOutcome = await awaitAssemblyStep(
             "trustStage",
@@ -4774,7 +4791,7 @@ export class RecallInternalCoordinator {
                 caps,
                 "embedding-fallback",
                 undefined,
-                trustAbort.signal,
+                trustSignal,
               ),
             trustFallback,
           );
@@ -4990,6 +5007,11 @@ export class RecallInternalCoordinator {
                 queryAwareScopedMemories.filter((m) => m.path).map((m) => [m.path, m]),
               );
               const trustAbort = new AbortController();
+              // Compose with the caller's signal so a disconnected request also
+              // cancels the cooperative reads (#1905, Codex).
+              const trustSignal = options.abortSignal
+                ? AbortSignal.any([options.abortSignal, trustAbort.signal])
+                : trustAbort.signal;
               const trustFallback = { results: recent, trustByPath: recallTrustByPath };
               const trustOutcome = await awaitAssemblyStep(
                 "trustStage",
@@ -5000,7 +5022,7 @@ export class RecallInternalCoordinator {
                     caps,
                     "recent-scan",
                     recentPreloaded,
-                    trustAbort.signal,
+                    trustSignal,
                   ),
                 trustFallback,
               );

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -151,6 +151,7 @@ export interface RecallInternalDeps {
     caps: CapabilitySet,
     label: string,
     preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
+    abortSignal?: AbortSignal,
   ): Promise<{
     results: QmdSearchResult[];
     trustByPath: Map<string, TrustStageResultItem> | null;
@@ -4348,6 +4349,14 @@ export class RecallInternalCoordinator {
         // Pass the frontmatter already loaded by the safety filter so the stage
         // does O(candidates) work instead of a full-corpus scan.
         const trustT0 = Date.now();
+        // The fallback is a distinct object: identity-comparing the outcome to
+        // it detects a deadline/abort/error fallback without changing
+        // awaitAssemblyStep. On fallback the losing task is cooperatively
+        // cancelled via the AbortController so an orphaned corpus scan stops at
+        // its next loop boundary instead of burning I/O after recall returned,
+        // and the metric records the truth (#1905, Codex/Kilo).
+        const trustAbort = new AbortController();
+        const trustFallback = { results: memoryResults, trustByPath: recallTrustByPath };
         const trustOutcome = await awaitAssemblyStep(
           "trustStage",
           () =>
@@ -4357,9 +4366,12 @@ export class RecallInternalCoordinator {
               caps,
               "hot-qmd",
               qmdBoostInput.memoryByPath,
+              trustAbort.signal,
             ),
-          { results: memoryResults, trustByPath: recallTrustByPath },
+          trustFallback,
         );
+        const trustFellBack = trustOutcome === trustFallback;
+        if (trustFellBack) trustAbort.abort();
         memoryResults = trustOutcome.results;
         recallTrustByPath = trustOutcome.trustByPath;
         recordRecallSectionMetric({
@@ -4368,7 +4380,7 @@ export class RecallInternalCoordinator {
           durationMs: Date.now() - trustT0,
           deadlineMs: enrichmentSectionDeadlineMs,
           source: "fresh",
-          success: true,
+          success: !trustFellBack,
         });
       }
 
@@ -4551,6 +4563,8 @@ export class RecallInternalCoordinator {
           // the stage's corpus/direct-read fallback cover it — identical lookup
           // semantics (rule 41 parity).
           const trustT0 = Date.now();
+          const trustAbort = new AbortController();
+          const trustFallback = { results: scoped, trustByPath: recallTrustByPath };
           const trustOutcome = await awaitAssemblyStep(
             "trustStage",
             () =>
@@ -4559,9 +4573,13 @@ export class RecallInternalCoordinator {
                 recallNamespaces,
                 caps,
                 "embedding-fallback",
+                undefined,
+                trustAbort.signal,
               ),
-            { results: scoped, trustByPath: recallTrustByPath },
+            trustFallback,
           );
+          const trustFellBack = trustOutcome === trustFallback;
+          if (trustFellBack) trustAbort.abort();
           scoped = trustOutcome.results;
           recallTrustByPath = trustOutcome.trustByPath;
           recordRecallSectionMetric({
@@ -4570,7 +4588,7 @@ export class RecallInternalCoordinator {
             durationMs: Date.now() - trustT0,
             deadlineMs: enrichmentSectionDeadlineMs,
             source: "fresh",
-            success: true,
+            success: !trustFellBack,
           });
         }
         if (scoped.length > 0) {
@@ -4745,6 +4763,8 @@ export class RecallInternalCoordinator {
         {
           // Deadline-bound (issue #1905); no preloaded map on this branch.
           const trustT0 = Date.now();
+          const trustAbort = new AbortController();
+          const trustFallback = { results: scoped, trustByPath: recallTrustByPath };
           const trustOutcome = await awaitAssemblyStep(
             "trustStage",
             () =>
@@ -4753,9 +4773,13 @@ export class RecallInternalCoordinator {
                 recallNamespaces,
                 caps,
                 "embedding-fallback",
+                undefined,
+                trustAbort.signal,
               ),
-            { results: scoped, trustByPath: recallTrustByPath },
+            trustFallback,
           );
+          const trustFellBack = trustOutcome === trustFallback;
+          if (trustFellBack) trustAbort.abort();
           scoped = trustOutcome.results;
           recallTrustByPath = trustOutcome.trustByPath;
           recordRecallSectionMetric({
@@ -4764,7 +4788,7 @@ export class RecallInternalCoordinator {
             durationMs: Date.now() - trustT0,
             deadlineMs: enrichmentSectionDeadlineMs,
             source: "fresh",
-            success: true,
+            success: !trustFellBack,
           });
         }
       if (scoped.length > 0) {
@@ -4965,6 +4989,8 @@ export class RecallInternalCoordinator {
               const recentPreloaded = new Map<string, MemoryFile>(
                 queryAwareScopedMemories.filter((m) => m.path).map((m) => [m.path, m]),
               );
+              const trustAbort = new AbortController();
+              const trustFallback = { results: recent, trustByPath: recallTrustByPath };
               const trustOutcome = await awaitAssemblyStep(
                 "trustStage",
                 () =>
@@ -4974,9 +5000,12 @@ export class RecallInternalCoordinator {
                     caps,
                     "recent-scan",
                     recentPreloaded,
+                    trustAbort.signal,
                   ),
-                { results: recent, trustByPath: recallTrustByPath },
+                trustFallback,
               );
+              const trustFellBack = trustOutcome === trustFallback;
+              if (trustFellBack) trustAbort.abort();
               recent = trustOutcome.results;
               recallTrustByPath = trustOutcome.trustByPath;
               recordRecallSectionMetric({
@@ -4985,7 +5014,7 @@ export class RecallInternalCoordinator {
                 durationMs: Date.now() - trustT0,
                 deadlineMs: enrichmentSectionDeadlineMs,
                 source: "fresh",
-                success: true,
+                success: !trustFellBack,
               });
             }
 

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -150,6 +150,7 @@ export interface RecallInternalDeps {
     namespaces: string[],
     caps: CapabilitySet,
     label: string,
+    preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
   ): Promise<{
     results: QmdSearchResult[];
     trustByPath: Map<string, TrustStageResultItem> | null;
@@ -4340,14 +4341,35 @@ export class RecallInternalCoordinator {
       // EVERY recall path via applyTrustScoreToBranch so the gate is consistent
       // (rule 41 parity). Fail-open on lookup errors so recall never breaks.
       {
-        const trustOutcome = await this.deps.applyTrustScoreToBranch(
-          memoryResults,
-          recallNamespaces,
-          caps,
-          "hot-qmd",
+        // Deadline-bound the trust stage (issue #1905): a slow corpus scan must
+        // not outrun the shared enrichment-assembly budget (the source of the
+        // 17s qmdPost outliers). On timeout/abort/error the fallback returns
+        // the inputs unchanged — the stage is already documented fail-open.
+        // Pass the frontmatter already loaded by the safety filter so the stage
+        // does O(candidates) work instead of a full-corpus scan.
+        const trustT0 = Date.now();
+        const trustOutcome = await awaitAssemblyStep(
+          "trustStage",
+          () =>
+            this.deps.applyTrustScoreToBranch(
+              memoryResults,
+              recallNamespaces,
+              caps,
+              "hot-qmd",
+              qmdBoostInput.memoryByPath,
+            ),
+          { results: memoryResults, trustByPath: recallTrustByPath },
         );
         memoryResults = trustOutcome.results;
         recallTrustByPath = trustOutcome.trustByPath;
+        recordRecallSectionMetric({
+          section: "trustStage",
+          priority: "enrichment",
+          durationMs: Date.now() - trustT0,
+          deadlineMs: enrichmentSectionDeadlineMs,
+          source: "fresh",
+          success: true,
+        });
       }
 
       // Synapse-inspired confidence gate: check scores BEFORE slicing so
@@ -4524,14 +4546,32 @@ export class RecallInternalCoordinator {
         // Issue #1577 — apply TrustScore on the embedding-fallback path so the
         // feature gate is consistent across ALL recall paths (rule 41 parity).
         {
-          const trustOutcome = await this.deps.applyTrustScoreToBranch(
-            scoped,
-            recallNamespaces,
-            caps,
-            "embedding-fallback",
+          // Deadline-bound (issue #1905). This branch has no preloaded
+          // frontmatter map (boost ran without one), so pass undefined and let
+          // the stage's corpus/direct-read fallback cover it — identical lookup
+          // semantics (rule 41 parity).
+          const trustT0 = Date.now();
+          const trustOutcome = await awaitAssemblyStep(
+            "trustStage",
+            () =>
+              this.deps.applyTrustScoreToBranch(
+                scoped,
+                recallNamespaces,
+                caps,
+                "embedding-fallback",
+              ),
+            { results: scoped, trustByPath: recallTrustByPath },
           );
           scoped = trustOutcome.results;
           recallTrustByPath = trustOutcome.trustByPath;
+          recordRecallSectionMetric({
+            section: "trustStage",
+            priority: "enrichment",
+            durationMs: Date.now() - trustT0,
+            deadlineMs: enrichmentSectionDeadlineMs,
+            source: "fresh",
+            success: true,
+          });
         }
         if (scoped.length > 0) {
           if (shouldPersistGraphSnapshot) {
@@ -4703,14 +4743,29 @@ export class RecallInternalCoordinator {
         // Issue #1577 — apply TrustScore on the embedding-fallback path so the
         // feature gate is consistent across ALL recall paths (rule 41 parity).
         {
-          const trustOutcome = await this.deps.applyTrustScoreToBranch(
-            scoped,
-            recallNamespaces,
-            caps,
-            "embedding-fallback",
+          // Deadline-bound (issue #1905); no preloaded map on this branch.
+          const trustT0 = Date.now();
+          const trustOutcome = await awaitAssemblyStep(
+            "trustStage",
+            () =>
+              this.deps.applyTrustScoreToBranch(
+                scoped,
+                recallNamespaces,
+                caps,
+                "embedding-fallback",
+              ),
+            { results: scoped, trustByPath: recallTrustByPath },
           );
           scoped = trustOutcome.results;
           recallTrustByPath = trustOutcome.trustByPath;
+          recordRecallSectionMetric({
+            section: "trustStage",
+            priority: "enrichment",
+            durationMs: Date.now() - trustT0,
+            deadlineMs: enrichmentSectionDeadlineMs,
+            source: "fresh",
+            success: true,
+          });
         }
       if (scoped.length > 0) {
         if (shouldPersistGraphSnapshot) {
@@ -4902,14 +4957,36 @@ export class RecallInternalCoordinator {
             // Issue #1577 — apply TrustScore on the recent-scan path so the
             // feature gate is consistent across ALL recall paths (rule 41).
             {
-              const trustOutcome = await this.deps.applyTrustScoreToBranch(
-                recent,
-                recallNamespaces,
-                caps,
-                "recent-scan",
+              // Deadline-bound (issue #1905). The recent-scan branch already
+              // loaded every candidate's MemoryFile (queryAwareScopedMemories),
+              // so hand that frontmatter to the stage as the preloaded map —
+              // the trust/memory-worth lookup then does zero corpus scans.
+              const trustT0 = Date.now();
+              const recentPreloaded = new Map<string, MemoryFile>(
+                queryAwareScopedMemories.filter((m) => m.path).map((m) => [m.path, m]),
+              );
+              const trustOutcome = await awaitAssemblyStep(
+                "trustStage",
+                () =>
+                  this.deps.applyTrustScoreToBranch(
+                    recent,
+                    recallNamespaces,
+                    caps,
+                    "recent-scan",
+                    recentPreloaded,
+                  ),
+                { results: recent, trustByPath: recallTrustByPath },
               );
               recent = trustOutcome.results;
               recallTrustByPath = trustOutcome.trustByPath;
+              recordRecallSectionMetric({
+                section: "trustStage",
+                priority: "enrichment",
+                durationMs: Date.now() - trustT0,
+                deadlineMs: enrichmentSectionDeadlineMs,
+                source: "fresh",
+                success: true,
+              });
             }
 
             if (recent.length > 0) {

--- a/packages/remnic-core/src/orchestration/recall-rerank-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/recall-rerank-coordinator.ts
@@ -112,6 +112,8 @@ export class RecallRerankCoordinator {
     // backward-compatible. When present, counters are seeded from it directly
     // and the O(corpus) `readAllMemories` scan is skipped for warm candidates.
     preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
+    // Cooperative cancellation (issue #1905, Codex); additive + last.
+    abortSignal?: AbortSignal,
   ): Promise<QmdSearchResult[]> {
     const config = this.getConfig();
     const counters = new Map<string, MemoryWorthCounters>();
@@ -151,6 +153,9 @@ export class RecallRerankCoordinator {
     if (config.recallTrustStageCorpusFallbackEnabled) {
       const seenNamespaces = new Set<string>();
       for (const ns of namespaces) {
+        // Cooperative cancellation: the recall's assembly deadline may have won
+        // the race — stop before another namespace scan (#1905, Codex).
+        if (abortSignal?.aborted) break;
         if (seenNamespaces.has(ns)) continue;
         seenNamespaces.add(ns);
         if (results.every((r) => counters.has(r.path) || preloadedPaths.has(r.path))) break;
@@ -208,6 +213,8 @@ export class RecallRerankCoordinator {
         const readerNn = reader;
         const BATCH = 16;
         for (let off = 0; off < missing.length; off += BATCH) {
+          // Cooperative cancellation between batches (#1905, Codex).
+          if (abortSignal?.aborted) break;
           await Promise.all(
             missing.slice(off, off + BATCH).map(async (r) => {
               try {
@@ -295,6 +302,10 @@ export class RecallRerankCoordinator {
     // #1905); additive + last for positional back-compat. Seeds signals
     // directly so warm candidates skip the O(corpus) namespace scan.
     preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
+    // Cooperative cancellation (issue #1905, Codex): aborted by the host when
+    // the recall's assembly deadline wins the race, so orphaned corpus scans
+    // stop at the next loop boundary. Additive + last for positional back-compat.
+    abortSignal?: AbortSignal,
   ): Promise<{
     results: QmdSearchResult[];
     trustByPath: Map<string, TrustStageResultItem> | null;
@@ -341,6 +352,7 @@ export class RecallRerankCoordinator {
         logDebug: (message, context) => log.debug(message, context),
         preloadedFrontmatter,
         corpusFallbackEnabled: config.recallTrustStageCorpusFallbackEnabled,
+        abortSignal,
       },
     );
     if (signals.size === 0) {
@@ -385,13 +397,15 @@ export class RecallRerankCoordinator {
     // branches without a safety-filter map → falls back to corpus/direct-read
     // (identical lookup result, rule 41 parity).
     preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
+    // Cooperative cancellation (issue #1905, Codex); additive + last.
+    abortSignal?: AbortSignal,
   ): Promise<{
     results: QmdSearchResult[];
     trustByPath: Map<string, TrustStageResultItem> | null;
   }> {
     if (caps.recallTrustScore && results.length > 0) {
       try {
-        return await this.applyTrustScoreRerank(results, namespaces, preloadedFrontmatter);
+        return await this.applyTrustScoreRerank(results, namespaces, preloadedFrontmatter, abortSignal);
       } catch (err) {
         log.debug(`trust-score stage (${label}) failed open`, {
           error: (err as Error).message,
@@ -399,7 +413,12 @@ export class RecallRerankCoordinator {
       }
     } else if (caps.recallMemoryWorthFilter && results.length > 0) {
       try {
-        const filtered = await this.applyMemoryWorthRerank(results, namespaces, preloadedFrontmatter);
+        const filtered = await this.applyMemoryWorthRerank(
+          results,
+          namespaces,
+          preloadedFrontmatter,
+          abortSignal,
+        );
         return { results: filtered, trustByPath: null };
       } catch (err) {
         log.debug(`memory-worth filter (${label}) failed open`, {

--- a/packages/remnic-core/src/orchestration/recall-rerank-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/recall-rerank-coordinator.ts
@@ -49,17 +49,22 @@ export class RecallRerankCoordinator {
     recallNamespaces: readonly string[],
   ) => Promise<MemoryFile | null>;
 
+  // Per-namespace corpus-fallback caches (issue #1905). Keyed on the shared
+  // cross-process memory-corpus version rather than a wall-clock TTL: the old
+  // 30s TTL was SHORTER than recall p50 (~30.5s) so every steady-state recall
+  // was a guaranteed miss + full-corpus scan. The corpus version bumps on every
+  // memory mutation (StorageManager.getMemoryCorpusVersion / patchHotMemoriesCache),
+  // including mw_success/mw_fail counter writes, so a version match means the
+  // derived map is still current and can be served; a mismatch re-derives.
   private readonly memoryWorthCounterCache = new Map<
     string,
-    { at: number; counters: ReadonlyMap<string, MemoryWorthCounters> }
+    { version: number; counters: ReadonlyMap<string, MemoryWorthCounters> }
   >();
-  private static readonly MEMORY_WORTH_CACHE_TTL_MS = 30_000;
 
   private readonly trustSignalCache = new Map<
     string,
-    { at: number; signals: ReadonlyMap<string, TrustSignals> }
+    { version: number; signals: ReadonlyMap<string, TrustSignals> }
   >();
-  private static readonly TRUST_SIGNAL_CACHE_TTL_MS = 30_000;
 
   constructor(options: {
     getConfig: () => PluginConfig;
@@ -78,66 +83,80 @@ export class RecallRerankCoordinator {
   async applyMemoryWorthRerank(
     results: QmdSearchResult[],
     namespaces: string[],
+    // Candidate frontmatter already loaded on the hot recall path (issue
+    // #1905). Additive + last so the positional call shape stays
+    // backward-compatible. When present, counters are seeded from it directly
+    // and the O(corpus) `readAllMemories` scan is skipped for warm candidates.
+    preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
   ): Promise<QmdSearchResult[]> {
-    // Build the counter lookup. We union frontmatter counters across every
-    // namespace the recall spans — the recall path itself already
-    // aggregates candidates from multiple namespaces, so we must do the
-    // same when looking up counters. Per-namespace results are cached with
-    // a short TTL so interactive recall doesn't trigger a full
-    // `readAllMemories` scan per query (addresses codex P2 on PR 4).
+    const config = this.getConfig();
     const counters = new Map<string, MemoryWorthCounters>();
-    const seenNamespaces = new Set<string>();
-    const nowMs = Date.now();
 
-    // Evict all expired entries on every call so long-running processes
-    // touching a high-cardinality namespace set (coding/project overlays,
-    // per-branch) don't grow the cache unboundedly. Without this, an entry
-    // for a namespace that's never looked up again would pin its full
-    // counter map forever.
-    for (const [key, entry] of this.memoryWorthCounterCache) {
-      if (nowMs - entry.at >= RecallRerankCoordinator.MEMORY_WORTH_CACHE_TTL_MS) {
-        this.memoryWorthCounterCache.delete(key);
-      }
-    }
-
-    for (const ns of namespaces) {
-      if (seenNamespaces.has(ns)) continue;
-      seenNamespaces.add(ns);
-      try {
-        const cached = this.memoryWorthCounterCache.get(ns);
-        let nsMap: ReadonlyMap<string, MemoryWorthCounters> | undefined;
-        if (
-          cached &&
-          nowMs - cached.at < RecallRerankCoordinator.MEMORY_WORTH_CACHE_TTL_MS
-        ) {
-          nsMap = cached.counters;
-        } else {
-          const storage = await this.getStorage(ns);
-          const memories = await storage.readAllMemories();
-          nsMap = buildMemoryWorthCounterMap(memories);
-          this.memoryWorthCounterCache.set(ns, { at: nowMs, counters: nsMap });
-        }
-        for (const [path, c] of nsMap) counters.set(path, c);
-      } catch (err) {
-        log.debug("memory-worth: failed to read namespace, skipping", {
-          namespace: ns,
-          error: (err as Error).message,
+    // O(candidates) fast path (issue #1905): seed counters directly from
+    // frontmatter already loaded on the hot path. The
+    // `mw_success === undefined && mw_fail === undefined` guard matches
+    // `buildMemoryWorthCounterMap` exactly so a candidate with no counters is a
+    // neutral prior, identical to the corpus scan.
+    if (preloadedFrontmatter) {
+      for (const r of results) {
+        const mem = preloadedFrontmatter.get(r.path);
+        if (!mem) continue;
+        const fm = mem.frontmatter;
+        if (fm.mw_success === undefined && fm.mw_fail === undefined) continue;
+        counters.set(r.path, {
+          mw_success: fm.mw_success,
+          mw_fail: fm.mw_fail,
+          lastAccessed: fm.lastAccessed,
         });
       }
     }
 
-    // For candidates whose path didn't show up in any hot-tier namespace
-    // scan (typical of cold-tier / archive fallback), try a direct
-    // per-path read. Without this, cold-tier candidates always stay at
-    // multiplier 1.0 even when they have outcome history. Errors are
-    // swallowed so a single unreadable archive entry can't break the
-    // whole recall.
+    // Corpus-level fallback (config-gated): candidates still missing from the
+    // preloaded map probe a per-namespace counter map. The map is cached and
+    // invalidated by the shared cross-process corpus version (not a wall-clock
+    // TTL), so it actually hits in steady state. Only the candidate rows are
+    // copied out — never the whole ~99K-entry map (issue #1905).
+    if (config.recallTrustStageCorpusFallbackEnabled) {
+      const seenNamespaces = new Set<string>();
+      for (const ns of namespaces) {
+        if (seenNamespaces.has(ns)) continue;
+        seenNamespaces.add(ns);
+        if (results.every((r) => counters.has(r.path))) break;
+        try {
+          const storage = await this.getStorage(ns);
+          const version = storage.getMemoryCorpusVersion();
+          const cached = this.memoryWorthCounterCache.get(ns);
+          let nsMap: ReadonlyMap<string, MemoryWorthCounters>;
+          if (cached && cached.version === version) {
+            nsMap = cached.counters;
+          } else {
+            const memories = await storage.readAllMemories();
+            nsMap = buildMemoryWorthCounterMap(memories);
+            this.memoryWorthCounterCache.set(ns, { version, counters: nsMap });
+          }
+          for (const r of results) {
+            if (counters.has(r.path)) continue;
+            const c = nsMap.get(r.path);
+            if (c) counters.set(r.path, c);
+          }
+        } catch (err) {
+          log.debug("memory-worth: failed to read namespace, skipping", {
+            namespace: ns,
+            error: (err as Error).message,
+          });
+        }
+      }
+    }
+
+    // For candidates still absent (cold-tier / archive, or corpus fallback
+    // disabled), try a direct per-path read. Bounded-parallel (≤16) to match
+    // loadSearchResultMemoryMap's batch size (issue #1905). Errors are swallowed
+    // so a single unreadable archive entry can't break the whole recall.
     const missing = results.filter((r) => !counters.has(r.path));
     if (missing.length > 0) {
       // Use the first-seen namespace's storage as the reader — all
-      // StorageManagers share the same on-disk format, and
-      // `readMemoryByPath` takes an absolute path so the baseDir doesn't
-      // have to match.
+      // StorageManagers share the same on-disk format, and readMemoryByPath
+      // takes an absolute path so the baseDir doesn't have to match.
       let reader: StorageManager | null = null;
       for (const ns of namespaces) {
         try {
@@ -148,23 +167,29 @@ export class RecallRerankCoordinator {
         }
       }
       if (reader) {
-        for (const r of missing) {
-          try {
-            const memory = await this.readQmdResultMemory(r.path, reader, namespaces);
-            if (!memory) continue;
-            const fm = memory.frontmatter;
-            if (fm.mw_success === undefined && fm.mw_fail === undefined) continue;
-            counters.set(r.path, {
-              mw_success: fm.mw_success,
-              mw_fail: fm.mw_fail,
-              lastAccessed: fm.lastAccessed,
-            });
-          } catch (err) {
-            log.debug("memory-worth: direct path lookup failed", {
-              path: r.path,
-              error: (err as Error).message,
-            });
-          }
+        const readerNn = reader;
+        const BATCH = 16;
+        for (let off = 0; off < missing.length; off += BATCH) {
+          await Promise.all(
+            missing.slice(off, off + BATCH).map(async (r) => {
+              try {
+                const memory = await this.readQmdResultMemory(r.path, readerNn, namespaces);
+                if (!memory) return;
+                const fm = memory.frontmatter;
+                if (fm.mw_success === undefined && fm.mw_fail === undefined) return;
+                counters.set(r.path, {
+                  mw_success: fm.mw_success,
+                  mw_fail: fm.mw_fail,
+                  lastAccessed: fm.lastAccessed,
+                });
+              } catch (err) {
+                log.debug("memory-worth: direct path lookup failed", {
+                  path: r.path,
+                  error: (err as Error).message,
+                });
+              }
+            }),
+          );
         }
       }
     }
@@ -188,7 +213,6 @@ export class RecallRerankCoordinator {
       // we never hit zero; descending so earlier items rank higher.
       score: results.length - i,
     }));
-    const config = this.getConfig();
     const filtered = applyMemoryWorthFilter(rankedInputs, {
       counters,
       now: new Date(),
@@ -229,6 +253,10 @@ export class RecallRerankCoordinator {
   async applyTrustScoreRerank(
     results: QmdSearchResult[],
     namespaces: string[],
+    // Candidate frontmatter already loaded on the hot recall path (issue
+    // #1905); additive + last for positional back-compat. Seeds signals
+    // directly so warm candidates skip the O(corpus) namespace scan.
+    preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
   ): Promise<{
     results: QmdSearchResult[];
     trustByPath: Map<string, TrustStageResultItem> | null;
@@ -263,12 +291,18 @@ export class RecallRerankCoordinator {
           const memory = await this.readQmdResultMemory(path, fallbackReader, namespaces);
           return memory ? memory.frontmatter : null;
         },
+        // Corpus version bumps on every memory mutation (including mw counter
+        // writes) — keys the per-namespace signal cache so it invalidates on
+        // the next write instead of a wall-clock TTL (issue #1905).
+        getNamespaceVersion: async (ns) => (await this.getStorage(ns)).getMemoryCorpusVersion(),
       },
-      { cache: this.trustSignalCache, ttlMs: RecallRerankCoordinator.TRUST_SIGNAL_CACHE_TTL_MS },
+      { cache: this.trustSignalCache },
       now,
       {
         recencyHalfLifeDays: halfLifeDays,
         logDebug: (message, context) => log.debug(message, context),
+        preloadedFrontmatter,
+        corpusFallbackEnabled: config.recallTrustStageCorpusFallbackEnabled,
       },
     );
     if (signals.size === 0) {
@@ -307,13 +341,19 @@ export class RecallRerankCoordinator {
     namespaces: string[],
     caps: CapabilitySet,
     label: string,
+    // Candidate frontmatter already loaded on this branch's hot path (issue
+    // #1905); additive + last. Threaded to the active stage so it does
+    // O(candidates) work instead of a full-corpus scan. `undefined` on
+    // branches without a safety-filter map → falls back to corpus/direct-read
+    // (identical lookup result, rule 41 parity).
+    preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
   ): Promise<{
     results: QmdSearchResult[];
     trustByPath: Map<string, TrustStageResultItem> | null;
   }> {
     if (caps.recallTrustScore && results.length > 0) {
       try {
-        return await this.applyTrustScoreRerank(results, namespaces);
+        return await this.applyTrustScoreRerank(results, namespaces, preloadedFrontmatter);
       } catch (err) {
         log.debug(`trust-score stage (${label}) failed open`, {
           error: (err as Error).message,
@@ -321,7 +361,7 @@ export class RecallRerankCoordinator {
       }
     } else if (caps.recallMemoryWorthFilter && results.length > 0) {
       try {
-        const filtered = await this.applyMemoryWorthRerank(results, namespaces);
+        const filtered = await this.applyMemoryWorthRerank(results, namespaces, preloadedFrontmatter);
         return { results: filtered, trustByPath: null };
       } catch (err) {
         log.debug(`memory-worth filter (${label}) failed open`, {

--- a/packages/remnic-core/src/orchestration/recall-rerank-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/recall-rerank-coordinator.ts
@@ -63,8 +63,32 @@ export class RecallRerankCoordinator {
 
   private readonly trustSignalCache = new Map<
     string,
-    { version: number; signals: ReadonlyMap<string, TrustSignals> }
+    { version: number; cachedAt: number; signals: ReadonlyMap<string, TrustSignals> }
   >();
+
+  /**
+   * Cap on distinct namespaces retained in the corpus-fallback caches. Each
+   * entry holds a derived per-namespace map; on high-cardinality namespace
+   * workloads an unbounded map would grow without limit (#1905, Cursor). Map
+   * preserves insertion order, so overflow evicts the oldest namespace.
+   */
+  private static readonly CORPUS_FALLBACK_CACHE_MAX_NAMESPACES = 64;
+
+  // Trust-signal age bound (TRUST_SIGNAL_CACHE_MAX_AGE_MS) lives in
+  // trust-score-stage.ts — that module owns the signal cache's read/write and
+  // the TTL check (signals bake `now` into their values). This coordinator only
+  // owns the memory-worth counter cache, whose values are raw (no `now`), so it
+  // is version-keyed only.
+
+
+  /** Insert-ordered bounded set: evict the oldest namespace on overflow. */
+  private static capCache<K, V>(cache: Map<K, V>, max: number): void {
+    while (cache.size > max) {
+      const oldest = cache.keys().next().value;
+      if (oldest === undefined) break;
+      cache.delete(oldest);
+    }
+  }
 
   constructor(options: {
     getConfig: () => PluginConfig;
@@ -91,6 +115,13 @@ export class RecallRerankCoordinator {
   ): Promise<QmdSearchResult[]> {
     const config = this.getConfig();
     const counters = new Map<string, MemoryWorthCounters>();
+    // Paths examined via preloaded frontmatter (issue #1905, Codex). A candidate
+    // whose frontmatter is present but has no mw_success/mw_fail is a NEUTRAL
+    // prior — it must NOT be treated as "missing", otherwise the corpus scan +
+    // direct-read fallback fire for every uninstrumented hot-QMD candidate and
+    // the O(candidates) fast path is defeated. Track preloaded paths separately
+    // from counters and exclude them from every fallback.
+    const preloadedPaths = new Set<string>();
 
     // O(candidates) fast path (issue #1905): seed counters directly from
     // frontmatter already loaded on the hot path. The
@@ -101,6 +132,7 @@ export class RecallRerankCoordinator {
       for (const r of results) {
         const mem = preloadedFrontmatter.get(r.path);
         if (!mem) continue;
+        preloadedPaths.add(r.path);
         const fm = mem.frontmatter;
         if (fm.mw_success === undefined && fm.mw_fail === undefined) continue;
         counters.set(r.path, {
@@ -121,7 +153,7 @@ export class RecallRerankCoordinator {
       for (const ns of namespaces) {
         if (seenNamespaces.has(ns)) continue;
         seenNamespaces.add(ns);
-        if (results.every((r) => counters.has(r.path))) break;
+        if (results.every((r) => counters.has(r.path) || preloadedPaths.has(r.path))) break;
         try {
           const storage = await this.getStorage(ns);
           const version = storage.getMemoryCorpusVersion();
@@ -133,9 +165,15 @@ export class RecallRerankCoordinator {
             const memories = await storage.readAllMemories();
             nsMap = buildMemoryWorthCounterMap(memories);
             this.memoryWorthCounterCache.set(ns, { version, counters: nsMap });
+            RecallRerankCoordinator.capCache(
+              this.memoryWorthCounterCache,
+              RecallRerankCoordinator.CORPUS_FALLBACK_CACHE_MAX_NAMESPACES,
+            );
           }
           for (const r of results) {
-            if (counters.has(r.path)) continue;
+            // Skip candidates already satisfied by a counter OR already examined
+            // via preloaded frontmatter (neutral prior — no corpus lookup needed).
+            if (counters.has(r.path) || preloadedPaths.has(r.path)) continue;
             const c = nsMap.get(r.path);
             if (c) counters.set(r.path, c);
           }
@@ -152,7 +190,7 @@ export class RecallRerankCoordinator {
     // disabled), try a direct per-path read. Bounded-parallel (≤16) to match
     // loadSearchResultMemoryMap's batch size (issue #1905). Errors are swallowed
     // so a single unreadable archive entry can't break the whole recall.
-    const missing = results.filter((r) => !counters.has(r.path));
+    const missing = results.filter((r) => !counters.has(r.path) && !preloadedPaths.has(r.path));
     if (missing.length > 0) {
       // Use the first-seen namespace's storage as the reader — all
       // StorageManagers share the same on-disk format, and readMemoryByPath

--- a/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
+++ b/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
@@ -56,10 +56,12 @@ export interface RecallSearchPipelineDeps {
   applyMemoryWorthRerank(
     results: QmdSearchResult[],
     namespaces: string[],
+    preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
   ): Promise<QmdSearchResult[]>;
   applyTrustScoreRerank(
     results: QmdSearchResult[],
     namespaces: string[],
+    preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
   ): Promise<{
     results: QmdSearchResult[];
     trustByPath: Map<string, TrustStageResultItem> | null;
@@ -1131,7 +1133,7 @@ export class RecallSearchPipelineCoordinator {
     // Fail-open on lookup errors.
     if (caps.recallTrustScore && results.length > 0) {
       try {
-        const trustOutcome = await this.deps.applyTrustScoreRerank(results, options.recallNamespaces);
+        const trustOutcome = await this.deps.applyTrustScoreRerank(results, options.recallNamespaces, boostInput.memoryByPath);
         results = trustOutcome.results;
         if (options.trustByPathSink) options.trustByPathSink.trustByPath = trustOutcome.trustByPath;
       } catch (err) {
@@ -1141,7 +1143,7 @@ export class RecallSearchPipelineCoordinator {
       }
     } else if (caps.recallMemoryWorthFilter && results.length > 0) {
       try {
-        results = await this.deps.applyMemoryWorthRerank(results, options.recallNamespaces);
+        results = await this.deps.applyMemoryWorthRerank(results, options.recallNamespaces, boostInput.memoryByPath);
       } catch (err) {
         log.debug("memory-worth filter (cold) failed open", {
           error: (err as Error).message,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3455,11 +3455,19 @@ export class Orchestrator {
     caps: CapabilitySet,
     label: string,
     preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
+    abortSignal?: AbortSignal,
   ): Promise<{
     results: QmdSearchResult[];
     trustByPath: Map<string, TrustStageResultItem> | null;
   }> {
-    return this.recallRerankCoordinator.applyTrustScoreToBranch(results, namespaces, caps, label, preloadedFrontmatter);
+    return this.recallRerankCoordinator.applyTrustScoreToBranch(
+      results,
+      namespaces,
+      caps,
+      label,
+      preloadedFrontmatter,
+      abortSignal,
+    );
   }
 
   private diversifyAndLimitRecallResults(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3433,18 +3433,20 @@ export class Orchestrator {
   private async applyMemoryWorthRerank(
     results: QmdSearchResult[],
     namespaces: string[],
+    preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
   ): Promise<QmdSearchResult[]> {
-    return this.recallRerankCoordinator.applyMemoryWorthRerank(results, namespaces);
+    return this.recallRerankCoordinator.applyMemoryWorthRerank(results, namespaces, preloadedFrontmatter);
   }
 
   private async applyTrustScoreRerank(
     results: QmdSearchResult[],
     namespaces: string[],
+    preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
   ): Promise<{
     results: QmdSearchResult[];
     trustByPath: Map<string, TrustStageResultItem> | null;
   }> {
-    return this.recallRerankCoordinator.applyTrustScoreRerank(results, namespaces);
+    return this.recallRerankCoordinator.applyTrustScoreRerank(results, namespaces, preloadedFrontmatter);
   }
 
   private async applyTrustScoreToBranch(
@@ -3452,11 +3454,12 @@ export class Orchestrator {
     namespaces: string[],
     caps: CapabilitySet,
     label: string,
+    preloadedFrontmatter?: ReadonlyMap<string, MemoryFile>,
   ): Promise<{
     results: QmdSearchResult[];
     trustByPath: Map<string, TrustStageResultItem> | null;
   }> {
-    return this.recallRerankCoordinator.applyTrustScoreToBranch(results, namespaces, caps, label);
+    return this.recallRerankCoordinator.applyTrustScoreToBranch(results, namespaces, caps, label, preloadedFrontmatter);
   }
 
   private diversifyAndLimitRecallResults(

--- a/packages/remnic-core/src/recall-rerank-coordinator.test.ts
+++ b/packages/remnic-core/src/recall-rerank-coordinator.test.ts
@@ -107,6 +107,42 @@ test("O(candidates): preloaded frontmatter covers candidates → no corpus scan,
   );
 });
 
+test("preloaded-but-neutral candidates do not trigger the corpus scan or direct read (#1905, Codex)", async () => {
+  const config = await baseConfig();
+  const corpus = makeFakes([]);
+  let directReads = 0;
+  const coord = new RecallRerankCoordinator({
+    getConfig: () => config,
+    getStorage: corpus.getStorage,
+    readQmdResultMemory: async () => {
+      directReads += 1;
+      return null;
+    },
+  });
+
+  // Both candidates are preloaded but carry NO mw counters — the typical
+  // uninstrumented hot-QMD result. They are neutral priors: the stage must
+  // treat them as EXAMINED, not "missing", so neither the corpus fallback nor
+  // the direct-read fallback fires. Before this guard, every neutral candidate
+  // re-triggered readAllMemories() after each corpus-version bump, defeating
+  // the O(candidates) fast path.
+  const results = [result("a", 2), result("b", 1)];
+  const preloaded = new Map<string, MemoryFile>([
+    ["/facts/a.md", mem("a")],
+    ["/facts/b.md", mem("b")],
+  ]);
+
+  const out = await coord.applyMemoryWorthRerank(results, ["default"], preloaded);
+
+  assert.equal(corpus.calls.readAll, 0, "neutral preloaded candidates must not trigger readAllMemories");
+  assert.equal(directReads, 0, "neutral preloaded candidates must not trigger direct reads");
+  assert.deepEqual(
+    out.map((r) => r.path),
+    ["/facts/a.md", "/facts/b.md"],
+    "order unchanged for neutral candidates (neutral prior does not rerank)",
+  );
+});
+
 test("golden parity: preloaded path ranks identically to the corpus-scan path (#1905)", async () => {
   const config = await baseConfig();
   const results = [result("bad", 3), result("mid", 2), result("good", 1)];

--- a/packages/remnic-core/src/recall-rerank-coordinator.test.ts
+++ b/packages/remnic-core/src/recall-rerank-coordinator.test.ts
@@ -1,0 +1,365 @@
+/**
+ * recall-rerank-coordinator.test.ts — issue #1905.
+ *
+ * Pins the O(candidates) inversion of the Memory-Worth / TrustScore recall
+ * stage:
+ *   - when the hot path's already-loaded frontmatter covers the candidates,
+ *     the stage does ZERO `readAllMemories()` / direct-read calls and its
+ *     counters come from that frontmatter;
+ *   - the preloaded (candidates) path produces byte-identical ranking to the
+ *     old corpus-map path for the same data (golden parity);
+ *   - cold-tier candidates absent from the preloaded map fall back to a
+ *     bounded-parallel (<=16) direct read whose counters match a reference;
+ *   - the corpus-fallback cache is invalidated by the shared corpus version,
+ *     not a wall-clock TTL (no stale counters after a mutation);
+ *   - with both feature flags off the stage touches storage zero times.
+ */
+
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import { resolveCapabilities } from "./capabilities.js";
+import { RecallRerankCoordinator } from "./orchestration/recall-rerank-coordinator.js";
+import { Orchestrator } from "./orchestrator.js";
+import type { PluginConfig, QmdSearchResult, MemoryFile } from "./types.js";
+import type { StorageManager } from "./index.js";
+
+async function baseConfig(overrides: Partial<PluginConfig> = {}): Promise<PluginConfig> {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-1905-"));
+  return parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    recallMemoryWorthFilterEnabled: true,
+    trustScoreEnabled: false,
+    ...overrides,
+  });
+}
+
+function result(id: string, score: number): QmdSearchResult {
+  return { docid: id, path: `/facts/${id}.md`, snippet: id, score };
+}
+
+// Only mw_* / lastAccessed are read by the counter builder; the fixture stays
+// narrow. The frontmatter cast is a deliberate test double for a value inference
+// cannot unify with the full MemoryFrontmatter shape.
+function mem(id: string, mw_success?: number, mw_fail?: number): MemoryFile {
+  const frontmatter = { mw_success, mw_fail } as unknown as MemoryFile["frontmatter"];
+  return { path: `/facts/${id}.md`, frontmatter, content: id };
+}
+
+interface FakeStorageState {
+  memories: MemoryFile[];
+  version: number;
+}
+
+/** Fake storage that counts corpus scans and reads its set from mutable state. */
+function makeFakes(initial: MemoryFile[], version = 1) {
+  const calls = { readAll: 0, corpusVersion: 0 };
+  const state: FakeStorageState = { memories: initial, version };
+  // Test double: only readAllMemories/getMemoryCorpusVersion are exercised.
+  const storage = {
+    readAllMemories: async () => {
+      calls.readAll += 1;
+      return state.memories;
+    },
+    getMemoryCorpusVersion: () => {
+      calls.corpusVersion += 1;
+      return state.version;
+    },
+  } as unknown as StorageManager;
+  return { calls, state, storage, getStorage: async () => storage };
+}
+
+test("O(candidates): preloaded frontmatter covers candidates → no corpus scan, no direct read (#1905)", async () => {
+  const config = await baseConfig();
+  const corpus = makeFakes([]);
+  let directReads = 0;
+  const coord = new RecallRerankCoordinator({
+    getConfig: () => config,
+    getStorage: corpus.getStorage,
+    readQmdResultMemory: async () => {
+      directReads += 1;
+      return null;
+    },
+  });
+
+  // Input order [bad, good]; only Memory-Worth counters differ. good must
+  // overtake bad purely from its preloaded counters.
+  const results = [result("bad", 2), result("good", 1)];
+  const preloaded = new Map<string, MemoryFile>([
+    ["/facts/bad.md", mem("bad", 0, 10)],
+    ["/facts/good.md", mem("good", 10, 0)],
+  ]);
+
+  const reordered = await coord.applyMemoryWorthRerank(results, ["default"], preloaded);
+
+  assert.equal(corpus.calls.readAll, 0, "readAllMemories must NOT be called on the warm path");
+  assert.equal(directReads, 0, "no per-candidate direct read when preloaded covers all candidates");
+  assert.deepEqual(
+    reordered.map((r) => r.path),
+    ["/facts/good.md", "/facts/bad.md"],
+    "high-worth candidate overtakes low-worth using preloaded counters",
+  );
+});
+
+test("golden parity: preloaded path ranks identically to the corpus-scan path (#1905)", async () => {
+  const config = await baseConfig();
+  const results = [result("bad", 3), result("mid", 2), result("good", 1)];
+  const memories = [mem("bad", 0, 8), mem("mid", 2, 2), mem("good", 12, 0)];
+
+  // Corpus path: no preloaded map, storage.readAllMemories supplies counters.
+  const corpus = makeFakes(memories);
+  const corpusCoord = new RecallRerankCoordinator({
+    getConfig: () => config,
+    getStorage: corpus.getStorage,
+    readQmdResultMemory: async () => null,
+  });
+  const viaCorpus = await corpusCoord.applyMemoryWorthRerank(results, ["default"]);
+  assert.equal(corpus.calls.readAll, 1, "corpus path performs exactly one scan");
+
+  // Preloaded path: same counters supplied inline.
+  const preloaded = new Map<string, MemoryFile>(memories.map((m) => [m.path, m]));
+  const warm = makeFakes([]);
+  const warmCoord = new RecallRerankCoordinator({
+    getConfig: () => config,
+    getStorage: warm.getStorage,
+    readQmdResultMemory: async () => null,
+  });
+  const viaPreloaded = await warmCoord.applyMemoryWorthRerank(results, ["default"], preloaded);
+
+  assert.equal(warm.calls.readAll, 0, "preloaded path performs zero scans");
+  assert.deepEqual(
+    viaPreloaded.map((r) => r.path),
+    viaCorpus.map((r) => r.path),
+    "preloaded and corpus paths produce identical ordering for identical data",
+  );
+});
+
+test("cold-tier miss → bounded-parallel direct read (<=16 concurrent), counters match (#1905)", async () => {
+  const config = await baseConfig();
+  const corpus = makeFakes([]); // corpus scan yields nothing → every candidate misses
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const byPath = new Map<string, MemoryFile>();
+  const N = 40;
+  const results: QmdSearchResult[] = [];
+  for (let i = 0; i < N; i += 1) {
+    const id = `cold${i}`;
+    results.push(result(id, N - i));
+    // Alternate success/fail so ordering depends on the direct-read counters.
+    byPath.set(`/facts/${id}.md`, mem(id, i % 2 === 0 ? 9 : 0, i % 2 === 0 ? 0 : 9));
+  }
+
+  const coord = new RecallRerankCoordinator({
+    getConfig: () => config,
+    getStorage: corpus.getStorage,
+    readQmdResultMemory: async (p) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      // Microtask yield (no wall clock): lets every callback in the current
+      // Promise.all batch reach this point before any resolves, so maxInFlight
+      // observes the true batch width deterministically.
+      await Promise.resolve();
+      inFlight -= 1;
+      return byPath.get(p) ?? null;
+    },
+  });
+
+  const reordered = await coord.applyMemoryWorthRerank(results, ["default"]);
+  assert.ok(maxInFlight > 1, "direct reads run in parallel");
+  assert.ok(maxInFlight <= 16, `direct-read concurrency must stay <=16 (saw ${maxInFlight})`);
+  // Every even-index (high mw_success) candidate must outrank its odd-index
+  // (high mw_fail) neighbor → the counters from the direct read were applied.
+  const rank = new Map(reordered.map((r, i) => [r.path, i]));
+  for (let i = 0; i + 1 < N; i += 2) {
+    assert.ok(
+      rank.get(`/facts/cold${i}.md`)! < rank.get(`/facts/cold${i + 1}.md`)!,
+      `high-worth cold${i} outranks low-worth cold${i + 1}`,
+    );
+  }
+});
+
+test("version-keyed cache: a corpus-version bump invalidates the cached counter map (#1905)", async () => {
+  const config = await baseConfig();
+  const results = [result("a", 2), result("b", 1)];
+  // Stage 1: b is low-worth (mw_fail) so a stays ahead.
+  const corpus = makeFakes([mem("a", 5, 0), mem("b", 0, 5)], 1);
+  const coord = new RecallRerankCoordinator({
+    getConfig: () => config,
+    getStorage: corpus.getStorage,
+    readQmdResultMemory: async () => null,
+  });
+
+  const first = await coord.applyMemoryWorthRerank(results, ["default"]);
+  assert.equal(corpus.calls.readAll, 1, "first recall scans");
+
+  // Second recall, SAME version → served from cache (no new scan).
+  await coord.applyMemoryWorthRerank(results, ["default"]);
+  assert.equal(corpus.calls.readAll, 1, "same version → cache hit, no rescan");
+
+  // Mutate the corpus (b becomes high-worth) and bump the version.
+  corpus.state.memories = [mem("a", 0, 5), mem("b", 5, 0)];
+  corpus.state.version += 1;
+  const third = await coord.applyMemoryWorthRerank(results, ["default"]);
+  assert.equal(corpus.calls.readAll, 2, "version bump forces a rescan (no stale counters)");
+
+  // Ordering must reflect the NEW counters: b now outranks a.
+  assert.deepEqual(first.map((r) => r.path), ["/facts/a.md", "/facts/b.md"]);
+  assert.deepEqual(third.map((r) => r.path), ["/facts/b.md", "/facts/a.md"]);
+});
+
+test("zero-semantics: both flags off → stage returns inputs unchanged with zero storage reads (#1905)", async () => {
+  const config = await baseConfig({
+    recallMemoryWorthFilterEnabled: false,
+    trustScoreEnabled: false,
+  });
+  const caps = resolveCapabilities(config);
+  assert.equal(caps.recallMemoryWorthFilter, false);
+  assert.equal(caps.recallTrustScore, false);
+
+  const corpus = makeFakes([mem("x", 9, 0)]);
+  let directReads = 0;
+  let getStorageCalls = 0;
+  const coord = new RecallRerankCoordinator({
+    getConfig: () => config,
+    getStorage: async () => {
+      getStorageCalls += 1;
+      return corpus.storage;
+    },
+    readQmdResultMemory: async () => {
+      directReads += 1;
+      return null;
+    },
+  });
+
+  const results = [result("x", 1), result("y", 2)];
+  const outcome = await coord.applyTrustScoreToBranch(results, ["default"], caps, "test");
+
+  assert.deepEqual(outcome.results, results, "results are returned unchanged");
+  assert.equal(outcome.trustByPath, null);
+  assert.equal(corpus.calls.readAll, 0, "no corpus scan when disabled");
+  assert.equal(getStorageCalls, 0, "getStorage never called when disabled");
+  assert.equal(directReads, 0, "no direct reads when disabled");
+});
+
+/**
+ * Write a fact into the default-namespace storage dir (mirrors the
+ * trust-score-recall-paths helper) so recall's recent-memory-scan branch has
+ * candidates to rank.
+ */
+async function writeFact(memoryDir: string, body: string, extra: string[] = []): Promise<void> {
+  const today = new Date().toISOString().slice(0, 10);
+  const id = `fact-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const lines = [
+    "---",
+    `id: ${id}`,
+    "category: fact",
+    `created: ${new Date().toISOString()}`,
+    `updated: ${new Date().toISOString()}`,
+    "source: extraction",
+    "confidence: 0.8",
+    "confidenceTier: high",
+    "tags: []",
+    ...extra,
+    "---",
+  ];
+  const factsDir = path.join(memoryDir, "facts", today);
+  await mkdir(factsDir, { recursive: true });
+  await writeFile(path.join(factsDir, `${id}.md`), `${lines.join("\n")}\n\n${body}\n`, "utf-8");
+}
+
+test("deadline-bound: a trust stage exceeding the assembly budget returns the pass-through fallback (#1905)", async () => {
+  // Integration test of the awaitAssemblyStep wrap: this deliberately exercises
+  // the real wall-clock enrichment-assembly deadline (deterministic time
+  // control is not available through the public recall API). A modest 400ms
+  // budget is far above the 2-file recent-scan yet the injected trust stage
+  // never resolves, so the deadline must fire and the recall must fall back to
+  // the unfiltered results without hanging or throwing.
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-1905-deadline-"));
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    multiGraphMemoryEnabled: false,
+    entityGraphEnabled: false,
+    timeGraphEnabled: false,
+    causalGraphEnabled: false,
+    extractionJudgeEnabled: false,
+    temporalSupersessionEnabled: false,
+    contradictionDetectionEnabled: false,
+    chunkingEnabled: false,
+    inlineSourceAttributionEnabled: false,
+    trustScoreEnabled: true,
+    initGateTimeoutMs: 200,
+    recallEnrichmentDeadlineMs: 2000,
+  });
+  const orchestrator = new Orchestrator(config);
+  try {
+    await writeFact(memoryDir, "Recallable fact: production DB uses pgBouncer.", [
+      "mw_success: 5",
+      "mw_fail: 0",
+    ]);
+    await writeFact(memoryDir, "Recallable fact: cache TTL is 60 seconds.", [
+      "mw_success: 3",
+      "mw_fail: 0",
+    ]);
+
+    // Inject a trust stage that NEVER resolves on the recent-scan branch (the
+    // branch that actually produces candidates here). Other branches (e.g. the
+    // disabled embedding fallback) run the real stage so control reaches
+    // recent-scan normally. The deadline wrap must win the race and substitute
+    // the pass-through fallback rather than await this forever — if the
+    // bare-await regression returned, recall would hang on this promise.
+    const stuck = Promise.withResolvers<{
+      results: QmdSearchResult[];
+      trustByPath: null;
+    }>();
+    const realStage = orchestrator.recallRerankCoordinator.applyTrustScoreToBranch.bind(
+      orchestrator.recallRerankCoordinator,
+    );
+    let recentScanStalled = false;
+    orchestrator.recallRerankCoordinator.applyTrustScoreToBranch = async (
+      results,
+      namespaces,
+      caps,
+      label,
+      preloadedFrontmatter,
+    ) => {
+      if (label === "recent-scan") {
+        recentScanStalled = true;
+        return stuck.promise;
+      }
+      return realStage(results, namespaces, caps, label, preloadedFrontmatter);
+    };
+
+    const start = Date.now();
+    const recall = await orchestrator.recall("database connection pooling", "sess-1905-deadline", {
+      xrayCapture: true,
+    });
+    const elapsed = Date.now() - start;
+
+    assert.equal(typeof recall, "string", "recall resolves to a string (does not hang) despite the never-resolving trust stage");
+    assert.ok(recentScanStalled, "the never-resolving trust stage ran on the recent-scan branch");
+    // The stage never produced output, so the recalled memories can ONLY come
+    // from the deadline fallback (the pre-trust recent-scan results).
+    const snapshot = orchestrator.getLastXraySnapshot();
+    assert.ok(snapshot, "X-ray snapshot captured");
+    assert.ok(
+      (snapshot!.results ?? []).length > 0,
+      "unfiltered recent-scan results survive as the deadline fallback",
+    );
+    // Bounded by the deadline (with generous slack for a loaded CI machine),
+    // proving the recall did not wait on the never-resolving stage.
+    assert.ok(elapsed < 30_000, `recall completed within a bounded window (took ${elapsed}ms)`);
+  } finally {
+    await orchestrator.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/recall-timings-access.test.ts
+++ b/packages/remnic-core/src/recall-timings-access.test.ts
@@ -201,6 +201,30 @@ test("recall timing records expose only the fixed telemetry schema", () => {
   });
 });
 
+test("trustStage is allowlisted and its ms is parsed (issue #1905)", () => {
+  const config = makeConfig(path.join(os.tmpdir(), "remnic-recall-timing-trust"));
+  recordRecallTiming(config, {
+    timestamp: new Date(0).toISOString(),
+    namespace: "default",
+    total: "10ms",
+    trustStage: "3ms",
+    recallPlan: "full",
+    queryPolicy: "general/full",
+  });
+  recordRecallTiming(config, {
+    timestamp: new Date(1).toISOString(),
+    namespace: "default",
+    total: "10ms",
+    trustStage: "2ms-cache",
+    recallPlan: "full",
+    queryPolicy: "general/full",
+  });
+  const records = getRecallTimings(config);
+  // newest-first ordering
+  assert.equal(records[0]?.timingsMs.trustStage, 2, "\"2ms-cache\" parses to numeric 2");
+  assert.equal(records[1]?.timingsMs.trustStage, 3, "\"3ms\" parses to numeric 3");
+});
+
 test("phases that did not run are omitted while measured zeros survive", () => {
   const config = makeConfig(path.join(os.tmpdir(), "remnic-recall-timing-phases"));
   recordRecallTiming(config, {

--- a/packages/remnic-core/src/recall-timings.ts
+++ b/packages/remnic-core/src/recall-timings.ts
@@ -44,6 +44,7 @@ const TIMING_FIELD_ALLOWLIST = [
   "compounding",
   "graphShadow",
   "qmdPost",
+  "trustStage",
 ] as const;
 // The ring buffer is process-local: a daemon restart or haproxy failover to
 // the other backend starts an empty history. processStartedAt lets consumers

--- a/packages/remnic-core/src/trust-score-stage.test.ts
+++ b/packages/remnic-core/src/trust-score-stage.test.ts
@@ -348,3 +348,50 @@ test("adapter: no half-life → no decay (raw counters)", () => {
   // Without decay, 5/1 success-heavy → confidence ~6 (raw count).
   assert.ok(worth!.confidence >= 5, "no half-life → raw confidence (no decay)");
 });
+
+test("signal cache: an aged entry re-derives even when the corpus version matches (#1905, Codex)", async () => {
+  // Trust signals bake wall-clock time into their values (ageDays,
+  // computeMemoryWorth(..., now) with recency half-life), so a version-only
+  // cache would serve stale decay forever on a read-only corpus. An entry
+  // older than TRUST_SIGNAL_CACHE_MAX_AGE_MS must re-derive; a fresh one with
+  // a matching version must be served without a corpus read.
+  const { buildTrustSignalsForRerank, TRUST_SIGNAL_CACHE_MAX_AGE_MS } = await import(
+    "./trust-score-stage.js"
+  );
+  const now = new Date("2026-07-01T12:00:00.000Z");
+  let corpusReads = 0;
+  const deps = {
+    readNamespaceMemories: async () => {
+      corpusReads += 1;
+      return [
+        { path: "a.md", frontmatter: { mw_success: 3, mw_fail: 0, lastAccessed: "2026-06-30" } },
+      ];
+    },
+    readMemoryFrontmatter: async () => null,
+    getNamespaceVersion: async () => 7,
+  };
+  const staleSignals = buildTrustSignalMap(
+    [{ path: "a.md", frontmatter: { mw_success: 3, mw_fail: 0, lastAccessed: "2026-06-30" } }],
+    new Date(now.getTime() - TRUST_SIGNAL_CACHE_MAX_AGE_MS - 1),
+    {},
+  );
+  const cache = {
+    cache: new Map([
+      [
+        "default",
+        {
+          version: 7,
+          cachedAt: now.getTime() - TRUST_SIGNAL_CACHE_MAX_AGE_MS - 1,
+          signals: staleSignals,
+        },
+      ],
+    ]),
+  };
+
+  await buildTrustSignalsForRerank(["a.md"], ["default"], deps, cache, now, {});
+  assert.equal(corpusReads, 1, "aged entry (version match) must re-derive from the corpus");
+
+  corpusReads = 0;
+  await buildTrustSignalsForRerank(["a.md"], ["default"], deps, cache, now, {});
+  assert.equal(corpusReads, 0, "fresh entry with matching version must serve from cache");
+});

--- a/packages/remnic-core/src/trust-score-stage.test.ts
+++ b/packages/remnic-core/src/trust-score-stage.test.ts
@@ -395,3 +395,77 @@ test("signal cache: an aged entry re-derives even when the corpus version matche
   await buildTrustSignalsForRerank(["a.md"], ["default"], deps, cache, now, {});
   assert.equal(corpusReads, 0, "fresh entry with matching version must serve from cache");
 });
+
+test("preloaded-but-neutral candidates skip the corpus and direct-read fallbacks (#1905, Cursor/Codex)", async () => {
+  // buildTrustSignalMap deliberately OMITS neutral memories (no trust fields),
+  // so a preloaded candidate can be examined yet absent from `signals`. It must
+  // be treated as EXAMINED — not missing — or every uninstrumented hot
+  // candidate re-triggers the namespace-wide corpus scan and a direct re-read,
+  // defeating the O(candidates) fast path.
+  const { buildTrustSignalsForRerank } = await import("./trust-score-stage.js");
+  const now = new Date("2026-07-01T12:00:00.000Z");
+  let corpusReads = 0;
+  let directReads = 0;
+  const deps = {
+    readNamespaceMemories: async () => {
+      corpusReads += 1;
+      return [];
+    },
+    readMemoryFrontmatter: async () => {
+      directReads += 1;
+      return null;
+    },
+    getNamespaceVersion: async () => 1,
+  };
+  const cache = { cache: new Map() };
+  // Neutral frontmatter: no mw_* / trust fields at all.
+  const preloadedFrontmatter = new Map([
+    ["a.md", { frontmatter: {} }],
+    ["b.md", { frontmatter: {} }],
+  ]);
+
+  const signals = await buildTrustSignalsForRerank(
+    ["a.md", "b.md"],
+    ["default"],
+    deps,
+    cache,
+    now,
+    { preloadedFrontmatter },
+  );
+
+  assert.equal(corpusReads, 0, "neutral preloaded candidates must not trigger a corpus scan");
+  assert.equal(directReads, 0, "neutral preloaded candidates must not trigger direct reads");
+  assert.equal(signals.size, 0, "neutral candidates stay absent (multiplier 1.0 downstream)");
+});
+
+test("cooperative abort stops the corpus and direct-read fallbacks at loop boundaries (#1905, Codex)", async () => {
+  const { buildTrustSignalsForRerank } = await import("./trust-score-stage.js");
+  const now = new Date("2026-07-01T12:00:00.000Z");
+  let corpusReads = 0;
+  let directReads = 0;
+  const deps = {
+    readNamespaceMemories: async () => {
+      corpusReads += 1;
+      return [];
+    },
+    readMemoryFrontmatter: async () => {
+      directReads += 1;
+      return null;
+    },
+    getNamespaceVersion: async () => 1,
+  };
+  const controller = new AbortController();
+  controller.abort(); // the recall deadline already won the race
+
+  await buildTrustSignalsForRerank(
+    ["a.md"],
+    ["ns1", "ns2"],
+    deps,
+    { cache: new Map() },
+    now,
+    { abortSignal: controller.signal },
+  );
+
+  assert.equal(corpusReads, 0, "an aborted signal must stop namespace scans before they start");
+  assert.equal(directReads, 0, "an aborted signal must stop direct-read batches before they start");
+});

--- a/packages/remnic-core/src/trust-score-stage.ts
+++ b/packages/remnic-core/src/trust-score-stage.ts
@@ -307,20 +307,33 @@ export interface TrustScoreRerankDeps {
   ): Promise<ReadonlyArray<{ path: string; frontmatter: TrustFrontmatterProjection }>>;
   /** Read one memory's frontmatter by path (cold-tier direct fallback). */
   readMemoryFrontmatter(path: string): Promise<TrustFrontmatterProjection | null>;
-}
-
-/** Per-namespace signal cache the host owns and the builder mutates. */
-export interface TrustScoreSignalCache {
-  cache: Map<string, { at: number; signals: ReadonlyMap<string, TrustSignals> }>;
-  ttlMs: number;
+  /**
+   * Current cross-process corpus version for a namespace (issue #1905). Used
+   * to key the per-namespace corpus-fallback cache so it invalidates on the
+   * next memory mutation instead of on a wall-clock timer that is shorter than
+   * recall latency (which produced a permanent steady-state miss).
+   */
+  getNamespaceVersion(namespace: string): Promise<number>;
 }
 
 /**
- * Build the `path → TrustSignals` map for recall candidates using a
- * per-namespace cache plus a direct-path fallback for cold-tier candidates
- * absent from the hot scan. Extracted from the orchestrator (issue #1577) so
- * the god file carries only thin wiring — the scoring itself is
- * {@link applyTrustScoreStage}.
+ * Per-namespace signal cache the host owns and the builder mutates. Keyed on
+ * the shared corpus version (issue #1905): an entry is valid iff its `version`
+ * still equals the namespace's current corpus version.
+ */
+export interface TrustScoreSignalCache {
+  cache: Map<string, { version: number; signals: ReadonlyMap<string, TrustSignals> }>;
+}
+
+/**
+ * Build the `path → TrustSignals` map for recall candidates.
+ *
+ * O(candidates) inversion (issue #1905): when the host passes
+ * `preloadedFrontmatter` (frontmatter already loaded on the hot recall path),
+ * candidate signals are seeded directly from it — no corpus scan. Only
+ * candidates still missing fall back to the corpus-level per-namespace map
+ * (config-gated, version-keyed so it actually hits in steady state) and then
+ * to a bounded-parallel direct per-path read.
  *
  * Fail-open: a single unreadable namespace or memory is logged and skipped so
  * a storage hiccup never breaks recall (mirrors `memory-worth-filter.ts`).
@@ -334,62 +347,102 @@ export async function buildTrustSignalsForRerank(
   options: {
     recencyHalfLifeDays?: number;
     logDebug?: (message: string, context: Record<string, unknown>) => void;
+    /**
+     * Candidate frontmatter already loaded on the hot recall path (issue
+     * #1905). When present, candidate signals are seeded from it before any
+     * corpus scan, so the common warm-candidate recall does zero
+     * `readNamespaceMemories` calls. Structural — a `MemoryFile` map satisfies
+     * `{ frontmatter: TrustFrontmatterProjection }` without importing it.
+     */
+    preloadedFrontmatter?: ReadonlyMap<string, { frontmatter: TrustFrontmatterProjection }>;
+    /**
+     * When false, skip the corpus-level `readNamespaceMemories` fallback
+     * entirely (candidates-first + direct-read only). Defaults to true so the
+     * corpus path stays reachable. See `recallTrustStageCorpusFallbackEnabled`.
+     */
+    corpusFallbackEnabled?: boolean;
   } = {},
 ): Promise<Map<string, TrustSignals>> {
-  const nowMs = now.getTime();
   const logDebug = options.logDebug ?? (() => {});
   const signals = new Map<string, TrustSignals>();
+  const corpusFallbackEnabled = options.corpusFallbackEnabled ?? true;
+  const halfLife = { recencyHalfLifeDays: options.recencyHalfLifeDays };
 
-  // Evict expired cache entries (mirrors the worth-cache discipline).
-  for (const [key, entry] of signalCache.cache) {
-    if (nowMs - entry.at >= signalCache.ttlMs) signalCache.cache.delete(key);
-  }
-
-  // Per-namespace hot scan with cache.
-  const seenNamespaces = new Set<string>();
-  for (const ns of namespaces) {
-    if (seenNamespaces.has(ns)) continue;
-    seenNamespaces.add(ns);
-    try {
-      const cached = signalCache.cache.get(ns);
-      let nsMap: ReadonlyMap<string, TrustSignals> | undefined;
-      if (cached && nowMs - cached.at < signalCache.ttlMs) {
-        nsMap = cached.signals;
-      } else {
-        const memories = await deps.readNamespaceMemories(ns);
-        nsMap = buildTrustSignalMap(memories, now, {
-          recencyHalfLifeDays: options.recencyHalfLifeDays,
-        });
-        signalCache.cache.set(ns, { at: nowMs, signals: nsMap });
-      }
-      for (const [path, s] of nsMap) signals.set(path, s);
-    } catch (err) {
-      logDebug("trust-score: failed to read namespace, skipping", {
-        namespace: ns,
-        error: (err as Error).message,
-      });
+  // O(candidates) fast path: seed signals from candidate frontmatter already
+  // loaded on the hot recall path. Reuses the exact `buildTrustSignalMap`
+  // computation so a candidate's signals equal what a corpus scan produced.
+  if (options.preloadedFrontmatter) {
+    const preloaded: Array<{ path: string; frontmatter: TrustFrontmatterProjection }> = [];
+    for (const path of candidatePaths) {
+      const mem = options.preloadedFrontmatter.get(path);
+      if (mem) preloaded.push({ path, frontmatter: mem.frontmatter });
+    }
+    if (preloaded.length > 0) {
+      const seeded = buildTrustSignalMap(preloaded, now, halfLife);
+      for (const [path, s] of seeded) signals.set(path, s);
     }
   }
 
-  // Direct per-path fallback for cold-tier candidates absent from the hot scan.
-  const missing = candidatePaths.filter((p) => !signals.has(p));
-  if (missing.length > 0) {
-    const fallbackMemories: Array<{ path: string; frontmatter: TrustFrontmatterProjection }> = [];
-    for (const path of missing) {
+  // Corpus-level fallback (config-gated): candidates still missing probe a
+  // per-namespace signal map, cached and invalidated by the shared
+  // cross-process corpus version. Only candidate rows are copied out — never
+  // the whole map (issue #1905, no per-recall full-map union).
+  if (corpusFallbackEnabled) {
+    const seenNamespaces = new Set<string>();
+    for (const ns of namespaces) {
+      if (seenNamespaces.has(ns)) continue;
+      seenNamespaces.add(ns);
+      if (candidatePaths.every((p) => signals.has(p))) break;
       try {
-        const frontmatter = await deps.readMemoryFrontmatter(path);
-        if (frontmatter) fallbackMemories.push({ path, frontmatter });
+        const version = await deps.getNamespaceVersion(ns);
+        const cached = signalCache.cache.get(ns);
+        let nsMap: ReadonlyMap<string, TrustSignals>;
+        if (cached && cached.version === version) {
+          nsMap = cached.signals;
+        } else {
+          const memories = await deps.readNamespaceMemories(ns);
+          nsMap = buildTrustSignalMap(memories, now, halfLife);
+          signalCache.cache.set(ns, { version, signals: nsMap });
+        }
+        for (const p of candidatePaths) {
+          if (signals.has(p)) continue;
+          const s = nsMap.get(p);
+          if (s) signals.set(p, s);
+        }
       } catch (err) {
-        logDebug("trust-score: direct path lookup failed", {
-          path,
+        logDebug("trust-score: failed to read namespace, skipping", {
+          namespace: ns,
           error: (err as Error).message,
         });
       }
     }
+  }
+
+  // Direct per-path fallback for candidates still absent (cold-tier / archive).
+  // Bounded-parallel (≤16) to match loadSearchResultMemoryMap's batch size.
+  const missing = candidatePaths.filter((p) => !signals.has(p));
+  if (missing.length > 0) {
+    const fallbackMemories: Array<{ path: string; frontmatter: TrustFrontmatterProjection }> = [];
+    const BATCH = 16;
+    for (let off = 0; off < missing.length; off += BATCH) {
+      const batch = await Promise.all(
+        missing.slice(off, off + BATCH).map(async (path) => {
+          try {
+            const frontmatter = await deps.readMemoryFrontmatter(path);
+            return frontmatter ? { path, frontmatter } : null;
+          } catch (err) {
+            logDebug("trust-score: direct path lookup failed", {
+              path,
+              error: (err as Error).message,
+            });
+            return null;
+          }
+        }),
+      );
+      for (const item of batch) if (item) fallbackMemories.push(item);
+    }
     if (fallbackMemories.length > 0) {
-      const fallbackSignals = buildTrustSignalMap(fallbackMemories, now, {
-        recencyHalfLifeDays: options.recencyHalfLifeDays,
-      });
+      const fallbackSignals = buildTrustSignalMap(fallbackMemories, now, halfLife);
       for (const [path, s] of fallbackSignals) signals.set(path, s);
     }
   }

--- a/packages/remnic-core/src/trust-score-stage.ts
+++ b/packages/remnic-core/src/trust-score-stage.ts
@@ -380,12 +380,28 @@ export async function buildTrustSignalsForRerank(
      * corpus path stays reachable. See `recallTrustStageCorpusFallbackEnabled`.
      */
     corpusFallbackEnabled?: boolean;
+    /**
+     * Cooperative cancellation (issue #1905, Codex): when the recall's shared
+     * enrichment-assembly deadline wins the race, the host aborts this signal
+     * so an orphaned corpus scan / direct-read loop stops at the next loop
+     * boundary instead of continuing to burn I/O after recall already returned.
+     */
+    abortSignal?: AbortSignal;
   } = {},
 ): Promise<Map<string, TrustSignals>> {
   const logDebug = options.logDebug ?? (() => {});
   const signals = new Map<string, TrustSignals>();
   const corpusFallbackEnabled = options.corpusFallbackEnabled ?? true;
   const halfLife = { recencyHalfLifeDays: options.recencyHalfLifeDays };
+
+  // Paths examined via preloaded frontmatter (issue #1905, Cursor/Codex).
+  // buildTrustSignalMap deliberately OMITS neutral memories (no trust fields),
+  // so a preloaded candidate can be examined yet absent from `signals` — it
+  // must NOT be treated as missing, or the corpus fallback + direct read fire
+  // for every uninstrumented hot candidate, defeating the O(candidates) path.
+  // Absent-from-signals still means multiplier 1.0 downstream, exactly what a
+  // corpus scan would have produced for the same neutral memory.
+  const preloadedPaths = new Set<string>();
 
   // O(candidates) fast path: seed signals from candidate frontmatter already
   // loaded on the hot recall path. Reuses the exact `buildTrustSignalMap`
@@ -394,7 +410,9 @@ export async function buildTrustSignalsForRerank(
     const preloaded: Array<{ path: string; frontmatter: TrustFrontmatterProjection }> = [];
     for (const path of candidatePaths) {
       const mem = options.preloadedFrontmatter.get(path);
-      if (mem) preloaded.push({ path, frontmatter: mem.frontmatter });
+      if (!mem) continue;
+      preloadedPaths.add(path);
+      preloaded.push({ path, frontmatter: mem.frontmatter });
     }
     if (preloaded.length > 0) {
       const seeded = buildTrustSignalMap(preloaded, now, halfLife);
@@ -409,9 +427,12 @@ export async function buildTrustSignalsForRerank(
   if (corpusFallbackEnabled) {
     const seenNamespaces = new Set<string>();
     for (const ns of namespaces) {
+      // Cooperative cancellation: the recall's assembly deadline may have won
+      // the race — stop before starting another namespace scan (#1905, Codex).
+      if (options.abortSignal?.aborted) break;
       if (seenNamespaces.has(ns)) continue;
       seenNamespaces.add(ns);
-      if (candidatePaths.every((p) => signals.has(p))) break;
+      if (candidatePaths.every((p) => signals.has(p) || preloadedPaths.has(p))) break;
       try {
         const version = await deps.getNamespaceVersion(ns);
         const cached = signalCache.cache.get(ns);
@@ -433,7 +454,9 @@ export async function buildTrustSignalsForRerank(
           capTrustSignalCache(signalCache.cache, TRUST_SIGNAL_CACHE_MAX_NAMESPACES);
         }
         for (const p of candidatePaths) {
-          if (signals.has(p)) continue;
+          // Preloaded paths were already examined — absent-from-signals means
+          // neutral (multiplier 1.0), identical to what the corpus map holds.
+          if (signals.has(p) || preloadedPaths.has(p)) continue;
           const s = nsMap.get(p);
           if (s) signals.set(p, s);
         }
@@ -447,12 +470,15 @@ export async function buildTrustSignalsForRerank(
   }
 
   // Direct per-path fallback for candidates still absent (cold-tier / archive).
+  // Preloaded paths are excluded — they were examined and are neutral priors.
   // Bounded-parallel (≤16) to match loadSearchResultMemoryMap's batch size.
-  const missing = candidatePaths.filter((p) => !signals.has(p));
+  const missing = candidatePaths.filter((p) => !signals.has(p) && !preloadedPaths.has(p));
   if (missing.length > 0) {
     const fallbackMemories: Array<{ path: string; frontmatter: TrustFrontmatterProjection }> = [];
     const BATCH = 16;
     for (let off = 0; off < missing.length; off += BATCH) {
+      // Cooperative cancellation between batches (#1905, Codex).
+      if (options.abortSignal?.aborted) break;
       const batch = await Promise.all(
         missing.slice(off, off + BATCH).map(async (path) => {
           try {

--- a/packages/remnic-core/src/trust-score-stage.ts
+++ b/packages/remnic-core/src/trust-score-stage.ts
@@ -319,10 +319,29 @@ export interface TrustScoreRerankDeps {
 /**
  * Per-namespace signal cache the host owns and the builder mutates. Keyed on
  * the shared corpus version (issue #1905): an entry is valid iff its `version`
- * still equals the namespace's current corpus version.
+ * still equals the namespace's current corpus version AND it is younger than
+ * TRUST_SIGNAL_CACHE_MAX_AGE_MS. The age bound is required because trust
+ * signals bake wall-clock time into their values (ageDays,
+ * computeMemoryWorth(..., now) with recency half-life) — pure version
+ * invalidation would serve stale decay on a read-only corpus (#1905, Codex).
  */
 export interface TrustScoreSignalCache {
-  cache: Map<string, { version: number; signals: ReadonlyMap<string, TrustSignals> }>;
+  cache: Map<string, { version: number; cachedAt: number; signals: ReadonlyMap<string, TrustSignals> }>;
+}
+
+/** See TrustScoreSignalCache — bounds time-based staleness of cached signals. */
+export const TRUST_SIGNAL_CACHE_MAX_AGE_MS = 300_000;
+
+/** Bound on distinct namespaces retained; overflow evicts the oldest. */
+export const TRUST_SIGNAL_CACHE_MAX_NAMESPACES = 64;
+
+/** Insert-ordered bounded set: evict the oldest namespace on overflow. */
+function capTrustSignalCache(cache: TrustScoreSignalCache["cache"], max: number): void {
+  while (cache.size > max) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
 }
 
 /**
@@ -396,13 +415,22 @@ export async function buildTrustSignalsForRerank(
       try {
         const version = await deps.getNamespaceVersion(ns);
         const cached = signalCache.cache.get(ns);
+        const nowMs = now.getTime();
         let nsMap: ReadonlyMap<string, TrustSignals>;
-        if (cached && cached.version === version) {
+        // Valid iff the corpus version still matches AND the entry is younger
+        // than the max age: trust signals bake `now` into their values, so an
+        // unchanged corpus still goes stale as wall-clock advances (#1905, Codex).
+        if (
+          cached &&
+          cached.version === version &&
+          nowMs - cached.cachedAt < TRUST_SIGNAL_CACHE_MAX_AGE_MS
+        ) {
           nsMap = cached.signals;
         } else {
           const memories = await deps.readNamespaceMemories(ns);
           nsMap = buildTrustSignalMap(memories, now, halfLife);
-          signalCache.cache.set(ns, { version, signals: nsMap });
+          signalCache.cache.set(ns, { version, cachedAt: nowMs, signals: nsMap });
+          capTrustSignalCache(signalCache.cache, TRUST_SIGNAL_CACHE_MAX_NAMESPACES);
         }
         for (const p of candidatePaths) {
           if (signals.has(p)) continue;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1028,6 +1028,14 @@ export interface PluginConfig {
    */
   recallMemoryWorthFilterEnabled: boolean;
   /**
+   * When false, the Trust/Memory-Worth recall stage skips its corpus-level
+   * fallback (a per-namespace `readAllMemories`-derived counter/signal map)
+   * and relies only on frontmatter already loaded on the hot recall path plus
+   * a bounded-parallel per-candidate direct read — fully O(candidates)
+   * (issue #1905). Default true keeps the corpus fallback reachable.
+   */
+  recallTrustStageCorpusFallbackEnabled: boolean;
+  /**
    * Serve `StorageManager.readAllMemories()` from a version-keyed in-process
    * cache of the full parsed corpus (issue #1902). Default true. When on, a
    * scan-once-then-serve fast path eliminates the repeated full-corpus disk

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -4339,6 +4339,11 @@
         "default": true,
         "description": "When true, recall multiplies candidate scores by the Memory Worth factor (mw_success / mw_fail counters, see issue #560). Memories with a history of failed sessions sink; neutral/uninstrumented memories are untouched. PR 5 bench: +0.60 precision@5 vs baseline on all 50 seeded cases. Operators can opt out with false."
       },
+      "recallTrustStageCorpusFallbackEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true (default), the Memory-Worth/TrustScore recall rerank stage probes a per-namespace corpus counter/signal map for candidates whose frontmatter was NOT already loaded on the hot path (cold-tier / embedding-fallback / archive rows). The map is version-keyed (invalidated on corpus mutation) and age-bounded for trust signals, so it hits in steady state without the old 30s-TTL permanent-miss. Set false to disable the corpus fallback entirely (only preloaded-candidate + direct-read paths run) — max performance when every candidate is hot, at the cost of neutral treatment for cold candidates."
+      },
       "hotMemoriesCacheEnabled": {
         "type": "boolean",
         "default": true,


### PR DESCRIPTION
## What

Closes #1905. Inverts the post-retrieval Memory-Worth/TrustScore rerank stage from **O(corpus)** to **O(candidates)** — this is the dominant per-recall cost (production `qmdPost` p50 **15.4s**, max 22.6s; the actual QMD search is 16ms).

## Changes (per the #1905 spec)
1. **O(candidates) inversion** — the four recall branch-stage entry points (`applyMemoryWorthRerank`, `applyTrustScoreRerank`, `applyTrustScoreToBranch` + the deps interfaces) now accept an optional trailing `preloadedFrontmatter: ReadonlyMap<string, MemoryFile>`. When supplied (the hot path already loads candidate `MemoryFile`s with frontmatter via `loadSearchResultMemoryMap`), candidate counters/signals are seeded directly from that frontmatter **before** any namespace scan, using the exact `mw_success === undefined && mw_fail === undefined` guard from `buildMemoryWorthCounterMap`. ~50 candidate rows no longer trigger a 99K-file `readAllMemories()` walk.
2. **Event invalidation** — the corpus-fallback caches switch from the self-defeating 30s wall-clock TTL (shorter than the 30.5s recall p50 → permanent steady-state miss) to version-keyed invalidation hooked into the existing memory-mutation chokepoint.
3. **Deadline-bound** — the bare trust `await` on all four recall paths (`recall-internal.ts`: hot-QMD, two embedding-fallback, recent-memory-scan) is wrapped in `awaitAssemblyStep`, so a slow corpus scan returns the unfiltered results as fallback instead of outrunning the assembly budget (the source of the 17s outliers).
4. **Observability** — the trust stage is added to the recall-timings allowlist (previously ~12s was structurally unattributed).

The pure scorers (`applyMemoryWorthFilter`, `applyTrustScoreStage`, `buildMemoryWorthCounterMap`, `buildTrustSignalMap`) are byte-identical.

## ⚠️ Reviewer: deliberate deviation from the spec
The spec suggested keying the corpus-fallback cache on `getMemoryStatusVersion()`. **I keyed it on `getMemoryCorpusVersion()` instead.** Reason: mw-counter outcome writes (`mw_success`/`mw_fail`) patch the hot cache via `patchHotMemoriesCache`, which bumps the **corpus** version (`storage.ts:2908`), NOT the status version (which only bumps on a `status` field change). Keying on status would serve stale counters after an outcome write. Flagging for explicit reviewer confirmation.

## Verification
- `pnpm --filter @remnic/core run build` + `check-types`: clean.
- Existing memory-worth/trust/rerank tests pass.
- `node scripts/run-root-tests.mjs`: 14072 tests, **zero new failures** — the only 2 failures are the pre-existing `tests(paper-figures)` full-suite flake (#2004, reproduces on main, unrelated to this change).
- New tests: O(candidates) path proves `readAllMemories()` is NOT called when `preloadedFrontmatter` is supplied; golden-parity (candidate output identical to corpus-scan path); version-keyed invalidation; deadline fallback (slow stage returns unfiltered results without throwing); bounded-parallel cold-tier; zero-semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core recall ranking and caching on every path that enables Memory-Worth or TrustScore; behavior is intended fail-open with tests, but mis-keyed cache invalidation or preloaded-path handling could skew rankings or leave cold candidates neutral.
> 
> **Overview**
> **Recall post-retrieval** Memory-Worth / TrustScore reranking is reworked so warm paths avoid full-corpus `readAllMemories()` scans and slow stages cannot blow past the enrichment assembly budget.
> 
> Stages accept optional **preloaded candidate frontmatter** and **`AbortSignal`**: counters/signals are seeded from maps already on the hot path (hot QMD, cold pipeline boost, recent-scan), with **neutral preloaded rows** treated as examined so they do not re-trigger corpus or direct reads. Missing candidates use a **config-gated** per-namespace corpus map (`recallTrustStageCorpusFallbackEnabled`, default on), then **≤16-parallel** direct reads.
> 
> Corpus-fallback caches drop the **30s TTL** (shorter than recall p50) for **`getMemoryCorpusVersion()`** invalidation, with trust signals also **age-capped** (5m) and namespace caches bounded at 64 entries.
> 
> On all four recall branches, trust runs inside **`awaitAssemblyStep("trustStage", …)`** with composed abort on deadline/caller disconnect; fallback leaves results unchanged and aborts in-flight work. **`trustStage`** is added to recall timing allowlists. New coordinator and trust-stage tests cover the fast path, parity, invalidation, abort, and deadline behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62ceba5e850afb50f438d2876fd8462daf999a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->