### PR TITLE
feat(connector-fireflies): add @remnic/connector-fireflies wearable source (#1898)

### DIFF
--- a/docs/wearables.md
+++ b/docs/wearables.md
@@ -11,6 +11,7 @@ Three connectors ship as à-la-carte optional packages:
 | `limitless` | `@remnic/connector-limitless` | Limitless Pendant | — |
 | `bee` | `@remnic/connector-bee` | Bee bracelet (Amazon) | Bee "facts" |
 | `omi` | `@remnic/connector-omi` | Omi necklace | Omi "memories" |
+| `fireflies` | `@remnic/connector-fireflies` | Fireflies.ai (cloud meeting notes) | — |
 
 Installing `@remnic/core` (or `@remnic/cli`) alone never pulls a
 connector in. Install only what you wear:
@@ -220,6 +221,7 @@ Credentials prefer environment variables over config values:
 | limitless | `REMNIC_LIMITLESS_API_KEY`, `LIMITLESS_API_KEY` |
 | bee | `REMNIC_BEE_API_TOKEN`, `BEE_API_TOKEN` (not needed in proxy mode) |
 | omi | `REMNIC_OMI_API_KEY`, `OMI_API_KEY` |
+| fireflies | `REMNIC_FIREFLIES_API_KEY`, `FIREFLIES_API_KEY` |
 
 Remember the gateway runs under launchd with an isolated environment —
 API keys must be in the plist `EnvironmentVariables` (or in config).
@@ -363,6 +365,22 @@ on the next QMD update after a sync (the sync triggers one).
   person ids. Map labels via the speaker registry.
 - `importNativeMemories: "review"` imports Omi's "memories" (its
   extracted facts) into the review queue.
+
+### Fireflies (`@remnic/connector-fireflies`)
+
+- Cloud meeting-transcript source, not a wearable device. Ingests
+  transcripts Fireflies already produced; it cannot make them
+  retroactively local.
+- Auth: create a key in the Fireflies app under **Settings → Developer
+  settings** and provide it via `REMNIC_FIREFLIES_API_KEY`,
+  `FIREFLIES_API_KEY`, or `apiKey`.
+- Transcripts are fetched from the GraphQL API
+  (`transcripts(fromDate, toDate)`) for the local day; per-sentence
+  second-offsets are converted to absolute UTC using the meeting start.
+- Meetings with a summary but no transcript become a single `note`
+  segment — still day-anchored recall material.
+- No native-memory import: Fireflies exposes summaries, not a separate
+  extracted-fact surface, so `importNativeMemories` has no effect here.
 
 ## Why this design
 

--- a/packages/connector-fireflies/README.md
+++ b/packages/connector-fireflies/README.md
@@ -1,0 +1,81 @@
+# @remnic/connector-fireflies
+
+Fireflies.ai meeting-transcript connector for [Remnic](https://github.com/joshuaswarren/remnic).
+
+Pulls your Fireflies meeting transcripts into Remnic's wearables pipeline as
+source `fireflies`: day transcripts at `<memoryDir>/wearables/fireflies/<date>.md`,
+searchable via `remnic wearables search`, with trust-gated memories exactly like
+the pendant connectors.
+
+> **Cloud-service caveat.** These transcripts were produced by Fireflies' cloud
+> ASR. Remnic ingests them but cannot make them retroactively local — set
+> expectations accordingly. No transcript leaves your machine again; Remnic only
+> reads.
+
+## Install
+
+À-la-carte — install alongside `@remnic/core` only if you use Fireflies:
+
+```sh
+npm install -g @remnic/connector-fireflies
+```
+
+Installing `@remnic/core` alone never pulls this in; core discovers it at
+runtime. If it is not installed, `remnic wearables` reports a clean install hint.
+
+## API key
+
+Create a key in the Fireflies app under **Settings → Developer settings**, then
+provide it via (checked in order):
+
+| Environment variable | |
+|---|---|
+| `REMNIC_FIREFLIES_API_KEY` | preferred |
+| `FIREFLIES_API_KEY` | provider-conventional |
+
+…or the config value `wearables.sources.fireflies.apiKey` (takes precedence).
+The config value wins over the environment. On launchd/systemd daemons, remember
+the process environment is isolated — set the key in the unit, not just a shell.
+
+## Configure
+
+```jsonc
+{
+  "wearables": {
+    "sources": {
+      "fireflies": {
+        "enabled": false,          // OFF until you turn it on
+        "memoryMode": "smart",     // off | review | auto | smart
+        "sourceTrust": 0.85
+      }
+    }
+  }
+}
+```
+
+`enabled` defaults to `false`; nothing syncs until you set it `true`. Enabling
+Fireflies neither enables nor syncs any other source.
+
+## Verify
+
+```sh
+remnic wearables check fireflies     # ok / bad-key / unreachable
+remnic wearables sync --source fireflies --date 2026-03-10
+remnic wearables search "roadmap"
+```
+
+## What it does
+
+- Queries `transcripts(fromDate, toDate)` on `https://api.fireflies.ai/graphql`
+  for the local day (IANA timezone decides day bounds, DST-aware, half-open
+  `[start, end)`).
+- Maps each transcript's `sentences` to diarized segments, converting the
+  per-sentence second-offsets to absolute UTC using the meeting start.
+- Meetings that expose a summary but no transcript become a single `note`
+  segment — still day-anchored recall material.
+- Speaker names come through as provider labels; the wearables speaker registry
+  owns final naming (`remnic wearables speakers set fireflies "Speaker 1" "Jane"`).
+
+## License
+
+MIT

--- a/packages/connector-fireflies/package.json
+++ b/packages/connector-fireflies/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@remnic/connector-fireflies",
+  "version": "9.9.0",
+  "description": "Fireflies.ai meeting-transcript connector for Remnic — pull, clean, and remember meeting transcripts",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
+    "check-types": "tsc --noEmit",
+    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/client.test.ts src/normalize.test.ts src/index.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "^9.9.0"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "tsx": "^4.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/connector-fireflies"
+  },
+  "keywords": [
+    "remnic",
+    "memory",
+    "fireflies",
+    "meeting",
+    "transcript",
+    "wearable"
+  ]
+}

--- a/packages/connector-fireflies/src/client.test.ts
+++ b/packages/connector-fireflies/src/client.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { FirefliesApiError, FirefliesClient } from "./client.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function transcriptsBody(transcripts: unknown[]): unknown {
+  return { data: { transcripts } };
+}
+
+test("constructor throws an actionable error when the API key is missing", () => {
+  assert.throws(() => new FirefliesClient({ apiKey: "" }), (err: unknown) => {
+    assert.ok(err instanceof FirefliesApiError);
+    assert.match(err.message, /REMNIC_FIREFLIES_API_KEY/);
+    return true;
+  });
+});
+
+test("listTranscripts posts a GraphQL query with the day window and skip", async () => {
+  let captured: { url: string; body: unknown; auth: string | null } | undefined;
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    captured = {
+      url: String(url),
+      body: JSON.parse(String(init?.body)),
+      auth: new Headers(init?.headers).get("authorization"),
+    };
+    return jsonResponse(transcriptsBody([{ id: "t1", title: "Sync" }]));
+  }) as typeof fetch;
+
+  const client = new FirefliesClient({ apiKey: "grn_test", fetchImpl });
+  const page = await client.listTranscripts({
+    fromDate: "2026-03-10T06:00:00.000Z",
+    toDate: "2026-03-11T05:00:00.000Z",
+    skip: 50,
+  });
+
+  assert.equal(page.transcripts.length, 1);
+  assert.equal(page.transcripts[0]?.id, "t1");
+  assert.equal(page.hadFullPage, false);
+  assert.equal(captured?.url, "https://api.fireflies.ai/graphql");
+  assert.equal(captured?.auth, "Bearer grn_test");
+  assert.equal(
+    (captured?.body as { variables: { fromDate: string; skip: number } }).variables.skip,
+    50,
+  );
+});
+
+test("hadFullPage is true when a full page of results returns", async () => {
+  const full = Array.from({ length: 50 }, (_unused, i) => ({ id: `t${i}` }));
+  const fetchImpl = (async () => jsonResponse(transcriptsBody(full))) as typeof fetch;
+  const client = new FirefliesClient({ apiKey: "grn_test", fetchImpl });
+  const page = await client.listTranscripts({ fromDate: "a", toDate: "b" });
+  assert.equal(page.transcripts.length, 50);
+  assert.equal(page.hadFullPage, true);
+});
+
+test("a GraphQL errors array is a backend failure, never an empty result", async () => {
+  const fetchImpl = (async () =>
+    jsonResponse({ errors: [{ message: "Something went wrong" }] })) as typeof fetch;
+  const client = new FirefliesClient({ apiKey: "grn_test", fetchImpl });
+  await assert.rejects(
+    client.listTranscripts({ fromDate: "a", toDate: "b" }),
+    (err: unknown) => {
+      assert.ok(err instanceof FirefliesApiError);
+      assert.match(err.message, /GraphQL error/);
+      return true;
+    },
+  );
+});
+
+test("verifyAuth reports a bad key on HTTP 401", async () => {
+  const fetchImpl = (async () => jsonResponse({ errors: ["nope"] }, 401)) as typeof fetch;
+  const client = new FirefliesClient({ apiKey: "grn_bad", fetchImpl });
+  const result = await client.verifyAuth();
+  assert.equal(result.ok, false);
+  assert.match(result.detail ?? "", /rejected the API key/);
+});
+
+test("verifyAuth reports a bad key on an auth-coded GraphQL error", async () => {
+  const fetchImpl = (async () =>
+    jsonResponse({
+      errors: [{ message: "invalid api key", extensions: { code: "unauthenticated" } }],
+    })) as typeof fetch;
+  const client = new FirefliesClient({ apiKey: "grn_bad", fetchImpl });
+  const result = await client.verifyAuth();
+  assert.equal(result.ok, false);
+  assert.match(result.detail ?? "", /rejected the API key/);
+});
+
+test("verifyAuth succeeds on a clean probe", async () => {
+  const fetchImpl = (async () => jsonResponse(transcriptsBody([]))) as typeof fetch;
+  const client = new FirefliesClient({ apiKey: "grn_ok", fetchImpl });
+  assert.deepEqual(await client.verifyAuth(), { ok: true });
+});
+
+test("5xx is retried with an injected sleep, then succeeds", async () => {
+  let calls = 0;
+  const sleeps: number[] = [];
+  const fetchImpl = (async () => {
+    calls += 1;
+    if (calls < 3) return jsonResponse({ error: "boom" }, 503);
+    return jsonResponse(transcriptsBody([{ id: "t9" }]));
+  }) as typeof fetch;
+  const client = new FirefliesClient({
+    apiKey: "grn_ok",
+    fetchImpl,
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  });
+  const page = await client.listTranscripts({ fromDate: "a", toDate: "b" });
+  assert.equal(calls, 3);
+  assert.equal(sleeps.length, 2);
+  assert.equal(page.transcripts[0]?.id, "t9");
+});
+
+test("a non-JSON body fails loudly", async () => {
+  const fetchImpl = (async () =>
+    new Response("<html>gateway</html>", { status: 200 })) as typeof fetch;
+  const client = new FirefliesClient({ apiKey: "grn_ok", fetchImpl });
+  await assert.rejects(client.listTranscripts({ fromDate: "a", toDate: "b" }), FirefliesApiError);
+});
+
+test("a missing data.transcripts array fails loudly", async () => {
+  const fetchImpl = (async () => jsonResponse({ data: { transcripts: "nope" } })) as typeof fetch;
+  const client = new FirefliesClient({ apiKey: "grn_ok", fetchImpl });
+  await assert.rejects(client.listTranscripts({ fromDate: "a", toDate: "b" }), FirefliesApiError);
+});

--- a/packages/connector-fireflies/src/client.test.ts
+++ b/packages/connector-fireflies/src/client.test.ts
@@ -132,3 +132,13 @@ test("a missing data.transcripts array fails loudly", async () => {
   const client = new FirefliesClient({ apiKey: "grn_ok", fetchImpl });
   await assert.rejects(client.listTranscripts({ fromDate: "a", toDate: "b" }), FirefliesApiError);
 });
+
+test("rawCount reflects the raw page size even when id-less rows are filtered out", async () => {
+  const rows = Array.from({ length: 50 }, (_unused, i) => (i < 3 ? { id: `t${i}` } : { noId: true }));
+  const fetchImpl = (async () => jsonResponse(transcriptsBody(rows))) as typeof fetch;
+  const client = new FirefliesClient({ apiKey: "grn_ok", fetchImpl });
+  const page = await client.listTranscripts({ fromDate: "a", toDate: "b" });
+  assert.equal(page.transcripts.length, 3);
+  assert.equal(page.rawCount, 50);
+  assert.equal(page.hadFullPage, true);
+});

--- a/packages/connector-fireflies/src/client.ts
+++ b/packages/connector-fireflies/src/client.ts
@@ -79,6 +79,8 @@ export interface TranscriptsPage {
   transcripts: FirefliesTranscript[];
   /** True when a full page came back (more may exist beyond this skip). */
   hadFullPage: boolean;
+  /** Raw row count Fireflies returned at this offset (drives the skip cursor). */
+  rawCount: number;
 }
 
 export interface FirefliesClientOptions {
@@ -152,7 +154,7 @@ export class FirefliesClient {
     const transcripts = raw.filter(
       (entry): entry is FirefliesTranscript => isRecord(entry) && typeof entry.id === "string",
     );
-    return { transcripts, hadFullPage: raw.length >= TRANSCRIPTS_MAX_PAGE_SIZE };
+    return { transcripts, hadFullPage: raw.length >= TRANSCRIPTS_MAX_PAGE_SIZE, rawCount: raw.length };
   }
 
   /** Cheap auth probe. */

--- a/packages/connector-fireflies/src/client.ts
+++ b/packages/connector-fireflies/src/client.ts
@@ -1,0 +1,299 @@
+/**
+ * Minimal Fireflies.ai GraphQL API client (raw fetch, no SDK).
+ *
+ * API verified against https://docs.fireflies.ai/graphql-api/query/transcripts
+ * and https://docs.fireflies.ai/fundamentals/authorization (fetched
+ * 2026-07-21):
+ *   - Endpoint: POST https://api.fireflies.ai/graphql
+ *   - Auth: `Authorization: Bearer <api key>`
+ *   - `transcripts(fromDate, toDate, limit, skip)` where fromDate/toDate are
+ *     ISO-8601 date-time strings and `limit` maxes at 50.
+ *   - Each transcript exposes `id`, `title`, `date` (epoch ms), `duration`
+ *     (minutes), `summary { overview short_summary }`, `participants`, and
+ *     `sentences { index speaker_name speaker_id text start_time end_time }`
+ *     where start_time/end_time are second-offsets from the meeting start.
+ *
+ * GraphQL transport returns HTTP 200 with an `errors` array on query/auth
+ * failure; those are surfaced as FirefliesApiError (a backend failure), never
+ * as an empty result (AGENTS.md §22).
+ */
+
+export const FIREFLIES_DEFAULT_ENDPOINT = "https://api.fireflies.ai/graphql";
+
+/** Hard API maximum for `limit` on the transcripts query. */
+export const TRANSCRIPTS_MAX_PAGE_SIZE = 50;
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 3;
+/** Backoff cap so a hostile retryAfter can't stall a sync for minutes. */
+const MAX_RETRY_DELAY_MS = 30_000;
+
+const TRANSCRIPTS_QUERY = `query RemnicTranscripts($fromDate: DateTime, $toDate: DateTime, $limit: Int, $skip: Int) {
+  transcripts(fromDate: $fromDate, toDate: $toDate, limit: $limit, skip: $skip) {
+    id
+    title
+    date
+    duration
+    participants
+    summary { overview short_summary }
+    speakers { id name }
+    sentences { index speaker_name speaker_id text start_time end_time }
+  }
+}`;
+
+const AUTH_PROBE_QUERY = `query RemnicFirefliesAuthProbe { transcripts(limit: 1) { id } }`;
+
+export interface FirefliesSentence {
+  index?: number;
+  speaker_name?: string | null;
+  speaker_id?: number | string | null;
+  text?: string | null;
+  start_time?: number | null;
+  end_time?: number | null;
+}
+
+export interface FirefliesSummary {
+  overview?: string | null;
+  short_summary?: string | null;
+}
+
+export interface FirefliesSpeaker {
+  id?: number | string | null;
+  name?: string | null;
+}
+
+export interface FirefliesTranscript {
+  id: string;
+  title?: string | null;
+  /** Meeting datetime — epoch milliseconds (Float) or an ISO string. */
+  date?: number | string | null;
+  /** Meeting duration in minutes (Fireflies reports minutes). */
+  duration?: number | null;
+  participants?: string[] | null;
+  summary?: FirefliesSummary | null;
+  speakers?: FirefliesSpeaker[] | null;
+  sentences?: FirefliesSentence[] | null;
+}
+
+export interface TranscriptsPage {
+  transcripts: FirefliesTranscript[];
+  /** True when a full page came back (more may exist beyond this skip). */
+  hadFullPage: boolean;
+}
+
+export interface FirefliesClientOptions {
+  apiKey: string;
+  /** Override the GraphQL endpoint (self-hosted / proxy setups). */
+  baseUrl?: string;
+  /** Injectable for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Per-request timeout (ms). */
+  timeoutMs?: number;
+  /** Injectable sleep for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export class FirefliesApiError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "FirefliesApiError";
+  }
+}
+
+/** Narrow unknown JSON to a plain object so field reads are actually checked. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export class FirefliesClient {
+  private readonly apiKey: string;
+  private readonly endpoint: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(options: FirefliesClientOptions) {
+    if (typeof options.apiKey !== "string" || options.apiKey.trim().length === 0) {
+      throw new FirefliesApiError(
+        "Fireflies API key is missing. Set wearables.sources.fireflies.apiKey " +
+          "or the REMNIC_FIREFLIES_API_KEY / FIREFLIES_API_KEY environment variable " +
+          "(create a key under Settings → Developer settings in the Fireflies app).",
+      );
+    }
+    this.apiKey = options.apiKey.trim();
+    this.endpoint = stripTrailingSlashes(options.baseUrl ?? FIREFLIES_DEFAULT_ENDPOINT);
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.sleep = options.sleep ?? defaultSleep;
+  }
+
+  /** One page of transcripts created inside the [fromDate, toDate) window. */
+  async listTranscripts(params: {
+    fromDate: string;
+    toDate: string;
+    skip?: number;
+    signal?: AbortSignal;
+  }): Promise<TranscriptsPage> {
+    const skip = Number.isInteger(params.skip) && (params.skip as number) > 0 ? (params.skip as number) : 0;
+    const data = await this.graphql(
+      TRANSCRIPTS_QUERY,
+      { fromDate: params.fromDate, toDate: params.toDate, limit: TRANSCRIPTS_MAX_PAGE_SIZE, skip },
+      params.signal,
+    );
+    const raw = isRecord(data) ? data.transcripts : undefined;
+    if (!Array.isArray(raw)) {
+      throw new FirefliesApiError(
+        "Fireflies API returned an unexpected transcripts shape (missing data.transcripts array)",
+      );
+    }
+    const transcripts = raw.filter(
+      (entry): entry is FirefliesTranscript => isRecord(entry) && typeof entry.id === "string",
+    );
+    return { transcripts, hadFullPage: raw.length >= TRANSCRIPTS_MAX_PAGE_SIZE };
+  }
+
+  /** Cheap auth probe. */
+  async verifyAuth(signal?: AbortSignal): Promise<{ ok: boolean; detail?: string }> {
+    try {
+      await this.graphql(AUTH_PROBE_QUERY, {}, signal);
+      return { ok: true };
+    } catch (err) {
+      if (err instanceof FirefliesApiError && (err.status === 401 || err.status === 403)) {
+        return {
+          ok: false,
+          detail:
+            "Fireflies rejected the API key (401/403) — create a new key under Settings → Developer settings",
+        };
+      }
+      return { ok: false, detail: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  private async graphql(
+    query: string,
+    variables: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      signal?.throwIfAborted();
+      const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+      const combined = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+      let response: Response;
+      try {
+        response = await this.fetchImpl(this.endpoint, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify({ query, variables }),
+          signal: combined,
+        });
+      } catch (err) {
+        if (signal?.aborted) throw err;
+        lastError = err;
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(backoffMs(attempt));
+          continue;
+        }
+        throw new FirefliesApiError(
+          `Fireflies API request failed after ${MAX_RETRIES + 1} attempts: ${describeNetworkError(err)}`,
+        );
+      }
+
+      if (response.status === 429 || response.status >= 500) {
+        lastError = new FirefliesApiError(`Fireflies API responded ${response.status}`, response.status);
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(await retryDelayMs(response, attempt));
+          continue;
+        }
+        throw lastError;
+      }
+      if (response.status === 401 || response.status === 403) {
+        throw new FirefliesApiError(`Fireflies API responded ${response.status}`, response.status);
+      }
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch {
+        throw new FirefliesApiError("Fireflies API returned a non-JSON body");
+      }
+      // GraphQL returns 200 with an `errors` array on failure. That is a
+      // backend failure, not an empty result (AGENTS.md §22): surface it so
+      // an expired token never reads as a quiet day.
+      const errors = isRecord(body) ? body.errors : undefined;
+      if (Array.isArray(errors) && errors.length > 0) {
+        throw graphqlError(errors[0]);
+      }
+      const data = isRecord(body) ? body.data : undefined;
+      if (data === undefined || data === null) {
+        throw new FirefliesApiError("Fireflies API returned no data and no errors");
+      }
+      return data;
+    }
+    throw lastError instanceof Error ? lastError : new FirefliesApiError("Fireflies API request failed");
+  }
+}
+
+function graphqlError(first: unknown): FirefliesApiError {
+  const record = isRecord(first) ? first : undefined;
+  const message = record && typeof record.message === "string" ? record.message : "unknown GraphQL error";
+  const extensions = record && isRecord(record.extensions) ? record.extensions : undefined;
+  const code = extensions && typeof extensions.code === "string" ? extensions.code : undefined;
+  const authLike =
+    code === "unauthenticated" ||
+    code === "forbidden" ||
+    /unauthor|forbidden|invalid.*(token|api key)|expired/i.test(message);
+  return new FirefliesApiError(`Fireflies GraphQL error: ${message}`, authLike ? 401 : undefined);
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, ms);
+  return promise;
+}
+
+/**
+ * Network/timeout failures wrap Node error text that can carry loader
+ * paths or stack fragments; sync errors reach MCP clients verbatim, so
+ * only the error name + code survive.
+ */
+function describeNetworkError(err: unknown): string {
+  if (isRecord(err)) {
+    const name = typeof err.name === "string" ? err.name : "Error";
+    const code = err.code;
+    return typeof code === "string" ? `${name} (${code})` : name;
+  }
+  return "network error";
+}
+
+/** Loop instead of `/\/+$/` — CodeQL js/polynomial-redos on user-set URLs. */
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
+  return value.slice(0, end);
+}
+
+function backoffMs(attempt: number): number {
+  return Math.min(MAX_RETRY_DELAY_MS, 1_000 * 2 ** attempt);
+}
+
+async function retryDelayMs(response: Response, attempt: number): Promise<number> {
+  const header = response.headers.get("retry-after");
+  if (header) {
+    const seconds = Number(header);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return Math.min(MAX_RETRY_DELAY_MS, seconds * 1_000);
+    }
+    const when = Date.parse(header);
+    if (Number.isFinite(when)) {
+      return Math.min(MAX_RETRY_DELAY_MS, Math.max(0, when - Date.now()));
+    }
+  }
+  return backoffMs(attempt);
+}

--- a/packages/connector-fireflies/src/index.test.ts
+++ b/packages/connector-fireflies/src/index.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { getWearableConnector } from "@remnic/core";
+import type { WearableSourceSettings } from "@remnic/core";
+
+import {
+  createFirefliesConnector,
+  ensureFirefliesConnectorRegistered,
+  resolveFirefliesApiKey,
+  wearableConnectorRegistration,
+} from "./index.js";
+
+function settings(overrides: Partial<WearableSourceSettings> = {}): WearableSourceSettings {
+  return {
+    enabled: true,
+    memoryMode: "smart",
+    sourceTrust: 0.85,
+    autoApproveTrust: 0.7,
+    reviewTrust: 0.45,
+    minConfidence: 0,
+    minImportance: "low",
+    maxMemoriesPerDay: 0,
+    importNativeMemories: "smart",
+    cleanup: {
+      mergeSameSpeaker: true,
+      stripFillers: true,
+      collapseRepeats: true,
+      dropLowQuality: true,
+    },
+    ...overrides,
+  };
+}
+
+test("importing the module registers the connector exactly once", () => {
+  assert.ok(getWearableConnector("fireflies"));
+  assert.equal(ensureFirefliesConnectorRegistered(), false);
+  assert.equal(wearableConnectorRegistration.id, "fireflies");
+});
+
+test("resolveFirefliesApiKey prefers config, then REMNIC_*, then provider env", () => {
+  assert.equal(resolveFirefliesApiKey("from-config", {}), "from-config");
+  assert.equal(
+    resolveFirefliesApiKey(undefined, {
+      REMNIC_FIREFLIES_API_KEY: "remnic-env",
+      FIREFLIES_API_KEY: "provider-env",
+    }),
+    "remnic-env",
+  );
+  assert.equal(
+    resolveFirefliesApiKey(undefined, { FIREFLIES_API_KEY: "provider-env" }),
+    "provider-env",
+  );
+  assert.equal(resolveFirefliesApiKey(undefined, {}), undefined);
+  assert.equal(resolveFirefliesApiKey("   ", {}), undefined);
+});
+
+test("fetchConversations normalizes transcripts through the shared shape", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        data: {
+          transcripts: [
+            {
+              id: "m-1",
+              title: "Weekly sync",
+              date: Date.parse("2026-03-10T14:00:00.000Z"),
+              duration: 15,
+              sentences: [
+                { speaker_name: "Jane", speaker_id: 0, text: "Hello", start_time: 1, end_time: 2 },
+              ],
+            },
+          ],
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    )) as typeof fetch;
+  try {
+    const connector = createFirefliesConnector({
+      settings: settings({ apiKey: "grn_test" }),
+      timezone: "America/Chicago",
+    });
+    const page = await connector.fetchConversations({
+      date: "2026-03-10",
+      timezone: "America/Chicago",
+    });
+    assert.equal(page.conversations.length, 1);
+    assert.equal(page.conversations[0]?.id, "m-1");
+    assert.equal(page.conversations[0]?.source, "fireflies");
+    assert.equal(page.conversations[0]?.segments[0]?.text, "Hello");
+    // A single partial page ends the day.
+    assert.equal(page.nextCursor, null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("fetchConversations advances the cursor across a full page", async () => {
+  const originalFetch = globalThis.fetch;
+  const full = Array.from({ length: 50 }, (_unused, i) => ({
+    id: `m-${i}`,
+    date: Date.parse("2026-03-10T14:00:00.000Z"),
+    sentences: [{ text: "x", speaker_id: 0, start_time: 0, end_time: 1 }],
+  }));
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ data: { transcripts: full } }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+  try {
+    const connector = createFirefliesConnector({
+      settings: settings({ apiKey: "grn_test" }),
+      timezone: "UTC",
+    });
+    const page = await connector.fetchConversations({ date: "2026-03-10", timezone: "UTC" });
+    assert.equal(page.conversations.length, 50);
+    assert.equal(page.nextCursor, "50");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("missing API key surfaces an actionable error at call time, not construction", async () => {
+  const connector = createFirefliesConnector({
+    settings: settings({ apiKey: undefined }),
+    timezone: "UTC",
+  });
+  // Construction did not throw; the call does, with the actionable message.
+  await assert.rejects(
+    connector.fetchConversations({ date: "2026-03-10", timezone: "UTC" }),
+    (err: unknown) => {
+      assert.ok(err instanceof Error);
+      assert.match(err.message, /REMNIC_FIREFLIES_API_KEY/);
+      return true;
+    },
+  );
+});

--- a/packages/connector-fireflies/src/index.test.ts
+++ b/packages/connector-fireflies/src/index.test.ts
@@ -136,3 +136,53 @@ test("missing API key surfaces an actionable error at call time, not constructio
     },
   );
 });
+
+test("a full page of id-less rows still advances the cursor by the raw count", async () => {
+  const originalFetch = globalThis.fetch;
+  const rows = Array.from({ length: 50 }, () => ({ noId: true, date: 0 }));
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ data: { transcripts: rows } }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+  try {
+    const connector = createFirefliesConnector({ settings: settings({ apiKey: "grn" }), timezone: "UTC" });
+    const page = await connector.fetchConversations({ date: "2026-03-10", timezone: "UTC" });
+    assert.equal(page.conversations.length, 0);
+    assert.equal(page.nextCursor, "50");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("transcripts with no resolvable date are dropped, not emitted with an empty start", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        data: {
+          transcripts: [
+            {
+              id: "ok",
+              date: Date.parse("2026-03-10T14:00:00.000Z"),
+              sentences: [{ text: "hi", speaker_id: 0, start_time: 0, end_time: 1 }],
+            },
+            {
+              id: "bad",
+              date: "not-a-date",
+              sentences: [{ text: "x", speaker_id: 0, start_time: 0, end_time: 1 }],
+            },
+          ],
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    )) as typeof fetch;
+  try {
+    const connector = createFirefliesConnector({ settings: settings({ apiKey: "grn" }), timezone: "UTC" });
+    const page = await connector.fetchConversations({ date: "2026-03-10", timezone: "UTC" });
+    assert.equal(page.conversations.length, 1);
+    assert.equal(page.conversations[0]?.id, "ok");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/connector-fireflies/src/index.ts
+++ b/packages/connector-fireflies/src/index.ts
@@ -1,0 +1,134 @@
+/**
+ * @remnic/connector-fireflies — Fireflies.ai meeting-transcript connector.
+ *
+ * À-la-carte optional companion of @remnic/core: installing core alone
+ * never pulls this in; core discovers it at runtime via a
+ * computed-specifier dynamic import (see wearables/registry.ts) or via
+ * a direct import of this module, which self-registers idempotently.
+ *
+ * API key: `wearables.sources.fireflies.apiKey`, else the
+ * `REMNIC_FIREFLIES_API_KEY` / `FIREFLIES_API_KEY` environment
+ * variables (checked in that order). Create a key under
+ * Settings → Developer settings in the Fireflies app.
+ */
+
+import {
+  registerWearableConnector,
+  getWearableConnector,
+  type WearableConnectorFactoryOptions,
+  type WearableConnectorRegistration,
+  type WearableFetchOptions,
+  type WearableFetchPage,
+  type WearableSourceConnector,
+} from "@remnic/core";
+
+import { FirefliesClient } from "./client.js";
+import { FIREFLIES_SOURCE_ID, firefliesDayWindow, transcriptToConversation } from "./normalize.js";
+
+export {
+  FirefliesClient,
+  FirefliesApiError,
+  FIREFLIES_DEFAULT_ENDPOINT,
+  TRANSCRIPTS_MAX_PAGE_SIZE,
+} from "./client.js";
+export type {
+  FirefliesTranscript,
+  FirefliesSentence,
+  FirefliesSummary,
+  FirefliesSpeaker,
+  TranscriptsPage,
+  FirefliesClientOptions,
+} from "./client.js";
+export {
+  FIREFLIES_SOURCE_ID,
+  firefliesDayWindow,
+  transcriptToConversation,
+} from "./normalize.js";
+
+const FIREFLIES_DISPLAY_NAME = "Fireflies.ai";
+
+export function resolveFirefliesApiKey(
+  configuredKey: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (typeof configuredKey === "string" && configuredKey.trim().length > 0) {
+    return configuredKey.trim();
+  }
+  // REMNIC_* first, then the provider-conventional name.
+  for (const name of ["REMNIC_FIREFLIES_API_KEY", "FIREFLIES_API_KEY"]) {
+    const value = env[name];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+export function createFirefliesConnector(
+  options: WearableConnectorFactoryOptions,
+): WearableSourceConnector {
+  // Key resolution happens lazily at call time (not factory time) so
+  // `wearables status` works without credentials and env changes take
+  // effect without a restart; the client constructor throws the
+  // actionable missing-key message.
+  let client: FirefliesClient | null = null;
+  const getClient = (): FirefliesClient => {
+    if (!client) {
+      client = new FirefliesClient({
+        apiKey: resolveFirefliesApiKey(options.settings.apiKey) ?? "",
+        baseUrl: options.settings.baseUrl,
+      });
+    }
+    return client;
+  };
+
+  return {
+    id: FIREFLIES_SOURCE_ID,
+    displayName: FIREFLIES_DISPLAY_NAME,
+    async verifyAuth(signal?: AbortSignal) {
+      return getClient().verifyAuth(signal);
+    },
+    async fetchConversations(opts: WearableFetchOptions): Promise<WearableFetchPage> {
+      const { fromDate, toDate } = firefliesDayWindow(opts.date, opts.timezone);
+      const skip = parseCursor(opts.cursor);
+      const page = await getClient().listTranscripts({
+        fromDate,
+        toDate,
+        skip,
+        signal: opts.signal,
+      });
+      return {
+        conversations: page.transcripts.map(transcriptToConversation),
+        // Advance the keyset only while full pages keep coming; a partial
+        // page ends the day. Guard against a runaway/looping cursor.
+        nextCursor: page.hadFullPage && page.transcripts.length > 0 ? String(skip + page.transcripts.length) : null,
+      };
+    },
+  };
+}
+
+/** Opaque cursor is the numeric `skip` offset; anything invalid restarts at 0. */
+function parseCursor(cursor: string | null | undefined): number {
+  if (typeof cursor !== "string") return 0;
+  const parsed = Number(cursor);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+}
+
+export const wearableConnectorRegistration: WearableConnectorRegistration = {
+  id: FIREFLIES_SOURCE_ID,
+  displayName: FIREFLIES_DISPLAY_NAME,
+  factory: createFirefliesConnector,
+};
+
+/**
+ * Idempotently register the connector with the core registry. Importing
+ * this module registers it as a side effect; calling this again is safe
+ * (returns false when already registered).
+ */
+export function ensureFirefliesConnectorRegistered(): boolean {
+  if (getWearableConnector(FIREFLIES_SOURCE_ID)) return false;
+  registerWearableConnector(wearableConnectorRegistration);
+  return true;
+}
+
+ensureFirefliesConnectorRegistered();

--- a/packages/connector-fireflies/src/index.ts
+++ b/packages/connector-fireflies/src/index.ts
@@ -98,10 +98,15 @@ export function createFirefliesConnector(
         signal: opts.signal,
       });
       return {
-        conversations: page.transcripts.map(transcriptToConversation),
-        // Advance the keyset only while full pages keep coming; a partial
-        // page ends the day. Guard against a runaway/looping cursor.
-        nextCursor: page.hadFullPage && page.transcripts.length > 0 ? String(skip + page.transcripts.length) : null,
+        conversations: page.transcripts
+          .map(transcriptToConversation)
+          // A transcript with no resolvable meeting date can't produce a
+          // valid conversation start; drop it rather than emit an empty
+          // startIso that would fail downstream parsing silently.
+          .filter((conversation) => conversation.startIso !== ""),
+        // Advance the keyset by the raw page size (not the id-filtered count)
+        // while full pages keep coming, so dropped rows never truncate the day.
+        nextCursor: page.hadFullPage ? String(skip + page.rawCount) : null,
       };
     },
   };

--- a/packages/connector-fireflies/src/normalize.test.ts
+++ b/packages/connector-fireflies/src/normalize.test.ts
@@ -102,3 +102,12 @@ test("UTC timezone yields plain UTC day bounds", () => {
   assert.equal(window.fromDate, "2026-07-01T00:00:00.000Z");
   assert.equal(window.toDate, "2026-07-02T00:00:00.000Z");
 });
+
+test("firefliesDayWindow rejects an invalid timezone instead of coercing to UTC", () => {
+  assert.throws(() => firefliesDayWindow("2026-03-10", "Not/AZone"), RangeError);
+});
+
+test("a transcript with no resolvable date yields an empty startIso (caller drops it)", () => {
+  const conv = transcriptToConversation({ id: "bad", date: "not-a-date", sentences: [] });
+  assert.equal(conv.startIso, "");
+});

--- a/packages/connector-fireflies/src/normalize.test.ts
+++ b/packages/connector-fireflies/src/normalize.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { FirefliesTranscript } from "./client.js";
+import {
+  FIREFLIES_SOURCE_ID,
+  firefliesDayWindow,
+  transcriptToConversation,
+} from "./normalize.js";
+
+test("maps sentences to segments with absolute UTC times from the meeting start", () => {
+  // 2026-03-10T14:00:00Z in epoch ms.
+  const start = Date.parse("2026-03-10T14:00:00.000Z");
+  const transcript: FirefliesTranscript = {
+    id: "t1",
+    title: "Roadmap sync",
+    date: start,
+    duration: 30,
+    summary: { overview: "Discussed Q3 roadmap." },
+    sentences: [
+      { index: 0, speaker_name: "Jane Doe", speaker_id: 0, text: "Let's start.", start_time: 5, end_time: 8 },
+      { index: 1, speaker_name: "John Roe", speaker_id: 1, text: "Agenda first.", start_time: 9, end_time: 12 },
+    ],
+  };
+
+  const conv = transcriptToConversation(transcript);
+  assert.equal(conv.id, "t1");
+  assert.equal(conv.source, FIREFLIES_SOURCE_ID);
+  assert.equal(conv.title, "Roadmap sync");
+  assert.equal(conv.summary, "Discussed Q3 roadmap.");
+  assert.equal(conv.startIso, "2026-03-10T14:00:00.000Z");
+  assert.equal(conv.endIso, "2026-03-10T14:30:00.000Z");
+  assert.equal(conv.segments.length, 2);
+  assert.deepEqual(conv.segments[0], {
+    text: "Let's start.",
+    speakerKey: "Jane Doe",
+    speakerName: "Jane Doe",
+    startIso: "2026-03-10T14:00:05.000Z",
+    endIso: "2026-03-10T14:00:08.000Z",
+  });
+});
+
+test("accepts an ISO string meeting date", () => {
+  const transcript: FirefliesTranscript = {
+    id: "t2",
+    date: "2026-03-10T14:00:00.000Z",
+    sentences: [{ text: "Hi", speaker_id: 3, start_time: 1, end_time: 2 }],
+  };
+  const conv = transcriptToConversation(transcript);
+  assert.equal(conv.startIso, "2026-03-10T14:00:00.000Z");
+  // No speaker_name → key falls back to the string speaker id.
+  assert.equal(conv.segments[0]?.speakerKey, "3");
+  assert.equal(conv.segments[0]?.speakerName, undefined);
+});
+
+test("never guesses isWearer", () => {
+  const conv = transcriptToConversation({
+    id: "t3",
+    date: 0,
+    sentences: [{ text: "hello", speaker_name: "Me", start_time: 0, end_time: 1 }],
+  });
+  assert.equal(conv.segments[0]?.isWearer, undefined);
+});
+
+test("degrades to a single note segment when a summary exists without a transcript", () => {
+  const conv = transcriptToConversation({
+    id: "t4",
+    date: Date.parse("2026-03-10T09:00:00.000Z"),
+    summary: { short_summary: "Quick standup, nothing blocking." },
+    sentences: [],
+  });
+  assert.equal(conv.segments.length, 1);
+  assert.deepEqual(conv.segments[0], {
+    text: "Quick standup, nothing blocking.",
+    speakerKey: "note",
+  });
+  assert.equal(conv.summary, "Quick standup, nothing blocking.");
+});
+
+test("empty transcript and empty summary yields zero segments", () => {
+  const conv = transcriptToConversation({ id: "t5", date: 0, sentences: [], summary: {} });
+  assert.equal(conv.segments.length, 0);
+});
+
+test("firefliesDayWindow returns half-open UTC bounds for a local day", () => {
+  const window = firefliesDayWindow("2026-03-10", "America/Chicago");
+  // CDT is UTC-5 in March (after the 2026-03-08 DST switch).
+  assert.equal(window.fromDate, "2026-03-10T05:00:00.000Z");
+  assert.equal(window.toDate, "2026-03-11T05:00:00.000Z");
+});
+
+test("firefliesDayWindow handles the spring-forward DST boundary", () => {
+  // 2026-03-08 is the US spring-forward day: the day starts CST (UTC-6),
+  // the next day starts CDT (UTC-5). Bounds must reflect the shift.
+  const window = firefliesDayWindow("2026-03-08", "America/Chicago");
+  assert.equal(window.fromDate, "2026-03-08T06:00:00.000Z");
+  assert.equal(window.toDate, "2026-03-09T05:00:00.000Z");
+});
+
+test("UTC timezone yields plain UTC day bounds", () => {
+  const window = firefliesDayWindow("2026-07-01", "UTC");
+  assert.equal(window.fromDate, "2026-07-01T00:00:00.000Z");
+  assert.equal(window.toDate, "2026-07-02T00:00:00.000Z");
+});

--- a/packages/connector-fireflies/src/normalize.ts
+++ b/packages/connector-fireflies/src/normalize.ts
@@ -1,0 +1,148 @@
+/**
+ * Normalize Fireflies.ai transcripts into Remnic's provider-agnostic
+ * `WearableConversation` shape, plus the timezone-aware day-window helpers
+ * the Fireflies `transcripts(fromDate, toDate)` filter needs.
+ *
+ * Fireflies sentences carry `start_time`/`end_time` as second-offsets from the
+ * meeting start (`date`, epoch ms); they are converted to absolute UTC here
+ * (the same trap the Omi connector handles). Speaker turns come as
+ * `speaker_name`/`speaker_id`; the wearables speaker registry owns final
+ * naming, so we never guess `isWearer`. Meetings that expose a summary but no
+ * transcript degrade to a single `note`-keyed segment — a note is still
+ * day-anchored recall material.
+ */
+
+import type {
+  WearableConversation,
+  WearableTranscriptSegment,
+} from "@remnic/core";
+
+import type { FirefliesTranscript } from "./client.js";
+
+export const FIREFLIES_SOURCE_ID = "fireflies";
+
+/** "GMT+05:30" → "+05:30"; plain "GMT" → "+00:00". */
+export function timezoneOffsetIso(instant: Date, timezone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "longOffset",
+    }).formatToParts(instant);
+    const name = parts.find((part) => part.type === "timeZoneName")?.value ?? "GMT";
+    const match = name.match(/GMT([+-]\d{2}:\d{2})?/);
+    return match?.[1] ?? "+00:00";
+  } catch {
+    return "+00:00";
+  }
+}
+
+/** ISO instant for local midnight of `date` in `timezone`. */
+export function zonedDayStartIso(date: string, timezone: string): string {
+  // Two-pass offset resolution: guess from midday (stable away from DST
+  // transitions), then re-derive at the candidate midnight itself.
+  let offset = timezoneOffsetIso(new Date(`${date}T12:00:00Z`), timezone);
+  const candidate = new Date(`${date}T00:00:00${offset}`);
+  const refined = timezoneOffsetIso(candidate, timezone);
+  if (refined !== offset) {
+    offset = refined;
+  }
+  return `${date}T00:00:00${offset}`;
+}
+
+export function nextIsoDate(date: string): string {
+  const parsed = new Date(`${date}T00:00:00Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + 1);
+  return parsed.toISOString().slice(0, 10);
+}
+
+/**
+ * Half-open [fromDate, toDate) UTC ISO bounds of a local day — the window the
+ * Fireflies `transcripts` query filters on.
+ */
+export function firefliesDayWindow(
+  date: string,
+  timezone: string,
+): { fromDate: string; toDate: string } {
+  return {
+    fromDate: new Date(zonedDayStartIso(date, timezone)).toISOString(),
+    toDate: new Date(zonedDayStartIso(nextIsoDate(date), timezone)).toISOString(),
+  };
+}
+
+/** Meeting start as epoch ms, from Fireflies' epoch-ms Float or ISO string. */
+function meetingStartMs(date: FirefliesTranscript["date"]): number {
+  if (typeof date === "number" && Number.isFinite(date)) return date;
+  if (typeof date === "string") {
+    const parsed = Date.parse(date);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return Number.NaN;
+}
+
+function offsetToIso(startMs: number, offsetSeconds: number | null | undefined): string | undefined {
+  if (Number.isNaN(startMs)) return undefined;
+  if (typeof offsetSeconds !== "number" || !Number.isFinite(offsetSeconds)) return undefined;
+  return new Date(startMs + offsetSeconds * 1_000).toISOString();
+}
+
+export function transcriptToConversation(transcript: FirefliesTranscript): WearableConversation {
+  const startMs = meetingStartMs(transcript.date);
+  const startIso = Number.isNaN(startMs) ? "" : new Date(startMs).toISOString();
+  // Fireflies reports `duration` in minutes.
+  const endIso =
+    !Number.isNaN(startMs) && typeof transcript.duration === "number" && Number.isFinite(transcript.duration)
+      ? new Date(startMs + transcript.duration * 60_000).toISOString()
+      : undefined;
+
+  const segments: WearableTranscriptSegment[] = [];
+  for (const sentence of transcript.sentences ?? []) {
+    const text = typeof sentence.text === "string" ? sentence.text.trim() : "";
+    if (text.length === 0) continue;
+    const speakerName =
+      typeof sentence.speaker_name === "string" && sentence.speaker_name.trim().length > 0
+        ? sentence.speaker_name.trim()
+        : undefined;
+    const speakerId =
+      sentence.speaker_id !== null && sentence.speaker_id !== undefined
+        ? String(sentence.speaker_id).trim()
+        : undefined;
+    const segStart = offsetToIso(startMs, sentence.start_time);
+    const segEnd = offsetToIso(startMs, sentence.end_time);
+    segments.push({
+      text,
+      speakerKey: speakerName ?? (speakerId && speakerId.length > 0 ? speakerId : "unknown"),
+      ...(speakerName !== undefined ? { speakerName } : {}),
+      ...(segStart !== undefined ? { startIso: segStart } : {}),
+      ...(segEnd !== undefined ? { endIso: segEnd } : {}),
+    });
+  }
+
+  const summaryText = firstNonEmpty(transcript.summary?.overview, transcript.summary?.short_summary);
+
+  // Note-only fallback: a meeting with a summary but no transcript still
+  // anchors recall for the day.
+  if (segments.length === 0 && summaryText !== undefined) {
+    segments.push({ text: summaryText, speakerKey: "note" });
+  }
+
+  const title = typeof transcript.title === "string" && transcript.title.trim().length > 0
+    ? transcript.title.trim()
+    : undefined;
+
+  return {
+    id: transcript.id,
+    source: FIREFLIES_SOURCE_ID,
+    ...(title !== undefined ? { title } : {}),
+    ...(summaryText !== undefined ? { summary: summaryText } : {}),
+    startIso,
+    ...(endIso !== undefined ? { endIso } : {}),
+    segments,
+  };
+}
+
+function firstNonEmpty(...values: Array<string | null | undefined>): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return undefined;
+}

--- a/packages/connector-fireflies/src/normalize.ts
+++ b/packages/connector-fireflies/src/normalize.ts
@@ -56,6 +56,22 @@ export function nextIsoDate(date: string): string {
 }
 
 /**
+ * Reject an invalid/unsupported IANA timezone loudly. `Intl.DateTimeFormat`
+ * throws a RangeError for an unknown zone; without this guard a typo'd
+ * timezone would silently coerce to UTC and shift every meeting's day window
+ * and timestamps (AGENTS.md §39 — reject, don't silently default).
+ */
+function assertValidTimezone(timezone: string): void {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+  } catch {
+    throw new RangeError(
+      `Invalid IANA timezone "${timezone}" for the Fireflies connector — check wearables.timezone.`,
+    );
+  }
+}
+
+/**
  * Half-open [fromDate, toDate) UTC ISO bounds of a local day — the window the
  * Fireflies `transcripts` query filters on.
  */
@@ -63,6 +79,7 @@ export function firefliesDayWindow(
   date: string,
   timezone: string,
 ): { fromDate: string; toDate: string } {
+  assertValidTimezone(timezone);
   return {
     fromDate: new Date(zonedDayStartIso(date, timezone)).toISOString(),
     toDate: new Date(zonedDayStartIso(nextIsoDate(date), timezone)).toISOString(),

--- a/packages/connector-fireflies/tsconfig.json
+++ b/packages/connector-fireflies/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2024"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-core/src/wearables/registry.ts
+++ b/packages/remnic-core/src/wearables/registry.ts
@@ -84,6 +84,7 @@ const BUILT_IN_CONNECTOR_PACKAGES: Array<{ id: string; suffix: string }> = [
   { id: "limitless", suffix: "connector-limitless" },
   { id: "bee", suffix: "connector-bee" },
   { id: "omi", suffix: "connector-omi" },
+  { id: "fireflies", suffix: "connector-fireflies" },
 ];
 
 const loadFailuresWarned = new Set<string>();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,21 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/connector-fireflies:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/connector-limitless:
     devDependencies:
       '@remnic/core':

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -526,7 +526,7 @@ tests/query-aware-prefilter.test.ts(262,27): TS7006
 tests/query-aware-prefilter.test.ts(299,38): TS2339
 tests/query-aware-prefilter.test.ts(304,34): TS2339
 tests/recall-no-recall-short-circuit.test.ts(15,3): TS2740
-tests/release-workflow-public-packages.test.ts(152,41): TS7016
+tests/release-workflow-public-packages.test.ts(153,41): TS7016
 tests/remnic-cli-service-candidates.test.ts(17,82): TS7006
 tests/remnic-plugin-register-migration.test.ts(66,12): TS2352
 tests/remnic-server-cli.test.ts(9,30): TS7016

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -24,6 +24,7 @@ const expectedPublishDirs = [
   "packages/connector-limitless",
   "packages/connector-bee",
   "packages/connector-omi",
+  "packages/connector-fireflies",
   "packages/hermes-provider",
   "packages/belief-ledger",
   "packages/remnic-server",


### PR DESCRIPTION
Part of #1898 (Phase 2 of the desktop-capture epic #1896). First of the three cloud meeting connectors.

## API verification (mandatory per #1898)

Verified against current Fireflies docs on **2026-07-21**:
- Endpoint: `POST https://api.fireflies.ai/graphql` — https://docs.fireflies.ai/graphql-api/query/transcripts
- Auth: `Authorization: Bearer <key>` — https://docs.fireflies.ai/fundamentals/authorization
- `transcripts(fromDate, toDate, limit, skip)`: `fromDate`/`toDate` are ISO-8601 DateTime; `limit` max 50.
- Transcript fields used: `id`, `title`, `date` (epoch ms), `duration` (minutes), `summary { overview short_summary }`, `participants`, `sentences { index speaker_name speaker_id text start_time end_time }` where `start_time`/`end_time` are second-offsets from meeting start.

## What this adds

New à-la-carte package `@remnic/connector-fireflies` implementing `WearableSourceConnector` (mirrors `@remnic/connector-limitless`). No new pipeline machinery — pure API client + normalizer.

- **client.ts** — GraphQL transport, retry/backoff on 429/5xx, timeout, injectable fetch. A GraphQL `errors` array (incl. auth-coded) is a backend failure, **never** an empty result (§22); auth errors map to a bad-key `verifyAuth` result.
- **normalize.ts** — transcript → `WearableConversation`; DST-aware half-open `[start,end)` local-day window (`firefliesDayWindow`); second-offset → absolute UTC from meeting start; summary-without-transcript → single `note` segment; never guesses `isWearer`.
- **index.ts** — lazy client, env-first key resolution (`REMNIC_FIREFLIES_API_KEY` → `FIREFLIES_API_KEY` → config), keyset (`skip`) cursor with cycle guard, idempotent self-registration.
- Registry discovery entry `{ id: "fireflies", suffix: "connector-fireflies" }`.
- `docs/wearables.md` connector + credentials tables + per-source section; package README with key-acquisition walkthrough and cloud-service caveat.

## À-la-carte (AGENTS.md §44)

Optional peer dep on `@remnic/core`; discovered via computed-specifier dynamic import; not a `dependencies` entry of any base package; auto-included in the topological publish order (`scripts/publish-order.mjs` globs `packages/*`). Base installs unaffected.

## Charter

`enabled` defaults `false`; enabling Fireflies neither enables nor syncs any other source. `memoryMode` gates memory creation independently (`off` → transcript only).

## Verification

- 23 package tests pass (client transport incl. GraphQL-errors-as-failure, 401/5xx-retry/malformed/missing-key; normalize incl. absolute-UTC offset mapping, note fallback, DST day bounds; index registration/key-precedence/pagination/lazy-key-error).
- `check-types` clean, `build` OK, core `registry.test.ts` green (4), `npm run preflight:quick` OK.
- Fixtures are synthetic (public-repo privacy).

## Not in this PR

Real-account fixture recording (needs an owner API key) — CI uses injected fetch mocks per #1898's testing note. Granola + Otter connectors and the Plaud investigation are separate slices under #1898.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated optional package with no core pipeline changes; risk is limited to outbound API reads when a user enables the source and supplies a key.
> 
> **Overview**
> Adds an optional **`@remnic/connector-fireflies`** package so Fireflies.ai meeting transcripts can flow through the same wearables pipeline as pendant connectors (day markdown, search, trust-gated memories). Core is unchanged beyond registering **`fireflies`** in the built-in connector loader.
> 
> The connector implements **`WearableSourceConnector`**: a GraphQL client against Fireflies’ **`transcripts(fromDate, toDate)`** API (pagination via **`skip`**, retries on 429/5xx, GraphQL **`errors`** treated as failures not empty days), normalization into **`WearableConversation`** (DST-aware local day windows, sentence offsets → UTC, summary-only meetings as a **`note`** segment), lazy API key resolution, and **`verifyAuth`**. **`importNativeMemories`** is documented as a no-op for this source.
> 
> **`docs/wearables.md`** and a package README cover install, credentials (`REMNIC_FIREFLIES_API_KEY` / `FIREFLIES_API_KEY` / config), and cloud-ASR caveats. Release publish-order tests include the new package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37f76fcef18b1f172dd216ac0b8fca09c672bd52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional Fireflies connector (`@remnic/connector-fireflies`) to import Fireflies meeting transcripts into the wearables pipeline.
  - Added Fireflies API key configuration via connector settings or `REMNIC_FIREFLIES_API_KEY` / `FIREFLIES_API_KEY`.
  - Normalizes transcripts into timestamped, diarized segments and creates “note” segments for transcriptless meetings when summaries exist, with improved auth verification, pagination, and retry/error handling.

- **Documentation**
  - Extended wearables connector docs and added a Fireflies connector README (setup and syncing guidance).

- **Tests**
  - Added unit coverage for client, normalization, and connector registration, plus updated release workflow expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->