### PR TITLE
test(core): share typed persistExtraction test double

### DIFF
--- a/.omp/rules/remnic-no-inline-persist-mock.md
+++ b/.omp/rules/remnic-no-inline-persist-mock.md
@@ -6,7 +6,6 @@ condition:
   - '\.persistExtraction\s*=\s*(async\b|\([^)]*\)\s*=>)'
 globs:
   - "**/packages/remnic-core/src/**/*.test.ts"
-  - "**/*.test.ts"
 ---
 
 You are replacing the orchestrator's `persistExtraction` method with an
@@ -20,7 +19,7 @@ Use the shared, production-typed factory instead:
 ```ts
 import { stubPersistExtraction } from "./testing/orchestrator-lite.js";
 
-// records each ExtractionResult; returns the factory's ids (or [] by default)
+// records each call's PersistExtractionArgs tuple; returns the factory's ids (or [] by default)
 const persistCalls = stubPersistExtraction(orchestrator, () => ["fact-1"]);
 // ...
 assert.equal(persistCalls.length, 1);

--- a/.omp/rules/remnic-no-inline-persist-mock.md
+++ b/.omp/rules/remnic-no-inline-persist-mock.md
@@ -1,0 +1,38 @@
+---
+name: remnic-no-inline-persist-mock
+description: "Tests must stub the orchestrator persist surface via stubPersistExtraction, not an inline `.persistExtraction = async …` assignment"
+interruptMode: never
+condition:
+  - '\.persistExtraction\s*=\s*(async\b|\([^)]*\)\s*=>)'
+globs:
+  - "**/packages/remnic-core/src/**/*.test.ts"
+  - "**/*.test.ts"
+---
+
+You are replacing the orchestrator's `persistExtraction` method with an
+inline test double (`orchestrator.persistExtraction = async () => [...]`).
+An inline arrow is untyped against the production signature, so a change
+to `persistExtraction`'s parameters or return type does not break the
+test — the mock silently drifts.
+
+Use the shared, production-typed factory instead:
+
+```ts
+import { stubPersistExtraction } from "./testing/orchestrator-lite.js";
+
+// records each ExtractionResult; returns the factory's ids (or [] by default)
+const persistCalls = stubPersistExtraction(orchestrator, () => ["fact-1"]);
+// ...
+assert.equal(persistCalls.length, 1);
+```
+
+`stubPersistExtraction` types the replacement as `PersistExtractionFn`
+(sourced from the extraction-run delegate contract), so a production
+signature change fails to compile in every consumer rather than passing
+a stale mock. The returned array is the call log — assert on `.length`
+instead of hand-rolling a counter.
+
+This rule does NOT match a delegate-deps field literal
+(`persistExtraction: async (...) => [...]` with a colon) — that is a
+legitimate `ExtractionRunCoordinatorDeps` value, not a method override —
+nor the factory's own `seam.persistExtraction = impl` assignment.

--- a/packages/remnic-core/src/faithfulness-graph-guard.test.ts
+++ b/packages/remnic-core/src/faithfulness-graph-guard.test.ts
@@ -26,6 +26,8 @@ import { readEdges } from "./graph.js";
 import type { ExtractionResult, PluginConfig } from "./types.js";
 import type { LocalLlmClient } from "./local-llm.js";
 import type { BufferTurn, ConversationThread } from "./types.js";
+import type { PersistExtractionFn } from "./testing/orchestrator-lite.js";
+import type { StorageManager } from "./storage.js";
 
 /**
  * Stub local LLM whose `chatCompletion` only answers faithfulness-gate calls
@@ -126,33 +128,18 @@ test("pending_review fact gets no graph edge; an active fact with the same entit
       faithfulnessStubLocalLlm((c) =>
         c.includes("closed permanently") ? "unsupported" : "entailed",
       );
-    const storage = await (orchestrator as unknown as {
-      getStorage: (ns: string) => Promise<{
-        ensureDirectories: () => Promise<void>;
-        readAllMemories: () => Promise<
-          Array<{
-            path: string;
-            frontmatter: { id: string; status?: string };
-          }>
-        >;
-      }>;
-    }).getStorage("default");
+    // getStorage + persistExtraction are private; reach them through a named production-typed surface.
+    const persist = orchestrator as unknown as {
+      getStorage: (ns: string) => Promise<StorageManager>;
+      persistExtraction: PersistExtractionFn;
+    };
+    const storage = await persist.getStorage("default");
     await storage.ensureDirectories();
 
     const sourceText =
       "The widget factory produces widgets. It launched last year. The team is small.";
 
-    const ids0 = await (orchestrator as unknown as {
-      persistExtraction: (
-        r: ExtractionResult,
-        s: unknown,
-        t: unknown,
-        ctx: unknown,
-        bn: unknown,
-        plan: unknown,
-        src: string,
-      ) => Promise<string[]>;
-    }).persistExtraction(
+    const ids0 = await persist.persistExtraction(
       factResult("The widget factory produces widgets daily.", "widget-factory"),
       storage,
       null,
@@ -166,17 +153,7 @@ test("pending_review fact gets no graph edge; an active fact with the same entit
 
     // fact1 → unsupported (pending_review). Under the bug it would originate an
     // entity edge to fact0; under the guard it must NOT.
-    const ids1 = await (orchestrator as unknown as {
-      persistExtraction: (
-        r: ExtractionResult,
-        s: unknown,
-        t: unknown,
-        ctx: unknown,
-        bn: unknown,
-        plan: unknown,
-        src: string,
-      ) => Promise<string[]>;
-    }).persistExtraction(
+    const ids1 = await persist.persistExtraction(
       factResult(
         "The widget factory closed permanently.",
         "widget-factory",
@@ -216,17 +193,7 @@ test("pending_review fact gets no graph edge; an active fact with the same entit
 
     // Control: an ACTIVE fact with the same entityRef DOES create entity edges
     // (proving the graph is wired and only pending_review is excluded).
-    const ids2 = await (orchestrator as unknown as {
-      persistExtraction: (
-        r: ExtractionResult,
-        s: unknown,
-        t: unknown,
-        ctx: unknown,
-        bn: unknown,
-        plan: unknown,
-        src: string,
-      ) => Promise<string[]>;
-    }).persistExtraction(
+    const ids2 = await persist.persistExtraction(
       factResult("The widget factory reopened this quarter.", "widget-factory"),
       storage,
       null,
@@ -312,26 +279,6 @@ function twoFactResult(
   } as unknown as ExtractionResult;
 }
 
-interface StorageLike {
-  ensureDirectories: () => Promise<void>;
-  dir: string;
-  readAllMemories: () => Promise<
-    Array<{ path: string; frontmatter: { id: string; status?: string } }>
-  >;
-}
-
-interface PersistExtractionSig {
-  (
-    r: ExtractionResult,
-    s: unknown,
-    t: string | null,
-    ctx: unknown,
-    bn: unknown,
-    plan: unknown,
-    src: string,
-  ): Promise<string[]>;
-}
-
 test("pending_review id must NOT enter persisted thread episodes across a cross-flush (#1635)", async () => {
   const { orchestrator, memoryDir } = await makeThreadHarness();
   try {
@@ -342,7 +289,7 @@ test("pending_review id must NOT enter persisted thread episodes across a cross-
       );
 
     const getStorage = orchestrator as unknown as {
-      getStorage: (ns: string) => Promise<StorageLike>;
+      getStorage: (ns: string) => Promise<StorageManager>;
     };
     const storage = await getStorage.getStorage("default");
     await storage.ensureDirectories();
@@ -365,7 +312,7 @@ test("pending_review id must NOT enter persisted thread episodes across a cross-
     assert.ok(threadId, "thread established via processTurn");
 
     const persist = orchestrator as unknown as {
-      persistExtraction: PersistExtractionSig;
+      persistExtraction: PersistExtractionFn;
       appendPersistedThreadEpisodes: (
         threadId: string,
         persistedIds: string[],

--- a/packages/remnic-core/src/orchestrator-chunked-hash-durability.test.ts
+++ b/packages/remnic-core/src/orchestrator-chunked-hash-durability.test.ts
@@ -29,15 +29,11 @@ import { Orchestrator } from "./orchestrator.js";
 import { ContentHashIndex, StorageManager } from "./storage.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
 import type { ExtractionResult, MemoryFile } from "./types.js";
+import type { PersistExtractionFn } from "./testing/orchestrator-lite.js";
 
 /** persistExtraction is private; reach it through an unknown-cast surface. */
 interface OrchestratorTestSurface {
-  persistExtraction: (
-    result: ExtractionResult,
-    storage: StorageManager,
-    threadId: string | null,
-    sourceContext?: { sourceConnector?: string; validAt?: string },
-  ) => Promise<string[]>;
+  persistExtraction: PersistExtractionFn;
   getStorage: (namespace: string) => Promise<StorageManager>;
 }
 

--- a/packages/remnic-core/src/orchestrator-connector-dedup.test.ts
+++ b/packages/remnic-core/src/orchestrator-connector-dedup.test.ts
@@ -27,28 +27,16 @@ import { ContentHashIndex, StorageManager } from "./storage.js";
 import type { ExtractionResult, ExtractedFact, MemoryFile, MemoryCategory } from "./types.js";
 import type { ResolvedScopeProfilePlan } from "./namespaces/scope-profiles.js";
 import { buildProcedurePersistBody } from "./procedural/procedure-types.js";
+import type { PersistExtractionFn } from "./testing/orchestrator-lite.js";
 
 // ---------------------------------------------------------------------------
 // Types — minimal surface of Orchestrator needed by these tests.
 // persistExtraction is private; cast through unknown to reach it without `any`.
 // ---------------------------------------------------------------------------
 
-/** Source-context shape accepted by persistExtraction (connector subset). */
-interface TestSourceContext {
-  sourceConnector?: string;
-  validAt?: string;
-}
-
 /** Orchestrator fields the tests touch (all exist on the real instance). */
 interface OrchestratorTestSurface {
-  persistExtraction: (
-    result: ExtractionResult,
-    storage: StorageManager,
-    threadId: string | null,
-    sourceContext?: TestSourceContext,
-    baseNamespace?: string,
-    scopeProfileWritePlan?: ResolvedScopeProfilePlan | null,
-  ) => Promise<string[]>;
+  persistExtraction: PersistExtractionFn;
   getStorage: (namespace: string) => Promise<StorageManager>;
   contentHashIndex: ContentHashIndex | null;
   // Private on the real instance; reached through the unknown-cast surface for

--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -15,6 +15,7 @@ import type { BufferState, BufferTurn } from "./types.js";
 import type { ImportTurn } from "./bulk-import/types.js";
 import { namespaceIdentityToken } from "./namespaces/identity.js";
 import { readNamespaceMaintenanceStatuses } from "./maintenance/namespace-planner.js";
+import { stubPersistExtraction } from "./testing/orchestrator-lite.js";
 
 function makeTurn(sessionKey: string, content: string): BufferTurn {
   return {
@@ -995,7 +996,6 @@ test("runExtraction fails closed on invalid extraction results when required", a
     config.extractionMinUserTurns = 1;
 
     let clearCalls = 0;
-    let persistCalls = 0;
     const orchestrator = Object.create(Orchestrator.prototype) as any;
     orchestrator.config = config;
     orchestrator.buffer = {
@@ -1020,10 +1020,7 @@ test("runExtraction fails closed on invalid extraction results when required", a
     orchestrator.extraction = {
       extract: async () => extractionResult,
     };
-    orchestrator.persistExtraction = async () => {
-      persistCalls += 1;
-      return ["fact-1"];
-    };
+    const persistCalls = stubPersistExtraction(orchestrator, () => ["fact-1"]);
 
     await assert.rejects(
       orchestrator.runExtraction([makeTurn("session-invalid", "remember bad output")], {
@@ -1034,7 +1031,7 @@ test("runExtraction fails closed on invalid extraction results when required", a
     );
 
     assert.equal(clearCalls, 0);
-    assert.equal(persistCalls, 0);
+    assert.equal(persistCalls.length, 0);
   }
 });
 
@@ -1044,7 +1041,6 @@ test("runExtraction persists processed fingerprints for empty extraction results
   config.extractionMinUserTurns = 1;
 
   let clearCalls = 0;
-  let persistCalls = 0;
   let saveMetaCalls = 0;
   let savedMeta:
     | {
@@ -1096,10 +1092,7 @@ test("runExtraction persists processed fingerprints for empty extraction results
       profileUpdates: [],
     }),
   };
-  orchestrator.persistExtraction = async () => {
-    persistCalls += 1;
-    return [];
-  };
+  const persistCalls = stubPersistExtraction(orchestrator);
 
   const turns = [
     {
@@ -1116,7 +1109,7 @@ test("runExtraction persists processed fingerprints for empty extraction results
 
   assert.equal(result.status, "skipped");
   assert.equal(result.reason, "empty_extraction_result");
-  assert.equal(persistCalls, 0);
+  assert.equal(persistCalls.length, 0);
   assert.equal(saveMetaCalls, 1);
   assert.equal(clearCalls, 1);
   assert.equal(savedMeta?.extractionCount, 1);
@@ -1135,7 +1128,6 @@ test("runExtraction does not persist processed fingerprints for failed empty ext
   config.extractionMinUserTurns = 1;
 
   let clearCalls = 0;
-  let persistCalls = 0;
   let saveMetaCalls = 0;
 
   const meta = {
@@ -1175,10 +1167,7 @@ test("runExtraction does not persist processed fingerprints for failed empty ext
       extractionFailure: "gateway_unavailable",
     }),
   };
-  orchestrator.persistExtraction = async () => {
-    persistCalls += 1;
-    return [];
-  };
+  const persistCalls = stubPersistExtraction(orchestrator);
 
   const turns = [
     {
@@ -1194,7 +1183,7 @@ test("runExtraction does not persist processed fingerprints for failed empty ext
 
   assert.equal(result.status, "skipped");
   assert.equal(result.reason, "empty_extraction_result");
-  assert.equal(persistCalls, 0);
+  assert.equal(persistCalls.length, 0);
   // #1908: a failed extraction now persists per-fingerprint retry-state to meta (one
   // saveMeta call), but MUST NOT record a processed fingerprint — the invariant
   // below (processedExtractionFingerprints stays []) is the real contract.
@@ -1226,7 +1215,7 @@ test("runExtraction clears the buffer on a failed extraction when extractionRetr
   orchestrator.extraction = {
     extract: async () => ({ facts: [], entities: [], questions: [], profileUpdates: [], extractionFailure: "gateway_unavailable" }),
   };
-  orchestrator.persistExtraction = async () => [];
+  stubPersistExtraction(orchestrator);
   const turns = [{ ...makeTurn("session-retry-off", "failed gateway"), logicalSessionKey: "logical-thread:retry-off", turnFingerprint: "fp-retry-off", persistProcessedFingerprint: true }];
   const result = await orchestrator.runExtraction(turns, { bufferKey: "logical-thread:retry-off" });
   assert.equal(result.status, "skipped");
@@ -1379,7 +1368,6 @@ test("runExtraction still clears the buffer when fingerprint persistence fails a
   config.extractionMinChars = 0;
   config.extractionMinUserTurns = 1;
   let clearCalls = 0;
-  let persistCalls = 0;
   let fingerprintWrites = 0;
   const orchestrator = Object.create(Orchestrator.prototype) as any;
   orchestrator.config = config;
@@ -1417,10 +1405,7 @@ test("runExtraction still clears the buffer when fingerprint persistence fails a
       profileUpdates: [],
     }),
   };
-  orchestrator.persistExtraction = async () => {
-    persistCalls += 1;
-    return ["fact-1"];
-  };
+  const persistCalls = stubPersistExtraction(orchestrator, () => ["fact-1"]);
   orchestrator.recordProcessedExtractionFingerprint = async () => {
     fingerprintWrites += 1;
     throw new Error("saveMeta failed");
@@ -1442,7 +1427,7 @@ test("runExtraction still clears the buffer when fingerprint persistence fails a
     },
   );
 
-  assert.equal(persistCalls, 1);
+  assert.equal(persistCalls.length, 1);
   assert.equal(fingerprintWrites, 1);
   assert.equal(clearCalls, 1);
 });
@@ -1515,7 +1500,7 @@ test("runExtraction persists fingerprint and extraction counters through one coh
       profileUpdates: [],
     }),
   };
-  orchestrator.persistExtraction = async () => ["fact-1"];
+  stubPersistExtraction(orchestrator, () => ["fact-1"]);
   orchestrator.requestQmdMaintenance = () => undefined;
   orchestrator.runTierMigrationCycle = async () => undefined;
 
@@ -1623,7 +1608,7 @@ test("runExtraction loads meta before updating extraction counters when fingerpr
       profileUpdates: [],
     }),
   };
-  orchestrator.persistExtraction = async () => ["fact-1"];
+  stubPersistExtraction(orchestrator, () => ["fact-1"]);
   orchestrator.requestQmdMaintenance = () => undefined;
   orchestrator.runTierMigrationCycle = async () => undefined;
 
@@ -1704,7 +1689,7 @@ test("runExtraction completes after late threading failures and saves the proces
       profileUpdates: [],
     }),
   };
-  orchestrator.persistExtraction = async () => ["fact-1"];
+  stubPersistExtraction(orchestrator, () => ["fact-1"]);
   orchestrator.threading = {
     processTurn: async () => "thread-15",
     appendEpisodeIds: async () => undefined,
@@ -1806,7 +1791,7 @@ test("runExtraction completes and clears the buffer when the post-persist meta s
       profileUpdates: [],
     }),
   };
-  orchestrator.persistExtraction = async () => ["fact-1"];
+  stubPersistExtraction(orchestrator, () => ["fact-1"]);
   orchestrator.requestQmdMaintenance = () => undefined;
   orchestrator.runTierMigrationCycle = async () => undefined;
 
@@ -1889,7 +1874,7 @@ test("runExtraction still runs follow-on extraction helpers when the post-persis
       profileUpdates: [],
     }),
   };
-  orchestrator.persistExtraction = async () => ["fact-1"];
+  stubPersistExtraction(orchestrator, () => ["fact-1"]);
   orchestrator.threading = {
     processTurn: async () => "thread-17",
     appendEpisodeIds: async () => {
@@ -1948,7 +1933,6 @@ test("runExtraction aborts before late buffer clearing when the caller cancels",
   config.extractionMinUserTurns = 1;
 
   let clearCalls = 0;
-  let persistCalls = 0;
   let resolveExtract!: (value: {
     facts: [];
     entities: [];
@@ -1986,10 +1970,7 @@ test("runExtraction aborts before late buffer clearing when the caller cancels",
   orchestrator.extraction = {
     extract: async () => extractPromise,
   };
-  orchestrator.persistExtraction = async () => {
-    persistCalls += 1;
-    return [];
-  };
+  const persistCalls = stubPersistExtraction(orchestrator);
 
   const abortController = new AbortController();
   const runPromise = orchestrator.runExtraction(
@@ -2012,7 +1993,7 @@ test("runExtraction aborts before late buffer clearing when the caller cancels",
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.equal(clearCalls, 0);
-  assert.equal(persistCalls, 0);
+  assert.equal(persistCalls.length, 0);
 });
 
 test("runExtraction still clears the session buffer after persistence even if reset abort fires late", async () => {
@@ -2057,10 +2038,10 @@ test("runExtraction still clears the session buffer after persistence even if re
       profileUpdates: [],
     }),
   };
-  orchestrator.persistExtraction = async () => {
+  stubPersistExtraction(orchestrator, () => {
     abortController.abort();
     return ["fact-1"];
-  };
+  });
   orchestrator.maybeScheduleConsolidation = () => undefined;
   orchestrator.requestQmdMaintenance = () => undefined;
   orchestrator.nonZeroExtractionsSinceConsolidation = 0;

--- a/packages/remnic-core/src/testing/orchestrator-lite.ts
+++ b/packages/remnic-core/src/testing/orchestrator-lite.ts
@@ -119,6 +119,14 @@ export function stubExtraction(
  */
 export type PersistExtractionFn = ExtractionRunCoordinatorDeps["persistExtraction"];
 
+/**
+ * The full argument tuple of a {@link PersistExtractionFn} call. Recording the
+ * whole tuple — not just the leading ExtractionResult — means a change to ANY
+ * parameter (storage, source-context, capability sets) surfaces in every
+ * consumer that reads the call log, not only the first argument.
+ */
+export type PersistExtractionArgs = Parameters<PersistExtractionFn>;
+
 /** The method-level persist seam replaced by {@link stubPersistExtraction}. */
 interface PersistExtractionSeam {
   persistExtraction: PersistExtractionFn;
@@ -126,23 +134,23 @@ interface PersistExtractionSeam {
 
 /**
  * Stub the orchestrator's `persistExtraction` method (the mutation surface the
- * extraction-run pipeline drives). Records the ExtractionResult of every call
- * for assertions; returns the factory's persisted-id list, or `[]` when no
- * factory is given. The replacement is typed as the production
- * {@link PersistExtractionFn}, so a production return-type change fails to
- * compile here rather than silently passing a stale mock.
+ * extraction-run pipeline drives). Records the full {@link PersistExtractionArgs}
+ * tuple of every call for assertions; returns the factory's persisted-id list,
+ * or `[]` when no factory is given. The replacement is typed as the production
+ * {@link PersistExtractionFn}, so a production signature change fails to compile
+ * here rather than silently passing a stale mock.
  */
 export function stubPersistExtraction(
   orchestrator: Orchestrator,
-  factory?: (result: ExtractionResult, call: number) => string[] | Promise<string[]>,
-): ExtractionResult[] {
-  const calls: ExtractionResult[] = [];
+  factory?: (args: PersistExtractionArgs, call: number) => string[] | Promise<string[]>,
+): PersistExtractionArgs[] {
+  const calls: PersistExtractionArgs[] = [];
   // `persistExtraction` is private and structurally unexpressible from outside
   // the class; the recorder replaces it in place. Named cast per rule.
   const seam = orchestrator as unknown as PersistExtractionSeam;
-  const impl: PersistExtractionFn = async (result) => {
-    calls.push(result);
-    return factory ? factory(result, calls.length) : [];
+  const impl: PersistExtractionFn = async (...args) => {
+    calls.push(args);
+    return factory ? factory(args, calls.length) : [];
   };
   seam.persistExtraction = impl;
   return calls;

--- a/packages/remnic-core/src/testing/orchestrator-lite.ts
+++ b/packages/remnic-core/src/testing/orchestrator-lite.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 
 import { parseConfig } from "../config.js";
 import type { Orchestrator } from "../orchestrator.js";
+import type { ExtractionRunCoordinatorDeps } from "../orchestration/extraction-run.js";
 import type { BufferTurn, ExtractionResult, PluginConfig } from "../types.js";
 
 /**
@@ -106,6 +107,44 @@ export function stubExtraction(
       return factory(turns, calls.length);
     },
   };
+  return calls;
+}
+
+/**
+ * The production `persistExtraction` signature (issue #2068). Sourced from the
+ * extraction-run delegate contract — the single canonical shape the orchestrator
+ * both exposes as a private method and delegates to. Test doubles and typed
+ * private-access surfaces import THIS so any production signature change breaks
+ * every consumer at compile time instead of drifting into stale inline casts.
+ */
+export type PersistExtractionFn = ExtractionRunCoordinatorDeps["persistExtraction"];
+
+/** The method-level persist seam replaced by {@link stubPersistExtraction}. */
+interface PersistExtractionSeam {
+  persistExtraction: PersistExtractionFn;
+}
+
+/**
+ * Stub the orchestrator's `persistExtraction` method (the mutation surface the
+ * extraction-run pipeline drives). Records the ExtractionResult of every call
+ * for assertions; returns the factory's persisted-id list, or `[]` when no
+ * factory is given. The replacement is typed as the production
+ * {@link PersistExtractionFn}, so a production return-type change fails to
+ * compile here rather than silently passing a stale mock.
+ */
+export function stubPersistExtraction(
+  orchestrator: Orchestrator,
+  factory?: (result: ExtractionResult, call: number) => string[] | Promise<string[]>,
+): ExtractionResult[] {
+  const calls: ExtractionResult[] = [];
+  // `persistExtraction` is private and structurally unexpressible from outside
+  // the class; the recorder replaces it in place. Named cast per rule.
+  const seam = orchestrator as unknown as PersistExtractionSeam;
+  const impl: PersistExtractionFn = async (result) => {
+    calls.push(result);
+    return factory ? factory(result, calls.length) : [];
+  };
+  seam.persistExtraction = impl;
   return calls;
 }
 


### PR DESCRIPTION
## What

Adds `stubPersistExtraction` and the `PersistExtractionFn` type to `packages/remnic-core/src/testing/orchestrator-lite.ts`, mirroring the existing `stubExtraction` seam. `PersistExtractionFn` is sourced from the extraction-run delegate contract (`ExtractionRunCoordinatorDeps["persistExtraction"]`), so any production signature change breaks every test consumer at compile time instead of silently drifting through stale inline mocks/casts.

## Migrated consumers

- **orchestrator-flush.test.ts** — 12 inline `orchestrator.persistExtraction = async () => [...]` overrides now call `stubPersistExtraction`; call-count assertions read the returned call log's `.length` (hand-rolled counters removed).
- **faithfulness-graph-guard.test.ts** — three duplicated inline 7-param cast literals and a local `PersistExtractionSig` alias collapse to the shared `PersistExtractionFn` (single named `persist` surface per the no-inline-cast-access rule); minimal storage stubs typed as the real `StorageManager`; dead `StorageLike` removed.
- **orchestrator-connector-dedup.test.ts** / **orchestrator-chunked-hash-durability.test.ts** — inline `persistExtraction` signatures in their `OrchestratorTestSurface` interfaces swapped for `PersistExtractionFn`; unused `TestSourceContext` removed.

Adds an advisory omp rule (`remnic-no-inline-persist-mock`) steering future tests to the factory.

## Verification

- `pnpm --filter @remnic/core check-types` clean.
- `tsx --test` on all four migrated files: 76 pass, 0 fail.
- `npm run preflight:quick`: OK.

Net −11 lines (shared type replaces duplicated inline signatures).

Closes #2068

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactors and documentation; production orchestration paths are unchanged.
> 
> **Overview**
> Introduces a **production-typed** `persistExtraction` test seam in `orchestrator-lite.ts`: `PersistExtractionFn` (from `ExtractionRunCoordinatorDeps`), `PersistExtractionArgs`, and `stubPersistExtraction`, which records full call tuples and replaces hand-rolled inline `orchestrator.persistExtraction = async …` mocks.
> 
> **`orchestrator-flush.test.ts`** is the main migration—dozens of inline stubs now use `stubPersistExtraction`, with assertions on the returned call log’s `.length` instead of manual counters.
> 
> Other tests only **swap duplicated inline signatures** for the shared type: faithfulness graph guard (single `persist` surface + `StorageManager`), connector-dedup, and chunked-hash durability `OrchestratorTestSurface` interfaces.
> 
> Adds an **omp advisory rule** (`remnic-no-inline-persist-mock`) to steer future tests toward the factory. **No runtime or extraction behavior changes**—compile-time safety and test consistency only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a35bb593a5020f6d089af6a411dea5ff1124f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a shared, production-typed persistence stub for extraction tests, with call tracking and configurable persisted IDs.
- **Tests**
  - Updated persistence-related tests to use the shared stub and consistent array-based call assertions.
  - Standardized test typing against the production persistence interfaces to prevent drift, without changing test behavior.
- **Chores**
  - Added a validation rule to flag inline persistence overrides in test files and encourage using the shared stub instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->