### PR TITLE
fix(cli): read connectors enabled flag from config in status (#2062)

### DIFF
--- a/packages/remnic-cli/src/connectors-status-config.test.ts
+++ b/packages/remnic-cli/src/connectors-status-config.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Regression for issue #2062: the standalone `remnic connectors status` row
+// builder hardcoded `enabled: true`, so status output lied when a connector
+// was disabled in config. It must reflect parsed config, matching the source
+// `connectors run` already reads.
+//
+// Exercises the real CLI dispatch (src/index.ts via tsx) so the assertion
+// guards the actual status branch, not a re-implementation of its logic. The
+// `--conditions=remnic-source` node flag mirrors the root test runner so the
+// child's dynamic `import("@remnic/core")` resolves to source without a build.
+const repoRoot = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
+const cliEntry = join(repoRoot, "packages", "remnic-cli", "src", "index.ts");
+
+test("connectors status reflects config enabled flags (issue #2062)", async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), "remnic-2062-status-"));
+  try {
+    const memoryDir = join(tempRoot, "mem");
+    const configPath = join(tempRoot, "remnic.json");
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        memoryDir,
+        connectors: {
+          googleDrive: { enabled: true },
+          notion: { enabled: false },
+        },
+      })
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      ["--conditions=remnic-source", "--import", "tsx", cliEntry, "connectors", "status", "--format", "json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          REMNIC_CLI_BIN: "1",
+          REMNIC_CONFIG_PATH: configPath,
+        },
+      }
+    );
+
+    assert.equal(result.status, 0, `status exited nonzero: ${result.stderr}`);
+    const rows = JSON.parse(result.stdout) as Array<{
+      id: string;
+      enabled: boolean;
+      lastSyncStatus: string;
+    }>;
+
+    const notion = rows.find((r) => r.id === "notion");
+    assert.ok(notion, "notion row must be present");
+    assert.equal(notion.enabled, false, "disabled connector must report enabled:false");
+
+    const drive = rows.find((r) => r.id === "google-drive");
+    assert.ok(drive, "google-drive row must be present");
+    assert.equal(drive.enabled, true, "enabled connector must report enabled:true");
+    assert.equal(drive.lastSyncStatus, "never", "never-synced connector must still report never");
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-cli/src/connectors-status-config.test.ts
+++ b/packages/remnic-cli/src/connectors-status-config.test.ts
@@ -67,3 +67,43 @@ test("connectors status reflects config enabled flags (issue #2062)", async () =
     await rm(tempRoot, { recursive: true, force: true });
   }
 });
+
+test("connectors status fails cleanly on invalid connector config (issue #2062)", async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), "remnic-2062-status-bad-"));
+  try {
+    const memoryDir = join(tempRoot, "mem");
+    const configPath = join(tempRoot, "remnic.json");
+    // Valid JSON, but a value parseConfig rejects (poll interval below the
+    // allowed floor). This exercises the status branch's own config guard,
+    // which must exit 2 without echoing the parser message (it can contain
+    // raw config values, e.g. secrets — Cursor Bugbot learned rule).
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        memoryDir,
+        connectors: { googleDrive: { pollIntervalMs: 5 } },
+      })
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      ["--conditions=remnic-source", "--import", "tsx", cliEntry, "connectors", "status", "--format", "json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          REMNIC_CLI_BIN: "1",
+          REMNIC_CONFIG_PATH: configPath,
+        },
+      }
+    );
+
+    assert.equal(result.status, 2, `expected exit 2, got ${result.status}: ${result.stderr}`);
+    assert.match(result.stderr, /^connectors status:/m);
+    // The caught parser message must not be echoed (it can carry config values).
+    assert.doesNotMatch(result.stderr, /pollIntervalMs/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -44,6 +44,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { gzipSync } from "node:zlib";
 import {
   parseConfig,
+  type PluginConfig,
   isOpenaiApiKeyDisabled,
   resolveEnvVars,
   resolveRemnicConfigRecord,
@@ -10088,17 +10089,34 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
     const memoryDir = resolveMemoryDir();
     const states = await listLiveConnectorStates(memoryDir);
     const stateMap = new Map(states.map((s: { id: string }) => [s.id, s]));
+    // Reflect the parsed config's enabled flags (same source `connectors run`
+    // uses) instead of hardcoding true, so disabled connectors report
+    // enabled:false in status/list output (issue #2062).
+    let connectorsCfg: PluginConfig["connectors"];
+    try {
+      const configPath = resolveConfigPath();
+      const raw = fs.existsSync(configPath)
+        ? JSON.parse(fs.readFileSync(configPath, "utf8"))
+        : {};
+      connectorsCfg = parseConfig(resolveRemnicConfigRecord(raw)).connectors;
+    } catch (err) {
+      process.stderr.write(
+        `connectors status: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exitCode = 2;
+      return;
+    }
     const rows = [
       {
         id: GDRIVE_ID as string,
         displayName: "Google Drive",
-        enabled: true,
+        enabled: connectorsCfg.googleDrive.enabled,
         state: stateMap.get(GDRIVE_ID as string) ?? null,
       },
       {
         id: NOTION_ID as string,
         displayName: "Notion",
-        enabled: true,
+        enabled: connectorsCfg.notion.enabled,
         state: stateMap.get(NOTION_ID as string) ?? null,
       },
     ];

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -10093,15 +10093,17 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
     // uses) instead of hardcoding true, so disabled connectors report
     // enabled:false in status/list output (issue #2062).
     let connectorsCfg: PluginConfig["connectors"];
+    const configPath = resolveConfigPath();
     try {
-      const configPath = resolveConfigPath();
       const raw = fs.existsSync(configPath)
         ? JSON.parse(fs.readFileSync(configPath, "utf8"))
         : {};
       connectorsCfg = parseConfig(resolveRemnicConfigRecord(raw)).connectors;
-    } catch (err) {
+    } catch {
+      // Report the path, never the caught error message: parse/validation
+      // errors can echo raw config values (e.g. secrets) into CLI output.
       process.stderr.write(
-        `connectors status: ${err instanceof Error ? err.message : String(err)}\n`,
+        `connectors status: failed to read config at ${configPath}\n`,
       );
       process.exitCode = 2;
       return;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -10098,7 +10098,10 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
       const raw = fs.existsSync(configPath)
         ? JSON.parse(fs.readFileSync(configPath, "utf8"))
         : {};
-      connectorsCfg = parseConfig(resolveRemnicConfigRecord(raw)).connectors;
+      // parseConfigQuietly (not parseConfig): this branch installs no logger,
+      // so parseConfig's coercion warnings would print raw config values
+      // (e.g. secrets) via console.warn (#2033).
+      connectorsCfg = parseConfigQuietly(raw).connectors;
     } catch {
       // Report the path, never the caught error message: parse/validation
       // errors can echo raw config values (e.g. secrets) into CLI output.


### PR DESCRIPTION
## Summary

`remnic connectors status` (and the text/markdown `list` path sharing the same row builder in the standalone CLI) hardcoded `enabled: true` for the built-in Google Drive and Notion connectors, so status output reported a disabled connector as enabled. `connectors run` already refused disabled connectors correctly — only the status/list display lied.

## Fix

Build the status rows from `parseConfig(...).connectors.<id>.enabled` — the same source `connectors run` reads — instead of a literal `true`. The renderer already maps `enabled:false` to `disabled` (text/markdown) and `no` (markdown table), so no renderer change is needed. Output schema is unchanged; only the boolean/label reflects config. A malformed config file now surfaces the same `connectors status:` error + exit code 2 as the branch's existing failure paths.

## Test

Adds `packages/remnic-cli/src/connectors-status-config.test.ts`, driving the real status dispatch (`src/index.ts` via tsx, `--conditions=remnic-source` like the root runner) with a config where Notion is disabled and Google Drive enabled:

- notion -> `enabled: false`
- google-drive -> `enabled: true`, `lastSyncStatus: "never"`

## Acceptance criteria

- [x] Disabled connector shows `enabled: false` in JSON and `disabled` in text/markdown
- [x] Enabled, never-synced connector still shows enabled + never synced
- [x] `connectors run` behavior unchanged (untouched)
- [x] Regression test covers a disabled built-in

Closes #2062

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display and config-read behavior only; no changes to sync/run logic or auth.
> 
> **Overview**
> **`remnic connectors status`** (and shared list row building) no longer hardcodes **`enabled: true`** for Google Drive and Notion. Rows now use **`parseConfigQuietly(...).connectors`** so disabled connectors show **`enabled: false`** in JSON and the existing **`disabled`** labels in text/markdown—aligned with **`connectors run`**.
> 
> Config load/parse failures on this path exit **2** with a **`connectors status:`** message that names the config path only (no parser text that could echo secrets). Parsing uses **`parseConfigQuietly`** instead of **`parseConfig`** so coercion warnings cannot leak raw config values to stderr.
> 
> Adds **`connectors-status-config.test.ts`**: end-to-end CLI tests for mixed enabled flags and for invalid config (exit 2, no **`pollIntervalMs`** in stderr).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e358f4749e639167734b55c9297f6487765d6016. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connector status now reflects the actual enabled/disabled state of Google Drive and Notion from the current configuration.
  * Enabled connectors that have never synced now correctly report their sync status as “never.”
  * Configuration read/parse failures now emit a clear error and exit with a non-zero status, avoiding misleading output.

* **Tests**
  * Added regression coverage for the `remnic connectors status` CLI, including both valid and invalid configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->