### PR TITLE
feat(server): env override for write rate limit (part of #2029)

### DIFF
--- a/packages/remnic-server/src/config.test.ts
+++ b/packages/remnic-server/src/config.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { parseConfig } from "@remnic/core";
-import { createAdminControls, loadConfigFile, mergeRemnicConfigForServer, parseServerConfig } from "./index.js";
+import { createAdminControls, envOverrides, loadConfigFile, mergeRemnicConfigForServer, parseServerConfig } from "./index.js";
 
 async function writeConfig(content: string): Promise<{ filePath: string; cleanup: () => Promise<void> }> {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-config-"));
@@ -257,5 +257,34 @@ test("parseServerConfig write rate limit keys: optional, string-coerced, invalid
       /server\.writeRateLimitWindowMs: expected a positive integer/,
       `writeRateLimitWindowMs=${JSON.stringify(bad)} must throw`,
     );
+  }
+});
+
+test("envOverrides surfaces write rate limit env vars, REMNIC_ over ENGRAM_ (issue #2029)", () => {
+  const keys = [
+    "REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS",
+    "REMNIC_WRITE_RATE_LIMIT_WINDOW_MS",
+    "ENGRAM_WRITE_RATE_LIMIT_MAX_REQUESTS",
+    "ENGRAM_WRITE_RATE_LIMIT_WINDOW_MS",
+  ];
+  const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+  try {
+    for (const k of keys) delete process.env[k];
+    process.env.REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS = "1800";
+    process.env.REMNIC_WRITE_RATE_LIMIT_WINDOW_MS = "30000";
+    // env arrives as strings; parseServerConfig coerces + validates them.
+    const parsed = parseServerConfig(envOverrides());
+    assert.equal(parsed.writeRateLimitMaxRequests, 1800);
+    assert.equal(parsed.writeRateLimitWindowMs, 30000);
+
+    // Legacy ENGRAM_ name is honored when the REMNIC_ name is unset.
+    delete process.env.REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS;
+    process.env.ENGRAM_WRITE_RATE_LIMIT_MAX_REQUESTS = "42";
+    assert.equal(parseServerConfig(envOverrides()).writeRateLimitMaxRequests, 42);
+  } finally {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
   }
 });

--- a/packages/remnic-server/src/config.test.ts
+++ b/packages/remnic-server/src/config.test.ts
@@ -260,7 +260,7 @@ test("parseServerConfig write rate limit keys: optional, string-coerced, invalid
   }
 });
 
-test("envOverrides surfaces write rate limit env vars, REMNIC_ over ENGRAM_ (issue #2029)", () => {
+test("envOverrides write rate limit env: precedence, legacy fallback, invalid rejected (issue #2029)", () => {
   const keys = [
     "REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS",
     "REMNIC_WRITE_RATE_LIMIT_WINDOW_MS",
@@ -268,19 +268,38 @@ test("envOverrides surfaces write rate limit env vars, REMNIC_ over ENGRAM_ (iss
     "ENGRAM_WRITE_RATE_LIMIT_WINDOW_MS",
   ];
   const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
-  try {
+  const clear = () => {
     for (const k of keys) delete process.env[k];
+  };
+  try {
+    // REMNIC_ wins over a conflicting ENGRAM_ value, for both fields.
+    clear();
     process.env.REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS = "1800";
+    process.env.ENGRAM_WRITE_RATE_LIMIT_MAX_REQUESTS = "99";
     process.env.REMNIC_WRITE_RATE_LIMIT_WINDOW_MS = "30000";
-    // env arrives as strings; parseServerConfig coerces + validates them.
-    const parsed = parseServerConfig(envOverrides());
+    process.env.ENGRAM_WRITE_RATE_LIMIT_WINDOW_MS = "1";
+    let parsed = parseServerConfig(envOverrides());
     assert.equal(parsed.writeRateLimitMaxRequests, 1800);
     assert.equal(parsed.writeRateLimitWindowMs, 30000);
 
-    // Legacy ENGRAM_ name is honored when the REMNIC_ name is unset.
-    delete process.env.REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS;
+    // Legacy ENGRAM_ name is honored when the REMNIC_ name is unset — both fields.
+    clear();
     process.env.ENGRAM_WRITE_RATE_LIMIT_MAX_REQUESTS = "42";
-    assert.equal(parseServerConfig(envOverrides()).writeRateLimitMaxRequests, 42);
+    process.env.ENGRAM_WRITE_RATE_LIMIT_WINDOW_MS = "45000";
+    parsed = parseServerConfig(envOverrides());
+    assert.equal(parsed.writeRateLimitMaxRequests, 42);
+    assert.equal(parsed.writeRateLimitWindowMs, 45000);
+
+    // Invalid env values reach validation and are rejected, not silently dropped.
+    for (const bad of ["0", "", "abc", "1.5"]) {
+      clear();
+      process.env.REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS = bad;
+      assert.throws(
+        () => parseServerConfig(envOverrides()),
+        /server\.writeRateLimitMaxRequests: expected a positive integer/,
+        `max=${JSON.stringify(bad)} must be rejected`,
+      );
+    }
   } finally {
     for (const k of keys) {
       if (saved[k] === undefined) delete process.env[k];

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -17,6 +17,8 @@ import path from "node:path";
 import { parseConfig, isOpenaiApiKeyDisabled, resolveRemnicConfigRecord, Orchestrator, EngramAccessService, EngramAccessHttpServer, initLogger, log, getAllValidTokens, getAllValidTokensCached, getAllValidTokenEntriesCached, expandTildePath, type PluginConfig, type RemnicAdminControls, type RemnicAdminDashboardStatus, type RemnicAdminModelOption, type RemnicAdminConfigPatch } from "@remnic/core";
 import { probeBetterSqlite3Driver } from "@remnic/core/runtime/better-sqlite";
 import { applyOAuthEnvOverrides, buildOAuthRequestHandler } from "./oauth.js";
+import { envOverrides, readCompatEnv } from "./server-env.js";
+export { envOverrides };
 
 // ── Config loading ──────────────────────────────────────────────────────────
 
@@ -39,10 +41,6 @@ export interface ServerConfig {
     /** OAuth authorization-server facade for ChatGPT dev-mode apps (parsed by oauth.ts). */
     oauth?: unknown;
   };
-}
-
-function readCompatEnv(primary: string, legacy: string): string | undefined {
-  return process.env[primary] ?? process.env[legacy];
 }
 
 function parseServerPort(value: unknown, source: string): number {
@@ -224,32 +222,6 @@ function loadResolvedConfig(resolved: ResolvedConfigPath): ServerConfig {
   }
 
   return loadConfigFile(resolved.path);
-}
-
-function envOverrides(): Partial<ServerConfig["server"]> & { remnic?: Record<string, unknown> } {
-  const overrides: Record<string, unknown> = {};
-  const remnic: Record<string, unknown> = {};
-
-  const port = readCompatEnv("REMNIC_PORT", "ENGRAM_PORT");
-  const host = readCompatEnv("REMNIC_HOST", "ENGRAM_HOST");
-  const authToken = readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN");
-  const adminConsoleEnabled = readCompatEnv("REMNIC_ADMIN_CONSOLE_ENABLED", "ENGRAM_ADMIN_CONSOLE_ENABLED");
-  const adminConsolePublicDir = readCompatEnv("REMNIC_ADMIN_CONSOLE_PUBLIC_DIR", "ENGRAM_ADMIN_CONSOLE_PUBLIC_DIR");
-  const adminConsolePrefillToken = readCompatEnv("REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN", "ENGRAM_ADMIN_CONSOLE_PREFILL_TOKEN");
-  const readinessOverride = process.env.REMNIC_READY_OVERRIDE;
-  if (port) overrides.port = port;
-  if (host) overrides.host = host;
-  if (authToken) overrides.authToken = authToken;
-  if (adminConsoleEnabled) overrides.adminConsoleEnabled = adminConsoleEnabled;
-  if (adminConsolePublicDir) overrides.adminConsolePublicDir = adminConsolePublicDir;
-  if (adminConsolePrefillToken) overrides.adminConsolePrefillToken = adminConsolePrefillToken;
-  if (readinessOverride !== undefined) overrides.readinessOverride = readinessOverride;
-
-  if (process.env.OPENAI_API_KEY) remnic.openaiApiKey = process.env.OPENAI_API_KEY;
-  const memoryDir = readCompatEnv("REMNIC_MEMORY_DIR", "ENGRAM_MEMORY_DIR");
-  if (memoryDir) remnic.memoryDir = memoryDir;
-
-  return { ...overrides, ...(Object.keys(remnic).length > 0 ? { remnic } : {}) };
 }
 
 export function mergeRemnicConfigForServer(

--- a/packages/remnic-server/src/server-env.ts
+++ b/packages/remnic-server/src/server-env.ts
@@ -1,0 +1,60 @@
+/**
+ * @remnic/server — environment-sourced server config.
+ *
+ * Extracted from index.ts (issue #2029): keeps the env → server-config surface
+ * in one place and keeps index.ts under its structural size ceiling. Values are
+ * returned as raw strings; `parseServerConfig` coerces/validates them.
+ */
+
+import type { ServerConfig } from "./index.js";
+
+/**
+ * Read an env var by its current `REMNIC_` name, falling back to the legacy
+ * `ENGRAM_` name.
+ */
+export function readCompatEnv(primary: string, legacy: string): string | undefined {
+  return process.env[primary] ?? process.env[legacy];
+}
+
+/**
+ * Collect server-config overrides sourced from environment variables. Merged
+ * over file config (file < env < cli) by the server startup path.
+ */
+export function envOverrides(): Partial<ServerConfig["server"]> & { remnic?: Record<string, unknown> } {
+  const overrides: Record<string, unknown> = {};
+  const remnic: Record<string, unknown> = {};
+
+  const port = readCompatEnv("REMNIC_PORT", "ENGRAM_PORT");
+  const host = readCompatEnv("REMNIC_HOST", "ENGRAM_HOST");
+  const authToken = readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN");
+  const adminConsoleEnabled = readCompatEnv("REMNIC_ADMIN_CONSOLE_ENABLED", "ENGRAM_ADMIN_CONSOLE_ENABLED");
+  const adminConsolePublicDir = readCompatEnv("REMNIC_ADMIN_CONSOLE_PUBLIC_DIR", "ENGRAM_ADMIN_CONSOLE_PUBLIC_DIR");
+  const adminConsolePrefillToken = readCompatEnv("REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN", "ENGRAM_ADMIN_CONSOLE_PREFILL_TOKEN");
+  const readinessOverride = process.env.REMNIC_READY_OVERRIDE;
+  // issue #2029: size the global write rate limit from env. The standalone
+  // server already honors `server.writeRateLimit*` in config; this makes it
+  // settable via the launchd/systemd environment without editing config.json.
+  const writeRateLimitMaxRequests = readCompatEnv(
+    "REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS",
+    "ENGRAM_WRITE_RATE_LIMIT_MAX_REQUESTS",
+  );
+  const writeRateLimitWindowMs = readCompatEnv(
+    "REMNIC_WRITE_RATE_LIMIT_WINDOW_MS",
+    "ENGRAM_WRITE_RATE_LIMIT_WINDOW_MS",
+  );
+  if (port) overrides.port = port;
+  if (host) overrides.host = host;
+  if (authToken) overrides.authToken = authToken;
+  if (adminConsoleEnabled) overrides.adminConsoleEnabled = adminConsoleEnabled;
+  if (adminConsolePublicDir) overrides.adminConsolePublicDir = adminConsolePublicDir;
+  if (adminConsolePrefillToken) overrides.adminConsolePrefillToken = adminConsolePrefillToken;
+  if (readinessOverride !== undefined) overrides.readinessOverride = readinessOverride;
+  if (writeRateLimitMaxRequests) overrides.writeRateLimitMaxRequests = writeRateLimitMaxRequests;
+  if (writeRateLimitWindowMs) overrides.writeRateLimitWindowMs = writeRateLimitWindowMs;
+
+  if (process.env.OPENAI_API_KEY) remnic.openaiApiKey = process.env.OPENAI_API_KEY;
+  const memoryDir = readCompatEnv("REMNIC_MEMORY_DIR", "ENGRAM_MEMORY_DIR");
+  if (memoryDir) remnic.memoryDir = memoryDir;
+
+  return { ...overrides, ...(Object.keys(remnic).length > 0 ? { remnic } : {}) };
+}

--- a/packages/remnic-server/src/server-env.ts
+++ b/packages/remnic-server/src/server-env.ts
@@ -49,8 +49,11 @@ export function envOverrides(): Partial<ServerConfig["server"]> & { remnic?: Rec
   if (adminConsolePublicDir) overrides.adminConsolePublicDir = adminConsolePublicDir;
   if (adminConsolePrefillToken) overrides.adminConsolePrefillToken = adminConsolePrefillToken;
   if (readinessOverride !== undefined) overrides.readinessOverride = readinessOverride;
-  if (writeRateLimitMaxRequests) overrides.writeRateLimitMaxRequests = writeRateLimitMaxRequests;
-  if (writeRateLimitWindowMs) overrides.writeRateLimitWindowMs = writeRateLimitWindowMs;
+  // Use `!== undefined` (not truthiness) so an explicitly-set empty/invalid
+  // value still reaches parseServerConfig and is rejected, rather than being
+  // silently dropped so file config wins (issue #2029 review).
+  if (writeRateLimitMaxRequests !== undefined) overrides.writeRateLimitMaxRequests = writeRateLimitMaxRequests;
+  if (writeRateLimitWindowMs !== undefined) overrides.writeRateLimitWindowMs = writeRateLimitWindowMs;
 
   if (process.env.OPENAI_API_KEY) remnic.openaiApiKey = process.env.OPENAI_API_KEY;
   const memoryDir = readCompatEnv("REMNIC_MEMORY_DIR", "ENGRAM_MEMORY_DIR");


### PR DESCRIPTION
## Problem

Per #2029, the standalone `remnic-server`'s global write rate limit (default 30 / 60s, shared across all clients of a daemon) could not be sized from the environment. The `server.writeRateLimitMaxRequests` / `writeRateLimitWindowMs` **config** fields already exist and are honored, but multi-agent deployments are typically configured via launchd/systemd env, not by editing `config.json`, so there was no ergonomic way to raise the cap — and a busy fleet trips `429 write_rate_limited` constantly at 30/min.

## Change

- **Env override**: `REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS` / `REMNIC_WRITE_RATE_LIMIT_WINDOW_MS` (with `ENGRAM_` legacy fallbacks), merged over file config in the existing `file < env < cli` order and coerced/validated by `parseServerConfig` (string→positive-int, same path the config fields use).
- **Refactor**: extracted `envOverrides` + `readCompatEnv` into a new `server-env.ts`. This keeps the env surface in one place and keeps `index.ts` under its structural ratchet ceiling (the addition would otherwise trip `check-ratchets`). `envOverrides` is re-exported from `index.ts` for compatibility.

## Tests

- New `config.test.ts` case: env vars flow through `envOverrides` → `parseServerConfig` to the parsed limit; `REMNIC_` takes precedence over `ENGRAM_`.
- Existing server config + relay write-quota suites unchanged and green. `preflight:quick` OK.

## Scope

Closes the configurability gap in #2029 (config + env). Two items from the issue remain as follow-ups because they require refactoring the structurally-capped `access-http.ts` (its ratchet ceiling forbids in-place growth): **(1)** logging rejected writes server-side (currently a bare throw), and **(2)** making the limit per-principal instead of a single global bucket. Tracked on #2029.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change on an existing rate-limit path; invalid env values fail at startup via existing validation.
> 
> **Overview**
> Adds **environment variables** to tune the standalone server’s global write rate limit without editing `config.json`: `REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS` and `REMNIC_WRITE_RATE_LIMIT_WINDOW_MS`, with legacy `ENGRAM_*` fallbacks. Values follow the existing **file &lt; env &lt; CLI** merge and the same `parseServerConfig` coercion/validation as the config fields.
> 
> **`readCompatEnv` and `envOverrides`** move from `index.ts` into new **`server-env.ts`** (re-exported from `index.ts` for compatibility). Rate-limit env keys use **`!== undefined`** so empty or invalid values are not dropped silently—they surface as parse errors instead of letting file config win.
> 
> Tests cover `REMNIC_` vs `ENGRAM_` precedence, legacy fallback, and rejection of invalid env values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 660b3ee43a11c19996dbeb54cae3e4b67f8398d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added centralized environment-based server overrides for port, host, authentication, admin console settings, readiness, OpenAI API key, and memory storage.
  - Added environment-configurable write rate limits (max requests and time window).
- **Compatibility**
  - Existing legacy `ENGRAM_` variables are still supported when `REMNIC_` equivalents are unset.
  - `REMNIC_` settings take priority over `ENGRAM_`.
- **Tests**
  - Added coverage for override prioritization and ensuring invalid env values are rejected.
- **Refactor**
  - Improved organization of environment configuration handling for easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->