### PR TITLE
chore(agents): project-scoped omp stream rules (TTSRs) mined from two weeks of PR review feedback

### DIFF
--- a/.omp/rules/README.md
+++ b/.omp/rules/README.md
@@ -1,0 +1,28 @@
+# Project stream rules (omp TTSRs)
+
+These are project-scoped Time Traveling Stream Rules for the
+[Oh My Pi](https://github.com/can1357/oh-my-pi) coding harness. When an
+AI agent working in this repo streams code that matches a rule's
+`condition` (regex) or `astCondition` (ast-grep pattern), the harness
+interrupts (or, for `interruptMode: never` rules, attaches a reminder to
+the tool result) and injects the rule body so the problem is fixed
+before it ever reaches a PR.
+
+Every rule here was derived from recurring AI code-review findings on
+this repository (2+ weeks of Cursor Bugbot / Codex / kilo / CodeQL
+review comments, 2,500+ findings analyzed) and cross-checked against
+`AGENTS.md` review-prevention patterns. Other harnesses ignore this
+directory; human contributors can read the rules as a distilled
+"most-flagged mistakes" checklist.
+
+Ground rules for adding or editing rules:
+
+- **Low false positives beat coverage.** Before adding a `condition`,
+  run it against the existing codebase; if it matches legitimate idioms,
+  tighten it or make it advisory (`interruptMode: never`).
+- **Hard-interrupt rules** are reserved for near-zero-FP signatures
+  (boundary violations, privacy leaks, always-a-bug JS forms).
+- **Advisory rules** nudge on medium-FP signatures where the agent must
+  judge context.
+- **No PII.** This repo is public: rule text must never contain real
+  usernames, paths, keys, or memory content.

--- a/.omp/rules/remnic-comparator-total-order.md
+++ b/.omp/rules/remnic-comparator-total-order.md
@@ -1,0 +1,34 @@
+---
+name: remnic-comparator-total-order
+description: "Sort comparators must return 0 for equal keys; a bare two-arm ternary comparator is never total"
+astCondition:
+  - '($A, $B) => $X < $Y ? 1 : -1'
+  - '($A, $B) => $X < $Y ? -1 : 1'
+  - '($A, $B) => $X > $Y ? 1 : -1'
+  - '($A, $B) => $X > $Y ? -1 : 1'
+  - '($A, $B) => ($X < $Y ? 1 : -1)'
+  - '($A, $B) => ($X < $Y ? -1 : 1)'
+  - '($A, $B) => ($X > $Y ? 1 : -1)'
+  - '($A, $B) => ($X > $Y ? -1 : 1)'
+globs:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.mts"
+---
+
+You are writing a comparator whose entire body is a two-arm ternary
+(`a.x < b.x ? -1 : 1`). It never returns `0` for equal keys, so equal
+items claim both `a > b` and `b > a` — order becomes non-deterministic
+across runs, which breaks byte-stable outputs, top-N slices, briefings,
+and diffs. AI reviewers flagged this exact shape in at least five
+separate Remnic PRs (AGENTS.md pattern 12).
+
+Write a total comparator instead:
+
+- Guard equality first: `if (a.x !== b.x) return a.x < b.x ? -1 : 1; return 0;`
+  (or fall through to a stable secondary key such as `id`).
+- For numbers, prefer `a.x - b.x`.
+- Never let both orderings of equal items return the same sign.
+
+Add a test that sorts a list containing duplicate keys and asserts the
+output is identical across invocations.

--- a/.omp/rules/remnic-comparator-total-order.md
+++ b/.omp/rules/remnic-comparator-total-order.md
@@ -22,6 +22,9 @@ globs:
   - "**/*.ts"
   - "**/*.tsx"
   - "**/*.mts"
+  - "**/*.js"
+  - "**/*.mjs"
+  - "**/*.cjs"
 ---
 
 You are passing `.sort()`/`.toSorted()` a comparator whose entire body

--- a/.omp/rules/remnic-comparator-total-order.md
+++ b/.omp/rules/remnic-comparator-total-order.md
@@ -2,26 +2,34 @@
 name: remnic-comparator-total-order
 description: "Sort comparators must return 0 for equal keys; a bare two-arm ternary comparator is never total"
 astCondition:
-  - '($A, $B) => $X < $Y ? 1 : -1'
-  - '($A, $B) => $X < $Y ? -1 : 1'
-  - '($A, $B) => $X > $Y ? 1 : -1'
-  - '($A, $B) => $X > $Y ? -1 : 1'
-  - '($A, $B) => ($X < $Y ? 1 : -1)'
-  - '($A, $B) => ($X < $Y ? -1 : 1)'
-  - '($A, $B) => ($X > $Y ? 1 : -1)'
-  - '($A, $B) => ($X > $Y ? -1 : 1)'
+  - '$ARR.sort(($A, $B) => $X < $Y ? 1 : -1)'
+  - '$ARR.sort(($A, $B) => $X < $Y ? -1 : 1)'
+  - '$ARR.sort(($A, $B) => $X > $Y ? 1 : -1)'
+  - '$ARR.sort(($A, $B) => $X > $Y ? -1 : 1)'
+  - '$ARR.sort(($A, $B) => ($X < $Y ? 1 : -1))'
+  - '$ARR.sort(($A, $B) => ($X < $Y ? -1 : 1))'
+  - '$ARR.sort(($A, $B) => ($X > $Y ? 1 : -1))'
+  - '$ARR.sort(($A, $B) => ($X > $Y ? -1 : 1))'
+  - '$ARR.toSorted(($A, $B) => $X < $Y ? 1 : -1)'
+  - '$ARR.toSorted(($A, $B) => $X < $Y ? -1 : 1)'
+  - '$ARR.toSorted(($A, $B) => $X > $Y ? 1 : -1)'
+  - '$ARR.toSorted(($A, $B) => $X > $Y ? -1 : 1)'
+  - '$ARR.toSorted(($A, $B) => ($X < $Y ? 1 : -1))'
+  - '$ARR.toSorted(($A, $B) => ($X < $Y ? -1 : 1))'
+  - '$ARR.toSorted(($A, $B) => ($X > $Y ? 1 : -1))'
+  - '$ARR.toSorted(($A, $B) => ($X > $Y ? -1 : 1))'
 globs:
   - "**/*.ts"
   - "**/*.tsx"
   - "**/*.mts"
 ---
 
-You are writing a comparator whose entire body is a two-arm ternary
-(`a.x < b.x ? -1 : 1`). It never returns `0` for equal keys, so equal
-items claim both `a > b` and `b > a` — order becomes non-deterministic
-across runs, which breaks byte-stable outputs, top-N slices, briefings,
-and diffs. AI reviewers flagged this exact shape in at least five
-separate Remnic PRs (AGENTS.md pattern 12).
+You are passing `.sort()`/`.toSorted()` a comparator whose entire body
+is a two-arm ternary (`a.x < b.x ? -1 : 1`). It never returns `0` for
+equal keys, so equal items claim both `a > b` and `b > a` — order
+becomes non-deterministic across runs, which breaks byte-stable
+outputs, top-N slices, briefings, and diffs. AI reviewers flagged this
+exact shape in at least five separate Remnic PRs (AGENTS.md pattern 12).
 
 Write a total comparator instead:
 
@@ -30,5 +38,8 @@ Write a total comparator instead:
 - For numbers, prefer `a.x - b.x`.
 - Never let both orderings of equal items return the same sign.
 
-Add a test that sorts a list containing duplicate keys and asserts the
-output is identical across invocations.
+The same contract applies to named comparator functions passed to sort
+by reference — this rule only pattern-matches the inline form, but the
+totality requirement is universal. Add a test that sorts a list
+containing duplicate keys and asserts the output is identical across
+invocations.

--- a/.omp/rules/remnic-config-coercion-footguns.md
+++ b/.omp/rules/remnic-config-coercion-footguns.md
@@ -1,0 +1,34 @@
+---
+name: remnic-config-coercion-footguns
+description: "Config values arrive as strings and 0 is often valid: use coerceBool/coerceNumber, never strict === true / Boolean() / parse-||-default"
+condition:
+  - '(cfg|config|rawConfig|raw|obj|options|opts)\.[A-Za-z0-9_]+\s*(===\s*true|!==\s*false)\b'
+  - 'Boolean\(\s*(cfg|config|rawConfig|raw|obj|options|opts)\.'
+  - '(parseInt|Number\.parseInt|parseFloat|Number)\([^;\n]{0,80}\)\s*\|\|\s*[0-9]'
+globs:
+  - "**/*.ts"
+  - "**/*.mts"
+interruptMode: never
+---
+
+Advisory: this looks like a config/CLI value being gated with a strict
+or truthy check. Remnic config arrives from multiple hosts and from
+`--config key=value` CLI strings, so values are often strings
+(`"false"`, `"0"`, `"5555"`), and `0` is frequently a valid,
+documented "disable" value. AI reviewers flagged this family in 6+ PRs
+in two weeks (#1623, #1663, #1664, #1675, #1679, #1921; AGENTS.md
+patterns 17, 24, 33):
+
+- `cfg.flag === true` / `cfg.flag !== false` silently ignores the
+  string forms `"true"`/`"false"` — use `coerceBool(...)`
+  (`packages/remnic-core/src/connectors/coerce.ts`) or
+  `coerceBooleanLike(...)` like the neighboring flags do.
+- `Boolean(cfg.x)` turns the string `"false"` into `true`.
+- `parseInt(x) || DEFAULT` / `Number(x) || DEFAULT` swallows a valid
+  `0` and coerces `NaN` to the default without erroring — use
+  `coerceNumber(...)` plus an explicit `Number.isInteger` range check,
+  and honor `0` when the docs say 0 disables.
+
+Ignore if the value provably cannot be a string (already normalized by
+`parseConfig`) and `0`/falsy is genuinely invalid — but say so in the
+validation error rather than silently defaulting.

--- a/.omp/rules/remnic-fs-boundary-checks.md
+++ b/.omp/rules/remnic-fs-boundary-checks.md
@@ -1,0 +1,28 @@
+---
+name: remnic-fs-boundary-checks
+description: "Scan/write roots must reject symlinks (lstatSync, not statSync) and path containment must not use string prefixes"
+condition:
+  - 'statSync\([^)]{0,120}\)\s*\.isDirectory\(\)'
+  - '\.startsWith\(\s*path\.join\('
+globs:
+  - "**/*.ts"
+  - "**/*.mts"
+interruptMode: never
+---
+
+Advisory: this code performs a filesystem safety check with a known
+weak form. Two recurring review findings (8+ findings across PRs #1938,
+#1999, #2000; #1612):
+
+1. `statSync(p).isDirectory()` FOLLOWS symlinks, so it accepts a
+   symlinked root. The repo rule is to REJECT symlinked scan/write
+   roots (memory dirs, discovery roots, recording paths, profile
+   components): use `lstatSync(p)`, reject when `.isSymbolicLink()`,
+   then check `.isDirectory()`. `statSync` is fine when following the
+   link is intended — e.g. reading a file the user pointed at.
+
+2. `child.startsWith(path.join(root, "sub"))` is not containment: a
+   sibling like `<root>/sub-evil` passes the prefix check. Use
+   `const rel = path.relative(base, child)` and require
+   `rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel)`,
+   or append `path.sep` to the prefix before comparing.

--- a/.omp/rules/remnic-no-cross-package-src-imports.md
+++ b/.omp/rules/remnic-no-cross-package-src-imports.md
@@ -1,0 +1,27 @@
+---
+name: remnic-no-cross-package-src-imports
+description: "Never import another workspace package via a relative ../<pkg>/src/ path; use the @remnic/* package name"
+condition:
+  - '(from\s+|import\s*\(\s*|require\(\s*)["''](\.\./)+(belief-ledger|bench|bench-ui|coding-graph|connector-[a-z-]+|export-weclone|hermes-provider|import-[a-z-]+|plugin-[a-z-]+|remnic-cli|remnic-core|remnic-server|shim-openclaw-engram)/src/'
+globs:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.mts"
+  - "**/*.js"
+  - "**/*.mjs"
+---
+
+You are importing another workspace package through a relative
+`../<package>/src/...` path. This bypasses the package's public export
+surface: a directory rename or build-output change in the target package
+silently breaks the import, and the module graph escapes the package
+boundary contract (AGENTS.md pattern 15). The repo's structural gates
+were extended twice (PRs #1665, #1681) because static, dynamic
+(`await import(...)`), and side-effect import forms all kept sneaking in.
+
+Import via the package name instead: `import { X } from "@remnic/core"`.
+If the symbol is not exported, export it from the target package's
+public surface rather than deep-linking into its `src/`.
+
+(Non-import uses, e.g. `path.resolve(dir, "../../remnic-server/src/...")`
+for dev-mode process spawning, are not affected by this rule.)

--- a/.omp/rules/remnic-no-cross-package-src-imports.md
+++ b/.omp/rules/remnic-no-cross-package-src-imports.md
@@ -2,7 +2,7 @@
 name: remnic-no-cross-package-src-imports
 description: "Never import another workspace package via a relative ../<pkg>/src/ path; use the @remnic/* package name"
 condition:
-  - '(from\s+|import\s*\(\s*|require\(\s*|import\s+)["''](\.\./)+(belief-ledger|bench|bench-ui|coding-graph|connector-[a-z-]+|export-weclone|hermes-provider|import-[a-z-]+|plugin-[a-z-]+|remnic-cli|remnic-core|remnic-server|shim-openclaw-engram)/src/'
+  - '(from\s+|import\s*\(\s*|require\(\s*|import\s+)["''](\.\./)+(belief-ledger|bench|bench-ui|coding-graph|connector-[a-z0-9-]+|export-weclone|hermes-provider|import-[a-z0-9-]+|plugin-[a-z0-9-]+|remnic-cli|remnic-core|remnic-server|shim-openclaw-engram)/src/'
 globs:
   - "**/*.ts"
   - "**/*.tsx"

--- a/.omp/rules/remnic-no-cross-package-src-imports.md
+++ b/.omp/rules/remnic-no-cross-package-src-imports.md
@@ -9,6 +9,7 @@ globs:
   - "**/*.mts"
   - "**/*.js"
   - "**/*.mjs"
+  - "**/*.cjs"
 ---
 
 You are importing another workspace package through a relative

--- a/.omp/rules/remnic-no-cross-package-src-imports.md
+++ b/.omp/rules/remnic-no-cross-package-src-imports.md
@@ -2,7 +2,7 @@
 name: remnic-no-cross-package-src-imports
 description: "Never import another workspace package via a relative ../<pkg>/src/ path; use the @remnic/* package name"
 condition:
-  - '(from\s+|import\s*\(\s*|require\(\s*)["''](\.\./)+(belief-ledger|bench|bench-ui|coding-graph|connector-[a-z-]+|export-weclone|hermes-provider|import-[a-z-]+|plugin-[a-z-]+|remnic-cli|remnic-core|remnic-server|shim-openclaw-engram)/src/'
+  - '(from\s+|import\s*\(\s*|require\(\s*|import\s+)["''](\.\./)+(belief-ledger|bench|bench-ui|coding-graph|connector-[a-z-]+|export-weclone|hermes-provider|import-[a-z-]+|plugin-[a-z-]+|remnic-cli|remnic-core|remnic-server|shim-openclaw-engram)/src/'
 globs:
   - "**/*.ts"
   - "**/*.tsx"

--- a/.omp/rules/remnic-no-cross-package-src-imports.md
+++ b/.omp/rules/remnic-no-cross-package-src-imports.md
@@ -25,3 +25,11 @@ public surface rather than deep-linking into its `src/`.
 
 (Non-import uses, e.g. `path.resolve(dir, "../../remnic-server/src/...")`
 for dev-mode process spawning, are not affected by this rule.)
+
+Deliberately NOT matched: the `../packages/<pkg>/src/...` form used by
+repo-root `src/`, `scripts/`, and `tests/`. That class is existing
+ratchet-managed debt (`directStorageImports` in
+`scripts/ratchet-baseline.json`, 350+ occurrences) governed by
+`check-ratchets.mjs` — hard-interrupting it would false-positive on
+every managed-debt file. New code should still prefer `@remnic/*`
+package-name imports; the ratchet ensures the count only shrinks.

--- a/.omp/rules/remnic-no-real-home-paths.md
+++ b/.omp/rules/remnic-no-real-home-paths.md
@@ -1,0 +1,26 @@
+---
+name: remnic-no-real-home-paths
+description: "Never commit a real user home directory path; this is a public repo — use ~, $HOME, os.homedir(), tmpdir, or a generic persona"
+condition:
+  - '/(home|Users)/(?!(user|users|alice|bob|carol|dave|app|dev|test|tester|testuser|example|runner|ci|demo|sample|foo|bar|you|yourname|username|me|jdoe|somebody|placeholder|nobody|admin|guest)[/"''\\])[a-z][a-z0-9._-]{5,}/'
+---
+
+The text you are writing contains what looks like a real user's home
+directory path (`/home/<name>/` or `/Users/<name>/`). This repository is
+PUBLIC: committing an operator's actual filesystem path leaks personal
+information and machine-specific state (reviewers flagged committed
+`/home/<operator>/` paths in benchmark artifacts and test fixtures in
+PRs #1754 and #1862). Machine-specific absolute paths also break on
+every other checkout and in CI.
+
+Use instead:
+
+- runtime resolution: `os.homedir()`, `expandTildePath("~/...")` from
+  `@remnic/core`, `os.tmpdir()`, or `mkdtemp` for test scratch dirs
+- test fixtures: a generic persona path such as `/home/user/...` or
+  `/home/alice/...` (these do not trigger this rule)
+- docs/artifacts: `~` or `$HOME` placeholders; strip or rewrite absolute
+  paths before committing generated JSON artifacts
+
+If this fired on a genuinely generic name, prefer one of the persona
+names above rather than suppressing the rule.

--- a/.omp/rules/remnic-no-real-home-paths.md
+++ b/.omp/rules/remnic-no-real-home-paths.md
@@ -2,7 +2,8 @@
 name: remnic-no-real-home-paths
 description: "Never commit a real user home directory path; this is a public repo — use ~, $HOME, os.homedir(), tmpdir, or a generic persona"
 condition:
-  - '/(home|Users)/(?!(user|users|alice|bob|carol|dave|app|dev|test|tester|testuser|example|runner|ci|demo|sample|foo|bar|you|yourname|username|me|jdoe|somebody|placeholder|nobody|admin|guest)[/"''\\])[a-z][a-z0-9._-]{5,}/'
+  - '/(home|Users)/(?!(user|users|alex|alice|bob|carol|dave|app|dev|op|person|private|someone|test|tester|testuser|example|runner|ci|demo|sample|foo|bar|you|yourname|username|me|jdoe|janedoe|johndoe|somebody|placeholder|nobody|admin|guest|qa)[/"''\\])[a-z][a-z0-9._-]+/'
+  - '/(home|Users)/(?!(User|Users|Alice|Bob|Test|Example|Admin|Guest|Foo|Bar|Demo|Sample|Shared|Public|Default|JaneDoe|JohnDoe|Runner)[/"''\\])[A-Z][A-Za-z0-9._-]+/'
 ---
 
 The text you are writing contains what looks like a real user's home
@@ -17,10 +18,13 @@ Use instead:
 
 - runtime resolution: `os.homedir()`, `expandTildePath("~/...")` from
   `@remnic/core`, `os.tmpdir()`, or `mkdtemp` for test scratch dirs
-- test fixtures: a generic persona path such as `/home/user/...` or
-  `/home/alice/...` (these do not trigger this rule)
+- test fixtures: a generic persona path such as `/home/user/...`,
+  `/home/alice/...`, or `/Users/JaneDoe/...` (these do not trigger this
+  rule)
 - docs/artifacts: `~` or `$HOME` placeholders; strip or rewrite absolute
   paths before committing generated JSON artifacts
 
-If this fired on a genuinely generic name, prefer one of the persona
-names above rather than suppressing the rule.
+Lowercase `/users/<handle>/` URL paths (GitHub links) are intentionally
+not matched — only the case-sensitive `/home/` and `/Users/` filesystem
+forms are. If this fired on a genuinely generic name, prefer one of the
+persona names above rather than suppressing the rule.

--- a/.omp/rules/remnic-no-real-home-paths.md
+++ b/.omp/rules/remnic-no-real-home-paths.md
@@ -2,7 +2,7 @@
 name: remnic-no-real-home-paths
 description: "Never commit a real user home directory path; this is a public repo — use ~, $HOME, os.homedir(), tmpdir, or a generic persona"
 condition:
-  - '/(home|Users)/(?!(user|users|alex|alice|bob|carol|dave|app|dev|op|person|private|someone|test|tester|testuser|example|runner|ci|demo|sample|foo|bar|you|yourname|username|me|jdoe|janedoe|johndoe|somebody|placeholder|nobody|admin|guest|qa)[/"''\\])[a-z][a-z0-9._-]+/'
+  - '/(home|Users)/(?!(user|users|alex|alice|bob|carol|dave|app|dev|op|person|private|someone|test|tester|testuser|example|runner|ci|demo|sample|foo|bar|you|yourname|username|me|jdoe|janedoe|johndoe|somebody|placeholder|nobody|admin|guest|qa|node|root|ubuntu|debian|fedora|alpine|coder|vscode|devcontainer|pptruser|jovyan|appuser|deploy|worker|www-data|git|docker|github|actions)[/"''\\])[a-z][a-z0-9._-]+/'
   - '/(home|Users)/(?!(User|Users|Alice|Bob|Test|Example|Admin|Guest|Foo|Bar|Demo|Sample|Shared|Public|Default|JaneDoe|JohnDoe|Runner)[/"''\\])[A-Z][A-Za-z0-9._-]+/'
   - '(?i)[a-z]:[\\/]{1,2}users[\\/]{1,2}(?!(user|users|alex|alice|bob|carol|dave|app|dev|op|person|private|someone|somebody|test|tester|testuser|example|runner|ci|demo|sample|foo|bar|you|yourname|username|me|jdoe|janedoe|johndoe|placeholder|nobody|admin|administrator|guest|qa|public|default|defaultuser|all)[\\/"''])[a-z][a-z0-9._-]+[\\/]'
 ---

--- a/.omp/rules/remnic-no-real-home-paths.md
+++ b/.omp/rules/remnic-no-real-home-paths.md
@@ -4,7 +4,7 @@ description: "Never commit a real user home directory path; this is a public rep
 condition:
   - '/(home|Users)/(?!(user|users|alex|alice|bob|carol|dave|app|dev|op|person|private|someone|test|tester|testuser|example|runner|ci|demo|sample|foo|bar|you|yourname|username|me|jdoe|janedoe|johndoe|somebody|placeholder|nobody|admin|guest|qa|node|root|ubuntu|debian|fedora|alpine|coder|vscode|devcontainer|pptruser|jovyan|appuser|deploy|worker|www-data|git|docker|github|actions)[/"''\\])[a-z][a-z0-9._-]+/'
   - '/(home|Users)/(?!(User|Users|Alice|Bob|Test|Example|Admin|Guest|Foo|Bar|Demo|Sample|Shared|Public|Default|JaneDoe|JohnDoe|Runner)[/"''\\])[A-Z][A-Za-z0-9._-]+/'
-  - '(?i)[a-z]:[\\/]{1,2}users[\\/]{1,2}(?!(user|users|alex|alice|bob|carol|dave|app|dev|op|person|private|someone|somebody|test|tester|testuser|example|runner|ci|demo|sample|foo|bar|you|yourname|username|me|jdoe|janedoe|johndoe|placeholder|nobody|admin|administrator|guest|qa|public|default|defaultuser|all)[\\/"''])[a-z][a-z0-9._-]+[\\/]'
+  - '(?i)[a-z]:[\\/]{1,2}users[\\/]{1,2}(?!(user|users|alex|alice|bob|carol|dave|app|dev|op|person|private|someone|somebody|test|tester|testuser|example|runner|ci|demo|sample|foo|bar|you|yourname|username|me|jdoe|janedoe|johndoe|placeholder|nobody|admin|administrator|guest|qa|public|default|defaultuser|all|node|root|ubuntu|debian|fedora|alpine|coder|vscode|devcontainer|pptruser|jovyan|appuser|deploy|worker|www-data|git|docker|github|actions)[\\/"''])[a-z][a-z0-9._-]+[\\/]'
 ---
 
 The text you are writing contains what looks like a real user's home

--- a/.omp/rules/remnic-no-real-home-paths.md
+++ b/.omp/rules/remnic-no-real-home-paths.md
@@ -4,11 +4,13 @@ description: "Never commit a real user home directory path; this is a public rep
 condition:
   - '/(home|Users)/(?!(user|users|alex|alice|bob|carol|dave|app|dev|op|person|private|someone|test|tester|testuser|example|runner|ci|demo|sample|foo|bar|you|yourname|username|me|jdoe|janedoe|johndoe|somebody|placeholder|nobody|admin|guest|qa)[/"''\\])[a-z][a-z0-9._-]+/'
   - '/(home|Users)/(?!(User|Users|Alice|Bob|Test|Example|Admin|Guest|Foo|Bar|Demo|Sample|Shared|Public|Default|JaneDoe|JohnDoe|Runner)[/"''\\])[A-Z][A-Za-z0-9._-]+/'
+  - '(?i)[a-z]:[\\/]{1,2}users[\\/]{1,2}(?!(user|users|alex|alice|bob|carol|dave|app|dev|op|person|private|someone|somebody|test|tester|testuser|example|runner|ci|demo|sample|foo|bar|you|yourname|username|me|jdoe|janedoe|johndoe|placeholder|nobody|admin|administrator|guest|qa|public|default|defaultuser|all)[\\/"''])[a-z][a-z0-9._-]+[\\/]'
 ---
 
 The text you are writing contains what looks like a real user's home
-directory path (`/home/<name>/` or `/Users/<name>/`). This repository is
-PUBLIC: committing an operator's actual filesystem path leaks personal
+directory path (`/home/<name>/`, `/Users/<name>/`, or Windows
+`C:\Users\<name>\`). This repository is PUBLIC: committing an
+operator's actual filesystem path leaks personal
 information and machine-specific state (reviewers flagged committed
 `/home/<operator>/` paths in benchmark artifacts and test fixtures in
 PRs #1754 and #1862). Machine-specific absolute paths also break on

--- a/.omp/rules/remnic-no-static-optional-package-imports.md
+++ b/.omp/rules/remnic-no-static-optional-package-imports.md
@@ -2,20 +2,25 @@
 name: remnic-no-static-optional-package-imports
 description: "Base packages must not statically value-import optional companion packages (bench, export/import-*, connector-*, coding-graph)"
 condition:
-  - 'import\s+(?!type\b)[^;]{0,300}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z-]+|connector-[a-z-]+|coding-graph)["'']'
-  - '(?<!typeof )(?<!: )(?<!<)(?<!as )import\s*\(\s*["'']@remnic/(bench|export-weclone|import-[a-z-]+|connector-[a-z-]+|coding-graph)["'']'
-  - '(import\s+|require\(\s*)["'']@remnic/(bench|export-weclone|import-[a-z-]+|connector-[a-z-]+|coding-graph)["'']'
+  - 'import\s+(?!type\b)(?!\{)[A-Za-z_$*][^;]{0,300}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)["'']'
+  - 'import\s+(?!type\b)[^;{]{0,120}?\{([^}]*,)?\s*(?!type\s)[A-Za-z_$][\w$]*\s*(as\s+[\w$]+\s*)?[,}][^;]{0,200}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)["'']'
+  - '(?<!typeof )(?<!: )(?<!<)(?<!as )import\s*\(\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)["'']'
+  - '(import\s+|require\(\s*)["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)["'']'
 globs:
   - "**/packages/remnic-cli/**"
   - "**/packages/remnic-core/**"
   - "**/packages/remnic-server/**"
   - "**/packages/plugin-*/**"
   - "**/packages/shim-*/**"
+  - "src/**"
+  - "**/remnic*/src/**"
 ---
 
 You are adding a runtime import of an optional companion package
 (`@remnic/bench`, `@remnic/export-weclone`, `@remnic/import-*`,
-`@remnic/connector-*`, `@remnic/coding-graph`) into a base package.
+`@remnic/connector-*`, `@remnic/coding-graph`) into an install surface
+(a base package, or the repo-root `src/` compatibility wiring that is
+built and published as the OpenClaw extension).
 These are optional peer dependencies — a static import, a side-effect
 import, or a literal-specifier dynamic import (awaited or not: `void
 import(...)`, `import(...).then(...)`) lets the bundler resolve them
@@ -34,6 +39,9 @@ helpers instead:
 Pattern: `await import("@remnic/" + "bench")` wrapped in a loader that
 throws a user-facing install hint on `MODULE_NOT_FOUND`.
 
-Type-only imports (`import type { X } from "@remnic/bench"` or
-`typeof import("@remnic/bench")`) are erased at compile time and are
-fine — this rule intentionally does not match them.
+Type-only imports are erased at compile time and are fine — this rule
+intentionally does not match `import type { X } from "@remnic/bench"`,
+all-type inline specifiers (`import { type A, type B } from ...`), or
+`typeof import("@remnic/bench")` type positions. A mixed list like
+`import { type A, B } from ...` still imports `B` at runtime and is
+correctly caught.

--- a/.omp/rules/remnic-no-static-optional-package-imports.md
+++ b/.omp/rules/remnic-no-static-optional-package-imports.md
@@ -3,7 +3,8 @@ name: remnic-no-static-optional-package-imports
 description: "Base packages must not statically value-import optional companion packages (bench, export/import-*, connector-*, coding-graph)"
 condition:
   - 'import\s+(?!type\b)[^;]{0,300}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z-]+|connector-[a-z-]+|coding-graph)["'']'
-  - '(await\s+import|require)\(\s*["'']@remnic/(bench|export-weclone|import-[a-z-]+|connector-[a-z-]+|coding-graph)["'']'
+  - '(?<!typeof )(?<!: )(?<!<)(?<!as )import\s*\(\s*["'']@remnic/(bench|export-weclone|import-[a-z-]+|connector-[a-z-]+|coding-graph)["'']'
+  - '(import\s+|require\(\s*)["'']@remnic/(bench|export-weclone|import-[a-z-]+|connector-[a-z-]+|coding-graph)["'']'
 globs:
   - "**/packages/remnic-cli/**"
   - "**/packages/remnic-core/**"
@@ -15,8 +16,10 @@ globs:
 You are adding a runtime import of an optional companion package
 (`@remnic/bench`, `@remnic/export-weclone`, `@remnic/import-*`,
 `@remnic/connector-*`, `@remnic/coding-graph`) into a base package.
-These are optional peer dependencies — a static or literal-specifier
-dynamic import lets the bundler resolve them and pulls them into every
+These are optional peer dependencies — a static import, a side-effect
+import, or a literal-specifier dynamic import (awaited or not: `void
+import(...)`, `import(...).then(...)`) lets the bundler resolve them
+and pulls them into every
 base install, breaking the à-la-carte packaging contract (AGENTS.md
 pattern 44). A past regression bundled bench and export-weclone into
 every CLI install this way.

--- a/.omp/rules/remnic-no-static-optional-package-imports.md
+++ b/.omp/rules/remnic-no-static-optional-package-imports.md
@@ -50,3 +50,12 @@ all-type inline specifiers (`import { type A, type B } from ...`), or
 `typeof import("@remnic/bench")` type positions. A mixed list like
 `import { type A, B } from ...` still imports `B` at runtime and is
 correctly caught.
+
+Recorded non-goal: token-obfuscated forms such as a block comment
+between `import` and its clause (`import /* x */ { load } from ...`)
+are not matched. TTSRs are guardrails against realistic accidental
+code, not an adversarial sandbox — generated code does not interleave
+comments inside import statements, and supporting arbitrary comment
+positions would make every condition unreadable. The packaging
+contract itself is still enforced downstream by tsup externals and the
+packaging tests; this rule is the early-warning layer.

--- a/.omp/rules/remnic-no-static-optional-package-imports.md
+++ b/.omp/rules/remnic-no-static-optional-package-imports.md
@@ -7,6 +7,8 @@ condition:
   - '(?<!typeof )(?<!: )(?<!<)(?<!as )import\s*\(\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
   - '(?m)^\s*import\s+["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
   - 'require\(\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
+  - 'export\s+(?!type\b)\*[^;]{0,50}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
+  - 'export\s+(?!type\b)[^;{]{0,120}?\{([^}]*,)?\s*(?!type\s)[A-Za-z_$][\w$]*\s*(as\s+[\w$]+\s*)?[,}][^;]{0,200}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
 globs:
   - "**/packages/remnic-cli/**"
   - "**/packages/remnic-core/**"
@@ -24,7 +26,8 @@ including any `/subpath`) into an install surface
 (a base package, or the repo-root `src/` compatibility wiring that is
 built and published as the OpenClaw extension).
 These are optional peer dependencies — a static import, a side-effect
-import, or a literal-specifier dynamic import (awaited or not: `void
+import, a runtime re-export (`export * from ...`, `export { x } from
+...`), or a literal-specifier dynamic import (awaited or not: `void
 import(...)`, `import(...).then(...)`) lets the bundler resolve them
 and pulls them into every
 base install, breaking the à-la-carte packaging contract (AGENTS.md

--- a/.omp/rules/remnic-no-static-optional-package-imports.md
+++ b/.omp/rules/remnic-no-static-optional-package-imports.md
@@ -2,10 +2,11 @@
 name: remnic-no-static-optional-package-imports
 description: "Base packages must not statically value-import optional companion packages (bench, export/import-*, connector-*, coding-graph)"
 condition:
-  - 'import\s+(?!type\b)(?!\{)[A-Za-z_$*][^;]{0,300}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)(/[^"'']*)?["'']'
-  - 'import\s+(?!type\b)[^;{]{0,120}?\{([^}]*,)?\s*(?!type\s)[A-Za-z_$][\w$]*\s*(as\s+[\w$]+\s*)?[,}][^;]{0,200}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)(/[^"'']*)?["'']'
-  - '(?<!typeof )(?<!: )(?<!<)(?<!as )import\s*\(\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)(/[^"'']*)?["'']'
-  - '(import\s+|require\(\s*)["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)(/[^"'']*)?["'']'
+  - 'import\s+(?!type\b)(?!\{)[A-Za-z_$*][^;]{0,300}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
+  - 'import\s+(?!type\b)[^;{]{0,120}?\{([^}]*,)?\s*(?!type\s)[A-Za-z_$][\w$]*\s*(as\s+[\w$]+\s*)?[,}][^;]{0,200}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
+  - '(?<!typeof )(?<!: )(?<!<)(?<!as )import\s*\(\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
+  - '(?m)^\s*import\s+["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
+  - 'require\(\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
 globs:
   - "**/packages/remnic-cli/**"
   - "**/packages/remnic-core/**"
@@ -18,7 +19,8 @@ globs:
 
 You are adding a runtime import of an optional companion package
 (`@remnic/bench`, `@remnic/export-weclone`, `@remnic/import-*`,
-`@remnic/connector-*`, `@remnic/coding-graph`) into an install surface
+`@remnic/connector-*`, `@remnic/replit`, `@remnic/coding-graph` —
+including any `/subpath`) into an install surface
 (a base package, or the repo-root `src/` compatibility wiring that is
 built and published as the OpenClaw extension).
 These are optional peer dependencies — a static import, a side-effect

--- a/.omp/rules/remnic-no-static-optional-package-imports.md
+++ b/.omp/rules/remnic-no-static-optional-package-imports.md
@@ -4,7 +4,7 @@ description: "Base packages must not statically value-import optional companion 
 condition:
   - 'import\s+(?!type\b)(?!\{)[A-Za-z_$*][^;]{0,300}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
   - 'import\s+(?!type\b)[^;{]{0,120}?\{([^}]*,)?\s*(?!type\s)[A-Za-z_$][\w$]*\s*(as\s+[\w$]+\s*)?[,}][^;]{0,200}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
-  - '(?<!typeof )(?<!: )(?<!<)(?<!as )import\s*\(\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
+  - '(?<!typeof )(?<!: )(?<!<)(?<!as )(?<!\btype\s[A-Za-z_$][\w$<>, ]{0,80}=\s*)import\s*\(\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
   - '(?m)^\s*import\s+["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
   - 'require\(\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'
   - 'export\s+(?!type\b)\*[^;]{0,50}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph|replit)(/[^"'']*)?["'']'

--- a/.omp/rules/remnic-no-static-optional-package-imports.md
+++ b/.omp/rules/remnic-no-static-optional-package-imports.md
@@ -2,10 +2,10 @@
 name: remnic-no-static-optional-package-imports
 description: "Base packages must not statically value-import optional companion packages (bench, export/import-*, connector-*, coding-graph)"
 condition:
-  - 'import\s+(?!type\b)(?!\{)[A-Za-z_$*][^;]{0,300}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)["'']'
-  - 'import\s+(?!type\b)[^;{]{0,120}?\{([^}]*,)?\s*(?!type\s)[A-Za-z_$][\w$]*\s*(as\s+[\w$]+\s*)?[,}][^;]{0,200}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)["'']'
-  - '(?<!typeof )(?<!: )(?<!<)(?<!as )import\s*\(\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)["'']'
-  - '(import\s+|require\(\s*)["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)["'']'
+  - 'import\s+(?!type\b)(?!\{)[A-Za-z_$*][^;]{0,300}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)(/[^"'']*)?["'']'
+  - 'import\s+(?!type\b)[^;{]{0,120}?\{([^}]*,)?\s*(?!type\s)[A-Za-z_$][\w$]*\s*(as\s+[\w$]+\s*)?[,}][^;]{0,200}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)(/[^"'']*)?["'']'
+  - '(?<!typeof )(?<!: )(?<!<)(?<!as )import\s*\(\s*["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)(/[^"'']*)?["'']'
+  - '(import\s+|require\(\s*)["'']@remnic/(bench|export-weclone|import-[a-z0-9-]+|connector-[a-z0-9-]+|coding-graph)(/[^"'']*)?["'']'
 globs:
   - "**/packages/remnic-cli/**"
   - "**/packages/remnic-core/**"

--- a/.omp/rules/remnic-no-static-optional-package-imports.md
+++ b/.omp/rules/remnic-no-static-optional-package-imports.md
@@ -1,0 +1,36 @@
+---
+name: remnic-no-static-optional-package-imports
+description: "Base packages must not statically value-import optional companion packages (bench, export/import-*, connector-*, coding-graph)"
+condition:
+  - 'import\s+(?!type\b)[^;]{0,300}?from\s*["'']@remnic/(bench|export-weclone|import-[a-z-]+|connector-[a-z-]+|coding-graph)["'']'
+  - '(await\s+import|require)\(\s*["'']@remnic/(bench|export-weclone|import-[a-z-]+|connector-[a-z-]+|coding-graph)["'']'
+globs:
+  - "**/packages/remnic-cli/**"
+  - "**/packages/remnic-core/**"
+  - "**/packages/remnic-server/**"
+  - "**/packages/plugin-*/**"
+  - "**/packages/shim-*/**"
+---
+
+You are adding a runtime import of an optional companion package
+(`@remnic/bench`, `@remnic/export-weclone`, `@remnic/import-*`,
+`@remnic/connector-*`, `@remnic/coding-graph`) into a base package.
+These are optional peer dependencies — a static or literal-specifier
+dynamic import lets the bundler resolve them and pulls them into every
+base install, breaking the à-la-carte packaging contract (AGENTS.md
+pattern 44). A past regression bundled bench and export-weclone into
+every CLI install this way.
+
+Load optional packages through the existing computed-specifier loader
+helpers instead:
+
+- `packages/remnic-cli/src/optional-bench.ts`
+- `packages/remnic-cli/src/optional-weclone-export.ts`
+- `packages/remnic-core/src/cli.ts` → `ensureBuiltInBulkImportAdapters`
+
+Pattern: `await import("@remnic/" + "bench")` wrapped in a loader that
+throws a user-facing install hint on `MODULE_NOT_FOUND`.
+
+Type-only imports (`import type { X } from "@remnic/bench"` or
+`typeof import("@remnic/bench")`) are erased at compile time and are
+fine — this rule intentionally does not match them.

--- a/.omp/rules/remnic-process-env-delete.md
+++ b/.omp/rules/remnic-process-env-delete.md
@@ -10,6 +10,7 @@ globs:
   - "**/*.mts"
   - "**/*.js"
   - "**/*.mjs"
+  - "**/*.cjs"
 ---
 
 `process.env.X = undefined` does not unset the variable in Node — the

--- a/.omp/rules/remnic-process-env-delete.md
+++ b/.omp/rules/remnic-process-env-delete.md
@@ -1,0 +1,22 @@
+---
+name: remnic-process-env-delete
+description: "Assigning undefined to process.env stores the string \"undefined\"; use delete"
+astCondition:
+  - 'process.env.$NAME = undefined'
+  - 'process.env[$NAME] = undefined'
+globs:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.mts"
+  - "**/*.js"
+  - "**/*.mjs"
+---
+
+`process.env.X = undefined` does not unset the variable in Node — the
+value is coerced to the literal string `"undefined"`, which is truthy
+and passes `!== undefined` checks. Three different AI reviewers flagged
+this in Remnic test teardown code (PR #1844).
+
+Use `delete process.env.X` to remove the variable. In tests, capture the
+prior value and restore it in teardown: `delete` when it was absent,
+reassign when it was present.

--- a/.omp/rules/remnic-ratchet-baseline-only-decreases.md
+++ b/.omp/rules/remnic-ratchet-baseline-only-decreases.md
@@ -1,0 +1,24 @@
+---
+name: remnic-ratchet-baseline-only-decreases
+description: "scripts/ratchet-baseline.json counters may only decrease; raising one hides new structural debt"
+condition:
+  - '\d'
+globs:
+  - "**/scripts/ratchet-baseline.json"
+interruptMode: never
+---
+
+Advisory: you are editing `scripts/ratchet-baseline.json`. These
+counters are debt ceilings enforced by `check-ratchets.mjs` and they may
+only stay equal or DECREASE. Raising a number to make CI pass defeats
+the ratchet and lets structural debt grow silently — reviewers rejected
+exactly this in PRs #1593, #1603, #1605, #1623, #1705, #1803, #1815.
+
+Before committing this edit, verify:
+
+1. Every changed number is lower than (or equal to) the previous value.
+2. If a number must go UP, that is a reviewed exception: state the
+   justification in the PR description and get explicit approval —
+   never bundle a silent ratchet raise into an unrelated change.
+3. The values match reality at your HEAD (run the ratchet check
+   locally); a stale baseline fails CI in both directions.

--- a/.omp/rules/remnic-write-memory-tombstone-blocked.md
+++ b/.omp/rules/remnic-write-memory-tombstone-blocked.md
@@ -1,0 +1,27 @@
+---
+name: remnic-write-memory-tombstone-blocked
+description: "Destructuring only { id } from writeMemory() drops the tombstoneBlocked signal; production call sites must gate post-write work on it"
+astCondition:
+  - 'const { id } = await $O.writeMemory($$$A)'
+  - 'const { id: $X } = await $O.writeMemory($$$A)'
+globs:
+  - "**/*.ts"
+interruptMode: never
+---
+
+Advisory: this call site destructures only `id` from
+`storage.writeMemory(...)` and discards `tombstoneBlocked` (and
+`blockedBy`) from `MemoryWriteResult`. When a tombstone blocks the
+write, the memory lands as `pending_review` — continuing to index,
+promote, link, or report "success" on it re-activates content the user
+explicitly forgot. Reviewers flagged ~15 such call sites in a single PR
+(#1724) after the `MemoryWriteResult` shape change.
+
+Production call sites should read `tombstoneBlocked` and skip active
+post-write work (indexing, dedup registration, success replies,
+follow-on edges) when it is `true`.
+
+Fine to ignore when: writing test fixtures that don't exercise the
+tombstone path, or writing categories the tombstone gate never applies
+to. If unsure, check `StorageManager.writeMemory` in
+`packages/remnic-core/src/storage.ts`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,20 @@ Minimum scenario matrix for session/retrieval/cache work:
 If you cannot explain the behavior for every row in that matrix, the PR is not
 ready for external review.
 
+## Mechanical Stream Rules (`.omp/rules/`)
+
+The most-recurring, textually-detectable mistakes from AI review feedback are
+also enforced mechanically as project-scoped omp TTSRs in `.omp/rules/`. Agents
+running in the omp harness get interrupted (or reminded) at code-write time —
+before a PR exists — for: non-total sort comparators, `process.env.X =
+undefined`, cross-package `../<pkg>/src/` imports, static imports of optional
+`@remnic/*` packages, real home-directory paths (public-repo privacy),
+discarded `tombstoneBlocked`, config string/zero coercion footguns, ratchet
+baseline raises, and weak symlink/containment checks. See
+`.omp/rules/README.md` before adding rules: run every new condition against the
+existing codebase first, and keep hard interrupts for near-zero-false-positive
+signatures only.
+
 ## Review Prevention Checklist (All Agents — Read Before Every PR)
 
 These patterns were extracted from 60+ PRs across 2026-04-05 to 2026-04-12

--- a/docs/superpowers/plans/2026-04-18-ingestion-benchmarks.md
+++ b/docs/superpowers/plans/2026-04-18-ingestion-benchmarks.md
@@ -151,7 +151,7 @@ export const CONDITIONAL_FRONTMATTER: Record<string, { field: string; requiredWh
 
 - [ ] **Step 2: Verify the file compiles**
 
-Run: `cd /Users/joshuawarren/src/remnic && npx tsc --noEmit packages/bench/src/ingestion-types.ts --target ES2022 --module ESNext --moduleResolution bundler --strict`
+Run: `cd ~/src/remnic && npx tsc --noEmit packages/bench/src/ingestion-types.ts --target ES2022 --module ESNext --moduleResolution bundler --strict`
 
 Expected: no errors
 
@@ -201,7 +201,7 @@ to:
 
 - [ ] **Step 3: Verify types compile**
 
-Run: `cd /Users/joshuawarren/src/remnic/packages/bench && npx tsc --noEmit`
+Run: `cd ~/src/remnic/packages/bench && npx tsc --noEmit`
 
 Expected: no errors
 
@@ -245,7 +245,7 @@ In `packages/bench/tsconfig.json`, add `"src/ingestion-types.ts"` to the `includ
 
 - [ ] **Step 3: Verify build**
 
-Run: `cd /Users/joshuawarren/src/remnic/packages/bench && npm run build`
+Run: `cd ~/src/remnic/packages/bench && npm run build`
 
 Expected: clean build, `dist/ingestion-types.js` and `dist/ingestion-types.d.ts` produced
 
@@ -307,7 +307,7 @@ In `packages/bench/tsconfig.json`, add `"src/fixtures/**/*.ts"` to the `include`
 
 - [ ] **Step 4: Verify build**
 
-Run: `cd /Users/joshuawarren/src/remnic/packages/bench && npm run build`
+Run: `cd ~/src/remnic/packages/bench && npm run build`
 
 Expected: clean build
 
@@ -546,7 +546,7 @@ export const emailFixture: FixtureGenerator = {
 
 - [ ] **Step 3: Verify build**
 
-Run: `cd /Users/joshuawarren/src/remnic/packages/bench && npm run build`
+Run: `cd ~/src/remnic/packages/bench && npm run build`
 
 Expected: clean build
 
@@ -756,7 +756,7 @@ Add `"src/ingestion-scorer.ts"` to `packages/bench/tsconfig.json` include array.
 
 - [ ] **Step 4: Verify build**
 
-Run: `cd /Users/joshuawarren/src/remnic/packages/bench && npm run build`
+Run: `cd ~/src/remnic/packages/bench && npm run build`
 
 Expected: clean build
 
@@ -930,7 +930,7 @@ Add `"src/benchmarks/remnic/**/*.ts"` to `packages/bench/tsconfig.json` include 
 
 - [ ] **Step 4: Verify build**
 
-Run: `cd /Users/joshuawarren/src/remnic/packages/bench && npm run build`
+Run: `cd ~/src/remnic/packages/bench && npm run build`
 
 Expected: clean build
 
@@ -1100,7 +1100,7 @@ Add to `REGISTERED_BENCHMARKS`:
 
 - [ ] **Step 3: Verify build**
 
-Run: `cd /Users/joshuawarren/src/remnic/packages/bench && npm run build`
+Run: `cd ~/src/remnic/packages/bench && npm run build`
 
 Expected: clean build
 
@@ -1325,7 +1325,7 @@ Add to `REGISTERED_BENCHMARKS`:
 - [ ] **Step 3: Verify build and commit**
 
 ```bash
-cd /Users/joshuawarren/src/remnic/packages/bench && npm run build
+cd ~/src/remnic/packages/bench && npm run build
 git add packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts packages/bench/src/registry.ts
 git commit -m "bench: add citation accuracy benchmark for ingestion tier
 
@@ -1496,7 +1496,7 @@ Add to `REGISTERED_BENCHMARKS`:
 - [ ] **Step 3: Verify build and commit**
 
 ```bash
-cd /Users/joshuawarren/src/remnic/packages/bench && npm run build
+cd ~/src/remnic/packages/bench && npm run build
 git add packages/bench/src/benchmarks/remnic/ingestion-schema-completeness/runner.ts packages/bench/src/registry.ts
 git commit -m "bench: add schema completeness benchmark for ingestion tier
 
@@ -1664,7 +1664,7 @@ Add to `REGISTERED_BENCHMARKS`:
 - [ ] **Step 3: Verify build and commit**
 
 ```bash
-cd /Users/joshuawarren/src/remnic/packages/bench && npm run build
+cd ~/src/remnic/packages/bench && npm run build
 git add packages/bench/src/benchmarks/remnic/ingestion-setup-friction/runner.ts packages/bench/src/registry.ts
 git commit -m "bench: add setup friction benchmark for ingestion tier
 
@@ -1866,7 +1866,7 @@ export const projectFolderFixture: FixtureGenerator = {
 - [ ] **Step 3: Verify build and commit**
 
 ```bash
-cd /Users/joshuawarren/src/remnic/packages/bench && npm run build
+cd ~/src/remnic/packages/bench && npm run build
 git add packages/bench/src/fixtures/inbox/project-folder.ts packages/bench/src/fixtures/inbox/project-folder-gold.ts
 git commit -m "bench: add project folder fixture generator
 
@@ -2031,7 +2031,7 @@ export const calendarFixture: FixtureGenerator = {
 - [ ] **Step 3: Verify build and commit**
 
 ```bash
-cd /Users/joshuawarren/src/remnic/packages/bench && npm run build
+cd ~/src/remnic/packages/bench && npm run build
 git add packages/bench/src/fixtures/inbox/calendar.ts packages/bench/src/fixtures/inbox/calendar-gold.ts
 git commit -m "bench: add calendar fixture generator
 
@@ -2235,7 +2235,7 @@ export const chatFixture: FixtureGenerator = {
 - [ ] **Step 3: Verify build and commit**
 
 ```bash
-cd /Users/joshuawarren/src/remnic/packages/bench && npm run build
+cd ~/src/remnic/packages/bench && npm run build
 git add packages/bench/src/fixtures/inbox/chat.ts packages/bench/src/fixtures/inbox/chat-gold.ts
 git commit -m "bench: add chat transcript fixture generator
 
@@ -2262,7 +2262,7 @@ export { chatFixture } from "./fixtures/inbox/chat.js";
 - [ ] **Step 2: Verify build and commit**
 
 ```bash
-cd /Users/joshuawarren/src/remnic/packages/bench && npm run build
+cd ~/src/remnic/packages/bench && npm run build
 git add packages/bench/src/index.ts
 git commit -m "bench: export all inbox fixtures from package index"
 ```

--- a/packages/remnic-cli/src/cli-command-surface.test.ts
+++ b/packages/remnic-cli/src/cli-command-surface.test.ts
@@ -49,7 +49,7 @@ before(async () => {
 
 after(async () => {
   if (originalHome === undefined) {
-    process.env.HOME = undefined;
+    delete process.env.HOME;
   } else {
     process.env.HOME = originalHome;
   }

--- a/packages/remnic-cli/src/run-cli.test.ts
+++ b/packages/remnic-cli/src/run-cli.test.ts
@@ -41,7 +41,7 @@ before(async () => {
 
 after(async () => {
   if (originalHome === undefined) {
-    process.env.HOME = undefined;
+    delete process.env.HOME;
   } else {
     process.env.HOME = originalHome;
   }
@@ -120,7 +120,7 @@ test("runCli honours env overrides and restores prior values afterwards", async 
     assert.equal(process.env.REMNIC_TEST_ENV_VAR, "original", "env override was restored to its pre-run value");
   } finally {
     if (previousValue === undefined) {
-      process.env.REMNIC_TEST_ENV_VAR = undefined;
+      delete process.env.REMNIC_TEST_ENV_VAR;
     } else {
       process.env.REMNIC_TEST_ENV_VAR = previousValue;
     }
@@ -138,7 +138,7 @@ test("runCli deletes env keys mapped to undefined and restores them afterwards",
     assert.equal(process.env.REMNIC_TEST_DELETE_VAR, "set", "deleted env key was restored after the run");
   } finally {
     if (previousValue === undefined) {
-      process.env.REMNIC_TEST_DELETE_VAR = undefined;
+      delete process.env.REMNIC_TEST_DELETE_VAR;
     } else {
       process.env.REMNIC_TEST_DELETE_VAR = previousValue;
     }


### PR DESCRIPTION
## What

Adds nine project-scoped [omp](https://github.com/can1357/oh-my-pi) Time Traveling Stream Rules under `.omp/rules/`, plus a README and an AGENTS.md pointer. When an AI agent working in this repo streams code matching a rule's regex/ast-grep condition, the harness interrupts (or attaches a reminder for advisory rules) **at write time — before a PR exists**. Other harnesses ignore the directory; humans can read the rules as a distilled most-flagged-mistakes list.

## How the rules were chosen

- Pulled all PR review comments updated since 2026-07-04: **4,335 comments across 193 PRs**, of which **2,527 are bot findings** (chatgpt-codex-connector, cursor, kilo-code-bot, github-advanced-security).
- Clustered findings into recurring patterns; kept only patterns that are (a) recurring across PRs and (b) detectable from the written code text with low false-positive risk. Large semantic clusters (cache invalidation, namespace scoping, schema/return-shape drift, date math, concurrency) were deliberately excluded — no reliable textual signature.
- **Every condition was run against the current tree before inclusion.** Candidates that matched existing legitimate idioms were tightened, demoted to advisory, or dropped entirely (e.g. `...(x ? { x } : {})` matched 185 intentional uses — dropped; `err.message` in responses matched legitimate input-error echoes in `access-http.ts` — dropped).

## Hard-interrupt rules (zero matches against current tree)

| Rule | Signature | Evidence |
|---|---|---|
| `remnic-comparator-total-order` | comparator body is a bare two-arm ternary (`a.x < b.x ? -1 : 1`), never returns 0 | PRs #1624 #1647 #1664 #1849 #1972; AGENTS.md #12 |
| `remnic-process-env-delete` | `process.env.X = undefined` (stores string `"undefined"`) | PR #1844, flagged by 3 bots |
| `remnic-no-cross-package-src-imports` | static/dynamic/require import via `../<pkg>/src/` | PRs #1665 #1681; AGENTS.md #15 |
| `remnic-no-static-optional-package-imports` | value-import of `@remnic/bench`, `export-weclone`, `import-*`, `connector-*`, `coding-graph` in base packages (type-only imports exempt) | AGENTS.md #44 + 6 PRs touching the contract |
| `remnic-no-real-home-paths` | realistic `/home/<name>/` or `/Users/<name>/` literals (generic test personas like `/home/alice/` exempt) | PRs #1754 #1862; public-repo privacy policy |

## Advisory rules (`interruptMode: never` — reminder only, no abort)

| Rule | Signature | Evidence |
|---|---|---|
| `remnic-write-memory-tombstone-blocked` | `const { id } = await x.writeMemory(...)` discarding `tombstoneBlocked` | ~15 findings in PR #1724 |
| `remnic-config-coercion-footguns` | `cfg.x === true` / `Boolean(cfg.x)` / `parseInt(x) \|\| N` | PRs #1623 #1663 #1664 #1675 #1679 #1921; AGENTS.md #17/#24/#33 |
| `remnic-ratchet-baseline-only-decreases` | any edit to `scripts/ratchet-baseline.json` | raises rejected in PRs #1593 #1603 #1605 #1623 #1705 #1803 #1815 |
| `remnic-fs-boundary-checks` | `statSync(p).isDirectory()` root guards; `.startsWith(path.join(` containment | 8+ findings, PRs #1938 #1999 #2000; #1612 |

## Verification

- All frontmatter parses as YAML; all regex conditions compile as JS `RegExp`.
- ast-grep patterns validated with `ast-grep 0.44.1` against positive and negative samples (guarded comparators, `import type`, multi-key destructures correctly do NOT match).
- Every hard-interrupt condition has **zero matches** against the current codebase.
- **Live end-to-end smoke test**: a headless `omp -p` run in this branch's worktree was asked to write a file containing exactly `process.env.TTSR_SMOKE = undefined;` — the TTSR interrupted the stream and the retried write produced `delete process.env.TTSR_SMOKE;` on disk.
- PII sweep of all added files: no names, emails, real paths, hosts, or keys.

Part of the review-churn-prevention effort (`docs/ops/pr-review-hardening-playbook.md`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and harness rules; test teardown changes align with Node env semantics and reduce review churn risk.
> 
> **Overview**
> Introduces **project-scoped Oh My Pi Time Traveling Stream Rules** under `.omp/rules/` so agents get interrupted or reminded at write time for recurring review mistakes—before a PR exists. A README documents how rules were mined from review feedback and how to add them (low false positives, hard vs advisory interrupts).
> 
> **Nine rules** cover sort comparators that never return `0`, `process.env.X = undefined`, cross-package `../<pkg>/src/` imports, static optional `@remnic/*` imports, real home paths in a public repo, discarded `writeMemory` `tombstoneBlocked`, config coercion footguns, ratchet baseline increases, and weak FS boundary checks (advisory where FP risk is higher).
> 
> **AGENTS.md** gains a **Mechanical Stream Rules** section pointing agents at `.omp/rules/README.md`.
> 
> Small **dogfood fixes**: ingestion benchmark plan docs replace a committed `/Users/...` path with `~/src/remnic`; CLI tests use `delete process.env.HOME` (and similar) instead of assigning `undefined` in teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f912096e3b1cf3a27b9c883823d40c40e9ae570e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->