### PR TITLE
perf(core): batch deindex in maintenance loops (#1911B)

### DIFF
--- a/packages/remnic-core/src/orchestration/batch-deindex-flush.test.ts
+++ b/packages/remnic-core/src/orchestration/batch-deindex-flush.test.ts
@@ -101,9 +101,21 @@ test("#1911B fact-archival flushes prior de-index entries when a later iteration
         staleDecayThreshold: 0,
         archiveDecayThreshold: 0,
       }),
-      // Succeeds for mem-a, throws for mem-b — the later iteration — after mem-b
-      // is already archived on disk but before its batch push.
-      async removeContentHashForMemory(_storage, memory): Promise<void> {
+      // Throws for mem-b — the later iteration — after mem-b is already archived
+      // AND queued for de-index, but before its content-hash cleanup completes.
+      // Asserts the production call passes the target storage instance and the
+      // fact-archival context.
+      async removeContentHashForMemory(targetStorage, memory, context): Promise<void> {
+        assert.equal(
+          targetStorage,
+          storage,
+          "removeContentHashForMemory must receive the target storage instance",
+        );
+        assert.equal(
+          context,
+          "fact-archival",
+          "removeContentHashForMemory must receive the fact-archival context",
+        );
         if (memory.frontmatter.id === "mem-b") throw boom;
       },
       async saveContentHashIndexes(): Promise<void> {},
@@ -119,13 +131,15 @@ test("#1911B fact-archival flushes prior de-index entries when a later iteration
     // Both were archived on disk before the failure.
     assert.deepEqual(archived, ["mem-a", "mem-b"]);
 
-    // The regression: mem-a's de-index entry was collected before mem-b threw.
-    // The finally-path flush must have removed mem-a's bucket from the temporal
-    // index even though the loop aborted. mem-b never reached the batch (its
-    // failure was before the push), so its bucket legitimately remains.
+    // Both facts were archived on disk AND queued for de-index — the queue push
+    // now precedes the throwing content-hash cleanup — so the finally-path flush
+    // must remove BOTH date buckets even though a later iteration threw. This
+    // fails on either ordering regression: move the flush out of `finally` and
+    // nothing is de-indexed (mem-a fails); move the queue push back after the
+    // throwing cleanup and mem-b is never queued (mem-b fails).
     const afterDates = await temporalDates(memoryDir);
     assert.equal(afterDates["2020-01-01"], undefined, "mem-a must be de-indexed via the finally flush");
-    assert.deepEqual(afterDates["2020-02-02"], [memB.path], "mem-b was never queued for de-index");
+    assert.equal(afterDates["2020-02-02"], undefined, "mem-b must be de-indexed even though later cleanup threw");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/orchestration/batch-deindex-flush.test.ts
+++ b/packages/remnic-core/src/orchestration/batch-deindex-flush.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  LifecyclePolicyCoordinator,
+  type LifecyclePolicyCoordinatorDeps,
+} from "./lifecycle-policy-coordinator.js";
+import { indexMemoryAsync } from "../temporal-index.js";
+import type { StorageManager } from "../index.js";
+import type { EmbeddingFallback } from "../embedding-fallback.js";
+import type { ExtractionEngine } from "../extraction.js";
+import type { MemoryFile, PluginConfig } from "../types.js";
+
+// Regression for the #1911B Cursor finding: the maintenance de-index loops
+// collect removals for a single batch flush. If a LATER iteration throws before
+// the flush, memories already archived/invalidated on disk must still be
+// de-indexed — the flush now lives in a `finally`. runFactArchival is the
+// smallest self-contained loop with this shape; the same finally guard is
+// applied to the consolidation-run INVALIDATE/MERGE and semantic-consolidation
+// archive loops.
+
+function makeFact(id: string, path: string, created: string): MemoryFile {
+  const memory = {
+    path,
+    content: `fact ${id}`,
+    frontmatter: {
+      id,
+      category: "fact",
+      created,
+      tags: ["project/remnic", "shared", `flat-${id}`],
+    },
+  };
+  // Test fixture: MemoryFile carries many optional fields the archival loop
+  // never reads; a full literal would be noise. Narrow, deliberate cast.
+  return memory as unknown as MemoryFile;
+}
+
+async function temporalDates(memoryDir: string): Promise<Record<string, string[]>> {
+  const raw: unknown = JSON.parse(
+    await readFile(join(memoryDir, "state", "index_time.json"), "utf8"),
+  );
+  if (raw && typeof raw === "object" && "dates" in raw) {
+    return raw.dates as Record<string, string[]>;
+  }
+  throw new Error("temporal index missing dates map");
+}
+
+test("#1911B fact-archival flushes prior de-index entries when a later iteration throws", async () => {
+  const memoryDir = await mkdtemp(join(tmpdir(), "remnic-batch-deindex-flush-"));
+  try {
+    const memA = makeFact("mem-a", "/tmp/mem-a.md", "2020-01-01T09:00:00.000Z");
+    const memB = makeFact("mem-b", "/tmp/mem-b.md", "2020-02-02T09:00:00.000Z");
+
+    // Seed the on-disk temporal index so a successful de-index is observable as
+    // the removal of the memory's date bucket.
+    await indexMemoryAsync(memoryDir, memA.path, memA.frontmatter.created, memA.frontmatter.tags ?? []);
+    await indexMemoryAsync(memoryDir, memB.path, memB.frontmatter.created, memB.frontmatter.tags ?? []);
+
+    const beforeDates = await temporalDates(memoryDir);
+    assert.deepEqual(beforeDates["2020-01-01"], [memA.path]);
+    assert.deepEqual(beforeDates["2020-02-02"], [memB.path]);
+
+    const archived: string[] = [];
+    const fakeStorage = {
+      // Both memories archive successfully on disk.
+      async archiveMemory(memory: MemoryFile): Promise<string> {
+        archived.push(memory.frontmatter.id);
+        return memory.frontmatter.id;
+      },
+    };
+    // runFactArchival only calls archiveMemory on the storage; the rest of the
+    // StorageManager surface is unused here.
+    const storage = fakeStorage as unknown as StorageManager;
+
+    const embeddingFallback = {
+      async removeFromIndex(): Promise<void> {},
+    } as unknown as EmbeddingFallback;
+
+    // Minimal config: the archival loop reads only these fields plus the
+    // queryAwareIndexing capability flag. A full PluginConfig literal is noise.
+    const config = {
+      memoryDir,
+      queryAwareIndexingEnabled: true,
+      factArchivalAgeDays: 0,
+      factArchivalProtectedCategories: [],
+      factArchivalMaxImportance: 1,
+      factArchivalMaxAccessCount: 1000,
+    } as unknown as PluginConfig;
+
+    const boom = new Error("content-hash removal exploded on a later iteration");
+    const deps: LifecyclePolicyCoordinatorDeps = {
+      config,
+      getStorage: () => storage,
+      extraction: {} as unknown as ExtractionEngine,
+      embeddingFallback,
+      getEffectiveLifecycleThresholds: () => ({
+        promoteHeatThreshold: 0,
+        staleDecayThreshold: 0,
+        archiveDecayThreshold: 0,
+      }),
+      // Succeeds for mem-a, throws for mem-b — the later iteration — after mem-b
+      // is already archived on disk but before its batch push.
+      async removeContentHashForMemory(_storage, memory): Promise<void> {
+        if (memory.frontmatter.id === "mem-b") throw boom;
+      },
+      async saveContentHashIndexes(): Promise<void> {},
+    };
+
+    const coordinator = new LifecyclePolicyCoordinator(deps);
+
+    await assert.rejects(
+      () => coordinator.runFactArchival([memA, memB]),
+      /content-hash removal exploded/,
+    );
+
+    // Both were archived on disk before the failure.
+    assert.deepEqual(archived, ["mem-a", "mem-b"]);
+
+    // The regression: mem-a's de-index entry was collected before mem-b threw.
+    // The finally-path flush must have removed mem-a's bucket from the temporal
+    // index even though the loop aborted. mem-b never reached the batch (its
+    // failure was before the push), so its bucket legitimately remains.
+    const afterDates = await temporalDates(memoryDir);
+    assert.equal(afterDates["2020-01-01"], undefined, "mem-a must be de-indexed via the finally flush");
+    assert.deepEqual(afterDates["2020-02-02"], [memB.path], "mem-b was never queued for de-index");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/orchestration/consolidation-run.ts
+++ b/packages/remnic-core/src/orchestration/consolidation-run.ts
@@ -30,7 +30,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { log } from "../logger.js";
 import { applyCommitmentLedgerLifecycle } from "../commitment-ledger.js";
 import { recordDreamsPhaseRun } from "../maintenance/dreams-ledger.js";
-import { deindexMemoryAsync } from "../temporal-index.js";
+import { deindexMemoriesBatchAsync } from "../temporal-index.js";
 import { isActiveMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import {
   resolveConsolidationCapabilities,
@@ -153,6 +153,13 @@ export class ConsolidationRunCoordinator {
       ? new Map(allMemories.map((m) => [m.frontmatter.id, m]))
       : null;
 
+    // Collect deindex entries from INVALIDATE/MERGE actions and de-index them in
+    // one batch after the loop, instead of a full index read-modify-write per
+    // memory. The queryAwareIndexing guard is preserved: memoryLookup is null when
+    // it is disabled, so toInvalidate/toMergeInvalidate stay null and nothing is
+    // collected.
+    const itemsDeindexBatch: Array<{ path: string; createdAt: string; tags: string[] }> = [];
+
     for (const item of result.items) {
       switch (item.action) {
         case "INVALIDATE": {
@@ -165,12 +172,11 @@ export class ConsolidationRunCoordinator {
             memoryItemMutated = true;
             await this.deps.embeddingFallback.removeFromIndex(item.existingId);
             if (toInvalidate?.path && toInvalidate.frontmatter?.created) {
-              await deindexMemoryAsync(
-                config.memoryDir,
-                toInvalidate.path,
-                toInvalidate.frontmatter.created,
-                toInvalidate.frontmatter.tags ?? [],
-              );
+              itemsDeindexBatch.push({
+                path: toInvalidate.path,
+                createdAt: toInvalidate.frontmatter.created,
+                tags: toInvalidate.frontmatter.tags ?? [],
+              });
             }
           }
           break;
@@ -216,18 +222,18 @@ export class ConsolidationRunCoordinator {
                 toMergeInvalidate?.path &&
                 toMergeInvalidate.frontmatter?.created
               ) {
-                await deindexMemoryAsync(
-                  config.memoryDir,
-                  toMergeInvalidate.path,
-                  toMergeInvalidate.frontmatter.created,
-                  toMergeInvalidate.frontmatter.tags ?? [],
-                );
+                itemsDeindexBatch.push({
+                  path: toMergeInvalidate.path,
+                  createdAt: toMergeInvalidate.frontmatter.created,
+                  tags: toMergeInvalidate.frontmatter.tags ?? [],
+                });
               }
             }
           }
           break;
       }
     }
+    await deindexMemoriesBatchAsync(config.memoryDir, itemsDeindexBatch);
 
     if (result.profileUpdates.length > 0) {
       await storage.appendToProfile(result.profileUpdates);
@@ -292,14 +298,14 @@ export class ConsolidationRunCoordinator {
       memoryItemMutated = true;
       log.info(`cleaned ${deletedCommitments.length} expired commitments`);
       if (resolveIndexingCapabilities(config).queryAwareIndexing) {
-        for (const m of deletedCommitments) {
-          await deindexMemoryAsync(
-            config.memoryDir,
-            m.path,
-            m.frontmatter.created,
-            m.frontmatter.tags ?? [],
-          );
-        }
+        await deindexMemoriesBatchAsync(
+          config.memoryDir,
+          deletedCommitments.map((m) => ({
+            path: m.path,
+            createdAt: m.frontmatter.created,
+            tags: m.frontmatter.tags ?? [],
+          })),
+        );
       }
     }
 
@@ -335,14 +341,14 @@ export class ConsolidationRunCoordinator {
       memoryItemMutated = true;
       log.info(`cleaned ${deletedTTL.length} TTL-expired memories`);
       if (resolveIndexingCapabilities(config).queryAwareIndexing) {
-        for (const m of deletedTTL) {
-          await deindexMemoryAsync(
-            config.memoryDir,
-            m.path,
-            m.frontmatter.created,
-            m.frontmatter.tags ?? [],
-          );
-        }
+        await deindexMemoriesBatchAsync(
+          config.memoryDir,
+          deletedTTL.map((m) => ({
+            path: m.path,
+            createdAt: m.frontmatter.created,
+            tags: m.frontmatter.tags ?? [],
+          })),
+        );
       }
     }
 

--- a/packages/remnic-core/src/orchestration/consolidation-run.ts
+++ b/packages/remnic-core/src/orchestration/consolidation-run.ts
@@ -30,7 +30,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { log } from "../logger.js";
 import { applyCommitmentLedgerLifecycle } from "../commitment-ledger.js";
 import { recordDreamsPhaseRun } from "../maintenance/dreams-ledger.js";
-import { deindexMemoriesBatchAsync } from "../temporal-index.js";
+import { deindexMemoriesBatchAsync } from "../temporal-index-batch.js";
 import { isActiveMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import {
   resolveConsolidationCapabilities,

--- a/packages/remnic-core/src/orchestration/consolidation-run.ts
+++ b/packages/remnic-core/src/orchestration/consolidation-run.ts
@@ -154,86 +154,91 @@ export class ConsolidationRunCoordinator {
       : null;
 
     // Collect deindex entries from INVALIDATE/MERGE actions and de-index them in
-    // one batch after the loop, instead of a full index read-modify-write per
-    // memory. The queryAwareIndexing guard is preserved: memoryLookup is null when
-    // it is disabled, so toInvalidate/toMergeInvalidate stay null and nothing is
-    // collected.
+    // one batch, instead of a full index read-modify-write per memory. The
+    // queryAwareIndexing guard is preserved: memoryLookup is null when it is
+    // disabled, so toInvalidate/toMergeInvalidate stay null and nothing is
+    // collected. The flush runs in `finally` so memories already invalidated on
+    // disk are still de-indexed if a later iteration throws; it runs exactly once
+    // (normal completion or throw) and any loop error still propagates after it.
     const itemsDeindexBatch: Array<{ path: string; createdAt: string; tags: string[] }> = [];
 
-    for (const item of result.items) {
-      switch (item.action) {
-        case "INVALIDATE": {
-          // Capture path/frontmatter before invalidation for index cleanup
-          const toInvalidate = resolveIndexingCapabilities(config).queryAwareIndexing
-            ? (memoryLookup?.get(item.existingId) ?? null)
-            : null;
-          if (await storage.invalidateMemory(item.existingId)) {
-            invalidated += 1;
-            memoryItemMutated = true;
-            await this.deps.embeddingFallback.removeFromIndex(item.existingId);
-            if (toInvalidate?.path && toInvalidate.frontmatter?.created) {
-              itemsDeindexBatch.push({
-                path: toInvalidate.path,
-                createdAt: toInvalidate.frontmatter.created,
-                tags: toInvalidate.frontmatter.tags ?? [],
-              });
-            }
-          }
-          break;
-        }
-        case "UPDATE":
-          if (item.updatedContent) {
-            await storage.updateMemory(
-              item.existingId,
-              item.updatedContent,
-              {
-                lineage: [item.existingId],
-              },
-            );
-            memoryItemMutated = true;
-            await this.deps.indexPersistedMemory(storage, item.existingId);
-            // updateMemory() only changes content/updated/lineage — path, created, and tags
-            // are preserved, so the temporal/tag index entry is already correct; no reindex needed.
-          }
-          break;
-        case "MERGE":
-          if (item.updatedContent && item.mergeWith) {
-            await storage.updateMemory(
-              item.existingId,
-              item.updatedContent,
-              {
-                supersedes: item.mergeWith,
-                lineage: [item.existingId, item.mergeWith],
-              },
-            );
-            memoryItemMutated = true;
-            await this.deps.indexPersistedMemory(storage, item.existingId);
-            // updateMemory() only changes content/updated/supersedes/lineage — path, created, and tags
-            // are preserved, so the temporal/tag index entry for the survivor is already correct.
-            // Capture before invalidation for index cleanup
-            const toMergeInvalidate = resolveIndexingCapabilities(config).queryAwareIndexing
-              ? (memoryLookup?.get(item.mergeWith) ?? null)
+    try {
+      for (const item of result.items) {
+        switch (item.action) {
+          case "INVALIDATE": {
+            // Capture path/frontmatter before invalidation for index cleanup
+            const toInvalidate = resolveIndexingCapabilities(config).queryAwareIndexing
+              ? (memoryLookup?.get(item.existingId) ?? null)
               : null;
-            if (await storage.invalidateMemory(item.mergeWith)) {
+            if (await storage.invalidateMemory(item.existingId)) {
               invalidated += 1;
-              merged += 1;
-              await this.deps.embeddingFallback.removeFromIndex(item.mergeWith);
-              if (
-                toMergeInvalidate?.path &&
-                toMergeInvalidate.frontmatter?.created
-              ) {
+              memoryItemMutated = true;
+              await this.deps.embeddingFallback.removeFromIndex(item.existingId);
+              if (toInvalidate?.path && toInvalidate.frontmatter?.created) {
                 itemsDeindexBatch.push({
-                  path: toMergeInvalidate.path,
-                  createdAt: toMergeInvalidate.frontmatter.created,
-                  tags: toMergeInvalidate.frontmatter.tags ?? [],
+                  path: toInvalidate.path,
+                  createdAt: toInvalidate.frontmatter.created,
+                  tags: toInvalidate.frontmatter.tags ?? [],
                 });
               }
             }
+            break;
           }
-          break;
+          case "UPDATE":
+            if (item.updatedContent) {
+              await storage.updateMemory(
+                item.existingId,
+                item.updatedContent,
+                {
+                  lineage: [item.existingId],
+                },
+              );
+              memoryItemMutated = true;
+              await this.deps.indexPersistedMemory(storage, item.existingId);
+              // updateMemory() only changes content/updated/lineage — path, created, and tags
+              // are preserved, so the temporal/tag index entry is already correct; no reindex needed.
+            }
+            break;
+          case "MERGE":
+            if (item.updatedContent && item.mergeWith) {
+              await storage.updateMemory(
+                item.existingId,
+                item.updatedContent,
+                {
+                  supersedes: item.mergeWith,
+                  lineage: [item.existingId, item.mergeWith],
+                },
+              );
+              memoryItemMutated = true;
+              await this.deps.indexPersistedMemory(storage, item.existingId);
+              // updateMemory() only changes content/updated/supersedes/lineage — path, created, and tags
+              // are preserved, so the temporal/tag index entry for the survivor is already correct.
+              // Capture before invalidation for index cleanup
+              const toMergeInvalidate = resolveIndexingCapabilities(config).queryAwareIndexing
+                ? (memoryLookup?.get(item.mergeWith) ?? null)
+                : null;
+              if (await storage.invalidateMemory(item.mergeWith)) {
+                invalidated += 1;
+                merged += 1;
+                await this.deps.embeddingFallback.removeFromIndex(item.mergeWith);
+                if (
+                  toMergeInvalidate?.path &&
+                  toMergeInvalidate.frontmatter?.created
+                ) {
+                  itemsDeindexBatch.push({
+                    path: toMergeInvalidate.path,
+                    createdAt: toMergeInvalidate.frontmatter.created,
+                    tags: toMergeInvalidate.frontmatter.tags ?? [],
+                  });
+                }
+              }
+            }
+            break;
+        }
       }
+    } finally {
+      await deindexMemoriesBatchAsync(config.memoryDir, itemsDeindexBatch);
     }
-    await deindexMemoriesBatchAsync(config.memoryDir, itemsDeindexBatch);
 
     if (result.profileUpdates.length > 0) {
       await storage.appendToProfile(result.profileUpdates);

--- a/packages/remnic-core/src/orchestration/lifecycle-policy-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/lifecycle-policy-coordinator.ts
@@ -34,7 +34,7 @@ import {
   resolveCreationMemoryCapabilities,
 } from "../capabilities.js";
 import { isActiveMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
-import { deindexMemoriesBatchAsync } from "../temporal-index.js";
+import { deindexMemoriesBatchAsync } from "../temporal-index-batch.js";
 import { extractTopics } from "../topics.js";
 import { log } from "../logger.js";
 import path from "node:path";

--- a/packages/remnic-core/src/orchestration/lifecycle-policy-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/lifecycle-policy-coordinator.ts
@@ -34,7 +34,7 @@ import {
   resolveCreationMemoryCapabilities,
 } from "../capabilities.js";
 import { isActiveMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
-import { deindexMemoryAsync } from "../temporal-index.js";
+import { deindexMemoriesBatchAsync } from "../temporal-index.js";
 import { extractTopics } from "../topics.js";
 import { log } from "../logger.js";
 import path from "node:path";
@@ -304,6 +304,10 @@ export class LifecyclePolicyCoordinator {
       this.config.factArchivalProtectedCategories,
     );
     let archivedCount = 0;
+    // Collect deindex entries and remove them in one batch after the loop rather
+    // than a full index read-modify-write per archived fact. Guard is preserved:
+    // entries are only collected when queryAwareIndexing is enabled.
+    const deindexBatch: Array<{ path: string; createdAt: string; tags: string[] }> = [];
 
     for (const memory of allMemories) {
       const fm = memory.frontmatter;
@@ -345,15 +349,18 @@ export class LifecyclePolicyCoordinator {
           memory.path &&
           memory.frontmatter?.created
         ) {
-          await deindexMemoryAsync(
-            this.config.memoryDir,
-            memory.path,
-            memory.frontmatter.created,
-            memory.frontmatter.tags ?? [],
-          );
+          deindexBatch.push({
+            path: memory.path,
+            createdAt: memory.frontmatter.created,
+            tags: memory.frontmatter.tags ?? [],
+          });
         }
         archivedCount++;
       }
+    }
+
+    if (deindexBatch.length > 0) {
+      await deindexMemoriesBatchAsync(this.config.memoryDir, deindexBatch);
     }
 
     // Save hash indexes if we removed any entries.

--- a/packages/remnic-core/src/orchestration/lifecycle-policy-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/lifecycle-policy-coordinator.ts
@@ -304,63 +304,67 @@ export class LifecyclePolicyCoordinator {
       this.config.factArchivalProtectedCategories,
     );
     let archivedCount = 0;
-    // Collect deindex entries and remove them in one batch after the loop rather
-    // than a full index read-modify-write per archived fact. Guard is preserved:
-    // entries are only collected when queryAwareIndexing is enabled.
+    // Collect deindex entries and remove them in one batch rather than a full
+    // index read-modify-write per archived fact. Guard is preserved: entries are
+    // only collected when queryAwareIndexing is enabled. The flush runs in
+    // `finally` so facts already archived on disk are still de-indexed if a later
+    // iteration throws; it runs exactly once and any loop error propagates after.
     const deindexBatch: Array<{ path: string; createdAt: string; tags: string[] }> = [];
 
-    for (const memory of allMemories) {
-      const fm = memory.frontmatter;
+    try {
+      for (const memory of allMemories) {
+        const fm = memory.frontmatter;
 
-      // Skip already-archived or superseded
-      if (fm.status && fm.status !== "active") continue;
+        // Skip already-archived or superseded
+        if (fm.status && fm.status !== "active") continue;
 
-      // Skip protected categories
-      if (protectedCategories.has(fm.category)) continue;
+        // Skip protected categories
+        if (protectedCategories.has(fm.category)) continue;
 
-      // Skip corrections (always keep)
-      if (fm.category === "correction") continue;
+        // Skip corrections (always keep)
+        if (fm.category === "correction") continue;
 
-      // Check age requirement
-      const createdMs = new Date(fm.created).getTime();
-      if (now - createdMs < ageCutoffMs) continue;
+        // Check age requirement
+        const createdMs = new Date(fm.created).getTime();
+        if (now - createdMs < ageCutoffMs) continue;
 
-      // Check importance (only archive low-importance facts)
-      const importanceScore = fm.importance?.score ?? 0.5;
-      if (importanceScore >= this.config.factArchivalMaxImportance) continue;
+        // Check importance (only archive low-importance facts)
+        const importanceScore = fm.importance?.score ?? 0.5;
+        if (importanceScore >= this.config.factArchivalMaxImportance) continue;
 
-      // Check access count
-      const accessCount = fm.accessCount ?? 0;
-      if (accessCount > this.config.factArchivalMaxAccessCount) continue;
+        // Check access count
+        const accessCount = fm.accessCount ?? 0;
+        if (accessCount > this.config.factArchivalMaxAccessCount) continue;
 
-      // All criteria met — archive
-      const result = await storage.archiveMemory(memory);
-      if (result) {
-        // Remove from the same storage-scoped content-hash index since it is
-        // no longer in hot search.
-        await this.deps.removeContentHashForMemory(
-          storage,
-          memory,
-          "fact-archival",
-        );
-        await this.deps.embeddingFallback.removeFromIndex(memory.frontmatter.id);
-        if (
-          resolveIndexingCapabilities(this.config).queryAwareIndexing &&
-          memory.path &&
-          memory.frontmatter?.created
-        ) {
-          deindexBatch.push({
-            path: memory.path,
-            createdAt: memory.frontmatter.created,
-            tags: memory.frontmatter.tags ?? [],
-          });
+        // All criteria met — archive
+        const result = await storage.archiveMemory(memory);
+        if (result) {
+          // Remove from the same storage-scoped content-hash index since it is
+          // no longer in hot search.
+          await this.deps.removeContentHashForMemory(
+            storage,
+            memory,
+            "fact-archival",
+          );
+          await this.deps.embeddingFallback.removeFromIndex(memory.frontmatter.id);
+          if (
+            resolveIndexingCapabilities(this.config).queryAwareIndexing &&
+            memory.path &&
+            memory.frontmatter?.created
+          ) {
+            deindexBatch.push({
+              path: memory.path,
+              createdAt: memory.frontmatter.created,
+              tags: memory.frontmatter.tags ?? [],
+            });
+          }
+          archivedCount++;
         }
-        archivedCount++;
       }
-    }
-
-    if (deindexBatch.length > 0) {
-      await deindexMemoriesBatchAsync(this.config.memoryDir, deindexBatch);
+    } finally {
+      if (deindexBatch.length > 0) {
+        await deindexMemoriesBatchAsync(this.config.memoryDir, deindexBatch);
+      }
     }
 
     // Save hash indexes if we removed any entries.

--- a/packages/remnic-core/src/orchestration/lifecycle-policy-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/lifecycle-policy-coordinator.ts
@@ -339,14 +339,10 @@ export class LifecyclePolicyCoordinator {
         // All criteria met — archive
         const result = await storage.archiveMemory(memory);
         if (result) {
-          // Remove from the same storage-scoped content-hash index since it is
-          // no longer in hot search.
-          await this.deps.removeContentHashForMemory(
-            storage,
-            memory,
-            "fact-archival",
-          );
-          await this.deps.embeddingFallback.removeFromIndex(memory.frontmatter.id);
+          // Queue de-indexing immediately after a successful archive, before
+          // the secondary content-hash / embedding cleanup can throw. A fact
+          // archived on disk must always be de-indexed; the finally-flush then
+          // removes every queued fact even if a later step throws.
           if (
             resolveIndexingCapabilities(this.config).queryAwareIndexing &&
             memory.path &&
@@ -358,6 +354,14 @@ export class LifecyclePolicyCoordinator {
               tags: memory.frontmatter.tags ?? [],
             });
           }
+          // Remove from the same storage-scoped content-hash index since it is
+          // no longer in hot search.
+          await this.deps.removeContentHashForMemory(
+            storage,
+            memory,
+            "fact-archival",
+          );
+          await this.deps.embeddingFallback.removeFromIndex(memory.frontmatter.id);
           archivedCount++;
         }
       }

--- a/packages/remnic-core/src/orchestration/persistence-index.ts
+++ b/packages/remnic-core/src/orchestration/persistence-index.ts
@@ -23,7 +23,8 @@ import { ContentHashIndex, StorageManager } from "../index.js";
 import { log } from "../logger.js";
 import { isActiveMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import { stripCitationForTemplate } from "../source-attribution.js";
-import { clearIndexesAsync, indexMemoriesBatchAsync, indexesExistAsync } from "../temporal-index.js";
+import { clearIndexesAsync, indexesExistAsync } from "../temporal-index.js";
+import { indexMemoriesBatchAsync } from "../temporal-index-batch.js";
 import { normalizeSupersessionKey } from "../temporal-supersession.js";
 import type { MemoryFile, MemoryFrontmatter, PluginConfig } from "../types.js";
 import {

--- a/packages/remnic-core/src/orchestration/semantic-consolidation-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/semantic-consolidation-coordinator.ts
@@ -42,7 +42,7 @@ import {
   gatewayTaskChainOptions,
 } from "../fallback-llm.js";
 import { resolveIndexingCapabilities, resolveConsolidationCapabilities } from "../capabilities.js";
-import { deindexMemoriesBatchAsync } from "../temporal-index.js";
+import { deindexMemoriesBatchAsync } from "../temporal-index-batch.js";
 import { runPeerProfileReasoner } from "../peers/index.js";
 import type { StorageManager } from "../index.js";
 import type { LocalLlmClient } from "../local-llm.js";

--- a/packages/remnic-core/src/orchestration/semantic-consolidation-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/semantic-consolidation-coordinator.ts
@@ -317,58 +317,63 @@ export class SemanticConsolidationCoordinator {
         result.memoriesConsolidated++;
 
         // Archive originals
-        // Collect deindex entries and remove them in one batch after the loop
-        // rather than a full index read-modify-write per archived source. Guard
-        // is preserved: entries are only collected when queryAwareIndexing is on.
+        // Collect deindex entries and remove them in one batch rather than a full
+        // index read-modify-write per archived source. Guard is preserved: entries
+        // are only collected when queryAwareIndexing is on.
         const clusterDeindexBatch: Array<{ path: string; createdAt: string; tags: string[] }> = [];
-        for (const m of cluster.memories) {
-          const archiveResult = await targetStorage.archiveMemory(m, {
-            actor: "semantic-consolidation",
-            reasonCode: "semantic-consolidation",
-            relatedMemoryIds: [canonicalId],
-          });
-          if (archiveResult) {
-            // Remove from the same storage-scoped content-hash index that
-            // originally deduped this memory.
-            await this.deps.removeContentHashForMemory(
-              targetStorage,
-              m,
-              "semantic-consolidation",
-            );
-            // Best-effort index cleanup: a failure here (e.g. on-disk index save
-            // under disk-full) must NOT abort the archival loop and thereby skip
-            // the catalog write touch below for an already-durable canonical write
-            // (kilo NV0mh).
-            try {
-              await this.deps.embeddingFallback.removeFromIndex(m.frontmatter.id);
-              if (
-                resolveIndexingCapabilities(this.config).queryAwareIndexing &&
-                m.path &&
-                m.frontmatter?.created
-              ) {
-                clusterDeindexBatch.push({
-                  path: m.path,
-                  createdAt: m.frontmatter.created,
-                  tags: m.frontmatter.tags ?? [],
-                });
+        try {
+          for (const m of cluster.memories) {
+            const archiveResult = await targetStorage.archiveMemory(m, {
+              actor: "semantic-consolidation",
+              reasonCode: "semantic-consolidation",
+              relatedMemoryIds: [canonicalId],
+            });
+            if (archiveResult) {
+              // Remove from the same storage-scoped content-hash index that
+              // originally deduped this memory.
+              await this.deps.removeContentHashForMemory(
+                targetStorage,
+                m,
+                "semantic-consolidation",
+              );
+              // Best-effort index cleanup: a failure here (e.g. on-disk index save
+              // under disk-full) must NOT abort the archival loop and thereby skip
+              // the catalog write touch below for an already-durable canonical write
+              // (kilo NV0mh).
+              try {
+                await this.deps.embeddingFallback.removeFromIndex(m.frontmatter.id);
+                if (
+                  resolveIndexingCapabilities(this.config).queryAwareIndexing &&
+                  m.path &&
+                  m.frontmatter?.created
+                ) {
+                  clusterDeindexBatch.push({
+                    path: m.path,
+                    createdAt: m.frontmatter.created,
+                    tags: m.frontmatter.tags ?? [],
+                  });
+                }
+              } catch (cleanupErr) {
+                log.warn(
+                  `[semantic-consolidation] index cleanup failed (non-fatal): ${cleanupErr}`,
+                );
               }
+              result.memoriesArchived++;
+            }
+          }
+        } finally {
+          // Best-effort batch index cleanup, flushed in `finally` so sources
+          // already archived on disk are de-indexed even if a later archive
+          // iteration throws. Never abort the cluster (and thereby skip the
+          // catalog touch in the outer `finally`) on an index write failure.
+          if (clusterDeindexBatch.length > 0) {
+            try {
+              await deindexMemoriesBatchAsync(targetStorage.dir, clusterDeindexBatch);
             } catch (cleanupErr) {
               log.warn(
                 `[semantic-consolidation] index cleanup failed (non-fatal): ${cleanupErr}`,
               );
             }
-            result.memoriesArchived++;
-          }
-        }
-        // Best-effort batch index cleanup: never abort the cluster (and thereby
-        // skip the catalog touch in `finally`) on an index write failure.
-        if (clusterDeindexBatch.length > 0) {
-          try {
-            await deindexMemoriesBatchAsync(targetStorage.dir, clusterDeindexBatch);
-          } catch (cleanupErr) {
-            log.warn(
-              `[semantic-consolidation] index cleanup failed (non-fatal): ${cleanupErr}`,
-            );
           }
         }
 

--- a/packages/remnic-core/src/orchestration/semantic-consolidation-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/semantic-consolidation-coordinator.ts
@@ -42,7 +42,7 @@ import {
   gatewayTaskChainOptions,
 } from "../fallback-llm.js";
 import { resolveIndexingCapabilities, resolveConsolidationCapabilities } from "../capabilities.js";
-import { deindexMemoryAsync } from "../temporal-index.js";
+import { deindexMemoriesBatchAsync } from "../temporal-index.js";
 import { runPeerProfileReasoner } from "../peers/index.js";
 import type { StorageManager } from "../index.js";
 import type { LocalLlmClient } from "../local-llm.js";
@@ -317,6 +317,10 @@ export class SemanticConsolidationCoordinator {
         result.memoriesConsolidated++;
 
         // Archive originals
+        // Collect deindex entries and remove them in one batch after the loop
+        // rather than a full index read-modify-write per archived source. Guard
+        // is preserved: entries are only collected when queryAwareIndexing is on.
+        const clusterDeindexBatch: Array<{ path: string; createdAt: string; tags: string[] }> = [];
         for (const m of cluster.memories) {
           const archiveResult = await targetStorage.archiveMemory(m, {
             actor: "semantic-consolidation",
@@ -342,12 +346,11 @@ export class SemanticConsolidationCoordinator {
                 m.path &&
                 m.frontmatter?.created
               ) {
-                await deindexMemoryAsync(
-                  targetStorage.dir,
-                  m.path,
-                  m.frontmatter.created,
-                  m.frontmatter.tags ?? [],
-                );
+                clusterDeindexBatch.push({
+                  path: m.path,
+                  createdAt: m.frontmatter.created,
+                  tags: m.frontmatter.tags ?? [],
+                });
               }
             } catch (cleanupErr) {
               log.warn(
@@ -355,6 +358,17 @@ export class SemanticConsolidationCoordinator {
               );
             }
             result.memoriesArchived++;
+          }
+        }
+        // Best-effort batch index cleanup: never abort the cluster (and thereby
+        // skip the catalog touch in `finally`) on an index write failure.
+        if (clusterDeindexBatch.length > 0) {
+          try {
+            await deindexMemoriesBatchAsync(targetStorage.dir, clusterDeindexBatch);
+          } catch (cleanupErr) {
+            log.warn(
+              `[semantic-consolidation] index cleanup failed (non-fatal): ${cleanupErr}`,
+            );
           }
         }
 

--- a/packages/remnic-core/src/temporal-index-batch.ts
+++ b/packages/remnic-core/src/temporal-index-batch.ts
@@ -1,0 +1,112 @@
+/**
+ * Batch temporal/tag index mutations.
+ *
+ * Split from temporal-index.ts (issue #1911B / #1995): maintenance loops that
+ * add or invalidate N memories at once collect their entries and call these once
+ * instead of paying the per-memory read-parse-stringify-write amplification.
+ * Both operations reuse the low-level primitives exported from temporal-index.ts;
+ * per-entry semantics are byte-identical to indexMemoryAsync / deindexMemoryAsync.
+ */
+
+import {
+  INDEX_VERSION,
+  addPathToSet,
+  addTagGraphEntry,
+  ensureStateDir,
+  isoDateFromTimestamp,
+  removePathFromAllSets,
+  removePathFromAllTagEntries,
+  removePathFromSet,
+  removeTagGraphEntry,
+  temporalEventFromEntry,
+  updateTagIndex,
+  updateTemporalIndex,
+  withMemoryDirMutex,
+  type TemporalIndexEntry,
+} from "./temporal-index.js";
+
+/**
+ * Batch-add multiple memories to both indexes in a single read-modify-write cycle.
+ * More efficient than calling indexMemoryAsync() per file when adding many at once.
+ */
+export async function indexMemoriesBatchAsync(
+  memoryDir: string,
+  entries: TemporalIndexEntry[]
+): Promise<void> {
+  if (entries.length === 0) return;
+  try {
+    await ensureStateDir(memoryDir);
+
+    await withMemoryDirMutex(memoryDir, async () => {
+      const temporalOk = await updateTemporalIndex(memoryDir, (index) => {
+        index.version = INDEX_VERSION;
+        for (const entry of entries) {
+          const dateKey = isoDateFromTimestamp(entry.createdAt);
+          removePathFromAllSets(index.dates, entry.path);
+          addPathToSet(index.dates, dateKey, entry.path);
+          index.events[entry.path] = temporalEventFromEntry(entry);
+        }
+      });
+      if (temporalOk) {
+        await updateTagIndex(memoryDir, (index) => {
+          for (const entry of entries) {
+            removePathFromAllTagEntries(index, entry.path);
+            for (const tag of entry.tags) {
+              if (tag && typeof tag === "string") {
+                addTagGraphEntry(index, tag, entry.path);
+              }
+            }
+          }
+        });
+      }
+    });
+  } catch {
+    // Fail silently
+  }
+}
+
+/**
+ * Batch-remove multiple memories from both indexes in a single read-modify-write
+ * cycle per index. Mirrors {@link indexMemoriesBatchAsync}: maintenance loops that
+ * invalidate/archive N memories collect their entries and call this once, replacing
+ * the O(N) full read-parse-stringify-write amplification of per-memory
+ * deindexMemoryAsync with O(1) temporal + O(1) tag write cycles.
+ *
+ * Per-entry semantics are byte-identical to deindexMemoryAsync: the date
+ * set for each entry's `createdAt` drops the path, the temporal event is deleted,
+ * and each tag graph entry is removed. The temporal half commits first; the tag
+ * half only runs if it succeeds, so a partial failure never leaves tags orphaned
+ * from a temporal entry that still exists.
+ */
+export async function deindexMemoriesBatchAsync(
+  memoryDir: string,
+  entries: ReadonlyArray<Pick<TemporalIndexEntry, "path" | "createdAt" | "tags">>,
+): Promise<void> {
+  if (entries.length === 0) return;
+  try {
+    await ensureStateDir(memoryDir);
+
+    await withMemoryDirMutex(memoryDir, async () => {
+      const temporalOk = await updateTemporalIndex(memoryDir, (index) => {
+        for (const entry of entries) {
+          const dateKey = isoDateFromTimestamp(entry.createdAt);
+          removePathFromSet(index.dates, dateKey, entry.path);
+          delete index.events[entry.path];
+        }
+      });
+      if (temporalOk) {
+        await updateTagIndex(memoryDir, (index) => {
+          for (const entry of entries) {
+            for (const tag of entry.tags) {
+              if (tag && typeof tag === "string") {
+                removeTagGraphEntry(index, tag, entry.path);
+              }
+            }
+          }
+        });
+      }
+    });
+  } catch {
+    // Fail silently — indexes are advisory only
+  }
+}

--- a/packages/remnic-core/src/temporal-index.test.ts
+++ b/packages/remnic-core/src/temporal-index.test.ts
@@ -11,7 +11,6 @@ import {
   clearIndexes,
   deindexMemory as deindexMemorySync,
   deindexMemoryAsync as deindexMemory,
-  deindexMemoriesBatchAsync,
   indexMemoriesBatch,
   indexMemory as indexMemorySync,
   indexMemoryAsync as indexMemory,
@@ -25,6 +24,7 @@ import {
   setIndexWriteFailureForTest,
   setIndexWriteObserverForTest,
 } from "./temporal-index.js";
+import { deindexMemoriesBatchAsync } from "./temporal-index-batch.js";
 
 test("legacy temporal-index exports preserve synchronous return timing and booleans", async () => {
   const memoryDir = await mkdtemp(join(tmpdir(), "remnic-temporal-index-sync-compat-"));

--- a/packages/remnic-core/src/temporal-index.test.ts
+++ b/packages/remnic-core/src/temporal-index.test.ts
@@ -11,6 +11,7 @@ import {
   clearIndexes,
   deindexMemory as deindexMemorySync,
   deindexMemoryAsync as deindexMemory,
+  deindexMemoriesBatchAsync,
   indexMemoriesBatch,
   indexMemory as indexMemorySync,
   indexMemoryAsync as indexMemory,
@@ -21,6 +22,7 @@ import {
   queryTemporalTimelineAsync,
   resolvePromptTagPrefilterAsync,
   setIndexReadObserverForTest,
+  setIndexWriteObserverForTest,
 } from "./temporal-index.js";
 
 test("legacy temporal-index exports preserve synchronous return timing and booleans", async () => {
@@ -643,4 +645,141 @@ test("temporal timeline generic edge selection honors small and zero limits", as
     }))?.length,
     4,
   );
+});
+
+// ─── #1911B: batch de-index ─────────────────────────────────────────────────
+
+interface DeindexEntry {
+  path: string;
+  createdAt: string;
+  tags: string[];
+}
+
+// A spread of memories across distinct dates with hierarchical (alias-producing)
+// and flat tags, so equivalence covers date sets, event map, tag graph, and aliases.
+function sampleMemories(prefix: string, count: number): DeindexEntry[] {
+  const entries: DeindexEntry[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const day = String((i % 28) + 1).padStart(2, "0");
+    entries.push({
+      path: `/tmp/${prefix}-memory-${i}.md`,
+      createdAt: `2026-05-${day}T09:00:00.000Z`,
+      tags: ["project/remnic", `worker/${i % 3}`, "shared", `flat-${i}`],
+    });
+  }
+  return entries;
+}
+
+async function seedIndex(memoryDir: string, entries: DeindexEntry[]): Promise<void> {
+  for (const e of entries) {
+    await indexMemory(memoryDir, e.path, e.createdAt, e.tags);
+  }
+}
+
+async function readRawIndexes(memoryDir: string): Promise<{ temporal: unknown; tags: unknown }> {
+  const temporal = JSON.parse(
+    await readFile(join(memoryDir, "state", "index_time.json"), "utf8"),
+  );
+  const tags = JSON.parse(
+    await readFile(join(memoryDir, "state", "index_tags.json"), "utf8"),
+  );
+  return { temporal, tags };
+}
+
+test("#1911B batch de-index yields the same final index as per-memory de-index", async () => {
+  const sequentialDir = await mkdtemp(join(tmpdir(), "remnic-deindex-seq-"));
+  const batchDir = await mkdtemp(join(tmpdir(), "remnic-deindex-batch-"));
+  const all = sampleMemories("equiv", 12);
+  await seedIndex(sequentialDir, all);
+  await seedIndex(batchDir, all);
+
+  // Remove a non-contiguous subset in a scrambled order; batching must not depend
+  // on removal order to reach the same final index.
+  const removed = [all[10], all[1], all[7], all[4], all[0]];
+
+  for (const e of removed) {
+    await deindexMemory(sequentialDir, e.path, e.createdAt, e.tags);
+  }
+  await deindexMemoriesBatchAsync(batchDir, removed);
+
+  const seq = await readRawIndexes(sequentialDir);
+  const batch = await readRawIndexes(batchDir);
+  assert.deepEqual(batch.temporal, seq.temporal);
+  assert.deepEqual(batch.tags, seq.tags);
+
+  // Survivors remain, removed paths are gone from both indexes.
+  const survivorPaths = all.filter((e) => !removed.includes(e)).map((e) => e.path);
+  const stillIndexed = await queryByTagsAsync(batchDir, ["shared"]);
+  assert.deepEqual(stillIndexed, new Set(survivorPaths));
+});
+
+test("#1911B de-indexing N memories performs exactly one temporal + one tag write", async () => {
+  const batchDir = await mkdtemp(join(tmpdir(), "remnic-deindex-writes-batch-"));
+  const seqDir = await mkdtemp(join(tmpdir(), "remnic-deindex-writes-seq-"));
+  const entries = sampleMemories("writes", 8);
+  await seedIndex(batchDir, entries);
+  await seedIndex(seqDir, entries);
+
+  const countWrites = (dir: string) => {
+    let temporal = 0;
+    let tags = 0;
+    setIndexWriteObserverForTest((filePath) => {
+      if (filePath.endsWith("index_time.json")) temporal += 1;
+      else if (filePath.endsWith("index_tags.json")) tags += 1;
+    });
+    return () => {
+      setIndexWriteObserverForTest(undefined);
+      return { temporal, tags };
+    };
+  };
+
+  const stopBatch = countWrites(batchDir);
+  await deindexMemoriesBatchAsync(batchDir, entries);
+  const batchWrites = stopBatch();
+  assert.deepEqual(batchWrites, { temporal: 1, tags: 1 });
+
+  const stopSeq = countWrites(seqDir);
+  for (const e of entries) {
+    await deindexMemory(seqDir, e.path, e.createdAt, e.tags);
+  }
+  const seqWrites = stopSeq();
+  // The per-memory path is the O(N) amplification this batch API replaces.
+  assert.deepEqual(seqWrites, { temporal: entries.length, tags: entries.length });
+});
+
+test("#1911B empty batch is a no-op that performs no writes", async () => {
+  const memoryDir = await mkdtemp(join(tmpdir(), "remnic-deindex-empty-"));
+  await seedIndex(memoryDir, sampleMemories("empty", 2));
+  let writes = 0;
+  setIndexWriteObserverForTest(() => {
+    writes += 1;
+  });
+  try {
+    await deindexMemoriesBatchAsync(memoryDir, []);
+  } finally {
+    setIndexWriteObserverForTest(undefined);
+  }
+  assert.equal(writes, 0);
+});
+
+test("#1911B batch de-index keeps tag index consistent when the temporal write fails", async () => {
+  const memoryDir = await mkdtemp(join(tmpdir(), "remnic-deindex-partialfail-"));
+  const entries = sampleMemories("partial", 4);
+  await seedIndex(memoryDir, entries);
+  const before = await readRawIndexes(memoryDir);
+
+  // Make the state dir read-only so writeJsonAtomic cannot create its tmp sibling;
+  // the temporal update fails first, so the tag half must be skipped entirely,
+  // leaving BOTH indexes at their pre-batch contents (no half-applied removal).
+  const stateDir = join(memoryDir, "state");
+  await fs.promises.chmod(stateDir, 0o500);
+  try {
+    await deindexMemoriesBatchAsync(memoryDir, entries);
+  } finally {
+    await fs.promises.chmod(stateDir, 0o700);
+  }
+
+  const after = await readRawIndexes(memoryDir);
+  assert.deepEqual(after.temporal, before.temporal);
+  assert.deepEqual(after.tags, before.tags);
 });

--- a/packages/remnic-core/src/temporal-index.test.ts
+++ b/packages/remnic-core/src/temporal-index.test.ts
@@ -812,7 +812,10 @@ test("#1911B a throwing write observer cannot fail a committed index write", asy
   // retry and ultimately report failure, skipping the paired tag phase and
   // leaving a half-applied index. Isolation must keep the outcome identical to
   // the control on BOTH indexes.
-  setIndexWriteObserverForTest(() => {
+  const observedWrites: string[] = [];
+  setIndexWriteObserverForTest((filePath) => {
+    // Scope to this directory so a concurrent test's index write never counts.
+    if (filePath.startsWith(throwDir)) observedWrites.push(filePath);
     throw new Error("observer boom");
   });
   try {
@@ -820,6 +823,14 @@ test("#1911B a throwing write observer cannot fail a committed index write", asy
   } finally {
     setIndexWriteObserverForTest(undefined);
   }
+
+  // The observer must have fired once per committed index write, in order:
+  // temporal commits first, then tags. This guards against a silent regression
+  // where observer dispatch is dropped and the isolation assertions below pass
+  // vacuously because nothing ever threw.
+  assert.equal(observedWrites.length, 2);
+  assert.ok(observedWrites[0]?.endsWith("index_time.json"));
+  assert.ok(observedWrites[1]?.endsWith("index_tags.json"));
 
   const control = await readRawIndexes(controlDir);
   const thrown = await readRawIndexes(throwDir);

--- a/packages/remnic-core/src/temporal-index.test.ts
+++ b/packages/remnic-core/src/temporal-index.test.ts
@@ -22,6 +22,7 @@ import {
   queryTemporalTimelineAsync,
   resolvePromptTagPrefilterAsync,
   setIndexReadObserverForTest,
+  setIndexWriteFailureForTest,
   setIndexWriteObserverForTest,
 } from "./temporal-index.js";
 
@@ -724,6 +725,8 @@ test("#1911B de-indexing N memories performs exactly one temporal + one tag writ
     let temporal = 0;
     let tags = 0;
     setIndexWriteObserverForTest((filePath) => {
+      // Scope to this directory so unrelated index writes never skew the count.
+      if (!filePath.startsWith(dir)) return;
       if (filePath.endsWith("index_time.json")) temporal += 1;
       else if (filePath.endsWith("index_tags.json")) tags += 1;
     });
@@ -733,16 +736,26 @@ test("#1911B de-indexing N memories performs exactly one temporal + one tag writ
     };
   };
 
+  // try/finally guarantees the global observer is cleared even if an awaited
+  // op throws, so it can never leak into a later test.
+  let batchWrites = { temporal: 0, tags: 0 };
   const stopBatch = countWrites(batchDir);
-  await deindexMemoriesBatchAsync(batchDir, entries);
-  const batchWrites = stopBatch();
+  try {
+    await deindexMemoriesBatchAsync(batchDir, entries);
+  } finally {
+    batchWrites = stopBatch();
+  }
   assert.deepEqual(batchWrites, { temporal: 1, tags: 1 });
 
+  let seqWrites = { temporal: 0, tags: 0 };
   const stopSeq = countWrites(seqDir);
-  for (const e of entries) {
-    await deindexMemory(seqDir, e.path, e.createdAt, e.tags);
+  try {
+    for (const e of entries) {
+      await deindexMemory(seqDir, e.path, e.createdAt, e.tags);
+    }
+  } finally {
+    seqWrites = stopSeq();
   }
-  const seqWrites = stopSeq();
   // The per-memory path is the O(N) amplification this batch API replaces.
   assert.deepEqual(seqWrites, { temporal: entries.length, tags: entries.length });
 });
@@ -768,18 +781,48 @@ test("#1911B batch de-index keeps tag index consistent when the temporal write f
   await seedIndex(memoryDir, entries);
   const before = await readRawIndexes(memoryDir);
 
-  // Make the state dir read-only so writeJsonAtomic cannot create its tmp sibling;
-  // the temporal update fails first, so the tag half must be skipped entirely,
-  // leaving BOTH indexes at their pre-batch contents (no half-applied removal).
-  const stateDir = join(memoryDir, "state");
-  await fs.promises.chmod(stateDir, 0o500);
+  // Deterministically fail the temporal write via the test-only hook. chmod is a
+  // no-op for privileged users (common in CI) and differs on Windows; the hook
+  // fails the same branch in every environment. Temporal fails first, so the tag
+  // half is skipped, leaving BOTH indexes at their pre-batch contents.
+  setIndexWriteFailureForTest((filePath) => filePath.endsWith("index_time.json"));
   try {
     await deindexMemoriesBatchAsync(memoryDir, entries);
   } finally {
-    await fs.promises.chmod(stateDir, 0o700);
+    setIndexWriteFailureForTest(undefined);
   }
 
   const after = await readRawIndexes(memoryDir);
   assert.deepEqual(after.temporal, before.temporal);
   assert.deepEqual(after.tags, before.tags);
+});
+
+test("#1911B a throwing write observer cannot fail a committed index write", async () => {
+  const throwDir = await mkdtemp(join(tmpdir(), "remnic-deindex-observer-throw-"));
+  const controlDir = await mkdtemp(join(tmpdir(), "remnic-deindex-observer-control-"));
+  const entries = sampleMemories("obsthrow", 3);
+  await seedIndex(throwDir, entries);
+  await seedIndex(controlDir, entries);
+
+  // Control: a clean batch de-index with no observer installed.
+  await deindexMemoriesBatchAsync(controlDir, entries);
+
+  // Same batch, but the committed-write observer throws. The exception fires
+  // only after the temporal rename has committed; if it escaped, the write would
+  // retry and ultimately report failure, skipping the paired tag phase and
+  // leaving a half-applied index. Isolation must keep the outcome identical to
+  // the control on BOTH indexes.
+  setIndexWriteObserverForTest(() => {
+    throw new Error("observer boom");
+  });
+  try {
+    await deindexMemoriesBatchAsync(throwDir, entries);
+  } finally {
+    setIndexWriteObserverForTest(undefined);
+  }
+
+  const control = await readRawIndexes(controlDir);
+  const thrown = await readRawIndexes(throwDir);
+  assert.deepEqual(thrown.temporal, control.temporal);
+  assert.deepEqual(thrown.tags, control.tags);
 });

--- a/packages/remnic-core/src/temporal-index.ts
+++ b/packages/remnic-core/src/temporal-index.ts
@@ -137,6 +137,18 @@ export function setIndexWriteObserverForTest(observer?: (filePath: string) => vo
   indexWriteObserverForTest = observer;
 }
 
+let indexWriteFailureForTest: ((filePath: string) => boolean) | undefined;
+
+/**
+ * Test-only hook to deterministically fail an atomic index write for matching
+ * paths. Return true to fail the write for a given path. Lets partial-failure
+ * branches be exercised without relying on filesystem permissions, which no-op
+ * for privileged users (common in containerized CI) and differ on Windows.
+ */
+export function setIndexWriteFailureForTest(shouldFail?: (filePath: string) => boolean): void {
+  indexWriteFailureForTest = shouldFail;
+}
+
 interface IndexLockOwner {
   pid: number;
   createdAt?: string;
@@ -420,9 +432,20 @@ async function writeJsonAtomic(filePath: string, data: unknown): Promise<boolean
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const tmp = uniqueTempPath(filePath);
     try {
+      if (indexWriteFailureForTest?.(filePath)) {
+        throw new Error("injected atomic-write failure (test)");
+      }
       await fs.promises.writeFile(tmp, payload, "utf8");
       await fs.promises.rename(tmp, filePath);
-      indexWriteObserverForTest?.(filePath);
+      // The observer fires only after the committed rename. Isolate its
+      // exceptions so a test hook can never turn a successful write into a
+      // retry or a false (failed) result, which would clear the cache and
+      // skip the paired tag-index phase.
+      try {
+        indexWriteObserverForTest?.(filePath);
+      } catch {
+        // Test hooks must not alter committed index-write results.
+      }
       return true;
     } catch {
       try {

--- a/packages/remnic-core/src/temporal-index.ts
+++ b/packages/remnic-core/src/temporal-index.ts
@@ -130,6 +130,13 @@ export function setIndexReadObserverForTest(observer?: () => void): void {
   indexReadObserverForTest = observer;
 }
 
+let indexWriteObserverForTest: ((filePath: string) => void) | undefined;
+
+/** Test-only observer fired once per committed atomic index write. */
+export function setIndexWriteObserverForTest(observer?: (filePath: string) => void): void {
+  indexWriteObserverForTest = observer;
+}
+
 interface IndexLockOwner {
   pid: number;
   createdAt?: string;
@@ -415,6 +422,7 @@ async function writeJsonAtomic(filePath: string, data: unknown): Promise<boolean
     try {
       await fs.promises.writeFile(tmp, payload, "utf8");
       await fs.promises.rename(tmp, filePath);
+      indexWriteObserverForTest?.(filePath);
       return true;
     } catch {
       try {
@@ -1060,6 +1068,52 @@ export async function indexMemoriesBatchAsync(
     });
   } catch {
     // Fail silently
+  }
+}
+
+/**
+ * Batch-remove multiple memories from both indexes in a single read-modify-write
+ * cycle per index. Mirrors {@link indexMemoriesBatchAsync}: maintenance loops that
+ * invalidate/archive N memories collect their entries and call this once, replacing
+ * the O(N) full read-parse-stringify-write amplification of per-memory
+ * {@link deindexMemoryAsync} with O(1) temporal + O(1) tag write cycles.
+ *
+ * Per-entry semantics are byte-identical to {@link deindexMemoryAsync}: the date
+ * set for each entry's `createdAt` drops the path, the temporal event is deleted,
+ * and each tag graph entry is removed. The temporal half commits first; the tag
+ * half only runs if it succeeds, so a partial failure never leaves tags orphaned
+ * from a temporal entry that still exists.
+ */
+export async function deindexMemoriesBatchAsync(
+  memoryDir: string,
+  entries: ReadonlyArray<Pick<TemporalIndexEntry, "path" | "createdAt" | "tags">>,
+): Promise<void> {
+  if (entries.length === 0) return;
+  try {
+    await ensureStateDir(memoryDir);
+
+    await withMemoryDirMutex(memoryDir, async () => {
+      const temporalOk = await updateTemporalIndex(memoryDir, (index) => {
+        for (const entry of entries) {
+          const dateKey = isoDateFromTimestamp(entry.createdAt);
+          removePathFromSet(index.dates, dateKey, entry.path);
+          delete index.events[entry.path];
+        }
+      });
+      if (temporalOk) {
+        await updateTagIndex(memoryDir, (index) => {
+          for (const entry of entries) {
+            for (const tag of entry.tags) {
+              if (tag && typeof tag === "string") {
+                removeTagGraphEntry(index, tag, entry.path);
+              }
+            }
+          }
+        });
+      }
+    });
+  } catch {
+    // Fail silently — indexes are advisory only
   }
 }
 

--- a/packages/remnic-core/src/temporal-index.ts
+++ b/packages/remnic-core/src/temporal-index.ts
@@ -32,6 +32,11 @@ export {
   indexesExist,
 } from "./temporal-index-compat.js";
 
+export {
+  deindexMemoriesBatchAsync,
+  indexMemoriesBatchAsync,
+} from "./temporal-index-batch.js";
+
 export interface TemporalIndex {
   /** version bumped when schema changes */
   version: number;

--- a/packages/remnic-core/src/temporal-index.ts
+++ b/packages/remnic-core/src/temporal-index.ts
@@ -87,7 +87,7 @@ export interface TagNode {
   parents?: string[];
 }
 
-const INDEX_VERSION = 2;
+export const INDEX_VERSION = 2;
 const TEMPORAL_INDEX_FILE = "index_time.json";
 const TAG_INDEX_FILE = "index_tags.json";
 const TAG_INDEX_VERSION = 2;
@@ -169,7 +169,7 @@ function tagIndexPath(memoryDir: string): string {
   return path.join(stateDir(memoryDir), TAG_INDEX_FILE);
 }
 
-async function ensureStateDir(memoryDir: string): Promise<void> {
+export async function ensureStateDir(memoryDir: string): Promise<void> {
   await fs.promises.mkdir(stateDir(memoryDir), { recursive: true });
 }
 
@@ -241,7 +241,7 @@ function withPathMutex<T>(filePath: string, update: () => Promise<T>): Promise<T
  * per-file writes and commit mismatched halves. The inner per-file writeChains
  * still protect each file; this outer chain just orders complete operations.
  */
-function withMemoryDirMutex<T>(memoryDir: string, op: () => Promise<T>): Promise<T> {
+export function withMemoryDirMutex<T>(memoryDir: string, op: () => Promise<T>): Promise<T> {
   const previous = opChains.get(memoryDir) ?? Promise.resolve();
   const run = previous.then(op, op);
   const tail = run.then(() => undefined, () => undefined);
@@ -484,7 +484,7 @@ function hasCurrentTemporalIndexSchema(raw: unknown): boolean {
     isRecord(raw.events);
 }
 
-async function updateTemporalIndex(memoryDir: string, update: (index: TemporalIndex) => void): Promise<boolean> {
+export async function updateTemporalIndex(memoryDir: string, update: (index: TemporalIndex) => void): Promise<boolean> {
   const indexPath = temporalIndexPath(memoryDir);
   return withPathMutex(indexPath, async () => {
     const ok = await withIndexFileLock(indexPath, async () => {
@@ -506,7 +506,7 @@ async function updateTemporalIndex(memoryDir: string, update: (index: TemporalIn
   });
 }
 
-async function updateTagIndex(memoryDir: string, update: (index: TagIndex) => void): Promise<void> {
+export async function updateTagIndex(memoryDir: string, update: (index: TagIndex) => void): Promise<void> {
   const indexPath = tagIndexPath(memoryDir);
   await withPathMutex(indexPath, async () => {
     await withIndexFileLock(indexPath, async () => {
@@ -530,7 +530,7 @@ async function updateTagIndex(memoryDir: string, update: (index: TagIndex) => vo
   });
 }
 
-function isoDateFromTimestamp(isoString: string): string {
+export function isoDateFromTimestamp(isoString: string): string {
   if (typeof isoString !== "string" || isoString.length < 10) {
     // Malformed frontmatter — fall back to today so the memory is still indexed.
     // Log a warning to surface data-quality issues without aborting the write.
@@ -551,7 +551,7 @@ function normalizedIsoTimestamp(value: string | undefined): string | undefined {
   }
 }
 
-function temporalEventFromEntry(entry: TemporalIndexEntry): TemporalIndexEvent {
+export function temporalEventFromEntry(entry: TemporalIndexEntry): TemporalIndexEvent {
   const createdAt = normalizedIsoTimestamp(entry.createdAt) ?? new Date(0).toISOString();
   const eventAt = normalizedIsoTimestamp(entry.validAt) ?? createdAt;
   const observedAt = normalizedIsoTimestamp(entry.observedAt);
@@ -596,7 +596,7 @@ function compareTemporalIndexEvents(
   return left.path.localeCompare(right.path);
 }
 
-function addPathToSet(record: Record<string, string[]>, key: string, p: string): void {
+export function addPathToSet(record: Record<string, string[]>, key: string, p: string): void {
   if (!record[key]) {
     record[key] = [];
   }
@@ -605,7 +605,7 @@ function addPathToSet(record: Record<string, string[]>, key: string, p: string):
   }
 }
 
-function removePathFromSet(record: Record<string, string[]>, key: string, p: string): void {
+export function removePathFromSet(record: Record<string, string[]>, key: string, p: string): void {
   if (!record[key]) return;
   record[key] = record[key].filter((x) => x !== p);
   if (record[key].length === 0) {
@@ -613,7 +613,7 @@ function removePathFromSet(record: Record<string, string[]>, key: string, p: str
   }
 }
 
-function removePathFromAllSets(record: Record<string, string[]>, p: string): void {
+export function removePathFromAllSets(record: Record<string, string[]>, p: string): void {
   for (const key of Object.keys(record)) {
     removePathFromSet(record, key, p);
   }
@@ -767,7 +767,7 @@ function ensureTagNode(index: TagIndex, canonical: string): TagNode {
   return created;
 }
 
-function addTagGraphEntry(index: TagIndex, rawTag: string, memoryPath: string): void {
+export function addTagGraphEntry(index: TagIndex, rawTag: string, memoryPath: string): void {
   const canonical = normalizeCanonicalTag(rawTag);
   if (!canonical) return;
   const node = ensureTagNode(index, canonical);
@@ -788,7 +788,7 @@ function addTagGraphEntry(index: TagIndex, rawTag: string, memoryPath: string): 
   }
 }
 
-function removeTagGraphEntry(index: TagIndex, rawTag: string, memoryPath: string): void {
+export function removeTagGraphEntry(index: TagIndex, rawTag: string, memoryPath: string): void {
   const canonical = normalizeCanonicalTag(rawTag);
   if (!canonical) return;
   const node = index.tags[canonical];
@@ -800,7 +800,7 @@ function removeTagGraphEntry(index: TagIndex, rawTag: string, memoryPath: string
   }
 }
 
-function removePathFromAllTagEntries(index: TagIndex, memoryPath: string): void {
+export function removePathFromAllTagEntries(index: TagIndex, memoryPath: string): void {
   for (const [canonical, nodeOrPaths] of Object.entries(index.tags)) {
     if (Array.isArray(nodeOrPaths)) {
       const paths = nodeOrPaths.filter((value) => value !== memoryPath);
@@ -1051,92 +1051,6 @@ export async function indexesExistAsync(memoryDir: string): Promise<boolean> {
     return loaded.kind === "ok" && loaded.currentSchema;
   } catch {
     return false;
-  }
-}
-
-/**
- * Batch-add multiple memories to both indexes in a single read-modify-write cycle.
- * More efficient than calling indexMemoryAsync() per file when adding many at once.
- */
-export async function indexMemoriesBatchAsync(
-  memoryDir: string,
-  entries: TemporalIndexEntry[]
-): Promise<void> {
-  if (entries.length === 0) return;
-  try {
-    await ensureStateDir(memoryDir);
-
-    await withMemoryDirMutex(memoryDir, async () => {
-      const temporalOk = await updateTemporalIndex(memoryDir, (index) => {
-        index.version = INDEX_VERSION;
-        for (const entry of entries) {
-          const dateKey = isoDateFromTimestamp(entry.createdAt);
-          removePathFromAllSets(index.dates, entry.path);
-          addPathToSet(index.dates, dateKey, entry.path);
-          index.events[entry.path] = temporalEventFromEntry(entry);
-        }
-      });
-      if (temporalOk) {
-        await updateTagIndex(memoryDir, (index) => {
-          for (const entry of entries) {
-            removePathFromAllTagEntries(index, entry.path);
-            for (const tag of entry.tags) {
-              if (tag && typeof tag === "string") {
-                addTagGraphEntry(index, tag, entry.path);
-              }
-            }
-          }
-        });
-      }
-    });
-  } catch {
-    // Fail silently
-  }
-}
-
-/**
- * Batch-remove multiple memories from both indexes in a single read-modify-write
- * cycle per index. Mirrors {@link indexMemoriesBatchAsync}: maintenance loops that
- * invalidate/archive N memories collect their entries and call this once, replacing
- * the O(N) full read-parse-stringify-write amplification of per-memory
- * {@link deindexMemoryAsync} with O(1) temporal + O(1) tag write cycles.
- *
- * Per-entry semantics are byte-identical to {@link deindexMemoryAsync}: the date
- * set for each entry's `createdAt` drops the path, the temporal event is deleted,
- * and each tag graph entry is removed. The temporal half commits first; the tag
- * half only runs if it succeeds, so a partial failure never leaves tags orphaned
- * from a temporal entry that still exists.
- */
-export async function deindexMemoriesBatchAsync(
-  memoryDir: string,
-  entries: ReadonlyArray<Pick<TemporalIndexEntry, "path" | "createdAt" | "tags">>,
-): Promise<void> {
-  if (entries.length === 0) return;
-  try {
-    await ensureStateDir(memoryDir);
-
-    await withMemoryDirMutex(memoryDir, async () => {
-      const temporalOk = await updateTemporalIndex(memoryDir, (index) => {
-        for (const entry of entries) {
-          const dateKey = isoDateFromTimestamp(entry.createdAt);
-          removePathFromSet(index.dates, dateKey, entry.path);
-          delete index.events[entry.path];
-        }
-      });
-      if (temporalOk) {
-        await updateTagIndex(memoryDir, (index) => {
-          for (const entry of entries) {
-            for (const tag of entry.tags) {
-              if (tag && typeof tag === "string") {
-                removeTagGraphEntry(index, tag, entry.path);
-              }
-            }
-          }
-        });
-      }
-    });
-  } catch {
-    // Fail silently — indexes are advisory only
   }
 }
 


### PR DESCRIPTION
## Summary

The **#1911B** slice of #1911, on top of the merged **#1911A** async index (PR #1945). Removes the O(N) deindex write amplification in maintenance loops: a consolidation/lifecycle/semantic pass that invalidates or archives N memories previously did a full temporal + tag read-parse-stringify-write **per memory** (2N whole-file rewrites). Each converted loop now collects removals and issues **one** temporal + **one** tag write cycle for the whole batch.

## Changes

- **`temporal-index.ts`**: add `deindexMemoriesBatchAsync(memoryDir, entries)` mirroring `indexMemoriesBatchAsync`. Per-entry semantics are byte-identical to `deindexMemoryAsync` — for each entry the date set for its `createdAt` drops the path, the temporal event is deleted, and each tag graph entry is removed. Temporal commits first under `withMemoryDirMutex`; the tag half runs only on success, so a partial failure never orphans tags. Adds a test-only committed-write observer (`setIndexWriteObserverForTest`) fired once per atomic index write.
- **`consolidation-run.ts`**: INVALIDATE/MERGE collected during the `result.items` loop and batched after it; expired-commitments and TTL-expired loops batched. `queryAwareIndexing` guards preserved (nothing is collected when disabled). Catalog write-touch accounting (`memoryItemMutated`) is untouched.
- **`lifecycle-policy-coordinator.ts`**: fact-archival loop collects then batches after the loop.
- **`semantic-consolidation-coordinator.ts`**: archive-originals loop collects then batches after the loop, kept inside a best-effort `try/catch` so a failed index write never aborts the cluster or skips the `finally` catalog touch.
- The single-memory contradiction-resolve path in `contradiction-linking-coordinator.ts` stays on `deindexMemoryAsync` (no batching needed).

## Guardrails preserved

- Ordering, aliases, timestamps, and index consistency are identical to per-memory de-index (batching is order-independent for the final index).
- Every `resolveIndexingCapabilities(config).queryAwareIndexing` guard is preserved verbatim.
- Fail-open/fail-silent semantics: `deindexMemoriesBatchAsync` swallows errors; index failures never crash consolidation. Temporal-first-then-tag commit ordering protects against half-applied removals on partial failure.

## Tests (new, `temporal-index.test.ts`)

- **Equivalence**: batch de-index of a scrambled subset yields a byte-identical final temporal + tag index vs sequential per-memory `deindexMemoryAsync` (proves all callers preserve the same final index).
- **O(1) writes**: de-indexing N memories performs exactly `{ temporal: 1, tags: 1 }` writes (vs `{ N, N }` for the per-memory path), asserted via the write observer.
- **Empty batch** is a no-op with zero writes.
- **Partial-failure consistency**: with the state dir read-only so the temporal write fails, both indexes stay at their pre-batch contents (tag half skipped).

## Verification

- `tsc --noEmit` on `@remnic/core`: clean.
- `temporal-index.test.ts`: 25/25 pass (4 new).
- `test:entity-hardening` (orchestration files touched): 254/254 pass.
- Consolidation/lifecycle/semantic integration incl. catalog-touch guardrail: `consolidation-catalog-touch`, `semantic-consolidation`, `orchestrator-lifecycle-policy`, `temporal-recall-end-to-end`, `consolidation-undo`: 34/34 pass.

Refs #1911

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consolidation, lifecycle, and semantic maintenance index cleanup; behavior is heavily tested but incorrect batching or finally ordering could leave stale recall entries or skip de-index on errors.
> 
> **Overview**
> **Batch de-indexing** replaces per-memory `deindexMemoryAsync` in consolidation (INVALIDATE/MERGE, expired commitments, TTL cleanup), fact archival, and semantic-consolidation archive loops. Removals are collected and applied via new **`deindexMemoriesBatchAsync`** in `temporal-index-batch.ts` (with **`indexMemoriesBatchAsync`** moved there too), cutting maintenance from **O(N)** full index rewrites to **one temporal + one tag** write per batch.
> 
> **Reliability (#1911B):** Those loops now **flush the de-index batch in `finally`**, and fact archival **queues de-index right after a successful archive** (before content-hash/embedding cleanup that can throw). Already-archived memories are still removed from the advisory index if a later iteration fails.
> 
> **`temporal-index.ts`** exports more primitives for the batch module and adds test hooks (`setIndexWriteObserverForTest`, `setIndexWriteFailureForTest`) plus observer isolation so test failures cannot undo committed writes.
> 
> **Tests** cover batch vs sequential equivalence, write counts, partial temporal failure, observer throws, and a **`runFactArchival`** regression for finally-flush behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fa395e7e0b7880f6dd01d73bfc477b33060b7cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved temporal/tag index cleanup efficiency by batching de-index operations across consolidation, fact archival, semantic consolidation, and expiration/TTL cleanup flows.

* **Reliability**
  * Preserved temporal/tag index consistency with batch de-indexing and ensured index cleanup still runs via finalization even when later steps fail.

* **Tests**
  * Added batch de-indexing equivalence and write-count assertions (including empty no-ops and deterministic failure behavior), plus new regressions validating cleanup flush after archival errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->