### PR TITLE
docs(relay): record completed Build Week feedback

### DIFF
--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -199,8 +199,9 @@ The user made the consequential product and risk decisions:
 - retain final video, `/feedback`, and submission authority.
 
 The repository's dated commits and review history are the durable in-window
-collaboration evidence. The official `/feedback` session ID is operator input;
-the user must select the actual primary build thread before submitting.
+collaboration evidence. The user completed `/feedback` for the primary build
+thread on 2026-07-18; the uploaded thread ID is
+`019f6219-6517-75e3-84fa-c905cef9978e`.
 
 ### GPT-5.6 inside the product
 
@@ -296,10 +297,10 @@ remnic bench run longmemeval \
   local credit policy.
 - [x] Third-party asset/license check and evidence-backed claim ledger.
 - [ ] User records and uploads the final public YouTube video with audio.
-- [ ] User runs `/feedback` in the actual primary Codex project thread and adds
-  that session ID.
+- [x] User ran `/feedback` in the primary Codex project thread and uploaded
+  session `019f6219-6517-75e3-84fa-c905cef9978e`.
 - [ ] User completes and submits the Devpost entry before July 21, 2026 at
   5:00 PM PDT.
 
-The final three actions are intentionally not automated by the repository or
-performed on the user's behalf.
+The final video upload and Devpost submission remain intentionally outside
+repository automation and under the user's control.

--- a/docs/remnic-relay/CLAIMS.md
+++ b/docs/remnic-relay/CLAIMS.md
@@ -55,9 +55,9 @@ evaluate only the new Relay extension:
 | New: isolated live mission | Issue #1968, PR #1999, merge `a236ad07` on 2026-07-18, with dated commits beginning `386aa5f3` on 2026-07-17; bounded Codex CLI runner, synthetic harness, isolation, live GPT-5.6 recording, replay binding. |
 | New: judge package | Issue #1969, PR #2012; dependency-free verifier/server, out-of-band launcher and executable trust chain, clean-room smoke, claims ledger, demo script, Devpost copy, and refreshed captures. The linked PR retains its current-head review and merge record. |
 
-The required Codex `/feedback` session ID is intentionally left to the user,
-who must select the real primary project thread before submitting. Dated Git
-history and PR review history remain additional in-window evidence.
+The user completed the required Codex `/feedback` upload on 2026-07-18 for the
+primary project thread `019f6219-6517-75e3-84fa-c905cef9978e`. Dated Git history
+and PR review history remain additional in-window evidence.
 
 ## License and third-party assets
 
@@ -74,6 +74,6 @@ history and PR review history remain additional in-window evidence.
 ## Final operator checks
 
 Before submission, the user should confirm that the final video matches this
-ledger, add the real `/feedback` session ID, verify the YouTube upload is public
-with audio and under three minutes, and submit before July 21, 2026 at 5:00 PM
-PDT. Those actions are deliberately outside repository automation.
+ledger, verify the YouTube upload is public with audio and under three minutes,
+and submit before July 21, 2026 at 5:00 PM PDT. The final upload and submission
+actions remain deliberately outside repository automation.

--- a/docs/remnic-relay/DEVPOST.md
+++ b/docs/remnic-relay/DEVPOST.md
@@ -219,5 +219,7 @@ without the stale belief).
 ## User-owned fields still required
 
 - public YouTube URL for the final under-three-minute video with audio;
-- the real Codex `/feedback` session ID from the primary build thread;
 - entrant/team details and final Devpost submission action.
+
+Completed operator evidence: `/feedback` was uploaded on 2026-07-18 for the
+primary build thread `019f6219-6517-75e3-84fa-c905cef9978e`.


### PR DESCRIPTION
## Summary

- record the completed Codex /feedback upload and primary thread ID across the Build Week checklist, claims ledger, and Devpost handoff
- leave only the public video upload and final Devpost submission as user-owned actions
- keep synthetic judge-run data and private video artifacts out of the repository

## Validation

- npm run preflight:quick
- git diff --cached --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to submission checklists and claims; no runtime, security, or data-handling code changes.
> 
> **Overview**
> Updates **HACKATHON.md**, **CLAIMS.md**, and **DEVPOST.md** to document that the required Codex **`/feedback`** upload is done for the primary build thread on **2026-07-18**, with session ID **`019f6219-6517-75e3-84fa-c905cef9978e`**.
> 
> The Build Week checklist marks that item complete and narrows remaining operator work to the **public YouTube video** and **final Devpost submission**. Wording that previously told the user to add the session ID later is replaced with completed-evidence language; final upload/submission steps stay explicitly outside repo automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14929dcd5a925abb6256e02fcd33a5fcf1caff2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hackathon documentation with completed `/feedback` submission evidence, including the upload date and primary project thread reference.
  * Revised operator checklists to reflect the completed feedback step and clarify remaining user-controlled actions.
  * Documented that final video upload and Devpost submission remain outstanding, including final video validation and submission requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->