### PR TITLE
test(bench): fix flaky late-replay-write cleanup test source identity

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -869,7 +869,7 @@ test("direct adapter cleans up late replay writes after timeout abort", async ()
     await this.storage.writeMemory(
       "fact",
       "Remember the aborted late replay code is garnet-99.",
-      { source: "extraction" },
+      { source: benchReplaySourceForTest(sessionId) },
     );
     lateWriteFinished = true;
   };


### PR DESCRIPTION
## Problem

The bench adapter test `direct adapter cleans up late replay writes after timeout abort` (`packages/bench/src/adapters/remnic-adapter.test.ts`) intermittently fails in CI, blocking required quality checks on unrelated PRs.

## Root cause

The test simulates a replay write that lands *after* a timeout abort, then asserts the adapter's post-abort cleanup removes it. The simulated write was created with `{ source: "extraction" }`.

Production cleanup (`cleanupAfterAbortedReplay` in `remnic-adapter.ts`) only removes a late memory when its `frontmatter.source` equals `benchCoreMemorySource(sessionId)`, i.e. `bench-replay-<sha256(sessionId).slice(0,16)>`. A write tagged `"extraction"` is never a target of that source-scoped cleanup, so whether the assertion held depended on timing rather than on the behavior under test — the flake.

## Source-identity contract

Bench replay writes carry a deterministic, session-derived source identity:

- Production: `benchCoreMemorySource(sessionId)` in `remnic-adapter.ts`
- Test mirror: the existing `benchReplaySourceForTest(sessionId)` helper in the test file

The abort cleanup keys off exactly this identity to distinguish replay-created memories from baseline/other-session memories. A test that exercises this cleanup must produce a write with the same identity, or it is not testing the real path.

## Change

Test-only, one line: the simulated late write now uses `benchReplaySourceForTest(sessionId)` instead of the literal `"extraction"`, matching the production replay source identity that cleanup targets. The test's structure and assertions (late write is removed; the preserved session's memory survives) are unchanged. No production behavior changes.

## Verification

Focused test, run 6x (1 + 5 repeats), all pass:

```
NODE_OPTIONS="--conditions=remnic-source" pnpm exec tsx --test \
  --test-name-pattern="direct adapter cleans up late replay writes after timeout abort" \
  packages/bench/src/adapters/remnic-adapter.test.ts
# pass 1 / fail 0  (x6)
```

Diff is a single file, `+1 -1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line test change with no production code touched.
> 
> **Overview**
> Fixes a **flaky** bench adapter test for **post-timeout abort cleanup** of late replay writes.
> 
> The mocked late `writeMemory` now tags memories with `benchReplaySourceForTest(sessionId)` instead of the literal `"extraction"`, matching production’s session-derived replay source (`benchCoreMemorySource`) that `cleanupAfterAbortedReplay` uses to remove replay-created memories. **Test-only**; no production behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2815a78fe3d3b35b79d4cf021111cd547a61d44a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated a replay cleanup test to tag late-replay writes with the correct session-specific source, improving alignment with expected cleanup behavior.
  * Enhanced timeout-abort cleanup assertions to check for the appropriate late-write conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->