### PR TITLE
fix(namespaces): reject out-of-namespace QMD hits before owner-stamping (#2077)

### DIFF
--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -181,15 +181,22 @@ export class NamespaceSearchRouter {
             );
             break;
         }
-        results = filterNamespaceSubtreeResults(record, results).map((result) => ({
-          ...result,
-          namespace,
-          // Resolve to an absolute path so the (namespace, path) identity is
-          // globally unique — same-relative-path hits from different namespaces
-          // stay distinct across every downstream consumer with no special
-          // handling. Display/citation surfaces relativize for portability (#2020).
-          path: resolveNamespaceResultPath(record.memoryDir, record.collection, result.path),
-        }));
+        results = filterNamespaceSubtreeResults(record, results)
+          .map((result) => ({
+            ...result,
+            namespace,
+            // Resolve to an absolute path so the (namespace, path) identity is
+            // globally unique — same-relative-path hits from different namespaces
+            // stay distinct across every downstream consumer with no special
+            // handling. Display/citation surfaces relativize for portability (#2020).
+            path: resolveNamespaceResultPath(record.memoryDir, record.collection, result.path),
+          }))
+          // Reject hits whose resolved path escapes the queried namespace's
+          // storage root (#2077). A stale/corrupt per-namespace collection can
+          // return a path owned by another namespace; stamping it would let
+          // downstream scope checks (which trust the stamped namespace) and
+          // absolute-path resolution surface a foreign-namespace memory.
+          .filter((result) => resolvedPathIsInsideNamespaceRoot(record.memoryDir, result.path));
         return { namespace, results };
       }),
     );
@@ -570,6 +577,11 @@ function daemonModeForBackend(backend: SearchBackend): boolean | null {
     : null;
 }
 
+function isContainedPath(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
 function pathIsInsideNamespaceSubtree(
   memoryDir: string,
   collection: string,
@@ -582,8 +594,22 @@ function pathIsInsideNamespaceSubtree(
   const candidate = path.isAbsolute(normalizedResultPath)
     ? path.normalize(normalizedResultPath)
     : path.resolve(memoryRoot, normalizedResultPath);
-  const relative = path.relative(namespacesRoot, candidate);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  return isContainedPath(namespacesRoot, candidate);
+}
+
+/**
+ * Reject a QMD hit whose resolved path escapes the queried namespace's storage
+ * root (#2077). `resolvedPath` is the already-resolved value produced by
+ * `resolveNamespaceResultPath`; a stale/corrupt per-namespace collection can
+ * yield an absolute path owned by another namespace, and stamping it with the
+ * queried namespace would surface a foreign-namespace memory downstream.
+ */
+function resolvedPathIsInsideNamespaceRoot(memoryDir: string, resolvedPath: string): boolean {
+  const root = path.resolve(memoryDir);
+  const candidate = path.isAbsolute(resolvedPath)
+    ? path.normalize(resolvedPath)
+    : path.resolve(root, resolvedPath);
+  return isContainedPath(root, candidate);
 }
 export function normalizeQmdResultPath(resultPath: string, collection: string): string {
   let value = resultPath.trim();

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -1,5 +1,6 @@
 import { resolveNamespaceCapabilities } from "../capabilities.js";
 import path from "node:path";
+import { realpathSync } from "node:fs";
 import type { PluginConfig, QmdSearchResult } from "../types.js";
 import type {
   SearchBackend,
@@ -579,7 +580,10 @@ function daemonModeForBackend(backend: SearchBackend): boolean | null {
 
 function isContainedPath(root: string, candidate: string): boolean {
   const relative = path.relative(root, candidate);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
 }
 
 function pathIsInsideNamespaceSubtree(
@@ -603,13 +607,26 @@ function pathIsInsideNamespaceSubtree(
  * `resolveNamespaceResultPath`; a stale/corrupt per-namespace collection can
  * yield an absolute path owned by another namespace, and stamping it with the
  * queried namespace would surface a foreign-namespace memory downstream.
+ *
+ * Lexical containment runs first — it is cheap and the only check possible when
+ * the file is not yet on disk (a stale collection may cite a since-deleted
+ * path). When both root and candidate exist, their filesystem realpaths are
+ * canonicalized and re-checked so a symlink planted inside the namespace root
+ * cannot resolve into another namespace or outside storage. An unresolved path
+ * (ENOENT) keeps the lexical result rather than rejecting the stale-collection
+ * case this guard targets.
  */
 function resolvedPathIsInsideNamespaceRoot(memoryDir: string, resolvedPath: string): boolean {
   const root = path.resolve(memoryDir);
   const candidate = path.isAbsolute(resolvedPath)
     ? path.normalize(resolvedPath)
     : path.resolve(root, resolvedPath);
-  return isContainedPath(root, candidate);
+  if (!isContainedPath(root, candidate)) return false;
+  try {
+    return isContainedPath(realpathSync.native(root), realpathSync.native(candidate));
+  } catch {
+    return true;
+  }
 }
 export function normalizeQmdResultPath(resultPath: string, collection: string): string {
   let value = resultPath.trim();

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -469,8 +469,8 @@ tests/memory-observation-type-shape.test.ts(24,15): TS2614
 tests/migrate-observations.test.ts(188,9): TS2322
 tests/namespace-migrate.test.ts(22,3): TS2740
 tests/namespace-migrate.test.ts(223,20): TS2339
-tests/namespace-search-router.test.ts(14,10): TS2352
-tests/namespace-search-router.test.ts(251,5): TS2353
+tests/namespace-search-router.test.ts(15,10): TS2352
+tests/namespace-search-router.test.ts(252,5): TS2353
 tests/namespaces-router.test.ts(15,3): TS2740
 tests/native-knowledge-openclaw-workspace.test.ts(11,38): TS2724
 tests/native-knowledge-recall.test.ts(175,5): TS2322

--- a/tests/namespace-search-router.test.ts
+++ b/tests/namespace-search-router.test.ts
@@ -339,12 +339,12 @@ test("NamespaceSearchRouter scopes backends by namespace root and keeps namespac
       const backend =
         backendCfg.qmdCollection === "openclaw-engram--ns-736861726564"
           ? backendForResultSet([
-              { docid: "shared-1", path: "/tmp/shared.md", score: 0.8, snippet: "shared" },
-              { docid: "dup", path: "/tmp/dup.md", score: 0.6, snippet: "shared dup" },
+              { docid: "shared-1", path: path.join(memoryDir, "namespaces", "shared", "facts", "shared.md"), score: 0.8, snippet: "shared" },
+              { docid: "dup", path: path.join(memoryDir, "namespaces", "shared", "facts", "dup.md"), score: 0.6, snippet: "shared dup" },
             ])
           : backendForResultSet([
-              { docid: "default-1", path: "/tmp/default.md", score: 0.9, snippet: "default" },
-              { docid: "dup", path: "/tmp/dup.md", score: 0.7, snippet: "default dup" },
+              { docid: "default-1", path: path.join(memoryDir, "facts", "default.md"), score: 0.9, snippet: "default" },
+              { docid: "dup", path: path.join(memoryDir, "facts", "dup.md"), score: 0.7, snippet: "default dup" },
             ]);
       backends.set(backendCfg.qmdCollection, backend);
       return backend;
@@ -368,11 +368,51 @@ test("NamespaceSearchRouter scopes backends by namespace root and keeps namespac
   assert.deepEqual(
     results.map((result) => [result.path, result.score, result.snippet]),
     [
-      ["/tmp/default.md", 0.9, "default"],
-      ["/tmp/shared.md", 0.8, "shared"],
-      ["/tmp/dup.md", 0.7, "default dup"],
-      ["/tmp/dup.md", 0.6, "shared dup"],
+      [path.join(memoryDir, "facts", "default.md"), 0.9, "default"],
+      [path.join(memoryDir, "namespaces", "shared", "facts", "shared.md"), 0.8, "shared"],
+      [path.join(memoryDir, "facts", "dup.md"), 0.7, "default dup"],
+      [path.join(memoryDir, "namespaces", "shared", "facts", "dup.md"), 0.6, "shared dup"],
     ],
+  );
+});
+
+test("NamespaceSearchRouter rejects QMD hits outside the queried namespace storage root", async () => {
+  const memoryDir = tmpDir("engram-ns-search-containment");
+  const cfg = baseConfig(memoryDir);
+  const sharedRoot = path.join(memoryDir, "namespaces", "shared");
+  const storageRouter = {
+    async storageFor(namespace: string) {
+      return {
+        dir: namespace === "default" ? memoryDir : path.join(memoryDir, "namespaces", namespace),
+      };
+    },
+  };
+
+  const router = new NamespaceSearchRouter(cfg, storageRouter, (backendCfg) =>
+    backendCfg.qmdCollection === "openclaw-engram--ns-736861726564"
+      ? backendForResultSet([
+          // In-root hit — kept.
+          { docid: "ok", path: path.join(sharedRoot, "facts", "ok.md"), score: 0.9, snippet: "ok" },
+          // Stale-collection hit whose absolute path belongs to another
+          // namespace's storage root (#2077) — must be rejected before the
+          // queried namespace is stamped as owner.
+          { docid: "leak", path: path.join(memoryDir, "namespaces", "other", "facts", "leak.md"), score: 0.95, snippet: "leak" },
+          // Absolute path fully outside the memory dir — must be rejected too.
+          { docid: "escape", path: "/etc/passwd", score: 0.99, snippet: "escape" },
+        ])
+      : backendForResultSet([]),
+  );
+
+  const results = await router.searchAcrossNamespaces({
+    query: "memory",
+    namespaces: ["shared"],
+    maxResults: 5,
+    mode: "search",
+  });
+
+  assert.deepEqual(
+    results.map((result) => [result.namespace, result.path]),
+    [["shared", path.join(sharedRoot, "facts", "ok.md")]],
   );
 });
 
@@ -458,7 +498,7 @@ test("NamespaceSearchRouter skips namespaces whose collection is missing", async
       ...backendForResultSet([
         {
           docid: `${backendCfg.qmdCollection}-1`,
-          path: `/tmp/${backendCfg.qmdCollection}.md`,
+          path: path.join(backendCfg.memoryDir, "facts", `${backendCfg.qmdCollection}.md`),
           score: 0.8,
           snippet: backendCfg.qmdCollection,
         },

--- a/tests/namespace-search-router.test.ts
+++ b/tests/namespace-search-router.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import type { PluginConfig } from "../src/types.js";
 import { NamespaceSearchRouter, namespaceCollectionName } from "../src/namespaces/search.js";
 import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions } from "../src/search/port.js";
@@ -602,4 +603,57 @@ test("NamespaceSearchRouter ensureNamespaceCollection returns cached availabilit
 
   assert.equal(state, "unknown");
   assert.equal(ensureCalls, 0);
+});
+
+test("NamespaceSearchRouter rejects a symlinked hit that escapes the namespace root and keeps a '..'-prefixed child (#2077)", async () => {
+  const memoryDir = mkdtempSync(path.join(os.tmpdir(), "engram-ns-symlink-"));
+  try {
+    const cfg = baseConfig(memoryDir);
+    const sharedRoot = path.join(memoryDir, "namespaces", "shared");
+    const otherRoot = path.join(memoryDir, "namespaces", "other");
+    mkdirSync(path.join(sharedRoot, "facts"), { recursive: true });
+    mkdirSync(path.join(otherRoot, "facts"), { recursive: true });
+    const secret = path.join(otherRoot, "facts", "secret.md");
+    writeFileSync(secret, "secret");
+    const linkInShared = path.join(sharedRoot, "facts", "link.md");
+    symlinkSync(secret, linkInShared);
+    const inRoot = path.join(sharedRoot, "facts", "ok.md");
+    writeFileSync(inRoot, "ok");
+    // A real file whose name begins with ".." — contained, must NOT be treated
+    // as parent traversal.
+    const dotNotes = path.join(sharedRoot, "..notes.md");
+    writeFileSync(dotNotes, "notes");
+
+    const storageRouter = {
+      async storageFor(namespace: string) {
+        return {
+          dir: namespace === "default" ? memoryDir : path.join(memoryDir, "namespaces", namespace),
+        };
+      },
+    };
+    const router = new NamespaceSearchRouter(cfg, storageRouter, (backendCfg) =>
+      backendCfg.qmdCollection === "openclaw-engram--ns-736861726564"
+        ? backendForResultSet([
+            { docid: "ok", path: inRoot, score: 0.9, snippet: "ok" },
+            { docid: "dotdot", path: dotNotes, score: 0.8, snippet: "notes" },
+            // Lexically inside the shared root, but realpath escapes into `other`.
+            { docid: "leak", path: linkInShared, score: 0.95, snippet: "leak" },
+          ])
+        : backendForResultSet([]),
+    );
+
+    const results = await router.searchAcrossNamespaces({
+      query: "memory",
+      namespaces: ["shared"],
+      maxResults: 5,
+      mode: "search",
+    });
+
+    assert.deepEqual(
+      results.map((result) => result.path),
+      [inRoot, dotNotes],
+    );
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

Part of #2077 (finding 1, P1). Focused single-file fix to keep the review surface small.

When a per-namespace QMD collection is stale/corrupt, `NamespaceSearchRouter.searchAcrossNamespaces` could return a hit whose absolute path lives in **another** namespace's storage root, then stamp it with the *queried* namespace. Downstream scope checks trust the stamped `namespace`, and absolute-path resolution can load the real owner — so a foreign-namespace memory could be injected/displayed.

## Change

- Reject any hit whose resolved path escapes the queried namespace's storage root, **before** the owner is stamped (the stamped result never leaves the function).
- Extract a small `isContainedPath(root, candidate)` primitive; reuse it in the existing nested-subtree filter and the new namespace-root check (removes the duplicated containment one-liner).

## Tests

- New: `NamespaceSearchRouter rejects QMD hits outside the queried namespace storage root` — verifies an in-root hit is kept while a sibling-namespace hit and a fully-outside path (`/etc/passwd`) are dropped.
- Updated the two existing router tests that used `/tmp/*` placeholder fixtures to realistic in-root paths (those placeholders were incidental, not an invariant).

## Verification

- `tests/namespace-search-router.test.ts` + core namespace/access-service tests: green.
- `npm run preflight:quick`: OK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches namespace isolation on the search hot path; behavior is additive filtering with targeted tests, but incorrect containment logic could drop valid hits or still leak cross-namespace paths.
> 
> **Overview**
> **Namespace search** now drops QMD hits whose resolved path is not under the queried namespace’s storage root, **after** path resolution but **before** results are returned with that namespace stamped as owner. That closes a case where stale or corrupt per-namespace indexes could return another namespace’s absolute path and have downstream scope checks trust the wrong owner (#2077).
> 
> Containment uses a shared `isContainedPath` helper (also used for the existing nested-`namespaces/` subtree filter). The new guard adds a `realpathSync` re-check when paths exist on disk so symlinks under the namespace root cannot resolve outside storage; missing files keep the lexical check so deleted paths from stale indexes are not over-rejected.
> 
> Router tests cover sibling-namespace leaks, paths outside the memory dir, symlink escapes, and `..`-prefixed filenames that must stay allowed; older multi-namespace tests use in-root paths instead of `/tmp` placeholders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 333e5d1f87bdc828d025b8d90d5b7283fd9260de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search results are now strictly limited to the queried namespace’s storage root, even after absolute path resolution.
  * Added protection against results that escape via stale paths or symlinks, preventing cross-namespace or out-of-scope exposure.
  * Improved path containment checks for more consistent namespace-scoped behavior.
* **Tests**
  * Updated namespace search assertions to use dynamically created storage directories.
  * Added coverage for rejected out-of-root hits, including symlink escape scenarios.
* **Chores**
  * Refreshed the TypeScript typecheck baseline to match updated error locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->