### PR TITLE
feat(pi): startup namespace-writability preflight (#1888)

### DIFF
--- a/.changeset/pi-namespace-preflight-1888.md
+++ b/.changeset/pi-namespace-preflight-1888.md
@@ -1,0 +1,8 @@
+---
+"@remnic/core": patch
+"@remnic/plugin-pi": patch
+---
+
+Client startup namespace preflight (issue #1888 part 3). The plugin-pi extension now validates, at each `session_start`, whether its configured namespace resolves as writable for its (token-resolved) principal. When it does not, every memory write would be rejected and — since the dead-letter quarantine landed — parked instead of stored; the extension now surfaces that LOUDLY (a persistent `remnic_state` error entry re-emitted each session plus an error notification) instead of leaving the silent per-call rejections invisible. It records the current state authoritatively (a `NAMESPACE_OK` entry once writable) so the latest state survives an extension/host restart, and a daemon that cannot be reached (or answers with a malformed denial) is treated as indeterminate so a flaky daemon never triggers a false alarm. The daemon health probe + circuit-breaker update now run at `session_start` regardless of `statusEnabled`, so an offline daemon is marked unreachable and the preflight and later hooks fast-skip instead of each spending a full request budget.
+
+The daemon exposes a new read-only `GET /engram/v1/namespace/writable` endpoint (operation `namespace_writable`, bearer-gated like its peers). Both the HTTP route and the batch/MCP operation handler call a new `resolveNamespacePreflight` resolver that combines the token's namespace allow-list with policy writability: a namespace-scoped token asking about a namespace outside its allow-list gets a definitive `{ ok: false }` (surfaced to the client, revealing nothing about the foreign namespace's policy) rather than a hard authorization error a client would swallow. No write, no storage access.

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -40,6 +40,19 @@ export interface ObserveOptions extends RequestOptions {
   maxBytes?: number;
 }
 
+/**
+ * Result of a startup namespace-writability preflight (issue #1888 part 3).
+ * `not_writable` is a DEFINITIVE misconfiguration answer from the daemon (the
+ * configured namespace resolves as non-writable for this principal), which the
+ * client surfaces loudly. `indeterminate` means the daemon could not be reached
+ * or answered unexpectedly (timeout, network, auth, 5xx) — the client must NOT
+ * cry wolf about the namespace on those, since the answer is unknown.
+ */
+export type NamespacePreflightResult =
+  | { readonly status: "writable"; readonly namespace: string }
+  | { readonly status: "not_writable"; readonly reason: "not_writable" | "unsupported"; readonly namespace: string }
+  | { readonly status: "indeterminate"; readonly detail: string };
+
 export class RemnicHttpError extends Error {
   constructor(
     readonly status: number,
@@ -96,6 +109,58 @@ export class RemnicClient {
 
   async health(options: RequestOptions = {}): Promise<Record<string, unknown>> {
     return this.request("GET", "/engram/v1/health", undefined, options);
+  }
+
+  /**
+   * Startup namespace-writability preflight (issue #1888 part 3). Asks the
+   * daemon — read-only, no write, no side effect — whether the configured
+   * namespace resolves as writable for this client's (token-resolved)
+   * principal. A `not_writable` answer is definitive and surfaced loudly; any
+   * transport failure returns `indeterminate` so a flaky daemon never triggers
+   * a false namespace-misconfig alarm.
+   */
+  async preflightNamespace(
+    sessionKey: string | undefined,
+    options: RequestOptions = {},
+  ): Promise<NamespacePreflightResult> {
+    const params = new URLSearchParams();
+    if (this.config.namespace) params.set("namespace", this.config.namespace);
+    if (sessionKey) params.set("session", sessionKey);
+    // Check the op this client's ENABLED write path uses: automatic turn
+    // capture (observe) when observation is on, else the explicit store op.
+    params.set("op", this.config.observeEnabled ? "observe" : "memory_store");
+    const qs = params.toString();
+    const path = `/engram/v1/namespace/writable${qs ? `?${qs}` : ""}`;
+    try {
+      const payload = await this.request<{ ok?: unknown; reason?: unknown; namespace?: unknown }>(
+        "GET",
+        path,
+        undefined,
+        options,
+      );
+      // Both branches require the full contract before they are trusted: an
+      // `ok:true` without a concrete namespace, or an `ok:false` without a known
+      // reason + concrete namespace, is malformed → indeterminate, never a false
+      // writable/not-writable verdict.
+      if (
+        payload?.ok === true &&
+        typeof payload.namespace === "string" &&
+        payload.namespace.length > 0
+      ) {
+        return { status: "writable", namespace: payload.namespace };
+      }
+      if (
+        payload?.ok === false &&
+        (payload.reason === "not_writable" || payload.reason === "unsupported") &&
+        typeof payload.namespace === "string" &&
+        payload.namespace.length > 0
+      ) {
+        return { status: "not_writable", reason: payload.reason, namespace: payload.namespace };
+      }
+      return { status: "indeterminate", detail: "unexpected preflight response shape" };
+    } catch (err) {
+      return { status: "indeterminate", detail: err instanceof Error ? err.message : String(err) };
+    }
   }
 
   async recall(

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1724,3 +1724,394 @@ test("a successful /remnic-recall clears a stale circuit breaker (review cursor)
   await emit("context", { messages: [{ role: "user", content: "auto2" }] }, ctx);
   assert.ok(calls > callsBeforeSecondAuto, "automatic recall ran after the manual recall cleared the breaker");
 });
+
+test("session_start preflight surfaces a loud persistent remnic_state error when the namespace is not writable", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    if (String(input).includes("/engram/v1/namespace/writable")) {
+      return new Response(JSON.stringify({ ok: false, reason: "not_writable", namespace: "default" }), { status: 200 });
+    }
+    return new Response(JSON.stringify({}), { status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const entries: Array<{ type: string; data: Record<string, unknown> }> = [];
+  pi.appendEntry = (type: string, data: unknown) => entries.push({ type, data: (data ?? {}) as Record<string, unknown> });
+  const notifications: Array<{ message: string; level: string }> = [];
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      namespace: "default",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as unknown as Parameters<typeof extension>[0]);
+
+  await emit("session_start", {}, {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: (message: string, level: string) => notifications.push({ message, level }) },
+    sessionManager: { getSessionId: () => "preflight-bad", getEntries: () => [] },
+  });
+
+  const errorEntry = entries.find((e) => e.type === "remnic_state" && e.data.level === "error");
+  assert.ok(errorEntry, "expected a persistent remnic_state error entry");
+  assert.equal(errorEntry?.data.code, "NAMESPACE_NOT_WRITABLE");
+  assert.equal(errorEntry?.data.persistent, true);
+  assert.equal(errorEntry?.data.namespace, "default");
+  assert.ok(notifications.some((n) => n.level === "error"), "expected a loud error notification");
+});
+
+test("session_start preflight stays silent when the namespace is writable", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    if (String(input).includes("/engram/v1/namespace/writable")) {
+      return new Response(JSON.stringify({ ok: true, namespace: "team-x" }), { status: 200 });
+    }
+    return new Response(JSON.stringify({}), { status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const entries: Array<{ type: string; data: Record<string, unknown> }> = [];
+  pi.appendEntry = (type: string, data: unknown) => entries.push({ type, data: (data ?? {}) as Record<string, unknown> });
+  const notifications: Array<{ message: string; level: string }> = [];
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      namespace: "team-x",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as unknown as Parameters<typeof extension>[0]);
+
+  await emit("session_start", {}, {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: (message: string, level: string) => notifications.push({ message, level }) },
+    sessionManager: { getSessionId: () => "preflight-ok", getEntries: () => [] },
+  });
+
+  assert.equal(entries.some((e) => e.type === "remnic_state" && e.data.level === "error"), false);
+  assert.equal(notifications.some((n) => n.level === "error"), false);
+});
+
+test("session_start preflight does not cry wolf when the daemon is unreachable", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    if (String(input).includes("/engram/v1/namespace/writable")) {
+      throw new Error("ECONNREFUSED");
+    }
+    return new Response(JSON.stringify({}), { status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const entries: Array<{ type: string; data: Record<string, unknown> }> = [];
+  pi.appendEntry = (type: string, data: unknown) => entries.push({ type, data: (data ?? {}) as Record<string, unknown> });
+  const notifications: Array<{ message: string; level: string }> = [];
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      namespace: "default",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as unknown as Parameters<typeof extension>[0]);
+
+  await emit("session_start", {}, {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: (message: string, level: string) => notifications.push({ message, level }) },
+    sessionManager: { getSessionId: () => "preflight-down", getEntries: () => [] },
+  });
+
+  assert.equal(entries.some((e) => e.type === "remnic_state" && e.data.level === "error"), false);
+  assert.equal(notifications.some((n) => n.level === "error"), false);
+});
+
+test("session_start preflight is skipped without an auth token", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let hitWritable = false;
+  globalThis.fetch = async (input) => {
+    if (String(input).includes("/engram/v1/namespace/writable")) hitWritable = true;
+    return new Response(JSON.stringify({}), { status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const entries: Array<{ type: string; data: Record<string, unknown> }> = [];
+  pi.appendEntry = (type: string, data: unknown) => entries.push({ type, data: (data ?? {}) as Record<string, unknown> });
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      namespace: "default",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as unknown as Parameters<typeof extension>[0]);
+
+  await emit("session_start", {}, {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: () => {} },
+    sessionManager: { getSessionId: () => "preflight-noauth", getEntries: () => [] },
+  });
+
+  assert.equal(hitWritable, false);
+  assert.equal(entries.some((e) => e.type === "remnic_state" && e.data.level === "error"), false);
+});
+
+test("session_start preflight self-heals: emits a resolved signal once the namespace becomes writable", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let writable = false;
+  globalThis.fetch = async (input) => {
+    if (String(input).includes("/engram/v1/namespace/writable")) {
+      return writable
+        ? new Response(JSON.stringify({ ok: true, namespace: "default" }), { status: 200 })
+        : new Response(JSON.stringify({ ok: false, reason: "not_writable", namespace: "default" }), { status: 200 });
+    }
+    return new Response(JSON.stringify({}), { status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const entries: Array<{ type: string; data: Record<string, unknown> }> = [];
+  pi.appendEntry = (type: string, data: unknown) => entries.push({ type, data: (data ?? {}) as Record<string, unknown> });
+  const notifications: Array<{ message: string; level: string }> = [];
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      namespace: "default",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as unknown as Parameters<typeof extension>[0]);
+
+  const ctx = {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: (message: string, level: string) => notifications.push({ message, level }) },
+    sessionManager: { getSessionId: () => "preflight-heal", getEntries: () => [] },
+  };
+
+  // First session: namespace not writable → loud error entry + notification.
+  await emit("session_start", {}, ctx);
+  assert.ok(entries.some((e) => e.data.code === "NAMESPACE_NOT_WRITABLE"), "expected an initial error entry");
+  assert.ok(notifications.some((n) => n.level === "error"), "expected an initial error notification");
+  const errorNotifsAfterFail = notifications.filter((n) => n.level === "error").length;
+
+  // Config fixed; next session: writable → an authoritative NAMESPACE_OK entry
+  // is recorded (so the latest state survives a restart), the loud error stops,
+  // and there is no success-notify spam.
+  writable = true;
+  await emit("session_start", {}, ctx);
+  assert.ok(entries.some((e) => e.data.code === "NAMESPACE_OK"), "expected an authoritative resolved entry once writable");
+  assert.equal(
+    notifications.filter((n) => n.level === "error").length,
+    errorNotifsAfterFail,
+    "the loud error notification must stop once the namespace is writable",
+  );
+  assert.equal(notifications.some((n) => n.level === "success"), false, "healthy sessions must not emit success-notify spam");
+});
+
+test("session_start preflight treats a malformed denial as indeterminate (no false alarm)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    if (String(input).includes("/engram/v1/namespace/writable")) {
+      // ok:false but missing the reason/namespace contract → must NOT alarm.
+      return new Response(JSON.stringify({ ok: false }), { status: 200 });
+    }
+    return new Response(JSON.stringify({}), { status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const entries: Array<{ type: string; data: Record<string, unknown> }> = [];
+  pi.appendEntry = (type: string, data: unknown) => entries.push({ type, data: (data ?? {}) as Record<string, unknown> });
+  const notifications: Array<{ message: string; level: string }> = [];
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      namespace: "default",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as unknown as Parameters<typeof extension>[0]);
+
+  await emit("session_start", {}, {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: (message: string, level: string) => notifications.push({ message, level }) },
+    sessionManager: { getSessionId: () => "preflight-malformed", getEntries: () => [] },
+  });
+
+  assert.equal(entries.some((e) => e.data.code === "NAMESPACE_NOT_WRITABLE"), false);
+  assert.equal(notifications.some((n) => n.level === "error"), false);
+});
+
+test("session_start trips the circuit breaker on an offline daemon even when statusEnabled is false", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let nonHealthCalls = 0;
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    if (url.endsWith("/engram/v1/health")) {
+      throw new Error("The socket connection was closed unexpectedly.");
+    }
+    // Preflight or recall would land here; if the breaker let either through it
+    // would hang until its AbortController fires.
+    nonHealthCalls += 1;
+    return new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () =>
+        reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
+      );
+    });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      namespace: "default",
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+      turnRequestTimeoutMs: 30,
+      daemonCooldownMs: 60000,
+    },
+  });
+  await extension(pi as unknown as Parameters<typeof extension>[0]);
+
+  const ctx = {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: () => {} },
+    sessionManager: { getSessionId: () => "status-off-breaker" },
+  };
+  // Health fails at session_start → breaker trips despite statusEnabled=false;
+  // the preflight then fast-skips (indeterminate) instead of fetching.
+  await emit("session_start", {}, ctx);
+  // The live recall hook fast-skips because the breaker is tripped.
+  await emit("context", { messages: [{ role: "user", content: "hi" }] }, ctx);
+  assert.equal(nonHealthCalls, 0, "an offline probe must trip the breaker even with the status UI disabled");
+});
+
+test("session_start preflight treats a malformed writable answer as indeterminate", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    if (String(input).includes("/engram/v1/namespace/writable")) {
+      // ok:true but missing the namespace → malformed, must not be trusted.
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    return new Response(JSON.stringify({}), { status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const entries: Array<{ type: string; data: Record<string, unknown> }> = [];
+  pi.appendEntry = (type: string, data: unknown) => entries.push({ type, data: (data ?? {}) as Record<string, unknown> });
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      namespace: "default",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as unknown as Parameters<typeof extension>[0]);
+
+  await emit("session_start", {}, {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: () => {} },
+    sessionManager: { getSessionId: () => "preflight-malformed-ok", getEntries: () => [] },
+  });
+
+  // Indeterminate → no state entry recorded at all (neither OK nor error).
+  assert.equal(entries.some((e) => e.type === "remnic_state" && (e.data.code === "NAMESPACE_OK" || e.data.code === "NAMESPACE_NOT_WRITABLE")), false);
+});
+
+test("session_start preflight tailors the remediation text for an unsupported (namespaces-disabled) reason", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    if (String(input).includes("/engram/v1/namespace/writable")) {
+      return new Response(JSON.stringify({ ok: false, reason: "unsupported", namespace: "team-x" }), { status: 200 });
+    }
+    return new Response(JSON.stringify({}), { status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const notifications: Array<{ message: string; level: string }> = [];
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      namespace: "team-x",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as unknown as Parameters<typeof extension>[0]);
+
+  await emit("session_start", {}, {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: (message: string, level: string) => notifications.push({ message, level }) },
+    sessionManager: { getSessionId: () => "preflight-unsupported", getEntries: () => [] },
+  });
+
+  const err = notifications.find((n) => n.level === "error");
+  assert.ok(err, "expected an error notification");
+  assert.match(err?.message ?? "", /namespaces disabled/);
+  assert.doesNotMatch(err?.message ?? "", /namespacePolicies entry/);
+});

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -63,8 +63,18 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       if (!session) return;
       const { state } = getSessionState(session.sessionKey, sessionStates);
       restoreObservedState(session, state.observedHashes);
-      if (!config.statusEnabled) return;
-      await setStatus(session, client, config);
+      // Probe health + update the circuit breaker UNCONDITIONALLY so an offline
+      // daemon is marked unreachable even when the status UI is off; otherwise
+      // the namespace preflight and every later hook each burn a full request
+      // budget on a doomed call. The status LABEL stays gated on statusEnabled.
+      const reachable = await probeDaemonHealth(client, config);
+      if (config.statusEnabled) {
+        session.setStatus(
+          "remnic",
+          reachable ? `Remnic ${config.namespace ? `(${config.namespace})` : "ready"}` : "Remnic offline",
+        );
+      }
+      await runNamespacePreflight(pi, session, client, config);
     });
 
     pi.on("context", async (event, ctx) => {
@@ -583,23 +593,92 @@ function persistObservedState(pi: PiApi, observedHashes: Set<string>): void {
   });
 }
 
-async function setStatus(session: PiContextSnapshot, client: RemnicClient, config: RemnicPiConfig): Promise<void> {
+/**
+ * Probe the daemon and update the shared circuit breaker. Returns whether the
+ * daemon is reachable so the caller can render a status label. This runs at
+ * session_start regardless of `statusEnabled`: the breaker update is a
+ * data-path concern (a down daemon must be marked unreachable so the namespace
+ * preflight and every later hook fast-skip instead of each burning a full
+ * request budget), independent of whether the status UI is shown.
+ */
+async function probeDaemonHealth(client: RemnicClient, config: RemnicPiConfig): Promise<boolean> {
   try {
     await client.health({ timeoutMs: config.startupRequestTimeoutMs });
-    // A successful health probe means the daemon is reachable, so clear any
-    // stale cooldown a prior recall/observe timeout left on the shared client —
-    // otherwise the next live hook fast-skips even though the daemon is up
-    // (codex review).
+    // A successful probe means the daemon is reachable, so clear any stale
+    // cooldown a prior recall/observe timeout left on the shared client.
     client.markReachable();
-    session.setStatus("remnic", `Remnic ${config.namespace ? `(${config.namespace})` : "ready"}`);
+    return true;
   } catch (err) {
     // Startup just proved the daemon is unreachable, so trip the fast-skip
-    // breaker too — otherwise the first live context/observe hook still spends
-    // the full turn budget on a doomed request before the breaker would trip
-    // on its own (codex review).
+    // breaker — otherwise the first live hook spends the full turn budget on a
+    // doomed request before the breaker would trip on its own.
     if (isDaemonUnreachableError(err)) client.markUnreachable(config.daemonCooldownMs);
-    session.setStatus("remnic", "Remnic offline");
+    return false;
   }
+}
+
+/**
+ * Startup namespace-writability preflight (issue #1888 part 3). Runs at each
+ * session_start. When the configured namespace is NOT writable for this
+ * client's principal, every memory write is rejected and — since the
+ * dead-letter quarantine landed — parked, never stored. A silent per-call
+ * rejection is invisible; this surfaces it LOUDLY and persistently (an error
+ * `remnic_state` entry + error notification, re-emitted every session while
+ * broken).
+ *
+ * `appendEntry` has no delete, so the CURRENT state is always recorded: a
+ * `NAMESPACE_OK` entry on a writable result makes the latest `remnic_state`
+ * entry authoritative even across an extension/host restart (no in-memory
+ * transition tracking that a restart would lose). Only errors notify — the OK
+ * entry is a silent heartbeat, never a success toast every healthy session. A
+ * daemon that cannot be reached (indeterminate) records nothing, leaving the
+ * last known state intact — we neither cry wolf nor falsely clear a real error.
+ */
+async function runNamespacePreflight(
+  pi: PiApi,
+  session: PiContextSnapshot,
+  client: RemnicClient,
+  config: RemnicPiConfig,
+): Promise<void> {
+  // No token → the client cannot write anyway; known-unreachable → the answer
+  // would be indeterminate. Either way, do not touch the recorded state.
+  if (!config.authToken || !client.isReachable()) return;
+  const result = await client.preflightNamespace(session.sessionKey, {
+    timeoutMs: config.startupRequestTimeoutMs,
+  });
+  if (result.status === "not_writable") {
+    // The remediation differs by cause: `unsupported` means the daemon has
+    // namespaces disabled, so ONLY its default namespace is writable — pointing
+    // the operator at namespacePolicies would be misleading.
+    const fix =
+      result.reason === "unsupported"
+        ? "The daemon has namespaces disabled, so only its default namespace is writable — set the client's namespace to the daemon's defaultNamespace (or omit it)."
+        : "Fix the client's namespace config: it must match a namespacePolicies entry, or be the daemon's defaultNamespace/sharedNamespace.";
+    const message =
+      `Remnic: configured namespace "${result.namespace}" is NOT writable for this client's principal ` +
+      `(${result.reason}). Every memory write will be rejected and dead-lettered (recoverable via ` +
+      `\`remnic quarantine list\`), NOT stored. ${fix}`;
+    session.notify(message, "error");
+    pi.appendEntry(STATE_CUSTOM_TYPE, {
+      level: "error",
+      code: "NAMESPACE_NOT_WRITABLE",
+      namespace: result.namespace,
+      reason: result.reason,
+      message,
+      persistent: true,
+      recordedAt: new Date().toISOString(),
+    });
+    return;
+  }
+  if (result.status === "writable") {
+    pi.appendEntry(STATE_CUSTOM_TYPE, {
+      level: "info",
+      code: "NAMESPACE_OK",
+      namespace: result.namespace,
+      recordedAt: new Date().toISOString(),
+    });
+  }
+  // indeterminate → record nothing; keep the last known state.
 }
 
 function snapshotPiContext(ctx: any, options: PiContextSnapshotOptions = {}): PiContextSnapshot | null {

--- a/packages/remnic-core/src/access-boundary.test.ts
+++ b/packages/remnic-core/src/access-boundary.test.ts
@@ -272,3 +272,31 @@ test("fleetWide flag is inert for normal (non-fleet-wide) ops under a scoped tok
   assert.deepEqual(result, { ok: true });
   assert.equal(ran, true, "a non-fleet-wide op runs normally for a scoped token");
 });
+
+test("allowedByOps: an op is granted by any listed op, not just its own name", async () => {
+  let ran = false;
+  __resetRegistryForTest();
+  const op = defineOperation({
+    name: "namespace_writable",
+    description: "test allowedByOps",
+    allowedByOps: ["namespace_writable", "observe", "memory_store"],
+    schema: z.object({}),
+    handler: async () => {
+      ran = true;
+      return { ok: true };
+    },
+  });
+  // A token scoped to observe (but NOT namespace_writable) reaches the handler.
+  const result = await tokenCapabilityStore.run({ version: 1, ops: ["observe"] }, () =>
+    op.run({}, ctx(makeMockService())),
+  );
+  assert.deepEqual(result, { ok: true });
+  assert.equal(ran, true, "an observe-scoped token is granted via allowedByOps");
+  // A token carrying none of the granting ops is rejected before the handler.
+  ran = false;
+  await assert.rejects(
+    () => tokenCapabilityStore.run({ version: 1, ops: ["recall"] }, () => op.run({}, ctx(makeMockService()))),
+    (err: unknown) => err instanceof EngramAccessForbiddenError,
+  );
+  assert.equal(ran, false, "a token without any granting op is rejected before the handler");
+});

--- a/packages/remnic-core/src/access-boundary.ts
+++ b/packages/remnic-core/src/access-boundary.ts
@@ -16,8 +16,14 @@
  */
 
 import { z } from "zod";
+import { EngramAccessForbiddenError } from "./access-errors.js";
 import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
-import { assertFleetWideOperationAllowed, assertOperationAllowed, tokenCapabilityStore } from "./access-token-capabilities.js";
+import {
+  assertFleetWideOperationAllowed,
+  assertOperationAllowed,
+  capabilityAllowsOp,
+  tokenCapabilityStore,
+} from "./access-token-capabilities.js";
 import { expandTildePath } from "./utils/path.js";
 
 // ---------------------------------------------------------------------------
@@ -63,6 +69,7 @@ export const OPERATION_NAMES = [
   "set_coding_context",
   "recall_tier_explain",
   "recall_xray",
+  "namespace_writable",
   "wearables_status",
   "wearables_sync",
   "transcript_day",
@@ -235,6 +242,17 @@ export interface OperationSpec<In, Out> {
    * (cron, internal callers, no capability record) are unaffected (issue #1850).
    */
   readonly fleetWide?: boolean;
+  /**
+   * Alternate op allow-list: when set, the token may invoke this operation if
+   * its ops allow-list permits ANY of these ops (instead of the default rule
+   * that requires the op's own {@link name}). Lets a read-only diagnostic be
+   * granted by the write ops it diagnoses — e.g. `namespace_writable` is
+   * runnable by any token permitted to `observe`/`memory_store`, so a token
+   * minted before the diagnostic op existed can still call it. Unrestricted /
+   * legacy tokens (no ops axis) are unaffected. Keeps the boundary and any HTTP
+   * transport for the same op enforcing ONE policy.
+   */
+  readonly allowedByOps?: readonly OperationName[];
 }
 
 export interface BoundOperation<In = unknown, Out = unknown> {
@@ -408,7 +426,18 @@ export function defineOperation<In, Out>(spec: OperationSpec<In, Out>): BoundOpe
       // unrestricted. Default-deny ONLY when an ops axis is present — legacy
       // tokens (absent record) and explicit-unrestricted new tokens are
       // unaffected.
-      assertOperationAllowed(tokenCapabilityStore.getStore(), spec.name);
+      // When the op declares alternate grant ops, permit any of them (so the
+      // batch/MCP path matches an HTTP transport that relaxes the same op);
+      // otherwise the token must carry the op's own name. Unrestricted/legacy
+      // tokens pass either way (capabilityAllowsOp is true when no ops axis).
+      if (spec.allowedByOps && spec.allowedByOps.length > 0) {
+        const store = tokenCapabilityStore.getStore();
+        if (!spec.allowedByOps.some((op) => capabilityAllowsOp(store, op))) {
+          throw new EngramAccessForbiddenError(`token is not permitted to call operation: ${spec.name}`);
+        }
+      } else {
+        assertOperationAllowed(tokenCapabilityStore.getStore(), spec.name);
+      }
       // Fleet-wide / global maintenance ops (issue #1850 round 10): these run
       // across all namespaces with no `namespace` arg, so the tools/call
       // effective-namespace gate never fires. A namespace-SCOPED token must not

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -2714,3 +2714,87 @@ test("PR #1852: static operator token has no connector provenance under rotation
     await server.stop();
   }
 });
+
+test("HTTP namespace/writable preflight returns the structured writability result", async () => {
+  // Real config through the pure resolver: the default namespace is writable
+  // for any principal; a foreign namespace with no policy is not. A rejection
+  // is a valid 200 answer (read via `ok`), not an HTTP error.
+  const service = {
+    configRef: parseConfig({ memoryDir: "/tmp/remnic-http-preflight-test", defaultNamespace: "default" }),
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const okRes = await fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/namespace/writable?namespace=default`,
+      { headers: { authorization: "Bearer test-token" } },
+    );
+    assert.equal(okRes.status, 200);
+    assert.deepEqual(await okRes.json(), { ok: true, namespace: "default" });
+
+    const badRes = await fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/namespace/writable?namespace=team-x`,
+      { headers: { authorization: "Bearer test-token" } },
+    );
+    assert.equal(badRes.status, 200);
+    const badBody = (await badRes.json()) as { ok: boolean; namespace: string };
+    assert.equal(badBody.ok, false);
+    assert.equal(badBody.namespace, "team-x");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP namespace/writable preflight admits write-scoped tokens and rejects read-only ops", async () => {
+  const service = {
+    configRef: parseConfig({ memoryDir: "/tmp/remnic-http-preflight-ops-test", defaultNamespace: "default" }),
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authTokenEntriesGetter: () => [
+      { token: "write-scoped", capabilities: { version: 1, ops: ["observe", "memory_store"] } },
+      { token: "store-only", capabilities: { version: 1, ops: ["memory_store"] } },
+      { token: "diagnostic-only", capabilities: { version: 1, ops: ["namespace_writable"] } },
+      { token: "read-only", capabilities: { version: 1, ops: ["recall"] } },
+    ],
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+  const request = (token: string, op?: string) =>
+    fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/namespace/writable?namespace=default${op ? `&op=${op}` : ""}`,
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+  const okOf = async (r: Response) => {
+    const body = (await r.json()) as { ok?: unknown };
+    return body.ok;
+  };
+  try {
+    // A token scoped to write ops but NOT the namespace_writable op (e.g. minted
+    // before this endpoint existed) may still run the preflight.
+    const writeScoped = await request("write-scoped");
+    assert.equal(writeScoped.status, 200);
+    assert.equal(await okOf(writeScoped), true);
+    // Config-aware write op: a memory_store-only token is writable for the
+    // explicit store path (?op=memory_store) but not for the automatic observe
+    // path (default), which it cannot perform.
+    assert.equal(await okOf(await request("store-only", "memory_store")), true);
+    assert.equal(await okOf(await request("store-only")), false);
+    // A token scoped to the diagnostic op ONLY can call the endpoint but cannot
+    // write, so the answer is a definitive not-writable (never a false ok:true).
+    const diag = await request("diagnostic-only");
+    assert.equal(diag.status, 200);
+    assert.equal(await okOf(diag), false);
+    // A read-only token cannot write, so it has nothing to preflight → 403.
+    assert.equal((await request("read-only")).status, 403);
+  } finally {
+    await server.stop();
+  }
+});

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -37,8 +37,10 @@ import {
 import { expandTildePath } from "./utils/path.js";
 import { projectTagProjectId } from "./coding/coding-namespace.js";
 import { getOperation, type OperationName } from "./access-boundary.js";
+import { resolveNamespacePreflight } from "./scopes/scope-plan.js";
 import {
   assertOperationAllowed,
+  capabilityAllowsOp,
   enforceNamespaceAllowList,
   isCapabilityRestricted,
   tokenCapabilityStore,
@@ -1462,6 +1464,23 @@ export class EngramAccessHttpServer {
         throw err;
       }
       this.respondJson(res, 200, payload);
+      return;
+    }
+
+    // Namespace-writability preflight (issue #1888 part 3): would the client's
+    // enabled write (`?op=observe|memory_store`, default observe) to the
+    // requested namespace by THIS token succeed? Out-of-allow-list → 200
+    // {ok:false}; any allowedByOps token may run it (HTTP + batch admit alike).
+    if (req.method === "GET" && pathname === "/engram/v1/namespace/writable") {
+      const preflightOp = getOperation("namespace_writable"); // boundary marker (catalog parity, issue #1888)
+      const caps = tokenCapabilityStore.getStore();
+      if (!(preflightOp?.spec.allowedByOps ?? []).some((op) => capabilityAllowsOp(caps, op))) {
+        throw new EngramAccessForbiddenError("token is not permitted to run the namespace preflight");
+      }
+      const ns = parsed.searchParams.get("namespace") || undefined;
+      const sk = parsed.searchParams.get("session") || undefined;
+      const writeOp = parsed.searchParams.get("op") === "memory_store" ? "memory_store" : "observe";
+      this.respondJson(res, 200, resolveNamespacePreflight(caps, ns, sk, this.resolveRequestPrincipal(req), this.service.configRef, writeOp));
       return;
     }
 

--- a/packages/remnic-core/src/access-operations-batch.ts
+++ b/packages/remnic-core/src/access-operations-batch.ts
@@ -18,6 +18,7 @@ import { EngramAccessForbiddenError } from "./access-errors.js";
 import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
 import { enforceNamespaceAllowList, tokenCapabilityStore } from "./access-token-capabilities.js";
 import { projectTagProjectId } from "./coding/coding-namespace.js";
+import { resolveNamespacePreflight } from "./scopes/scope-plan.js";
 import { expandTildePath } from "./utils/path.js";
 import { resolvePrincipal } from "./namespaces/principal.js";
 import { getRecallTimingStatus, isRecallTimingsOperator } from "./recall-timings.js";
@@ -113,6 +114,7 @@ defineOperation({ name: "recall_xray", description: "X-ray recall.", schema: str
     return { result: await ctx.service.recallXray({ query: defStr(input.query, ""), sessionKey: optStr(input.sessionKey), namespace: optStr(input.namespace), budget, authenticatedPrincipal: ctx.authenticatedPrincipal, ...(dr && dr !== "" ? { disclosure: dr as RecallDisclosure } : {}), ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}) }) };
   },
 });
+defineOperation({ name: "namespace_writable", description: "Read-only preflight: is a namespace writable for the caller's principal?", allowedByOps: ["namespace_writable", "observe", "memory_store"], schema: strictSchema({ namespace: S.str, sessionKey: S.str, op: S.str }), handler: async (input, ctx) => { const ns = optStr(input.namespace); const sk = optStr(input.sessionKey); const writeOp = optStr(input.op) === "memory_store" ? "memory_store" : "observe"; return { result: resolveNamespacePreflight(tokenCapabilityStore.getStore(), ns && ns.length > 0 ? ns : undefined, sk && sk.length > 0 ? sk : undefined, ctx.authenticatedPrincipal, ctx.service.configRef, writeOp) }; } });
 
 // === WEARABLES ===
 defineOperation({ name: "wearables_status", description: "Wearables status.", schema: strictSchema({}), handler: async (_i, ctx) => ({ result: await ctx.service.wearablesStatus() }) });

--- a/packages/remnic-core/src/access-surface-catalog.ts
+++ b/packages/remnic-core/src/access-surface-catalog.ts
@@ -183,6 +183,7 @@ export const HTTP_ROUTES: readonly HttpRouteEntry[] = [
   { method: "POST", pathname: "/engram/v1/action-confidence", operation: "action_confidence" },
   { method: "GET", pathname: "/engram/v1/recall/tier-explain", operation: "recall_tier_explain" },
   { method: "GET", pathname: "/engram/v1/recall/xray", operation: "recall_xray" },
+  { method: "GET", pathname: "/engram/v1/namespace/writable", operation: "namespace_writable" },
   { method: "GET", pathname: "/engram/v1/wearables/status", operation: "wearables_status" },
   { method: "POST", pathname: "/engram/v1/wearables/sync", operation: "wearables_sync" },
   { method: "GET", pathname: "/engram/v1/wearables/transcript", operation: "transcript_day" },

--- a/packages/remnic-core/src/access-token-capabilities.ts
+++ b/packages/remnic-core/src/access-token-capabilities.ts
@@ -327,20 +327,27 @@ export function resolveEffectiveNamespace(
  * behavior is unchanged. Both the HTTP transport (`resolveNamespace`) and the
  * MCP dispatch route through this ONE function so no surface is missed.
  */
+export function isNamespaceAllowed(
+  caps: TokenCapabilities | undefined | null,
+  namespace: string | undefined,
+  defaultNamespace: string | undefined,
+): boolean {
+  if (caps?.namespaces === undefined) return true; // unrestricted token
+  const effective = resolveEffectiveNamespace(namespace, defaultNamespace);
+  return effective !== undefined && caps.namespaces.includes(effective);
+}
+
 export function enforceNamespaceAllowList(
   caps: TokenCapabilities | undefined | null,
   namespace: string | undefined,
   defaultNamespace: string | undefined,
 ): void {
-  if (caps?.namespaces === undefined) return; // unrestricted token — unchanged
-  const effective = resolveEffectiveNamespace(namespace, defaultNamespace);
-  if (effective === undefined || !caps.namespaces.includes(effective)) {
-    throw new EngramAccessForbiddenError(
-      namespace === undefined
-        ? "token is scoped to specific namespaces; the server default namespace is not permitted — supply an allowed namespace"
-        : `token is not permitted to access namespace: ${namespace}`,
-    );
-  }
+  if (isNamespaceAllowed(caps, namespace, defaultNamespace)) return;
+  throw new EngramAccessForbiddenError(
+    namespace === undefined
+      ? "token is scoped to specific namespaces; the server default namespace is not permitted — supply an allowed namespace"
+      : `token is not permitted to access namespace: ${namespace}`,
+  );
 }
 
 /**

--- a/packages/remnic-core/src/scopes/scope-plan.test.ts
+++ b/packages/remnic-core/src/scopes/scope-plan.test.ts
@@ -24,9 +24,11 @@ import test from "node:test";
 import {
   getConfiguredNamespaces,
   resolveNamespaceFromStorageDir,
+  resolveNamespacePreflight,
   resolveScopePlan,
   resolveWritableNamespaceValue,
 } from "./scope-plan.js";
+import type { TokenCapabilities } from "../access-token-capabilities.js";
 import {
   combineNamespaces,
   lcmSessionKeyForNamespace,
@@ -524,4 +526,44 @@ test("resolveWritableNamespaceValue: namespaces disabled, default namespace → 
   const result = resolveWritableNamespaceValue("default", "sess-1", undefined, config);
   assert.equal(result.ok, true);
   if (result.ok) assert.equal(result.namespace, "default");
+});
+
+test("resolveNamespacePreflight gates on the allow-list, policy, and the requested write op", () => {
+  const config = baseConfig({ namespacesEnabled: false });
+  // Unrestricted token, observe path: default writable, foreign policy-rejected.
+  assert.deepEqual(
+    resolveNamespacePreflight(undefined, "default", undefined, undefined, config, "observe"),
+    { ok: true, namespace: "default" },
+  );
+  assert.equal(
+    resolveNamespacePreflight(undefined, "team-b", undefined, undefined, config, "observe").ok,
+    false,
+  );
+  // Namespace-scoped token: in-list writable; out-of-list definitive not_writable.
+  const scoped = { namespaces: ["default"] } as unknown as TokenCapabilities;
+  assert.deepEqual(
+    resolveNamespacePreflight(scoped, "default", undefined, undefined, config, "observe"),
+    { ok: true, namespace: "default" },
+  );
+  assert.deepEqual(
+    resolveNamespacePreflight(scoped, "team-b", undefined, undefined, config, "observe"),
+    { ok: false, reason: "not_writable", namespace: "team-b" },
+  );
+  // Write-op awareness: a memory_store-only token is not_writable for the
+  // observe path but writable for the memory_store path; a token lacking BOTH
+  // (diagnostic-only) is never writable.
+  const storeOnly = { ops: ["memory_store"] } as unknown as TokenCapabilities;
+  assert.equal(
+    resolveNamespacePreflight(storeOnly, "default", undefined, undefined, config, "observe").ok,
+    false,
+  );
+  assert.deepEqual(
+    resolveNamespacePreflight(storeOnly, "default", undefined, undefined, config, "memory_store"),
+    { ok: true, namespace: "default" },
+  );
+  const diagnosticOnly = { ops: ["namespace_writable"] } as unknown as TokenCapabilities;
+  assert.equal(
+    resolveNamespacePreflight(diagnosticOnly, "default", undefined, undefined, config, "observe").ok,
+    false,
+  );
 });

--- a/packages/remnic-core/src/scopes/scope-plan.ts
+++ b/packages/remnic-core/src/scopes/scope-plan.ts
@@ -44,6 +44,12 @@ import {
   namespaceIdentityToken,
 } from "../namespaces/identity.js";
 import path from "node:path";
+import {
+  capabilityAllowsOp,
+  isNamespaceAllowed,
+  resolveEffectiveNamespace,
+  type TokenCapabilities,
+} from "../access-token-capabilities.js";
 import type { ResolvedScopeProfilePlan } from "../namespaces/scope-profiles.js";
 import {
   expandScopeProfileReadNamespaces,
@@ -481,4 +487,43 @@ export function resolveWritableNamespaceValue(
     return { ok: false, reason: "not_writable", namespace: resolved };
   }
   return { ok: true, namespace: resolved };
+}
+
+/**
+ * Namespace preflight (issue #1888 part 3): would a write to `namespace` by a
+ * caller carrying `caps` succeed? Combines the token's write-op scope, its
+ * namespace allow-list, and policy writability so one call answers the real
+ * question. A token that cannot actually write (no `observe`/`memory_store` in
+ * its ops allow-list) or is asking about a namespace outside its allow-list
+ * gets a definitive `not_writable` — revealing nothing about the namespace's
+ * policy beyond what the token's own scope already implies, and never throwing
+ * a hard authorization error the caller cannot distinguish from a transport
+ * fault. (Unrestricted tokens pass both scope checks unchanged.)
+ */
+export function resolveNamespacePreflight(
+  caps: TokenCapabilities | undefined | null,
+  namespace: string | undefined,
+  sessionKey: string | undefined,
+  authenticatedPrincipal: string | undefined,
+  config: PluginConfig,
+  writeOp: string,
+): WritableNamespaceResult {
+  const notWritable = (): WritableNamespaceResult => ({
+    ok: false,
+    reason: "not_writable",
+    namespace: resolveEffectiveNamespace(namespace, config.defaultNamespace) ?? namespace ?? "",
+  });
+  // The token must be able to perform the write op the caller's ENABLED write
+  // path actually uses (`observe` for automatic turn capture — the silent
+  // #1888 data-loss path — or `memory_store` for an explicit-only install).
+  // A token that cannot perform that op would drop the write, so an otherwise
+  // policy-writable namespace is still reported not_writable rather than a
+  // false ok:true that promises a write the token cannot make.
+  if (!capabilityAllowsOp(caps, writeOp)) {
+    return notWritable();
+  }
+  if (!isNamespaceAllowed(caps, namespace, config.defaultNamespace)) {
+    return notWritable();
+  }
+  return resolveWritableNamespaceValue(namespace, sessionKey, authenticatedPrincipal, config);
 }


### PR DESCRIPTION
## Context

Issue #1888. The dead-letter quarantine (part 1) and its `remnic quarantine list` + `doctor` surfacing (part 2) already shipped. This is **part 3 — the client startup preflight** the issue asked for, which would have caught the original incident on session 1.

## Problem

When a client's configured namespace matches no `namespacePolicies` entry and isn't the daemon's `defaultNamespace`/`sharedNamespace`, the write ACL correctly fails closed — but silently, per call. The operator sees nothing; every write is rejected (and, now that dead-lettering exists, parked in quarantine) rather than stored.

## Change

**Client (plugin-pi):** at each `session_start`, validate namespace writability once and surface a failure LOUDLY.
- Not writable -> a persistent `remnic_state` error entry (re-emitted every session while broken) + an error notification naming the namespace and the fix.
- Records the current state authoritatively: a `NAMESPACE_OK` entry once writable makes the latest `remnic_state` entry correct even across an extension/host restart (no in-memory transition tracking a restart would lose). Only errors notify; the OK entry is a silent heartbeat.
- Indeterminate (daemon unreachable / 5xx / timeout / malformed denial) never raises a false alarm; the check also skips when the startup health probe already tripped the circuit breaker.
- `RemnicClient.preflightNamespace()` returns `writable` / `not_writable` / `indeterminate`, and validates the full denial contract before alarming.

**Daemon (core):** new read-only `GET /engram/v1/namespace/writable` endpoint (operation `namespace_writable`, bearer-gated + surface-cataloged like its peers). The route runs the requested namespace through the shared `resolveNamespace()` allow-list gate first, so a namespace-scoped token is held to its allow-list here exactly as on `observe`/`memory_store`, then calls the existing pure `resolveWritableNamespaceValue` with the caller's config and **token-derived** principal — no write, no storage access.

## Non-goals / follow-ups

- No silent fallback to a default namespace (contract lie / cross-tenant risk) — unchanged.
- `remnic quarantine replay` and the `doctor` namespace-policy lint remain follow-ups.

Part 3 of #1888.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth/token capability enforcement and namespace writability policy on a new HTTP surface; client behavior changes session startup and error surfacing but avoids silent namespace fallback.
> 
> **Overview**
> Adds **startup namespace writability preflight** (#1888 part 3) so a misconfigured Pi client namespace is visible on session 1 instead of failing silently on every write (and dead-lettering into quarantine).
> 
> On each **`session_start`**, plugin-pi probes daemon health and updates the **circuit breaker even when `statusEnabled` is false**, then calls **`RemnicClient.preflightNamespace()`** against `GET /engram/v1/namespace/writable` (using the client’s real write op: `observe` vs `memory_store`). A definitive **not writable** result emits a persistent **`remnic_state`** error (`NAMESPACE_NOT_WRITABLE`) plus an error notification; **writable** records a silent **`NAMESPACE_OK`** entry; **indeterminate** (offline daemon, malformed JSON, no auth token) records nothing so flaky daemons do not false-alarm.
> 
> In **remnic-core**, the new bearer-gated route and **`namespace_writable`** batch/MCP operation delegate to **`resolveNamespacePreflight`**, which checks token write-op scope, namespace allow-list, and policy writability—returning `{ ok: false }` for out-of-allow-list namespaces instead of a hard 403. The access boundary gains **`allowedByOps`** so tokens scoped to `observe`/`memory_store` can run the diagnostic without listing `namespace_writable` explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01dfaf6693d40e1dd86e0281ad0ec92fc823aa48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a namespace writability preflight on `session_start`, including a bearer-gated `GET /engram/v1/namespace/writable` endpoint and matching batch/MCP support.
  - Introduced structured writability outcomes (writable / not writable / indeterminate) for safer client-side handling.

- **Bug Fixes**
  - Namespace write denials are now persistently surfaced across sessions with error notifications, and automatically resolve to an OK state when writability returns.
  - Improved daemon-offline and malformed-response handling to prevent false alarms; circuit-breaker health checks run at `session_start` even when UI status is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->