### PR TITLE
docs(rules): window-2 TTSR analysis outcome — coverage confirmed, rejected candidates recorded

### DIFF
--- a/.omp/rules/README.md
+++ b/.omp/rules/README.md
@@ -9,11 +9,11 @@ the tool result) and injects the rule body so the problem is fixed
 before it ever reaches a PR.
 
 Every rule here was derived from recurring AI code-review findings on
-this repository (2+ weeks of Cursor Bugbot / Codex / kilo / CodeQL
-review comments, 2,500+ findings analyzed) and cross-checked against
-`AGENTS.md` review-prevention patterns. Other harnesses ignore this
-directory; human contributors can read the rules as a distilled
-"most-flagged mistakes" checklist.
+this repository (four weeks of Cursor Bugbot / Codex / kilo / CodeQL
+review comments, 2026-06-20 through 2026-07-18, 3,100+ bot findings
+analyzed) and cross-checked against `AGENTS.md` review-prevention
+patterns. Other harnesses ignore this directory; human contributors can
+read the rules as a distilled "most-flagged mistakes" checklist.
 
 Ground rules for adding or editing rules:
 
@@ -26,3 +26,37 @@ Ground rules for adding or editing rules:
   judge context.
 - **No PII.** This repo is public: rule text must never contain real
   usernames, paths, keys, or memory content.
+
+## Evaluated and rejected candidates
+
+These patterns recurred in review findings but FAILED the
+false-positive bar against the actual tree. Do not re-propose them as
+conditions without new evidence; each baseline below is the receipt.
+
+- **`String(err)` / `err.message` in logs, throws, or response fields**
+  — 462 occurrences of the standard
+  `error instanceof Error ? error.message : String(error)`
+  normalization idiom. Whether a message reaches an operator/client
+  surface (the actual leak) is semantic; `access-http.ts` legitimately
+  echoes input-validation messages. Reviewers keep catching the real
+  cases; a rule cannot.
+- **`coerce*(...) ?? <default>`** — this IS the config-parser idiom
+  (`config.ts` uses `coerceBooleanLike(cfg.x) ?? <default>` for nearly
+  every flag). The recurring bug — an explicitly-set-but-unrecognized
+  value silently becoming the default, worst as fail-open `?? true` —
+  is about which default and whether unrecognized input should warn,
+  not about the syntax. Fix belongs in the coercion helpers, not a
+  per-callsite rule.
+- **Inline `NODE_OPTIONS=` / `VAR=value cmd` in npm scripts**
+  (Windows-hostile) — 20 existing scripts use the
+  `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source"`
+  convention for POSIX-only dev/test scripts.
+- **`../packages/<pkg>/src/` imports** — 361 ratchet-managed
+  occurrences (`directStorageImports`); see the note in
+  `remnic-no-cross-package-src-imports.md`.
+
+The dominant review clusters of 2026-06-20..07-04 (namespace/ACL
+scoping, flush-plan lifecycle races, catalog-touch ordering) are
+semantic, single-subsystem invariants with no textual signature —
+that class is governed by the scenario-matrix workflow in `AGENTS.md`,
+not by stream rules.

--- a/.omp/rules/README.md
+++ b/.omp/rules/README.md
@@ -40,23 +40,30 @@ conditions without new evidence; each baseline below is the receipt.
   surface (the actual leak) is semantic; `access-http.ts` legitimately
   echoes input-validation messages. Reviewers keep catching the real
   cases; a rule cannot.
-- **`coerce*(...) ?? <default>`** — this IS the config-parser idiom
-  (`config.ts` uses `coerceBooleanLike(cfg.x) ?? <default>` for nearly
-  every flag). The recurring bug — an explicitly-set-but-unrecognized
-  value silently becoming the default, worst as fail-open `?? true` —
-  is about which default and whether unrecognized input should warn,
-  not about the syntax. Fix belongs in the coercion helpers, not a
-  per-callsite rule.
+- **`coerce*(...) ?? <default>`** — co-occurs with the standard config
+  fallback pattern (`config.ts` parses nearly every flag as
+  `coerceBooleanLike(cfg.x) ?? <default>`), so a per-callsite condition
+  would flag valid coercion everywhere. The recurring bug — an
+  explicitly-set-but-unrecognized value silently becoming the default,
+  worst as fail-open `?? true` — is about which default and whether
+  unrecognized input should warn; the fix belongs in the coercion
+  helpers, not a stream rule.
 - **Inline `NODE_OPTIONS=` / `VAR=value cmd` in npm scripts**
-  (Windows-hostile) — 20 existing scripts use the
-  `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source"`
-  convention for POSIX-only dev/test scripts.
-- **`../packages/<pkg>/src/` imports** — 361 ratchet-managed
-  occurrences (`directStorageImports`); see the note in
+  (Windows-hostile) — 20 existing dev/test scripts use this convention
+  deliberately; no viable rule exists without first rewriting every
+  script.
+- **`../packages/<pkg>/src/` imports** — used ~360 times across the
+  existing tree (tests, scripts, and the root `src/` compatibility
+  wiring; grep receipt in PR #2010 review threads), so a hard interrupt
+  would fire on routine edits. The narrower slice of core files
+  importing `storage.ts` directly is separately ratchet-managed as
+  `directStorageImports`. See the note in
   `remnic-no-cross-package-src-imports.md`.
 
-The dominant review clusters of 2026-06-20..07-04 (namespace/ACL
-scoping, flush-plan lifecycle races, catalog-touch ordering) are
-semantic, single-subsystem invariants with no textual signature —
+The dominant review clusters in the 2026-06-20..07-04 subset (605
+findings across 40 PRs; the full derivation corpus spans four weeks) —
+namespace/ACL scoping, flush-plan lifecycle races, catalog-touch
+ordering — are semantic, single-subsystem invariants with no textual
+signature;
 that class is governed by the scenario-matrix workflow in `AGENTS.md`,
 not by stream rules.

--- a/.omp/rules/remnic-no-cross-package-src-imports.md
+++ b/.omp/rules/remnic-no-cross-package-src-imports.md
@@ -28,9 +28,9 @@ public surface rather than deep-linking into its `src/`.
 for dev-mode process spawning, are not affected by this rule.)
 
 Deliberately NOT matched: the `../packages/<pkg>/src/...` form used by
-repo-root `src/`, `scripts/`, and `tests/`. That class is existing
-ratchet-managed debt (`directStorageImports` in
-`scripts/ratchet-baseline.json`, 350+ occurrences) governed by
-`check-ratchets.mjs` — hard-interrupting it would false-positive on
-every managed-debt file. New code should still prefer `@remnic/*`
-package-name imports; the ratchet ensures the count only shrinks.
+repo-root `src/`, `scripts/`, and `tests/`. That form appears ~360
+times in the existing tree, so hard-interrupting it would fire on
+routine edits to those files. New code should still prefer `@remnic/*`
+package-name imports. (The narrower slice of core files importing
+`storage.ts` directly is separately ratchet-managed as
+`directStorageImports` in `scripts/ratchet-baseline.json`.)


### PR DESCRIPTION
## What

Documents the outcome of analyzing the **2026-06-20..07-04** review window (605 bot findings across 40 PRs) against the nine TTSRs shipped in #2010, in `.omp/rules/README.md`.

## Findings

**Coverage confirmed** — the window's mechanical findings map to existing rules:
- symlink/containment guards (~18 findings, PRs #1487 #1488 #1506 #1517 #1563) → `remnic-fs-boundary-checks`
- config strict-check/coercion family (~17 findings, PRs #1506 #1517 #1519 #1590 #1593) → `remnic-config-coercion-footguns`
- ratchet-baseline raise (#1590) → `remnic-ratchet-baseline-only-decreases`
- two-arm ternary comparators → `remnic-comparator-total-order`

**No new rule justified** — every recurring candidate failed the false-positive bar against the actual tree, and the README now records the receipts so they are not re-proposed naively:
| Candidate | Why rejected |
|---|---|
| `String(err)` / `err.message` rules | 462 occurrences of the standard `instanceof Error ? .message : String(err)` normalization idiom; surface-reachability is semantic |
| `coerce*(...) ?? default` | it IS the config-parser idiom; the bug class (fail-open default for unrecognized explicit input) is a helper-level fix, not a per-callsite rule |
| inline `NODE_OPTIONS=` npm scripts | 20 existing scripts use the convention deliberately |
| `../packages/<pkg>/src/` imports | 361 ratchet-managed occurrences (already documented in the cross-package rule) |

The window's two dominant clusters — namespace/ACL scoping (#1506, #1519, ~80 findings) and flush-plan lifecycle races (#1487) — are semantic single-subsystem invariants with no textual signature; they belong to the AGENTS.md scenario-matrix workflow.

Also updates the README derivation scope to the full four-week corpus (3,100+ findings, 2026-06-20..07-18).

Docs-only change to `.omp/rules/README.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to `.omp/rules/`; no runtime, harness behavior, or rule conditions change.
> 
> **Overview**
> **Documents the outcome of a second review-window pass** on Oh My Pi stream rules without adding new TTSRs.
> 
> The `.omp/rules/README.md` derivation scope is widened to **four weeks** (2026-06-20 through 2026-07-18, 3,100+ bot findings). A new **“Evaluated and rejected candidates”** section records why recurring patterns (`String(err)` / `err.message`, `coerce*(...) ?? default`, inline `NODE_OPTIONS=` in npm scripts, `../packages/<pkg>/src/` imports) **failed the false-positive bar**, with grep-style baselines so they are not re-proposed as stream conditions. It also states that dominant clusters in the mid-window subset (namespace/ACL scoping, flush-plan races, catalog-touch ordering) are **semantic invariants** handled via `AGENTS.md` scenario matrices, not regex/ast rules.
> 
> `remnic-no-cross-package-src-imports.md` is aligned with that README: the deliberately unmatched `../packages/<pkg>/src/` form is described as **~360 existing uses** (routine edits would false-positive), with **`directStorageImports`** called out as the narrower ratchet-managed slice instead of implying the whole `../packages/` path class is ratchet-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbf96223abb876688ce12f95fc9b562a536fa4d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated harness rules documentation with revised analysis window and clearer sourcing, including cross-checks against review-prevention patterns.
  * Added an “Evaluated and rejected candidates” section listing recurring condition patterns that fail the false-positive threshold.
  * Clarified that certain import scenarios are excluded intentionally, with guidance to prefer `@remnic/*` imports and note related tracking elsewhere.
  * Documented that dominant review clusters are handled via the scenario-matrix workflow rather than stream rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->