### PR TITLE
fix(core): warn on unrecognized config values; document namespace/ACL + flush-plan scenario matrices

### DIFF
--- a/.changeset/coerce-warn-unrecognized.md
+++ b/.changeset/coerce-warn-unrecognized.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Warn on present-but-unrecognized config values instead of silently defaulting them. The shared `coerceBool` / `coerceNumber` helpers (`connectors/coerce.ts`) now log a warning when a value is present but unrecognized (e.g. a typo like `"fales"` or an unsupported token like `"disabled"`) before returning `undefined`, so an operator misconfiguration no longer silently takes the caller's default — frequently a fail-open `?? true`. Absent values (`undefined`/`null`/empty string) still fall through silently, since absence legitimately means "use the default". Both helpers accept an optional `label` (the config key) for an actionable message. `config.ts`'s duplicate `coerceBooleanLike` now delegates its boolean/string path to the canonical `coerceBool` (retaining numeric `1`/`0` handling), inheriting the warning and removing the duplicated parser. The already-loud edge coercers (`access-boundary.ts`, `emit-legacy-tools.ts`) that throw on unrecognized input are unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,8 @@ cancel those reruns. Work with this, not against it:
 
 ## Why Stateful PRs Churn (Read Before Touching Lifecycle Logic)
 
-PRs in retrieval, session identity, compaction, cache, or reset/end-of-session code
+PRs in retrieval, session identity, compaction, cache, reset/end-of-session,
+namespace/ACL scoping, or flush-plan/extraction lifecycle code
 often attract many review rounds for the same structural reason:
 
 1. The subsystem is stateful across multiple entrypoints.
@@ -169,6 +170,36 @@ Minimum scenario matrix for session/retrieval/cache work:
 
 If you cannot explain the behavior for every row in that matrix, the PR is not
 ready for external review.
+
+Minimum scenario matrix for namespace/ACL scoping work (the dominant review
+cluster of 2026-06-20..07-04, ~80 findings concentrated in #1506/#1519 — a
+semantic, single-subsystem invariant class with no textual signature, so it is
+NOT catchable by a `.omp/rules/` stream rule; model it here instead):
+
+- read path and write path resolve through the SAME namespace resolver
+  (`resolveWritableNamespace` / scoped-key helpers), never `defaultNamespace`
+  on one side
+- authenticated principal — never a client-supplied `actor`/namespace — drives
+  authorization AND the audit trail
+- slot-based lookups reject foreign plugin IDs
+- search scope constrained to the session-derived namespace (no cross-tenant
+  leakage from an un-namespaced scan)
+- catalog `lastWriteAt` / last-seen markers keyed by the sanitized namespace,
+  with a reversible encoding (no lossy collision between distinct namespaces)
+- profile/scope layering precedence is deterministic and applied identically on
+  every entrypoint
+
+Minimum scenario matrix for flush-plan / extraction lifecycle work (#1487 and
+kin — also semantic, not stream-rule-able):
+
+- timed-out `before_reset` flush aborts the in-flight extraction before the
+  buffer is cleared (late flush cannot clear turns buffered after reset)
+- explicit/force flush bypasses the dedupe fingerprint (`skipDedupeCheck`)
+- buffer key is propagated through every extraction path (no `"default"`
+  fallback clearing the wrong buffer)
+- persisted head/marker advances only after a non-empty, fully-persisted batch
+- deadline is shared across retries (elapsed time subtracted, not reset)
+- `session_end` drains the same way as `before_reset`
 
 ## Mechanical Stream Rules (`.omp/rules/`)
 

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -348,23 +348,19 @@ function parsePortNumber(
 // fall back to their own default. Guards against the "string `false` is
 // truthy" footgun (CLAUDE.md gotcha #36) when config values arrive from
 // CLI/env/JSON sources where booleans are sometimes string-typed.
-function coerceBooleanLike(value: unknown): boolean | undefined {
-  if (typeof value === "boolean") return value;
+//
+// The boolean/string path delegates to the canonical `coerceBool`
+// (connectors/coerce.ts), which warns on a present-but-unrecognized string
+// rather than letting a typo silently take the caller's default (often a
+// fail-open `?? true`). Numeric 1/0 is handled here because config values can
+// arrive as JSON numbers, which `coerceBool` intentionally does not accept.
+function coerceBooleanLike(value: unknown, label?: string): boolean | undefined {
   if (typeof value === "number") {
     if (value === 1) return true;
     if (value === 0) return false;
     return undefined;
   }
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "on") {
-      return true;
-    }
-    if (normalized === "false" || normalized === "0" || normalized === "no" || normalized === "off") {
-      return false;
-    }
-  }
-  return undefined;
+  return coerceBool(value, label);
 }
 
 function readNestedConfig(

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -35,7 +35,7 @@ import { expandTildePath } from "./utils/path.js";
 // boolean-coercion logic that connectors/index.ts already exports. The helper
 // lives in connectors/coerce.ts (a tiny, dependency-free module) so neither
 // config.ts → connectors/index.ts nor the reverse circular import arises.
-import { coerceBool, coerceInstallExtension, coerceNumber } from "./connectors/coerce.js";
+import { coerceBool, coerceInstallExtension, coerceNumber, warnUnrecognizedConfig } from "./connectors/coerce.js";
 import { hasLegacyConnectorEntries } from "./connectors/paths.js";
 import {
   resolveEmitLegacyTools,
@@ -358,6 +358,10 @@ function coerceBooleanLike(value: unknown, label?: string): boolean | undefined 
   if (typeof value === "number") {
     if (value === 1) return true;
     if (value === 0) return false;
+    warnUnrecognizedConfig(
+      `ignoring unrecognized boolean value ${JSON.stringify(value)}${label ? ` for ${label}` : ""}; ` +
+        `expected true|false|1|0|yes|no|on|off — using default`,
+    );
     return undefined;
   }
   return coerceBool(value, label);

--- a/packages/remnic-core/src/connectors/coerce.test.ts
+++ b/packages/remnic-core/src/connectors/coerce.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from "node:assert";
 import { afterEach, beforeEach, test } from "node:test";
 
 import { coerceBool, coerceNumber } from "./coerce.js";
-import { initLogger } from "../logger.js";
+import { initLogger, resetLogger } from "../logger.js";
 
 let warnings: string[];
 
@@ -85,19 +85,47 @@ test("coerceNumber accepts finite numbers and numeric strings without warning", 
   assert.deepEqual(warnings, []);
 });
 
-test("coerceNumber returns undefined silently for absent or non-finite number inputs", () => {
+test("coerceNumber returns undefined silently for absent inputs", () => {
   assert.equal(coerceNumber(undefined), undefined);
   assert.equal(coerceNumber(null), undefined);
   assert.equal(coerceNumber(""), undefined);
+  assert.equal(coerceNumber("   "), undefined);
+  assert.deepEqual(warnings, [], "absent numeric inputs do not warn");
+});
+
+test("coerceNumber warns on present non-finite number inputs and returns undefined", () => {
   assert.equal(coerceNumber(Number.NaN), undefined);
   assert.equal(coerceNumber(Number.POSITIVE_INFINITY), undefined);
-  assert.deepEqual(warnings, [], "absent / non-finite numeric inputs do not warn");
+  assert.equal(coerceNumber(Number.NEGATIVE_INFINITY, "ttlMs"), undefined);
+  assert.equal(warnings.length, 3);
+  assert.match(warnings[0], /non-finite numeric value/);
+  assert.match(warnings[2], /for ttlMs/);
 });
 
 test("coerceNumber warns on a present-but-unparseable string and returns undefined", () => {
   assert.equal(coerceNumber("abc"), undefined);
-  assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /unrecognized numeric value "abc"/);
+  assert.equal(coerceNumber("NaN"), undefined);
+  assert.equal(coerceNumber("Infinity"), undefined);
   assert.equal(coerceNumber("12px", "maxResults"), undefined);
-  assert.match(warnings[1], /for maxResults/);
+  assert.equal(warnings.length, 4);
+  assert.match(warnings[0], /unrecognized numeric value "abc"/);
+  assert.match(warnings[3], /for maxResults/);
+});
+
+test("warns via console when no logger backend is installed (standalone-core path)", () => {
+  resetLogger();
+  const originalWarn = console.warn;
+  const captured: string[] = [];
+  console.warn = (msg?: unknown) => {
+    captured.push(String(msg));
+  };
+  try {
+    assert.equal(coerceBool("disabled"), undefined);
+    assert.equal(coerceNumber("abc"), undefined);
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert.equal(captured.length, 2);
+  assert.match(captured[0], /^remnic: ignoring unrecognized boolean value "disabled"/);
+  assert.match(captured[1], /^remnic: ignoring unrecognized numeric value "abc"/);
 });

--- a/packages/remnic-core/src/connectors/coerce.test.ts
+++ b/packages/remnic-core/src/connectors/coerce.test.ts
@@ -1,0 +1,103 @@
+import { strict as assert } from "node:assert";
+import { afterEach, beforeEach, test } from "node:test";
+
+import { coerceBool, coerceNumber } from "./coerce.js";
+import { initLogger } from "../logger.js";
+
+let warnings: string[];
+
+beforeEach(() => {
+  warnings = [];
+  initLogger(
+    {
+      info() {},
+      warn(msg: string) {
+        warnings.push(msg);
+      },
+      error() {},
+      debug() {},
+    },
+    false,
+    { timestamps: false },
+  );
+});
+
+afterEach(() => {
+  // Restore the no-op backend so later suites do not inherit this capture sink.
+  initLogger({ info() {}, warn() {}, error() {}, debug() {} });
+});
+
+test("coerceBool recognizes canonical true/false spellings without warning", () => {
+  for (const t of ["true", "1", "yes", "on", "TRUE", " On "]) {
+    assert.equal(coerceBool(t), true, `${t} → true`);
+  }
+  for (const f of ["false", "0", "no", "off", "FALSE", " Off "]) {
+    assert.equal(coerceBool(f), false, `${f} → false`);
+  }
+  assert.equal(coerceBool(true), true);
+  assert.equal(coerceBool(false), false);
+  assert.deepEqual(warnings, [], "recognized values must not warn");
+});
+
+test("coerceBool returns undefined silently for absent values", () => {
+  assert.equal(coerceBool(undefined), undefined);
+  assert.equal(coerceBool(null), undefined);
+  assert.equal(coerceBool(""), undefined);
+  assert.equal(coerceBool("   "), undefined);
+  assert.deepEqual(warnings, [], "absent/empty must be treated as 'use default', no warning");
+});
+
+test("coerceBool warns on a present-but-unrecognized string and returns undefined", () => {
+  assert.equal(coerceBool("disabled"), undefined);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /unrecognized boolean value "disabled"/);
+  assert.match(warnings[0], /using default/);
+});
+
+test("coerceBool includes the label in the warning when provided", () => {
+  assert.equal(coerceBool("fales", "qmdForceCpu"), undefined);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /for qmdForceCpu/);
+});
+
+test("coerceBool does not warn on inherited Object keys (prototype safety)", () => {
+  assert.equal(coerceBool("constructor"), undefined);
+  assert.equal(coerceBool("toString"), undefined);
+  assert.equal(coerceBool("hasOwnProperty"), undefined);
+  // These are unrecognized strings, so each warns exactly once — never matched
+  // as a truthy/falsy token via the prototype chain.
+  assert.equal(warnings.length, 3);
+});
+
+test("coerceBool returns undefined without warning for non-string, non-boolean inputs", () => {
+  assert.equal(coerceBool(2), undefined);
+  assert.equal(coerceBool({}), undefined);
+  assert.equal(coerceBool([]), undefined);
+  assert.deepEqual(warnings, []);
+});
+
+test("coerceNumber accepts finite numbers and numeric strings without warning", () => {
+  assert.equal(coerceNumber(5), 5);
+  assert.equal(coerceNumber(0), 0);
+  assert.equal(coerceNumber(-3.5), -3.5);
+  assert.equal(coerceNumber("42"), 42);
+  assert.equal(coerceNumber(" 7 "), 7);
+  assert.deepEqual(warnings, []);
+});
+
+test("coerceNumber returns undefined silently for absent or non-finite number inputs", () => {
+  assert.equal(coerceNumber(undefined), undefined);
+  assert.equal(coerceNumber(null), undefined);
+  assert.equal(coerceNumber(""), undefined);
+  assert.equal(coerceNumber(Number.NaN), undefined);
+  assert.equal(coerceNumber(Number.POSITIVE_INFINITY), undefined);
+  assert.deepEqual(warnings, [], "absent / non-finite numeric inputs do not warn");
+});
+
+test("coerceNumber warns on a present-but-unparseable string and returns undefined", () => {
+  assert.equal(coerceNumber("abc"), undefined);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /unrecognized numeric value "abc"/);
+  assert.equal(coerceNumber("12px", "maxResults"), undefined);
+  assert.match(warnings[1], /for maxResults/);
+});

--- a/packages/remnic-core/src/connectors/coerce.ts
+++ b/packages/remnic-core/src/connectors/coerce.ts
@@ -5,12 +5,27 @@
  * connectors/index.ts can import them without creating a circular dependency.
  */
 
-import { log } from "../logger.js";
+import { isLoggerInitialized, log } from "../logger.js";
 
 const BOOL_TOKENS: Record<string, boolean> = {
   true: true, "1": true, yes: true, on: true,
   false: false, "0": false, no: false, off: false,
 };
+
+/**
+ * Surface a "present but unrecognized config value" diagnostic. Routes through
+ * the installed logger when a host has called `initLogger`, and otherwise falls
+ * back to `console.warn` so the standalone `@remnic/core` path (documented to
+ * call `parseConfig()` without a logger) does not silently discard the warning
+ * and re-introduce the fail-open default this whole change exists to prevent.
+ */
+export function warnUnrecognizedConfig(message: string): void {
+  if (isLoggerInitialized()) {
+    log.warn(message);
+  } else {
+    console.warn(`remnic: ${message}`);
+  }
+}
 
 /**
  * Generic boolean coercion: converts string representations of booleans
@@ -38,7 +53,7 @@ export function coerceBool(value: unknown, label?: string): boolean | undefined 
     const v = value.trim().toLowerCase();
     if (v === "") return undefined;
     if (Object.hasOwn(BOOL_TOKENS, v)) return BOOL_TOKENS[v];
-    log.warn(
+    warnUnrecognizedConfig(
       `ignoring unrecognized boolean value ${JSON.stringify(value)}${label ? ` for ${label}` : ""}; ` +
         `expected true|false|1|0|yes|no|on|off — using default`,
     );
@@ -77,14 +92,19 @@ export function coerceInstallExtension(value: unknown): boolean | undefined {
  */
 export function coerceNumber(value: unknown, label?: string): number | undefined {
   if (typeof value === "number") {
-    return Number.isFinite(value) ? value : undefined;
+    if (Number.isFinite(value)) return value;
+    warnUnrecognizedConfig(
+      `ignoring non-finite numeric value ${JSON.stringify(value)}${label ? ` for ${label}` : ""}; ` +
+        `expected a finite number — using default`,
+    );
+    return undefined;
   }
   if (typeof value === "string") {
     const trimmed = value.trim();
     if (trimmed.length === 0) return undefined;
     const n = Number(trimmed);
     if (Number.isFinite(n)) return n;
-    log.warn(
+    warnUnrecognizedConfig(
       `ignoring unrecognized numeric value ${JSON.stringify(value)}${label ? ` for ${label}` : ""}; ` +
         `expected a finite number — using default`,
     );

--- a/packages/remnic-core/src/connectors/coerce.ts
+++ b/packages/remnic-core/src/connectors/coerce.ts
@@ -5,6 +5,13 @@
  * connectors/index.ts can import them without creating a circular dependency.
  */
 
+import { log } from "../logger.js";
+
+const BOOL_TOKENS: Record<string, boolean> = {
+  true: true, "1": true, yes: true, on: true,
+  false: false, "0": false, no: false, off: false,
+};
+
 /**
  * Generic boolean coercion: converts string representations of booleans
  * (e.g. from CLI `--config someFlag=false`) to proper boolean values.
@@ -13,15 +20,28 @@
  * Returns `undefined` when the value is neither a boolean nor a recognised
  * string, so callers can fall back to a default.
  *
+ * A value that is PRESENT but unrecognised (a non-empty string like `"disabled"`
+ * or a typo like `"fales"`) is logged at warn level before returning `undefined`,
+ * so an operator typo does not silently take the caller's default — which is
+ * frequently a fail-open `?? true`. Absent values (`undefined`/`null`/empty
+ * string) fall through silently: absence legitimately means "use the default".
+ * Pass `label` (the config key) to make the warning actionable.
+ *
  * CLAUDE.md gotcha #36: String "false" is truthy in JavaScript.
  * CLAUDE.md gotcha #28: Coerce CLI values to expected types at input boundaries.
+ * CLAUDE.md gotcha #51: Reject/flag present-but-unrecognized values; don't
+ * silently default them.
  */
-export function coerceBool(value: unknown): boolean | undefined {
+export function coerceBool(value: unknown, label?: string): boolean | undefined {
   if (typeof value === "boolean") return value;
   if (typeof value === "string") {
     const v = value.trim().toLowerCase();
-    if (["false", "0", "no", "off"].includes(v)) return false;
-    if (["true", "1", "yes", "on"].includes(v)) return true;
+    if (v === "") return undefined;
+    if (Object.hasOwn(BOOL_TOKENS, v)) return BOOL_TOKENS[v];
+    log.warn(
+      `ignoring unrecognized boolean value ${JSON.stringify(value)}${label ? ` for ${label}` : ""}; ` +
+        `expected true|false|1|0|yes|no|on|off — using default`,
+    );
   }
   return undefined;
 }
@@ -33,7 +53,7 @@ export function coerceBool(value: unknown): boolean | undefined {
  * Delegates to the generic `coerceBool` helper. Kept for backward compatibility.
  */
 export function coerceInstallExtension(value: unknown): boolean | undefined {
-  return coerceBool(value);
+  return coerceBool(value, "installExtension");
 }
 
 /**
@@ -46,9 +66,16 @@ export function coerceInstallExtension(value: unknown): boolean | undefined {
  * - string: trimmed, parsed with `Number()`. Returns `undefined` on
  *   empty, NaN, or Infinity.
  *
+ * A PRESENT but unparseable string (a non-empty value that is not a finite
+ * number) is logged at warn level before returning `undefined`, for the same
+ * reason as `coerceBool`: a typo must not silently take the caller's default.
+ * Absent values (`undefined`/`null`/empty string) fall through silently.
+ * Pass `label` (the config key) to make the warning actionable.
+ *
  * CLAUDE.md gotcha #28: Coerce CLI values to expected types at input boundaries.
+ * CLAUDE.md gotcha #51: Flag present-but-unrecognized values.
  */
-export function coerceNumber(value: unknown): number | undefined {
+export function coerceNumber(value: unknown, label?: string): number | undefined {
   if (typeof value === "number") {
     return Number.isFinite(value) ? value : undefined;
   }
@@ -56,7 +83,11 @@ export function coerceNumber(value: unknown): number | undefined {
     const trimmed = value.trim();
     if (trimmed.length === 0) return undefined;
     const n = Number(trimmed);
-    return Number.isFinite(n) ? n : undefined;
+    if (Number.isFinite(n)) return n;
+    log.warn(
+      `ignoring unrecognized numeric value ${JSON.stringify(value)}${label ? ` for ${label}` : ""}; ` +
+        `expected a finite number — using default`,
+    );
   }
   return undefined;
 }

--- a/packages/remnic-core/src/logger.ts
+++ b/packages/remnic-core/src/logger.ts
@@ -60,6 +60,22 @@ export function initLogger(backend?: LoggerBackend, debug?: boolean, options?: L
   _clock = options?.clock ?? (() => new Date().toISOString());
 }
 
+// Whether a real backend has been installed via initLogger. Lets diagnostics
+// that must not be swallowed (config misconfiguration warnings) fall back to
+// console when a host-agnostic consumer uses core without calling initLogger.
+export function isLoggerInitialized(): boolean {
+  return _backend !== NOOP_LOGGER;
+}
+
+// Restore the pristine no-op backend (as at module load, before initLogger).
+// Primarily a test seam for exercising the standalone/no-host path.
+export function resetLogger(): void {
+  _backend = NOOP_LOGGER;
+  _debug = false;
+  _timestamps = true;
+  _clock = () => new Date().toISOString();
+}
+
 // Format one log line: "<iso> remnic: <msg>" when timestamps are enabled,
 // otherwise the legacy "remnic: <msg>". Timestamp is per-call.
 function fmt(msg: string, label = "remnic"): string {


### PR DESCRIPTION
Addresses two follow-ups from the TTSR analysis (#2010, #2024).

## 1. Kill the fail-open silent-default class at the source

The `coerceBool`/`coerceBooleanLike` helpers silently defaulted **explicitly-set-but-unrecognized** values — worst as fail-open `?? true` — which drew **15+ review findings across 6 PRs** (#1517 #1519 #1590 #1593 et al.).

- `connectors/coerce.ts` `coerceBool` / `coerceNumber` now `log.warn` when a value is **present but unrecognized** (a typo like `"fales"` or unsupported token like `"disabled"`) before returning `undefined`. **Absent** values (`undefined`/`null`/empty string) still fall through silently — absence legitimately means "use the default". Optional `label` param names the offending config key.
- `config.ts`'s duplicate `coerceBooleanLike` now delegates its boolean/string path to the canonical `coerceBool` (keeping numeric `1`/`0`), **inheriting the warn and removing the duplicated parser** (erasure).
- `access-boundary.ts` and `emit-legacy-tools.ts` already **throw** on unrecognized input (louder than a warn) — verified, left unchanged.
- Prototype-safe: uses an `Object.hasOwn` token table, not `key in obj` (no inherited-key false matches like `"constructor"`).

**Tests:** new `connectors/coerce.test.ts` — 9 cases covering recognized / absent / present-unrecognized / labelled / prototype-safety / non-string inputs for both helpers. Regression: config + emit-legacy-tools + connectors 208/208, entity-hardening gate 254/254, remnic-core `tsc` clean.

Follow-on (not this PR): high-value callers can pass `label` opportunistically for sharper messages.

## 2. Document the un-rule-able review clusters (AGENTS.md / CLAUDE.md)

The dominant clusters of the 2026-06-20..07-04 window — namespace/ACL scoping (~80 findings in #1506/#1519) and flush-plan/extraction lifecycle (#1487) — are semantic single-subsystem invariants with **no textual signature**, so they are not `.omp/rules/` stream-rule material; they're scenario-matrix territory. The "Why Stateful PRs Churn" section now names both subsystems and adds an explicit **scenario matrix** for each (read/write namespace symmetry, principal-not-actor auth, slot-ID rejection, cross-tenant scan scope, reversible catalog keys; abort-before-clear flush, skipDedupe on force-flush, buffer-key propagation, head-advance-only-on-persisted, shared retry deadline, session_end parity).

`CLAUDE.md` is a symlink to `AGENTS.md`, so it is updated by the same edit.

Docs-and-core change; no public API signature change (the new `label` params are optional).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to diagnostics on bad config input; parsing semantics for valid and absent values are unchanged, with new unit tests.
> 
> **Overview**
> **Config coercion** now **warns** when a value is present but unrecognized, instead of returning `undefined` and letting callers fall back—often to fail-open `?? true`. `coerceBool` and `coerceNumber` in `connectors/coerce.ts` log via `warnUnrecognizedConfig` (logger when initialized, otherwise `console.warn`); absent/`null`/empty strings stay silent. Optional `label` names the config key. Parsing uses an `Object.hasOwn` token table for prototype safety.
> 
> `config.ts` **`coerceBooleanLike`** delegates string/boolean handling to `coerceBool` and warns on unrecognized numeric inputs; JSON `1`/`0` stays local. **`logger.ts`** adds `isLoggerInitialized` and `resetLogger` for that fallback path and tests.
> 
> New **`connectors/coerce.test.ts`** covers recognized/absent/unrecognized/label/prototype and no-logger behavior. Patch changeset for `@remnic/core`.
> 
> **AGENTS.md** expands “Why Stateful PRs Churn” with scenario matrices for **namespace/ACL scoping** and **flush-plan/extraction lifecycle** (semantic invariants not covered by `.omp/rules/` stream rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ea427352f7b9ab58d2ba52e199b9261bceaf55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration values that are present but unrecognized now generate clear warnings instead of silently falling back to defaults.
  * Boolean and numeric configuration parsing is more consistent across the application.
  * Warnings can identify the affected configuration setting for easier troubleshooting.
  * Missing or empty configuration values continue to be handled without warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->