### PR TITLE
fix(memory_search): reach base collection on scope-profile deployments (#2018)

### DIFF
--- a/packages/remnic-core/src/access-memory-search-fanout.test.ts
+++ b/packages/remnic-core/src/access-memory-search-fanout.test.ts
@@ -73,28 +73,39 @@ function profilePlan(overrides: Partial<ResolvedScopeProfilePlan> = {}): Resolve
 // Wrapper that defaults defaultAtFlatRoot=true so each gate condition is
 // exercised independently (a `null` result means a NON-flat-root gate blocked,
 // not the flat-root gate). The dedicated flat-root-false test covers that gate.
-function applyFallback(
+// `probed` records whether the provider was invoked, so the lazy-probe tests
+// can assert ineligible profiles never touch the default store.
+async function applyFallback(
   plan: ResolvedScopeProfilePlan,
   config: PluginConfig,
   principal: string | undefined,
   defaultAtFlatRoot = true,
-): string | null {
-  return resolveMemorySearchDefaultFallback({ profilePlan: plan, config, principal, defaultAtFlatRoot });
+  probed: { value: boolean } = { value: false },
+): Promise<{ fallback: string | null; probed: boolean }> {
+  const result = await resolveMemorySearchDefaultFallback({
+    profilePlan: plan,
+    config,
+    principal,
+    defaultAtFlatRootProvider: () => {
+      probed.value = true;
+      return Promise.resolve(defaultAtFlatRoot);
+    },
+  });
+  return { fallback: result, probed: probed.value };
 }
 
-test("resolveMemorySearchDefaultFallback returns the default namespace on a flat-root legacy deployment (#2018)", () => {
-  const fallback = applyFallback(profilePlan(), pluginConfig(), "operator-x");
+test("resolveMemorySearchDefaultFallback returns the default namespace on a flat-root legacy deployment (#2018)", async () => {
+  const { fallback, probed } = await applyFallback(profilePlan(), pluginConfig(), "operator-x");
   assert.equal(fallback, "default");
+  assert.equal(probed, true, "the flat-root provider must be probed when cheap gates pass");
 });
 
-test("resolveMemorySearchDefaultFallback returns null when the default namespace is not at the flat root (#2056 r4)", () => {
-  // Hosted scope-profile deployment: default lives under namespaces/<default>,
-  // so reaching it would mix memories across the profile stack.
-  const fallback = applyFallback(profilePlan(), pluginConfig(), "operator-x", false);
+test("resolveMemorySearchDefaultFallback returns null when the default namespace is not at the flat root (#2056 r4)", async () => {
+  const { fallback } = await applyFallback(profilePlan(), pluginConfig(), "operator-x", false);
   assert.equal(fallback, null);
 });
 
-test("resolveMemorySearchDefaultFallback returns null for a project-only lockdown (#1501)", () => {
+test("resolveMemorySearchDefaultFallback returns null for a project-only lockdown and never probes storage (#1501, #2056 r6)", async () => {
   const plan = profilePlan({
     profile: {
       readOrder: ["userProject"],
@@ -108,16 +119,17 @@ test("resolveMemorySearchDefaultFallback returns null for a project-only lockdow
       },
     },
   });
-  const fallback = applyFallback(plan, pluginConfig(), "operator-x");
+  const { fallback, probed } = await applyFallback(plan, pluginConfig(), "operator-x");
+  assert.equal(fallback, null);
+  assert.equal(probed, false, "ineligible profiles must not probe the default store");
+});
+
+test("resolveMemorySearchDefaultFallback returns null when the profile self is already the default", async () => {
+  const { fallback } = await applyFallback(profilePlan({ baseNamespace: "default" }), pluginConfig(), "default");
   assert.equal(fallback, null);
 });
 
-test("resolveMemorySearchDefaultFallback returns null when the profile self is already the default", () => {
-  const fallback = applyFallback(profilePlan({ baseNamespace: "default" }), pluginConfig(), "default");
-  assert.equal(fallback, null);
-});
-
-test("resolveMemorySearchDefaultFallback returns null when only serverShared (no userGlobal) is in readOrder", () => {
+test("resolveMemorySearchDefaultFallback returns null when only serverShared (no userGlobal) is in readOrder", async () => {
   // serverShared maps to sharedNamespace, NOT the default: a profile that
   // reads only userProject + serverShared deliberately reads the shared
   // namespace, not the default, so the fallback must not fire.
@@ -134,16 +146,14 @@ test("resolveMemorySearchDefaultFallback returns null when only serverShared (no
       },
     },
   });
-  const fallback = applyFallback(plan, pluginConfig(), "operator-x");
+  const { fallback } = await applyFallback(plan, pluginConfig(), "operator-x");
   assert.equal(fallback, null);
 });
 
-test("resolveMemorySearchDefaultFallback returns null when readOrder omits userGlobal even if a readable userGlobal layer is materialized (#2056 r3)", () => {
+test("resolveMemorySearchDefaultFallback returns null when readOrder omits userGlobal even if a readable userGlobal layer is materialized (#2056 r3)", async () => {
   // resolveScopeProfilePlan always materializes a userGlobal layer regardless
-  // of readOrder (scope-profiles.ts adds "userGlobal" to layerIds
-  // unconditionally). A profile that intentionally omits userGlobal from
-  // readOrder must not get the default-namespace fallback just because the
-  // materialized layer resolved readable — consent lives in readOrder.
+  // of readOrder. A profile that intentionally omits userGlobal from readOrder
+  // must not get the fallback just because the materialized layer is readable.
   const plan = profilePlan({
     profile: {
       readOrder: ["userProject"],
@@ -161,22 +171,22 @@ test("resolveMemorySearchDefaultFallback returns null when readOrder omits userG
       { id: "userGlobal", kind: "user-global", namespace: "operator-x", readable: true, writable: true, promotable: true, reason: "materialized but not in readOrder" },
     ],
   });
-  const fallback = applyFallback(plan, pluginConfig(), "operator-x");
+  const { fallback } = await applyFallback(plan, pluginConfig(), "operator-x");
   assert.equal(fallback, null);
 });
 
-test("resolveMemorySearchDefaultFallback ACL-gates the default namespace", () => {
+test("resolveMemorySearchDefaultFallback ACL-gates the default namespace", async () => {
   const config = pluginConfig({
     defaultNamespace: "root",
     namespacePolicies: [
       { name: "root", readPrincipals: ["owner"], writePrincipals: ["owner"] },
     ],
   } as Partial<PluginConfig>);
-  const fallback = applyFallback(profilePlan(), config, "operator-x");
+  const { fallback } = await applyFallback(profilePlan(), config, "operator-x");
   assert.equal(fallback, null);
 });
 
-test("resolveMemorySearchDefaultFallback returns null when the resolved userGlobal layer is unreadable (#2056 r2)", () => {
+test("resolveMemorySearchDefaultFallback returns null when the resolved userGlobal layer is unreadable (#2056 r2)", async () => {
   // userGlobal is listed in readOrder but resolved unreadable (e.g. a policy
   // withholding the principal): a deliberate omission must not trigger the
   // fallback.
@@ -185,11 +195,11 @@ test("resolveMemorySearchDefaultFallback returns null when the resolved userGlob
       { id: "userGlobal", kind: "user-global", namespace: "operator-x", readable: false, writable: false, promotable: false, reason: "policy withholds principal" },
     ],
   });
-  const fallback = applyFallback(plan, pluginConfig(), "operator-x");
+  const { fallback } = await applyFallback(plan, pluginConfig(), "operator-x");
   assert.equal(fallback, null);
 });
 
-test("resolveMemorySearchDefaultFallback returns null when the principal owns a dedicated namespace (#2056 r2 / #1501 privateOnly)", () => {
+test("resolveMemorySearchDefaultFallback returns null when the principal owns a dedicated namespace (#2056 r2 / #1501 privateOnly)", async () => {
   // Multi-tenant scope-profile deployment: the principal has its own policy,
   // so its self namespace is NOT the configured default. Reaching into the
   // default would read another namespace — the fallback must not fire even
@@ -199,7 +209,7 @@ test("resolveMemorySearchDefaultFallback returns null when the principal owns a 
       { name: "operator-x", readPrincipals: ["operator-x"], writePrincipals: ["operator-x"] },
     ],
   } as Partial<PluginConfig>);
-  const fallback = applyFallback(profilePlan(), config, "operator-x");
+  const { fallback } = await applyFallback(profilePlan(), config, "operator-x");
   assert.equal(fallback, null);
 });
 

--- a/packages/remnic-core/src/access-memory-search-fanout.test.ts
+++ b/packages/remnic-core/src/access-memory-search-fanout.test.ts
@@ -30,7 +30,7 @@ function profilePlan(overrides: Partial<ResolvedScopeProfilePlan> = {}): Resolve
         enabled: false,
         targets: ["userGlobal"],
         categories: ["fact"],
-        minConfidenceTier: "medium",
+        minConfidenceTier: "inferred",
       },
     },
     baseNamespace: "operator-x",
@@ -80,6 +80,31 @@ test("resolveMemorySearchDefaultFallback returns null when the profile self is a
     profilePlan: profilePlan({ baseNamespace: "default" }),
     config: pluginConfig(),
     principal: "default",
+  });
+  assert.equal(fallback, null);
+});
+
+test("resolveMemorySearchDefaultFallback returns null when only serverShared (no userGlobal) is in readOrder", () => {
+  // serverShared maps to sharedNamespace, NOT the default: a profile that
+  // reads only userProject + serverShared deliberately reads the shared
+  // namespace, not the default, so the fallback must not fire.
+  const plan = profilePlan({
+    profile: {
+      readOrder: ["userProject", "serverShared"],
+      writeDefault: "userProject",
+      promotionTargets: ["serverShared"],
+      autoPromote: {
+        enabled: false,
+        targets: ["serverShared"],
+        categories: ["fact"],
+        minConfidenceTier: "inferred",
+      },
+    },
+  });
+  const fallback = resolveMemorySearchDefaultFallback({
+    profilePlan: plan,
+    config: pluginConfig(),
+    principal: "operator-x",
   });
   assert.equal(fallback, null);
 });

--- a/packages/remnic-core/src/access-memory-search-fanout.test.ts
+++ b/packages/remnic-core/src/access-memory-search-fanout.test.ts
@@ -20,10 +20,34 @@ function pluginConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
 }
 
 function profilePlan(overrides: Partial<ResolvedScopeProfilePlan> = {}): ResolvedScopeProfilePlan {
+  const base = overrides.baseNamespace ?? "operator-x";
+  const readOrder = overrides.profile?.readOrder ?? ["userProject", "userGlobal", "serverShared"];
+  // Build a layer per readOrder entry so the resolved-userGlobal-readable gate
+  // mirrors what resolveScopeProfilePlan produces (the unit under test reads
+  // profilePlan.layers, not the raw readOrder).
+  const layerKind: Record<string, "user-project" | "user-global" | "server-shared"> = {
+    userProject: "user-project",
+    userGlobal: "user-global",
+    serverShared: "server-shared",
+  };
+  const layerNamespace: Record<string, string> = {
+    userProject: `${base}-project`,
+    userGlobal: base,
+    serverShared: "shared",
+  };
+  const layers = readOrder.map((id) => ({
+    id,
+    kind: layerKind[id],
+    namespace: layerNamespace[id],
+    readable: true,
+    writable: id === "userProject",
+    promotable: id === "userGlobal",
+    reason: "test fixture",
+  }));
   return {
     profileId: "standard",
     profile: {
-      readOrder: ["userProject", "userGlobal", "serverShared"],
+      readOrder,
       writeDefault: "userProject",
       promotionTargets: ["userGlobal", "serverShared"],
       autoPromote: {
@@ -33,15 +57,18 @@ function profilePlan(overrides: Partial<ResolvedScopeProfilePlan> = {}): Resolve
         minConfidenceTier: "inferred",
       },
     },
-    baseNamespace: "operator-x",
+    baseNamespace: base,
     writeLayer: "userProject",
     writeNamespace: "",
-    readNamespaces: ["operator-x", "shared"],
-    layers: [],
+    readNamespaces: [base, "shared"],
+
     promotionTargets: [],
     warnings: [],
     ...overrides,
-  } as ResolvedScopeProfilePlan;
+    // Recompute layers from the (possibly overridden) readOrder/baseNamespace
+    // unless the caller supplied their own.
+    layers: overrides.layers ?? layers,
+  } as unknown as ResolvedScopeProfilePlan;
 }
 
 test("resolveMemorySearchDefaultFallback returns the default namespace when a global layer is intended and self resolved away (#2018)", () => {
@@ -114,6 +141,41 @@ test("resolveMemorySearchDefaultFallback ACL-gates the default namespace", () =>
     defaultNamespace: "root",
     namespacePolicies: [
       { name: "root", readPrincipals: ["owner"], writePrincipals: ["owner"] },
+    ],
+  } as Partial<PluginConfig>);
+  const fallback = resolveMemorySearchDefaultFallback({
+    profilePlan: profilePlan(),
+    config,
+    principal: "operator-x",
+  });
+  assert.equal(fallback, null);
+});
+
+test("resolveMemorySearchDefaultFallback returns null when the resolved userGlobal layer is unreadable (#2056 r2)", () => {
+  // userGlobal is listed in readOrder but resolved unreadable (e.g. a policy
+  // withholding the principal): a deliberate omission must not trigger the
+  // fallback.
+  const plan = profilePlan({
+    layers: [
+      { id: "userGlobal", kind: "user-global", namespace: "operator-x", readable: false, writable: false, promotable: false, reason: "policy withholds principal" },
+    ],
+  });
+  const fallback = resolveMemorySearchDefaultFallback({
+    profilePlan: plan,
+    config: pluginConfig(),
+    principal: "operator-x",
+  });
+  assert.equal(fallback, null);
+});
+
+test("resolveMemorySearchDefaultFallback returns null when the principal owns a dedicated namespace (#2056 r2 / #1501 privateOnly)", () => {
+  // Multi-tenant scope-profile deployment: the principal has its own policy,
+  // so its self namespace is NOT the configured default. Reaching into the
+  // default would read another namespace — the fallback must not fire even
+  // though userGlobal is readable and baseNamespace differs from default.
+  const config = pluginConfig({
+    namespacePolicies: [
+      { name: "operator-x", readPrincipals: ["operator-x"], writePrincipals: ["operator-x"] },
     ],
   } as Partial<PluginConfig>);
   const fallback = resolveMemorySearchDefaultFallback({

--- a/packages/remnic-core/src/access-memory-search-fanout.test.ts
+++ b/packages/remnic-core/src/access-memory-search-fanout.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  mergeMemorySearchDefaultFallback,
+  resolveMemorySearchDefaultFallback,
+} from "./access-memory-search-fanout.js";
+import type { ResolvedScopeProfilePlan } from "./namespaces/scope-profiles.js";
+import type { PluginConfig } from "./types.js";
+
+function pluginConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
+  return {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    memoryDir: "/synthetic/mem",
+    ...overrides,
+  } as unknown as PluginConfig;
+}
+
+function profilePlan(overrides: Partial<ResolvedScopeProfilePlan> = {}): ResolvedScopeProfilePlan {
+  return {
+    profileId: "standard",
+    profile: {
+      readOrder: ["userProject", "userGlobal", "serverShared"],
+      writeDefault: "userProject",
+      promotionTargets: ["userGlobal", "serverShared"],
+      autoPromote: {
+        enabled: false,
+        targets: ["userGlobal"],
+        categories: ["fact"],
+        minConfidenceTier: "medium",
+      },
+    },
+    baseNamespace: "operator-x",
+    writeLayer: "userProject",
+    writeNamespace: "",
+    readNamespaces: ["operator-x", "shared"],
+    layers: [],
+    promotionTargets: [],
+    warnings: [],
+    ...overrides,
+  } as ResolvedScopeProfilePlan;
+}
+
+test("resolveMemorySearchDefaultFallback returns the default namespace when a global layer is intended and self resolved away (#2018)", () => {
+  const fallback = resolveMemorySearchDefaultFallback({
+    profilePlan: profilePlan(),
+    config: pluginConfig(),
+    principal: "operator-x",
+  });
+  assert.equal(fallback, "default");
+});
+
+test("resolveMemorySearchDefaultFallback returns null for a project-only lockdown (#1501)", () => {
+  const plan = profilePlan({
+    profile: {
+      readOrder: ["userProject"],
+      writeDefault: "userProject",
+      promotionTargets: [],
+      autoPromote: {
+        enabled: false,
+        targets: [],
+        categories: ["fact"],
+        minConfidenceTier: "explicit",
+      },
+    },
+  });
+  const fallback = resolveMemorySearchDefaultFallback({
+    profilePlan: plan,
+    config: pluginConfig(),
+    principal: "operator-x",
+  });
+  assert.equal(fallback, null);
+});
+
+test("resolveMemorySearchDefaultFallback returns null when the profile self is already the default", () => {
+  const fallback = resolveMemorySearchDefaultFallback({
+    profilePlan: profilePlan({ baseNamespace: "default" }),
+    config: pluginConfig(),
+    principal: "default",
+  });
+  assert.equal(fallback, null);
+});
+
+test("resolveMemorySearchDefaultFallback ACL-gates the default namespace", () => {
+  const config = pluginConfig({
+    defaultNamespace: "root",
+    namespacePolicies: [
+      { name: "root", readPrincipals: ["owner"], writePrincipals: ["owner"] },
+    ],
+  } as Partial<PluginConfig>);
+  const fallback = resolveMemorySearchDefaultFallback({
+    profilePlan: profilePlan(),
+    config,
+    principal: "operator-x",
+  });
+  assert.equal(fallback, null);
+});
+
+test("mergeMemorySearchDefaultFallback dedupes and passes through", () => {
+  assert.deepEqual(mergeMemorySearchDefaultFallback(["a", "b"], "default"), ["a", "b", "default"]);
+  assert.deepEqual(mergeMemorySearchDefaultFallback(["default", "b"], "default"), ["default", "b"]);
+  assert.deepEqual(mergeMemorySearchDefaultFallback(["a", "b"], null), ["a", "b"]);
+});

--- a/packages/remnic-core/src/access-memory-search-fanout.test.ts
+++ b/packages/remnic-core/src/access-memory-search-fanout.test.ts
@@ -136,6 +136,37 @@ test("resolveMemorySearchDefaultFallback returns null when only serverShared (no
   assert.equal(fallback, null);
 });
 
+test("resolveMemorySearchDefaultFallback returns null when readOrder omits userGlobal even if a readable userGlobal layer is materialized (#2056 r3)", () => {
+  // resolveScopeProfilePlan always materializes a userGlobal layer regardless
+  // of readOrder (scope-profiles.ts adds \"userGlobal\" to layerIds
+  // unconditionally). A profile that intentionally omits userGlobal from
+  // readOrder must not get the default-namespace fallback just because the
+  // materialized layer resolved readable — consent lives in readOrder.
+  const plan = profilePlan({
+    profile: {
+      readOrder: ["userProject"],
+      writeDefault: "userProject",
+      promotionTargets: [],
+      autoPromote: {
+        enabled: false,
+        targets: [],
+        categories: ["fact"],
+        minConfidenceTier: "explicit",
+      },
+    },
+    layers: [
+      { id: "userProject", kind: "user-project", namespace: "operator-x-project", readable: false, writable: false, promotable: false, reason: "no coding context" },
+      { id: "userGlobal", kind: "user-global", namespace: "operator-x", readable: true, writable: true, promotable: true, reason: "materialized but not in readOrder" },
+    ],
+  });
+  const fallback = resolveMemorySearchDefaultFallback({
+    profilePlan: plan,
+    config: pluginConfig(),
+    principal: "operator-x",
+  });
+  assert.equal(fallback, null);
+});
+
 test("resolveMemorySearchDefaultFallback ACL-gates the default namespace", () => {
   const config = pluginConfig({
     defaultNamespace: "root",

--- a/packages/remnic-core/src/access-memory-search-fanout.test.ts
+++ b/packages/remnic-core/src/access-memory-search-fanout.test.ts
@@ -61,7 +61,6 @@ function profilePlan(overrides: Partial<ResolvedScopeProfilePlan> = {}): Resolve
     writeLayer: "userProject",
     writeNamespace: "",
     readNamespaces: [base, "shared"],
-
     promotionTargets: [],
     warnings: [],
     ...overrides,
@@ -71,13 +70,28 @@ function profilePlan(overrides: Partial<ResolvedScopeProfilePlan> = {}): Resolve
   } as unknown as ResolvedScopeProfilePlan;
 }
 
-test("resolveMemorySearchDefaultFallback returns the default namespace when a global layer is intended and self resolved away (#2018)", () => {
-  const fallback = resolveMemorySearchDefaultFallback({
-    profilePlan: profilePlan(),
-    config: pluginConfig(),
-    principal: "operator-x",
-  });
+// Wrapper that defaults defaultAtFlatRoot=true so each gate condition is
+// exercised independently (a `null` result means a NON-flat-root gate blocked,
+// not the flat-root gate). The dedicated flat-root-false test covers that gate.
+function applyFallback(
+  plan: ResolvedScopeProfilePlan,
+  config: PluginConfig,
+  principal: string | undefined,
+  defaultAtFlatRoot = true,
+): string | null {
+  return resolveMemorySearchDefaultFallback({ profilePlan: plan, config, principal, defaultAtFlatRoot });
+}
+
+test("resolveMemorySearchDefaultFallback returns the default namespace on a flat-root legacy deployment (#2018)", () => {
+  const fallback = applyFallback(profilePlan(), pluginConfig(), "operator-x");
   assert.equal(fallback, "default");
+});
+
+test("resolveMemorySearchDefaultFallback returns null when the default namespace is not at the flat root (#2056 r4)", () => {
+  // Hosted scope-profile deployment: default lives under namespaces/<default>,
+  // so reaching it would mix memories across the profile stack.
+  const fallback = applyFallback(profilePlan(), pluginConfig(), "operator-x", false);
+  assert.equal(fallback, null);
 });
 
 test("resolveMemorySearchDefaultFallback returns null for a project-only lockdown (#1501)", () => {
@@ -94,20 +108,12 @@ test("resolveMemorySearchDefaultFallback returns null for a project-only lockdow
       },
     },
   });
-  const fallback = resolveMemorySearchDefaultFallback({
-    profilePlan: plan,
-    config: pluginConfig(),
-    principal: "operator-x",
-  });
+  const fallback = applyFallback(plan, pluginConfig(), "operator-x");
   assert.equal(fallback, null);
 });
 
 test("resolveMemorySearchDefaultFallback returns null when the profile self is already the default", () => {
-  const fallback = resolveMemorySearchDefaultFallback({
-    profilePlan: profilePlan({ baseNamespace: "default" }),
-    config: pluginConfig(),
-    principal: "default",
-  });
+  const fallback = applyFallback(profilePlan({ baseNamespace: "default" }), pluginConfig(), "default");
   assert.equal(fallback, null);
 });
 
@@ -128,17 +134,13 @@ test("resolveMemorySearchDefaultFallback returns null when only serverShared (no
       },
     },
   });
-  const fallback = resolveMemorySearchDefaultFallback({
-    profilePlan: plan,
-    config: pluginConfig(),
-    principal: "operator-x",
-  });
+  const fallback = applyFallback(plan, pluginConfig(), "operator-x");
   assert.equal(fallback, null);
 });
 
 test("resolveMemorySearchDefaultFallback returns null when readOrder omits userGlobal even if a readable userGlobal layer is materialized (#2056 r3)", () => {
   // resolveScopeProfilePlan always materializes a userGlobal layer regardless
-  // of readOrder (scope-profiles.ts adds \"userGlobal\" to layerIds
+  // of readOrder (scope-profiles.ts adds "userGlobal" to layerIds
   // unconditionally). A profile that intentionally omits userGlobal from
   // readOrder must not get the default-namespace fallback just because the
   // materialized layer resolved readable — consent lives in readOrder.
@@ -159,11 +161,7 @@ test("resolveMemorySearchDefaultFallback returns null when readOrder omits userG
       { id: "userGlobal", kind: "user-global", namespace: "operator-x", readable: true, writable: true, promotable: true, reason: "materialized but not in readOrder" },
     ],
   });
-  const fallback = resolveMemorySearchDefaultFallback({
-    profilePlan: plan,
-    config: pluginConfig(),
-    principal: "operator-x",
-  });
+  const fallback = applyFallback(plan, pluginConfig(), "operator-x");
   assert.equal(fallback, null);
 });
 
@@ -174,11 +172,7 @@ test("resolveMemorySearchDefaultFallback ACL-gates the default namespace", () =>
       { name: "root", readPrincipals: ["owner"], writePrincipals: ["owner"] },
     ],
   } as Partial<PluginConfig>);
-  const fallback = resolveMemorySearchDefaultFallback({
-    profilePlan: profilePlan(),
-    config,
-    principal: "operator-x",
-  });
+  const fallback = applyFallback(profilePlan(), config, "operator-x");
   assert.equal(fallback, null);
 });
 
@@ -191,11 +185,7 @@ test("resolveMemorySearchDefaultFallback returns null when the resolved userGlob
       { id: "userGlobal", kind: "user-global", namespace: "operator-x", readable: false, writable: false, promotable: false, reason: "policy withholds principal" },
     ],
   });
-  const fallback = resolveMemorySearchDefaultFallback({
-    profilePlan: plan,
-    config: pluginConfig(),
-    principal: "operator-x",
-  });
+  const fallback = applyFallback(plan, pluginConfig(), "operator-x");
   assert.equal(fallback, null);
 });
 
@@ -209,11 +199,7 @@ test("resolveMemorySearchDefaultFallback returns null when the principal owns a 
       { name: "operator-x", readPrincipals: ["operator-x"], writePrincipals: ["operator-x"] },
     ],
   } as Partial<PluginConfig>);
-  const fallback = resolveMemorySearchDefaultFallback({
-    profilePlan: profilePlan(),
-    config,
-    principal: "operator-x",
-  });
+  const fallback = applyFallback(profilePlan(), config, "operator-x");
   assert.equal(fallback, null);
 });
 

--- a/packages/remnic-core/src/access-memory-search-fanout.ts
+++ b/packages/remnic-core/src/access-memory-search-fanout.ts
@@ -35,8 +35,23 @@ export function resolveMemorySearchDefaultFallback(options: {
   profilePlan: ResolvedScopeProfilePlan;
   config: PluginConfig;
   principal: string | undefined;
+  /**
+   * True only when the configured default namespace's storage root equals
+   * `config.memoryDir` (the legacy flat-root layout), i.e. the bulk corpus
+   * genuinely lives under the default namespace's base collection. This is
+   * the explicit legacy-flat-root/migration signal — without it the fallback
+   * must not fire, so a hosted scope-profile deployment (per-principal
+   * self namespaces, default under `namespaces/<default>`) never reaches
+   * into the default corpus (#2056 r4).
+   */
+  defaultAtFlatRoot: boolean;
 }): string | null {
-  const { profilePlan, config, principal } = options;
+  const { profilePlan, config, principal, defaultAtFlatRoot } = options;
+  // Defense-in-depth: principalSelfIsDefault is only ever true alongside
+  // defaultAtFlatRoot on legacy flat-root deployments (a hosted scope-profile
+  // principal with its own policy fails this even when default is at the flat
+  // root). It is NOT redundant — it keeps a policy-having principal isolated
+  // from the flat default corpus.
   const principalSelfIsDefault =
     defaultNamespaceForPrincipal(principal, config) === config.defaultNamespace;
   // readOrder must explicitly intend userGlobal (resolveScopeProfilePlan
@@ -52,6 +67,7 @@ export function resolveMemorySearchDefaultFallback(options: {
   const selfResolvedAwayFromDefault =
     profilePlan.baseNamespace !== config.defaultNamespace;
   if (
+    defaultAtFlatRoot &&
     profileIntendsUserGlobal &&
     userGlobalLayerReadable &&
     principalSelfIsDefault &&
@@ -61,6 +77,20 @@ export function resolveMemorySearchDefaultFallback(options: {
     return config.defaultNamespace;
   }
   return null;
+}
+
+/**
+ * Issue #2018 r4: the explicit legacy-flat-root signal — the configured
+ * default namespace's storage root equals `config.memoryDir`. Resolved from
+ * storage (not inferred from config/policy shape) so a hosted scope-profile
+ * deployment never reaches into the default corpus.
+ */
+export async function defaultNamespaceAtFlatRoot(
+  getStorage: (namespace: string) => Promise<{ dir: string }>,
+  config: { defaultNamespace: string; memoryDir: string },
+): Promise<boolean> {
+  const storage = await getStorage(config.defaultNamespace);
+  return storage.dir === config.memoryDir;
 }
 
 /**

--- a/packages/remnic-core/src/access-memory-search-fanout.ts
+++ b/packages/remnic-core/src/access-memory-search-fanout.ts
@@ -17,8 +17,11 @@ import type { PluginConfig } from "./types.js";
  * narrow profile (#1501 project-only lockdown) or the read ACL says otherwise.
  *
  * Conditions for including the default namespace:
- *   - the profile intends a global/shared read layer (`readOrder` includes
- *     `userGlobal` or `serverShared`), so a project-only lockdown is honored;
+ *   - the profile intends the principal's own global read layer (`readOrder`
+ *     includes `userGlobal`). `serverShared` maps to `sharedNamespace`, NOT
+ *     the default, so it must not trigger this fallback — a
+ *     `["userProject", "serverShared"]` profile deliberately reads only the
+ *     shared namespace, not the default;
  *   - the profile resolved the principal's self namespace AWAY from the
  *     configured default (otherwise it is already in the set);
  *   - the principal is authorized to read the default namespace.
@@ -32,8 +35,7 @@ export function resolveMemorySearchDefaultFallback(options: {
 }): string | null {
   const { profilePlan, config, principal } = options;
   const profileAllowsGlobalLayer =
-    profilePlan.profile.readOrder.includes("userGlobal") ||
-    profilePlan.profile.readOrder.includes("serverShared");
+    profilePlan.profile.readOrder.includes("userGlobal");
   const selfResolvedAwayFromDefault =
     profilePlan.baseNamespace !== config.defaultNamespace;
   if (

--- a/packages/remnic-core/src/access-memory-search-fanout.ts
+++ b/packages/remnic-core/src/access-memory-search-fanout.ts
@@ -1,0 +1,118 @@
+import { canReadNamespace } from "./namespaces/principal.js";
+import type { ResolvedScopeProfilePlan } from "./namespaces/scope-profiles.js";
+import { log } from "./logger.js";
+import type { SearchDegradation, SearchExecutionOptions } from "./search/port.js";
+import type { PluginConfig } from "./types.js";
+
+/**
+ * Issue #2018: `memory_search` has no sessionKey, so — unlike recall — it
+ * cannot resolve a coding overlay. With scope profiles active and no overlay,
+ * `expandScopeProfileReadNamespaces` derives a per-principal self namespace.
+ * On a legacy flat-root deployment the corpus still lives under the configured
+ * DEFAULT namespace's base collection, which that derived set excludes, so
+ * every query silently returned 0.
+ *
+ * Returns the configured default namespace to merge into the profile read set
+ * when the base collection must stay reachable, or `null` when a deliberately
+ * narrow profile (#1501 project-only lockdown) or the read ACL says otherwise.
+ *
+ * Conditions for including the default namespace:
+ *   - the profile intends a global/shared read layer (`readOrder` includes
+ *     `userGlobal` or `serverShared`), so a project-only lockdown is honored;
+ *   - the profile resolved the principal's self namespace AWAY from the
+ *     configured default (otherwise it is already in the set);
+ *   - the principal is authorized to read the default namespace.
+ *
+ * Pure and side-effect-free so callers can unit-test the decision directly.
+ */
+export function resolveMemorySearchDefaultFallback(options: {
+  profilePlan: ResolvedScopeProfilePlan;
+  config: PluginConfig;
+  principal: string | undefined;
+}): string | null {
+  const { profilePlan, config, principal } = options;
+  const profileAllowsGlobalLayer =
+    profilePlan.profile.readOrder.includes("userGlobal") ||
+    profilePlan.profile.readOrder.includes("serverShared");
+  const selfResolvedAwayFromDefault =
+    profilePlan.baseNamespace !== config.defaultNamespace;
+  if (
+    profileAllowsGlobalLayer &&
+    selfResolvedAwayFromDefault &&
+    canReadNamespace(principal, config.defaultNamespace, config)
+  ) {
+    return config.defaultNamespace;
+  }
+  return null;
+}
+
+/**
+ * Merge the {@link resolveMemorySearchDefaultFallback} result into a profile
+ * read-namespace set without duplicates. Returns the original set unchanged
+ * when no fallback applies.
+ */
+export function mergeMemorySearchDefaultFallback(
+  profileNamespaces: string[],
+  fallback: string | null,
+): string[] {
+  if (!fallback || profileNamespaces.includes(fallback)) return profileNamespaces;
+  return [...profileNamespaces, fallback];
+}
+
+
+/**
+ * Run a memory_search namespace fanout with the observability required by
+ * issue #2018: a silent empty fanout is surfaced as a warning (never silently
+ * empty), and per-namespace backend degradations — which memory_search
+ * previously swallowed — are collected and warned so a missing collection
+ * looks different from a genuine no-matches.
+ *
+ * `search` is injected so this stays free of the orchestrator type.
+ */
+export async function runMemorySearchFanout<TResult>(options: {
+  query: string;
+  namespaces: string[];
+  maxResults?: number;
+  principal?: string;
+  requestedNamespace?: string;
+  collection?: string;
+  search(params: {
+    query: string;
+    namespaces: string[];
+    maxResults?: number;
+    mode: "search";
+    execution: SearchExecutionOptions;
+  }): Promise<TResult[]>;
+}): Promise<TResult[]> {
+  const { query, namespaces, maxResults, principal, requestedNamespace, collection } = options;
+  if (namespaces.length === 0) {
+    log.warn("memory_search resolved zero readable namespaces", {
+      principal: principal ?? null,
+      requestedNamespace: requestedNamespace ?? null,
+      collection: collection ?? null,
+    });
+    return [];
+  }
+  log.debug("memory_search fanout", {
+    principal: principal ?? null,
+    namespaces,
+    collection: collection ?? null,
+  });
+  const degradations: SearchDegradation[] = [];
+  const results = await options.search({
+    query,
+    namespaces,
+    maxResults,
+    mode: "search",
+    execution: {
+      onDegradation: (degradation) => degradations.push(degradation),
+    },
+  });
+  if (degradations.length > 0) {
+    log.warn("memory_search backend degradation", {
+      principal: principal ?? null,
+      degradations,
+    });
+  }
+  return results;
+}

--- a/packages/remnic-core/src/access-memory-search-fanout.ts
+++ b/packages/remnic-core/src/access-memory-search-fanout.ts
@@ -39,14 +39,22 @@ export function resolveMemorySearchDefaultFallback(options: {
   const { profilePlan, config, principal } = options;
   const principalSelfIsDefault =
     defaultNamespaceForPrincipal(principal, config) === config.defaultNamespace;
+  // readOrder must explicitly intend userGlobal (resolveScopeProfilePlan
+  // always materializes a userGlobal layer even when readOrder omits it, so
+  // the layer's presence alone is not consent), AND that layer must have
+  // resolved readable (a listed-but-unreadable layer is a deliberate
+  // omission). serverShared maps to sharedNamespace, not the default.
+  const profileIntendsUserGlobal =
+    profilePlan.profile.readOrder.includes("userGlobal");
   const userGlobalLayerReadable = profilePlan.layers.some(
     (layer) => layer.id === "userGlobal" && layer.readable && Boolean(layer.namespace),
   );
   const selfResolvedAwayFromDefault =
     profilePlan.baseNamespace !== config.defaultNamespace;
   if (
-    principalSelfIsDefault &&
+    profileIntendsUserGlobal &&
     userGlobalLayerReadable &&
+    principalSelfIsDefault &&
     selfResolvedAwayFromDefault &&
     canReadNamespace(principal, config.defaultNamespace, config)
   ) {

--- a/packages/remnic-core/src/access-memory-search-fanout.ts
+++ b/packages/remnic-core/src/access-memory-search-fanout.ts
@@ -29,29 +29,29 @@ import type { PluginConfig } from "./types.js";
  *     (otherwise it is already in the set);
  *   - the principal is authorized to read the default namespace.
  *
- * Pure and side-effect-free so callers can unit-test the decision directly.
+ * The flat-root signal is resolved lazily via {@link defaultAtFlatRootProvider}
+ * — the provider is only invoked once the cheap gates (readOrder consent,
+ * resolved-layer readability, principal-self, self-resolved-away, ACL) all
+ * pass, so a project-only / serverShared-only / unreadable-userGlobal
+ * profile never touches the default store (#2056 r6).
  */
-export function resolveMemorySearchDefaultFallback(options: {
+export async function resolveMemorySearchDefaultFallback(options: {
   profilePlan: ResolvedScopeProfilePlan;
   config: PluginConfig;
   principal: string | undefined;
   /**
    * True only when the configured default namespace's storage root equals
-   * `config.memoryDir` (the legacy flat-root layout), i.e. the bulk corpus
-   * genuinely lives under the default namespace's base collection. This is
-   * the explicit legacy-flat-root/migration signal — without it the fallback
-   * must not fire, so a hosted scope-profile deployment (per-principal
-   * self namespaces, default under `namespaces/<default>`) never reaches
-   * into the default corpus (#2056 r4).
+   * `config.memoryDir` (the legacy flat-root layout). Invoked ONLY after the
+   * cheap gates pass, so ineligible profiles never probe the default store.
    */
-  defaultAtFlatRoot: boolean;
-}): string | null {
-  const { profilePlan, config, principal, defaultAtFlatRoot } = options;
-  // Defense-in-depth: principalSelfIsDefault is only ever true alongside
-  // defaultAtFlatRoot on legacy flat-root deployments (a hosted scope-profile
-  // principal with its own policy fails this even when default is at the flat
-  // root). It is NOT redundant — it keeps a policy-having principal isolated
-  // from the flat default corpus.
+  defaultAtFlatRootProvider: () => Promise<boolean>;
+}): Promise<string | null> {
+  const { profilePlan, config, principal } = options;
+  // Defense-in-depth: principalSelfIsDefault is only ever true alongside a
+  // flat-root default on legacy deployments (a hosted scope-profile principal
+  // with its own policy fails this even when default is at the flat root). It
+  // is NOT redundant — it keeps a policy-having principal isolated from the
+  // flat default corpus.
   const principalSelfIsDefault =
     defaultNamespaceForPrincipal(principal, config) === config.defaultNamespace;
   // readOrder must explicitly intend userGlobal (resolveScopeProfilePlan
@@ -67,16 +67,19 @@ export function resolveMemorySearchDefaultFallback(options: {
   const selfResolvedAwayFromDefault =
     profilePlan.baseNamespace !== config.defaultNamespace;
   if (
-    defaultAtFlatRoot &&
-    profileIntendsUserGlobal &&
-    userGlobalLayerReadable &&
-    principalSelfIsDefault &&
-    selfResolvedAwayFromDefault &&
-    canReadNamespace(principal, config.defaultNamespace, config)
+    !(
+      profileIntendsUserGlobal &&
+      userGlobalLayerReadable &&
+      principalSelfIsDefault &&
+      selfResolvedAwayFromDefault &&
+      canReadNamespace(principal, config.defaultNamespace, config)
+    )
   ) {
-    return config.defaultNamespace;
+    // Cheap gates failed — never probe the default store.
+    return null;
   }
-  return null;
+  const defaultAtFlatRoot = await options.defaultAtFlatRootProvider();
+  return defaultAtFlatRoot ? config.defaultNamespace : null;
 }
 
 /**

--- a/packages/remnic-core/src/access-memory-search-fanout.ts
+++ b/packages/remnic-core/src/access-memory-search-fanout.ts
@@ -1,4 +1,4 @@
-import { canReadNamespace } from "./namespaces/principal.js";
+import { canReadNamespace, defaultNamespaceForPrincipal } from "./namespaces/principal.js";
 import type { ResolvedScopeProfilePlan } from "./namespaces/scope-profiles.js";
 import { log } from "./logger.js";
 import type { SearchDegradation, SearchExecutionOptions } from "./search/port.js";
@@ -13,17 +13,20 @@ import type { PluginConfig } from "./types.js";
  * every query silently returned 0.
  *
  * Returns the configured default namespace to merge into the profile read set
- * when the base collection must stay reachable, or `null` when a deliberately
- * narrow profile (#1501 project-only lockdown) or the read ACL says otherwise.
+ * when the base collection must stay reachable, or `null` otherwise. ALL of:
  *
- * Conditions for including the default namespace:
- *   - the profile intends the principal's own global read layer (`readOrder`
- *     includes `userGlobal`). `serverShared` maps to `sharedNamespace`, NOT
- *     the default, so it must not trigger this fallback — a
- *     `["userProject", "serverShared"]` profile deliberately reads only the
- *     shared namespace, not the default;
- *   - the profile resolved the principal's self namespace AWAY from the
- *     configured default (otherwise it is already in the set);
+ *   - the default namespace is THIS principal's own self store — i.e. the
+ *     principal has no dedicated namespace policy, so
+ *     `defaultNamespaceForPrincipal` resolves to the configured default. On a
+ *     multi-tenant scope-profile deployment every principal has its own
+ *     policy; reaching into the default would read ANOTHER namespace, so the
+ *     fallback must not fire (#2056 r2 / #1501 privateOnly);
+ *   - the profile resolved `userGlobal` as a READABLE layer (not just listed
+ *     it in `readOrder`). `serverShared` maps to `sharedNamespace`, not the
+ *     default, and an unreadable resolved layer is a deliberate omission —
+ *     neither may trigger this fallback (#2056 r2);
+ *   - the profile's resolved self namespace is NOT already the default
+ *     (otherwise it is already in the set);
  *   - the principal is authorized to read the default namespace.
  *
  * Pure and side-effect-free so callers can unit-test the decision directly.
@@ -34,12 +37,16 @@ export function resolveMemorySearchDefaultFallback(options: {
   principal: string | undefined;
 }): string | null {
   const { profilePlan, config, principal } = options;
-  const profileAllowsGlobalLayer =
-    profilePlan.profile.readOrder.includes("userGlobal");
+  const principalSelfIsDefault =
+    defaultNamespaceForPrincipal(principal, config) === config.defaultNamespace;
+  const userGlobalLayerReadable = profilePlan.layers.some(
+    (layer) => layer.id === "userGlobal" && layer.readable && Boolean(layer.namespace),
+  );
   const selfResolvedAwayFromDefault =
     profilePlan.baseNamespace !== config.defaultNamespace;
   if (
-    profileAllowsGlobalLayer &&
+    principalSelfIsDefault &&
+    userGlobalLayerReadable &&
     selfResolvedAwayFromDefault &&
     canReadNamespace(principal, config.defaultNamespace, config)
   ) {

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -1330,7 +1330,7 @@ function makeConfigWithScopeProfile(): PluginConfig {
           enabled: false,
           targets: ["userGlobal"],
           categories: ["fact"],
-          minConfidenceTier: "medium",
+          minConfidenceTier: "inferred",
         },
       },
     },
@@ -1360,7 +1360,7 @@ function makeServiceWithConfig(config: PluginConfig): {
       async search() { throw new Error("qmd.search should not run in namespace mode"); },
       async searchGlobal() { throw new Error("qmd.searchGlobal should not run in namespace mode"); },
     },
-    async getStorage() { return {} as StorageManager; },
+    async getStorage() { return { dir: config.memoryDir } as StorageManager; },
     async searchAcrossNamespaces(params) {
       captured.namespaces = params.namespaces;
       captured.execution = params.execution;

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -1339,10 +1339,10 @@ function makeConfigWithScopeProfile(): PluginConfig {
 
 function makeServiceWithConfig(config: PluginConfig): {
   service: EngramAccessService;
-  captured: { namespaces?: string[]; execution?: unknown };
+  captured: { namespaces?: string[]; execution?: unknown; getStorageCalls: string[] };
 } {
   const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
-  const captured: { namespaces?: string[]; execution?: unknown } = {};
+  const captured: { namespaces?: string[]; execution?: unknown; getStorageCalls: string[] } = { getStorageCalls: [] };
   type OrchLike = {
     config: PluginConfig;
     qmd: { search(): Promise<unknown[]>; searchGlobal(): Promise<unknown[]> };
@@ -1360,7 +1360,7 @@ function makeServiceWithConfig(config: PluginConfig): {
       async search() { throw new Error("qmd.search should not run in namespace mode"); },
       async searchGlobal() { throw new Error("qmd.searchGlobal should not run in namespace mode"); },
     },
-    async getStorage() { return { dir: config.memoryDir } as StorageManager; },
+    async getStorage(namespace: string) { captured.getStorageCalls.push(namespace); return { dir: config.memoryDir } as StorageManager; },
     async searchAcrossNamespaces(params) {
       captured.namespaces = params.namespaces;
       captured.execution = params.execution;
@@ -1471,4 +1471,21 @@ test("memorySearch threads backend degradations to a warning (#2018)", async () 
   } finally {
     reset();
   }
+});
+
+test("memorySearch does not probe default storage for an explicit namespace or before auth (#2056 r5)", async () => {
+  const config = makeConfigWithScopeProfile();
+  const { service, captured } = makeServiceWithConfig(config);
+  // Explicit-namespace queries ignore the default-namespace fallback, so the
+  // flat-root storage probe must not run (and must not run before the auth
+  // check rejects an unauthorized principal).
+  await assert.rejects(
+    () => service.memorySearch({ query: "x", namespace: "team", principal: "stranger" }),
+    /namespace is not readable: team/,
+  );
+  assert.deepEqual(
+    captured.getStorageCalls,
+    [],
+    "default-namespace storage must not be probed for an explicit-namespace query",
+  );
 });

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { EngramAccessInputError, EngramAccessService } from "./access-service.js";
+import { type LoggerBackend, initLogger } from "./logger.js";
 import { namespaceIdentityToken } from "./namespaces/identity.js";
 import { namespaceCollectionName } from "./namespaces/search.js";
 import { SecureStoreLockedError } from "./secure-store/index.js";
@@ -87,6 +88,19 @@ function makeService(): {
   };
 
   return { service, storage, getStorageCalls };
+}
+
+// memory_search now threads an `execution.onDegradation` observer into
+// searchAcrossNamespaces (issue #2018 observability). Tests that assert the
+// fanout shape compare only the fields they care about, not the whole object.
+function searchParamsSubset(params: unknown): {
+  query: unknown;
+  namespaces: unknown;
+  maxResults: unknown;
+  mode: unknown;
+} {
+  const p = params as { query?: unknown; namespaces?: unknown; maxResults?: unknown; mode?: unknown };
+  return { query: p.query, namespaces: p.namespaces, maxResults: p.maxResults, mode: p.mode };
 }
 
 test("getWritableStorageForNamespace denies read-only principals before storage lookup", async () => {
@@ -908,7 +922,7 @@ test("memorySearch without an explicit namespace uses readable recall namespaces
     principal: "reader",
   });
 
-  assert.deepEqual(searchParams, {
+  assert.deepEqual(searchParamsSubset(searchParams), {
     query: "deployment notes",
     namespaces: ["default", "shared"],
     maxResults: 3,
@@ -936,7 +950,7 @@ test("memorySearch with an explicit namespace searches only that readable namesp
     principal: "reader",
   });
 
-  assert.deepEqual(searchParams, {
+  assert.deepEqual(searchParamsSubset(searchParams), {
     query: "release note",
     namespaces: ["team"],
     maxResults: 2,
@@ -1027,7 +1041,7 @@ test("memorySearch treats global collection as ACL-scoped when namespaces are en
   });
 
   assert.equal(globalSearchCalls, 0);
-  assert.deepEqual(searchParams, {
+  assert.deepEqual(searchParamsSubset(searchParams), {
     query: "runbook",
     namespaces: ["default", "shared"],
     maxResults: undefined,
@@ -1057,7 +1071,7 @@ test("memorySearch accepts a namespace-scoped collection for the requested names
     principal: "reader",
   });
 
-  assert.deepEqual(searchParams, {
+  assert.deepEqual(searchParamsSubset(searchParams), {
     query: "release note",
     namespaces: ["team"],
     maxResults: undefined,
@@ -1086,7 +1100,7 @@ test("memorySearch accepts a readable namespace-scoped collection without duplic
     principal: "reader",
   });
 
-  assert.deepEqual(searchParams, {
+  assert.deepEqual(searchParamsSubset(searchParams), {
     query: "release note",
     namespaces: ["team"],
     maxResults: undefined,
@@ -1289,5 +1303,172 @@ test("offlineSyncSnapshot does not trust client base capture time for server fas
     assert.deepEqual(snapshot.files, [baseFile]);
   } finally {
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+// ─── Issue #2018: memory_search must reach the base collection ───────────────
+//
+// On a namespaces-enabled deployment with a flat-root default namespace, the
+// bulk corpus lives under the DEFAULT namespace's base QMD collection. recall
+// reaches it via the coding-overlay fallbacks, but memory_search has no
+// sessionKey (so no coding context). With scope profiles active and a
+// non-default principal, the profile read set collapsed to the derived
+// principal-self + shared namespaces and EXCLUDED the default namespace —
+// every query silently returned 0.
+
+function makeConfigWithScopeProfile(): PluginConfig {
+  const base = makeConfig();
+  return {
+    ...base,
+    defaultScopeProfile: "standard",
+    scopeProfiles: {
+      standard: {
+        readOrder: ["userProject", "userGlobal", "serverShared"],
+        writeDefault: "userProject",
+        promotionTargets: ["userGlobal", "serverShared"],
+        autoPromote: {
+          enabled: false,
+          targets: ["userGlobal"],
+          categories: ["fact"],
+          minConfidenceTier: "medium",
+        },
+      },
+    },
+  } as unknown as PluginConfig;
+}
+
+function makeServiceWithConfig(config: PluginConfig): {
+  service: EngramAccessService;
+  captured: { namespaces?: string[]; execution?: unknown };
+} {
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const captured: { namespaces?: string[]; execution?: unknown } = {};
+  type OrchLike = {
+    config: PluginConfig;
+    qmd: { search(): Promise<unknown[]>; searchGlobal(): Promise<unknown[]> };
+    getStorage(namespace: string): Promise<StorageManager>;
+    searchAcrossNamespaces(params: {
+      namespaces?: string[];
+      maxResults?: number;
+      mode?: string;
+      execution?: unknown;
+    }): Promise<unknown[]>;
+  };
+  const orchestrator: OrchLike = {
+    config,
+    qmd: {
+      async search() { throw new Error("qmd.search should not run in namespace mode"); },
+      async searchGlobal() { throw new Error("qmd.searchGlobal should not run in namespace mode"); },
+    },
+    async getStorage() { return {} as StorageManager; },
+    async searchAcrossNamespaces(params) {
+      captured.namespaces = params.namespaces;
+      captured.execution = params.execution;
+      return [];
+    },
+  };
+  (service as unknown as { orchestrator: OrchLike }).orchestrator = orchestrator;
+  return { service, captured };
+}
+
+function captureLogs(): { backend: LoggerBackend; warn: string[]; reset: () => void } {
+  const warn: string[] = [];
+  const backend: LoggerBackend = {
+    info() {},
+    warn(msg) { warn.push(msg); },
+    error() {},
+    debug() {},
+  };
+  initLogger(backend, false, { timestamps: false });
+  return { backend, warn, reset: () => initLogger({ info() {}, warn() {}, error() {}, debug() {} }, false) };
+}
+
+test("memorySearch includes the default namespace for a scope-profile principal without coding context (#2018)", async () => {
+  // Before the fix the fanout resolved to ["operator-x", "shared"] and the
+  // base collection (default namespace) was never queried — every search
+  // returned 0 on a flat-root deployment.
+  const { service, captured } = makeServiceWithConfig(makeConfigWithScopeProfile());
+  await service.memorySearch({ query: "exact phrase", principal: "operator-x" });
+  assert.ok(
+    captured.namespaces?.includes("default"),
+    `default namespace must be in fanout, got ${JSON.stringify(captured.namespaces)}`,
+  );
+});
+
+test("memorySearch preserves scope-profile project/global layers alongside the default namespace (#2018)", async () => {
+  const { service, captured } = makeServiceWithConfig(makeConfigWithScopeProfile());
+  await service.memorySearch({ query: "exact phrase", principal: "operator-x" });
+  // The derived self namespace ("operator-x") and shared must still be present;
+  // the fix ADDS the default, it does not replace the profile stack.
+  assert.ok(captured.namespaces?.includes("operator-x"));
+  assert.ok(captured.namespaces?.includes("shared"));
+  assert.ok(captured.namespaces?.includes("default"));
+});
+
+test("memorySearch ACL-gates the default namespace fallback (#2018)", async () => {
+  // If the principal cannot read the default namespace, the fallback must NOT
+  // add it. Configure a protected default via a namespace policy that excludes
+  // the principal, and confirm "default" is absent while the policy name is
+  // still reachable through the profile stack only when readable.
+  const config = makeConfigWithScopeProfile();
+  (config as unknown as { defaultNamespace: string }).defaultNamespace = "root";
+  (config as unknown as { namespacePolicies: Array<{ name: string; readPrincipals: string[]; writePrincipals: string[] }> }).namespacePolicies = [
+    { name: "root", readPrincipals: ["owner"], writePrincipals: ["owner"] },
+  ];
+  const { service, captured } = makeServiceWithConfig(config);
+  await service.memorySearch({ query: "exact phrase", principal: "operator-x" });
+  assert.ok(
+    !captured.namespaces?.includes("root"),
+    "default namespace must NOT be added when the principal lacks read access",
+  );
+});
+
+test("memorySearch surfaces an empty namespace resolution as a warning, never silently empty (#2018)", async () => {
+  const { reset, warn } = captureLogs();
+  try {
+    // defaultRecallNamespaces: [] + no scope profile + no policies ⇒ the
+    // readable recall set is empty, exercising the silent-empty branch.
+    const config = {
+      ...makeConfig(),
+      defaultRecallNamespaces: [],
+    } as unknown as PluginConfig;
+    const { service } = makeServiceWithConfig(config);
+    const result = await service.memorySearch({ query: "anything", principal: "operator-x" });
+    assert.equal(result.count, 0);
+    assert.ok(
+      warn.some((line) => line.includes("memory_search resolved zero readable namespaces")),
+      "expected a zero-namespace warning",
+    );
+  } finally {
+    reset();
+  }
+});
+
+test("memorySearch threads backend degradations to a warning (#2018)", async () => {
+  const { reset, warn } = captureLogs();
+  try {
+    const config = makeConfigWithScopeProfile();
+    const { service } = makeServiceWithConfig(config);
+    (service as unknown as {
+      orchestrator: {
+        searchAcrossNamespaces(params: {
+          execution?: { onDegradation?: (d: unknown) => void };
+        }): Promise<unknown[]>;
+      };
+    }).orchestrator.searchAcrossNamespaces = async (params) => {
+      params.execution?.onDegradation?.({
+        backend: "qmd",
+        code: "backend_unavailable",
+        detail: "namespace collection missing: operator-x",
+      });
+      return [];
+    };
+    await service.memorySearch({ query: "anything", principal: "operator-x" });
+    assert.ok(
+      warn.some((line) => line.includes("memory_search backend degradation")),
+      "expected a backend-degradation warning",
+    );
+  } finally {
+    reset();
   }
 });

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -34,6 +34,7 @@ import test from "node:test";
 
 import { EngramAccessService } from "./access-service.js";
 import { Orchestrator } from "./orchestrator.js";
+import type { StorageManager } from "./storage.js";
 import type { EngramAccessObserveRequest } from "./access-service.js";
 import {
   combineNamespaces,
@@ -810,6 +811,7 @@ test("#1501 implicit memorySearch honors active scope profile readOrder", async 
   const orch = {
     config,
     qmd: { isAvailable: () => true },
+    getStorage: async () => ({ dir: config.memoryDir } as StorageManager),
     searchAcrossNamespaces: async (options: { namespaces: string[] }) => {
       searchedNamespaces = options.namespaces;
       return [];
@@ -862,11 +864,13 @@ test("#1501 memorySearch collection names stay constrained to active scope profi
   const orch = {
     config,
     qmd: { isAvailable: () => true },
+    getStorage: async () => ({ dir: config.memoryDir } as StorageManager),
     searchAcrossNamespaces: async (options: { namespaces: string[] }) => {
       searchedNamespaces = options.namespaces;
       return [];
     },
   } as unknown as Orchestrator;
+
   const service = new EngramAccessService(orch);
   const sharedCollection = namespaceCollectionName(config.qmdCollection, "shared", {
     defaultNamespace: config.defaultNamespace,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -82,6 +82,11 @@ import {
 import { CrossNamespaceBudget, type BudgetWarning } from "./cross-namespace-budget.js";
 import { log } from "./logger.js";
 import {
+  mergeMemorySearchDefaultFallback,
+  resolveMemorySearchDefaultFallback,
+  runMemorySearchFanout,
+} from "./access-memory-search-fanout.js";
+import {
   buildQualityScore,
   buildProposedActions,
   groupActionsByStatus,
@@ -2046,18 +2051,27 @@ export class EngramAccessService {
       codingContext: null,
       codingOverlay: null,
     });
-    const namespaces = profilePlan
-      ? expandScopeProfileReadNamespaces({
-          profilePlan,
-          principalSelfNamespace: profilePlan.baseNamespace,
-          config: this.orchestrator.config,
-          principal,
-          codingOverlay: null,
-          legacyRecallNamespaces,
-        })
-      : legacyRecallNamespaces;
-    if (profilePlan) return namespaces;
-    return namespaces.filter((ns) =>
+    if (profilePlan) {
+      // Issue #2018: memory_search has no sessionKey, so unlike recall it
+      // cannot resolve a coding overlay. Reach the base collection (default
+      // namespace) when the profile intends a global layer and the principal
+      // is authorized — see access-memory-search-fanout.ts for the contract.
+      const profileNamespaces = expandScopeProfileReadNamespaces({
+        profilePlan,
+        principalSelfNamespace: profilePlan.baseNamespace,
+        config: this.orchestrator.config,
+        principal,
+        codingOverlay: null,
+        legacyRecallNamespaces,
+      });
+      const fallback = resolveMemorySearchDefaultFallback({
+        profilePlan,
+        config: this.orchestrator.config,
+        principal,
+      });
+      return mergeMemorySearchDefaultFallback(profileNamespaces, fallback);
+    }
+    return legacyRecallNamespaces.filter((ns) =>
       canReadNamespace(principal, ns, this.orchestrator.config),
     );
   }
@@ -4746,14 +4760,15 @@ export class EngramAccessService {
         readableNamespaces,
         namespace?.trim() ? undefined : principal,
       );
-      results = namespaces.length === 0
-        ? []
-        : await this.orchestrator.searchAcrossNamespaces({
-            query,
-            namespaces,
-            maxResults,
-            mode: "search",
-          });
+      results = await runMemorySearchFanout({
+        query,
+        namespaces,
+        maxResults,
+        principal,
+        requestedNamespace: namespace,
+        collection,
+        search: (params) => this.orchestrator.searchAcrossNamespaces(params),
+      });
     }
 
     return {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2071,15 +2071,12 @@ export class EngramAccessService {
         codingOverlay: null,
         legacyRecallNamespaces,
       });
-      const defaultAtFlatRoot = await defaultNamespaceAtFlatRoot(
-        (n) => this.orchestrator.getStorage(n),
-        this.orchestrator.config,
-      );
-      const fallback = resolveMemorySearchDefaultFallback({
+      const fallback = await resolveMemorySearchDefaultFallback({
         profilePlan,
         config: this.orchestrator.config,
         principal,
-        defaultAtFlatRoot,
+        defaultAtFlatRootProvider: () =>
+          defaultNamespaceAtFlatRoot((n) => this.orchestrator.getStorage(n), this.orchestrator.config),
       });
       return mergeMemorySearchDefaultFallback(profileNamespaces, fallback);
     }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -82,6 +82,7 @@ import {
 import { CrossNamespaceBudget, type BudgetWarning } from "./cross-namespace-budget.js";
 import { log } from "./logger.js";
 import {
+  defaultNamespaceAtFlatRoot,
   mergeMemorySearchDefaultFallback,
   resolveMemorySearchDefaultFallback,
   runMemorySearchFanout,
@@ -2025,7 +2026,11 @@ export class EngramAccessService {
     return resolved;
   }
 
-  private resolveReadableNamespacesForSearch(namespace: string | undefined, principal?: string): string[] {
+  private resolveReadableNamespacesForSearch(
+    namespace: string | undefined,
+    principal?: string,
+    options?: { defaultAtFlatRoot?: boolean },
+  ): string[] {
     const requested = namespace?.trim();
     if (requested) {
       return [this.resolveReadableNamespace(requested, principal)];
@@ -2068,6 +2073,7 @@ export class EngramAccessService {
         profilePlan,
         config: this.orchestrator.config,
         principal,
+        defaultAtFlatRoot: options?.defaultAtFlatRoot === true,
       });
       return mergeMemorySearchDefaultFallback(profileNamespaces, fallback);
     }
@@ -4754,7 +4760,11 @@ export class EngramAccessService {
         ? await this.orchestrator.qmd.searchGlobal(query, maxResults)
         : await this.orchestrator.qmd.search(query, collection, maxResults);
     } else {
-      const readableNamespaces = this.resolveReadableNamespacesForSearch(namespace, principal);
+      const defaultAtFlatRoot = await defaultNamespaceAtFlatRoot(
+        (n) => this.orchestrator.getStorage(n),
+        this.orchestrator.config,
+      );
+      const readableNamespaces = this.resolveReadableNamespacesForSearch(namespace, principal, { defaultAtFlatRoot });
       const namespaces = this.resolveMemorySearchNamespacesForCollection(
         collection,
         readableNamespaces,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2026,11 +2026,10 @@ export class EngramAccessService {
     return resolved;
   }
 
-  private resolveReadableNamespacesForSearch(
+  private async resolveReadableNamespacesForSearch(
     namespace: string | undefined,
     principal?: string,
-    options?: { defaultAtFlatRoot?: boolean },
-  ): string[] {
+  ): Promise<string[]> {
     const requested = namespace?.trim();
     if (requested) {
       return [this.resolveReadableNamespace(requested, principal)];
@@ -2059,8 +2058,11 @@ export class EngramAccessService {
     if (profilePlan) {
       // Issue #2018: memory_search has no sessionKey, so unlike recall it
       // cannot resolve a coding overlay. Reach the base collection (default
-      // namespace) when the profile intends a global layer and the principal
-      // is authorized — see access-memory-search-fanout.ts for the contract.
+      // namespace) only when the profile intends a global layer and the
+      // principal is authorized — see access-memory-search-fanout.ts. The
+      // flat-root storage probe runs lazily HERE (after auth, no explicit
+      // namespace, profile active) so explicit-namespace queries and auth
+      // rejections never touch the default store (#2056 r5).
       const profileNamespaces = expandScopeProfileReadNamespaces({
         profilePlan,
         principalSelfNamespace: profilePlan.baseNamespace,
@@ -2069,11 +2071,15 @@ export class EngramAccessService {
         codingOverlay: null,
         legacyRecallNamespaces,
       });
+      const defaultAtFlatRoot = await defaultNamespaceAtFlatRoot(
+        (n) => this.orchestrator.getStorage(n),
+        this.orchestrator.config,
+      );
       const fallback = resolveMemorySearchDefaultFallback({
         profilePlan,
         config: this.orchestrator.config,
         principal,
-        defaultAtFlatRoot: options?.defaultAtFlatRoot === true,
+        defaultAtFlatRoot,
       });
       return mergeMemorySearchDefaultFallback(profileNamespaces, fallback);
     }
@@ -4760,11 +4766,7 @@ export class EngramAccessService {
         ? await this.orchestrator.qmd.searchGlobal(query, maxResults)
         : await this.orchestrator.qmd.search(query, collection, maxResults);
     } else {
-      const defaultAtFlatRoot = await defaultNamespaceAtFlatRoot(
-        (n) => this.orchestrator.getStorage(n),
-        this.orchestrator.config,
-      );
-      const readableNamespaces = this.resolveReadableNamespacesForSearch(namespace, principal, { defaultAtFlatRoot });
+      const readableNamespaces = await this.resolveReadableNamespacesForSearch(namespace, principal);
       const namespaces = this.resolveMemorySearchNamespacesForCollection(
         collection,
         readableNamespaces,


### PR DESCRIPTION
## Problem

`engram.memory_search` (MCP `memory_search`) returned `count: 0` for **every** query on a namespaces-enabled deployment with a flat-root default namespace and an active scope profile, while `recall` retrieved the same content. The failure was silent — no error, no log line.

Closes #2018.

## Root cause

`memory_search` has no `sessionKey`, so — unlike `recall` — it cannot resolve a coding overlay (the MCP surface and the operation schema don't carry one). With scope profiles active and no overlay:

- `resolveReadableNamespacesForSearch` -> `resolveScopeProfilePlan({ codingContext: null })` -> `expandScopeProfileReadNamespaces` returns only the **derived** principal-self + shared namespaces.
- On a legacy flat-root deployment the corpus lives under the configured **default** namespace's base QMD collection, which that derived set excludes.
- The fanout therefore never queried the collection holding the data, so every query silently returned 0.

`recall` reaches the base collection because its path resolves a coding overlay from the session key (project layer readable -> fallbacks include the base).

## Fix

When a scope profile is active, merge the configured default namespace into the memory_search fanout when **all** hold:

1. the profile intends a global/shared read layer (`readOrder` includes `userGlobal` or `serverShared`) — so a deliberately project-only lockdown stays locked down (#1501);
2. the profile resolved the principal's self namespace **away** from the configured default (otherwise it is already in the set);
3. the principal is authorized to read the default namespace (ACL).

The decision is a pure function (`resolveMemorySearchDefaultFallback`) so it is unit-tested directly.

## Observability (acceptance criterion #3)

- A resolved-empty fanout now emits `memory_search resolved zero readable namespaces` with the resolution inputs — never silently empty.
- `memory_search` now threads `execution.onDegradation` into `searchAcrossNamespaces`; per-namespace collection misses / backend unavailability (previously swallowed) are collected and warned as `memory_search backend degradation`, so a missing collection is distinguishable from a genuine no-matches.

## Tests

- `access-memory-search-fanout.test.ts` — unit tests for the fallback decision (global layer intended, project-only lockdown excluded, self-already-default, ACL-gated) and the merge helper.
- `access-service-namespace.test.ts` — regression: scope-profile + non-default principal -> default namespace in fanout; project/global layers preserved alongside; ACL-gated; empty-resolution warning; backend-degradation warning. Existing `deepEqual` fanout assertions updated to target the fields they care about (`memory_search` now threads `execution.onDegradation`).

## Scope-profile isolation preserved

The two `#1501` lockdown tests (`userProject`-only and `userGlobal`-only profiles) still pass: a profile with no global/shared read layer gets no default-namespace fallback, and a `shared`-collection request against a `userGlobal`-only profile is still rejected as not-namespace-scoped.

## Verification

- `npm run preflight:quick` — OK (lint, check-types, check-config-contract, check-review-patterns, check-ratchets, check-docs-parity, registration/SDK/access-surface tests).
- Structural ratchet: `access-service.ts` 5884 -> 5899 lines (under the 5911 ceiling, #1995); the new logic lives in `access-memory-search-fanout.ts`.

## Acceptance (#2018)

- [x] `memory_search` reaches the base collection (default namespace) on a namespaces-enabled, flat-root-default, scope-profile deployment.
- [x] Regression test: default namespace at flat root + scope-profile principal + no explicit `namespace` arg.
- [x] Empty namespace resolution is observable (warn), never silently empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes namespace fanout and ACL/isolation gates for memory search on scope-profile deployments; incorrect fallback could expose another tenant’s default corpus or skip the base collection, though the change is heavily unit- and integration-tested.
> 
> **Overview**
> Fixes **`memory_search` returning zero hits** on namespaces-enabled, flat-root-default deployments with active scope profiles, where recall still found the same corpus. Without a `sessionKey`, profile read expansion no longer includes the configured **default** namespace where the legacy base collection lives.
> 
> **Namespace resolution** is now async and, when a scope profile applies, may **merge the default namespace** into the fanout only after gated checks: `readOrder` includes **`userGlobal`** with a readable layer, the principal’s self store is the configured default (no dedicated policy), self namespace differs from default, ACL allows reading default, and a **lazy storage probe** confirms the default namespace root equals `memoryDir` (flat-root legacy layout). Project-only profiles, `serverShared`-only reads, multi-tenant principals with own policies, and non-flat-root hosts are excluded.
> 
> **Fanout execution** moves to `runMemorySearchFanout`, which warns on **zero resolved namespaces** and surfaces **`execution.onDegradation`** from `searchAcrossNamespaces` as `memory_search backend degradation` logs instead of swallowing them.
> 
> Logic lives in new **`access-memory-search-fanout.ts`**; **`EngramAccessService.memorySearch`** wires it in. Tests cover the fallback matrix, integration fanout/ACL/warnings, and relaxed search-param assertions for the new `execution` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea54c31509592cde66ae217f9dabc4370ccc9e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced legacy memory search for scope profiles with a conditional default-collection fallback and namespace fanout execution.
  - Added clearer warnings when resolved search namespaces are empty.
  - Surfaced backend fanout degradation details in warnings.
- **Bug Fixes**
  - Strengthened ACL/readability gating for default-namespace fallback and prevented unauthorized/cross-scope results.
  - Avoided duplicate namespace entries when applying the fallback.
- **Tests**
  - Expanded coverage for the new Issue `#2018` behavior, including fallback inclusion/denial, empty-resolution warnings, and degradation/observation assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->