### PR TITLE
Deterministic artifact selection for paper figures

### DIFF
--- a/scripts/generate-paper-figures.mjs
+++ b/scripts/generate-paper-figures.mjs
@@ -162,7 +162,11 @@ function findArtifact({ benchmarkId, tier, model, systemName = "remnic" }) {
       if (systemName === undefined) return true;
       return sn === systemName;
     })
-    .sort((a, b) => String(b.doc.finishedAt).localeCompare(String(a.doc.finishedAt)));
+    .sort((a, b) => {
+      const timeDiff = String(b.doc.finishedAt).localeCompare(String(a.doc.finishedAt));
+      if (timeDiff !== 0) return timeDiff;
+      return a.name.localeCompare(b.name);
+    });
   return candidates[0] ?? null;
 }
 

--- a/tests/paper-figures.test.mjs
+++ b/tests/paper-figures.test.mjs
@@ -355,11 +355,24 @@ test("Figure 2: with no committed memcorrect artifact, every adapter bar is DATA
 // ─── 4. Determinism ───────────────────────────────────────────────────────
 
 test("generation is byte-identical across runs (deterministic)", () => {
-  const out1 = mkdtempSync(join(tmpdir(), "fig-run1-"));
-  const out2 = mkdtempSync(join(tmpdir(), "fig-run2-"));
+  // Use hermetic copies of only the git-tracked artifacts so the test is
+  // isolated from UNTRACKED leftovers in the gitignored results dir.
+  const tmpResults = mkdtempSync(join(tmpdir(), "fig-det-results-"));
+  const out1 = mkdtempSync(join(tmpdir(), "fig-det-out1-"));
+  const out2 = mkdtempSync(join(tmpdir(), "fig-det-out2-"));
   try {
-    runGenerator({ REMNIC_FIGURES_OUT_DIR: out1 });
-    runGenerator({ REMNIC_FIGURES_OUT_DIR: out2 });
+    assert.ok(
+      copyTrackedResults(tmpResults).length > 0,
+      "git-tracked artifacts must exist to regenerate from",
+    );
+    runGenerator({
+      REMNIC_FIGURES_RESULTS_DIR: tmpResults,
+      REMNIC_FIGURES_OUT_DIR: out1,
+    });
+    runGenerator({
+      REMNIC_FIGURES_RESULTS_DIR: tmpResults,
+      REMNIC_FIGURES_OUT_DIR: out2,
+    });
     for (const f of [
       "fig1-locomo-longmemeval.svg",
       "fig2-memcorrect-metrics.svg",
@@ -370,6 +383,7 @@ test("generation is byte-identical across runs (deterministic)", () => {
       assert.equal(a, b, `${f} must be byte-identical across runs`);
     }
   } finally {
+    rmSync(tmpResults, { recursive: true, force: true });
     rmSync(out1, { recursive: true, force: true });
     rmSync(out2, { recursive: true, force: true });
   }


### PR DESCRIPTION
# Deterministic artifact selection for paper figures

## Summary

The paper-figures byte-identical test was flaky because the `findArtifact` function sorted artifacts only by `finishedAt` timestamp, which can produce non-deterministic ordering when multiple artifacts share the same timestamp. This caused the generator to pick different artifacts across test runs, leading to differing SVG outputs. The fix adds a secondary sort by filename to guarantee a stable order. Additionally, the test for deterministic generation was updated to isolate from untracked artifact leftovers by using hermetic copies of only the git-tracked artifacts.

Fixes #2004

## Changes

- scripts/generate-paper-figures.mjs: Modified `findArtifact` to sort by timestamp descending, then filename ascending.
- tests/paper-figures.test.mjs: Updated the \"generation is byte-identical across runs\" test to use hermetic copies of git-tracked artifacts only, preventing interference from untracked leftovers.

## Testing

- Ran the updated test suite: `npm test` (which runs `scripts/run-root-tests.mjs`).
- Verified the specific test passes: `node --test tests/paper-figures.test.mjs -g \"generation is byte-identical across runs\"`.
- Confirmed all paper-figures tests pass.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured artifact selection is deterministic when multiple artifacts have the same completion time.
  * Added a consistent filename-based tie-breaker for reliable figure generation.

* **Tests**
  * Improved determinism testing by using isolated, controlled input artifacts and separate output directories.
  * Enhanced test cleanup for temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->