### PR TITLE
feat(bench): emit LoCoMo per-category aggregates (#1878)

### DIFF
--- a/.changeset/locomo-category-aggregates-1878.md
+++ b/.changeset/locomo-category-aggregates-1878.md
@@ -1,0 +1,5 @@
+---
+"@remnic/bench": patch
+---
+
+Published-benchmark harness: emit an optional per-category aggregate breakdown (`results.categoryAggregates`) for benchmarks whose tasks stamp a `categoryName` detail — today only LoCoMo. This makes the adversarial-vs-answerable metric split issue #1878 tracks readable straight from the result artifact instead of hand-computed from task-id category suffixes. The `computeCategoryAggregates` helper groups finished task results by `categoryName` and reuses `aggregateTaskScores`; it reads only the category label (no oracle leak), sorts output keys for deterministic serialization, and is omitted when empty so other benchmarks' output shape is unchanged. Additive and provider-free — no change to recall, answering, scoring, or the abstention gate.

--- a/packages/bench/src/benchmarks/published/category-aggregates.test.ts
+++ b/packages/bench/src/benchmarks/published/category-aggregates.test.ts
@@ -17,6 +17,19 @@ function makeTask(categoryName: string | undefined, scores: Record<string, numbe
   };
 }
 
+function makeRawTask(details: Record<string, unknown>): TaskResult {
+  return {
+    taskId: "t-raw",
+    question: "q",
+    expected: "e",
+    actual: "a",
+    scores: { llm_judge: 1 },
+    latencyMs: 0,
+    tokens: { input: 0, output: 0 },
+    details,
+  };
+}
+
 function meanOf(result: Record<string, AggregateMetrics>, category: string, metric: string): number {
   const categoryAgg = result[category];
   assert.ok(categoryAgg, `expected category "${category}"`);
@@ -69,4 +82,27 @@ test("computeCategoryAggregates output keys are sorted regardless of task order"
 test("computeCategoryAggregates returns an empty map for no categorized tasks", () => {
   assert.deepEqual(computeCategoryAggregates([]), {});
   assert.deepEqual(computeCategoryAggregates([makeTask(undefined, { llm_judge: 1 })]), {});
+});
+
+test("computeCategoryAggregates skips non-string and whitespace-only categoryName", () => {
+  const tasks: TaskResult[] = [
+    makeRawTask({ categoryName: null }),
+    makeRawTask({ categoryName: 3 }),
+    makeRawTask({ categoryName: { name: "adversarial" } }),
+    makeRawTask({ categoryName: "   " }),
+    makeRawTask({}),
+    makeTask("adversarial", { llm_judge: 0 }),
+  ];
+
+  const result = computeCategoryAggregates(tasks);
+
+  assert.deepEqual(Object.keys(result), ["adversarial"]);
+  assert.equal(meanOf(result, "adversarial", "llm_judge"), 0);
+});
+
+test("computeCategoryAggregates keeps a __proto__ category as an own key", () => {
+  const result = computeCategoryAggregates([makeRawTask({ categoryName: "__proto__" })]);
+
+  assert.deepEqual(Object.keys(result), ["__proto__"]);
+  assert.ok(Object.hasOwn(result, "__proto__"));
 });

--- a/packages/bench/src/benchmarks/published/category-aggregates.test.ts
+++ b/packages/bench/src/benchmarks/published/category-aggregates.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { AggregateMetrics, TaskResult } from "../../types.js";
+import { computeCategoryAggregates } from "./category-aggregates.js";
+
+function makeTask(categoryName: string | undefined, scores: Record<string, number>): TaskResult {
+  return {
+    taskId: `t-${categoryName ?? "none"}`,
+    question: "q",
+    expected: "e",
+    actual: "a",
+    scores,
+    latencyMs: 0,
+    tokens: { input: 0, output: 0 },
+    details: categoryName === undefined ? {} : { categoryName },
+  };
+}
+
+function meanOf(result: Record<string, AggregateMetrics>, category: string, metric: string): number {
+  const categoryAgg = result[category];
+  assert.ok(categoryAgg, `expected category "${category}"`);
+  const metricAgg = categoryAgg[metric];
+  assert.ok(metricAgg, `expected metric "${metric}" in "${category}"`);
+  return metricAgg.mean;
+}
+
+test("computeCategoryAggregates groups scores by category name", () => {
+  const tasks: TaskResult[] = [
+    makeTask("single_hop", { llm_judge: 1, contains_answer: 1 }),
+    makeTask("single_hop", { llm_judge: 1, contains_answer: 0 }),
+    makeTask("adversarial", { llm_judge: 0, contains_answer: 0 }),
+    makeTask("adversarial", { llm_judge: 0.5, contains_answer: 0 }),
+  ];
+
+  const result = computeCategoryAggregates(tasks);
+
+  assert.deepEqual(Object.keys(result), ["adversarial", "single_hop"]);
+  assert.equal(meanOf(result, "adversarial", "llm_judge"), 0.25);
+  assert.equal(meanOf(result, "single_hop", "llm_judge"), 1);
+  assert.equal(meanOf(result, "single_hop", "contains_answer"), 0.5);
+});
+
+test("computeCategoryAggregates skips tasks without a valid categoryName", () => {
+  const tasks: TaskResult[] = [
+    makeTask("adversarial", { llm_judge: 0 }),
+    makeTask(undefined, { llm_judge: 1 }),
+    makeTask("", { llm_judge: 1 }),
+  ];
+
+  const result = computeCategoryAggregates(tasks);
+
+  assert.deepEqual(Object.keys(result), ["adversarial"]);
+  assert.equal(meanOf(result, "adversarial", "llm_judge"), 0);
+});
+
+test("computeCategoryAggregates output keys are sorted regardless of task order", () => {
+  const tasks: TaskResult[] = [
+    makeTask("temporal", { llm_judge: 1 }),
+    makeTask("adversarial", { llm_judge: 0 }),
+    makeTask("multi_hop", { llm_judge: 1 }),
+  ];
+
+  const result = computeCategoryAggregates(tasks);
+
+  assert.deepEqual(Object.keys(result), ["adversarial", "multi_hop", "temporal"]);
+});
+
+test("computeCategoryAggregates returns an empty map for no categorized tasks", () => {
+  assert.deepEqual(computeCategoryAggregates([]), {});
+  assert.deepEqual(computeCategoryAggregates([makeTask(undefined, { llm_judge: 1 })]), {});
+});

--- a/packages/bench/src/benchmarks/published/category-aggregates.ts
+++ b/packages/bench/src/benchmarks/published/category-aggregates.ts
@@ -19,7 +19,7 @@ export function computeCategoryAggregates(tasks: readonly TaskResult[]): Record<
   const scoresByCategory = new Map<string, Record<string, number>[]>();
   for (const task of tasks) {
     const categoryName = task.details?.categoryName;
-    if (typeof categoryName !== "string" || categoryName.length === 0) {
+    if (typeof categoryName !== "string" || categoryName.trim().length === 0) {
       continue;
     }
     const bucket = scoresByCategory.get(categoryName);
@@ -29,12 +29,9 @@ export function computeCategoryAggregates(tasks: readonly TaskResult[]): Record<
       scoresByCategory.set(categoryName, [task.scores]);
     }
   }
-  const categoryAggregates: Record<string, AggregateMetrics> = {};
-  for (const categoryName of [...scoresByCategory.keys()].sort()) {
-    const scores = scoresByCategory.get(categoryName);
-    if (scores) {
-      categoryAggregates[categoryName] = aggregateTaskScores(scores);
-    }
-  }
-  return categoryAggregates;
+  // Build via Object.fromEntries (own-property define, not assignment) so a
+  // category literally named "__proto__" becomes an own key instead of
+  // invoking the prototype setter and vanishing from Object.keys.
+  const sortedEntries = [...scoresByCategory.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return Object.fromEntries(sortedEntries.map(([categoryName, scores]) => [categoryName, aggregateTaskScores(scores)]));
 }

--- a/packages/bench/src/benchmarks/published/category-aggregates.ts
+++ b/packages/bench/src/benchmarks/published/category-aggregates.ts
@@ -1,0 +1,40 @@
+import { aggregateTaskScores } from "../../scorer.js";
+import type { AggregateMetrics, TaskResult } from "../../types.js";
+
+/**
+ * Group finished task results by their `categoryName` detail and aggregate
+ * each group's scores, reusing the same `aggregateTaskScores` the overall
+ * result uses. Benchmarks that stamp a `categoryName` detail (LoCoMo) get a
+ * per-category breakdown — e.g. the adversarial-vs-answerable split issue
+ * #1878 tracks — read straight from the artifact instead of hand-computed
+ * from task-id category suffixes.
+ *
+ * It reads only the category label, never the question, expected answer, or
+ * evidence, so it cannot leak an oracle signal into scoring. Tasks without a
+ * non-empty string `categoryName` are skipped so a malformed detail cannot
+ * fabricate a bucket. Output keys are sorted for deterministic, diff-stable
+ * serialization; benchmarks that stamp no category yield an empty map.
+ */
+export function computeCategoryAggregates(tasks: readonly TaskResult[]): Record<string, AggregateMetrics> {
+  const scoresByCategory = new Map<string, Record<string, number>[]>();
+  for (const task of tasks) {
+    const categoryName = task.details?.categoryName;
+    if (typeof categoryName !== "string" || categoryName.length === 0) {
+      continue;
+    }
+    const bucket = scoresByCategory.get(categoryName);
+    if (bucket) {
+      bucket.push(task.scores);
+    } else {
+      scoresByCategory.set(categoryName, [task.scores]);
+    }
+  }
+  const categoryAggregates: Record<string, AggregateMetrics> = {};
+  for (const categoryName of [...scoresByCategory.keys()].sort()) {
+    const scores = scoresByCategory.get(categoryName);
+    if (scores) {
+      categoryAggregates[categoryName] = aggregateTaskScores(scores);
+    }
+  }
+  return categoryAggregates;
+}

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -393,6 +393,13 @@ async function executeTrialWithFailure(
       latencyMs: 0,
       tokens: { input: 0, output: 0 },
       details: {
+        // Preserve the trial's category so a failed trial is still attributed
+        // to its per-category bucket (computeCategoryAggregates), keeping the
+        // per-category breakdown consistent with the overall aggregates that
+        // already count this failure row (issue #1878).
+        ...(typeof trial.extraDetails?.categoryName === "string"
+          ? { categoryName: trial.extraDetails.categoryName }
+          : {}),
         // `error` is retained for compatibility with existing diagnostics.
         // The structured marker is the authoritative run-status signal; an
         // arbitrary benchmark-owned `extraDetails.error` must not make a

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -55,6 +55,7 @@ import {
   rougeL,
   timed,
 } from "../../scorer.js";
+import { computeCategoryAggregates } from "./category-aggregates.js";
 import type {
   BenchmarkMode,
   BenchmarkResult,
@@ -866,6 +867,7 @@ async function buildBenchmarkResult(
         .map((failure) => `${failure.taskId}: ${failure.message.slice(0, 240)}`)
         .join("; ")}${failedTasks.length > 3 ? `; and ${failedTasks.length - 3} more` : ""})`
     : undefined;
+  const categoryAggregates = computeCategoryAggregates(tasks);
 
   return {
     meta: {
@@ -904,6 +906,12 @@ async function buildBenchmarkResult(
     results: {
       tasks,
       aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+      // Per-category breakdown for benchmarks that stamp a `categoryName`
+      // detail (LoCoMo). Omitted when empty so other benchmarks' output shape
+      // is unchanged (issue #1878).
+      ...(Object.keys(categoryAggregates).length > 0
+        ? { categoryAggregates }
+        : {}),
     },
     environment: {
       os: process.platform,

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -209,6 +209,15 @@ export interface BenchmarkResult {
     tasks: TaskResult[];
     aggregates: AggregateMetrics;
     statistics?: StatisticalReport;
+    /**
+     * Optional per-category aggregate breakdown keyed by a benchmark-defined
+     * category label (e.g. LoCoMo's single_hop/adversarial). Populated by
+     * benchmarks whose tasks carry a `categoryName` detail so per-category
+     * metrics — such as the adversarial-vs-answerable split issue #1878
+     * tracks — are read straight from the artifact instead of hand-computed
+     * from task ids.
+     */
+    categoryAggregates?: Record<string, AggregateMetrics>;
   };
   environment: {
     os: string;


### PR DESCRIPTION
## Context

The read-time abstention gate that issue #1878 asked for already shipped in PR #1884 (adapter support assessment, harness gate, empty/weak abstention instruction, default-on for the `real` profile, reversible opt-out, fail-open, tests, docs). The one open item in #1878 is its acceptance **measurement**: an adversarial-vs-answerable `llm_judge` split, which today has to be hand-computed from per-task `taskId` category suffixes.

This PR ships that measurement instrument so the split is read straight from the result artifact.

## Change

- `results.categoryAggregates?` — new **optional** field on `BenchmarkResult.results` (metric aggregates keyed by category label).
- `computeCategoryAggregates()` — a pure helper (`packages/bench/src/benchmarks/published/category-aggregates.ts`) that groups finished task results by the `categoryName` detail the LoCoMo runner **already** stamps and reuses the existing `aggregateTaskScores`.
- Wired into the shared published-benchmark harness, right beside the existing `aggregates` computation, and **omitted when empty** so benchmarks that stamp no category keep their current output shape.

Properties that keep it clean and safe:
- **Provider-free / no oracle leak:** reads only the category label — never the question, expected answer, or evidence.
- **Deterministic:** output keys are sorted, so serialization is diff-stable regardless of task order.
- **Additive & minimal:** optional field; in practice only LoCoMo stamps `categoryName`. No change to recall, answering, scoring, or the abstention gate.
- Tasks without a valid `categoryName` are skipped (a malformed detail can't fabricate a bucket).

Wired in the harness rather than the LoCoMo runner because `locomo/runner.ts` sits exactly at its structural-ratchet ceiling, and the harness is the natural home for result aggregation.

## Tests

Model-free unit tests (`category-aggregates.test.ts`): grouping, skip-behavior for missing/empty category, sort determinism, and the empty case. Existing harness + LoCoMo runner tests still pass (40/40 across the touched suites).

## Scope note

This does **not** by itself close #1878 — its acceptance is a calibrated, uncapped 1,986-task real-profile LoCoMo rerun proving adversarial lift above 0.245 without answerable-category regression (credential-gated benchmark run). This PR makes that run's headline metric readable directly from the artifact.

Part of #1878.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmark results now optionally include per-category aggregate metrics in `results.categoryAggregates`.
  * Category aggregates are derived from completed tasks’ `categoryName`, with deterministic (sorted) category keys.

* **Bug Fixes**
  * Aggregates skip missing, empty, whitespace-only, or non-string category labels.
  * Special category value handling avoids prototype-related issues (e.g., `"__proto__"`).

* **Compatibility**
  * Existing recall, answering, scoring, and abstention behavior remains unchanged, and benchmarks without category data keep the prior result shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, read-only aggregation on existing task scores with no changes to scoring or execution paths beyond preserving category on failure details.
> 
> **Overview**
> Adds **optional** `results.categoryAggregates` to published benchmark artifacts so LoCoMo-style runs can read adversarial vs answerable (and other category) metric splits from the result JSON instead of deriving them from task IDs.
> 
> A new `computeCategoryAggregates` helper groups finished tasks by the existing `details.categoryName` label, reuses `aggregateTaskScores` per bucket, skips invalid labels, sorts keys for stable output, and is omitted entirely when no categorized tasks exist. The harness calls it when building `BenchmarkResult` and **copies `categoryName` onto failed trial rows** so per-category totals stay aligned with overall aggregates. Scoring, recall, and abstention behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d92d06b060930c3fc57bd72bcd0b3f71a69edf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->