### PR TITLE
fix(ci): skip relay isolation tests when unprivileged user namespaces are unavailable

### DIFF
--- a/scripts/relay/userns.ts
+++ b/scripts/relay/userns.ts
@@ -1,0 +1,39 @@
+import { spawnSync } from "node:child_process";
+
+import { RELAY_UNSHARE_NAMESPACE_ARGS } from "./network-gateway.js";
+
+let cached: boolean | undefined;
+
+/**
+ * Whether this host can create the unprivileged user namespace the relay
+ * isolation sandbox needs.
+ *
+ * The relay tests spawn `/usr/bin/unshare --user --map-root-user ...`. On hosts
+ * that disallow unprivileged user namespaces — notably GitHub-hosted
+ * `ubuntu-latest` runners, where `kernel.apparmor_restrict_unprivileged_userns=1`
+ * — that call dies at the `/proc/self/uid_map` write with "Operation not
+ * permitted", so the sandbox never starts and the isolation assertions can never
+ * run. There the tests are not meaningful and must skip rather than fail.
+ *
+ * The probe replays the exact namespace flags the tests use against `/bin/true`,
+ * so it is faithful to what the sandbox requires. The result is cached because it
+ * cannot change within a process. It fails closed (returns false, i.e. skip) on
+ * any error or on a non-Linux platform.
+ */
+export function relayUserNamespacesAvailable(): boolean {
+  if (cached !== undefined) return cached;
+  if (process.platform !== "linux") {
+    cached = false;
+    return cached;
+  }
+  try {
+    const result = spawnSync("/usr/bin/unshare", [...RELAY_UNSHARE_NAMESPACE_ARGS, "/bin/true"], {
+      stdio: "ignore",
+      timeout: 10_000,
+    });
+    cached = result.error === undefined && result.status === 0;
+  } catch {
+    cached = false;
+  }
+  return cached;
+}

--- a/tests/relay-isolated-runner.test.ts
+++ b/tests/relay-isolated-runner.test.ts
@@ -484,7 +484,7 @@ test("Relay run roots reject non-empty and symlinked targets and clean only mark
   }
 });
 
-test("synthetic fixture copies contain no symlinks and hidden contract flips stale to corrected behavior", { skip: !relayUserNamespacesAvailable() }, async () => {
+test("synthetic fixture copies contain no symlinks and fixture manifests, locators, and schemas validate", async () => {
   await assertTreeContainsNoSymlinks(fixtures);
   await verifyRelayFixtureManifest(fixtures);
   assert.deepEqual(
@@ -512,6 +512,9 @@ test("synthetic fixture copies contain no symlinks and hidden contract flips sta
       }),
     /unsupported keyword uniqueItems/
   );
+});
+
+test("hidden contract flips stale to corrected behavior", { skip: !relayUserNamespacesAvailable() }, async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "relay-fixture-behavior-"));
   const staleWorkspace = path.join(root, "stale");
   const correctedWorkspace = path.join(root, "corrected");

--- a/tests/relay-isolated-runner.test.ts
+++ b/tests/relay-isolated-runner.test.ts
@@ -55,6 +55,7 @@ import {
 import { resolveRelayAuthSourcePath, resolveRelayCreditLedgerPolicy } from "../scripts/relay/preflight-lib.js";
 import { listRelayMcpTools, startRelayRemnicHarness } from "../scripts/relay/remnic-harness.js";
 import { assertRelaySourceLocators } from "../scripts/relay/source-grounding.js";
+import { relayUserNamespacesAvailable } from "../scripts/relay/userns.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const fixtures = path.join(repoRoot, "fixtures", "remnic-relay");
@@ -267,7 +268,7 @@ test("Relay gives every Codex call a network namespace with allow-listed egress 
 
 test(
   "model shell and a directly named interpreter cannot read Codex auth, trusted output, parent mounts, or trusted environment",
-  { skip: process.platform !== "linux" },
+  { skip: !relayUserNamespacesAvailable() },
   async () => {
     const parent = await mkdtemp(path.join(os.tmpdir(), "relay-credential-boundary-"));
     const directories = await prepareRelayRunDirectories(repoRoot, path.join(parent, "run"));
@@ -483,7 +484,7 @@ test("Relay run roots reject non-empty and symlinked targets and clean only mark
   }
 });
 
-test("synthetic fixture copies contain no symlinks and hidden contract flips stale to corrected behavior", async () => {
+test("synthetic fixture copies contain no symlinks and hidden contract flips stale to corrected behavior", { skip: !relayUserNamespacesAvailable() }, async () => {
   await assertTreeContainsNoSymlinks(fixtures);
   await verifyRelayFixtureManifest(fixtures);
   assert.deepEqual(
@@ -559,7 +560,7 @@ test("Builder module initialization cannot short-circuit public or hidden contra
   }
 });
 
-test("Builder contract tests cannot read host files or reach host networking", async () => {
+test("Builder contract tests cannot read host files or reach host networking", { skip: !relayUserNamespacesAvailable() }, async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "relay-contract-isolation-"));
   const workspace = path.join(root, "workspace");
   const sentinel = path.join(root, "host-only-sentinel.txt");
@@ -631,7 +632,7 @@ test("isolated Remnic token lists only recall and the real Correction Contract r
   }
 });
 
-test("the bounded mission runner produces a complete 16-event cold-start recovery receipt", async () => {
+test("the bounded mission runner produces a complete 16-event cold-start recovery receipt", { skip: !relayUserNamespacesAvailable() }, async () => {
   const directories = await prepareRelayRunDirectories(repoRoot);
   const harness = await startRelayRemnicHarness(directories.memoryDir);
   const executor = new MockRelayExecutor(harness);
@@ -665,7 +666,7 @@ test("the bounded mission runner produces a complete 16-event cold-start recover
   }
 });
 
-test("approval and executor failures stop before unauthorized or downstream Codex calls and cleanup stays bounded", async () => {
+test("approval and executor failures stop before unauthorized or downstream Codex calls and cleanup stays bounded", { skip: !relayUserNamespacesAvailable() }, async () => {
   const unapprovedDirectories = await prepareRelayRunDirectories(repoRoot);
   const unapprovedHarness = await startRelayRemnicHarness(unapprovedDirectories.memoryDir);
   const unapprovedExecutor = new MockRelayExecutor(unapprovedHarness);


### PR DESCRIPTION
The release/publish pipeline has been failing at `Verify quality gates` (`pnpm test`) since the relay "Build Week" tests landed, blocking every publish.

## Root cause

`tests/relay-isolated-runner.test.ts` builds its sandbox by spawning `/usr/bin/unshare --user --map-root-user --mount --net --pid --fork ...`. On hosts that disallow **unprivileged user namespaces** — including the default GitHub-hosted `ubuntu-latest` runner, where `kernel.apparmor_restrict_unprivileged_userns=1` — that call dies at the `/proc/self/uid_map` write:

```
unshare: write failed /proc/self/uid_map: Operation not permitted
```

The sandbox never starts, so the dependent public/hidden contract and mission-runner assertions never execute and the tests fail. They were gated only on `process.platform === "linux"`, so they ran (and failed) on such runners, turning `pnpm test` red before the publish step.

## Fix

- Add `relayUserNamespacesAvailable()` (`scripts/relay/userns.ts`): a cached probe that replays the exact `RELAY_UNSHARE_NAMESPACE_ARGS` against `/bin/true` and **fails closed** (returns `false` on any error or non-Linux platform).
- Gate the five isolation tests on it instead of the bare platform check. They now **run** wherever unprivileged userns works and **skip** — rather than fail — where it does not.

## Verification

On a userns-capable host, the full file runs green with nothing skipped:

```
# tests 14
# pass 14
# fail 0
# skipped 0
```

`pnpm run check-types` passes. On a runner where `unshare` is denied, the probe returns `false`, so the five tests skip and the suite goes green — unblocking publish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only gating and a small probe helper; no production relay or runtime behavior changes.
> 
> **Overview**
> Unblocks CI on hosts (e.g. GitHub `ubuntu-latest`) where unprivileged user namespaces are blocked: relay isolation tests that spawn `unshare` with `RELAY_UNSHARE_NAMESPACE_ARGS` no longer fail when the sandbox cannot start.
> 
> Adds **`relayUserNamespacesAvailable()`** in `scripts/relay/userns.ts`—a cached, fail-closed probe that runs the same `unshare` flags as the sandbox against `/bin/true`. Five tests in `tests/relay-isolated-runner.test.ts` now use `{ skip: !relayUserNamespacesAvailable() }` instead of a Linux-only platform check, so they **skip** where userns is denied and still **run** on capable Linux hosts.
> 
> Also splits the combined fixture test: static manifest/locator/schema checks stay always-on; the hidden-contract stale→corrected behavior test is its own case and shares the userns skip gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb167816a9578c327ac4a5758bbcd395e4a6890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolated-environment test reliability by detecting whether the host supports the required unprivileged user namespaces.
  * Isolation-dependent tests now skip gracefully when prerequisites aren’t met, reducing false failures on unsupported setups.
* **Tests**
  * Refined isolation-related test logic to separate fixture validation and contract-behavior checks, each conditionally run based on environment support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->