### PR TITLE
feat(core): per-principal write rate limit buckets (closes #2029)

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1083,7 +1083,7 @@ export class EngramAccessHttpServer {
     ) {
       this.enforceTokenOp("capsule_export"); // boundary dispatch (issue #1525)
       const body = await this.readValidatedBody(req, "capsuleExport");
-      this.ensureWriteRateLimitAvailable();
+      this.ensureWriteRateLimitAvailable(req);
       const result = await this.service.capsuleExport({
         name: body.name,
         namespace: this.resolveNamespace(req, body.namespace),
@@ -1094,7 +1094,7 @@ export class EngramAccessHttpServer {
         includeTranscripts: body.includeTranscripts,
         encrypt: body.encrypt,
       });
-      this.recordWriteRateLimitHit();
+      this.recordWriteRateLimitHit(req);
       this.respondJson(res, 200, result);
       return;
     }
@@ -1105,7 +1105,7 @@ export class EngramAccessHttpServer {
     ) {
       this.enforceTokenOp("capsule_import"); // boundary dispatch (issue #1525)
       const body = await this.readValidatedBody(req, "capsuleImport");
-      this.ensureWriteRateLimitAvailable();
+      this.ensureWriteRateLimitAvailable(req);
       const result = await this.service.capsuleImport({
         archivePath: expandTildePath(body.archivePath),
         namespace: this.resolveNamespace(req, body.namespace),
@@ -1113,7 +1113,7 @@ export class EngramAccessHttpServer {
         mode: body.mode,
         passphrase: body.passphrase,
       });
-      this.recordWriteRateLimitHit();
+      this.recordWriteRateLimitHit(req);
       this.respondJson(res, 200, result);
       return;
     }
@@ -1624,12 +1624,12 @@ export class EngramAccessHttpServer {
         // attempt may have consumed the last quota slot; the retry returns the
         // cached response without requiring another. Matches memory_store's
         // hook-in-the-lock pattern (#1434 invariant).
-        { enforceWriteQuota: () => this.ensureWriteRateLimitAvailable() },
+        { enforceWriteQuota: () => this.ensureWriteRateLimitAvailable(req) },
       );
       // A replayed (deduplicated) observe must not consume a second write-quota
       // slot — same invariant as memory_store/suggestion_submit (#1434).
       if (this.shouldCountWriteRateLimit(response as { dryRun?: boolean; idempotencyReplay?: boolean })) {
-        this.recordWriteRateLimitHit();
+        this.recordWriteRateLimitHit(req);
       }
       this.respondJson(res, 202, response);
       return;
@@ -1656,13 +1656,13 @@ export class EngramAccessHttpServer {
     ) {
       this.enforceTokenOp("lcm_compaction_flush"); // boundary dispatch (issue #1525)
       const body = await this.readValidatedBody(req, "lcmCompactionFlush");
-      this.ensureWriteRateLimitAvailable();
+      this.ensureWriteRateLimitAvailable(req);
       const response = await this.service.lcmCompactionFlush({
         sessionKey: body.sessionKey,
         namespace: this.resolveNamespace(req, body.namespace),
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
       });
-      this.recordWriteRateLimitHit();
+      this.recordWriteRateLimitHit(req);
       this.respondJson(res, 200, response);
       return;
     }
@@ -1673,7 +1673,7 @@ export class EngramAccessHttpServer {
     ) {
       this.enforceTokenOp("lcm_compaction_record"); // boundary dispatch (issue #1525)
       const body = await this.readValidatedBody(req, "lcmCompactionRecord");
-      this.ensureWriteRateLimitAvailable();
+      this.ensureWriteRateLimitAvailable(req);
       const response = await this.service.lcmCompactionRecord({
         sessionKey: body.sessionKey,
         namespace: this.resolveNamespace(req, body.namespace),
@@ -1681,7 +1681,7 @@ export class EngramAccessHttpServer {
         tokensAfter: body.tokensAfter,
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
       });
-      this.recordWriteRateLimitHit();
+      this.recordWriteRateLimitHit(req);
       this.respondJson(res, 200, response);
       return;
     }
@@ -1739,7 +1739,7 @@ export class EngramAccessHttpServer {
             authenticatedPrincipal: this.resolveRequestPrincipal(req),
             hooks: {
               enforceWriteQuota: () => {
-                releaseWriteQuota ??= this.reserveWriteRateLimitSlot();
+                releaseWriteQuota ??= this.reserveWriteRateLimitSlot(req);
               },
             },
           },
@@ -1821,14 +1821,14 @@ export class EngramAccessHttpServer {
       const output = (await op.run(envelope, {
         service: this.service,
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
-        hooks: { enforceWriteQuota: () => this.ensureWriteRateLimitAvailable() },
+        hooks: { enforceWriteQuota: () => this.ensureWriteRateLimitAvailable(req) },
         // Phase 1 provenance: server-resolved connector identity from the
         // bearer token (REST path, mirroring the MCP tools/call dispatch).
         sourceConnector: this.resolveConnector(req),
       })) as { result: EngramAccessWriteResponse };
       const response = output.result;
       if (this.shouldCountWriteRateLimit(response as { dryRun?: boolean; idempotencyReplay?: boolean })) {
-        this.recordWriteRateLimitHit();
+        this.recordWriteRateLimitHit(req);
       }
       this.respondJson(res, this.writeResponseStatus(response), response);
       return;
@@ -1846,7 +1846,7 @@ export class EngramAccessHttpServer {
       const isWriteSubcommand =
         body.subcommand === "record" || body.subcommand === "supersede";
       if (isWriteSubcommand) {
-        this.ensureWriteRateLimitAvailable();
+        this.ensureWriteRateLimitAvailable(req);
       }
       const op = getOperation("coding_decision");
       if (!op) {
@@ -1858,7 +1858,7 @@ export class EngramAccessHttpServer {
         sourceConnector: this.resolveConnector(req),
       })) as { result: unknown };
       if (isWriteSubcommand) {
-        this.recordWriteRateLimitHit();
+        this.recordWriteRateLimitHit(req);
       }
       this.respondJson(res, 200, output.result);
       return;
@@ -1871,7 +1871,7 @@ export class EngramAccessHttpServer {
       const body = await this.readJsonBody(req);
       const isWriteSubcommand = body.subcommand === "refresh";
       if (isWriteSubcommand) {
-        this.ensureWriteRateLimitAvailable();
+        this.ensureWriteRateLimitAvailable(req);
       }
       const op = getOperation("coding_architecture");
       if (!op) {
@@ -1883,7 +1883,7 @@ export class EngramAccessHttpServer {
         sourceConnector: this.resolveConnector(req),
       })) as { result: unknown };
       if (isWriteSubcommand) {
-        this.recordWriteRateLimitHit();
+        this.recordWriteRateLimitHit(req);
       }
       this.respondJson(res, 200, output.result);
       return;
@@ -1917,7 +1917,7 @@ export class EngramAccessHttpServer {
       // mirror the apply route's precheck + accounting to bound files under
       // state/corrections/pending instead of letting an HTTP client create
       // unbounded plan files without consuming write quota.
-      this.ensureWriteRateLimitAvailable();
+      this.ensureWriteRateLimitAvailable(req);
       const body = await this.readJsonBody(req);
       const op = getOperation("memory_correct_plan");
       if (!op) {
@@ -1927,13 +1927,13 @@ export class EngramAccessHttpServer {
         service: this.service,
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
       })) as { result: unknown };
-      this.recordWriteRateLimitHit();
+      this.recordWriteRateLimitHit(req);
       this.respondJson(res, 200, output.result);
       return;
     }
 
     if (req.method === "POST" && pathname === "/engram/v1/correction/apply") {
-      this.ensureWriteRateLimitAvailable();
+      this.ensureWriteRateLimitAvailable(req);
       const body = await this.readJsonBody(req);
       const op = getOperation("memory_correct_apply");
       if (!op) {
@@ -1943,7 +1943,7 @@ export class EngramAccessHttpServer {
         service: this.service,
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
       })) as { result: unknown };
-      this.recordWriteRateLimitHit();
+      this.recordWriteRateLimitHit(req);
       this.respondJson(res, 200, output.result);
       return;
     }
@@ -1996,10 +1996,10 @@ export class EngramAccessHttpServer {
       // (enforceWriteQuota), atomic with the real miss and never on a replay; no
       // HTTP pre-check, so a stale peek can't 429 a safe replay (#1434 Codex review).
       const response = await this.service.suggestionSubmit(request, {
-        enforceWriteQuota: () => this.ensureWriteRateLimitAvailable(),
+        enforceWriteQuota: () => this.ensureWriteRateLimitAvailable(req),
       });
       if (this.shouldCountWriteRateLimit(response as { dryRun?: boolean; idempotencyReplay?: boolean })) {
-        this.recordWriteRateLimitHit();
+        this.recordWriteRateLimitHit(req);
       }
       this.respondJson(res, this.writeResponseStatus(response), response);
       return;
@@ -2188,7 +2188,7 @@ export class EngramAccessHttpServer {
     if (req.method === "POST" && pathname === "/engram/v1/review-disposition") {
       this.enforceTokenOp("review_disposition"); // boundary dispatch (issue #1525)
       const body = await this.readValidatedBody(req, "reviewDisposition");
-      this.ensureWriteRateLimitAvailable();
+      this.ensureWriteRateLimitAvailable(req);
       const response = await this.service.reviewDisposition({
         memoryId: body.memoryId,
         status: body.status,
@@ -2197,7 +2197,7 @@ export class EngramAccessHttpServer {
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
       });
       if (this.shouldCountWriteRateLimit(response as unknown as { dryRun?: boolean; idempotencyReplay?: boolean })) {
-        this.recordWriteRateLimitHit();
+        this.recordWriteRateLimitHit(req);
       }
       this.respondJson(res, 200, response);
       return;
@@ -2208,7 +2208,7 @@ export class EngramAccessHttpServer {
       const body = await this.readValidatedBody(req, "trustZonePromote");
       const dryRun = body.dryRun === true;
       if (!dryRun) {
-        this.ensureWriteRateLimitAvailable();
+        this.ensureWriteRateLimitAvailable(req);
       }
       const response = await this.service.trustZonePromote({
         recordId: body.recordId,
@@ -2221,7 +2221,7 @@ export class EngramAccessHttpServer {
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
       });
       if (this.shouldCountWriteRateLimit(response as unknown as { dryRun?: boolean; idempotencyReplay?: boolean })) {
-        this.recordWriteRateLimitHit();
+        this.recordWriteRateLimitHit(req);
       }
       this.respondJson(res, response.dryRun ? 200 : 201, response);
       return;
@@ -2232,7 +2232,7 @@ export class EngramAccessHttpServer {
       const body = await this.readValidatedBody(req, "trustZoneDemoSeed");
       const dryRun = body.dryRun === true;
       if (!dryRun) {
-        this.ensureWriteRateLimitAvailable();
+        this.ensureWriteRateLimitAvailable(req);
       }
       const response = await this.service.trustZoneDemoSeed({
         scenario: body.scenario,
@@ -2242,7 +2242,7 @@ export class EngramAccessHttpServer {
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
       });
       if (this.shouldCountWriteRateLimit(response as unknown as { dryRun?: boolean; idempotencyReplay?: boolean })) {
-        this.recordWriteRateLimitHit();
+        this.recordWriteRateLimitHit(req);
       }
       this.respondJson(res, response.dryRun ? 200 : 201, response);
       return;
@@ -2817,7 +2817,7 @@ export class EngramAccessHttpServer {
       const dryRun = body.dryRun === true;
       const namespace = this.resolveNamespace(req, typeof body.namespace === "string" ? body.namespace : undefined);
       if (!dryRun) {
-        this.ensureWriteRateLimitAvailable();
+        this.ensureWriteRateLimitAvailable(req);
       }
       const result = await this.service.dreamsRun({
         phase: phase as import("./types.js").DreamsPhase,
@@ -2826,7 +2826,7 @@ export class EngramAccessHttpServer {
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
       });
       if (this.shouldCountWriteRateLimit(result as { dryRun?: boolean; idempotencyReplay?: boolean })) {
-        this.recordWriteRateLimitHit();
+        this.recordWriteRateLimitHit(req);
       }
       this.respondJson(res, 200, result);
       return;
@@ -2969,7 +2969,7 @@ export class EngramAccessHttpServer {
         // Rate-limit the promotion write, matching every other write route
         // (observe, trust-zone promotion, etc.). The check throws on limit
         // exceeded; the hit is recorded after the write succeeds.
-        this.ensureWriteRateLimitAvailable();
+        this.ensureWriteRateLimitAvailable(req);
         const result = await this.service.adminPromoteMemory({
           sourceMemoryId: body.sourceMemoryId,
           namespace: typeof body.namespace === "string" ? body.namespace : undefined,
@@ -2979,7 +2979,7 @@ export class EngramAccessHttpServer {
           reason: body.reason,
         });
         // actor is derived from the authenticated principal inside adminPromoteMemory;
-        this.recordWriteRateLimitHit();
+        this.recordWriteRateLimitHit(req);
         this.respondJson(res, 200, result);
       } catch (err) {
         if (err instanceof EngramAccessInputError) {
@@ -3236,7 +3236,7 @@ export class EngramAccessHttpServer {
     const observeSelfEnforcesQuota =
       toolName === "engram.observe" || toolName === "remnic.observe";
     if (isMcpWrite && !observeSelfEnforcesQuota) {
-      this.ensureWriteRateLimitAvailable();
+      this.ensureWriteRateLimitAvailable(req);
     }
 
     const sessionId = (() => {
@@ -3275,7 +3275,7 @@ export class EngramAccessHttpServer {
       sessionId,
       correlationId: mcpCorrelationId,
       enforceWriteQuota: observeSelfEnforcesQuota
-        ? () => this.ensureWriteRateLimitAvailable()
+        ? () => this.ensureWriteRateLimitAvailable(req)
         : undefined,
       sourceConnector: this.resolveConnector(req),
       abortSignal,
@@ -3299,7 +3299,7 @@ export class EngramAccessHttpServer {
       // dryRun/idempotencyReplay guards.
       const counts = structured ? this.shouldCountWriteRateLimit(structured) : true;
       if (!isError && !isRejectedCodegraph && counts) {
-        this.recordWriteRateLimitHit();
+        this.recordWriteRateLimitHit(req);
       }
     }
     // A mutating tool may have committed just before the client disconnected.
@@ -3859,22 +3859,26 @@ export class EngramAccessHttpServer {
     return 200;
   }
 
-  private ensureWriteRateLimitAvailable(): void {
-    if (!this.writeLimiter.hasCapacity()) {
+  private ensureWriteRateLimitAvailable(req?: IncomingMessage): void {
+    if (!this.writeLimiter.hasCapacity(this.principalForRateLimit(req))) {
       throw new HttpError(429, "write_rate_limited", "write_rate_limited");
     }
   }
 
-  private recordWriteRateLimitHit(): void {
-    this.writeLimiter.record();
+  private recordWriteRateLimitHit(req?: IncomingMessage): void {
+    this.writeLimiter.record(this.principalForRateLimit(req));
   }
 
-  private reserveWriteRateLimitSlot(): () => void {
-    const release = this.writeLimiter.reserve();
+  private reserveWriteRateLimitSlot(req?: IncomingMessage): () => void {
+    const release = this.writeLimiter.reserve(this.principalForRateLimit(req));
     if (!release) {
       throw new HttpError(429, "write_rate_limited", "write_rate_limited");
     }
     return release;
+  }
+
+  private principalForRateLimit(req?: IncomingMessage): string | undefined {
+    return req ? this.resolveRequestPrincipal(req) : undefined;
   }
 
   private shouldCountWriteRateLimit(response: { dryRun?: boolean; idempotencyReplay?: boolean }): boolean {

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -3878,7 +3878,11 @@ export class EngramAccessHttpServer {
   }
 
   private principalForRateLimit(req?: IncomingMessage): string | undefined {
-    return req ? this.resolveRequestPrincipal(req) : undefined;
+    if (!req) return undefined;
+    // Fall back to the authenticated connector identity when no principal is
+    // resolved, so per-connector bearer tokens are isolated from each other
+    // even without a principal header/server principal (issue #2029 review).
+    return this.resolveRequestPrincipal(req) ?? this.resolveConnector(req);
   }
 
   private shouldCountWriteRateLimit(response: { dryRun?: boolean; idempotencyReplay?: boolean }): boolean {

--- a/packages/remnic-core/src/access-mcp-cancellation.test.ts
+++ b/packages/remnic-core/src/access-mcp-cancellation.test.ts
@@ -282,7 +282,7 @@ test("MCP write quota is recorded after commit even when the client disconnects 
   });
   const serverHost = server as unknown as {
     mcpServer: EngramMcpServer;
-    writeLimiter: { slots: Array<{ readonly recordedAt: number }> };
+    writeLimiter: { totalSlots(): number };
   };
   const originalHandleRequest = serverHost.mcpServer.handleRequest.bind(serverHost.mcpServer);
   serverHost.mcpServer.handleRequest = async (request, options) => {
@@ -318,7 +318,7 @@ test("MCP write quota is recorded after commit even when the client disconnects 
 
     await waitFor(operationSettled.promise);
     await new Promise<void>((resolve) => setImmediate(resolve));
-    assert.equal(serverHost.writeLimiter.slots.length, 1);
+    assert.equal(serverHost.writeLimiter.totalSlots(), 1);
     assert.equal(responseStarted, false, "the disconnected client must not receive the committed write response");
   } finally {
     releaseOperation.resolve();

--- a/packages/remnic-core/src/relay/mission-access.test.ts
+++ b/packages/remnic-core/src/relay/mission-access.test.ts
@@ -367,25 +367,25 @@ test("Relay write quota releases the exact reservation when timestamps collide",
     adminConsoleEnabled: false,
   });
   const internals = server as unknown as {
-    writeLimiter: { slots: Array<{ readonly recordedAt: number }> };
+    writeLimiter: { slotsFor(principal?: string): ReadonlyArray<{ readonly recordedAt: number }> };
     reserveWriteRateLimitSlot: () => () => void;
   };
   const originalNow = Date.now;
   try {
     Date.now = () => 1_754_000_000_000;
     const releaseCommitted = internals.reserveWriteRateLimitSlot();
-    const committedSlot = internals.writeLimiter.slots[0];
+    const committedSlot = internals.writeLimiter.slotsFor()[0];
     const releaseFailed = internals.reserveWriteRateLimitSlot();
-    const failedSlot = internals.writeLimiter.slots[1];
+    const failedSlot = internals.writeLimiter.slotsFor()[1];
     assert.ok(committedSlot);
     assert.ok(failedSlot);
     assert.notEqual(committedSlot, failedSlot);
 
     releaseFailed();
-    assert.deepEqual(internals.writeLimiter.slots, [committedSlot]);
+    assert.deepEqual(internals.writeLimiter.slotsFor(), [committedSlot]);
 
     releaseCommitted();
-    assert.deepEqual(internals.writeLimiter.slots, []);
+    assert.deepEqual(internals.writeLimiter.slotsFor(), []);
   } finally {
     Date.now = originalNow;
   }

--- a/packages/remnic-core/src/write-rate-limiter.test.ts
+++ b/packages/remnic-core/src/write-rate-limiter.test.ts
@@ -73,3 +73,33 @@ test("WriteRateLimiter: buckets are isolated per principal (issue #2029)", () =>
   assert.equal(limiter.slotsFor("bob").length, 1);
   assert.equal(limiter.totalSlots(), 2, "each principal keeps its own window");
 });
+
+test("WriteRateLimiter: rolling-window end is exclusive (issue #2029 review)", () => {
+  const realNow = Date.now;
+  try {
+    let now = 1_000_000;
+    Date.now = () => now;
+    const limiter = new WriteRateLimiter(1, 1000);
+    limiter.record();
+    now += 1000; // exactly at recordedAt + windowMs
+    assert.equal(limiter.hasCapacity(), true, "a slot at the exact window end is expired");
+  } finally {
+    Date.now = realNow;
+  }
+});
+
+test("WriteRateLimiter: expired buckets from transient principals are swept globally (issue #2029 review)", () => {
+  const realNow = Date.now;
+  try {
+    let now = 1_000_000;
+    Date.now = () => now;
+    const limiter = new WriteRateLimiter(5, 1000);
+    limiter.record("ephemeral-1");
+    limiter.record("ephemeral-2");
+    assert.equal(limiter.totalSlots(), 2);
+    now += 1001; // both windows expire
+    assert.equal(limiter.totalSlots(), 0, "expired buckets are swept, not reported as live");
+  } finally {
+    Date.now = realNow;
+  }
+});

--- a/packages/remnic-core/src/write-rate-limiter.test.ts
+++ b/packages/remnic-core/src/write-rate-limiter.test.ts
@@ -40,10 +40,10 @@ test("WriteRateLimiter: reserve returns a release, refuses at the limit, frees o
   const limiter = new WriteRateLimiter(1, 60_000);
   const release = limiter.reserve();
   assert.ok(release, "first reservation succeeds");
-  assert.equal(limiter.slots.length, 1);
+  assert.equal(limiter.slotsFor().length, 1);
   assert.equal(limiter.reserve(), null, "second reservation refused at the limit");
   release?.();
-  assert.equal(limiter.slots.length, 0, "release frees the reserved slot");
+  assert.equal(limiter.slotsFor().length, 0, "release frees the reserved slot");
   assert.ok(limiter.reserve(), "capacity restored after release");
 });
 
@@ -60,4 +60,16 @@ test("WriteRateLimiter: old slots pruned after the rolling window", () => {
   } finally {
     Date.now = realNow;
   }
+});
+
+test("WriteRateLimiter: buckets are isolated per principal (issue #2029)", () => {
+  const limiter = new WriteRateLimiter(1, 60_000);
+  limiter.record("alice");
+  assert.equal(limiter.hasCapacity("alice"), false, "alice is at her own limit");
+  assert.equal(limiter.hasCapacity("bob"), true, "bob is unaffected by alice");
+  assert.equal(limiter.hasCapacity(), true, "the no-principal global bucket is separate");
+  limiter.record("bob");
+  assert.equal(limiter.slotsFor("alice").length, 1);
+  assert.equal(limiter.slotsFor("bob").length, 1);
+  assert.equal(limiter.totalSlots(), 2, "each principal keeps its own window");
 });

--- a/packages/remnic-core/src/write-rate-limiter.ts
+++ b/packages/remnic-core/src/write-rate-limiter.ts
@@ -50,8 +50,16 @@ export class WriteRateLimiter {
   }
 
   private prune(slots: Slot[], now: number): void {
-    while (slots.length > 0 && now - (slots[0]?.recordedAt ?? 0) > this.windowMs) {
+    while (slots.length > 0 && now - (slots[0]?.recordedAt ?? 0) >= this.windowMs) {
       slots.shift();
+    }
+  }
+
+  /** Prune every bucket to the current window; drop buckets that go empty. */
+  private sweep(now: number): void {
+    for (const [key, slots] of this.buckets) {
+      this.prune(slots, now);
+      if (slots.length === 0) this.buckets.delete(key);
     }
   }
 
@@ -62,6 +70,7 @@ export class WriteRateLimiter {
 
   /** Total live reservations across all principals (test/introspection). */
   totalSlots(): number {
+    this.sweep(Date.now());
     let total = 0;
     for (const slots of this.buckets.values()) total += slots.length;
     return total;
@@ -69,15 +78,10 @@ export class WriteRateLimiter {
 
   /** True if a write may proceed for the principal. Logs (sampled) when not. */
   hasCapacity(principal?: string): boolean {
+    this.sweep(Date.now());
     const key = this.key(principal);
     const slots = this.buckets.get(key);
-    if (!slots) return true;
-    this.prune(slots, Date.now());
-    if (slots.length === 0) {
-      this.buckets.delete(key);
-      return true;
-    }
-    if (slots.length >= this.maxRequests) {
+    if (slots && slots.length >= this.maxRequests) {
       this.logRejected(key);
       return false;
     }
@@ -86,6 +90,7 @@ export class WriteRateLimiter {
 
   /** Record a committed write against the principal's rolling window. */
   record(principal?: string): void {
+    this.sweep(Date.now());
     const key = this.key(principal);
     const slots = this.buckets.get(key) ?? this.buckets.set(key, []).get(key)!;
     slots.push({ recordedAt: Date.now() });

--- a/packages/remnic-core/src/write-rate-limiter.ts
+++ b/packages/remnic-core/src/write-rate-limiter.ts
@@ -1,12 +1,16 @@
 /**
- * Global write rate limiter for the access HTTP surface (issue #1937/#2029).
+ * Per-principal write rate limiter for the access HTTP surface
+ * (issues #1937 / #2029).
  *
- * Extracted from access-http.ts so the limiter is a cohesive unit (and so the
- * host file stays under its structural ceiling). Deliberately transport-
- * agnostic: it never throws `HttpError` — callers translate a refusal into
- * their own 429. It logs a sampled warning when it refuses a write, so a
- * sustained limit condition is diagnosable server-side instead of only via
- * client warnings (previously the refusal was a bare throw with no trace).
+ * Extracted from access-http.ts so the limiter is a cohesive unit. Each
+ * principal (authenticated caller identity) gets its own rolling-window
+ * bucket, so one chatty connector cannot starve writes for the others;
+ * requests with no resolved principal share a single global bucket.
+ *
+ * Deliberately transport-agnostic: it never throws `HttpError` — callers
+ * translate a refusal into their own 429. It logs a sampled warning when it
+ * refuses a write, so a sustained limit condition is diagnosable server-side
+ * (previously the refusal was a bare throw with no trace).
  */
 
 import { log } from "./logger.js";
@@ -18,6 +22,10 @@ const DEFAULT_MAX_REQUESTS = 30;
 // At most one rejection warning per this interval, carrying a rejected-count,
 // so a storm is visible without flooding the log.
 const LOG_INTERVAL_MS = 10_000;
+// Bucket key for requests with no resolved principal.
+const GLOBAL_BUCKET = "";
+
+type Slot = { readonly recordedAt: number };
 
 function sanitizePositiveInteger(value: number | undefined, fallback: number): number {
   return typeof value === "number" && Number.isInteger(value) && value >= 1 ? value : fallback;
@@ -26,9 +34,9 @@ function sanitizePositiveInteger(value: number | undefined, fallback: number): n
 export class WriteRateLimiter {
   readonly maxRequests: number;
   readonly windowMs: number;
-  // Rolling window of recorded/reserved write timestamps. Exposed readonly for
-  // tests that assert reservation/release accounting.
-  readonly slots: Array<{ readonly recordedAt: number }> = [];
+  // One rolling window per principal. Empty buckets are pruned so the map does
+  // not grow without bound.
+  private readonly buckets = new Map<string, Slot[]>();
   private lastLogAt = 0;
   private suppressed = 0;
 
@@ -37,55 +45,86 @@ export class WriteRateLimiter {
     this.windowMs = sanitizePositiveInteger(windowMs, DEFAULT_WINDOW_MS);
   }
 
-  private prune(now: number): void {
-    while (this.slots.length > 0 && now - (this.slots[0]?.recordedAt ?? 0) > this.windowMs) {
-      this.slots.shift();
+  private key(principal?: string): string {
+    return principal?.trim() ? principal.trim() : GLOBAL_BUCKET;
+  }
+
+  private prune(slots: Slot[], now: number): void {
+    while (slots.length > 0 && now - (slots[0]?.recordedAt ?? 0) > this.windowMs) {
+      slots.shift();
     }
   }
 
-  /** True if a write may proceed. Logs a sampled warning when it may not. */
-  hasCapacity(): boolean {
-    this.prune(Date.now());
-    if (this.slots.length >= this.maxRequests) {
-      this.logRejected();
+  /** Live reservation/record count for a principal (test/introspection). */
+  slotsFor(principal?: string): ReadonlyArray<Slot> {
+    return this.buckets.get(this.key(principal)) ?? [];
+  }
+
+  /** Total live reservations across all principals (test/introspection). */
+  totalSlots(): number {
+    let total = 0;
+    for (const slots of this.buckets.values()) total += slots.length;
+    return total;
+  }
+
+  /** True if a write may proceed for the principal. Logs (sampled) when not. */
+  hasCapacity(principal?: string): boolean {
+    const key = this.key(principal);
+    const slots = this.buckets.get(key);
+    if (!slots) return true;
+    this.prune(slots, Date.now());
+    if (slots.length === 0) {
+      this.buckets.delete(key);
+      return true;
+    }
+    if (slots.length >= this.maxRequests) {
+      this.logRejected(key);
       return false;
     }
     return true;
   }
 
-  /** Record a committed write against the rolling window. */
-  record(): void {
-    this.slots.push({ recordedAt: Date.now() });
+  /** Record a committed write against the principal's rolling window. */
+  record(principal?: string): void {
+    const key = this.key(principal);
+    const slots = this.buckets.get(key) ?? this.buckets.set(key, []).get(key)!;
+    slots.push({ recordedAt: Date.now() });
   }
 
   /**
    * Reserve a slot for an in-flight write. Returns a release function, or
-   * `null` when the limit is already reached (caller raises its own 429).
+   * `null` when the principal is already at the limit (caller raises its 429).
    */
-  reserve(): (() => void) | null {
-    if (!this.hasCapacity()) return null;
-    const slot = { recordedAt: Date.now() };
-    this.slots.push(slot);
+  reserve(principal?: string): (() => void) | null {
+    if (!this.hasCapacity(principal)) return null;
+    const key = this.key(principal);
+    const slots = this.buckets.get(key) ?? this.buckets.set(key, []).get(key)!;
+    const slot: Slot = { recordedAt: Date.now() };
+    slots.push(slot);
     let active = true;
     return () => {
       if (!active) return;
       active = false;
-      const index = this.slots.indexOf(slot);
-      if (index >= 0) this.slots.splice(index, 1);
+      const current = this.buckets.get(key);
+      if (!current) return;
+      const index = current.indexOf(slot);
+      if (index >= 0) current.splice(index, 1);
+      if (current.length === 0) this.buckets.delete(key);
     };
   }
 
-  private logRejected(): void {
+  private logRejected(principal: string): void {
     const now = Date.now();
     this.suppressed += 1;
     if (now - this.lastLogAt < LOG_INTERVAL_MS) return;
     const rejected = this.suppressed;
     this.suppressed = 0;
     this.lastLogAt = now;
+    const who = principal === GLOBAL_BUCKET ? "(no principal)" : principal;
     log.warn(
-      `write_rate_limited: rejected ${rejected} write(s); global limit is ` +
-        `${this.maxRequests} per ${this.windowMs}ms. Raise server.writeRateLimitMaxRequests ` +
-        `(or REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS) if sustained.`,
+      `write_rate_limited: rejected ${rejected} write(s) for principal ${who}; ` +
+        `per-principal limit is ${this.maxRequests} per ${this.windowMs}ms. Raise ` +
+        `server.writeRateLimitMaxRequests (or REMNIC_WRITE_RATE_LIMIT_MAX_REQUESTS) if sustained.`,
     );
   }
 }


### PR DESCRIPTION
## Problem

Final item of #2029: the write rate limiter used a **single global bucket**, so one chatty connector/principal could exhaust the window and starve writes for every other caller on the same daemon.

## Change

- `WriteRateLimiter` now keys its rolling window **per principal** (a `Map<principal, slots[]>`). Each principal gets an independent budget; requests with no resolved principal share a single global bucket. Empty buckets are pruned on release/expiry so the map stays bounded (principals are a small, bounded set).
- `access-http` delegators (`ensureWriteRateLimitAvailable` / `recordWriteRateLimitHit` / `reserveWriteRateLimitSlot`) take the request and resolve the principal in one place via the existing `resolveRequestPrincipal(req)`; the 36 call sites pass `req` (threaded structurally). Rejection logging now names the principal.
- New introspection: `slotsFor(principal?)` and `totalSlots()` (used by tests).

## Tests

- `write-rate-limiter.test.ts`: added a per-principal isolation case (one principal at its limit doesn't affect another or the global bucket); existing cases updated to `slotsFor()`.
- The two tests that reached limiter internals updated (`totalSlots()` / `slotsFor()`); behavior unchanged. `preflight:quick` OK (29/29).

## Scope

Closes #2029: configurability (config in `main`, env in #2030), server-side rejection logging (#2034), and per-principal isolation (this PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every gated write route and MCP mutating tools; behavior change is intentional (fairness) but mis-keying principals could over- or under-limit callers.
> 
> **Overview**
> **Write rate limiting is no longer one shared quota for the whole daemon.** `WriteRateLimiter` keeps a separate rolling window per caller key (principal or connector), so one noisy client cannot exhaust the 30/min budget for everyone else. Requests with no resolved identity still use a single shared fallback bucket.
> 
> **HTTP and MCP write paths now pass the incoming request into quota checks and accounting.** `ensureWriteRateLimitAvailable`, `recordWriteRateLimitHit`, and `reserveWriteRateLimitSlot` resolve the bucket via `principalForRateLimit(req)` (request principal, else bearer connector). Rejection logs name the principal.
> 
> The limiter also treats the window end as exclusive, sweeps expired per-principal buckets, and exposes `slotsFor(principal?)` / `totalSlots()` for tests instead of a global `slots` array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2d66aa419f58a94d9291a3913cbb26701a8525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Write-rate limits are now enforced per principal (with a shared fallback when no principal is available), using the requesting identity for consistent quota behavior.
  * Reserved write capacity is released correctly on cancellation, disconnects, and failures.
  * MCP tools/observations and other write operations now apply the same principal-specific quota consistently.
* **Tests**
  * Updated existing quota-related assertions and added coverage for principal isolation, rolling-window expiry boundaries, and cleanup behavior after rate-limit windows lapse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->