### PR TITLE
fix(recall): relativize debug snapshot internal paths (#2077)

### DIFF
--- a/packages/remnic-core/src/access-recall-response.ts
+++ b/packages/remnic-core/src/access-recall-response.ts
@@ -245,7 +245,7 @@ export async function assembleRecallResponse(
   const debugSnapshot = debug?.snapshot;
   const safeDebug =
     debug && debugSnapshot
-      ? { ...debug, snapshot: displaySafeRecallSnapshot(debugSnapshot, deps.orchestrator.config.memoryDir) }
+      ? { ...debug, snapshot: displaySafeRecallSnapshot(debugSnapshot, deps.orchestrator.config) }
       : debug;
 
   // Fire-and-forget audit recording. Must never block or crash recall.

--- a/packages/remnic-core/src/access-recall-response.ts
+++ b/packages/remnic-core/src/access-recall-response.ts
@@ -245,7 +245,7 @@ export async function assembleRecallResponse(
   const debugSnapshot = debug?.snapshot;
   const safeDebug =
     debug && debugSnapshot
-      ? { ...debug, snapshot: displaySafeRecallSnapshot(debugSnapshot, deps.orchestrator.config) }
+      ? { ...debug, snapshot: displaySafeRecallSnapshot(debugSnapshot, deps.orchestrator.config.memoryDir) }
       : debug;
 
   // Fire-and-forget audit recording. Must never block or crash recall.

--- a/packages/remnic-core/src/access-recall-response.ts
+++ b/packages/remnic-core/src/access-recall-response.ts
@@ -15,7 +15,7 @@ import { type BudgetDecision, toBudgetWarning } from "./cross-namespace-budget.j
 import { decideDisclosureEscalation } from "./recall-disclosure-escalation.js";
 import { type TagMatchMode, applyTagFilter, normalizeTags, parseTagMatch } from "./recall-tag-filter.js";
 import type { RecallDisclosure, RecallPlanMode } from "./types.js";
-import { displaySafeBudgetsApplied } from "./orchestration/recall-result-formatter.js";
+import { displaySafeBudgetsApplied, displaySafeRecallSnapshot } from "./orchestration/recall-result-formatter.js";
 
 /**
  * Build the recall response from the completed pipeline (issue #1906 review
@@ -238,6 +238,15 @@ export async function assembleRecallResponse(
     request.includeDebug === true,
     request.sessionKey,
   );
+  // Relativize the debug snapshot's absolute internal paths (#2077). The
+  // snapshot returned by buildRecallDebug is the LIVE cached object (kept
+  // absolute for tracking/x-ray), so build a display-safe COPY rather than
+  // mutating it — mirroring the top-level `budgetsApplied` relativization.
+  const debugSnapshot = debug?.snapshot;
+  const safeDebug =
+    debug && debugSnapshot
+      ? { ...debug, snapshot: displaySafeRecallSnapshot(debugSnapshot, deps.orchestrator.config.memoryDir) }
+      : debug;
 
   // Fire-and-forget audit recording. Must never block or crash recall.
   let auditAnomalies: AccessAuditResult["anomalies"] | undefined;
@@ -295,7 +304,7 @@ export async function assembleRecallResponse(
       auditAnomalies,
       budgetWarning: toBudgetWarning(budgetDecision),
       latencyMs: snapshot?.latencyMs ?? (Date.now() - startedAt),
-      debug,
+      debug: safeDebug,
     },
     // Non-null when this recall reserved a cross-namespace budget event at
     // admission (#1906). Single-flight followers use it to record their OWN

--- a/packages/remnic-core/src/orchestration/recall-result-formatter-display-safe.test.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter-display-safe.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { displaySafeRecallSnapshot } from "./recall-result-formatter.js";
+import { namespaceIdentityToken } from "../namespaces/identity.js";
+
+test("displaySafeRecallSnapshot relativizes result, budget, and tier-anchor paths without mutating input (#2077)", () => {
+  const memoryDir = "/srv/memory";
+  const nsToken = namespaceIdentityToken("team-alpha");
+  const nsAnchorAbs = `${memoryDir}/namespaces/${nsToken}/facts/2026-07-19/a.md`;
+  const flatAbs = `${memoryDir}/facts/2026-07-19/b.md`;
+  const snapshot = {
+    resultPaths: [flatAbs],
+    resultNamespaces: [undefined],
+    budgetsApplied: {
+      includedMemoryPaths: [flatAbs],
+      includedMemoryNamespaces: [undefined],
+    },
+    tierExplain: {
+      tier: "direct-answer",
+      tierReason: "single high-confidence hit",
+      filteredBy: [],
+      candidatesConsidered: 1,
+      latencyMs: 1,
+      sourceAnchors: [
+        { path: nsAnchorAbs, lineRange: [1, 2] as [number, number] },
+        { path: flatAbs },
+      ],
+    },
+  };
+
+  const safe = displaySafeRecallSnapshot(snapshot, memoryDir);
+
+  assert.deepEqual(safe.resultPaths, ["facts/2026-07-19/b.md"]);
+  assert.deepEqual(safe.budgetsApplied.includedMemoryPaths, ["facts/2026-07-19/b.md"]);
+  // A namespaced anchor renders as "<namespace>/…" — never the raw, reversible
+  // identity token — and a flat default-namespace anchor stays memoryDir-relative.
+  assert.deepEqual(safe.tierExplain.sourceAnchors, [
+    { path: "team-alpha/facts/2026-07-19/a.md", lineRange: [1, 2] },
+    { path: "facts/2026-07-19/b.md" },
+  ]);
+
+  // The input snapshot must not be mutated — the live cache keeps absolute paths.
+  assert.equal(snapshot.tierExplain.sourceAnchors[0].path, nsAnchorAbs);
+  assert.equal(snapshot.resultPaths[0], flatAbs);
+});

--- a/packages/remnic-core/src/orchestration/recall-result-formatter-display-safe.test.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter-display-safe.test.ts
@@ -1,31 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { displaySafeRecallSnapshot } from "./recall-result-formatter.js";
-import { namespaceIdentityToken } from "../namespaces/identity.js";
-import type { PluginConfig } from "../types.js";
 
 test("displaySafeRecallSnapshot relativizes result, budget, and tier-anchor paths without mutating input (#2077)", () => {
   const memoryDir = "/srv/memory";
-  // A namespace stored under its encoded identity token…
-  const encodedToken = namespaceIdentityToken("team-alpha");
-  const encodedAnchorAbs = `${memoryDir}/namespaces/${encodedToken}/facts/2026-07-19/a.md`;
-  // …and a namespace whose LITERAL name is itself token-shaped and is preserved
-  // raw on disk (ns-616c706861 would otherwise decode to "alpha").
-  const rawTokenNs = "ns-616c706861";
-  const rawAnchorAbs = `${memoryDir}/namespaces/${rawTokenNs}/facts/2026-07-19/c.md`;
+  const nsAnchorAbs = `${memoryDir}/namespaces/ns-616c706861/facts/2026-07-19/a.md`;
   const flatAbs = `${memoryDir}/facts/2026-07-19/b.md`;
-
-  const config = {
-    memoryDir,
-    namespacesEnabled: true,
-    defaultNamespace: "global",
-    sharedNamespace: "shared",
-    namespacePolicies: [
-      { name: "team-alpha", readPrincipals: ["*"], writePrincipals: ["*"] },
-      { name: rawTokenNs, readPrincipals: ["*"], writePrincipals: ["*"] },
-    ],
-  } as unknown as PluginConfig;
-
   const snapshot = {
     resultPaths: [flatAbs],
     resultNamespaces: [undefined],
@@ -40,27 +20,25 @@ test("displaySafeRecallSnapshot relativizes result, budget, and tier-anchor path
       candidatesConsidered: 1,
       latencyMs: 1,
       sourceAnchors: [
-        { path: encodedAnchorAbs, lineRange: [1, 2] as [number, number] },
-        { path: rawAnchorAbs },
+        { path: nsAnchorAbs, lineRange: [1, 2] as [number, number] },
         { path: flatAbs },
       ],
     },
   };
 
-  const safe = displaySafeRecallSnapshot(snapshot, config);
+  const safe = displaySafeRecallSnapshot(snapshot, memoryDir);
 
   assert.deepEqual(safe.resultPaths, ["facts/2026-07-19/b.md"]);
   assert.deepEqual(safe.budgetsApplied.includedMemoryPaths, ["facts/2026-07-19/b.md"]);
+  // Anchors are rendered memoryDir-relative — no absolute operator path, and the
+  // TRUE on-disk storage segment (never a decoded guess that could mislabel a
+  // token-shaped or catalog-owned namespace whose owner the anchor does not carry).
   assert.deepEqual(safe.tierExplain.sourceAnchors, [
-    // An encoded token resolves back to the real namespace name.
-    { path: "team-alpha/facts/2026-07-19/a.md", lineRange: [1, 2] },
-    // A token-shaped LITERAL namespace name is preserved, never decoded to "alpha".
-    { path: "ns-616c706861/facts/2026-07-19/c.md" },
-    // A flat default-namespace anchor stays memoryDir-relative.
+    { path: "namespaces/ns-616c706861/facts/2026-07-19/a.md", lineRange: [1, 2] },
     { path: "facts/2026-07-19/b.md" },
   ]);
 
   // The input snapshot must not be mutated — the live cache keeps absolute paths.
-  assert.equal(snapshot.tierExplain.sourceAnchors[0].path, encodedAnchorAbs);
+  assert.equal(snapshot.tierExplain.sourceAnchors[0].path, nsAnchorAbs);
   assert.equal(snapshot.resultPaths[0], flatAbs);
 });

--- a/packages/remnic-core/src/orchestration/recall-result-formatter-display-safe.test.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter-display-safe.test.ts
@@ -4,23 +4,26 @@ import { displaySafeRecallSnapshot } from "./recall-result-formatter.js";
 
 test("displaySafeRecallSnapshot relativizes result, budget, and tier-anchor paths without mutating input (#2077)", () => {
   const memoryDir = "/srv/memory";
-  const nsAnchorAbs = `${memoryDir}/namespaces/ns-616c706861/facts/2026-07-19/a.md`;
   const flatAbs = `${memoryDir}/facts/2026-07-19/b.md`;
+  const nsResultAbs = `${memoryDir}/namespaces/tok-team/facts/2026-07-19/r.md`;
+  // An anchor that is NOT among the returned results — no authoritative owner.
+  const unmatchedAnchorAbs = `${memoryDir}/namespaces/ns-616c706861/facts/2026-07-19/a.md`;
   const snapshot = {
-    resultPaths: [flatAbs],
-    resultNamespaces: [undefined],
+    resultPaths: [flatAbs, nsResultAbs],
+    resultNamespaces: [undefined, "team-alpha"],
     budgetsApplied: {
-      includedMemoryPaths: [flatAbs],
-      includedMemoryNamespaces: [undefined],
+      includedMemoryPaths: [flatAbs, nsResultAbs],
+      includedMemoryNamespaces: [undefined, "team-alpha"],
     },
     tierExplain: {
       tier: "direct-answer",
       tierReason: "single high-confidence hit",
       filteredBy: [],
-      candidatesConsidered: 1,
+      candidatesConsidered: 2,
       latencyMs: 1,
       sourceAnchors: [
-        { path: nsAnchorAbs, lineRange: [1, 2] as [number, number] },
+        { path: nsResultAbs, lineRange: [1, 2] as [number, number] },
+        { path: unmatchedAnchorAbs },
         { path: flatAbs },
       ],
     },
@@ -28,17 +31,21 @@ test("displaySafeRecallSnapshot relativizes result, budget, and tier-anchor path
 
   const safe = displaySafeRecallSnapshot(snapshot, memoryDir);
 
-  assert.deepEqual(safe.resultPaths, ["facts/2026-07-19/b.md"]);
-  assert.deepEqual(safe.budgetsApplied.includedMemoryPaths, ["facts/2026-07-19/b.md"]);
-  // Anchors are rendered memoryDir-relative — no absolute operator path, and the
-  // TRUE on-disk storage segment (never a decoded guess that could mislabel a
-  // token-shaped or catalog-owned namespace whose owner the anchor does not carry).
+  assert.deepEqual(safe.resultPaths, ["facts/2026-07-19/b.md", "team-alpha/facts/2026-07-19/r.md"]);
+  assert.deepEqual(safe.budgetsApplied.includedMemoryPaths, [
+    "facts/2026-07-19/b.md",
+    "team-alpha/facts/2026-07-19/r.md",
+  ]);
   assert.deepEqual(safe.tierExplain.sourceAnchors, [
-    { path: "namespaces/ns-616c706861/facts/2026-07-19/a.md", lineRange: [1, 2] },
+    // Anchor coincides with a namespaced result → reuses its authoritative namespace.
+    { path: "team-alpha/facts/2026-07-19/r.md", lineRange: [1, 2] },
+    // Anchor not among the results → truthful storage-relative segment, never a decode.
+    { path: "namespaces/ns-616c706861/facts/2026-07-19/a.md" },
+    // Anchor coincides with a default-namespace result → memoryDir-relative.
     { path: "facts/2026-07-19/b.md" },
   ]);
 
   // The input snapshot must not be mutated — the live cache keeps absolute paths.
-  assert.equal(snapshot.tierExplain.sourceAnchors[0].path, nsAnchorAbs);
-  assert.equal(snapshot.resultPaths[0], flatAbs);
+  assert.equal(snapshot.tierExplain.sourceAnchors[0].path, nsResultAbs);
+  assert.equal(snapshot.resultPaths[1], nsResultAbs);
 });

--- a/packages/remnic-core/src/orchestration/recall-result-formatter-display-safe.test.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter-display-safe.test.ts
@@ -2,12 +2,30 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { displaySafeRecallSnapshot } from "./recall-result-formatter.js";
 import { namespaceIdentityToken } from "../namespaces/identity.js";
+import type { PluginConfig } from "../types.js";
 
 test("displaySafeRecallSnapshot relativizes result, budget, and tier-anchor paths without mutating input (#2077)", () => {
   const memoryDir = "/srv/memory";
-  const nsToken = namespaceIdentityToken("team-alpha");
-  const nsAnchorAbs = `${memoryDir}/namespaces/${nsToken}/facts/2026-07-19/a.md`;
+  // A namespace stored under its encoded identity token…
+  const encodedToken = namespaceIdentityToken("team-alpha");
+  const encodedAnchorAbs = `${memoryDir}/namespaces/${encodedToken}/facts/2026-07-19/a.md`;
+  // …and a namespace whose LITERAL name is itself token-shaped and is preserved
+  // raw on disk (ns-616c706861 would otherwise decode to "alpha").
+  const rawTokenNs = "ns-616c706861";
+  const rawAnchorAbs = `${memoryDir}/namespaces/${rawTokenNs}/facts/2026-07-19/c.md`;
   const flatAbs = `${memoryDir}/facts/2026-07-19/b.md`;
+
+  const config = {
+    memoryDir,
+    namespacesEnabled: true,
+    defaultNamespace: "global",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "team-alpha", readPrincipals: ["*"], writePrincipals: ["*"] },
+      { name: rawTokenNs, readPrincipals: ["*"], writePrincipals: ["*"] },
+    ],
+  } as unknown as PluginConfig;
+
   const snapshot = {
     resultPaths: [flatAbs],
     resultNamespaces: [undefined],
@@ -22,24 +40,27 @@ test("displaySafeRecallSnapshot relativizes result, budget, and tier-anchor path
       candidatesConsidered: 1,
       latencyMs: 1,
       sourceAnchors: [
-        { path: nsAnchorAbs, lineRange: [1, 2] as [number, number] },
+        { path: encodedAnchorAbs, lineRange: [1, 2] as [number, number] },
+        { path: rawAnchorAbs },
         { path: flatAbs },
       ],
     },
   };
 
-  const safe = displaySafeRecallSnapshot(snapshot, memoryDir);
+  const safe = displaySafeRecallSnapshot(snapshot, config);
 
   assert.deepEqual(safe.resultPaths, ["facts/2026-07-19/b.md"]);
   assert.deepEqual(safe.budgetsApplied.includedMemoryPaths, ["facts/2026-07-19/b.md"]);
-  // A namespaced anchor renders as "<namespace>/…" — never the raw, reversible
-  // identity token — and a flat default-namespace anchor stays memoryDir-relative.
   assert.deepEqual(safe.tierExplain.sourceAnchors, [
+    // An encoded token resolves back to the real namespace name.
     { path: "team-alpha/facts/2026-07-19/a.md", lineRange: [1, 2] },
+    // A token-shaped LITERAL namespace name is preserved, never decoded to "alpha".
+    { path: "ns-616c706861/facts/2026-07-19/c.md" },
+    // A flat default-namespace anchor stays memoryDir-relative.
     { path: "facts/2026-07-19/b.md" },
   ]);
 
   // The input snapshot must not be mutated — the live cache keeps absolute paths.
-  assert.equal(snapshot.tierExplain.sourceAnchors[0].path, nsAnchorAbs);
+  assert.equal(snapshot.tierExplain.sourceAnchors[0].path, encodedAnchorAbs);
   assert.equal(snapshot.resultPaths[0], flatAbs);
 });

--- a/packages/remnic-core/src/orchestration/recall-result-formatter.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter.ts
@@ -20,8 +20,7 @@
 import { buildHandleIndexForResults } from "../recall-handles.js";
 import path from "node:path";
 import { renderEpistemicHedge } from "../trust-score.js";
-import { resolveIdentityContinuityCapabilities, resolveNamespaceCapabilities } from "../capabilities.js";
-import { resolveNamespaceFromStorageDir } from "../scopes/scope-plan.js";
+import { resolveIdentityContinuityCapabilities } from "../capabilities.js";
 import type { StorageManager } from "../index.js";
 import type { ObjectiveStateSearchResult } from "../objective-state.js";
 import type { CausalTrajectorySearchResult } from "../causal-trajectory.js";
@@ -116,31 +115,6 @@ export function displaySafeBudgetsApplied<
 }
 
 /**
- * Resolve the owning namespace of an absolute anchor path under
- * `<memoryDir>/namespaces/<segment>/…` via the canonical
- * `resolveNamespaceFromStorageDir` resolver, so `displayResultPath` renders it
- * as `<namespace>/…` (never the raw storage segment) while correctly preserving
- * a namespace whose literal name is itself token-shaped (#2077). Returns
- * undefined for a default-namespace (flat-root) or non-absolute path, whose
- * memoryDir-relative form is already display-safe.
- */
-function anchorNamespace(anchorPath: string, config: PluginConfig): string | undefined {
-  if (!path.isAbsolute(anchorPath)) return undefined;
-  const nsRoot = path.join(path.resolve(config.memoryDir), "namespaces");
-  const rel = path.relative(nsRoot, path.resolve(anchorPath));
-  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) return undefined;
-  const [segment] = rel.split(path.sep);
-  if (!segment) return undefined;
-  const configuredNamespaces = resolveNamespaceCapabilities(config).namespaces
-    ? [config.defaultNamespace, config.sharedNamespace, ...config.namespacePolicies.map((p) => p.name)]
-    : [config.defaultNamespace];
-  return resolveNamespaceFromStorageDir(path.join(nsRoot, segment), {
-    config,
-    configuredNamespaces,
-  });
-}
-
-/**
  * Return a display-safe copy of a recall snapshot for the `includeDebug=true`
  * surface (#2077). `resultPaths`, `budgetsApplied.includedMemoryPaths`, and
  * `tierExplain.sourceAnchors[].path` are rendered memoryDir-relative — the same
@@ -161,8 +135,7 @@ export function displaySafeRecallSnapshot<
       sourceAnchors?: Array<{ path: string; lineRange?: [number, number] }>;
     };
   },
->(snapshot: T, config: PluginConfig): T {
-  const memoryDir = config.memoryDir;
+>(snapshot: T, memoryDir: string): T {
   const resultPaths = snapshot.resultPaths?.map((p, i) =>
     displayResultPath(p, memoryDir, snapshot.resultNamespaces?.[i]),
   );
@@ -172,7 +145,7 @@ export function displaySafeRecallSnapshot<
           ...snapshot.tierExplain,
           sourceAnchors: snapshot.tierExplain.sourceAnchors.map((anchor) => ({
             ...anchor,
-            path: displayResultPath(anchor.path, memoryDir, anchorNamespace(anchor.path, config)),
+            path: displayResultPath(anchor.path, memoryDir),
           })),
         }
       : undefined;

--- a/packages/remnic-core/src/orchestration/recall-result-formatter.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter.ts
@@ -116,11 +116,12 @@ export function displaySafeBudgetsApplied<
 
 /**
  * Return a display-safe copy of a recall snapshot for the `includeDebug=true`
- * surface (#2077). `resultPaths` and `budgetsApplied.includedMemoryPaths` are
- * rendered memoryDir-relative — the same relativization the top-level recall
- * response already applies — so the debug flag never leaks operator filesystem
- * paths even though the live snapshot keeps absolute paths for tracking/x-ray.
- * Returns a shallow copy; the input snapshot is never mutated.
+ * surface (#2077). `resultPaths`, `budgetsApplied.includedMemoryPaths`, and
+ * `tierExplain.sourceAnchors[].path` are rendered memoryDir-relative — the same
+ * relativization the top-level recall response already applies — so the debug
+ * flag never leaks operator filesystem paths even though the live snapshot
+ * keeps absolute paths for tracking/x-ray. Returns a shallow copy; the input
+ * snapshot is never mutated.
  */
 export function displaySafeRecallSnapshot<
   T extends {
@@ -130,17 +131,31 @@ export function displaySafeRecallSnapshot<
       includedMemoryPaths?: string[];
       includedMemoryNamespaces?: Array<string | undefined>;
     };
+    tierExplain?: {
+      sourceAnchors?: Array<{ path: string; lineRange?: [number, number] }>;
+    };
   },
 >(snapshot: T, memoryDir: string): T {
   const resultPaths = snapshot.resultPaths?.map((p, i) =>
     displayResultPath(p, memoryDir, snapshot.resultNamespaces?.[i]),
   );
+  const tierExplain =
+    snapshot.tierExplain?.sourceAnchors
+      ? {
+          ...snapshot.tierExplain,
+          sourceAnchors: snapshot.tierExplain.sourceAnchors.map((anchor) => ({
+            ...anchor,
+            path: displayResultPath(anchor.path, memoryDir),
+          })),
+        }
+      : undefined;
   return {
     ...snapshot,
     ...(resultPaths ? { resultPaths } : {}),
     ...(snapshot.budgetsApplied
       ? { budgetsApplied: displaySafeBudgetsApplied(snapshot.budgetsApplied, memoryDir) }
       : {}),
+    ...(tierExplain ? { tierExplain } : {}),
   };
 }
 

--- a/packages/remnic-core/src/orchestration/recall-result-formatter.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter.ts
@@ -21,6 +21,7 @@ import { buildHandleIndexForResults } from "../recall-handles.js";
 import path from "node:path";
 import { renderEpistemicHedge } from "../trust-score.js";
 import { resolveIdentityContinuityCapabilities } from "../capabilities.js";
+import { namespaceIdentityFromToken } from "../namespaces/identity.js";
 import type { StorageManager } from "../index.js";
 import type { ObjectiveStateSearchResult } from "../objective-state.js";
 import type { CausalTrajectorySearchResult } from "../causal-trajectory.js";
@@ -115,6 +116,23 @@ export function displaySafeBudgetsApplied<
 }
 
 /**
+ * Decode the owning namespace of an absolute anchor path under
+ * `<memoryDir>/namespaces/<identity-token>/…` so `displayResultPath` renders it
+ * as `<namespace>/…` rather than exposing the reversible identity token (#2077).
+ * Returns undefined for default-namespace (flat-root) or non-absolute paths,
+ * whose memoryDir-relative form is already display-safe.
+ */
+function namespaceForAnchorPath(anchorPath: string, memoryDir: string): string | undefined {
+  if (!path.isAbsolute(anchorPath)) return undefined;
+  const nsRoot = path.join(path.resolve(memoryDir), "namespaces");
+  const rel = path.relative(nsRoot, path.resolve(anchorPath));
+  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) return undefined;
+  const [token] = rel.split(path.sep);
+  if (!token) return undefined;
+  return namespaceIdentityFromToken(token) ?? undefined;
+}
+
+/**
  * Return a display-safe copy of a recall snapshot for the `includeDebug=true`
  * surface (#2077). `resultPaths`, `budgetsApplied.includedMemoryPaths`, and
  * `tierExplain.sourceAnchors[].path` are rendered memoryDir-relative — the same
@@ -145,7 +163,7 @@ export function displaySafeRecallSnapshot<
           ...snapshot.tierExplain,
           sourceAnchors: snapshot.tierExplain.sourceAnchors.map((anchor) => ({
             ...anchor,
-            path: displayResultPath(anchor.path, memoryDir),
+            path: displayResultPath(anchor.path, memoryDir, namespaceForAnchorPath(anchor.path, memoryDir)),
           })),
         }
       : undefined;

--- a/packages/remnic-core/src/orchestration/recall-result-formatter.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter.ts
@@ -114,6 +114,36 @@ export function displaySafeBudgetsApplied<
   };
 }
 
+/**
+ * Return a display-safe copy of a recall snapshot for the `includeDebug=true`
+ * surface (#2077). `resultPaths` and `budgetsApplied.includedMemoryPaths` are
+ * rendered memoryDir-relative — the same relativization the top-level recall
+ * response already applies — so the debug flag never leaks operator filesystem
+ * paths even though the live snapshot keeps absolute paths for tracking/x-ray.
+ * Returns a shallow copy; the input snapshot is never mutated.
+ */
+export function displaySafeRecallSnapshot<
+  T extends {
+    resultPaths?: string[];
+    resultNamespaces?: Array<string | undefined>;
+    budgetsApplied?: {
+      includedMemoryPaths?: string[];
+      includedMemoryNamespaces?: Array<string | undefined>;
+    };
+  },
+>(snapshot: T, memoryDir: string): T {
+  const resultPaths = snapshot.resultPaths?.map((p, i) =>
+    displayResultPath(p, memoryDir, snapshot.resultNamespaces?.[i]),
+  );
+  return {
+    ...snapshot,
+    ...(resultPaths ? { resultPaths } : {}),
+    ...(snapshot.budgetsApplied
+      ? { budgetsApplied: displaySafeBudgetsApplied(snapshot.budgetsApplied, memoryDir) }
+      : {}),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Coordinator
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/orchestration/recall-result-formatter.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter.ts
@@ -116,12 +116,14 @@ export function displaySafeBudgetsApplied<
 
 /**
  * Return a display-safe copy of a recall snapshot for the `includeDebug=true`
- * surface (#2077). `resultPaths`, `budgetsApplied.includedMemoryPaths`, and
- * `tierExplain.sourceAnchors[].path` are rendered memoryDir-relative — the same
- * relativization the top-level recall response already applies — so the debug
- * flag never leaks operator filesystem paths even though the live snapshot
- * keeps absolute paths for tracking/x-ray. Returns a shallow copy; the input
- * snapshot is never mutated.
+ * surface (#2077). `resultPaths` and `budgetsApplied.includedMemoryPaths` are
+ * rendered namespace-relative from their aligned namespace metadata; a
+ * `tierExplain.sourceAnchors[]` entry reuses that SAME authoritative metadata
+ * when its absolute path matches a result/included path, and otherwise falls
+ * back to the memoryDir-relative on-disk form. Either way the debug flag never
+ * leaks absolute operator paths, and an anchor is never attributed to a decoded
+ * (guessed) namespace — an anchor carries no owner of its own. Returns a
+ * shallow copy; the input snapshot is never mutated.
  */
 export function displaySafeRecallSnapshot<
   T extends {
@@ -139,13 +141,25 @@ export function displaySafeRecallSnapshot<
   const resultPaths = snapshot.resultPaths?.map((p, i) =>
     displayResultPath(p, memoryDir, snapshot.resultNamespaces?.[i]),
   );
+  // Authoritative absolute-path -> namespace map recorded at capture time, so a
+  // tier anchor that coincides with a returned result renders under the SAME
+  // namespace as that result instead of the raw storage segment (#2077).
+  const namespaceByPath = new Map<string, string | undefined>();
+  snapshot.resultPaths?.forEach((p, i) => {
+    if (!namespaceByPath.has(p)) namespaceByPath.set(p, snapshot.resultNamespaces?.[i]);
+  });
+  snapshot.budgetsApplied?.includedMemoryPaths?.forEach((p, i) => {
+    if (!namespaceByPath.has(p)) {
+      namespaceByPath.set(p, snapshot.budgetsApplied?.includedMemoryNamespaces?.[i]);
+    }
+  });
   const tierExplain =
     snapshot.tierExplain?.sourceAnchors
       ? {
           ...snapshot.tierExplain,
           sourceAnchors: snapshot.tierExplain.sourceAnchors.map((anchor) => ({
             ...anchor,
-            path: displayResultPath(anchor.path, memoryDir),
+            path: displayResultPath(anchor.path, memoryDir, namespaceByPath.get(anchor.path)),
           })),
         }
       : undefined;

--- a/packages/remnic-core/src/orchestration/recall-result-formatter.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter.ts
@@ -20,8 +20,8 @@
 import { buildHandleIndexForResults } from "../recall-handles.js";
 import path from "node:path";
 import { renderEpistemicHedge } from "../trust-score.js";
-import { resolveIdentityContinuityCapabilities } from "../capabilities.js";
-import { namespaceIdentityFromToken } from "../namespaces/identity.js";
+import { resolveIdentityContinuityCapabilities, resolveNamespaceCapabilities } from "../capabilities.js";
+import { resolveNamespaceFromStorageDir } from "../scopes/scope-plan.js";
 import type { StorageManager } from "../index.js";
 import type { ObjectiveStateSearchResult } from "../objective-state.js";
 import type { CausalTrajectorySearchResult } from "../causal-trajectory.js";
@@ -116,20 +116,28 @@ export function displaySafeBudgetsApplied<
 }
 
 /**
- * Decode the owning namespace of an absolute anchor path under
- * `<memoryDir>/namespaces/<identity-token>/…` so `displayResultPath` renders it
- * as `<namespace>/…` rather than exposing the reversible identity token (#2077).
- * Returns undefined for default-namespace (flat-root) or non-absolute paths,
- * whose memoryDir-relative form is already display-safe.
+ * Resolve the owning namespace of an absolute anchor path under
+ * `<memoryDir>/namespaces/<segment>/…` via the canonical
+ * `resolveNamespaceFromStorageDir` resolver, so `displayResultPath` renders it
+ * as `<namespace>/…` (never the raw storage segment) while correctly preserving
+ * a namespace whose literal name is itself token-shaped (#2077). Returns
+ * undefined for a default-namespace (flat-root) or non-absolute path, whose
+ * memoryDir-relative form is already display-safe.
  */
-function namespaceForAnchorPath(anchorPath: string, memoryDir: string): string | undefined {
+function anchorNamespace(anchorPath: string, config: PluginConfig): string | undefined {
   if (!path.isAbsolute(anchorPath)) return undefined;
-  const nsRoot = path.join(path.resolve(memoryDir), "namespaces");
+  const nsRoot = path.join(path.resolve(config.memoryDir), "namespaces");
   const rel = path.relative(nsRoot, path.resolve(anchorPath));
   if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) return undefined;
-  const [token] = rel.split(path.sep);
-  if (!token) return undefined;
-  return namespaceIdentityFromToken(token) ?? undefined;
+  const [segment] = rel.split(path.sep);
+  if (!segment) return undefined;
+  const configuredNamespaces = resolveNamespaceCapabilities(config).namespaces
+    ? [config.defaultNamespace, config.sharedNamespace, ...config.namespacePolicies.map((p) => p.name)]
+    : [config.defaultNamespace];
+  return resolveNamespaceFromStorageDir(path.join(nsRoot, segment), {
+    config,
+    configuredNamespaces,
+  });
 }
 
 /**
@@ -153,7 +161,8 @@ export function displaySafeRecallSnapshot<
       sourceAnchors?: Array<{ path: string; lineRange?: [number, number] }>;
     };
   },
->(snapshot: T, memoryDir: string): T {
+>(snapshot: T, config: PluginConfig): T {
+  const memoryDir = config.memoryDir;
   const resultPaths = snapshot.resultPaths?.map((p, i) =>
     displayResultPath(p, memoryDir, snapshot.resultNamespaces?.[i]),
   );
@@ -163,7 +172,7 @@ export function displaySafeRecallSnapshot<
           ...snapshot.tierExplain,
           sourceAnchors: snapshot.tierExplain.sourceAnchors.map((anchor) => ({
             ...anchor,
-            path: displayResultPath(anchor.path, memoryDir, namespaceForAnchorPath(anchor.path, memoryDir)),
+            path: displayResultPath(anchor.path, memoryDir, anchorNamespace(anchor.path, config)),
           })),
         }
       : undefined;

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -4993,4 +4993,75 @@ test("recordCitationUsage surfaces a locked-store error during category-namespac
     }),
     (err: unknown) => err instanceof SecureStoreLockedError,
   );
+test("recall debug snapshot relativizes absolute internal paths (#2077)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-2077-debug-"));
+  try {
+    await writeText(
+      memoryDir,
+      "facts/2026-07-19/fact-1.md",
+      memoryDoc("fact-1", "Debug relativization coverage."),
+    );
+    const storage = new StorageManager(memoryDir);
+    const includedAbs = path.join(memoryDir, "facts/2026-07-19/fact-1.md");
+    const snapshot = {
+      sessionKey: "sess-dbg",
+      recordedAt: "2026-07-19T00:00:00.000Z",
+      queryHash: "hash",
+      queryLen: 5,
+      memoryIds: ["fact-1"],
+      namespace: "global",
+      fallbackUsed: false,
+      sourcesUsed: ["memories"],
+      budgetsApplied: {
+        appliedTopK: 1,
+        includedMemoryPaths: [includedAbs],
+        includedMemoryNamespaces: [undefined],
+      },
+      resultPaths: [includedAbs],
+      resultNamespaces: [undefined],
+    };
+    const service = new EngramAccessService({
+      config: {
+        memoryDir,
+        namespacesEnabled: true,
+        defaultNamespace: "global",
+        sharedNamespace: "shared",
+        principalFromSessionKeyMode: "prefix",
+        principalFromSessionKeyRules: [],
+        namespacePolicies: [],
+        defaultRecallNamespaces: ["self"],
+        searchBackend: "qmd",
+        qmdEnabled: true,
+      },
+      recall: async () => "ctx",
+      lastRecall: { get: () => snapshot, getMostRecent: () => snapshot },
+      getStorage: async () => storage,
+      recallIntrospection: {
+        getLastIntentSnapshot: async () => null,
+        getLastGraphRecallSnapshot: async () => null,
+      },
+    } as unknown as ConstructorParameters<typeof EngramAccessService>[0]);
+
+    const response = await service.recall({
+      query: "hello",
+      sessionKey: "sess-dbg",
+      namespace: "global",
+      includeDebug: true,
+    });
+
+    // Debug snapshot must be display-relative, not operator-absolute (#2077).
+    assert.deepEqual(response.debug?.snapshot?.resultPaths, ["facts/2026-07-19/fact-1.md"]);
+    assert.deepEqual(
+      response.debug?.snapshot?.budgetsApplied?.includedMemoryPaths,
+      ["facts/2026-07-19/fact-1.md"],
+    );
+    // Top-level budget metadata stays relative (unchanged behavior).
+    assert.deepEqual(response.budgetsApplied?.includedMemoryPaths, ["facts/2026-07-19/fact-1.md"]);
+    // The live cached snapshot must NOT be mutated — it keeps absolute paths
+    // for tracking / x-ray; only the debug copy is relativized.
+    assert.deepEqual(snapshot.resultPaths, [includedAbs]);
+    assert.deepEqual(snapshot.budgetsApplied.includedMemoryPaths, [includedAbs]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
 });

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -4993,6 +4993,8 @@ test("recordCitationUsage surfaces a locked-store error during category-namespac
     }),
     (err: unknown) => err instanceof SecureStoreLockedError,
   );
+});
+
 test("recall debug snapshot relativizes absolute internal paths (#2077)", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-2077-debug-"));
   try {

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -5019,6 +5019,14 @@ test("recall debug snapshot relativizes absolute internal paths (#2077)", async 
       },
       resultPaths: [includedAbs],
       resultNamespaces: [undefined],
+      tierExplain: {
+        tier: "direct-answer",
+        tierReason: "high-confidence single hit",
+        filteredBy: [],
+        candidatesConsidered: 1,
+        latencyMs: 3,
+        sourceAnchors: [{ path: includedAbs, lineRange: [1, 2] }],
+      },
     };
     const service = new EngramAccessService({
       config: {
@@ -5055,12 +5063,17 @@ test("recall debug snapshot relativizes absolute internal paths (#2077)", async 
       response.debug?.snapshot?.budgetsApplied?.includedMemoryPaths,
       ["facts/2026-07-19/fact-1.md"],
     );
+    // tierExplain source anchors must be relativized too (#2077 review).
+    assert.deepEqual(response.debug?.snapshot?.tierExplain?.sourceAnchors, [
+      { path: "facts/2026-07-19/fact-1.md", lineRange: [1, 2] },
+    ]);
     // Top-level budget metadata stays relative (unchanged behavior).
     assert.deepEqual(response.budgetsApplied?.includedMemoryPaths, ["facts/2026-07-19/fact-1.md"]);
     // The live cached snapshot must NOT be mutated — it keeps absolute paths
     // for tracking / x-ray; only the debug copy is relativized.
     assert.deepEqual(snapshot.resultPaths, [includedAbs]);
     assert.deepEqual(snapshot.budgetsApplied.includedMemoryPaths, [includedAbs]);
+    assert.deepEqual(snapshot.tierExplain.sourceAnchors, [{ path: includedAbs, lineRange: [1, 2] }]);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Part of #2077 (finding 3, P2). Focused fix; small review surface.

With `includeDebug=true`, `assembleRecallResponse` returned the live `LastRecallSnapshot` verbatim inside `response.debug.snapshot`, still carrying absolute internal `resultPaths` and `budgetsApplied.includedMemoryPaths`. The recall-budget PR (#2064) made the **top-level** `budgetsApplied` display-safe but left the debug-flag surface leaking operator filesystem paths — same display-relativization class as the other recall/citation surfaces.

## Change

- Add `displaySafeRecallSnapshot(snapshot, memoryDir)` to `orchestration/recall-result-formatter.ts`, reusing the existing `displayResultPath` + `displaySafeBudgetsApplied` helpers to relativize `resultPaths` (with the parallel `resultNamespaces`) and `budgetsApplied.includedMemoryPaths`.
- Apply it in `assembleRecallResponse` to a **copy** of the debug snapshot. The snapshot returned by `buildRecallDebug` is the live cached object (kept absolute for tracking/x-ray), so it is never mutated.

## Tests

- New `access-service.test.ts` case: an `includeDebug=true` recall whose snapshot holds absolute `resultPaths` and `budgetsApplied.includedMemoryPaths` returns **relative** paths in `response.debug.snapshot`, keeps the top-level `budgetsApplied` relative, and asserts the live cached snapshot is **not** mutated (still absolute).

## Verification

- `access-service`, `access-mcp`, recall-xray, namespace suites: 160 green.
- `npm run preflight:quick`: OK (incl. `check-types` / test-typecheck baseline match).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only path sanitization on the debug response surface, following the existing budgetsApplied pattern without changing recall logic or auth.
> 
> **Overview**
> With **`includeDebug=true`**, recall responses no longer expose the live cached snapshot’s absolute filesystem paths inside **`response.debug.snapshot`**. **`assembleRecallResponse`** now runs **`displaySafeRecallSnapshot`** on a **copy** of that snapshot (the in-memory cache stays absolute for tracking/x-ray), matching how top-level **`budgetsApplied`** is already sanitized.
> 
> **`displaySafeRecallSnapshot`** (in **`recall-result-formatter.ts`**) reuses **`displayResultPath`** / **`displaySafeBudgetsApplied`** to rewrite **`resultPaths`**, budget **`includedMemoryPaths`**, and **`tierExplain.sourceAnchors`**. Anchors that match a returned result reuse its namespace metadata; unmatched anchors get storage-relative paths without guessing a namespace.
> 
> Unit and **`access-service`** tests cover namespaced vs default paths, anchor behavior, and input immutability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40d34749d7419f31bc6b3cfd9ea4a559e045bcc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Recall debug responses now show display-safe, memory-directory-relative paths for `resultPaths`, included memory budget paths, and tier source anchors.
  - Namespaced tier anchors now display the correct namespace prefix rather than internal token/segment details.
  - Debug rendering is non-destructive, so any cached debug snapshot remains unchanged when `includeDebug` is enabled.
- **Tests**
  - Added API-level and unit coverage to verify path rewriting (including namespaced vs default anchors) and to confirm input immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->