### PR TITLE
fix(core): dead-letter quarantine for ACL-rejected writes (#1888)

### DIFF
--- a/.changeset/observe-write-quarantine-1888.md
+++ b/.changeset/observe-write-quarantine-1888.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Dead-letter quarantine for writes rejected by the namespace write-ACL (issue #1888, part 1). When `observe` / `memory_store` / `suggestion_submit` fail namespace authorization, the payload used to be dropped with no recoverable copy — a misconfigured client namespace silently destroyed every write in the window. The ACL rejection stays fail-closed and loud; the payload is now parked under `<memoryDir>/state/quarantine/<principalSafe>/` (outside any memory namespace, principal-keyed, bounded by count and age) before the rejection re-throws, following the "reject loudly but never destroy state" posture. A new `NamespaceNotWritableError` (subclass of `EngramAccessInputError`, so existing HTTP-400 mapping is unchanged) carries the attempted namespace + principal to the write surface; `EngramAccessInputError` moved alongside it into `access-errors.ts` and is re-exported from `access-service.ts` for compatibility. Non-ACL input errors and writable namespaces are never quarantined. Doctor surfacing, a replay command, and the client-side startup preflight follow in separate PRs.

--- a/packages/remnic-core/src/access-errors.ts
+++ b/packages/remnic-core/src/access-errors.ts
@@ -1,2 +1,23 @@
 /** Authenticated caller lacks the required authorization (HTTP 403). */
 export class EngramAccessForbiddenError extends Error {}
+
+/** Invalid caller input (HTTP 400). */
+export class EngramAccessInputError extends Error {}
+
+/**
+ * A write rejected by the namespace write-ACL (issue #1888). Subclasses
+ * EngramAccessInputError so every existing catch/HTTP-400 mapping still
+ * applies, but carries the attempted namespace + principal so the observe/
+ * write surfaces can dead-letter the payload before re-throwing (fail-closed
+ * placement is unchanged; only the destroyed-payload behavior is fixed).
+ */
+export class NamespaceNotWritableError extends EngramAccessInputError {
+  constructor(
+    readonly attemptedNamespace: string,
+    readonly principal: string | undefined,
+    message?: string
+  ) {
+    super(message ?? `namespace is not writable: ${attemptedNamespace}`);
+    this.name = "NamespaceNotWritableError";
+  }
+}

--- a/packages/remnic-core/src/access-observe-quarantine.test.ts
+++ b/packages/remnic-core/src/access-observe-quarantine.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Issue #1888: a write rejected by the namespace write-ACL must be
+ * dead-lettered (payload preserved for replay) AND still throw loudly — the
+ * fail-closed placement is unchanged; only the destroyed-payload behavior is
+ * fixed.
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { EngramAccessService, NamespaceNotWritableError } from "./access-service.js";
+import { Orchestrator } from "./orchestrator.js";
+import type { CodingContext, PluginConfig } from "./types.js";
+import { WriteQuarantineStore } from "./write-quarantine.js";
+
+function makeService(memoryDir: string): EngramAccessService {
+  const orch = Object.create(Orchestrator.prototype) as Orchestrator;
+  const internals = orch as unknown as {
+    config: PluginConfig;
+    _codingContextBySession: Map<string, CodingContext>;
+  };
+  internals.config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    codingMode: { projectScope: true },
+    memoryDir,
+  } as unknown as PluginConfig;
+  internals._codingContextBySession = new Map();
+  return new EngramAccessService(orch);
+}
+
+async function withService(fn: (service: EngramAccessService, dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-1888-"));
+  try {
+    await fn(makeService(dir), dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("memory_store rejected by the namespace ACL is quarantined and still throws (#1888)", async () => {
+  await withService(async (service, dir) => {
+    await assert.rejects(
+      service.memoryStore({
+        content: "secret data",
+        namespace: "victim-secret",
+        authenticatedPrincipal: "alice",
+        sessionKey: "s-1",
+      } as unknown as Parameters<EngramAccessService["memoryStore"]>[0]),
+      NamespaceNotWritableError
+    );
+
+    const records = await new WriteQuarantineStore(dir).list();
+    assert.equal(records.length, 1);
+    assert.equal(records[0]?.operation, "memory_store");
+    assert.equal(records[0]?.principal, "alice");
+    assert.equal(records[0]?.attemptedNamespace, "victim-secret");
+    assert.equal((records[0]?.payload as { content?: string } | undefined)?.content, "secret data");
+  });
+});
+
+test("suggestion_submit rejected by the namespace ACL is quarantined and still throws (#1888)", async () => {
+  await withService(async (service, dir) => {
+    await assert.rejects(
+      service.suggestionSubmit({
+        content: "a suggestion",
+        namespace: "victim-secret",
+        authenticatedPrincipal: "alice",
+        sessionKey: "s-2",
+      } as unknown as Parameters<EngramAccessService["suggestionSubmit"]>[0]),
+      NamespaceNotWritableError
+    );
+
+    const records = await new WriteQuarantineStore(dir).list();
+    assert.equal(records.length, 1);
+    assert.equal(records[0]?.operation, "suggestion_submit");
+  });
+});
+
+test("a non-ACL input error on a writable namespace is NOT quarantined (#1888)", async () => {
+  await withService(async (service, dir) => {
+    // `default` is writable, so namespace resolution succeeds; the request then
+    // fails a later validation (unsupported schemaVersion). That rejection is
+    // not a namespace-ACL denial, so nothing is quarantined.
+    await assert.rejects(
+      service.memoryStore({
+        content: "fine",
+        namespace: "default",
+        schemaVersion: 999,
+        authenticatedPrincipal: "alice",
+        sessionKey: "s-3",
+      } as unknown as Parameters<EngramAccessService["memoryStore"]>[0]),
+      (err: unknown) => err instanceof Error && !(err instanceof NamespaceNotWritableError)
+    );
+
+    assert.equal(await new WriteQuarantineStore(dir).count(), 0);
+  });
+});
+
+test("a dry-run rejected write is NOT quarantined (#1888)", async () => {
+  await withService(async (service, dir) => {
+    await assert.rejects(
+      service.memoryStore({
+        content: "dry run",
+        namespace: "victim-secret",
+        authenticatedPrincipal: "alice",
+        sessionKey: "s-4",
+        dryRun: true,
+      } as unknown as Parameters<EngramAccessService["memoryStore"]>[0]),
+      NamespaceNotWritableError
+    );
+
+    // A dry run is a no-persist validation, so nothing is parked.
+    assert.equal(await new WriteQuarantineStore(dir).count(), 0);
+  });
+});

--- a/packages/remnic-core/src/access-observe-write-surface.ts
+++ b/packages/remnic-core/src/access-observe-write-surface.ts
@@ -32,9 +32,11 @@ import type { MemoryActionOutcome, MemoryActionType } from "./types.js";
 import { exportWorkBoardMarkdown, exportWorkBoardSnapshot, importWorkBoardSnapshot } from "./work/board.js";
 import { wrapWorkLayerContext } from "./work/boundary.js";
 import { WorkStorage } from "./work/storage.js";
+import { WriteQuarantineStore, type QuarantineOperation } from "./write-quarantine.js";
 import {
   ENGRAM_ACCESS_WRITE_SCHEMA_VERSION,
   EngramAccessInputError,
+  NamespaceNotWritableError,
   type CodingScopedWriteInput,
   type EngramAccessBriefingRequest,
   type EngramAccessBriefingResponse,
@@ -118,7 +120,49 @@ export interface AccessObserveWriteSurfaceDeps {
 }
 
 export class AccessObserveWriteSurface {
+  private quarantineStoreInstance?: WriteQuarantineStore;
+
   constructor(private readonly deps: AccessObserveWriteSurfaceDeps) {}
+
+  private quarantineStore(): WriteQuarantineStore {
+    if (!this.quarantineStoreInstance) {
+      this.quarantineStoreInstance = new WriteQuarantineStore(
+        this.deps.orchestrator.config.memoryDir,
+      );
+    }
+    return this.quarantineStoreInstance;
+  }
+
+  /**
+   * Dead-letter a write the namespace ACL just rejected (issue #1888). Only
+   * acts on {@link NamespaceNotWritableError}; other input errors pass through
+   * untouched. Parking is best-effort — a quarantine failure is logged and
+   * swallowed so it never masks or replaces the original loud rejection, which
+   * the caller re-throws. The ACL placement is unchanged; the payload simply
+   * stops being destroyed.
+   */
+  private async parkRejectedWrite(
+    err: unknown,
+    operation: QuarantineOperation,
+    payload: unknown,
+  ): Promise<void> {
+    if (!(err instanceof NamespaceNotWritableError)) return;
+    try {
+      await this.quarantineStore().quarantine({
+        operation,
+        principal: err.principal,
+        attemptedNamespace: err.attemptedNamespace,
+        payload,
+      });
+      log.warn(
+        `quarantine: parked rejected ${operation} write for principal=${err.principal ?? "-"} attemptedNamespace=${err.attemptedNamespace} (namespace not writable); replay after fixing config`,
+      );
+    } catch (quarantineErr) {
+      log.warn(
+        `quarantine: failed to park rejected ${operation} write: ${quarantineErr instanceof Error ? quarantineErr.message : String(quarantineErr)}`,
+      );
+    }
+  }
 
   async qmdHealth(
     searchBackend: string,
@@ -369,7 +413,16 @@ export class AccessObserveWriteSurface {
     request: EngramAccessMemoryStoreRequest,
     hooks?: { enforceWriteQuota?: () => void | Promise<void> }
   ): Promise<EngramAccessWriteResponse> {
-    const namespace = await this.deps.resolveCodingScopedWriteNamespace(request);
+    let namespace: string;
+    try {
+      namespace = await this.deps.resolveCodingScopedWriteNamespace(request);
+    } catch (err) {
+      // A dry run is a no-persist validation, so never dead-letter it.
+      if (request.dryRun !== true) {
+        await this.parkRejectedWrite(err, "memory_store", request);
+      }
+      throw err;
+    }
     const schemaVersion = request.schemaVersion ?? ENGRAM_ACCESS_WRITE_SCHEMA_VERSION;
     if (schemaVersion !== ENGRAM_ACCESS_WRITE_SCHEMA_VERSION) {
       throw new EngramAccessInputError(`unsupported schemaVersion: ${schemaVersion}`);
@@ -445,7 +498,16 @@ export class AccessObserveWriteSurface {
     request: EngramAccessSuggestionSubmitRequest,
     hooks?: { enforceWriteQuota?: () => void | Promise<void> }
   ): Promise<EngramAccessWriteResponse> {
-    const namespace = await this.deps.resolveCodingScopedWriteNamespace(request);
+    let namespace: string;
+    try {
+      namespace = await this.deps.resolveCodingScopedWriteNamespace(request);
+    } catch (err) {
+      // A dry run is a no-persist validation, so never dead-letter it.
+      if (request.dryRun !== true) {
+        await this.parkRejectedWrite(err, "suggestion_submit", request);
+      }
+      throw err;
+    }
     const schemaVersion = request.schemaVersion ?? ENGRAM_ACCESS_WRITE_SCHEMA_VERSION;
     if (schemaVersion !== ENGRAM_ACCESS_WRITE_SCHEMA_VERSION) {
       throw new EngramAccessInputError(`unsupported schemaVersion: ${schemaVersion}`);
@@ -543,7 +605,13 @@ export class AccessObserveWriteSurface {
     //    self base leaves NO coding context bound to the session, matching how
     //    `memory_store` resolves its full scoped write namespace before any
     //    session mutation.
-    const scope = await this.deps.resolveMemoryScopePlan(request);
+    let scope: MemoryScopePlan;
+    try {
+      scope = await this.deps.resolveMemoryScopePlan(request);
+    } catch (err) {
+      await this.parkRejectedWrite(err, "observe", request);
+      throw err;
+    }
     const writeNamespace = scope.writeNamespace;
 
     // Backward-compatible BASE writable namespace (pre-#1495 response semantics)

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -266,7 +266,10 @@ import { AccessRecallSurface } from "./access-recall-surface.js";
 import { AccessIdentityContinuitySurface } from "./access-identity-continuity-surface.js";
 import { selfDeps } from "./orchestration/self-deps.js";
 
-export class EngramAccessInputError extends Error {}
+import { EngramAccessInputError, NamespaceNotWritableError } from "./access-errors.js";
+// Re-exported so existing `import { … } from "./access-service.js"` callers keep
+// working after these classes moved to ./access-errors (issue #1888).
+export { EngramAccessInputError, NamespaceNotWritableError } from "./access-errors.js";
 
 function qmdCollectionPathParts(resultPath: string): {
   collection: string;
@@ -1476,10 +1479,12 @@ export class EngramAccessService {
       this.orchestrator.config,
     );
     if (!result.ok) {
-      throw new EngramAccessInputError(
-        result.reason === "unsupported"
-          ? `unsupported namespace: ${result.namespace}`
-          : `namespace is not writable: ${result.namespace}`,
+      if (result.reason === "unsupported") {
+        throw new EngramAccessInputError(`unsupported namespace: ${result.namespace}`);
+      }
+      throw new NamespaceNotWritableError(
+        result.namespace,
+        this.resolveRequestPrincipal(sessionKey, authenticatedPrincipal),
       );
     }
     return result.namespace;
@@ -1605,9 +1610,8 @@ export class EngramAccessService {
         profilePlan.writeNamespace.length > 0 &&
         profilePlan.readNamespaces.includes(profilePlan.writeNamespace);
       if (!selectedLayer?.writable || !writeNamespaceReadable) {
-        throw new EngramAccessInputError(
-          `scope profile ${profilePlan.profileId} has no writable layer inside the profile read stack for principal ${principal ?? "anonymous"}`,
-        );
+        throw new NamespaceNotWritableError(profilePlan.writeNamespace, principal,
+          `scope profile ${profilePlan.profileId} has no writable layer for principal ${principal ?? "anonymous"}`);
       }
       return profilePlan.writeNamespace;
     }
@@ -1626,7 +1630,7 @@ export class EngramAccessService {
     // no separate write policy.
     const base = defaultNamespaceForPrincipal(principal, this.orchestrator.config);
     if (!canWriteNamespace(principal, base, this.orchestrator.config)) {
-      throw new EngramAccessInputError(`namespace is not writable: ${base}`);
+      throw new NamespaceNotWritableError(base, principal);
     }
     return combineNamespaces(base, overlay.namespace);
   }
@@ -1837,9 +1841,8 @@ export class EngramAccessService {
         profilePlan.readNamespaces.includes(profilePlan.writeNamespace);
       if (!selectedLayer?.writable || !writeNamespaceReadable) {
         clearSeededContext();
-        throw new EngramAccessInputError(
-          `scope profile ${profilePlan.profileId} has no writable layer inside the profile read stack for principal ${principal ?? "anonymous"}`,
-        );
+        throw new NamespaceNotWritableError(profilePlan.writeNamespace, principal,
+          `scope profile ${profilePlan.profileId} has no writable layer for principal ${principal ?? "anonymous"}`);
       }
       const legacyRecallNamespaces = Array.isArray(this.orchestrator.config.defaultRecallNamespaces)
         ? recallNamespacesForPrincipal(principal, this.orchestrator.config)
@@ -1913,9 +1916,7 @@ export class EngramAccessService {
         !canWriteNamespace(principal, baseNamespace, this.orchestrator.config)
       ) {
         clearSeededContext();
-        throw new EngramAccessInputError(
-          `namespace is not writable: ${baseNamespace}`,
-        );
+        throw new NamespaceNotWritableError(baseNamespace, principal);
       }
       return {
         principal,
@@ -1942,9 +1943,7 @@ export class EngramAccessService {
     // it, so it needs no separate write policy — rule 42 / 47 / 48).
     if (!canWriteNamespace(principal, baseNamespace, this.orchestrator.config)) {
       clearSeededContext();
-      throw new EngramAccessInputError(
-        `namespace is not writable: ${baseNamespace}`,
-      );
+      throw new NamespaceNotWritableError(baseNamespace, principal);
     }
     const writeNamespace = overlaidBase;
     const readNamespaces = [writeNamespace];

--- a/packages/remnic-core/src/write-quarantine.test.ts
+++ b/packages/remnic-core/src/write-quarantine.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readdir, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { WriteQuarantineStore } from "./write-quarantine.js";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-quarantine-"));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function isInside(root: string, child: string): boolean {
+  const rel = path.relative(path.resolve(root), path.resolve(child));
+  return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
+test("quarantine writes a record under state/quarantine and list() returns it", async () => {
+  await withTempDir(async (dir) => {
+    const store = new WriteQuarantineStore(dir);
+    const written = await store.quarantine({
+      operation: "memory_store",
+      principal: "alice",
+      attemptedNamespace: "victim-secret",
+      payload: { content: "hello" },
+    });
+
+    assert.ok(isInside(path.join(dir, "state", "quarantine"), written));
+
+    const records = await store.list();
+    assert.equal(records.length, 1);
+    assert.equal(records[0]?.operation, "memory_store");
+    assert.equal(records[0]?.principal, "alice");
+    assert.equal(records[0]?.attemptedNamespace, "victim-secret");
+    assert.deepEqual(records[0]?.payload, { content: "hello" });
+  });
+});
+
+test("principal with path-traversal characters stays contained in the root", async () => {
+  await withTempDir(async (dir) => {
+    const store = new WriteQuarantineStore(dir);
+    const written = await store.quarantine({
+      operation: "observe",
+      principal: "../../etc",
+      attemptedNamespace: "default",
+      payload: { messages: [] },
+    });
+
+    assert.ok(isInside(store.root, written), `escaped root: ${written}`);
+
+    // The principal is preserved verbatim in the record even though the
+    // on-disk segment is encoded.
+    const records = await store.list();
+    assert.equal(records.length, 1);
+    assert.equal(records[0]?.principal, "../../etc");
+  });
+});
+
+test("count reflects entries across principals", async () => {
+  await withTempDir(async (dir) => {
+    const store = new WriteQuarantineStore(dir);
+    await store.quarantine({ operation: "memory_store", principal: "alice", attemptedNamespace: "ns", payload: 1 });
+    await store.quarantine({ operation: "observe", principal: "bob", attemptedNamespace: "ns", payload: 2 });
+    assert.equal(await store.count(), 2);
+  });
+});
+
+test("maxEntriesPerPrincipal caps a principal bucket", async () => {
+  await withTempDir(async (dir) => {
+    const store = new WriteQuarantineStore(dir, { maxEntriesPerPrincipal: 2, maxAgeMs: 60 * 60 * 1000 });
+    for (let i = 0; i < 5; i++) {
+      await store.quarantine({ operation: "memory_store", principal: "alice", attemptedNamespace: "ns", payload: i });
+      await store.quarantine({ operation: "memory_store", principal: "bob", attemptedNamespace: "ns", payload: i });
+    }
+    const records = await store.list();
+    // The cap is per principal, not global: two survive for each.
+    assert.equal(records.length, 4);
+    assert.equal(records.filter((r) => r.principal === "alice").length, 2);
+    assert.equal(records.filter((r) => r.principal === "bob").length, 2);
+  });
+});
+
+test("age cap drops records older than maxAgeMs", async () => {
+  await withTempDir(async (dir) => {
+    const store = new WriteQuarantineStore(dir, { maxEntriesPerPrincipal: 1000, maxAgeMs: 1_000 });
+    const oldPath = await store.quarantine({
+      operation: "memory_store",
+      principal: "alice",
+      attemptedNamespace: "ns",
+      payload: "old",
+    });
+    // Backdate the first record an hour into the past.
+    const hourAgo = new Date(Date.now() - 60 * 60 * 1000);
+    await utimes(oldPath, hourAgo, hourAgo);
+
+    // A fresh write into the same bucket triggers the prune.
+    await store.quarantine({
+      operation: "memory_store",
+      principal: "alice",
+      attemptedNamespace: "ns",
+      payload: "new",
+    });
+
+    const records = await store.list();
+    assert.equal(records.length, 1);
+    assert.equal(records[0]?.payload, "new");
+  });
+});
+
+test("list() skips malformed and wrong-shape JSON files", async () => {
+  await withTempDir(async (dir) => {
+    const store = new WriteQuarantineStore(dir);
+    await store.quarantine({ operation: "memory_store", principal: "alice", attemptedNamespace: "ns", payload: "ok" });
+
+    // Drop a corrupt file and a valid-JSON-but-wrong-shape file beside the good
+    // record in the principal bucket.
+    const quarantineRoot = path.join(dir, "state", "quarantine");
+    const [principalName] = await readdir(quarantineRoot);
+    const principalDir = path.join(quarantineRoot, principalName ?? "");
+    await writeFile(path.join(principalDir, "corrupt.json"), "{ not json", "utf8");
+    await writeFile(path.join(principalDir, "wrong-shape.json"), "{}", "utf8");
+
+    const records = await store.list();
+    assert.equal(records.length, 1);
+    assert.equal(records[0]?.payload, "ok");
+    assert.equal(await store.count(), 1);
+  });
+});
+
+test("constructor rejects invalid retention caps", () => {
+  assert.throws(() => new WriteQuarantineStore("/tmp/x", { maxEntriesPerPrincipal: 0, maxAgeMs: 1000 }));
+  assert.throws(() => new WriteQuarantineStore("/tmp/x", { maxEntriesPerPrincipal: 1.5, maxAgeMs: 1000 }));
+  assert.throws(() => new WriteQuarantineStore("/tmp/x", { maxEntriesPerPrincipal: 10, maxAgeMs: Number.NaN }));
+  assert.throws(() => new WriteQuarantineStore("/tmp/x", { maxEntriesPerPrincipal: 10, maxAgeMs: 0 }));
+});
+
+test("expired records are dropped on read even without a follow-up write", async () => {
+  await withTempDir(async (dir) => {
+    const store = new WriteQuarantineStore(dir, { maxEntriesPerPrincipal: 1000, maxAgeMs: 1_000 });
+    const only = await store.quarantine({
+      operation: "memory_store",
+      principal: "alice",
+      attemptedNamespace: "ns",
+      payload: "old",
+    });
+    const hourAgo = new Date(Date.now() - 60 * 60 * 1000);
+    await utimes(only, hourAgo, hourAgo);
+
+    // No further write; list()/count() must expire it and delete the file.
+    assert.equal(await store.count(), 0);
+    assert.deepEqual(await store.list(), []);
+  });
+});
+
+test("a symlinked state directory is not followed outside the memory dir", async () => {
+  await withTempDir(async (dir) => {
+    const external = await mkdtemp(path.join(tmpdir(), "remnic-quarantine-ext-"));
+    try {
+      // Replace <memoryDir>/state with a symlink to an external directory.
+      await symlink(external, path.join(dir, "state"), "dir");
+      const store = new WriteQuarantineStore(dir);
+
+      await assert.rejects(
+        store.quarantine({ operation: "memory_store", principal: "alice", attemptedNamespace: "ns", payload: "x" })
+      );
+      // Nothing was written into the external directory.
+      assert.deepEqual(await readdir(external), []);
+    } finally {
+      await rm(external, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/remnic-core/src/write-quarantine.ts
+++ b/packages/remnic-core/src/write-quarantine.ts
@@ -1,0 +1,232 @@
+/**
+ * Dead-letter quarantine for writes rejected by the namespace write-ACL
+ * (issue #1888).
+ *
+ * When `observe` / `memory_store` / `suggestion_submit` fail namespace
+ * authorization, the payload used to be dropped with no recoverable copy: a
+ * client configured with a namespace that matches no policy (and is not the
+ * default/shared namespace) had every write in the window silently destroyed.
+ * The ACL rejection is CORRECT and stays fail-closed; this store only
+ * preserves the payload so it can be replayed after the config is fixed,
+ * following the AGENTS.md "reject loudly but never destroy state" posture
+ * (patterns 14/42).
+ *
+ * Records live OUTSIDE any memory namespace at
+ * `<memoryDir>/state/quarantine/<principalSafe>/<timestamp>-<id>.json`, keyed
+ * by the encoded principal, and are bounded per principal by count and age.
+ * Every path is resolved from `memoryDir` through `resolveSafeStoragePath`, so
+ * a symlinked `state`/`quarantine` cannot redirect writes outside the memory
+ * directory. The store never re-routes a payload into a writable namespace.
+ */
+
+import { randomUUID } from "node:crypto";
+import { lstat, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { encodeStoragePathSegment, resolveSafeStoragePath } from "./storage-paths.js";
+
+export type QuarantineOperation = "observe" | "memory_store" | "suggestion_submit";
+
+export interface QuarantineEntryInput {
+  operation: QuarantineOperation;
+  /** Authenticated principal the write was attributed to, if any. */
+  principal: string | undefined;
+  /** Namespace the caller attempted to write and was denied. */
+  attemptedNamespace: string;
+  /** The original request payload, preserved verbatim for replay. */
+  payload: unknown;
+  /** ISO timestamp; defaults to now. Injectable for deterministic tests. */
+  timestamp?: string;
+}
+
+export interface QuarantinedRecord {
+  operation: QuarantineOperation;
+  principal: string | null;
+  attemptedNamespace: string;
+  timestamp: string;
+  payload: unknown;
+}
+
+export interface QuarantineCaps {
+  /** Keep at most this many records per principal (newest win). */
+  maxEntriesPerPrincipal: number;
+  /** Drop records older than this many milliseconds. */
+  maxAgeMs: number;
+}
+
+export const DEFAULT_QUARANTINE_CAPS: QuarantineCaps = {
+  maxEntriesPerPrincipal: 500,
+  maxAgeMs: 14 * 24 * 60 * 60 * 1000,
+};
+
+const QUARANTINE_DIRNAME = "quarantine";
+
+function validateCaps(caps: QuarantineCaps): void {
+  if (!Number.isInteger(caps.maxEntriesPerPrincipal) || caps.maxEntriesPerPrincipal < 1) {
+    throw new Error(
+      `WriteQuarantineStore: maxEntriesPerPrincipal must be a positive integer (got ${caps.maxEntriesPerPrincipal})`,
+    );
+  }
+  if (!Number.isFinite(caps.maxAgeMs) || caps.maxAgeMs <= 0) {
+    throw new Error(
+      `WriteQuarantineStore: maxAgeMs must be a positive finite number of milliseconds (got ${caps.maxAgeMs})`,
+    );
+  }
+}
+
+function isQuarantinedRecord(value: unknown): value is QuarantinedRecord {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    (record.operation === "observe" ||
+      record.operation === "memory_store" ||
+      record.operation === "suggestion_submit") &&
+    (record.principal === null || typeof record.principal === "string") &&
+    typeof record.attemptedNamespace === "string" &&
+    typeof record.timestamp === "string" &&
+    "payload" in record
+  );
+}
+
+export class WriteQuarantineStore {
+  private readonly memoryDir: string;
+
+  constructor(
+    memoryDir: string,
+    private readonly caps: QuarantineCaps = DEFAULT_QUARANTINE_CAPS,
+  ) {
+    validateCaps(caps);
+    this.memoryDir = path.resolve(memoryDir);
+  }
+
+  /** Absolute quarantine root (`<memoryDir>/state/quarantine`). */
+  get root(): string {
+    return path.join(this.memoryDir, "state", QUARANTINE_DIRNAME);
+  }
+
+  /**
+   * Resolve a path under the quarantine root, checked for containment and
+   * symlink traversal from `memoryDir` down — so a symlinked `state` or
+   * `quarantine` component that escapes the memory directory is rejected.
+   */
+  private safeDir(...segments: string[]): Promise<string> {
+    return resolveSafeStoragePath(this.memoryDir, "state", QUARANTINE_DIRNAME, ...segments);
+  }
+
+  /**
+   * Park a rejected write. Returns the absolute path of the record written.
+   * Prunes the principal's bucket to the configured caps afterward.
+   */
+  async quarantine(input: QuarantineEntryInput): Promise<string> {
+    const timestamp = input.timestamp ?? new Date().toISOString();
+    const record: QuarantinedRecord = {
+      operation: input.operation,
+      principal: input.principal ?? null,
+      attemptedNamespace: input.attemptedNamespace,
+      timestamp,
+      payload: input.payload,
+    };
+    const principalSegment = encodeStoragePathSegment(input.principal ?? "unknown");
+    const fileName = `${timestamp.replace(/[:.]/g, "-")}-${randomUUID().slice(0, 8)}.json`;
+
+    const dir = await this.safeDir(principalSegment);
+    await mkdir(dir, { recursive: true });
+    // The temp write uses the exclusive `wx` flag so a pre-planted symlink at
+    // the temp name can never be followed (O_EXCL); rename is atomic (rule 42).
+    const finalPath = await this.safeDir(principalSegment, fileName);
+    const tmpPath = await this.safeDir(principalSegment, `${fileName}.tmp`);
+    await writeFile(tmpPath, JSON.stringify(record, null, 2), { encoding: "utf8", flag: "wx" });
+    await rename(tmpPath, finalPath);
+
+    await this.pruneDir(dir);
+    return finalPath;
+  }
+
+  /**
+   * All valid, non-expired quarantined records across every principal, oldest
+   * first. Expired records are deleted on read (lazy GC), so an inactive
+   * principal bucket with no follow-up write is still bounded by age.
+   */
+  async list(): Promise<QuarantinedRecord[]> {
+    const now = Date.now();
+    const records: QuarantinedRecord[] = [];
+    for (const dir of await this.principalDirs()) {
+      for (const file of await this.entryFiles(dir)) {
+        const info = await stat(file).catch(() => null);
+        if (!info) continue;
+        if (now - info.mtimeMs > this.caps.maxAgeMs) {
+          await rm(file, { force: true }).catch(() => {});
+          continue;
+        }
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(await readFile(file, "utf8"));
+        } catch {
+          continue;
+        }
+        if (isQuarantinedRecord(parsed)) records.push(parsed);
+      }
+    }
+    records.sort((a, b) => (a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0));
+    return records;
+  }
+
+  /** Total valid, non-expired quarantined record count across every principal. */
+  async count(): Promise<number> {
+    return (await this.list()).length;
+  }
+
+  /** lstat (no symlink follow): true only for a real directory. */
+  private async isRealDir(dir: string): Promise<boolean> {
+    const info = await lstat(dir).catch(() => null);
+    return info?.isDirectory() === true;
+  }
+
+  private async quarantineRoot(): Promise<string | null> {
+    try {
+      return await this.safeDir();
+    } catch {
+      return null;
+    }
+  }
+
+  private async principalDirs(): Promise<string[]> {
+    const root = await this.quarantineRoot();
+    if (!root || !(await this.isRealDir(root))) return [];
+    const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(root, entry.name))
+      .sort();
+  }
+
+  private async entryFiles(dir: string): Promise<string[]> {
+    if (!(await this.isRealDir(dir))) return [];
+    const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .map((entry) => path.join(dir, entry.name))
+      .sort();
+  }
+
+  private async pruneDir(dir: string): Promise<void> {
+    const files = await this.entryFiles(dir);
+    const now = Date.now();
+    const survivors: Array<{ path: string; mtimeMs: number }> = [];
+    for (const file of files) {
+      const info = await stat(file).catch(() => null);
+      if (!info) continue;
+      if (now - info.mtimeMs > this.caps.maxAgeMs) {
+        await rm(file, { force: true }).catch(() => {});
+        continue;
+      }
+      survivors.push({ path: file, mtimeMs: info.mtimeMs });
+    }
+    const surplus = survivors.length - this.caps.maxEntriesPerPrincipal;
+    if (surplus <= 0) return;
+    survivors.sort((a, b) => a.mtimeMs - b.mtimeMs || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+    for (const victim of survivors.slice(0, surplus)) {
+      await rm(victim.path, { force: true }).catch(() => {});
+    }
+  }
+}


### PR DESCRIPTION
## Context

Issue #1888: the namespace write-ACL rejection is correct and stays fail-closed, but it was also **silent and destructive** — a client configured with a namespace that matches no policy and isn't the default/shared namespace had every `observe` / `memory_store` / `suggestion_submit` in the window dropped with no recoverable copy (the jw14m2 incident). The daemon behaved correctly; the system lost data.

This is **part 1 of 3** for #1888 — the load-bearing fix (stop destroying the payload). Doctor surfacing + a replay command (CLI) and the client-side startup preflight (plugin-pi) follow in separate, focused PRs.

## Change (core only)

- **`WriteQuarantineStore`** (`namespaces/write-quarantine.ts`): parks a rejected write under `<memoryDir>/state/quarantine/<principalSafe>/` — **outside any memory namespace**, principal-keyed via `encodeStoragePathSegment`, contained with `resolveSafeStoragePath` (symlink + traversal guard), written atomically (temp + rename), and bounded per principal by count and age.
- **`NamespaceNotWritableError`**: subclass of `EngramAccessInputError` (so every existing `instanceof` catch / HTTP-400 mapping is unchanged), carrying the attempted namespace + principal. The four namespace-ACL throw sites raise it. `EngramAccessInputError` moved into `access-errors.ts` alongside it and is **re-exported** from `access-service.ts` for compatibility.
- **Wiring**: the observe/write surface catches `NamespaceNotWritableError` around namespace resolution, parks the payload best-effort (a quarantine failure is logged and swallowed — it never masks or replaces the loud rejection), then re-throws. Placement is unchanged; nothing is ever re-routed to a writable namespace.

## Invariants held

- Fail-closed placement unchanged; the rejection still throws (still HTTP 400).
- Never re-route to `defaultNamespace` (no contract lie / cross-tenant risk).
- Non-ACL input errors (e.g. unsupported schemaVersion) and writable namespaces are **not** quarantined.
- Payload lives at the same trust level as memories (local, under `state/`, gitignored); principal path segment is encoded and containment-checked.

## Tests

- `namespaces/write-quarantine.test.ts`: write+list, path-traversal containment, count across principals, count cap, age cap (backdated mtime), malformed-JSON skip.
- `access-observe-quarantine.test.ts`: `memory_store` and `suggestion_submit` rejected by the ACL are quarantined **and still throw** `NamespaceNotWritableError`; a non-ACL error on a writable namespace is **not** quarantined.
- The churn-prone `access-service-coding-write.test.ts` and `access-boundary.test.ts` suites still pass (their `/not writable/` assertions hold — the subclass preserves the message).

Verification: root `tsc --noEmit` clean, structural ratchets pass (error classes extracted so `access-service.ts` stays under its ceiling), biome clean on new files.

Part of #1888.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches namespace authorization and write paths for observe/store/submit; quarantine is best-effort and does not bypass ACL, but misconfiguration could accumulate sensitive payloads on disk until replay tooling lands.
> 
> **Overview**
> **Namespace write-ACL denials no longer discard the request body.** When `observe`, `memory_store`, or `suggestion_submit` fail because the target namespace is not writable, the call still fails closed (HTTP 400 unchanged), but the full request is parked first under `<memoryDir>/state/quarantine/<principalSafe>/` via a new `WriteQuarantineStore` (principal-keyed JSON, count/age caps, safe path resolution).
> 
> **`NamespaceNotWritableError`** subclasses `EngramAccessInputError` and carries `attemptedNamespace` + `principal`; namespace ACL sites in `access-service` now throw it instead of a generic input error. **`EngramAccessInputError`** lives in `access-errors.ts` and is re-exported from `access-service` for compatibility.
> 
> **`AccessObserveWriteSurface`** wraps namespace resolution for the three operations: on `NamespaceNotWritableError` it best-effort quarantines (skipped for `dryRun` on store/submit), logs, then re-throws. Non-ACL validation errors are never quarantined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd7556adbd502b1a33f090e88b0ef602c7187e26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dead-letter quarantine for `observe`, `memory_store`, and `suggestion_submit` when namespace write permission is denied, storing the rejected payload for later review (age/count limits).
  * Introduced `NamespaceNotWritableError` (and `EngramAccessInputError`) for clearer input/namespace write failures.
* **Bug Fixes**
  * Denied namespace writes remain fail-closed and now preserve operation metadata in exactly one quarantine record; non-ACL validation failures and dry-runs are not quarantined.
* **Tests**
  * Added quarantine behavior, retention/pruning, and filesystem path-safety coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->