### PR TITLE
fix(#2004): deterministic paper-figures artifact selection + hermetic test env

### DIFF
--- a/scripts/generate-paper-figures.mjs
+++ b/scripts/generate-paper-figures.mjs
@@ -159,8 +159,16 @@ function finishedAtEpoch(v) {
  * Operates on `{ name, doc }` entries.
  */
 function compareArtifactsByRecency(a, b) {
-  const dt = finishedAtEpoch(b.doc?.finishedAt) - finishedAtEpoch(a.doc?.finishedAt);
-  if (dt !== 0) return dt;
+  const ea = finishedAtEpoch(a.doc?.finishedAt);
+  const eb = finishedAtEpoch(b.doc?.finishedAt);
+  // Newest finishedAt first — but ONLY trust the epoch delta when both values
+  // are finite and differ. If both are missing/unparseable, `eb - ea` would be
+  // (-Infinity) - (-Infinity) = NaN, which Array.sort treats as equality and
+  // resolves by input/readdir order — the exact flake we are removing. When
+  // exactly one is finite, the finite (real) run wins. Otherwise fall through to
+  // the stable filename tiebreak so selection is ALWAYS deterministic (#2004).
+  if (Number.isFinite(ea) && Number.isFinite(eb) && ea !== eb) return eb - ea;
+  if (Number.isFinite(ea) !== Number.isFinite(eb)) return Number.isFinite(ea) ? -1 : 1;
   if (a.name < b.name) return 1;
   if (a.name > b.name) return -1;
   return 0;
@@ -273,13 +281,15 @@ function findMemCorrectArtifacts() {
     };
     const key = String(adapter).toLowerCase();
     // finishedAt lives at doc.finishedAt (published) or meta.timestamp (nested
-    // BenchmarkResult). Compare as epoch-ms (not locale-sensitive
-    // localeCompare — #2004); on an exact tie the name-sorted iteration above
-    // keeps the codepoint-first file, so selection stays deterministic.
+    // BenchmarkResult). Keep the NEWEST per adapter using the SAME deterministic
+    // comparator as findArtifact, so every selection path shares one tiebreak
+    // direction (largest-filename-wins on an exact tie) — never localeCompare or
+    // readdir order (#2004).
     const finishedAt = String(doc?.finishedAt ?? doc?.meta?.timestamp ?? "");
+    const cand = { name, doc: { finishedAt } };
     const prev = byAdapter.get(key);
-    if (!prev || finishedAtEpoch(prev.finishedAt) < finishedAtEpoch(finishedAt)) {
-      byAdapter.set(key, { entry, finishedAt });
+    if (!prev || compareArtifactsByRecency(cand, prev.cand) < 0) {
+      byAdapter.set(key, { entry, cand });
     }
   }
   return [...byAdapter.values()].map((x) => x.entry);

--- a/scripts/generate-paper-figures.mjs
+++ b/scripts/generate-paper-figures.mjs
@@ -27,7 +27,7 @@
 import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync } from "node:fs";
 import { dirname, join, resolve, basename } from "node:path";
 import { execFileSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
@@ -96,13 +96,21 @@ function trackedResultsNames() {
   if (process.env.REMNIC_FIGURES_RESULTS_DIR) return null; // temp seam: fixtures are deliberate
   return readManifestNames() ?? trackedResultsNamesFromGit();
 }
-// Refresh the manifest from git BEFORE reading it into the filter cache, so a
-// newly-tracked artifact is reflected in THIS run (cursor thread: manifest
-// refresh stale filter cache). No-op when git is unavailable (CI) — the
-// committed manifest is the source of truth. Function declarations below are
-// hoisted, so this call is safe above their definition.
-refreshArtifactManifest();
-const TRACKED_RESULTS_NAMES = trackedResultsNames();
+// NOTE: the manifest refresh + tracked-name resolution are NOT run at module
+// load. Running them at import time (a) performs a git write side effect and
+// (b) couples selection to the ambient env of whoever imported the module
+// (tests import this file to unit-test the pure comparators). main() refreshes
+// the manifest before rendering; the tracked-name filter is resolved lazily and
+// cached on first use.
+let _trackedNamesResolved = false;
+let _trackedNamesCache = null;
+function trackedResultsNamesCached() {
+  if (!_trackedNamesResolved) {
+    _trackedNamesCache = trackedResultsNames();
+    _trackedNamesResolved = true;
+  }
+  return _trackedNamesCache;
+}
 
 // Keep the committed manifest in sync with git when git is available (local dev).
 // No-op in CI (git not reliably callable there) — the committed manifest is the
@@ -125,6 +133,40 @@ function loadJson(absPath) {
 }
 
 /**
+ * Parse an ISO-8601 `finishedAt` to epoch-ms. Unparseable / missing values sort
+ * OLDEST (`-Infinity`) so a malformed artifact can never win the newest slot.
+ */
+function finishedAtEpoch(v) {
+  const t = Date.parse(String(v ?? ""));
+  return Number.isNaN(t) ? -Number.POSITIVE_INFINITY : t;
+}
+
+/**
+ * Deterministic "newest first" ordering for committed artifacts (issue #2004).
+ *
+ * Primary key: `finishedAt` as an EPOCH-MS number (never String.localeCompare —
+ * ICU collation depends on the LANG/LC_ALL the process inherits, and the root
+ * test runner's spawned workers inherit a different env than an isolated run,
+ * so a locale-sensitive compare made figure selection env-dependent).
+ *
+ * Secondary key: the FILENAME in descending codepoint order. This is a STABLE
+ * tiebreaker: two artifacts that share a `finishedAt` must never resolve by
+ * `readdirSync` order, which is filesystem/OS/load dependent — the exact class
+ * of nondeterminism that made the byte-identical figure test flake in the full
+ * suite but pass in isolation. Filenames are `<iso-date>-<benchmark>-…` so the
+ * codepoint-max filename is also the chronologically-latest-labelled run.
+ *
+ * Operates on `{ name, doc }` entries.
+ */
+function compareArtifactsByRecency(a, b) {
+  const dt = finishedAtEpoch(b.doc?.finishedAt) - finishedAtEpoch(a.doc?.finishedAt);
+  if (dt !== 0) return dt;
+  if (a.name < b.name) return 1;
+  if (a.name > b.name) return -1;
+  return 0;
+}
+
+/**
  * Find the real (non-mock) published artifact for a benchmark id + tier. Returns
  * the newest matching artifact, or null when none is committed. Mocks
  * (*-mock000.json) are NEVER returned — they are placeholders, not results.
@@ -138,10 +180,11 @@ function loadJson(absPath) {
  */
 function findArtifact({ benchmarkId, tier, model, systemName = "remnic" }) {
   if (!existsSync(RESULTS_DIR)) return null;
+  const tracked = trackedResultsNamesCached();
   const candidates = readdirSync(RESULTS_DIR)
     .filter((name) => name.endsWith(".json"))
     .filter((name) => !name.includes("mock000"))
-    .filter((name) => !TRACKED_RESULTS_NAMES || TRACKED_RESULTS_NAMES.has(name))
+    .filter((name) => !tracked || tracked.has(name))
     .map((name) => ({ name, abs: join(RESULTS_DIR, name) }))
     .map(({ name, abs }) => {
       try {
@@ -162,7 +205,15 @@ function findArtifact({ benchmarkId, tier, model, systemName = "remnic" }) {
       if (systemName === undefined) return true;
       return sn === systemName;
     })
-    .sort((a, b) => String(b.doc.finishedAt).localeCompare(String(a.doc.finishedAt)));
+    .sort(compareArtifactsByRecency);
+  if (process.env.REMNIC_FIGURES_DEBUG) {
+    const line = `[figdebug] find ${benchmarkId}/${tier ?? "-"}/${model ?? "-"}/${systemName ?? "-"} ` +
+      `RESULTS_DIR=${RESULTS_DIR} LANG=${process.env.LANG ?? ""} LC_ALL=${process.env.LC_ALL ?? ""} ` +
+      `collator=${Intl.Collator().resolvedOptions().locale} ` +
+      `candidates=[${candidates.map((c) => `${c.name}@${c.doc.finishedAt}`).join(", ")}] ` +
+      `-> ${candidates[0]?.name ?? "NONE"}`;
+    process.stderr.write(line + "\n");
+  }
   return candidates[0] ?? null;
 }
 
@@ -183,10 +234,11 @@ function findMemCorrectArtifacts() {
   // sorted last in readdirSync, so multiple committed seeds for one adapter
   // could plot stale metrics and mislabel the legend "real" (cursor thread:
   // MemCorrect map picks arbitrary run).
+  const tracked = trackedResultsNamesCached();
   const byAdapter = new Map();
   for (const name of readdirSync(RESULTS_DIR).sort()) {
     if (!name.endsWith(".json") || name.includes("mock000")) continue;
-    if (TRACKED_RESULTS_NAMES && !TRACKED_RESULTS_NAMES.has(name)) continue;
+    if (tracked && !tracked.has(name)) continue;
     const abs = join(RESULTS_DIR, name);
     let doc;
     try {
@@ -221,10 +273,12 @@ function findMemCorrectArtifacts() {
     };
     const key = String(adapter).toLowerCase();
     // finishedAt lives at doc.finishedAt (published) or meta.timestamp (nested
-    // BenchmarkResult); both are ISO-8601 so lexicographic compare orders them.
+    // BenchmarkResult). Compare as epoch-ms (not locale-sensitive
+    // localeCompare — #2004); on an exact tie the name-sorted iteration above
+    // keeps the codepoint-first file, so selection stays deterministic.
     const finishedAt = String(doc?.finishedAt ?? doc?.meta?.timestamp ?? "");
     const prev = byAdapter.get(key);
-    if (!prev || String(prev.finishedAt).localeCompare(finishedAt) < 0) {
+    if (!prev || finishedAtEpoch(prev.finishedAt) < finishedAtEpoch(finishedAt)) {
       byAdapter.set(key, { entry, finishedAt });
     }
   }
@@ -889,6 +943,13 @@ function writeFigure(filename, svg) {
 }
 
 function main() {
+  // Refresh the committed manifest from git (local dev) BEFORE the tracked-name
+  // filter is resolved, so a newly-tracked artifact is reflected in THIS run.
+  // No-op in CI / under the RESULTS_DIR seam. Deferred here (not module load)
+  // so importing this file for its pure comparators has no git write side
+  // effect (issue #2004).
+  refreshArtifactManifest();
+  _trackedNamesResolved = false;
   mkdirSync(FIGURES_DIR, { recursive: true });
 
   const f1 = figure1();
@@ -922,4 +983,11 @@ function main() {
   console.log(`  fig3 TrustScore components: REAL (source-extracted)`);
 }
 
-main();
+// Run only when invoked directly (`node scripts/generate-paper-figures.mjs`).
+// When imported (tests exercising the pure comparators) main() must NOT run —
+// it would render figures + write the manifest as an import side effect.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}
+
+export { compareArtifactsByRecency, finishedAtEpoch };

--- a/tests/paper-figures.test.mjs
+++ b/tests/paper-figures.test.mjs
@@ -26,6 +26,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { compareArtifactsByRecency } from "../scripts/generate-paper-figures.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
@@ -41,10 +42,26 @@ const TRUST_SCORE_SRC = join(
 );
 
 function runGenerator(env = {}) {
+  // Hermetic env (#2004): the root test runner injects
+  // NODE_OPTIONS=--conditions=remnic-source and may carry stray
+  // REMNIC_FIGURES_* / locale vars into the worker that an isolated
+  // `tsx --test` run never sees. The committed figures are produced by
+  // `pnpm run figures:paper` (`node scripts/generate-paper-figures.mjs`, a
+  // clean env), so the regeneration MUST run in that same environment or the
+  // byte-identical assertion compares two different regimes and flakes.
+  // Strip the leaking vars and pin the collation locale so any locale-sensitive
+  // compare is stable regardless of who spawned the suite.
+  const childEnv = { ...process.env };
+  delete childEnv.NODE_OPTIONS;
+  delete childEnv.REMNIC_FIGURES_RESULTS_DIR;
+  delete childEnv.REMNIC_FIGURES_OUT_DIR;
+  delete childEnv.REMNIC_FIGURES_DEBUG;
+  childEnv.LC_ALL = "C";
+  childEnv.LANG = "C";
   return spawnSync(process.execPath, [GEN], {
     cwd: REPO_ROOT,
     encoding: "utf8",
-    env: { ...process.env, ...env },
+    env: { ...childEnv, ...env },
   });
 }
 
@@ -118,9 +135,12 @@ function copyTrackedResults(dest) {
 }
 
 function findRealArtifact(benchmarkId, tier) {
-  // Match the generator: among committed (manifest-tracked), non-mock
-  // artifacts for this benchmark+tier, return the NEWEST by finishedAt — not
-  // the first filename sort (cursor thread: picks wrong benchmark artifact).
+  // Match the generator EXACTLY (#2004): among committed (manifest-tracked),
+  // non-mock artifacts for this benchmark+tier, return the NEWEST run using the
+  // generator's own deterministic comparator (epoch-ms + filename tiebreak, no
+  // locale-sensitive localeCompare). Using the same comparator the committed
+  // figure was rendered with is what keeps this assertion in lockstep with the
+  // SVG across environments.
   const matches = [];
   for (const name of readdirSync(RESULTS_DIR)) {
     if (!name.endsWith(".json") || name.includes("mock000")) continue;
@@ -130,7 +150,7 @@ function findRealArtifact(benchmarkId, tier) {
       matches.push({ name, doc });
     }
   }
-  matches.sort((a, b) => String(b.doc.finishedAt).localeCompare(String(a.doc.finishedAt)));
+  matches.sort(compareArtifactsByRecency);
   return matches[0] ?? null;
 }
 
@@ -188,7 +208,12 @@ test("committed figures are in sync with the generator (regeneration is byte-ide
       copyTrackedResults(tmpResults).length > 0,
       "git-tracked artifacts must exist to regenerate from",
     );
-    runGenerator({ REMNIC_FIGURES_RESULTS_DIR: tmpResults, REMNIC_FIGURES_OUT_DIR: tmpOut });
+    const res = runGenerator({ REMNIC_FIGURES_RESULTS_DIR: tmpResults, REMNIC_FIGURES_OUT_DIR: tmpOut });
+    // Surface a spawn failure as a clear assertion instead of a downstream
+    // ENOENT when readFileSync can't find an unwritten figure (#2004): under
+    // full-suite concurrency a failed/partial spawn otherwise masquerades as a
+    // figure mismatch flake.
+    assert.equal(res.status, 0, `generator failed:\n${res.stderr}`);
     for (const f of [
       "fig1-locomo-longmemeval.svg",
       "fig2-memcorrect-metrics.svg",
@@ -202,6 +227,30 @@ test("committed figures are in sync with the generator (regeneration is byte-ide
     rmSync(tmpResults, { recursive: true, force: true });
     rmSync(tmpOut, { recursive: true, force: true });
   }
+});
+
+test("artifact selection breaks a finishedAt tie deterministically (no localeCompare/readdir dependence) — #2004", () => {
+  // Root cause of the #2004 flake: two committed same-benchmark+tier artifacts
+  // whose finishedAt collate-equal made the "newest wins" sort fall back to
+  // readdirSync order, which is filesystem/OS/load dependent. The figure
+  // committed in one environment and the figure regenerated inside the
+  // full-suite worker could then choose different artifacts — byte mismatch in
+  // the full suite, pass in isolation. The comparator must break ties by a
+  // stable key (filename codepoint order), never by input/readdir order.
+  const tie = "2026-07-17T07:29:53.153Z";
+  const A = { name: "2026-07-17-longmemeval-alpha.json", doc: { finishedAt: tie } };
+  const B = { name: "2026-07-17-longmemeval-bravo.json", doc: { finishedAt: tie } };
+  const pick = (arr) => [...arr].sort(compareArtifactsByRecency)[0].name;
+  assert.equal(
+    pick([A, B]),
+    pick([B, A]),
+    "tie winner must not depend on candidate/readdir order (was localeCompare→0→input order)",
+  );
+  // Distinct timestamps still resolve newest-first, regardless of input order.
+  const older = { name: "2026-07-14-longmemeval-opus.json", doc: { finishedAt: "2026-07-14T04:02:21.944Z" } };
+  const newer = { name: "2026-07-17-longmemeval-luna.json", doc: { finishedAt: tie } };
+  assert.equal(pick([older, newer]), newer.name, "newest finishedAt wins");
+  assert.equal(pick([newer, older]), newer.name, "newest finishedAt wins regardless of input order");
 });
 
 // ─── 2. Real values trace to committed artifacts / source ─────────────────

--- a/tests/paper-figures.test.mjs
+++ b/tests/paper-figures.test.mjs
@@ -251,6 +251,20 @@ test("artifact selection breaks a finishedAt tie deterministically (no localeCom
   const newer = { name: "2026-07-17-longmemeval-luna.json", doc: { finishedAt: tie } };
   assert.equal(pick([older, newer]), newer.name, "newest finishedAt wins");
   assert.equal(pick([newer, older]), newer.name, "newest finishedAt wins regardless of input order");
+
+  // Both finishedAt missing/unparseable: epoch subtraction would be NaN, which
+  // Array.sort treats as equality and resolves by input order. The comparator
+  // must still fall through to the filename tiebreak (#2004).
+  const m1 = { name: "2026-07-01-longmemeval-mmm.json", doc: {} };
+  const m2 = { name: "2026-07-02-longmemeval-nnn.json", doc: { finishedAt: "not-a-date" } };
+  assert.equal(pick([m1, m2]), pick([m2, m1]), "both-missing finishedAt orders by filename, not input order");
+  assert.equal(pick([m1, m2]), m2.name, "filename codepoint-max wins when neither has a valid finishedAt");
+
+  // Exactly one valid finishedAt: the real (finite) run wins regardless of order.
+  const realRun = { name: "2026-07-01-longmemeval-aaa.json", doc: { finishedAt: "2026-07-01T00:00:00.000Z" } };
+  const noDate = { name: "2026-07-09-longmemeval-zzz.json", doc: {} };
+  assert.equal(pick([realRun, noDate]), realRun.name, "a run with a valid finishedAt beats one without");
+  assert.equal(pick([noDate, realRun]), realRun.name, "valid finishedAt wins regardless of input order");
 });
 
 // ─── 2. Real values trace to committed artifacts / source ─────────────────


### PR DESCRIPTION
## What

Closes #2004. Root-causes and fixes the paper-figures full-suite flake that was failing the required `tests (root)` gate and the release-and-publish workflow.

## Root cause (three cooperating mechanisms)
1. **Non-deterministic artifact selection** — `findArtifact` / `findMemCorrectArtifacts` (generator) and `findRealArtifact` (test) ordered candidates with `String.localeCompare(finishedAt)` and no tiebreaker: on a `finishedAt` tie `localeCompare` returns 0 and V8's stable sort falls back to `readdirSync` order (filesystem/OS/load-dependent); `localeCompare` is additionally locale-sensitive via inherited `LANG`/`LC_ALL`.
2. **Env leakage into the generator subprocess** — the test spawned the generator with `{...process.env}`; in the full suite `scripts/run-root-tests.mjs` injects `NODE_OPTIONS=--conditions=remnic-source` (and can carry stray `REMNIC_FIGURES_*`/locale vars) into the tsx workers, so full-suite regeneration ran in a different regime than the clean-env `pnpm run figures:paper` that produced the committed figures. Isolation never sees these vars — exactly the isolation-vs-full-suite divergence.
3. **Swallowed spawn failures** — the byte-identical test ignored `spawnSync` status, so a failed spawn under load surfaced as a bogus figure mismatch.

## Fix
- `compareArtifactsByRecency(a,b)`: epoch-ms primary key + filename codepoint DESC tiebreak — never `localeCompare`; used by the generator and the test.
- Test `runGenerator` is now hermetic: strips `NODE_OPTIONS` + `REMNIC_FIGURES_*`, pins `LC_ALL=C`/`LANG=C` — isolation and full-suite regenerate identically, matching `figures:paper`.
- Generator side effects (manifest refresh, tracked-name resolution) deferred out of module top-level; `main()` guarded to direct invocation; comparator exported.
- Spawn status asserted; permanent tie-determinism regression subtest added; env-gated `REMNIC_FIGURES_DEBUG` selection trace kept for future diagnosis.

Committed SVGs are byte-identical under the deterministic selection — no regeneration needed.

## Evidence
- Pre/post discrimination: reverting the comparator to the old `localeCompare` body makes the new regression subtest FAIL (11/12); with the fix, 12/12.
- Isolation: 12/12. Full `node scripts/run-root-tests.mjs`: **green twice consecutively** (14169 tests, 0 fail both runs), with the byte-identical + Tier-F + tie-determinism subtests all passing.
- Fresh generator run diffs byte-identical vs all three committed SVGs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to paper figure generation and its tests; no auth, data, or release runtime paths—only deterministic artifact picking and CI test stability.
> 
> **Overview**
> Fixes **#2004** full-suite flakes in the paper-figures pipeline by making benchmark artifact selection and test regeneration **environment-independent**.
> 
> **Generator (`generate-paper-figures.mjs`):** Replaces `localeCompare` on `finishedAt` with `compareArtifactsByRecency` (epoch-ms primary, filename codepoint DESC tiebreak), including edge cases where both timestamps are missing (NaN sort). `findArtifact` and MemCorrect per-adapter “newest” logic share this comparator. Manifest refresh and tracked-name resolution move off **module import** to lazy cache + `main()` only; `main()` runs only when the script is invoked directly; comparators are **exported** for tests. Optional `REMNIC_FIGURES_DEBUG` stderr trace remains.
> 
> **Tests (`paper-figures.test.mjs`):** `runGenerator` strips leaking `NODE_OPTIONS` / `REMNIC_FIGURES_*` and pins `LC_ALL`/`LANG=C` so full-suite workers match `pnpm run figures:paper`. `findRealArtifact` uses the same comparator as the generator. Byte-identical regeneration **asserts spawn exit 0**; new unit test locks tie-breaking when `finishedAt` ties or is invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c6c1221469d113be3870202cf9a5d556b5a4fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->