### PR TITLE
docs(agents): public-repo issue/PR hygiene — no PII, generalize beyond one deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # Remnic - Agent Guide
 
+> **PUBLIC, OPEN-SOURCE REPOSITORY.** Remnic is a public open-source project.
+> Everything pushed to GitHub — commits, issues, PRs, review comments — is
+> world-readable. Never include PII or operator-specific infrastructure details
+> (hostnames, internal IPs, usernames/home paths, client or project names,
+> memory IDs or memory content, links to private repos/docs). Write issues and
+> PRs for the general case: describe the reproducing deployment *shape* and
+> design fixes that benefit all users, not one operator's setup. Full rules:
+> "PUBLIC REPOSITORY — Privacy Policy" below.
+
 ## Architecture Boundaries (Non-Negotiable)
 
 Remnic is a multi-platform memory system. Keep these boundaries intact on every change:
@@ -167,6 +176,10 @@ These patterns were extracted from 60+ PRs across 2026-04-05 to 2026-04-12
 (including deep analysis of PRs #343-#408 with 980+ review comments).
 Every item below was caught by a reviewer (Cursor Bugbot, Codex, or CodeQL) and
 required a follow-up commit to fix. Follow these rules to ship clean on the first push.
+
+Also: this is a **public repo** — issue and PR text must follow the
+"PUBLIC REPOSITORY — Privacy Policy" section (no PII or operator-specific
+details; describe problems and design fixes for all users, not one deployment).
 
 ### 1. Input Validation — Reject Invalid Inputs Explicitly
 
@@ -1676,6 +1689,30 @@ Old, low-importance memories are summarized:
 - `git diff --cached` contains NO personal information
 - No hardcoded API keys, URLs with tokens, or credentials
 - No references to specific users or their data
+
+### Issues, PRs, and review comments are public too
+
+The rules above apply to EVERYTHING pushed to GitHub, not just commits — issue
+bodies, PR descriptions, review replies, and commit messages.
+
+1. **No PII or operator-specific details** in issue/PR text: hostnames, internal
+   IPs/subnets/VIP addresses, usernames or home-directory paths, client or
+   project names, memory IDs, quoted memory content, or links/paths to an
+   operator's private repos and docs.
+2. **Describe the deployment *shape*, not the deployment** — state the config
+   conditions that reproduce the behavior (e.g. "namespaces enabled, default
+   namespace at the flat root, ~100k-file base collection"), never "on <host>".
+   Round counts, strip identifying values from quoted logs/output, and replace
+   concrete examples with placeholders or synthetic equivalents.
+3. **Generalize the problem statement** — an issue must describe a defect or
+   gap as it affects ANY user who meets the reproducing conditions, and
+   proposed fixes must be designed for all use cases, not one operator's
+   workflow. If a report only makes sense for a single deployment, it belongs
+   in that operator's private notes, with a distilled general issue filed here.
+4. **Audit before submitting**: re-read the issue/PR body the way a stranger
+   would. `gh issue view <n> --json body` piped through a grep for your hosts,
+   IPs, usernames, and org/client names is cheap — run it before and after
+   posting.
 
 ## Agent Notes: Retrieval Explain Surface (issues #518, #570)
 


### PR DESCRIPTION
## Problem

AGENTS.md's "PUBLIC REPOSITORY — Privacy Policy" section only covered **commits**. Nothing told agents that issue bodies, PR descriptions, and review comments are equally world-readable, and nothing required framing issues/PRs for the general case rather than one operator's deployment. Result observed in practice: agent-filed issues containing hostnames, internal IPs, home-directory paths, memory IDs with quoted memory content, and private-doc references (since scrubbed by editing the issues).

## Change (docs only, AGENTS.md — CLAUDE.md is a symlink)

1. **Top-of-file callout**: the privacy section sat at line ~1650 of ~1900; a blockquote right under the H1 now states the repo is public OSS and summarizes the rules.
2. **New subsection under the privacy policy** — "Issues, PRs, and review comments are public too": no PII/operator-specific details; describe the deployment *shape* (reproducing config conditions), not the deployment; generalize the problem statement and design fixes for all users; audit issue/PR text before and after posting.
3. **One pointer line** in the Review Prevention Checklist intro.

No code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to contributor guidance; no runtime, security, or API behavior is modified.
> 
> **Overview**
> **AGENTS.md** now treats GitHub issues, PRs, and review comments as public surfaces, not just commits.
> 
> A **top-of-file blockquote** under the H1 summarizes that the repo is world-readable OSS and points agents to the full privacy policy (PII, operator-specific infra, general-case framing).
> 
> Under **PUBLIC REPOSITORY — Privacy Policy**, a new subsection **"Issues, PRs, and review comments are public too"** adds four rules: no PII/operator details in issue/PR text; describe deployment *shape* (reproducing config) not a specific host; generalize problems and fixes for all users; audit text before/after posting (e.g. `gh issue view` + grep).
> 
> The **Review Prevention Checklist** intro gains a one-line reminder to follow that privacy section when writing issue/PR text.
> 
> Docs only; **CLAUDE.md** remains a symlink to **AGENTS.md**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a39b9f2f3c407008f1cfcd5ba545c5b9a42d8d8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->