### PR TITLE
fix(access): decode category-named namespaces via storage probe (#2077)

### DIFF
--- a/packages/remnic-core/src/access-citation-namespace.ts
+++ b/packages/remnic-core/src/access-citation-namespace.ts
@@ -1,0 +1,68 @@
+import * as nodePath from "node:path";
+import { isPathInsideStorageRoot } from "./storage-paths.js";
+import { ALL_CATEGORY_DIRS } from "./utils/category-dir.js";
+
+/** Minimal storage surface the citation namespace decoder probes. */
+interface CitationProbeStorage {
+  dir: string;
+  readMemoryByPath(filePath: string): Promise<unknown | null>;
+}
+
+type CitationStorageResolver = (namespace: string) => Promise<CitationProbeStorage>;
+
+/**
+ * Probe whether `namespace` actually stores a memory at the cited relative
+ * path (#2077). Used to disambiguate a namespace whose name equals a memory
+ * category dir (e.g. `facts`) from a bare default category lead: a namespaced
+ * citation `facts/facts/a.md` (namespace `facts`, remaining `facts/a.md`) is
+ * owned, while a default `facts/a.md` (remaining `a.md`, no category dir) is
+ * not. Returns false on any resolution/read failure or path escape.
+ */
+async function namespaceOwnsRelativePath(
+  getStorage: CitationStorageResolver,
+  namespace: string,
+  relativePath: string,
+): Promise<boolean> {
+  const remainder = relativePath === namespace ? "" : relativePath.slice(namespace.length + 1);
+  if (!remainder) return false;
+  let storage: CitationProbeStorage;
+  try {
+    storage = await getStorage(namespace);
+  } catch {
+    return false;
+  }
+  const storageRoot = nodePath.resolve(storage.dir);
+  const candidate = nodePath.resolve(storageRoot, remainder);
+  if (!isPathInsideStorageRoot(storageRoot, candidate)) return false;
+  const memory = await storage.readMemoryByPath(candidate).catch(() => null);
+  return memory !== null;
+}
+
+/**
+ * Resolve which authorized namespace owns a *relative* cited path.
+ *
+ * Attributes to the longest authorized namespace that prefixes the cited path
+ * (namespace names may contain "/"). A bare category lead like a default
+ * `facts/a.md` is not a namespace. A namespace whose name equals a category dir
+ * (e.g. `facts`, rendered `facts/facts/a.md`) is ambiguous with that bare lead,
+ * so it counts only when its storage actually owns the remaining relative path
+ * (#2077). Falls back to `fallbackNamespace` when nothing matches.
+ */
+export async function decodeCitationNamespace(
+  getStorage: CitationStorageResolver,
+  authorizedNamespaces: readonly string[],
+  memoryPath: string,
+  fallbackNamespace: string,
+): Promise<string> {
+  let nsMatch = "";
+  for (const ns of authorizedNamespaces) {
+    if (!ns) continue;
+    const isPrefix = memoryPath === ns || memoryPath.startsWith(`${ns}/`);
+    if (!isPrefix || ns.length <= nsMatch.length) continue;
+    if (ALL_CATEGORY_DIRS.includes(ns) && !(await namespaceOwnsRelativePath(getStorage, ns, memoryPath))) {
+      continue;
+    }
+    nsMatch = ns;
+  }
+  return nsMatch || fallbackNamespace;
+}

--- a/packages/remnic-core/src/access-citation-namespace.ts
+++ b/packages/remnic-core/src/access-citation-namespace.ts
@@ -1,5 +1,6 @@
 import * as nodePath from "node:path";
 import { isPathInsideStorageRoot } from "./storage-paths.js";
+import { SecureStoreLockedError } from "./secure-store/secure-fs.js";
 import { ALL_CATEGORY_DIRS } from "./utils/category-dir.js";
 
 /** Minimal storage surface the citation namespace decoder probes. */
@@ -16,7 +17,9 @@ type CitationStorageResolver = (namespace: string) => Promise<CitationProbeStora
  * category dir (e.g. `facts`) from a bare default category lead: a namespaced
  * citation `facts/facts/a.md` (namespace `facts`, remaining `facts/a.md`) is
  * owned, while a default `facts/a.md` (remaining `a.md`, no category dir) is
- * not. Returns false on any resolution/read failure or path escape.
+ * not. Returns false on any resolution/read failure or path escape — except a
+ * locked encrypted store (`SecureStoreLockedError`), which propagates so a
+ * locked read is never silently mistaken for "not owned" (AGENTS.md §6).
  */
 async function namespaceOwnsRelativePath(
   getStorage: CitationStorageResolver,
@@ -34,7 +37,10 @@ async function namespaceOwnsRelativePath(
   const storageRoot = nodePath.resolve(storage.dir);
   const candidate = nodePath.resolve(storageRoot, remainder);
   if (!isPathInsideStorageRoot(storageRoot, candidate)) return false;
-  const memory = await storage.readMemoryByPath(candidate).catch(() => null);
+  const memory = await storage.readMemoryByPath(candidate).catch((err: unknown) => {
+    if (err instanceof SecureStoreLockedError) throw err;
+    return null;
+  });
   return memory !== null;
 }
 

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -11,6 +11,7 @@ import {
   type CitationUsageRequest,
   type CitationUsageResult,
 } from "./access-citation.js";
+import { decodeCitationNamespace } from "./access-citation-namespace.js";
 import { coordinateRecall, type RecallCoordinatorHost, type RecallExecResult } from "./access-recall-concurrency.js";
 import { resolveNamespaceCapabilities,
   resolveMemoryLifecycleCapabilities,
@@ -165,7 +166,6 @@ import {
   type GraphSnapshotNodeMetadata,
 } from "./graph-snapshot.js";
 import * as nodePath from "node:path";
-import { ALL_CATEGORY_DIRS } from "./utils/category-dir.js";
 import {
   buildBriefing,
   FileCalendarSource,
@@ -5037,16 +5037,12 @@ export class EngramAccessService {
             if (nodePath.isAbsolute(memoryPath)) {
               throw new EngramAccessInputError("cited path is outside the caller's readable namespaces");
             }
-            // Attribute to the longest authorized namespace that prefixes the cited
-            // path (namespace names may contain "/"); a bare category lead like a
-            // default `facts/a.md` is not a namespace (#2020).
-            let nsMatch = "";
-            for (const ns of authorizedNamespaces) {
-              if (!ns || ALL_CATEGORY_DIRS.includes(ns)) continue;
-              if ((memoryPath === ns || memoryPath.startsWith(`${ns}/`)) && ns.length > nsMatch.length) nsMatch = ns;
-            }
-            if (nsMatch) return nsMatch;
-            return fallbackNamespace;
+            return decodeCitationNamespace(
+              (ns) => this.orchestrator.getStorage(ns),
+              authorizedNamespaces,
+              memoryPath,
+              fallbackNamespace,
+            );
           }
           return resolved.namespace;
         },

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -158,9 +158,9 @@ tests/access-mcp.test.ts(163,69): TS7031
 tests/access-mcp.test.ts(163,89): TS7031
 tests/access-mcp.test.ts(191,29): TS7031
 tests/access-mcp.test.ts(191,42): TS7031
-tests/access-service.test.ts(434,35): TS2339
 tests/access-service.test.ts(435,35): TS2339
-tests/access-service.test.ts(2083,5): TS2349
+tests/access-service.test.ts(436,35): TS2339
+tests/access-service.test.ts(2084,5): TS2349
 tests/amb-bridge.test.ts(20,8): TS7016
 tests/amb-bridge.test.ts(477,9): TS7034
 tests/amb-bridge.test.ts(482,20): TS7006

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -4838,3 +4838,73 @@ test("recordCitationUsage prefers the cited path before id-only lookup", async (
   assert.equal(findCalls, 1);
   assert.deepEqual(tracked, [{ ids: ["same-id", "same-id"], paths: [firstPath, secondPath] }]);
 });
+
+test("recordCitationUsage decodes a namespace whose name equals a category dir when storage owns the cited path (#2077)", async () => {
+  const memoryDir = "/tmp/engram-2077";
+  const factsRoot = `${memoryDir}/namespaces/facts`;
+  const ownedAbs = `${factsRoot}/facts/2026-07-19/mem-1.md`;
+  const tracked: Array<{ ids: string[]; paths: string[]; namespaces?: Array<string | undefined> }> = [];
+  const storageFor = (ns: string) => ({
+    dir: ns === "global" ? memoryDir : `${memoryDir}/namespaces/${ns}`,
+    readMemoryByPath: async (candidate: string) =>
+      ns === "facts" && candidate === ownedAbs
+        ? { path: candidate, frontmatter: { id: "mem-1", category: "fact" }, content: "owned" }
+        : null,
+    readAllMemories: async () => {
+      throw new Error("citation tracking must not parse all memories");
+    },
+    findExistingMemoryPaths: async (ids: string[]) =>
+      ns === "facts" && ids.includes("mem-1")
+        ? new Map([["mem-1", [ownedAbs]]])
+        : new Map<string, string[]>(),
+  });
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      defaultRecallNamespaces: ["self", "shared"],
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        { name: "facts", readPrincipals: ["reader"], writePrincipals: ["facts-owner"] },
+      ],
+    },
+    getStorage: async (ns: string) => storageFor(ns),
+    trackMemoryAccess: (
+      ids: string[],
+      paths: string[],
+      namespaces?: Array<string | undefined>,
+    ) => {
+      tracked.push({ ids, paths, namespaces });
+    },
+  } as unknown as ConstructorParameters<typeof EngramAccessService>[0]);
+
+  // Cited as `facts/facts/...`: namespace `facts`, remaining `facts/2026-07-19/mem-1.md`.
+  // The old blanket category-name exclusion dropped this and fell back to the
+  // writable `global`, missing the real owner (#2077).
+  const owned = await service.recordCitationUsage({
+    namespace: "global",
+    authenticatedPrincipal: "reader",
+    entries: [{ path: "facts/facts/2026-07-19/mem-1.md", lineStart: 1, lineEnd: 1, note: "" }],
+    rolloutIds: [],
+  });
+
+  assert.deepEqual(owned, { submitted: 1, matched: 1 });
+  assert.equal(tracked.length, 1);
+  assert.deepEqual(tracked[0]?.namespaces, ["facts"]);
+  assert.deepEqual(tracked[0]?.paths, [ownedAbs]);
+
+  // A bare default `facts/orphan.md` (no category dir after the ns name) is NOT
+  // owned by the `facts` namespace and must still fall back to the writable one.
+  tracked.length = 0;
+  const bare = await service.recordCitationUsage({
+    namespace: "global",
+    authenticatedPrincipal: "reader",
+    entries: [{ path: "facts/orphan.md", lineStart: 1, lineEnd: 1, note: "" }],
+    rolloutIds: [],
+  });
+  assert.deepEqual(bare, { submitted: 1, matched: 0 });
+  assert.equal(tracked.length, 0);
+});

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -14,6 +14,7 @@ import {
   keyring,
   runSecureStoreInit,
   runSecureStoreUnlock,
+  SecureStoreLockedError,
   type ScryptParams,
 } from "../src/secure-store/index.js";
 import { StorageManager } from "../src/storage.js";
@@ -4907,4 +4908,89 @@ test("recordCitationUsage decodes a namespace whose name equals a category dir w
   });
   assert.deepEqual(bare, { submitted: 1, matched: 0 });
   assert.equal(tracked.length, 0);
+});
+
+test("recordCitationUsage falls back when a category-named namespace probe read fails (#2077)", async () => {
+  const memoryDir = "/tmp/engram-2077-probefail";
+  const tracked: Array<{ ids: string[]; paths: string[]; namespaces?: Array<string | undefined> }> = [];
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [{ name: "facts", readPrincipals: ["reader"], writePrincipals: ["facts-owner"] }],
+      defaultRecallNamespaces: ["self", "shared"],
+    },
+    getStorage: async (ns: string) => ({
+      dir: ns === "global" ? memoryDir : `${memoryDir}/namespaces/${ns}`,
+      readMemoryByPath: async () => {
+        throw new Error("disk read error");
+      },
+      readAllMemories: async () => {
+        throw new Error("citation tracking must not parse all memories");
+      },
+      findExistingMemoryPaths: async () => new Map<string, string[]>(),
+    }),
+    trackMemoryAccess: (
+      ids: string[],
+      paths: string[],
+      namespaces?: Array<string | undefined>,
+    ) => {
+      tracked.push({ ids, paths, namespaces });
+    },
+  } as unknown as ConstructorParameters<typeof EngramAccessService>[0]);
+
+  const result = await service.recordCitationUsage({
+    namespace: "global",
+    authenticatedPrincipal: "reader",
+    entries: [{ path: "facts/facts/2026-07-19/mem-1.md", lineStart: 1, lineEnd: 1, note: "" }],
+    rolloutIds: [],
+  });
+
+  // A generic probe read failure is treated as "not owned", so decoding falls
+  // back to the writable `global` namespace, which does not contain the memory.
+  assert.deepEqual(result, { submitted: 1, matched: 0 });
+  assert.equal(tracked.length, 0);
+});
+
+test("recordCitationUsage surfaces a locked-store error during category-namespace probe (#2077)", async () => {
+  const memoryDir = "/tmp/engram-2077-locked";
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [{ name: "facts", readPrincipals: ["reader"], writePrincipals: ["facts-owner"] }],
+      defaultRecallNamespaces: ["self", "shared"],
+    },
+    getStorage: async (ns: string) => ({
+      dir: ns === "global" ? memoryDir : `${memoryDir}/namespaces/${ns}`,
+      readMemoryByPath: async () => {
+        throw new SecureStoreLockedError();
+      },
+      readAllMemories: async () => {
+        throw new Error("citation tracking must not parse all memories");
+      },
+      findExistingMemoryPaths: async () => new Map<string, string[]>(),
+    }),
+    trackMemoryAccess: () => {},
+  } as unknown as ConstructorParameters<typeof EngramAccessService>[0]);
+
+  // A locked encrypted store must NOT be silently mistaken for "not owned"
+  // (AGENTS.md §6) — the error propagates instead of falling back.
+  await assert.rejects(
+    service.recordCitationUsage({
+      namespace: "global",
+      authenticatedPrincipal: "reader",
+      entries: [{ path: "facts/facts/2026-07-19/mem-1.md", lineStart: 1, lineEnd: 1, note: "" }],
+      rolloutIds: [],
+    }),
+    (err: unknown) => err instanceof SecureStoreLockedError,
+  );
 });


### PR DESCRIPTION
## Summary

Part of #2077 (finding 2, P2). Focused fix; kept the review surface small.

The citation decoder (`recordCitationUsage` → `resolveNamespaceForPath`) excluded **any** authorized namespace whose name equals a category dir (e.g. `facts`) to avoid misreading a default `facts/a.md` citation as belonging to a `facts` namespace. But that blanket exclusion also dropped a namespace **literally named** `facts` — rendered `facts/facts/a.md` — so its citations fell back to the writable namespace and access tracking missed (or updated the wrong same-id) memory.

## Change

- Replace the blanket `ALL_CATEGORY_DIRS.includes(ns)` skip with a **storage-ownership probe**: a category-named namespace counts as the owner only when its storage actually contains the remaining relative path (via `readMemoryByPath`). Non-category namespaces keep the existing longest-prefix behavior.
- Extract the decode into a sibling module `access-citation-namespace.ts` (`decodeCitationNamespace`) so `access-service.ts` stays under its structural size ratchet (#1520/#1995). No baseline was raised.

## Tests

- New `access-service.test.ts` case: a `facts/facts/…` citation whose `facts`-namespace storage owns the path resolves to `facts` (not the writable `global`); and a bare default `facts/orphan.md` that `facts` does **not** own still falls back to the writable namespace (matched 0). This proves the guard still protects the default-category case rather than just being removed.

## Verification

- `access-citation.test.ts` + `access-service.test.ts`: 93 green.
- `npm run preflight:quick`: OK (lint, check-types, config-contract, ratchets, docs-parity, quick suites).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how relative citation paths map to namespaces for access tracking; behavior is narrowed with path checks and explicit locked-store handling, with targeted tests.
> 
> **Overview**
> Fixes citation namespace decoding when an authorized namespace is **named like a memory category** (e.g. `facts`). The previous rule skipped every category-named namespace, so paths such as `facts/facts/…` were attributed to the writable fallback instead of the real `facts` namespace, breaking citation access tracking (#2077).
> 
> Citation decoding is moved into `decodeCitationNamespace` in `access-citation-namespace.ts`. Longest-prefix matching is unchanged for normal namespaces; for names that match category dirs, a namespace counts only if a **storage probe** (`readMemoryByPath` on the path remainder, with root containment checks) shows it actually owns the cited file. Bare default paths like `facts/orphan.md` still do not match. `SecureStoreLockedError` propagates instead of being treated as “not owned.”
> 
> `access-service` wires the helper into `recordCitationUsage` path resolution. Tests cover owned vs bare paths, probe read failures, and locked-store behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19451f8dc9bfe361ab393795012c576153f5ac1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved citation attribution for namespaces that overlap with category directories (e.g., `facts`), ensuring the correct owning namespace is selected.
  - Correctly resolves ownership for relative cited paths, including cases where namespace names contain nested path segments.
  - Avoids incorrect “fallback” attribution when a cited path isn’t owned; safely rejects invalid or out-of-bounds paths.
  - Preserves locked-store behavior by propagating lock errors instead of treating them as not-owned.
- **Tests**
  - Added coverage for additional namespace/category ownership scenarios and locked-store handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->