### PR TITLE
feat(doctor): config-time namespace-policy lint (#1888)

### DIFF
--- a/.changeset/doctor-namespace-lint-1888.md
+++ b/.changeset/doctor-namespace-lint-1888.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+"@remnic/cli": patch
+---
+
+Config-time namespace-policy lint in `remnic doctor` (issue #1888 improvement 3). When a configured write namespace is writable by no one — namespace enforcement is on, and it is neither the `defaultNamespace` nor a `namespacePolicies` entry that grants a writer — every write to it is rejected by the namespace ACL and dead-lettered rather than stored. `doctor` now surfaces this as a "Namespace policy" warning with remediation (and a failed check when the configured `namespace` value is invalid), catching the misconfiguration at config time before a session silently loses memory. Backed by a new principal-agnostic `isNamespacePolicyCovered(namespace, config)` helper exported from `@remnic/core` that mirrors `canWriteNamespace` semantics (namespaces-off ⇒ all writable; `sharedNamespace` is not implicitly writable).

--- a/packages/remnic-cli/src/doctor-namespace-lint.ts
+++ b/packages/remnic-cli/src/doctor-namespace-lint.ts
@@ -1,0 +1,69 @@
+import { type PluginConfig, isNamespacePolicyCovered } from "@remnic/core";
+
+/** A single `remnic doctor` check row (mirrors the inline shape in cmdDoctor). */
+export interface DoctorCheck {
+  name: string;
+  ok: boolean;
+  warn?: boolean;
+  detail: string;
+  remediation?: string;
+}
+
+/** Outcome of reading the raw client/plugin `namespace` key for the config-time lint. */
+export interface ConfiguredNamespace {
+  /** The trimmed configured write namespace, when present and usable. */
+  configuredNamespace?: string;
+  /** True when a `namespace` key is present but not a non-empty string. */
+  invalid: boolean;
+}
+
+/**
+ * Read the raw configured write namespace (issue #1888 improvement 3). It is not
+ * a parsed EngramConfig field — a client/plugin sets it in the raw record — so it
+ * is captured here to lint against the parsed namespace policy. A present-but-blank
+ * `namespace` is surfaced as invalid rather than silently skipped.
+ */
+export function readConfiguredNamespace(remnicCfg: Record<string, unknown>): ConfiguredNamespace {
+  if (!("namespace" in remnicCfg)) return { invalid: false };
+  const value = remnicCfg.namespace;
+  if (typeof value === "string" && value.trim().length > 0) {
+    return { configuredNamespace: value.trim(), invalid: false };
+  }
+  return { invalid: true };
+}
+
+/**
+ * Build the config-time namespace-policy lint row (issue #1888 improvement 3). A
+ * configured write namespace that is writable by no one (no default, no policy
+ * granting a writer) has every write rejected by the ACL and dead-lettered; catch
+ * it at config time before a session silently loses memory. Returns undefined when
+ * there is nothing to lint (no configured namespace and the value was not invalid).
+ */
+export function buildNamespacePolicyCheck(args: {
+  invalid: boolean;
+  configuredNamespace?: string;
+  config?: PluginConfig;
+}): DoctorCheck | undefined {
+  if (args.invalid) {
+    return {
+      name: "Namespace policy",
+      ok: false,
+      detail: "config `namespace` is set but is not a non-empty string",
+      remediation:
+        "Set `namespace` to a non-empty string (a namespacePolicies name or the default namespace), or remove it.",
+    };
+  }
+  if (!args.config || !args.configuredNamespace) return undefined;
+  const covered = isNamespacePolicyCovered(args.configuredNamespace, args.config);
+  return {
+    name: "Namespace policy",
+    ok: covered,
+    warn: !covered,
+    detail: covered
+      ? `configured namespace "${args.configuredNamespace}" is writable`
+      : `configured namespace "${args.configuredNamespace}" is writable by no one — its namespacePolicies entry grants no writer, or it has no entry and is not the default namespace`,
+    remediation: covered
+      ? undefined
+      : `Give "${args.configuredNamespace}" a namespacePolicies entry with a non-blank writePrincipals value, or set namespace to a writable one — otherwise every write is rejected and dead-lettered.`,
+  };
+}

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -175,6 +175,11 @@ import {
 // only uses it). Load lazily so the CLI works without it — see
 // optional-weclone-export.ts for the install-hint behaviour.
 import { loadWecloneExportModule } from "./optional-weclone-export.js";
+import {
+  type ConfiguredNamespace,
+  readConfiguredNamespace,
+  buildNamespacePolicyCheck,
+} from "./doctor-namespace-lint.js";
 import { WriteQuarantineStore } from "@remnic/core/write-quarantine.js";
 import { renderQuarantineList, type QuarantineFormat } from "./quarantine-cli.js";
 import { drainOfflineSyncImpressions, resolveOfflineImpressionRotation, parseConfigQuietly, pickOfflineConfigRecord } from "./offline-impression-rotation.js";
@@ -6542,11 +6547,13 @@ async function cmdDoctor(): Promise<void> {
   let standaloneConfig: ReturnType<typeof parseConfig> | undefined;
   let standaloneConfigError: string | undefined;
   let standaloneOpenaiApiKeyExplicitlyFalse = false;
+  let configuredNs: ConfiguredNamespace = { invalid: false };
   if (configExists) {
     try {
       const raw = JSON.parse(fs.readFileSync(configPath, "utf8"));
       const remnicCfg = resolveRemnicConfigRecord(raw);
       standaloneOpenaiApiKeyExplicitlyFalse = isOpenaiApiKeyDisabled(remnicCfg.openaiApiKey);
+      configuredNs = readConfiguredNamespace(remnicCfg);
       standaloneConfig = parseConfig(remnicCfg);
     } catch (err) {
       standaloneConfigError = err instanceof Error ? err.message : String(err);
@@ -6593,6 +6600,14 @@ async function cmdDoctor(): Promise<void> {
       detail: "unable to inspect quarantine store",
     });
   }
+
+  // Config-time namespace-policy lint (issue #1888 improvement 3): see doctor-namespace-lint.ts.
+  const nsPolicyCheck = buildNamespacePolicyCheck({
+    invalid: configuredNs.invalid,
+    configuredNamespace: configuredNs.configuredNamespace,
+    config: standaloneConfig,
+  });
+  if (nsPolicyCheck) checks.push(nsPolicyCheck);
 
   // ── OpenClaw config checks ──────────────────────────────────────────────────
   const openclawConfigPath = resolveOpenclawConfigPath();

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -349,7 +349,7 @@ export { MeilisearchBackend } from "./search/meilisearch-backend.js";
 // ---------------------------------------------------------------------------
 
 export { buildEntityRecallSection } from "./entity-retrieval.js";
-export { resolvePrincipal } from "./namespaces/principal.js";
+export { isNamespacePolicyCovered, resolvePrincipal } from "./namespaces/principal.js";
 export {
   NamespaceCatalog,
   type NamespaceRecord,

--- a/packages/remnic-core/src/namespaces/principal.test.ts
+++ b/packages/remnic-core/src/namespaces/principal.test.ts
@@ -12,7 +12,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { canReadNamespace, resolvePrincipal } from "./principal.js";
+import { canReadNamespace, isNamespacePolicyCovered, resolvePrincipal } from "./principal.js";
 import type { PluginConfig } from "../types.js";
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -248,4 +248,40 @@ test("resolvePrincipal: regex rules are skipped for overlong session keys", () =
   });
 
   assert.equal(resolvePrincipal("a".repeat(1_000), config), "default");
+});
+
+test("isNamespacePolicyCovered mirrors canWriteNamespace: default + policy-with-writers covered; shared/no-writers/uncovered not", () => {
+  const config = makeConfig(true, [
+    { name: "team-a", readPrincipals: [], writePrincipals: ["alice"] },
+    { name: "readonly-ns", readPrincipals: ["*"], writePrincipals: [] },
+    { name: "blank-writer-ns", readPrincipals: ["*"], writePrincipals: [""] },
+  ]);
+  // Covered: the default namespace, and a policy that grants at least one writer.
+  assert.equal(isNamespacePolicyCovered("default", config), true);
+  assert.equal(isNamespacePolicyCovered("team-a", config), true);
+  // NOT covered: shared is not implicitly writable (matches canWriteNamespace),
+  // a policy with no writePrincipals grants nobody, and an unlisted namespace is
+  // the jw14m2-class misconfiguration #1888 targets (writes rejected + parked).
+  assert.equal(isNamespacePolicyCovered("shared", config), false);
+  assert.equal(isNamespacePolicyCovered("readonly-ns", config), false);
+  // Blank writer entries never match a real principal, so they grant no one.
+  assert.equal(isNamespacePolicyCovered("blank-writer-ns", config), false);
+  assert.equal(isNamespacePolicyCovered("team-b", config), false);
+  // Namespaces disabled: every write is allowed, so nothing is flagged.
+  const disabled = makeConfig(false);
+  assert.equal(isNamespacePolicyCovered("anything", disabled), true);
+  assert.equal(isNamespacePolicyCovered("team-b", disabled), true);
+});
+
+test("isNamespacePolicyCovered: an explicit default-namespace policy overrides the default fallback", () => {
+  // canWriteNamespace looks up a policy BEFORE falling back to defaultNamespace,
+  // so a policy naming the default with no (or blank-only) writers makes the
+  // default unwritable. The lint must mirror that precedence, not short-circuit
+  // on `namespace === defaultNamespace`.
+  const emptyDefault = makeConfig(true, [{ name: "default", readPrincipals: ["*"], writePrincipals: [] }]);
+  assert.equal(isNamespacePolicyCovered("default", emptyDefault), false);
+  const blankDefault = makeConfig(true, [{ name: "default", readPrincipals: [], writePrincipals: [" "] }]);
+  assert.equal(isNamespacePolicyCovered("default", blankDefault), false);
+  const grantedDefault = makeConfig(true, [{ name: "default", readPrincipals: [], writePrincipals: ["alice"] }]);
+  assert.equal(isNamespacePolicyCovered("default", grantedDefault), true);
 });

--- a/packages/remnic-core/src/namespaces/principal.ts
+++ b/packages/remnic-core/src/namespaces/principal.ts
@@ -68,6 +68,31 @@ export function canWriteNamespace(principal: string | undefined, namespace: stri
 }
 
 /**
+ * Config-time namespace-policy lint (issue #1888 improvement 3). Principal-
+ * agnostic mirror of {@link canWriteNamespace}: true when the namespace is
+ * writable by AT LEAST ONE principal. When namespace enforcement is off every
+ * write is allowed. Otherwise an explicit `namespacePolicies` entry takes
+ * precedence (exactly as `canWriteNamespace`): with a matching policy the
+ * namespace is covered only if that policy grants at least one non-blank
+ * writer — even when the name equals `defaultNamespace`; without a policy it
+ * is covered only if it IS the `defaultNamespace`. The `sharedNamespace` is
+ * NOT implicitly writable (matching
+ * `canWriteNamespace`), and a policy entry with no `writePrincipals` grants
+ * nobody. A configured namespace that is NOT covered is writable for no one,
+ * so every write to it is rejected by the ACL and dead-lettered — `remnic
+ * doctor` warns on that before a session silently loses memory.
+ */
+export function isNamespacePolicyCovered(namespace: string, config: PluginConfig): boolean {
+  if (!resolveNamespaceCapabilities(config).namespaces) return true;
+  // An explicit policy wins over the default fallback (exactly as
+  // canWriteNamespace), so a policy naming the default with no writers is NOT
+  // covered. Only fall back to defaultNamespace when no policy matches.
+  const policy = config.namespacePolicies.find((p) => p.name === namespace);
+  if (!policy) return namespace === config.defaultNamespace;
+  return policy.writePrincipals.some((w) => w.trim().length > 0);
+}
+
+/**
  * Default "self" namespace for a principal.
  *
  * Heuristic:


### PR DESCRIPTION
## Context

Issue #1888 improvement 3 (config-time lint). Parts 1-2 dead-lettered ACL-rejected writes and surfaced the parked count in `doctor`; part 3 added the client startup preflight. This adds the **config-time lint** so the misconfiguration is caught before any write is attempted.

## Change

`remnic doctor` gains a **"Namespace policy"** check: when a configured write namespace matches no `namespacePolicies` entry and is neither the `defaultNamespace` nor the `sharedNamespace`, it is writable for nobody — every write to it is rejected by the namespace ACL and dead-lettered rather than stored. The check warns with remediation (add a policy entry, or use the default namespace).

Backed by a new principal-agnostic `isNamespacePolicyCovered(namespace, config)` helper exported from `@remnic/core` and unit-tested.

Part of #1888.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only diagnostic on config load in `doctor`; no changes to ACL enforcement or write paths at runtime.
> 
> **Overview**
> **`remnic doctor`** now runs a **Namespace policy** check when the raw config sets a client/plugin `namespace` write target. Invalid values (present but not a non-empty string) fail the check with remediation; valid values are checked against parsed namespace policy via new **`isNamespacePolicyCovered`** in `@remnic/core`.
> 
> That helper mirrors **`canWriteNamespace`** without a principal: with enforcement on, only the default namespace (when no matching policy) or a policy with at least one non-blank `writePrincipals` entry counts as writable—**`shared`** is not implicitly writable, and an explicit policy on `default` with no writers is not covered. Uncovered namespaces produce a **warning** with remediation so misconfigs that would dead-letter every write are caught before runtime.
> 
> Logic lives in **`doctor-namespace-lint.ts`** and is wired into standalone config parsing in **`cmdDoctor`**; unit tests cover precedence and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0554748c4db83cee6e6f6bf4a37c711b70083356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `remnic doctor` now adds a config-time **“Namespace policy”** diagnostic for the configured write namespace, including remediation when the `namespace` value is missing/invalid or when no enabled policy writers cover it.
  * Clarified policy coverage behavior: `default` can be covered when appropriate, while `shared` is not implicitly covered.
* **Bug Fixes**
  * Helps prevent unexpected namespace write rejection and dead-lettering by detecting coverage gaps before runtime.
* **Tests**
  * Added additional test coverage for namespace policy determination, including cases where enforcement is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->