### PR TITLE
fix(cli): status health probe sends auth token when one is resolvable

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4857,14 +4857,17 @@ function resolveStatusProbeToken(): string | undefined {
   const operatorToken = oauthResolveOperatorToken();
   if (operatorToken) return operatorToken;
   try {
-    const [first] = listTokens();
-    if (first && typeof first.token === "string" && first.token.length > 0) {
-      return first.token;
-    }
+    // Connector tokens authorize health EXCEPT chatgpt-minted ones, which
+    // the access server pins to /mcp only (tokenPathPolicy). Skip those so
+    // a ChatGPT entry at the head of the store doesn't produce a misleading
+    // 401 when an ordinary connector token would authenticate health.
+    const usable = listTokens().find(
+      (t) => t.connector !== "chatgpt" && typeof t.token === "string" && t.token.length > 0,
+    );
+    if (usable) return usable.token;
   } catch {
     // Token store missing/unreadable — fall through to the open probe.
   }
-  return undefined;
 }
 
 export const __statusHealthTestHooks = { resolveStatusProbeToken };
@@ -5023,7 +5026,15 @@ function oauthResolveOperatorToken(): string | undefined {
     const server = raw.server;
     if (server && typeof server === "object" && "authToken" in server) {
       const candidate = (server as Record<string, unknown>).authToken;
-      if (typeof candidate === "string" && candidate.length > 0) {
+      // A config created by `remnic init` may still hold the literal
+      // `${REMNIC_AUTH_TOKEN}` placeholder; treat that as unresolved so
+      // callers fall through to other sources (env, token store) rather
+      // than sending the placeholder as a real bearer token.
+      if (
+        typeof candidate === "string" &&
+        candidate.length > 0 &&
+        !candidate.includes("${")
+      ) {
         return candidate;
       }
     }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4844,6 +4844,31 @@ function cmdInit(): void {
   console.log("  npx --package @remnic/server remnic-server");
 }
 
+/**
+ * Resolve a bearer token for the local status/health probe (issue #2006).
+ * Precedence mirrors the daemon: operator token first (env
+ * `REMNIC_AUTH_TOKEN` / `ENGRAM_AUTH_TOKEN`, then config `server.authToken`
+ * via `oauthResolveOperatorToken()`), then any connector token from the
+ * local token store — the access server accepts connector tokens for
+ * health. Returns `undefined` for open daemons so the probe stays
+ * unauthenticated exactly as before.
+ */
+function resolveStatusProbeToken(): string | undefined {
+  const operatorToken = oauthResolveOperatorToken();
+  if (operatorToken) return operatorToken;
+  try {
+    const [first] = listTokens();
+    if (first && typeof first.token === "string" && first.token.length > 0) {
+      return first.token;
+    }
+  } catch {
+    // Token store missing/unreadable — fall through to the open probe.
+  }
+  return undefined;
+}
+
+export const __statusHealthTestHooks = { resolveStatusProbeToken };
+
 async function cmdStatus(json: boolean): Promise<void> {
   const { running, pid } = isServiceRunning();
   if (json) {
@@ -4857,14 +4882,22 @@ async function cmdStatus(json: boolean): Promise<void> {
   console.log(`Remnic server: running${pid ? ` (pid ${pid})` : ""}`);
 
   const port = inferPort();
+  const probeToken = resolveStatusProbeToken();
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 3000);
   try {
     const response = await fetch(`http://127.0.0.1:${port}/engram/v1/health`, {
       signal: controller.signal,
+      ...(probeToken ? { headers: { Authorization: `Bearer ${probeToken}` } } : {}),
     });
     if (!response.ok) {
-      console.log(`Health: server responded with ${response.status} ${response.statusText}`);
+      const hint =
+        response.status === 401 && !probeToken
+          ? " (daemon requires auth and no local token was found — set REMNIC_AUTH_TOKEN, configure server.authToken, or run 'remnic token generate')"
+          : response.status === 401
+            ? " (local token rejected by the daemon)"
+            : "";
+      console.log(`Health: server responded with ${response.status} ${response.statusText}${hint}`);
     } else {
       const health = (await response.json()) as { status?: unknown };
       const status = typeof health.status === "string" ? health.status : "ok";

--- a/packages/remnic-cli/src/status-health-auth.test.ts
+++ b/packages/remnic-cli/src/status-health-auth.test.ts
@@ -113,3 +113,38 @@ test("env token takes precedence over a present config token", async () => {
   process.env.REMNIC_AUTH_TOKEN = "env-operator-token";
   assert.equal(resolveStatusProbeToken(), "env-operator-token");
 });
+
+test("skips chatgpt connector tokens (mcp-only) and uses the next ordinary connector token", async () => {
+  await mkdir(path.join(tempHome, ".remnic"), { recursive: true });
+  await writeFile(
+    path.join(tempHome, ".remnic", "tokens.json"),
+    JSON.stringify({
+      tokens: [
+        { token: "chatgpt-mcp-only-token", connector: "chatgpt", createdAt: "2026-07-18T00:00:00.000Z" },
+        { token: "ordinary-connector-token", connector: "cli", createdAt: "2026-07-18T00:00:00.000Z" },
+      ],
+    }),
+  );
+  assert.equal(resolveStatusProbeToken(), "ordinary-connector-token");
+});
+
+test("returns undefined when the only connector token is chatgpt (mcp-only)", async () => {
+  await mkdir(path.join(tempHome, ".remnic"), { recursive: true });
+  await writeFile(
+    path.join(tempHome, ".remnic", "tokens.json"),
+    JSON.stringify({
+      tokens: [{ token: "chatgpt-mcp-only-token", connector: "chatgpt", createdAt: "2026-07-18T00:00:00.000Z" }],
+    }),
+  );
+  assert.equal(resolveStatusProbeToken(), undefined);
+});
+
+test("treats the \${REMNIC_AUTH_TOKEN} config placeholder as unresolved (falls through)", async () => {
+  await writeFile(
+    process.env.REMNIC_CONFIG_PATH!,
+    JSON.stringify({ server: { authToken: "${REMNIC_AUTH_TOKEN}" } }),
+  );
+  // No env token, no connector store → undefined (placeholder did not leak).
+  assert.equal(resolveStatusProbeToken(), undefined);
+});
+

--- a/packages/remnic-cli/src/status-health-auth.test.ts
+++ b/packages/remnic-cli/src/status-health-auth.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the authenticated `remnic status` health probe (issue #2006).
+ *
+ * `cmdStatus` previously fetched `/engram/v1/health` with no Authorization
+ * header, so an auth-enforcing daemon reported "401 Unauthorized" while
+ * fully healthy — indistinguishable from a broken daemon during triage.
+ *
+ * The fix resolves a probe token via `resolveStatusProbeToken()` (env →
+ * config `server.authToken` → first connector token from the local store →
+ * undefined for open daemons) and sends `Authorization: Bearer` when one
+ * is found. The fetch wiring is a two-line conditional; the load-bearing
+ * logic is the precedence, so these tests exercise the resolver directly
+ * via the `__statusHealthTestHooks` seam under temp-HOME isolation.
+ *
+ * (The full `cmdStatus` path can't be driven through the in-process
+ * `runCli` harness: `PID_FILE` is a module-scope constant frozen at
+ * import with the host HOME, so `isServiceRunning()` never sees the
+ * temp dir — run-cli.ts documents this limitation itself.)
+ */
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { after, before, beforeEach, test } from "node:test";
+
+import { __statusHealthTestHooks } from "./index.js";
+
+const resolveStatusProbeToken = __statusHealthTestHooks.resolveStatusProbeToken;
+
+let tempHome = "";
+let originalHome: string | undefined;
+let originalAuthEnv: string | undefined;
+let originalLegacyAuthEnv: string | undefined;
+let originalConfigPath: string | undefined;
+
+before(async () => {
+  originalHome = process.env.HOME;
+  tempHome = await mkdtemp(path.join(os.tmpdir(), "remnic-status-test-home-"));
+  process.env.HOME = tempHome;
+  originalAuthEnv = process.env.REMNIC_AUTH_TOKEN;
+  originalLegacyAuthEnv = process.env.ENGRAM_AUTH_TOKEN;
+  originalConfigPath = process.env.REMNIC_CONFIG_PATH;
+  // Point the dispatcher at an empty temp config so it does not pick up a
+  // stray remnic.config.json the test runner dropped somewhere.
+  process.env.REMNIC_CONFIG_PATH = path.join(tempHome, "remnic.config.json");
+});
+
+after(async () => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalAuthEnv === undefined) delete process.env.REMNIC_AUTH_TOKEN;
+  else process.env.REMNIC_AUTH_TOKEN = originalAuthEnv;
+  if (originalLegacyAuthEnv === undefined) delete process.env.ENGRAM_AUTH_TOKEN;
+  else process.env.ENGRAM_AUTH_TOKEN = originalLegacyAuthEnv;
+  if (originalConfigPath === undefined) delete process.env.REMNIC_CONFIG_PATH;
+  else process.env.REMNIC_CONFIG_PATH = originalConfigPath;
+  await rm(tempHome, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  delete process.env.REMNIC_AUTH_TOKEN;
+  delete process.env.ENGRAM_AUTH_TOKEN;
+  await rm(path.join(tempHome, ".remnic"), { recursive: true, force: true });
+  await rm(path.join(tempHome, ".config"), { recursive: true, force: true });
+  await rm(process.env.REMNIC_CONFIG_PATH!, { force: true });
+});
+
+test("env REMNIC_AUTH_TOKEN wins over every other source", () => {
+  process.env.REMNIC_AUTH_TOKEN = "env-operator-token";
+  assert.equal(resolveStatusProbeToken(), "env-operator-token");
+});
+
+test("legacy env ENGRAM_AUTH_TOKEN is accepted when REMNIC_AUTH_TOKEN is unset", () => {
+  process.env.ENGRAM_AUTH_TOKEN = "legacy-env-token";
+  assert.equal(resolveStatusProbeToken(), "legacy-env-token");
+});
+
+test("falls back to config server.authToken when no env token is set", async () => {
+  // resolveConfigPath() honours REMNIC_CONFIG_PATH (set in `before`).
+  await writeFile(
+    process.env.REMNIC_CONFIG_PATH!,
+    JSON.stringify({ server: { authToken: "config-file-token" } }),
+  );
+  assert.equal(resolveStatusProbeToken(), "config-file-token");
+});
+
+test("falls back to the first connector token from the local token store", async () => {
+  await mkdir(path.join(tempHome, ".remnic"), { recursive: true });
+  await writeFile(
+    path.join(tempHome, ".remnic", "tokens.json"),
+    JSON.stringify({
+      tokens: [
+        { token: "second-connector-token", connector: "other", createdAt: "2026-07-18T00:00:00.000Z" },
+        { token: "first-connector-token", connector: "primary", createdAt: "2026-07-17T00:00:00.000Z" },
+      ],
+    }),
+  );
+  // listTokens() returns store order; the first entry is what the probe uses.
+  const token = resolveStatusProbeToken();
+  assert.ok(typeof token === "string" && token.length > 0);
+  assert.ok(token === "first-connector-token" || token === "second-connector-token");
+});
+
+test("returns undefined for an open daemon (no token anywhere) — probe stays unauthenticated", () => {
+  assert.equal(resolveStatusProbeToken(), undefined);
+});
+
+test("env token takes precedence over a present config token", async () => {
+  await writeFile(
+    process.env.REMNIC_CONFIG_PATH!,
+    JSON.stringify({ server: { authToken: "config-file-token" } }),
+  );
+  process.env.REMNIC_AUTH_TOKEN = "env-operator-token";
+  assert.equal(resolveStatusProbeToken(), "env-operator-token");
+});


### PR DESCRIPTION
Fixes #2006.

## Problem

`cmdStatus` fetched `/engram/v1/health` with no Authorization header, so an auth-enforcing daemon (connector token store populated, or `server.authToken` set) reported:

```
Remnic server: running (pid NNNN)
Health: server responded with 401 Unauthorized
```

while the daemon was in fact fully healthy (an authenticated probe returned `ok:true`). Observed live on macstudio 2026-07-18 — misleading during incident triage: an operator (or agent) reading `remnic status` cannot tell a broken daemon from a healthy auth-enforcing one.

## Fix

`resolveStatusProbeToken()` resolves a probe token using the daemon's own precedence:

1. env `REMNIC_AUTH_TOKEN` / `ENGRAM_AUTH_TOKEN` (the legacy alias) via the existing `oauthResolveOperatorToken()`
2. config `server.authToken`
3. first entry from the local connector token store (`listTokens()`) — connector tokens are valid for health per the access-http auth model

The probe sends `Authorization: Bearer` when a token is found, and stays unauthenticated for open daemons (no behavior change there). The 401 path now distinguishes the two operator-confusing cases: a missing token prints a hint pointing at the three sources (`set REMNIC_AUTH_TOKEN`, `server.authToken`, or `remnic token generate`); a rejected token is reported as "local token rejected by the daemon."

## Verification

- `status-health-auth.test.ts`: 6 cases covering the precedence (env wins; legacy env; config fallback; token-store fallback; undefined for open daemons; env-over-config) — all pass. Exercised via a `__statusHealthTestHooks.resolveStatusProbeToken` seam.
- `npm run preflight:quick` → OK.

### Why the test seam (and not a full `runCli` integration test)

`cmdStatus` can't be driven through the in-process `runCli` harness: `PID_FILE` is a module-scope constant frozen at import with the host HOME, so `isServiceRunning()` never sees a temp dir. `run-cli.ts` documents this limitation itself ("module-scope constants in index.ts that read env vars at load time ... are frozen ... tests that need to isolate module-scope env derivatives should use spawnSync instead"). The load-bearing logic is the token precedence; the fetch-header wiring is a two-line conditional, so the resolver seam is the right test surface. The exported hook also doubles as the justification for keeping `resolveStatusProbeToken` as a named function (multi-source precedence with a try/catch — not a tiny wrapper).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only local health probing and operator-token resolution; no server or auth model changes.
> 
> **Overview**
> Fixes **`remnic status`** reporting **401** on `/engram/v1/health` for healthy, auth-enforcing daemons by resolving a bearer token and sending **`Authorization: Bearer`** when one exists; open daemons stay unauthenticated.
> 
> **`resolveStatusProbeToken()`** mirrors daemon precedence: operator token via **`oauthResolveOperatorToken()`** (env `REMNIC_AUTH_TOKEN` / `ENGRAM_AUTH_TOKEN`, then config **`server.authToken`**), then the first usable connector token from **`listTokens()`** (skipping **chatgpt** MCP-only tokens). **`oauthResolveOperatorToken()`** now ignores config values that still contain **`${`** so init placeholders like **`${REMNIC_AUTH_TOKEN}`** are not sent as real credentials.
> 
> 401 output adds hints for missing vs rejected local tokens. **`status-health-auth.test.ts`** covers precedence, ChatGPT skipping, and placeholder handling via **`__statusHealthTestHooks`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36ac6f558ae608948ef6d73abac0200ded0bc2b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->