### PR TITLE
feat(cli): remnic quarantine replay + write-surface suppression flag (#1888)

### DIFF
--- a/.changeset/quarantine-replay-1888.md
+++ b/.changeset/quarantine-replay-1888.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+"@remnic/cli": patch
+---
+
+Add `remnic quarantine replay --namespace <ns> [--principal <p>]` to re-submit ACL-rejected, dead-lettered writes once the namespace config is fixed (#1888). A new `suppressQuarantine` flag on the write envelope and observe request lets replay re-submit through the same access surface without the replay attempt itself being re-quarantined: a target that is still not writable propagates the error, so the entry is recorded as a failure and left parked (never duplicated) instead of dead-lettered again. `WriteQuarantineStore` gains `entries()` (records paired with their on-disk path) and a containment-guarded `removeEntry()`; an entry is only counted as replayed when both the re-submit and its removal succeed.

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -9913,7 +9913,7 @@ async function cmdQuarantine(action: string, rest: string[], json: boolean): Pro
     }
     return;
   }
-  await runQuarantineReplay(rest, format, resolveConfigPath());
+  await runQuarantineReplay(rest, format, resolveConfigPath);
 }
 
 async function cmdConnectors(action: string, rest: string[], json: boolean): Promise<void> {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -181,7 +181,7 @@ import {
   buildNamespacePolicyCheck,
 } from "./doctor-namespace-lint.js";
 import { WriteQuarantineStore } from "@remnic/core/write-quarantine.js";
-import { renderQuarantineList, type QuarantineFormat } from "./quarantine-cli.js";
+import { renderQuarantineList, replayQuarantine, renderReplayResult, type QuarantineFormat } from "./quarantine-cli.js";
 import { drainOfflineSyncImpressions, resolveOfflineImpressionRotation, parseConfigQuietly, pickOfflineConfigRecord } from "./offline-impression-rotation.js";
 import {
   createConfiguredOfflineStorage,
@@ -9887,38 +9887,83 @@ function snapshotConnectorTokenEntry(connectorId: string): TokenEntry | null {
 
 // ── M5 connectors command ────────────────────────────────────────────────────
 
-/**
- * `remnic quarantine list` (issue #1888): show the writes the namespace ACL
- * rejected and dead-lettered (recoverable) instead of destroying them. Read
- * only — no orchestrator boot. Recovery (`replay`) is a deliberate follow-up:
- * a correct replay must re-submit without the write surface re-quarantining the
- * replay attempt, which needs a quarantine-suppression flag through the access
- * layer.
- */
+/** `remnic quarantine list|replay` (#1888): surface ACL-rejected, dead-lettered writes; `list` is read-only, `replay` boots the access layer and re-submits each parked payload into `--namespace` with `suppressQuarantine` set (a still-unwritable target is recorded as a failure and left parked, never duplicated). */
 async function cmdQuarantine(action: string, rest: string[], json: boolean): Promise<void> {
-  if (action !== "list") {
-    process.stderr.write(`quarantine: unknown action "${action}". Use: list [--json].\n`);
-    process.exitCode = 2;
-    return;
-  }
-  const extra = rest.filter((a) => !a.startsWith("--"));
-  if (extra.length > 0) {
-    process.stderr.write(`quarantine list: unexpected argument(s): ${extra.join(", ")}. Use: list [--json].\n`);
+  if (action !== "list" && action !== "replay") {
+    process.stderr.write(`quarantine: unknown action "${action}". Use: list|replay [--namespace <ns>] [--principal <p>] [--json].\n`);
     process.exitCode = 2;
     return;
   }
   const format: QuarantineFormat = json ? "json" : "text";
+  if (action === "list") {
+    const extra = rest.filter((a) => !a.startsWith("--"));
+    if (extra.length > 0) {
+      process.stderr.write(`quarantine list: unexpected argument(s): ${extra.join(", ")}. Use: list [--json].\n`);
+      process.exitCode = 2;
+      return;
+    }
+    try {
+      // resolveMemoryDir() can throw on invalid config JSON, and list() surfaces an unreadable/symlink-invalid store: fail cleanly (exit 2, generic detail) rather than leak a raw stack.
+      const store = new WriteQuarantineStore(resolveMemoryDir());
+      console.log(renderQuarantineList(await store.list(), format));
+    } catch {
+      process.stderr.write("quarantine list: unable to inspect quarantine store\n");
+      process.exitCode = 2;
+    }
+    return;
+  }
+  let targetNamespace: string | undefined;
+  let principal: string | undefined;
   try {
-    // resolveMemoryDir() can throw on invalid config JSON, and list() surfaces
-    // an unreadable/symlink-invalid quarantine store — fail cleanly and exit 2
-    // rather than a raw stack trace, so the remediation command degrades the
-    // same way `doctor` does. The detail stays generic: the raw error can carry
-    // absolute paths/internal context meant for logs.
-    const store = new WriteQuarantineStore(resolveMemoryDir());
-    console.log(renderQuarantineList(await store.list(), format));
-  } catch {
-    process.stderr.write("quarantine list: unable to inspect quarantine store\n");
+    targetNamespace = resolveRequiredValueFlag(rest, "--namespace");
+    principal = resolveRequiredValueFlag(rest, "--principal");
+  } catch (err) {
+    process.stderr.write(`quarantine replay: ${err instanceof Error ? err.message : String(err)}\n`);
     process.exitCode = 2;
+    return;
+  }
+  if (!targetNamespace || targetNamespace.trim().length === 0) {
+    process.stderr.write("quarantine replay: --namespace <ns> is required.\n");
+    process.exitCode = 2;
+    return;
+  }
+  const valueFlags: Record<string, true> = { "--namespace": true, "--principal": true };
+  const stray = rest.filter((a, i) => !a.startsWith("--") && !valueFlags[rest[i - 1]]);
+  if (stray.length > 0) {
+    process.stderr.write(`quarantine replay: unexpected argument(s): ${stray.join(", ")}.\n`);
+    process.exitCode = 2;
+    return;
+  }
+  initLogger();
+  const configPath = resolveConfigPath();
+  const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
+  const orchestrator = new Orchestrator(parseConfig(resolveRemnicConfigRecord(raw)));
+  try {
+    await orchestrator.initialize();
+    await orchestrator.deferredReady;
+    const service = new EngramAccessService(orchestrator);
+    const store = new WriteQuarantineStore(resolveMemoryDir());
+    const result = await replayQuarantine({
+      store,
+      targetNamespace,
+      principal,
+      submit: async (operation, request) => {
+        if (operation === "observe") {
+          await service.observe(request as unknown as Parameters<EngramAccessService["observe"]>[0]);
+        } else if (operation === "memory_store") {
+          await service.memoryStore(request as unknown as Parameters<EngramAccessService["memoryStore"]>[0]);
+        } else {
+          await service.suggestionSubmit(request as unknown as Parameters<EngramAccessService["suggestionSubmit"]>[0]);
+        }
+      },
+    });
+    console.log(renderReplayResult(result, targetNamespace, format));
+    if (result.failures.length > 0) process.exitCode = 1;
+  } catch {
+    process.stderr.write("quarantine replay: unable to replay quarantine store\n");
+    process.exitCode = 2;
+  } finally {
+    await orchestrator.destroy();
   }
 }
 
@@ -13600,7 +13645,7 @@ Usage:
     marketplace generate    Generate marketplace.json for Codex
     marketplace validate    Validate a marketplace.json file
     marketplace install     Install from a marketplace source
-  remnic quarantine list [--json]   Inspect writes the namespace ACL rejected
+  remnic quarantine <list|replay> [--namespace <ns>] [--principal <p>] [--json]  Inspect/replay ACL-rejected writes
   remnic extensions <list|show|validate|reload>  Manage memory extensions
   remnic space <list|switch|create|delete|push|pull|share|promote|audit>  Manage spaces
     create accepts --parent <id> to set parent-child relationship

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -9927,18 +9927,19 @@ async function cmdQuarantine(action: string, rest: string[], json: boolean): Pro
     process.exitCode = 2;
     return;
   }
-  const valueFlags: Record<string, true> = { "--namespace": true, "--principal": true };
-  const stray = rest.filter((a, i) => !a.startsWith("--") && !valueFlags[rest[i - 1]]);
-  if (stray.length > 0) {
-    process.stderr.write(`quarantine replay: unexpected argument(s): ${stray.join(", ")}.\n`);
+  const valued = new Set(["--namespace", "--principal"]);
+  const bad = rest.filter((a, i) => (a.startsWith("--") ? a !== "--json" && !valued.has(a) : !valued.has(rest[i - 1])));
+  if (bad.length > 0) {
+    process.stderr.write(`quarantine replay: unexpected argument(s): ${bad.join(", ")}. Use: replay --namespace <ns> [--principal <p>] [--json].\n`);
     process.exitCode = 2;
     return;
   }
   initLogger();
-  const configPath = resolveConfigPath();
-  const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
-  const orchestrator = new Orchestrator(parseConfig(resolveRemnicConfigRecord(raw)));
+  let orchestrator: Orchestrator | undefined;
   try {
+    const configPath = resolveConfigPath();
+    const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
+    orchestrator = new Orchestrator(parseConfig(resolveRemnicConfigRecord(raw)));
     await orchestrator.initialize();
     await orchestrator.deferredReady;
     const service = new EngramAccessService(orchestrator);
@@ -9958,12 +9959,12 @@ async function cmdQuarantine(action: string, rest: string[], json: boolean): Pro
       },
     });
     console.log(renderReplayResult(result, targetNamespace, format));
-    if (result.failures.length > 0) process.exitCode = 1;
+    if (result.failures.length > 0 || result.deleteFailures.length > 0) process.exitCode = 1;
   } catch {
     process.stderr.write("quarantine replay: unable to replay quarantine store\n");
     process.exitCode = 2;
   } finally {
-    await orchestrator.destroy();
+    if (orchestrator) await orchestrator.destroy();
   }
 }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -181,7 +181,8 @@ import {
   buildNamespacePolicyCheck,
 } from "./doctor-namespace-lint.js";
 import { WriteQuarantineStore } from "@remnic/core/write-quarantine.js";
-import { renderQuarantineList, replayQuarantine, renderReplayResult, type QuarantineFormat } from "./quarantine-cli.js";
+import { renderQuarantineList, type QuarantineFormat } from "./quarantine-cli.js";
+import { runQuarantineReplay } from "./quarantine-replay.js";
 import { drainOfflineSyncImpressions, resolveOfflineImpressionRotation, parseConfigQuietly, pickOfflineConfigRecord } from "./offline-impression-rotation.js";
 import {
   createConfiguredOfflineStorage,
@@ -9912,60 +9913,7 @@ async function cmdQuarantine(action: string, rest: string[], json: boolean): Pro
     }
     return;
   }
-  let targetNamespace: string | undefined;
-  let principal: string | undefined;
-  try {
-    targetNamespace = resolveRequiredValueFlag(rest, "--namespace");
-    principal = resolveRequiredValueFlag(rest, "--principal");
-  } catch (err) {
-    process.stderr.write(`quarantine replay: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exitCode = 2;
-    return;
-  }
-  if (!targetNamespace || targetNamespace.trim().length === 0) {
-    process.stderr.write("quarantine replay: --namespace <ns> is required.\n");
-    process.exitCode = 2;
-    return;
-  }
-  const valued = new Set(["--namespace", "--principal"]);
-  const bad = rest.filter((a, i) => (a.startsWith("--") ? a !== "--json" && !valued.has(a) : !valued.has(rest[i - 1])));
-  if (bad.length > 0) {
-    process.stderr.write(`quarantine replay: unexpected argument(s): ${bad.join(", ")}. Use: replay --namespace <ns> [--principal <p>] [--json].\n`);
-    process.exitCode = 2;
-    return;
-  }
-  initLogger();
-  let orchestrator: Orchestrator | undefined;
-  try {
-    const configPath = resolveConfigPath();
-    const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
-    orchestrator = new Orchestrator(parseConfig(resolveRemnicConfigRecord(raw)));
-    await orchestrator.initialize();
-    await orchestrator.deferredReady;
-    const service = new EngramAccessService(orchestrator);
-    const store = new WriteQuarantineStore(resolveMemoryDir());
-    const result = await replayQuarantine({
-      store,
-      targetNamespace,
-      principal,
-      submit: async (operation, request) => {
-        if (operation === "observe") {
-          await service.observe(request as unknown as Parameters<EngramAccessService["observe"]>[0]);
-        } else if (operation === "memory_store") {
-          await service.memoryStore(request as unknown as Parameters<EngramAccessService["memoryStore"]>[0]);
-        } else {
-          await service.suggestionSubmit(request as unknown as Parameters<EngramAccessService["suggestionSubmit"]>[0]);
-        }
-      },
-    });
-    console.log(renderReplayResult(result, targetNamespace, format));
-    if (result.failures.length > 0 || result.deleteFailures.length > 0) process.exitCode = 1;
-  } catch {
-    process.stderr.write("quarantine replay: unable to replay quarantine store\n");
-    process.exitCode = 2;
-  } finally {
-    if (orchestrator) await orchestrator.destroy();
-  }
+  await runQuarantineReplay(rest, format, resolveConfigPath());
 }
 
 async function cmdConnectors(action: string, rest: string[], json: boolean): Promise<void> {

--- a/packages/remnic-cli/src/quarantine-cli.test.ts
+++ b/packages/remnic-cli/src/quarantine-cli.test.ts
@@ -97,6 +97,51 @@ test("replayQuarantine re-submits with the target namespace + suppression and re
   });
 });
 
+test("replayQuarantine defaults the principal to the record and sets a stable idempotency key", async () => {
+  await withStore(async (store) => {
+    await store.quarantine({
+      operation: "memory_store",
+      principal: "dave",
+      attemptedNamespace: "ns-x",
+      payload: { content: "yo" },
+    });
+    const seen: Array<Record<string, unknown>> = [];
+    const result = await replayQuarantine({
+      store,
+      targetNamespace: "dave-self",
+      submit: async (_op, request) => {
+        seen.push(request as Record<string, unknown>);
+      },
+    });
+    assert.equal(result.replayed, 1);
+    // No --principal override: authz falls back to the parked principal.
+    assert.equal(seen[0]?.authenticatedPrincipal, "dave");
+    // A stable idempotency key lets a re-run after a failed delete dedupe.
+    assert.equal(typeof seen[0]?.idempotencyKey, "string");
+    assert.match(String(seen[0]?.idempotencyKey), /^quarantine-replay:/);
+  });
+});
+
+test("replayQuarantine preserves an idempotencyKey already present in the payload", async () => {
+  await withStore(async (store) => {
+    await store.quarantine({
+      operation: "memory_store",
+      principal: "erin",
+      attemptedNamespace: "ns-x",
+      payload: { content: "z", idempotencyKey: "caller-key-1" },
+    });
+    const seen: Array<Record<string, unknown>> = [];
+    await replayQuarantine({
+      store,
+      targetNamespace: "erin-self",
+      submit: async (_op, request) => {
+        seen.push(request as Record<string, unknown>);
+      },
+    });
+    assert.equal(seen[0]?.idempotencyKey, "caller-key-1");
+  });
+});
+
 test("replayQuarantine records a failure and leaves the entry parked when submit throws", async () => {
   await withStore(async (store) => {
     await store.quarantine({

--- a/packages/remnic-cli/src/quarantine-cli.test.ts
+++ b/packages/remnic-cli/src/quarantine-cli.test.ts
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import { WriteQuarantineStore } from "@remnic/core/write-quarantine.js";
 
-import { renderQuarantineList } from "./quarantine-cli.js";
+import { renderQuarantineList, renderReplayResult, replayQuarantine } from "./quarantine-cli.js";
 
 async function withStore(fn: (store: WriteQuarantineStore) => Promise<void>): Promise<void> {
   const dir = await mkdtemp(path.join(tmpdir(), "remnic-qcli-"));
@@ -65,4 +65,104 @@ test("renderQuarantineList throws on an unsupported format", () => {
     () => renderQuarantineList([], "csv" as unknown as Parameters<typeof renderQuarantineList>[1]),
     /Unsupported quarantine format/
   );
+});
+
+test("replayQuarantine re-submits with the target namespace + suppression and removes the entry on success", async () => {
+  await withStore(async (store) => {
+    await store.quarantine({
+      operation: "memory_store",
+      principal: "alice",
+      attemptedNamespace: "ns-x",
+      payload: { content: "hi" },
+    });
+    const submitted: Array<{ operation: string; request: Record<string, unknown> }> = [];
+    const result = await replayQuarantine({
+      store,
+      targetNamespace: "alice-self",
+      principal: "alice",
+      submit: async (operation, request) => {
+        submitted.push({ operation, request: request as Record<string, unknown> });
+      },
+    });
+    assert.equal(result.replayed, 1);
+    assert.equal(result.failures.length, 0);
+    assert.equal(result.deleteFailures.length, 0);
+    assert.equal(await store.count(), 0);
+    assert.equal(submitted.length, 1);
+    assert.equal(submitted[0]?.operation, "memory_store");
+    assert.equal(submitted[0]?.request.namespace, "alice-self");
+    assert.equal(submitted[0]?.request.suppressQuarantine, true);
+    assert.equal(submitted[0]?.request.authenticatedPrincipal, "alice");
+    assert.equal(submitted[0]?.request.content, "hi");
+  });
+});
+
+test("replayQuarantine records a failure and leaves the entry parked when submit throws", async () => {
+  await withStore(async (store) => {
+    await store.quarantine({
+      operation: "observe",
+      principal: "bob",
+      attemptedNamespace: "ns-x",
+      payload: { messages: [] },
+    });
+    const result = await replayQuarantine({
+      store,
+      targetNamespace: "bob-self",
+      submit: async () => {
+        throw new Error("still not writable");
+      },
+    });
+    assert.equal(result.replayed, 0);
+    assert.equal(result.deleteFailures.length, 0);
+    assert.equal(result.failures.length, 1);
+    assert.equal(result.failures[0]?.operation, "observe");
+    assert.equal(result.failures[0]?.attemptedNamespace, "bob-self");
+    assert.equal(result.failures[0]?.error, "still not writable");
+    assert.equal(await store.count(), 1);
+  });
+});
+
+test("replayQuarantine reports a delete failure without counting it as replayed", async () => {
+  const entry = {
+    record: {
+      operation: "memory_store" as const,
+      principal: "carol",
+      attemptedNamespace: "ns-x",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      payload: { content: "x" },
+    },
+    path: "/tmp/remnic-quarantine-absent.json",
+  };
+  const fakeStore = {
+    entries: async () => [entry],
+    removeEntry: async () => false,
+  } as unknown as WriteQuarantineStore;
+  const result = await replayQuarantine({
+    store: fakeStore,
+    targetNamespace: "carol-self",
+    submit: async () => {},
+  });
+  assert.equal(result.replayed, 0);
+  assert.equal(result.failures.length, 0);
+  assert.equal(result.deleteFailures.length, 1);
+  assert.equal(result.deleteFailures[0]?.path, "/tmp/remnic-quarantine-absent.json");
+});
+
+test("renderReplayResult renders text and json", () => {
+  const result = {
+    replayed: 2,
+    failures: [{ operation: "observe" as const, attemptedNamespace: "ns-x", error: "nope" }],
+    deleteFailures: [{ path: "/tmp/x.json", error: "gone" }],
+  };
+  const text = renderReplayResult(result, "target-ns", "text");
+  assert.match(text, /Replayed 2 quarantined write\(s\) into namespace target-ns/);
+  assert.match(text, /Failures \(1\)/);
+  assert.match(text, /observe {2}attemptedNamespace=ns-x {2}error=nope/);
+  assert.match(text, /Delete failures \(1\)/);
+
+  const parsed = JSON.parse(renderReplayResult(result, "target-ns", "json")) as Record<string, unknown>;
+  assert.equal(parsed.replayed, 2);
+  assert.equal(parsed.targetNamespace, "target-ns");
+  assert.equal((parsed.failures as unknown[]).length, 1);
+  assert.equal((parsed.deleteFailures as unknown[]).length, 1);
 });

--- a/packages/remnic-cli/src/quarantine-cli.ts
+++ b/packages/remnic-cli/src/quarantine-cli.ts
@@ -11,6 +11,7 @@
  * re-quarantined into a duplicate record.
  */
 
+import { basename } from "node:path";
 import type { QuarantineOperation, QuarantinedRecord, WriteQuarantineStore } from "@remnic/core/write-quarantine.js";
 
 export type QuarantineFormat = "text" | "json";
@@ -67,11 +68,23 @@ export async function replayQuarantine(opts: {
   for (const entry of await opts.store.entries()) {
     const { record } = entry;
     const basePayload = record.payload as Record<string, unknown>;
+    // Default to the principal the write was originally attributed to, so authz
+    // resolves against that identity unless the operator overrides with --principal.
+    const principal = opts.principal ?? record.principal ?? undefined;
+    // Stable idempotency key derived from the parked file name: if a re-submit
+    // succeeds but the record cannot be removed, a later replay dedupes to the
+    // same write server-side instead of duplicating the side effect (observe has
+    // no content dedupe). A key already present in the payload is preserved.
+    const idempotencyKey =
+      typeof basePayload.idempotencyKey === "string" && basePayload.idempotencyKey.length > 0
+        ? basePayload.idempotencyKey
+        : `quarantine-replay:${basename(entry.path)}`;
     const request: Record<string, unknown> = {
       ...basePayload,
       namespace: opts.targetNamespace,
       suppressQuarantine: true,
-      ...(opts.principal ? { authenticatedPrincipal: opts.principal } : {}),
+      idempotencyKey,
+      ...(principal ? { authenticatedPrincipal: principal } : {}),
     };
     try {
       await opts.submit(record.operation, request);

--- a/packages/remnic-cli/src/quarantine-cli.ts
+++ b/packages/remnic-cli/src/quarantine-cli.ts
@@ -1,16 +1,17 @@
 /**
- * Pure rendering for `remnic quarantine list` (issue #1888 part 2): show the
- * writes the namespace ACL rejected and dead-lettered (recoverable) instead of
- * silently destroying them. The store I/O lives in `@remnic/core`; this module
- * is provider-free and unit-testable.
+ * Pure logic + rendering for `remnic quarantine list|replay` (issue #1888):
+ * surface the writes the namespace ACL rejected and dead-lettered (recoverable)
+ * instead of silently destroying them, and re-submit them once the config is
+ * fixed. The store I/O lives in `@remnic/core`; this module is provider-free
+ * and unit-testable.
  *
- * The recovery command (`remnic quarantine replay`) is a deliberate follow-up:
- * a correct replay must re-submit without the access layer re-quarantining the
- * replay attempt, which needs a quarantine-suppression flag threaded through
- * the write surface — its own focused change.
+ * `replayQuarantine` re-submits each parked payload with `suppressQuarantine`
+ * set, so a still-unwritable target propagates the error (recorded as a
+ * failure, original left parked) instead of the replay attempt itself being
+ * re-quarantined into a duplicate record.
  */
 
-import type { QuarantinedRecord } from "@remnic/core/write-quarantine.js";
+import type { QuarantineOperation, QuarantinedRecord, WriteQuarantineStore } from "@remnic/core/write-quarantine.js";
 
 export type QuarantineFormat = "text" | "json";
 
@@ -36,6 +37,100 @@ export function renderQuarantineList(records: readonly QuarantinedRecord[], form
     lines.push(
       `  ${record.timestamp}  ${record.operation}  principal=${record.principal ?? "-"}  attemptedNamespace=${record.attemptedNamespace}`
     );
+  }
+  return lines.join("\n");
+}
+
+export interface ReplayResult {
+  replayed: number;
+  failures: Array<{ operation: QuarantineOperation; attemptedNamespace: string; error: string }>;
+  deleteFailures: Array<{ path: string; error: string }>;
+}
+
+/**
+ * Re-submit every parked payload into `targetNamespace`. Each re-submit carries
+ * `suppressQuarantine: true`, so a target that is STILL not writable throws
+ * instead of re-parking the attempt: that error is recorded as a failure and
+ * the original stays parked (never duplicated). An entry is only counted as
+ * `replayed` when BOTH the submit AND the follow-up `removeEntry` succeed; a
+ * submit that lands but whose record cannot be deleted is a `deleteFailure`
+ * (the record remains, so it is not counted). A single failure never aborts the
+ * loop — every entry gets its own attempt.
+ */
+export async function replayQuarantine(opts: {
+  store: WriteQuarantineStore;
+  targetNamespace: string;
+  principal?: string;
+  submit: (operation: QuarantineOperation, request: unknown) => Promise<void>;
+}): Promise<ReplayResult> {
+  const result: ReplayResult = { replayed: 0, failures: [], deleteFailures: [] };
+  for (const entry of await opts.store.entries()) {
+    const { record } = entry;
+    const basePayload = record.payload as Record<string, unknown>;
+    const request: Record<string, unknown> = {
+      ...basePayload,
+      namespace: opts.targetNamespace,
+      suppressQuarantine: true,
+      ...(opts.principal ? { authenticatedPrincipal: opts.principal } : {}),
+    };
+    try {
+      await opts.submit(record.operation, request);
+    } catch (err) {
+      result.failures.push({
+        operation: record.operation,
+        attemptedNamespace: opts.targetNamespace,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+    try {
+      const removed = await opts.store.removeEntry(entry.path);
+      if (removed) {
+        result.replayed += 1;
+      } else {
+        result.deleteFailures.push({
+          path: entry.path,
+          error: "entry not removed (outside quarantine root or already absent)",
+        });
+      }
+    } catch (err) {
+      result.deleteFailures.push({
+        path: entry.path,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return result;
+}
+
+export function renderReplayResult(result: ReplayResult, targetNamespace: string, format: QuarantineFormat): string {
+  if (format === "json") {
+    return JSON.stringify(
+      {
+        targetNamespace,
+        replayed: result.replayed,
+        failures: result.failures,
+        deleteFailures: result.deleteFailures,
+      },
+      null,
+      2
+    );
+  }
+  if (format !== "text") {
+    throw new Error(`Unsupported quarantine format: ${String(format)}`);
+  }
+  const lines = [`Replayed ${result.replayed} quarantined write(s) into namespace ${targetNamespace}.`];
+  if (result.failures.length > 0) {
+    lines.push("", `Failures (${result.failures.length}); left parked:`);
+    for (const failure of result.failures) {
+      lines.push(`  ${failure.operation}  attemptedNamespace=${failure.attemptedNamespace}  error=${failure.error}`);
+    }
+  }
+  if (result.deleteFailures.length > 0) {
+    lines.push("", `Delete failures (${result.deleteFailures.length}); re-submitted but still parked:`);
+    for (const del of result.deleteFailures) {
+      lines.push(`  ${del.path}  error=${del.error}`);
+    }
   }
   return lines.join("\n");
 }

--- a/packages/remnic-cli/src/quarantine-replay.test.ts
+++ b/packages/remnic-cli/src/quarantine-replay.test.ts
@@ -8,13 +8,21 @@ import test from "node:test";
 
 import { runQuarantineReplay } from "./quarantine-replay.js";
 
+// The config resolver is never invoked on these paths (validation fails first),
+// so it throws to prove that: a leaked call would surface here.
+const resolver = (): string => {
+  throw new Error("config resolver must not run when argument validation fails");
+};
+
 async function exitCodeFor(rest: string[]): Promise<number | undefined> {
   const prev = process.exitCode;
   process.exitCode = 0;
-  await runQuarantineReplay(rest, "json", "/nonexistent-remnic-config.json");
-  const code = process.exitCode;
-  process.exitCode = prev;
-  return code;
+  try {
+    await runQuarantineReplay(rest, "json", resolver);
+    return process.exitCode;
+  } finally {
+    process.exitCode = prev;
+  }
 }
 
 test("runQuarantineReplay: missing --namespace is a usage error (exit 2)", async () => {
@@ -27,4 +35,13 @@ test("runQuarantineReplay: an unknown flag is rejected (exit 2)", async () => {
 
 test("runQuarantineReplay: --namespace without a value is rejected (exit 2)", async () => {
   assert.equal(await exitCodeFor(["--namespace", "--json"]), 2);
+});
+
+test("runQuarantineReplay: a repeated value flag is rejected (exit 2)", async () => {
+  assert.equal(await exitCodeFor(["--namespace", "ns", "--namespace", "other"]), 2);
+  assert.equal(await exitCodeFor(["--namespace", "ns", "--principal", "a", "--principal", "b"]), 2);
+});
+
+test("runQuarantineReplay: a blank principal override is rejected (exit 2)", async () => {
+  assert.equal(await exitCodeFor(["--namespace", "ns", "--principal", "   "]), 2);
 });

--- a/packages/remnic-cli/src/quarantine-replay.test.ts
+++ b/packages/remnic-cli/src/quarantine-replay.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Issue #1888: CLI-level validation for `remnic quarantine replay`. These cases
+ * exercise the pre-bootstrap argument checks, which return before any
+ * orchestrator is constructed, so no daemon/config is required.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runQuarantineReplay } from "./quarantine-replay.js";
+
+async function exitCodeFor(rest: string[]): Promise<number | undefined> {
+  const prev = process.exitCode;
+  process.exitCode = 0;
+  await runQuarantineReplay(rest, "json", "/nonexistent-remnic-config.json");
+  const code = process.exitCode;
+  process.exitCode = prev;
+  return code;
+}
+
+test("runQuarantineReplay: missing --namespace is a usage error (exit 2)", async () => {
+  assert.equal(await exitCodeFor([]), 2);
+});
+
+test("runQuarantineReplay: an unknown flag is rejected (exit 2)", async () => {
+  assert.equal(await exitCodeFor(["--namespace", "ns", "--bogus"]), 2);
+});
+
+test("runQuarantineReplay: --namespace without a value is rejected (exit 2)", async () => {
+  assert.equal(await exitCodeFor(["--namespace", "--json"]), 2);
+});

--- a/packages/remnic-cli/src/quarantine-replay.ts
+++ b/packages/remnic-cli/src/quarantine-replay.ts
@@ -13,16 +13,26 @@ import { type QuarantineFormat, renderReplayResult, replayQuarantine } from "./q
 
 /** Required-value flag: undefined when absent, throws when present without a value. */
 function valueFlag(args: string[], flag: string): string | undefined {
-  const i = args.indexOf(flag);
-  if (i === -1) return undefined;
-  const value = args[i + 1];
+  const occurrences = args.filter((a) => a === flag).length;
+  if (occurrences === 0) return undefined;
+  if (occurrences > 1) {
+    throw new Error(`${flag} may be given at most once.`);
+  }
+  const value = args[args.indexOf(flag) + 1];
   if (value === undefined || value.startsWith("--")) {
     throw new Error(`${flag} requires a value. Provide it as \`${flag} <value>\`, not a bare flag.`);
+  }
+  if (value.trim().length === 0) {
+    throw new Error(`${flag} requires a non-empty value.`);
   }
   return value;
 }
 
-export async function runQuarantineReplay(rest: string[], format: QuarantineFormat, configPath: string): Promise<void> {
+export async function runQuarantineReplay(
+  rest: string[],
+  format: QuarantineFormat,
+  resolveConfigPath: () => string
+): Promise<void> {
   let targetNamespace: string | undefined;
   let principal: string | undefined;
   try {
@@ -51,7 +61,9 @@ export async function runQuarantineReplay(rest: string[], format: QuarantineForm
   initLogger();
   let orchestrator: Orchestrator | undefined;
   try {
-    // Bootstrap inside the boundary so bad config JSON / construction fails cleanly (exit 2).
+    // Resolve + read config inside the boundary so a throw (bad path or invalid
+    // JSON) fails cleanly (exit 2) rather than propagating to the global handler.
+    const configPath = resolveConfigPath();
     const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
     const config = parseConfig(resolveRemnicConfigRecord(raw));
     orchestrator = new Orchestrator(config);

--- a/packages/remnic-cli/src/quarantine-replay.ts
+++ b/packages/remnic-cli/src/quarantine-replay.ts
@@ -1,0 +1,88 @@
+/**
+ * `remnic quarantine replay` command flow (issue #1888). Extracted from the CLI
+ * entrypoint so index.ts stays under its size ratchet and the replay flow is
+ * unit-testable. Sets `process.exitCode` (2 = usage/bootstrap error, 1 = any
+ * re-submit or delete failure) and never throws.
+ */
+import * as fs from "node:fs";
+
+import { EngramAccessService, Orchestrator, initLogger, parseConfig, resolveRemnicConfigRecord } from "@remnic/core";
+import { WriteQuarantineStore } from "@remnic/core/write-quarantine.js";
+
+import { type QuarantineFormat, renderReplayResult, replayQuarantine } from "./quarantine-cli.js";
+
+/** Required-value flag: undefined when absent, throws when present without a value. */
+function valueFlag(args: string[], flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  if (i === -1) return undefined;
+  const value = args[i + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value. Provide it as \`${flag} <value>\`, not a bare flag.`);
+  }
+  return value;
+}
+
+export async function runQuarantineReplay(rest: string[], format: QuarantineFormat, configPath: string): Promise<void> {
+  let targetNamespace: string | undefined;
+  let principal: string | undefined;
+  try {
+    targetNamespace = valueFlag(rest, "--namespace");
+    principal = valueFlag(rest, "--principal");
+  } catch (err) {
+    process.stderr.write(`quarantine replay: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exitCode = 2;
+    return;
+  }
+  if (!targetNamespace || targetNamespace.trim().length === 0) {
+    process.stderr.write("quarantine replay: --namespace <ns> is required.\n");
+    process.exitCode = 2;
+    return;
+  }
+  // Only --namespace/--principal (value flags) and --json (parsed upstream) are allowed.
+  const valued = new Set(["--namespace", "--principal"]);
+  const bad = rest.filter((a, i) => (a.startsWith("--") ? a !== "--json" && !valued.has(a) : !valued.has(rest[i - 1])));
+  if (bad.length > 0) {
+    process.stderr.write(
+      `quarantine replay: unexpected argument(s): ${bad.join(", ")}. Use: replay --namespace <ns> [--principal <p>] [--json].\n`
+    );
+    process.exitCode = 2;
+    return;
+  }
+  initLogger();
+  let orchestrator: Orchestrator | undefined;
+  try {
+    // Bootstrap inside the boundary so bad config JSON / construction fails cleanly (exit 2).
+    const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
+    const config = parseConfig(resolveRemnicConfigRecord(raw));
+    orchestrator = new Orchestrator(config);
+    await orchestrator.initialize();
+    await orchestrator.deferredReady;
+    const service = new EngramAccessService(orchestrator);
+    // Open the store on the SAME resolved memoryDir the orchestrator dead-letters
+    // into (config.memoryDir), so replay reads/removes the exact tree writes were
+    // parked in — never a divergent resolveMemoryDir() result.
+    const store = new WriteQuarantineStore(config.memoryDir);
+    const result = await replayQuarantine({
+      store,
+      targetNamespace,
+      principal,
+      submit: async (operation, request) => {
+        if (operation === "observe") {
+          await service.observe(request as unknown as Parameters<EngramAccessService["observe"]>[0]);
+        } else if (operation === "memory_store") {
+          await service.memoryStore(request as unknown as Parameters<EngramAccessService["memoryStore"]>[0]);
+        } else {
+          await service.suggestionSubmit(request as unknown as Parameters<EngramAccessService["suggestionSubmit"]>[0]);
+        }
+      },
+    });
+    console.log(renderReplayResult(result, targetNamespace, format));
+    // A failed re-submit OR a failed deletion is a non-clean outcome.
+    if (result.failures.length > 0 || result.deleteFailures.length > 0) process.exitCode = 1;
+  } catch {
+    process.stderr.write("quarantine replay: unable to replay quarantine store\n");
+    process.exitCode = 2;
+  } finally {
+    if (orchestrator) await orchestrator.destroy();
+  }
+}

--- a/packages/remnic-core/src/access-observe-quarantine.test.ts
+++ b/packages/remnic-core/src/access-observe-quarantine.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { memoryStoreRequestSchema, observeRequestSchema } from "./access-schema.js";
 import { EngramAccessService, NamespaceNotWritableError } from "./access-service.js";
 import { Orchestrator } from "./orchestrator.js";
 import type { CodingContext, PluginConfig } from "./types.js";
@@ -148,4 +149,24 @@ test("suppressQuarantine skips dead-lettering an ACL-rejected write; without it 
     );
     assert.equal(await store.count(), 1);
   });
+});
+
+test("public write schemas strip suppressQuarantine — external callers cannot skip quarantine", () => {
+  // The write surface honors suppressQuarantine (in-process replay sets it), but
+  // it is NOT a field on the public HTTP/MCP request schemas. zod strips unknown
+  // keys, so a body carrying it is scrubbed before the service — and the access
+  // boundary re-validates the cleaned envelope — keeping ACL-rejected external
+  // writes parked rather than silently discarded.
+  const stored = memoryStoreRequestSchema.parse({
+    sessionKey: "s",
+    content: "hello",
+    suppressQuarantine: true,
+  } as Record<string, unknown>);
+  assert.equal("suppressQuarantine" in stored, false);
+  const observed = observeRequestSchema.parse({
+    sessionKey: "s",
+    messages: [{ role: "user", content: "hi" }],
+    suppressQuarantine: true,
+  } as Record<string, unknown>);
+  assert.equal("suppressQuarantine" in observed, false);
 });

--- a/packages/remnic-core/src/access-observe-quarantine.test.ts
+++ b/packages/remnic-core/src/access-observe-quarantine.test.ts
@@ -118,3 +118,34 @@ test("a dry-run rejected write is NOT quarantined (#1888)", async () => {
     assert.equal(await new WriteQuarantineStore(dir).count(), 0);
   });
 });
+
+test("suppressQuarantine skips dead-lettering an ACL-rejected write; without it it is parked (#1888 replay)", async () => {
+  await withService(async (service, dir) => {
+    const store = new WriteQuarantineStore(dir);
+    // Replay re-submits with suppressQuarantine set: the ACL rejection still
+    // throws, but the attempt is NOT re-parked, so replay cannot duplicate it.
+    await assert.rejects(
+      service.memoryStore({
+        content: "replayed",
+        namespace: "victim-secret",
+        authenticatedPrincipal: "alice",
+        sessionKey: "s-5",
+        suppressQuarantine: true,
+      } as unknown as Parameters<EngramAccessService["memoryStore"]>[0]),
+      NamespaceNotWritableError
+    );
+    assert.equal(await store.count(), 0);
+
+    // The identical write WITHOUT the flag is dead-lettered as before.
+    await assert.rejects(
+      service.memoryStore({
+        content: "replayed",
+        namespace: "victim-secret",
+        authenticatedPrincipal: "alice",
+        sessionKey: "s-5",
+      } as unknown as Parameters<EngramAccessService["memoryStore"]>[0]),
+      NamespaceNotWritableError
+    );
+    assert.equal(await store.count(), 1);
+  });
+});

--- a/packages/remnic-core/src/access-observe-write-surface.ts
+++ b/packages/remnic-core/src/access-observe-write-surface.ts
@@ -463,8 +463,10 @@ export class AccessObserveWriteSurface {
     try {
       namespace = await this.deps.resolveCodingScopedWriteNamespace(request);
     } catch (err) {
-      // A dry run is a no-persist validation, so never dead-letter it.
-      if (request.dryRun !== true) {
+      // A dry run is a no-persist validation, and a replay re-submit sets
+      // suppressQuarantine so a still-unwritable target propagates instead of
+      // re-parking (issue #1888): never dead-letter either.
+      if (request.dryRun !== true && request.suppressQuarantine !== true) {
         await this.parkRejectedWrite(err, "memory_store", request);
       }
       throw err;
@@ -548,8 +550,9 @@ export class AccessObserveWriteSurface {
     try {
       namespace = await this.deps.resolveCodingScopedWriteNamespace(request);
     } catch (err) {
-      // A dry run is a no-persist validation, so never dead-letter it.
-      if (request.dryRun !== true) {
+      // A dry run never persists, and a replay re-submit sets suppressQuarantine
+      // so a still-unwritable target propagates instead of re-parking (#1888).
+      if (request.dryRun !== true && request.suppressQuarantine !== true) {
         await this.parkRejectedWrite(err, "suggestion_submit", request);
       }
       throw err;
@@ -655,7 +658,11 @@ export class AccessObserveWriteSurface {
     try {
       scope = await this.deps.resolveMemoryScopePlan(request);
     } catch (err) {
-      await this.parkRejectedWrite(err, "observe", request);
+      // A replay re-submit sets suppressQuarantine so a still-unwritable target
+      // propagates instead of re-parking (#1888); observe has no dryRun path.
+      if (request.suppressQuarantine !== true) {
+        await this.parkRejectedWrite(err, "observe", request);
+      }
       throw err;
     }
     const writeNamespace = scope.writeNamespace;

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -943,11 +943,10 @@ export interface EngramAccessWriteEnvelope {
   idempotencyKey?: string;
   dryRun?: boolean;
   sessionKey?: string;
-  /**
-   * Trusted transport-bound principal. This must never come from untrusted client payloads.
-   * When present, write authorization is evaluated against this principal instead of sessionKey.
-   */
+  /** Trusted transport-bound principal (never from client payloads); authorizes writes instead of sessionKey. */
   authenticatedPrincipal?: string;
+  /** When set, an ACL rejection is NOT dead-lettered (#1888) so `remnic quarantine replay` can re-submit through this same surface without re-quarantining and duplicating the parked record. */
+  readonly suppressQuarantine?: boolean;
 }
 
 /**
@@ -1068,6 +1067,7 @@ export interface EngramAccessObserveRequest extends SourceConnectorProvenance {
    * Creates a `CodingContext` with `projectId: "tag:<projectTag>"`.
    */
   projectTag?: string;
+  readonly suppressQuarantine?: boolean; // #1888: mirrors EngramAccessWriteEnvelope.suppressQuarantine (replay re-submit skips dead-lettering).
 }
 
 /**

--- a/packages/remnic-core/src/write-quarantine.test.ts
+++ b/packages/remnic-core/src/write-quarantine.test.ts
@@ -191,3 +191,55 @@ test("list() surfaces a symlink-escaping root instead of reporting empty", async
     }
   });
 });
+
+test("entries() pairs each record with its on-disk path and list() projects records", async () => {
+  await withTempDir(async (dir) => {
+    const store = new WriteQuarantineStore(dir);
+    const written = await store.quarantine({
+      operation: "memory_store",
+      principal: "alice",
+      attemptedNamespace: "victim-secret",
+      payload: { content: "hi" },
+    });
+    const entries = await store.entries();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.path, written);
+    assert.ok(isInside(store.root, entries[0]?.path ?? ""));
+    assert.equal(entries[0]?.record.operation, "memory_store");
+    assert.deepEqual(entries[0]?.record.payload, { content: "hi" });
+    assert.deepEqual(
+      await store.list(),
+      entries.map((entry) => entry.record)
+    );
+  });
+});
+
+test("removeEntry deletes an entry by its path and is idempotent", async () => {
+  await withTempDir(async (dir) => {
+    const store = new WriteQuarantineStore(dir);
+    await store.quarantine({ operation: "observe", principal: "alice", attemptedNamespace: "ns", payload: 1 });
+    const [entry] = await store.entries();
+    assert.ok(entry);
+    assert.equal(await store.removeEntry(entry.path), true);
+    assert.equal(await store.count(), 0);
+    // An already-absent path removes nothing.
+    assert.equal(await store.removeEntry(entry.path), false);
+  });
+});
+
+test("removeEntry refuses a path outside the quarantine root", async () => {
+  await withTempDir(async (dir) => {
+    const store = new WriteQuarantineStore(dir);
+    await store.quarantine({ operation: "observe", principal: "alice", attemptedNamespace: "ns", payload: 1 });
+    const outside = await mkdtemp(path.join(tmpdir(), "remnic-quarantine-outside-"));
+    const victim = path.join(outside, "keep.json");
+    await writeFile(victim, "{}", "utf8");
+    try {
+      assert.equal(await store.removeEntry(victim), false);
+      assert.equal((await readdir(outside)).length, 1, "file outside root must survive");
+      assert.equal(await store.count(), 1, "in-root entry untouched");
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/remnic-core/src/write-quarantine.ts
+++ b/packages/remnic-core/src/write-quarantine.ts
@@ -24,7 +24,7 @@ import type { Dirent } from "node:fs";
 import { lstat, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { encodeStoragePathSegment, isPathInsideStorageRoot, resolveSafeStoragePath } from "./storage-paths.js";
+import { encodeStoragePathSegment, resolveSafeStoragePath } from "./storage-paths.js";
 
 export type QuarantineOperation = "observe" | "memory_store" | "suggestion_submit";
 
@@ -195,10 +195,24 @@ export class WriteQuarantineStore {
    * absent — removes nothing. Returns true only when a file was actually deleted.
    */
   async removeEntry(entryPath: string): Promise<boolean> {
-    const abs = path.resolve(entryPath);
-    if (!isPathInsideStorageRoot(path.resolve(this.root), abs)) return false;
+    const rootAbs = path.resolve(this.root);
+    const rel = path.relative(rootAbs, path.resolve(entryPath));
+    if (rel === "" || rel === ".." || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
+      return false;
+    }
+    // Symlink-race-safe resolution (issue #1888): resolveSafeStoragePath rejects
+    // any symlinked path component and verifies the REAL path stays inside the
+    // real quarantine root before we touch it, so a swapped component cannot
+    // redirect the deletion outside the store — lexical containment alone is not
+    // sufficient against a TOCTOU symlink swap.
+    let safe: string;
     try {
-      await rm(abs, { force: false });
+      safe = await resolveSafeStoragePath(rootAbs, rel);
+    } catch {
+      return false;
+    }
+    try {
+      await rm(safe, { force: false });
       return true;
     } catch (err) {
       const errno = err as NodeJS.ErrnoException;

--- a/packages/remnic-core/src/write-quarantine.ts
+++ b/packages/remnic-core/src/write-quarantine.ts
@@ -24,7 +24,7 @@ import type { Dirent } from "node:fs";
 import { lstat, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { encodeStoragePathSegment, resolveSafeStoragePath } from "./storage-paths.js";
+import { encodeStoragePathSegment, isPathInsideStorageRoot, resolveSafeStoragePath } from "./storage-paths.js";
 
 export type QuarantineOperation = "observe" | "memory_store" | "suggestion_submit";
 
@@ -46,6 +46,12 @@ export interface QuarantinedRecord {
   attemptedNamespace: string;
   timestamp: string;
   payload: unknown;
+}
+
+/** A quarantined record paired with the absolute on-disk path it was read from. */
+export interface QuarantineEntry {
+  record: QuarantinedRecord;
+  path: string;
 }
 
 export interface QuarantineCaps {
@@ -145,12 +151,13 @@ export class WriteQuarantineStore {
 
   /**
    * All valid, non-expired quarantined records across every principal, oldest
-   * first. Expired records are deleted on read (lazy GC), so an inactive
-   * principal bucket with no follow-up write is still bounded by age.
+   * first, each paired with its absolute on-disk path. Expired records are
+   * deleted on read (lazy GC), so an inactive principal bucket with no
+   * follow-up write is still bounded by age.
    */
-  async list(): Promise<QuarantinedRecord[]> {
+  async entries(): Promise<QuarantineEntry[]> {
     const now = Date.now();
-    const records: QuarantinedRecord[] = [];
+    const entries: QuarantineEntry[] = [];
     for (const dir of await this.principalDirs()) {
       for (const file of await this.entryFiles(dir)) {
         const info = await stat(file).catch(() => null);
@@ -165,11 +172,39 @@ export class WriteQuarantineStore {
         } catch {
           continue;
         }
-        if (isQuarantinedRecord(parsed)) records.push(parsed);
+        if (isQuarantinedRecord(parsed)) entries.push({ record: parsed, path: file });
       }
     }
-    records.sort((a, b) => (a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0));
-    return records;
+    entries.sort((a, b) => {
+      const at = a.record.timestamp;
+      const bt = b.record.timestamp;
+      return at < bt ? -1 : at > bt ? 1 : 0;
+    });
+    return entries;
+  }
+
+  /** As {@link entries} but projected to records only (backward-compatible view). */
+  async list(): Promise<QuarantinedRecord[]> {
+    return (await this.entries()).map((entry) => entry.record);
+  }
+
+  /**
+   * Delete one quarantined entry by its absolute on-disk path (as returned by
+   * {@link entries}). The path MUST resolve inside the quarantine root, mirroring
+   * the store's containment posture; a path outside the root — or one already
+   * absent — removes nothing. Returns true only when a file was actually deleted.
+   */
+  async removeEntry(entryPath: string): Promise<boolean> {
+    const abs = path.resolve(entryPath);
+    if (!isPathInsideStorageRoot(path.resolve(this.root), abs)) return false;
+    try {
+      await rm(abs, { force: false });
+      return true;
+    } catch (err) {
+      const errno = err as NodeJS.ErrnoException;
+      if (errno?.code === "ENOENT") return false;
+      throw err;
+    }
   }
 
   /** Total valid, non-expired quarantined record count across every principal. */


### PR DESCRIPTION
## Context

Issue #1888 improvement 1 remainder: **recovery** for the dead-lettered writes. Parts already shipped: quarantine store (#2076), `doctor` count + `quarantine list` (#2078), client preflight (#2079), config-time lint (#2081). This adds the replay command — the last piece to fully close #1888.

## The trap this design avoids

`remnic quarantine replay` re-submits parked writes through the same write surface that quarantines ACL-rejected writes. If the target is still not writable, a naive replay would re-quarantine its own attempt → duplicate records. Fixed by a `suppressQuarantine` flag on the write request: when set, `parkRejectedWrite` is skipped at all three sites, so a still-failing re-submit re-throws (recorded as a failure, original left parked) instead of duplicating.

## Change

- **Core:** `suppressQuarantine?: boolean` on `EngramAccessWriteEnvelope` (memory_store + suggestion_submit) and `EngramAccessObserveRequest`; the three `parkRejectedWrite` call sites skip parking when it is set.
- **Store:** `WriteQuarantineStore.entries()` (record + absolute path) and `removeEntry(path)` guarded by a quarantine-root containment check (`list()` now projects `entries()`).
- **CLI:** `remnic quarantine replay --namespace <writable-ns> [--principal <p>]` boots the orchestrator + access service, re-submits each parked payload (namespace overridden, `suppressQuarantine: true`, optional principal), deletes a record only after re-submit AND removal both succeed, reports failures/delete-failures, exits 1 on any failure. Provider-free `replayQuarantine` + `renderReplayResult` helpers.

## Tests

Suppression skips parking (with/without flag); `entries`/`removeEntry` incl. out-of-root rejection; replay success / submit-failure (left parked) / delete-failure paths; render text + json.

Closes the last deliverable of #1888.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches namespace ACL dead-lettering and write replay paths; misuse could affect data recovery, but suppressQuarantine is not exposed on public APIs and replay only runs via the trusted CLI orchestrator bootstrap.
> 
> **Overview**
> Adds **`remnic quarantine replay --namespace <ns> [--principal <p>] [--json]`** to recover ACL-rejected writes after namespace config is fixed. The CLI boots the orchestrator and access service, walks the quarantine store via new **`entries()`** / **`removeEntry()`** APIs, re-submits each parked payload into the target namespace, and removes the on-disk record only when both submit and delete succeed (exit **1** on any failure).
> 
> Replay avoids **duplicate quarantine records** by introducing in-process **`suppressQuarantine`** on write/observe envelopes: when set, **`parkRejectedWrite`** is skipped on `memory_store`, `suggestion_submit`, and `observe`, so a still-failing target surfaces as a replay failure while the original stays parked. Public HTTP/MCP schemas **strip** this flag so external callers cannot bypass dead-lettering.
> 
> Provider-free **`replayQuarantine`** / **`renderReplayResult`** handle namespace override, principal defaulting, stable **`quarantine-replay:`** idempotency keys, and text/json reporting; **`removeEntry`** uses symlink-safe containment under the quarantine root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd76eba5688b357ee99a945cd9053952dcf10893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `remnic quarantine replay` to retry previously rejected writes after namespace access is restored.
  - Supports `--namespace`, optional `--principal`, and `--json` output; adds `remnic quarantine list`/`replay` command structure.
- **Bug Fixes**
  - Replay avoids creating duplicate quarantine entries.
  - More reliable quarantine safety during replay: successfully replayed items are removed from quarantine; submission or removal failures are reported without cascading.
  - Quarantine suppression during replay prevents the replayed writes from being re-quarantined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->