### PR TITLE
feat(core): extract WriteRateLimiter + log rejected writes (part of #2029)

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath, URL } from "node:url";
 import { gunzipSync } from "node:zlib";
 import { log } from "./logger.js";
+import { WriteRateLimiter } from "./write-rate-limiter.js";
 import { abortError, isAbortError } from "./abort-error.js";
 import { EngramAccessForbiddenError } from "./access-errors.js";
 import {
@@ -220,10 +221,6 @@ const RELAY_ADMIN_CONSOLE_ASSETS = new Map<string, string>([
   ["replay.json", "application/json; charset=utf-8"],
 ]);
 
-// Defaults for the write rate limit; overridable per instance via
-// `writeRateLimitWindowMs` / `writeRateLimitMaxRequests` (issue #1937).
-const WRITE_RATE_LIMIT_WINDOW_MS = 60_000;
-const WRITE_RATE_LIMIT_MAX_REQUESTS = 30;
 const TRUST_ZONE_RECORD_KINDS = ["memory", "artifact", "state", "trajectory", "external"] as const;
 const TRUST_ZONE_SOURCE_CLASSES = ["tool_output", "web_content", "subagent_trace", "system_memory", "user_input", "manual"] as const;
 
@@ -401,9 +398,7 @@ export class EngramAccessHttpServer {
     res: ServerResponse,
     ctx: { authorized: boolean },
   ) => Promise<boolean>;
-  private readonly writeRequestSlots: Array<{ readonly recordedAt: number }> = [];
-  private readonly writeRateLimitMaxRequests: number;
-  private readonly writeRateLimitWindowMs: number;
+  private readonly writeLimiter: WriteRateLimiter;
   private readonly mcpServer: EngramMcpServer;
   private server: Server | null = null;
   private boundPort = 0;
@@ -440,20 +435,10 @@ export class EngramAccessHttpServer {
     this.maxBodyBytes = Number.isFinite(options.maxBodyBytes)
       ? Math.max(1, Math.floor(options.maxBodyBytes ?? 131072))
       : 131072;
-    // Defensive inline validation (config parsers reject invalid values
-    // loudly upstream; this only guards direct programmatic constructions).
-    this.writeRateLimitMaxRequests =
-      typeof options.writeRateLimitMaxRequests === "number" &&
-      Number.isInteger(options.writeRateLimitMaxRequests) &&
-      options.writeRateLimitMaxRequests >= 1
-        ? options.writeRateLimitMaxRequests
-        : WRITE_RATE_LIMIT_MAX_REQUESTS;
-    this.writeRateLimitWindowMs =
-      typeof options.writeRateLimitWindowMs === "number" &&
-      Number.isInteger(options.writeRateLimitWindowMs) &&
-      options.writeRateLimitWindowMs >= 1
-        ? options.writeRateLimitWindowMs
-        : WRITE_RATE_LIMIT_WINDOW_MS;
+    this.writeLimiter = new WriteRateLimiter(
+      options.writeRateLimitMaxRequests,
+      options.writeRateLimitWindowMs,
+    );
     this.adminConsoleEnabled = options.adminConsoleEnabled !== false;
     this.adminConsolePublicDir = options.adminConsolePublicDir ?? defaultAdminConsolePublicDir;
     this.adminConsolePrefillToken = options.adminConsolePrefillToken === true ? this.authToken : undefined;
@@ -3875,33 +3860,21 @@ export class EngramAccessHttpServer {
   }
 
   private ensureWriteRateLimitAvailable(): void {
-    const now = Date.now();
-    while (
-      this.writeRequestSlots.length > 0 &&
-      now - (this.writeRequestSlots[0]?.recordedAt ?? 0) > this.writeRateLimitWindowMs
-    ) {
-      this.writeRequestSlots.shift();
-    }
-    if (this.writeRequestSlots.length >= this.writeRateLimitMaxRequests) {
+    if (!this.writeLimiter.hasCapacity()) {
       throw new HttpError(429, "write_rate_limited", "write_rate_limited");
     }
   }
 
   private recordWriteRateLimitHit(): void {
-    this.writeRequestSlots.push({ recordedAt: Date.now() });
+    this.writeLimiter.record();
   }
 
   private reserveWriteRateLimitSlot(): () => void {
-    this.ensureWriteRateLimitAvailable();
-    const slot = { recordedAt: Date.now() };
-    this.writeRequestSlots.push(slot);
-    let active = true;
-    return () => {
-      if (!active) return;
-      active = false;
-      const index = this.writeRequestSlots.indexOf(slot);
-      if (index >= 0) this.writeRequestSlots.splice(index, 1);
-    };
+    const release = this.writeLimiter.reserve();
+    if (!release) {
+      throw new HttpError(429, "write_rate_limited", "write_rate_limited");
+    }
+    return release;
   }
 
   private shouldCountWriteRateLimit(response: { dryRun?: boolean; idempotencyReplay?: boolean }): boolean {

--- a/packages/remnic-core/src/access-mcp-cancellation.test.ts
+++ b/packages/remnic-core/src/access-mcp-cancellation.test.ts
@@ -282,7 +282,7 @@ test("MCP write quota is recorded after commit even when the client disconnects 
   });
   const serverHost = server as unknown as {
     mcpServer: EngramMcpServer;
-    writeRequestSlots: Array<{ readonly recordedAt: number }>;
+    writeLimiter: { slots: Array<{ readonly recordedAt: number }> };
   };
   const originalHandleRequest = serverHost.mcpServer.handleRequest.bind(serverHost.mcpServer);
   serverHost.mcpServer.handleRequest = async (request, options) => {
@@ -318,7 +318,7 @@ test("MCP write quota is recorded after commit even when the client disconnects 
 
     await waitFor(operationSettled.promise);
     await new Promise<void>((resolve) => setImmediate(resolve));
-    assert.equal(serverHost.writeRequestSlots.length, 1);
+    assert.equal(serverHost.writeLimiter.slots.length, 1);
     assert.equal(responseStarted, false, "the disconnected client must not receive the committed write response");
   } finally {
     releaseOperation.resolve();

--- a/packages/remnic-core/src/relay/mission-access.test.ts
+++ b/packages/remnic-core/src/relay/mission-access.test.ts
@@ -367,25 +367,25 @@ test("Relay write quota releases the exact reservation when timestamps collide",
     adminConsoleEnabled: false,
   });
   const internals = server as unknown as {
-    writeRequestSlots: Array<{ readonly recordedAt: number }>;
+    writeLimiter: { slots: Array<{ readonly recordedAt: number }> };
     reserveWriteRateLimitSlot: () => () => void;
   };
   const originalNow = Date.now;
   try {
     Date.now = () => 1_754_000_000_000;
     const releaseCommitted = internals.reserveWriteRateLimitSlot();
-    const committedSlot = internals.writeRequestSlots[0];
+    const committedSlot = internals.writeLimiter.slots[0];
     const releaseFailed = internals.reserveWriteRateLimitSlot();
-    const failedSlot = internals.writeRequestSlots[1];
+    const failedSlot = internals.writeLimiter.slots[1];
     assert.ok(committedSlot);
     assert.ok(failedSlot);
     assert.notEqual(committedSlot, failedSlot);
 
     releaseFailed();
-    assert.deepEqual(internals.writeRequestSlots, [committedSlot]);
+    assert.deepEqual(internals.writeLimiter.slots, [committedSlot]);
 
     releaseCommitted();
-    assert.deepEqual(internals.writeRequestSlots, []);
+    assert.deepEqual(internals.writeLimiter.slots, []);
   } finally {
     Date.now = originalNow;
   }

--- a/packages/remnic-core/src/write-rate-limiter.test.ts
+++ b/packages/remnic-core/src/write-rate-limiter.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { log } from "./logger.js";
+import { WriteRateLimiter } from "./write-rate-limiter.js";
+
+test("WriteRateLimiter: defaults applied when unset or invalid (issue #1937)", () => {
+  assert.equal(new WriteRateLimiter().maxRequests, 30);
+  assert.equal(new WriteRateLimiter().windowMs, 60_000);
+  assert.equal(new WriteRateLimiter(0).maxRequests, 30, "0 is invalid -> default");
+  assert.equal(new WriteRateLimiter(1.5).maxRequests, 30, "non-integer -> default");
+  const custom = new WriteRateLimiter(120, 30_000);
+  assert.equal(custom.maxRequests, 120);
+  assert.equal(custom.windowMs, 30_000);
+});
+
+test("WriteRateLimiter: capacity check, record, and sampled rejection logging (issue #2029)", () => {
+  const limiter = new WriteRateLimiter(1, 60_000);
+  const warnings: string[] = [];
+  const originalWarn = log.warn;
+  log.warn = (msg: string) => {
+    warnings.push(msg);
+  };
+  try {
+    assert.equal(limiter.hasCapacity(), true);
+    limiter.record();
+    assert.equal(limiter.hasCapacity(), false, "over the limit after one recorded write");
+    assert.equal(limiter.hasCapacity(), false);
+    assert.ok(
+      warnings.some((w) => w.includes("write_rate_limited")),
+      "a refused write is logged server-side",
+    );
+    assert.equal(warnings.length, 1, "logging is sampled within the interval, not per-refusal");
+  } finally {
+    log.warn = originalWarn;
+  }
+});
+
+test("WriteRateLimiter: reserve returns a release, refuses at the limit, frees on release", () => {
+  const limiter = new WriteRateLimiter(1, 60_000);
+  const release = limiter.reserve();
+  assert.ok(release, "first reservation succeeds");
+  assert.equal(limiter.slots.length, 1);
+  assert.equal(limiter.reserve(), null, "second reservation refused at the limit");
+  release?.();
+  assert.equal(limiter.slots.length, 0, "release frees the reserved slot");
+  assert.ok(limiter.reserve(), "capacity restored after release");
+});
+
+test("WriteRateLimiter: old slots pruned after the rolling window", () => {
+  const realNow = Date.now;
+  try {
+    let now = 1_000_000;
+    Date.now = () => now;
+    const limiter = new WriteRateLimiter(1, 1000);
+    limiter.record();
+    assert.equal(limiter.hasCapacity(), false, "at the limit within the window");
+    now += 1001;
+    assert.equal(limiter.hasCapacity(), true, "slot pruned once older than the window");
+  } finally {
+    Date.now = realNow;
+  }
+});

--- a/packages/remnic-core/src/write-rate-limiter.ts
+++ b/packages/remnic-core/src/write-rate-limiter.ts
@@ -1,0 +1,91 @@
+/**
+ * Global write rate limiter for the access HTTP surface (issue #1937/#2029).
+ *
+ * Extracted from access-http.ts so the limiter is a cohesive unit (and so the
+ * host file stays under its structural ceiling). Deliberately transport-
+ * agnostic: it never throws `HttpError` — callers translate a refusal into
+ * their own 429. It logs a sampled warning when it refuses a write, so a
+ * sustained limit condition is diagnosable server-side instead of only via
+ * client warnings (previously the refusal was a bare throw with no trace).
+ */
+
+import { log } from "./logger.js";
+
+// Defaults; overridable per instance via the constructor (config/env feed these
+// through the server's `writeRateLimit*` settings).
+const DEFAULT_WINDOW_MS = 60_000;
+const DEFAULT_MAX_REQUESTS = 30;
+// At most one rejection warning per this interval, carrying a rejected-count,
+// so a storm is visible without flooding the log.
+const LOG_INTERVAL_MS = 10_000;
+
+function sanitizePositiveInteger(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1 ? value : fallback;
+}
+
+export class WriteRateLimiter {
+  readonly maxRequests: number;
+  readonly windowMs: number;
+  // Rolling window of recorded/reserved write timestamps. Exposed readonly for
+  // tests that assert reservation/release accounting.
+  readonly slots: Array<{ readonly recordedAt: number }> = [];
+  private lastLogAt = 0;
+  private suppressed = 0;
+
+  constructor(maxRequests?: number, windowMs?: number) {
+    this.maxRequests = sanitizePositiveInteger(maxRequests, DEFAULT_MAX_REQUESTS);
+    this.windowMs = sanitizePositiveInteger(windowMs, DEFAULT_WINDOW_MS);
+  }
+
+  private prune(now: number): void {
+    while (this.slots.length > 0 && now - (this.slots[0]?.recordedAt ?? 0) > this.windowMs) {
+      this.slots.shift();
+    }
+  }
+
+  /** True if a write may proceed. Logs a sampled warning when it may not. */
+  hasCapacity(): boolean {
+    this.prune(Date.now());
+    if (this.slots.length >= this.maxRequests) {
+      this.logRejected();
+      return false;
+    }
+    return true;
+  }
+
+  /** Record a committed write against the rolling window. */
+  record(): void {
+    this.slots.push({ recordedAt: Date.now() });
+  }
+
+  /**
+   * Reserve a slot for an in-flight write. Returns a release function, or
+   * `null` when the limit is already reached (caller raises its own 429).
+   */
+  reserve(): (() => void) | null {
+    if (!this.hasCapacity()) return null;
+    const slot = { recordedAt: Date.now() };
+    this.slots.push(slot);
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      const index = this.slots.indexOf(slot);
+      if (index >= 0) this.slots.splice(index, 1);
+    };
+  }
+
+  private logRejected(): void {
+    const now = Date.now();
+    this.suppressed += 1;
+    if (now - this.lastLogAt < LOG_INTERVAL_MS) return;
+    const rejected = this.suppressed;
+    this.suppressed = 0;
+    this.lastLogAt = now;
+    log.warn(
+      `write_rate_limited: rejected ${rejected} write(s); global limit is ` +
+        `${this.maxRequests} per ${this.windowMs}ms. Raise server.writeRateLimitMaxRequests ` +
+        `(or REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS) if sustained.`,
+    );
+  }
+}


### PR DESCRIPTION
## Problem

Per #2029, the global write rate limiter refused writes with a **bare `throw`** (`429 write_rate_limited`) and **no server-side log** — a sustained limit condition was invisible except via client-side `observe failed: write_rate_limited` warnings. The limiter also lived inline in `access-http.ts`, which is at its structural ratchet ceiling (so it couldn't grow to add logging).

## Change

- **Extract** the limiter into `write-rate-limiter.ts` (`WriteRateLimiter`: rolling-window slots, pruning, `hasCapacity` / `record` / `reserve`→release). It is transport-agnostic — it never throws `HttpError`; `access-http.ts` keeps same-named one-line delegators (`ensureWriteRateLimitAvailable` / `recordWriteRateLimitHit` / `reserveWriteRateLimitSlot`) that raise the 429, so the 30+ call sites are unchanged. `shouldCountWriteRateLimit` (stateless) stays in place.
- **Sampled rejection logging**: at most one `log.warn` per 10 s, carrying a rejected-count, naming the limit and the config/env knob to raise it. Diagnosable without flooding.
- Extraction drops `access-http.ts` below its ratchet ceiling (the addition would otherwise trip `check-ratchets`).

## Tests

- New `write-rate-limiter.test.ts`: defaults/validation, capacity + record, sampled logging (asserts a single warn across repeated refusals), reserve/refuse/release, window pruning.
- Updated the two tests that reached the old internals (`writeRequestSlots` → `writeLimiter.slots`); behavior unchanged. `preflight:quick` OK (29/29).

## Scope

Part of #2029. The remaining item — making the limit **per-principal** instead of one global bucket — builds directly on this extracted limiter and ships as a follow-up PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of existing rate-limit logic with added observability; external write-quota and 429 semantics are intentionally unchanged per tests.
> 
> **Overview**
> Moves the access HTTP **global write rate limit** out of `access-http.ts` into a dedicated **`WriteRateLimiter`** (`write-rate-limiter.ts`) with the same rolling window, defaults (30 per 60s), `hasCapacity` / `record` / `reserve`→release semantics, and config validation. **`EngramAccessHttpServer`** keeps the same private helpers and **429 `write_rate_limited`** behavior; only the implementation delegates to `writeLimiter`, so existing REST/MCP/Relay call sites stay unchanged.
> 
> **New behavior:** when the limit is hit, the limiter emits **sampled `log.warn`** (at most once per 10s with a rejected count and config/env hints) instead of refusing with no server-side trace.
> 
> Adds **`write-rate-limiter.test.ts`**; MCP cancellation and Relay mission tests now assert **`writeLimiter.slots`** instead of the removed inline `writeRequestSlots`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78d1275fa12ed84d06f36e8693096ce886f5940c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->