### PR TITLE
perf(core): make recall deadline losers cooperatively stop (#1907)

### DIFF
--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -75,6 +75,7 @@ import { type TrustZoneSearchResult, searchTrustZoneRecords } from "../trust-zon
 import type { CodingContext, EngramTraceEvent, IdentityInjectionMode, MemoryFile, MemoryIntent, PluginConfig, QmdSearchResult, RecallPlanMode, RecallSectionConfig } from "../types.js";
 import { type VerifiedEpisodeResult, compareVerifiedEpisodeResults, searchVerifiedEpisodes } from "../verified-recall.js";
 import { type WorkProductLedgerSearchResult, searchWorkProductLedgerEntries } from "../work-product-ledger.js";
+import { abortError } from "../abort-error.js";
 import {
   applyQueryAwareCandidateFilter,
   filterRecallCandidates,
@@ -3411,7 +3412,7 @@ export class RecallInternalCoordinator {
 
     const awaitAssemblyStep = async <T>(
       name: string,
-      task: () => Promise<T>,
+      task: (stepSignal: AbortSignal) => Promise<T>,
       fallback: T,
     ): Promise<T> => {
       if (options.abortSignal?.aborted) {
@@ -3430,11 +3431,23 @@ export class RecallInternalCoordinator {
         return fallback;
       }
 
+      // Task-level deadline abort (#1907): give the step a child controller and
+      // pass its signal into the task so the losing task cooperatively stops
+      // instead of running to completion on the daemon thread after the race is
+      // lost. Compose with the request signal so a client disconnect ALSO stops
+      // the step's cooperative reads. This step controller only maps to the
+      // step's `fallback` (fail-open, rule 41); it never rejects the recall —
+      // a request-level abort rejects at the next throwIfRecallAborted boundary.
+      const stepController = new AbortController();
+      const stepSignal = options.abortSignal
+        ? AbortSignal.any([options.abortSignal, stepController.signal])
+        : stepController.signal;
+
       let timeoutHandle: NodeJS.Timeout | undefined;
       try {
         const result = await (timeoutMs !== null
           ? Promise.race<T | { status: "timed_out" }>([
-              task(),
+              task(stepSignal),
               new Promise<{ status: "timed_out" }>((resolve) => {
                 timeoutHandle = setTimeout(
                   () => resolve({ status: "timed_out" }),
@@ -3442,14 +3455,15 @@ export class RecallInternalCoordinator {
                 );
               }),
             ])
-          : task());
+          : task(stepSignal));
         if (timeoutHandle) clearTimeout(timeoutHandle);
         if (
           typeof result === "object" &&
           result !== null &&
           "status" in result &&
-          (result as { status?: unknown }).status === "timed_out"
+          result.status === "timed_out"
         ) {
+          stepController.abort(abortError(`recall assembly [${name}] deadline exceeded`));
           log.debug(
             `recall phase-1 assembly [${name}]: timed out within shared ${enrichmentSectionDeadlineMs}ms budget ` +
               `at +${Date.now() - phase1Start}ms`,
@@ -3459,6 +3473,7 @@ export class RecallInternalCoordinator {
         return result as T;
       } catch (err) {
         if (timeoutHandle) clearTimeout(timeoutHandle);
+        stepController.abort(abortError(`recall assembly [${name}] failed`));
         log.warn(
           `recall phase-1 assembly [${name}] failed open: ${
             err instanceof Error ? err.message : String(err)
@@ -4350,35 +4365,25 @@ export class RecallInternalCoordinator {
         // does O(candidates) work instead of a full-corpus scan.
         const trustT0 = Date.now();
         // The fallback is a distinct object: identity-comparing the outcome to
-        // it detects a deadline/abort/error fallback without changing
-        // awaitAssemblyStep. On fallback the losing task is cooperatively
-        // cancelled via the AbortController so an orphaned corpus scan stops at
-        // its next loop boundary instead of burning I/O after recall returned,
-        // and the metric records the truth (#1905, Codex/Kilo).
-        const trustAbort = new AbortController();
-        // Also honor the caller's abort (e.g. a disconnected request) while the
-        // stage runs: compose the deadline controller with the request signal so
-        // EITHER cancels the cooperative reads. AbortSignal.any manages the
-        // listener lifecycle internally — no manual disposal (#1905, Codex).
-        const trustSignal = options.abortSignal
-          ? AbortSignal.any([options.abortSignal, trustAbort.signal])
-          : trustAbort.signal;
+        // it detects a deadline/abort/error fallback so the metric records the
+        // truth. awaitAssemblyStep injects a step signal that aborts the losing
+        // task on deadline (or when the request disconnects), so an orphaned
+        // corpus scan stops at its next loop boundary (#1905/#1907).
         const trustFallback = { results: memoryResults, trustByPath: recallTrustByPath };
         const trustOutcome = await awaitAssemblyStep(
           "trustStage",
-          () =>
+          (stepSignal) =>
             this.deps.applyTrustScoreToBranch(
               memoryResults,
               recallNamespaces,
               caps,
               "hot-qmd",
               qmdBoostInput.memoryByPath,
-              trustSignal,
+              stepSignal,
             ),
           trustFallback,
         );
         const trustFellBack = trustOutcome === trustFallback;
-        if (trustFellBack) trustAbort.abort();
         memoryResults = trustOutcome.results;
         recallTrustByPath = trustOutcome.trustByPath;
         recordRecallSectionMetric({
@@ -4570,28 +4575,21 @@ export class RecallInternalCoordinator {
           // the stage's corpus/direct-read fallback cover it — identical lookup
           // semantics (rule 41 parity).
           const trustT0 = Date.now();
-          const trustAbort = new AbortController();
-          // Compose with the caller's signal so a disconnected request also
-          // cancels the cooperative reads (#1905, Codex).
-          const trustSignal = options.abortSignal
-            ? AbortSignal.any([options.abortSignal, trustAbort.signal])
-            : trustAbort.signal;
           const trustFallback = { results: scoped, trustByPath: recallTrustByPath };
           const trustOutcome = await awaitAssemblyStep(
             "trustStage",
-            () =>
+            (stepSignal) =>
               this.deps.applyTrustScoreToBranch(
                 scoped,
                 recallNamespaces,
                 caps,
                 "embedding-fallback",
                 undefined,
-                trustSignal,
+                stepSignal,
               ),
             trustFallback,
           );
           const trustFellBack = trustOutcome === trustFallback;
-          if (trustFellBack) trustAbort.abort();
           scoped = trustOutcome.results;
           recallTrustByPath = trustOutcome.trustByPath;
           recordRecallSectionMetric({
@@ -4775,28 +4773,21 @@ export class RecallInternalCoordinator {
         {
           // Deadline-bound (issue #1905); no preloaded map on this branch.
           const trustT0 = Date.now();
-          const trustAbort = new AbortController();
-          // Compose with the caller's signal so a disconnected request also
-          // cancels the cooperative reads (#1905, Codex).
-          const trustSignal = options.abortSignal
-            ? AbortSignal.any([options.abortSignal, trustAbort.signal])
-            : trustAbort.signal;
           const trustFallback = { results: scoped, trustByPath: recallTrustByPath };
           const trustOutcome = await awaitAssemblyStep(
             "trustStage",
-            () =>
+            (stepSignal) =>
               this.deps.applyTrustScoreToBranch(
                 scoped,
                 recallNamespaces,
                 caps,
                 "embedding-fallback",
                 undefined,
-                trustSignal,
+                stepSignal,
               ),
             trustFallback,
           );
           const trustFellBack = trustOutcome === trustFallback;
-          if (trustFellBack) trustAbort.abort();
           scoped = trustOutcome.results;
           recallTrustByPath = trustOutcome.trustByPath;
           recordRecallSectionMetric({
@@ -5006,28 +4997,21 @@ export class RecallInternalCoordinator {
               const recentPreloaded = new Map<string, MemoryFile>(
                 queryAwareScopedMemories.filter((m) => m.path).map((m) => [m.path, m]),
               );
-              const trustAbort = new AbortController();
-              // Compose with the caller's signal so a disconnected request also
-              // cancels the cooperative reads (#1905, Codex).
-              const trustSignal = options.abortSignal
-                ? AbortSignal.any([options.abortSignal, trustAbort.signal])
-                : trustAbort.signal;
               const trustFallback = { results: recent, trustByPath: recallTrustByPath };
               const trustOutcome = await awaitAssemblyStep(
                 "trustStage",
-                () =>
+                (stepSignal) =>
                   this.deps.applyTrustScoreToBranch(
                     recent,
                     recallNamespaces,
                     caps,
                     "recent-scan",
                     recentPreloaded,
-                    trustSignal,
+                    stepSignal,
                   ),
                 trustFallback,
               );
               const trustFellBack = trustOutcome === trustFallback;
-              if (trustFellBack) trustAbort.abort();
               recent = trustOutcome.results;
               recallTrustByPath = trustOutcome.trustByPath;
               recordRecallSectionMetric({

--- a/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
+++ b/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
@@ -813,17 +813,13 @@ export class RecallSearchPipelineCoordinator {
     ): Promise<T> => {
       throwIfRecallAborted(options.abortSignal);
       const remainingMs = deadlineRemainingMs();
-      // Task-level deadline abort (#1907): compose the caller's request signal
-      // with a per-step controller so EITHER a client disconnect or this step's
-      // own deadline cooperatively stops the losing task, instead of letting it
-      // run to completion on the daemon thread after the race is lost. A step
-      // deadline maps to `fallback` (fail-open); only a request-level abort
-      // rejects, and that reject is driven by options.abortSignal, not here.
+      // Step-level deadline abort (#1907): compose the caller's request signal with
+      // a per-step controller so a disconnect OR this step's deadline stops the task.
       const stepController = new AbortController();
       const stepSignal = options.abortSignal
         ? AbortSignal.any([options.abortSignal, stepController.signal])
         : stepController.signal;
-      if (remainingMs === 0) {
+      const abandonToDeadline = () => {
         stepController.abort(abortError(`cold-tier recall ${label} deadline exceeded`));
         try {
           onDeadline?.();
@@ -831,10 +827,12 @@ export class RecallSearchPipelineCoordinator {
           // Observers must never break recall.
         }
         log.debug(`cold-tier recall ${label} skipped: shared assembly deadline expired`);
+      };
+      if (remainingMs === 0) {
+        abandonToDeadline();
         return fallback;
       }
       if (remainingMs === null) return task(stepSignal);
-
       let timeoutHandle: NodeJS.Timeout | undefined;
       let timedOut = false;
       const taskPromise = task(stepSignal).catch((err) => {
@@ -844,28 +842,19 @@ export class RecallSearchPipelineCoordinator {
         }
         throw err;
       });
-
       try {
         return await Promise.race<T>([
           taskPromise,
           new Promise<T>((resolve) => {
             timeoutHandle = setTimeout(() => {
               timedOut = true;
-              stepController.abort(abortError(`cold-tier recall ${label} deadline exceeded`));
-              try {
-                onDeadline?.();
-              } catch {
-                // Observers must never break recall.
-              }
-              log.debug(
-                `cold-tier recall ${label} skipped: shared assembly deadline expired`,
-              );
+              abandonToDeadline();
               resolve(fallback);
             }, remainingMs);
           }),
         ]);
       } finally {
-        if (timeoutHandle) clearTimeout(timeoutHandle);
+        clearTimeout(timeoutHandle);
       }
     };
 

--- a/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
+++ b/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
@@ -18,6 +18,7 @@
 
 import { createHash } from "node:crypto";
 import path from "node:path";
+import { abortError } from "../abort-error.js";
 import { type CapabilitySet, type GraphConstructionCapabilitySet, resolveCapabilities, resolveConversationContextCapabilities, resolveGraphConstructionCapabilities, resolveIndexingCapabilities, resolveMemoryLifecycleCapabilities, resolveNamespaceCapabilities, resolvePipelineProcessingCapabilities, resolveQmdCapabilities, resolveRecallEnhancementCapabilities } from "../capabilities.js";
 import { EmbeddingFallback } from "../embedding-fallback.js";
 import { StorageManager } from "../index.js";
@@ -804,7 +805,7 @@ export class RecallSearchPipelineCoordinator {
     const runColdStepWithinDeadline = async <T>(
       label: string,
       fallback: T,
-      task: () => Promise<T>,
+      task: (stepSignal: AbortSignal) => Promise<T>,
       // Invoked when the deadline abandons this step (before it started or
       // while it runs), so callers can report the abandonment and gate off
       // late observer callbacks (#1536, cursor round-6 on #1544).
@@ -812,7 +813,18 @@ export class RecallSearchPipelineCoordinator {
     ): Promise<T> => {
       throwIfRecallAborted(options.abortSignal);
       const remainingMs = deadlineRemainingMs();
+      // Task-level deadline abort (#1907): compose the caller's request signal
+      // with a per-step controller so EITHER a client disconnect or this step's
+      // own deadline cooperatively stops the losing task, instead of letting it
+      // run to completion on the daemon thread after the race is lost. A step
+      // deadline maps to `fallback` (fail-open); only a request-level abort
+      // rejects, and that reject is driven by options.abortSignal, not here.
+      const stepController = new AbortController();
+      const stepSignal = options.abortSignal
+        ? AbortSignal.any([options.abortSignal, stepController.signal])
+        : stepController.signal;
       if (remainingMs === 0) {
+        stepController.abort(abortError(`cold-tier recall ${label} deadline exceeded`));
         try {
           onDeadline?.();
         } catch {
@@ -821,11 +833,11 @@ export class RecallSearchPipelineCoordinator {
         log.debug(`cold-tier recall ${label} skipped: shared assembly deadline expired`);
         return fallback;
       }
-      if (remainingMs === null) return task();
+      if (remainingMs === null) return task(stepSignal);
 
       let timeoutHandle: NodeJS.Timeout | undefined;
       let timedOut = false;
-      const taskPromise = task().catch((err) => {
+      const taskPromise = task(stepSignal).catch((err) => {
         if (timedOut) {
           log.debug(`cold-tier recall ${label} failed after deadline: ${err}`);
           return fallback;
@@ -839,6 +851,7 @@ export class RecallSearchPipelineCoordinator {
           new Promise<T>((resolve) => {
             timeoutHandle = setTimeout(() => {
               timedOut = true;
+              stepController.abort(abortError(`cold-tier recall ${label} deadline exceeded`));
               try {
                 onDeadline?.();
               } catch {
@@ -895,7 +908,7 @@ export class RecallSearchPipelineCoordinator {
         longTerm = await runColdStepWithinDeadline(
           "qmd lookup",
           [],
-          () =>
+          (stepSignal) =>
             this.deps.fetchQmdMemoryResultsWithArtifactTopUp(
               options.prompt,
               coldFetchLimit,
@@ -907,7 +920,7 @@ export class RecallSearchPipelineCoordinator {
                 collection: coldCollection,
                 queryAwarePrefilter: options.queryAwarePrefilter,
                 searchOptions: this.deps.buildConfiguredQmdSearchOptions(options.prompt),
-                abortSignal: options.abortSignal,
+                abortSignal: stepSignal,
                 onDegradation: (degradation) => {
                   if (coldQmdObserverActive) {
                     options.onDegradation?.(degradation);
@@ -929,17 +942,14 @@ export class RecallSearchPipelineCoordinator {
       }
     }
     if (longTerm.length === 0) {
-      // Deadline-aware abort: terminate the scoring worker when the shared
-      // assembly deadline wins, not just when the caller aborts (#1674).
-      const da = new AbortController();
-      if (options.abortSignal?.aborted) da.abort();
-      else options.abortSignal?.addEventListener("abort", () => da.abort(), { once: true });
+      // The archive-scan scoring worker terminates when EITHER the caller
+      // aborts or this step's own deadline wins — both flow through the
+      // step signal injected by runColdStepWithinDeadline (#1674, #1907).
       longTerm = await runColdStepWithinDeadline(
         "archive scan", [],
-        () => this.deps.searchLongTermArchiveFallback(
+        (stepSignal) => this.deps.searchLongTermArchiveFallback(
           options.prompt, options.recallNamespaces, options.recallResultLimit,
-          options.queryAwarePrefilter, da.signal),
-        () => da.abort(),
+          options.queryAwarePrefilter, stepSignal),
       );
       if (longTerm.length > 0) {
         log.debug("cold-tier recall source=archive-scan");

--- a/packages/remnic-core/src/recall-cold-deadline.test.ts
+++ b/packages/remnic-core/src/recall-cold-deadline.test.ts
@@ -1,0 +1,132 @@
+/**
+ * recall-cold-deadline.test.ts — issue #1907.
+ *
+ * Pins the task-level cancellation contract of runColdStepWithinDeadline
+ * inside RecallSearchPipelineCoordinator.applyColdFallbackPipeline:
+ *   - when the per-step deadline wins, the losing cold task's INJECTED signal
+ *     is aborted (so an orphaned archive scan stops cooperatively) and the
+ *     step returns its fallback (fail-open);
+ *   - a task-level deadline must NOT abort the request-level signal;
+ *   - a task that completes normally (no deadline) never aborts the injected
+ *     step signal.
+ */
+
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import {
+  RecallSearchPipelineCoordinator,
+  type RecallSearchPipelineDeps,
+} from "./orchestration/recall-search-pipeline.js";
+import type { PluginConfig, QmdSearchResult, RecallPlanMode } from "./types.js";
+
+async function coldConfig() {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-1907-cold-"));
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    namespacesEnabled: false,
+  });
+  return { memoryDir, config };
+}
+
+/**
+ * Minimal deps for the archive-scan branch. qmd.isAvailable() === false forces
+ * the cold-qmd block to be skipped, so control reaches the archive-scan step;
+ * an empty archive result returns [] before any namespace/storage-router work,
+ * keeping the stub surface tight. The cast is a deliberate test double.
+ */
+function coldDeps(
+  config: PluginConfig,
+  searchLongTermArchiveFallback: RecallSearchPipelineDeps["searchLongTermArchiveFallback"],
+): RecallSearchPipelineDeps {
+  return {
+    config,
+    qmd: { isAvailable: () => false },
+    namespaceFromPath: () => "default",
+    searchLongTermArchiveFallback,
+  } as unknown as RecallSearchPipelineDeps;
+}
+
+test("#1907: cold archive-scan deadline aborts the injected step signal, returns fallback, leaves the request signal intact", async () => {
+  const { memoryDir, config } = await coldConfig();
+  try {
+    const stuck = Promise.withResolvers<QmdSearchResult[]>();
+    let capturedStepSignal: AbortSignal | undefined;
+    const deps = coldDeps(config, async (_prompt, _ns, _limit, _prefilter, abortSignal) => {
+      capturedStepSignal = abortSignal;
+      return stuck.promise; // never resolves — the deadline must win the race
+    });
+    const coordinator = new RecallSearchPipelineCoordinator(deps);
+
+    const requestController = new AbortController();
+    const result = await coordinator.applyColdFallbackPipeline({
+      prompt: "long term recall",
+      recallNamespaces: ["default"],
+      recallResultLimit: 5,
+      recallMode: "full" as RecallPlanMode,
+      deadlineAtMs: Date.now() + 120,
+      abortSignal: requestController.signal,
+    });
+
+    assert.deepEqual(result, [], "the step returns its fallback when the deadline wins");
+    assert.ok(capturedStepSignal, "archive scan received an injected step signal");
+    assert.equal(
+      capturedStepSignal!.aborted,
+      true,
+      "the injected step signal is aborted on deadline so the losing task stops",
+    );
+    assert.equal(
+      requestController.signal.aborted,
+      false,
+      "a task-level deadline must NOT abort the request-level signal",
+    );
+
+    // A late resolution of the abandoned task cannot change the already-returned
+    // fallback — no late side effect on the recall result.
+    stuck.resolve([{ docid: "late", path: "/facts/late.md", snippet: "late", score: 1 }]);
+    await Promise.resolve();
+    assert.deepEqual(result, [], "the fallback is unaffected by the abandoned task settling late");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("#1907: a cold step that completes before its deadline never aborts the injected step signal", async () => {
+  const { memoryDir, config } = await coldConfig();
+  try {
+    let capturedStepSignal: AbortSignal | undefined;
+    const deps = coldDeps(config, async (_prompt, _ns, _limit, _prefilter, abortSignal) => {
+      capturedStepSignal = abortSignal;
+      return []; // resolves immediately, well within the deadline
+    });
+    const coordinator = new RecallSearchPipelineCoordinator(deps);
+
+    const requestController = new AbortController();
+    const result = await coordinator.applyColdFallbackPipeline({
+      prompt: "long term recall",
+      recallNamespaces: ["default"],
+      recallResultLimit: 5,
+      recallMode: "full" as RecallPlanMode,
+      deadlineAtMs: Date.now() + 30_000,
+      abortSignal: requestController.signal,
+    });
+
+    assert.deepEqual(result, [], "empty archive returns []");
+    assert.ok(capturedStepSignal, "archive scan received an injected step signal");
+    assert.equal(
+      capturedStepSignal!.aborted,
+      false,
+      "normal completion must not abort the injected step signal",
+    );
+    assert.equal(requestController.signal.aborted, false, "request signal untouched");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/recall-cold-deadline.test.ts
+++ b/packages/remnic-core/src/recall-cold-deadline.test.ts
@@ -59,9 +59,20 @@ test("#1907: cold archive-scan deadline aborts the injected step signal, returns
   try {
     const stuck = Promise.withResolvers<QmdSearchResult[]>();
     let capturedStepSignal: AbortSignal | undefined;
+    // Observable side-effect channel. A cooperatively-cancelled worker sees
+    // stepSignal.aborted === true by the time it settles late and performs no
+    // write; if the deadline's abort wiring is removed the signal never aborts,
+    // so the late completion leaks "late" here and the assertion below fails.
+    const lateWrites: string[] = [];
+    const abandonedTaskSettled = Promise.withResolvers<void>();
     const deps = coldDeps(config, async (_prompt, _ns, _limit, _prefilter, abortSignal) => {
       capturedStepSignal = abortSignal;
-      return stuck.promise; // never resolves — the deadline must win the race
+      const late = await stuck.promise; // does not settle before the deadline wins
+      if (!abortSignal?.aborted) {
+        for (const hit of late) lateWrites.push(hit.docid);
+      }
+      abandonedTaskSettled.resolve();
+      return late;
     });
     const coordinator = new RecallSearchPipelineCoordinator(deps);
 
@@ -88,11 +99,17 @@ test("#1907: cold archive-scan deadline aborts the injected step signal, returns
       "a task-level deadline must NOT abort the request-level signal",
     );
 
-    // A late resolution of the abandoned task cannot change the already-returned
-    // fallback — no late side effect on the recall result.
+    // The abandoned task's LATE completion has no observable side effect: a
+    // cooperative worker sees its injected signal aborted and performs no write.
+    // Deterministic — we await the abandoned task's own settlement, not a bare
+    // microtask flush.
     stuck.resolve([{ docid: "late", path: "/facts/late.md", snippet: "late", score: 1 }]);
-    await Promise.resolve();
-    assert.deepEqual(result, [], "the fallback is unaffected by the abandoned task settling late");
+    await abandonedTaskSettled.promise;
+    assert.deepEqual(
+      lateWrites,
+      [],
+      "the abandoned task observed its abort and performed no late write",
+    );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/recall-rerank-coordinator.test.ts
+++ b/packages/remnic-core/src/recall-rerank-coordinator.test.ts
@@ -399,3 +399,84 @@ test("deadline-bound: a trust stage exceeding the assembly budget returns the pa
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("#1907: assembly deadline aborts the losing task's injected signal but not the request signal", async () => {
+  // awaitAssemblyStep now injects a per-step AbortSignal into the task so the
+  // losing task cooperatively stops instead of running to completion after the
+  // Promise.race is lost. A task-level deadline must abort ONLY that injected
+  // step signal — never the request-level signal, which alone is allowed to
+  // reject the whole recall (#1907, fail-open guardrail).
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-1907-assembly-"));
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    multiGraphMemoryEnabled: false,
+    entityGraphEnabled: false,
+    timeGraphEnabled: false,
+    causalGraphEnabled: false,
+    extractionJudgeEnabled: false,
+    temporalSupersessionEnabled: false,
+    contradictionDetectionEnabled: false,
+    chunkingEnabled: false,
+    inlineSourceAttributionEnabled: false,
+    trustScoreEnabled: true,
+    initGateTimeoutMs: 200,
+    recallEnrichmentDeadlineMs: 2000,
+  });
+  const orchestrator = new Orchestrator(config);
+  try {
+    await writeFact(memoryDir, "Recallable fact: production DB uses pgBouncer.", [
+      "mw_success: 5",
+      "mw_fail: 0",
+    ]);
+
+    const stuck = Promise.withResolvers<{
+      results: QmdSearchResult[];
+      trustByPath: null;
+    }>();
+    let capturedStepSignal: AbortSignal | undefined;
+    const realStage = orchestrator.recallRerankCoordinator.applyTrustScoreToBranch.bind(
+      orchestrator.recallRerankCoordinator,
+    );
+    orchestrator.recallRerankCoordinator.applyTrustScoreToBranch = async (
+      results,
+      namespaces,
+      caps,
+      label,
+      preloadedFrontmatter,
+      abortSignal,
+    ) => {
+      if (label === "recent-scan") {
+        capturedStepSignal = abortSignal;
+        return stuck.promise; // never resolves — force the deadline to win
+      }
+      return realStage(results, namespaces, caps, label, preloadedFrontmatter, abortSignal);
+    };
+
+    const requestController = new AbortController();
+    const recall = await orchestrator.recall(
+      "database connection pooling",
+      "sess-1907-assembly",
+      { xrayCapture: true, abortSignal: requestController.signal },
+    );
+
+    assert.equal(typeof recall, "string", "recall resolves despite the never-resolving stage");
+    assert.ok(capturedStepSignal, "the trust stage received an injected step signal");
+    assert.equal(
+      capturedStepSignal!.aborted,
+      true,
+      "the injected step signal is aborted when the assembly deadline wins",
+    );
+    assert.equal(
+      requestController.signal.aborted,
+      false,
+      "a task-level deadline must NOT abort the request-level signal",
+    );
+  } finally {
+    await orchestrator.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Make the two `Promise.race`-based recall deadline helpers cooperatively stop their losing task instead of running it to completion on the daemon thread after the race is lost.
- `awaitAssemblyStep` (`recall-internal.ts`) and `runColdStepWithinDeadline` (`recall-search-pipeline.ts`) now mint a per-step `AbortController`, compose it with the request signal via `AbortSignal.any`, and pass the linked signal into the task. On deadline/step-failure the step controller aborts (losing task stops at its next cooperative boundary) while the helper still returns its `fallback`.
- Two abort levels stay distinct: a **task-level** deadline maps to `fallback` (fail-open, rule 41); only a **request-level** disconnect rejects the recall at the next `throwIfRecallAborted` boundary. A step deadline never aborts the request signal.
- Cancellation is now centralized in the helpers, so the per-caller boilerplate is deleted: the four `trustStage` sites drop their hand-rolled `trustAbort` controller + `AbortSignal.any` composition, and the cold archive-scan caller drops its manual `da` controller + `onDeadline` abort. The cold-qmd fetch now receives the linked step signal so it stops on deadline too.

This is the deadline-loser slice of #1907 (1907B), layered on the merged MCP request-cancellation plumbing (1907A, #1944). It touches only the deadline helpers and their callers; the merged MCP/HTTP `AbortSignal` propagation is unchanged.

Part of #1907.

## Verification

- `pnpm --filter @remnic/core check-types` (exit 0)
- `node --import tsx --test recall-rerank-coordinator.test.ts` — 8/8 (includes the new #1907 assembly-deadline test and the existing #1905 test, both green)
- `node --import tsx --test recall-cold-deadline.test.ts` — 2/2 (new: cold deadline aborts injected step signal + no late side effect; normal completion never aborts)
- `node --import tsx --test access-mcp-cancellation.test.ts access-http-cancellation.test.ts` — 12/12 (merged 1907A propagation preserved)
- `node --import tsx --test trust-score-recall-paths.test.ts` — 14/14; `temporal-supersession.test.ts` — 59/59 (cold-tier/trust regression)

## Safety

- Fail-open preserved: a step-level `AbortError` maps to the step's existing fallback, never propagates out of the helpers.
- No production data, benchmark data, paid model/API calls, or persisted memory state touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core recall timing and cancellation on hot enrichment and cold-tier paths; behavior is intended to stay fail-open but wrong abort wiring could change recall results or leave work running.
> 
> **Overview**
> Recall enrichment and cold-tier steps that lose a `Promise.race` against a shared deadline now get a **per-step** `AbortSignal` (request signal composed via `AbortSignal.any`) so cooperative work stops instead of finishing on the daemon thread after recall has already moved on.
> 
> **`awaitAssemblyStep`** and **`runColdStepWithinDeadline`** own that wiring: tasks take `(stepSignal) => …`, the step controller aborts on timeout or step failure (still **fail-open** with the existing fallback), and a step deadline does **not** abort the caller’s request signal. Hand-rolled `trustAbort` / `da` controllers at the four `trustStage` sites and the cold archive path are removed in favor of the injected signal; cold QMD fetch uses the same linked signal.
> 
> New tests pin the contract for assembly and cold archive deadlines (injected signal aborted, no late side effects, request signal untouched on normal completion).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3b3de4686ece07b75c0edec02c0eb02aa0fdb8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recall deadline handling with per-step, cooperative cancellation for assembly trust stages and cold fallback sub-steps.
  - Ensures deadline timeouts still fail open by returning the intended fallback while aborting only the affected step work.
  - Prevents internal step cancellation from aborting the caller-provided request signal or other concurrent recall operations.

- **Tests**
  - Added coverage to verify step-level abort behavior for both cold archive-scan fallback and assembly/rerank trust-stage deadlines (fail-open vs successful completion).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->