### PR TITLE
feat(connector-granola): add @remnic/connector-granola wearable source (#1898)

### DIFF
--- a/docs/wearables.md
+++ b/docs/wearables.md
@@ -12,6 +12,7 @@ Three connectors ship as à-la-carte optional packages:
 | `bee` | `@remnic/connector-bee` | Bee bracelet (Amazon) | Bee "facts" |
 | `omi` | `@remnic/connector-omi` | Omi necklace | Omi "memories" |
 | `fireflies` | `@remnic/connector-fireflies` | Fireflies.ai (cloud meeting notes) | — |
+| `granola` | `@remnic/connector-granola` | Granola (cloud meeting notes) | — |
 
 Installing `@remnic/core` (or `@remnic/cli`) alone never pulls a
 connector in. Install only what you wear:
@@ -222,6 +223,7 @@ Credentials prefer environment variables over config values:
 | bee | `REMNIC_BEE_API_TOKEN`, `BEE_API_TOKEN` (not needed in proxy mode) |
 | omi | `REMNIC_OMI_API_KEY`, `OMI_API_KEY` |
 | fireflies | `REMNIC_FIREFLIES_API_KEY`, `FIREFLIES_API_KEY` |
+| granola | `REMNIC_GRANOLA_API_KEY`, `GRANOLA_API_KEY` |
 
 Remember the gateway runs under launchd with an isolated environment —
 API keys must be in the plist `EnvironmentVariables` (or in config).
@@ -381,6 +383,24 @@ on the next QMD update after a sync (the sync triggers one).
   segment — still day-anchored recall material.
 - No native-memory import: Fireflies exposes summaries, not a separate
   extracted-fact surface, so `importNativeMemories` has no effect here.
+
+### Granola (`@remnic/connector-granola`)
+
+- Cloud meeting-notes source, not a wearable device. Ingests notes and
+  transcripts Granola already produced; it cannot make them
+  retroactively local. Requires a Granola Business/Enterprise plan.
+- Auth: create a key in the Granola desktop app under **Settings →
+  Connectors → API keys** and provide it via `REMNIC_GRANOLA_API_KEY`,
+  `GRANOLA_API_KEY`, or `apiKey`.
+- Notes for the local day are listed via
+  `GET /v1/notes?created_after=&created_before=`, then each note's
+  transcript is fetched with `?include=transcript`. Meeting timing
+  prefers the linked calendar event, then transcript times, then the
+  note's creation time.
+- Speaker keys come from `speaker.source` (`microphone` = the wearer,
+  `speaker` = other audio) or the iOS `diarization_label`.
+- Notes with a summary but no transcript become a single `note` segment.
+  A note that 404s on detail fetch is skipped, not fatal.
 
 ## Why this design
 

--- a/packages/connector-granola/README.md
+++ b/packages/connector-granola/README.md
@@ -25,14 +25,13 @@ runtime. If it is not installed, `remnic wearables` reports a clean install hint
 ## API key
 
 Create a key in the Granola desktop app under **Settings → Connectors → API
-keys** (choose the note access scopes), then provide it via (checked in order):
+keys** (choose the note access scopes). The connector resolves the key in this
+order — the **config value takes precedence**, then the environment variables:
 
-| Environment variable | |
-|---|---|
-| `REMNIC_GRANOLA_API_KEY` | preferred |
-| `GRANOLA_API_KEY` | provider-conventional |
+1. `wearables.sources.granola.apiKey` (config; wins when set)
+2. `REMNIC_GRANOLA_API_KEY` (preferred env var)
+3. `GRANOLA_API_KEY` (provider-conventional env var)
 
-…or the config value `wearables.sources.granola.apiKey` (takes precedence).
 On launchd/systemd daemons the process environment is isolated — set the key in
 the unit, not just a shell.
 
@@ -73,9 +72,9 @@ remnic wearables search "roadmap"
 - Speaker keys come from `speaker.source` (`microphone` = the wearer's own audio,
   `speaker` = other meeting audio) or the iOS `diarization_label`. The wearables
   speaker registry owns final naming.
-- Notes with a summary but no transcript become a single `note` segment.
-- The Granola API only returns notes that already have an AI summary + transcript;
-  a note that 404s on detail fetch is skipped, not fatal.
+- The notes list returns summaries; a note's detail record may lack a transcript
+  (the field is nullable), so a summary-only note becomes a single `note`
+  segment. A note that 404s on the detail fetch is skipped, not fatal.
 
 ## License
 

--- a/packages/connector-granola/README.md
+++ b/packages/connector-granola/README.md
@@ -1,0 +1,82 @@
+# @remnic/connector-granola
+
+Granola meeting-notes connector for [Remnic](https://github.com/joshuaswarren/remnic).
+
+Pulls your Granola meeting notes + transcripts into Remnic's wearables pipeline
+as source `granola`: day transcripts at `<memoryDir>/wearables/granola/<date>.md`,
+searchable via `remnic wearables search`, with trust-gated memories exactly like
+the pendant connectors.
+
+> **Cloud-service caveat.** These notes/transcripts were produced by Granola's
+> cloud. Remnic ingests them but cannot make them retroactively local. Requires
+> a Granola **Business/Enterprise** plan to create an API key.
+
+## Install
+
+À-la-carte — install alongside `@remnic/core` only if you use Granola:
+
+```sh
+npm install -g @remnic/connector-granola
+```
+
+Installing `@remnic/core` alone never pulls this in; core discovers it at
+runtime. If it is not installed, `remnic wearables` reports a clean install hint.
+
+## API key
+
+Create a key in the Granola desktop app under **Settings → Connectors → API
+keys** (choose the note access scopes), then provide it via (checked in order):
+
+| Environment variable | |
+|---|---|
+| `REMNIC_GRANOLA_API_KEY` | preferred |
+| `GRANOLA_API_KEY` | provider-conventional |
+
+…or the config value `wearables.sources.granola.apiKey` (takes precedence).
+On launchd/systemd daemons the process environment is isolated — set the key in
+the unit, not just a shell.
+
+## Configure
+
+```jsonc
+{
+  "wearables": {
+    "sources": {
+      "granola": {
+        "enabled": false,          // OFF until you turn it on
+        "memoryMode": "smart",     // off | review | auto | smart
+        "sourceTrust": 0.85
+      }
+    }
+  }
+}
+```
+
+`enabled` defaults to `false`; nothing syncs until you set it `true`. Enabling
+Granola neither enables nor syncs any other source.
+
+## Verify
+
+```sh
+remnic wearables check granola      # ok / bad-key / unreachable
+remnic wearables sync --source granola --date 2026-03-10
+remnic wearables search "roadmap"
+```
+
+## What it does
+
+- Lists notes for the local day via `GET /v1/notes?created_after=&created_before=`
+  (half-open `[start, end)`, DST-aware), then fetches each note's transcript with
+  `GET /v1/notes/{id}?include=transcript`.
+- Meeting timing prefers the linked calendar event (`scheduled_start/end_time`),
+  falling back to the transcript times, then the note's `created_at`.
+- Speaker keys come from `speaker.source` (`microphone` = the wearer's own audio,
+  `speaker` = other meeting audio) or the iOS `diarization_label`. The wearables
+  speaker registry owns final naming.
+- Notes with a summary but no transcript become a single `note` segment.
+- The Granola API only returns notes that already have an AI summary + transcript;
+  a note that 404s on detail fetch is skipped, not fatal.
+
+## License
+
+MIT

--- a/packages/connector-granola/package.json
+++ b/packages/connector-granola/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@remnic/connector-granola",
+  "version": "9.9.0",
+  "description": "Granola meeting-notes connector for Remnic — pull, clean, and remember meeting transcripts and notes",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
+    "check-types": "tsc --noEmit",
+    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/client.test.ts src/normalize.test.ts src/index.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "^9.9.0"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "tsx": "^4.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/connector-granola"
+  },
+  "keywords": [
+    "remnic",
+    "memory",
+    "granola",
+    "meeting",
+    "transcript",
+    "wearable"
+  ]
+}

--- a/packages/connector-granola/src/client.test.ts
+++ b/packages/connector-granola/src/client.test.ts
@@ -120,3 +120,21 @@ test("a missing notes array fails loudly", async () => {
   const client = new GranolaClient({ apiKey: "grn_ok", fetchImpl });
   await assert.rejects(client.listNotes({ createdAfter: "a", createdBefore: "b" }), GranolaApiError);
 });
+
+test("hasMore=true with a missing cursor is a loud failure, not a silent short day", async () => {
+  const fetchImpl = (async () =>
+    jsonResponse({ notes: [{ id: "not_a" }], hasMore: true })) as typeof fetch;
+  const client = new GranolaClient({ apiKey: "grn_ok", fetchImpl });
+  await assert.rejects(client.listNotes({ createdAfter: "a", createdBefore: "b" }), (err: unknown) => {
+    assert.ok(err instanceof GranolaApiError);
+    assert.match(err.message, /no pagination cursor/);
+    return true;
+  });
+});
+
+test("hasMore=true with an empty-string cursor also fails loudly", async () => {
+  const fetchImpl = (async () =>
+    jsonResponse({ notes: [{ id: "not_a" }], hasMore: true, cursor: "" })) as typeof fetch;
+  const client = new GranolaClient({ apiKey: "grn_ok", fetchImpl });
+  await assert.rejects(client.listNotes({ createdAfter: "a", createdBefore: "b" }), GranolaApiError);
+});

--- a/packages/connector-granola/src/client.test.ts
+++ b/packages/connector-granola/src/client.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GranolaApiError, GranolaClient } from "./client.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test("constructor throws an actionable error when the API key is missing", () => {
+  assert.throws(() => new GranolaClient({ apiKey: "" }), (err: unknown) => {
+    assert.ok(err instanceof GranolaApiError);
+    assert.match(err.message, /REMNIC_GRANOLA_API_KEY/);
+    return true;
+  });
+});
+
+test("listNotes sends the day window and bearer auth, returns notes + cursor", async () => {
+  let captured: { url: string; auth: string | null } | undefined;
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    captured = { url: String(url), auth: new Headers(init?.headers).get("authorization") };
+    return jsonResponse({ notes: [{ id: "not_a", title: "Sync" }], hasMore: true, cursor: "c2" });
+  }) as typeof fetch;
+  const client = new GranolaClient({ apiKey: "grn_test", fetchImpl });
+  const page = await client.listNotes({
+    createdAfter: "2026-03-10T06:00:00.000Z",
+    createdBefore: "2026-03-11T05:00:00.000Z",
+  });
+  assert.equal(page.notes.length, 1);
+  assert.equal(page.notes[0]?.id, "not_a");
+  assert.equal(page.nextCursor, "c2");
+  assert.match(captured?.url ?? "", /created_after=2026-03-10T06%3A00%3A00.000Z/);
+  assert.match(captured?.url ?? "", /created_before=2026-03-11T05%3A00%3A00.000Z/);
+  assert.equal(captured?.auth, "Bearer grn_test");
+});
+
+test("hasMore=false yields a null cursor even if a cursor is present", async () => {
+  const fetchImpl = (async () =>
+    jsonResponse({ notes: [{ id: "not_a" }], hasMore: false, cursor: "ignored" })) as typeof fetch;
+  const client = new GranolaClient({ apiKey: "grn_test", fetchImpl });
+  const page = await client.listNotes({ createdAfter: "a", createdBefore: "b" });
+  assert.equal(page.nextCursor, null);
+});
+
+test("an empty notes array is a valid empty result, not an error", async () => {
+  const fetchImpl = (async () => jsonResponse({ notes: [], hasMore: false, cursor: null })) as typeof fetch;
+  const client = new GranolaClient({ apiKey: "grn_test", fetchImpl });
+  const page = await client.listNotes({ createdAfter: "a", createdBefore: "b" });
+  assert.deepEqual(page, { notes: [], nextCursor: null });
+});
+
+test("getNote fetches a single note with the transcript include", async () => {
+  let url = "";
+  const fetchImpl = (async (u: string | URL | Request) => {
+    url = String(u);
+    return jsonResponse({ id: "not_a", title: "Sync", transcript: [] });
+  }) as typeof fetch;
+  const client = new GranolaClient({ apiKey: "grn_test", fetchImpl });
+  const note = await client.getNote("not_a");
+  assert.equal(note.id, "not_a");
+  assert.match(url, /\/v1\/notes\/not_a\?include=transcript$/);
+});
+
+test("getNote surfaces a 404 as a GranolaApiError with status 404", async () => {
+  const fetchImpl = (async () => jsonResponse({ error: "not found" }, 404)) as typeof fetch;
+  const client = new GranolaClient({ apiKey: "grn_test", fetchImpl });
+  await assert.rejects(client.getNote("not_gone"), (err: unknown) => {
+    assert.ok(err instanceof GranolaApiError);
+    assert.equal(err.status, 404);
+    return true;
+  });
+});
+
+test("verifyAuth reports a bad key on 401", async () => {
+  const fetchImpl = (async () => jsonResponse({ error: "unauthorized" }, 401)) as typeof fetch;
+  const client = new GranolaClient({ apiKey: "grn_bad", fetchImpl });
+  const result = await client.verifyAuth();
+  assert.equal(result.ok, false);
+  assert.match(result.detail ?? "", /rejected the API key/);
+});
+
+test("verifyAuth succeeds on a clean probe", async () => {
+  const fetchImpl = (async () => jsonResponse({ notes: [], hasMore: false, cursor: null })) as typeof fetch;
+  const client = new GranolaClient({ apiKey: "grn_ok", fetchImpl });
+  assert.deepEqual(await client.verifyAuth(), { ok: true });
+});
+
+test("5xx is retried with an injected sleep, then succeeds", async () => {
+  let calls = 0;
+  const sleeps: number[] = [];
+  const fetchImpl = (async () => {
+    calls += 1;
+    if (calls < 3) return jsonResponse({ error: "boom" }, 503);
+    return jsonResponse({ notes: [{ id: "not_a" }], hasMore: false, cursor: null });
+  }) as typeof fetch;
+  const client = new GranolaClient({
+    apiKey: "grn_ok",
+    fetchImpl,
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  });
+  const page = await client.listNotes({ createdAfter: "a", createdBefore: "b" });
+  assert.equal(calls, 3);
+  assert.equal(sleeps.length, 2);
+  assert.equal(page.notes[0]?.id, "not_a");
+});
+
+test("a non-JSON body fails loudly", async () => {
+  const fetchImpl = (async () => new Response("<html/>", { status: 200 })) as typeof fetch;
+  const client = new GranolaClient({ apiKey: "grn_ok", fetchImpl });
+  await assert.rejects(client.listNotes({ createdAfter: "a", createdBefore: "b" }), GranolaApiError);
+});
+
+test("a missing notes array fails loudly", async () => {
+  const fetchImpl = (async () => jsonResponse({ notes: "nope", hasMore: false })) as typeof fetch;
+  const client = new GranolaClient({ apiKey: "grn_ok", fetchImpl });
+  await assert.rejects(client.listNotes({ createdAfter: "a", createdBefore: "b" }), GranolaApiError);
+});

--- a/packages/connector-granola/src/client.test.ts
+++ b/packages/connector-granola/src/client.test.ts
@@ -138,3 +138,14 @@ test("hasMore=true with an empty-string cursor also fails loudly", async () => {
   const client = new GranolaClient({ apiKey: "grn_ok", fetchImpl });
   await assert.rejects(client.listNotes({ createdAfter: "a", createdBefore: "b" }), GranolaApiError);
 });
+
+test("a note row without a string id fails loudly, not silently dropped", async () => {
+  const fetchImpl = (async () =>
+    jsonResponse({ notes: [{ id: "not_a" }, { title: "no id" }], hasMore: false, cursor: null })) as typeof fetch;
+  const client = new GranolaClient({ apiKey: "grn_ok", fetchImpl });
+  await assert.rejects(client.listNotes({ createdAfter: "a", createdBefore: "b" }), (err: unknown) => {
+    assert.ok(err instanceof GranolaApiError);
+    assert.match(err.message, /without a string id/);
+    return true;
+  });
+});

--- a/packages/connector-granola/src/client.ts
+++ b/packages/connector-granola/src/client.ts
@@ -136,9 +136,16 @@ export class GranolaClient {
     if (!Array.isArray(notesRaw)) {
       throw new GranolaApiError("Granola API returned an unexpected /v1/notes shape (missing notes array)");
     }
-    const notes = notesRaw.filter(
-      (entry): entry is GranolaNote => isRecord(entry) && typeof entry.id === "string",
-    );
+    // `id` is required by the List Notes schema; a row missing it is a
+    // backend/schema failure. Reject the page rather than silently dropping
+    // rows and advancing the cursor over an incomplete day (§22).
+    const notes: GranolaNote[] = [];
+    for (const entry of notesRaw) {
+      if (!isRecord(entry) || typeof entry.id !== "string") {
+        throw new GranolaApiError("Granola API returned a note row without a string id");
+      }
+      notes.push(entry as unknown as GranolaNote);
+    }
     const hasMore = isRecord(payload) && payload.hasMore === true;
     const cursor = isRecord(payload) && typeof payload.cursor === "string" ? payload.cursor : null;
     if (hasMore && (cursor === null || cursor.length === 0)) {

--- a/packages/connector-granola/src/client.ts
+++ b/packages/connector-granola/src/client.ts
@@ -1,0 +1,269 @@
+/**
+ * Minimal Granola public API client (raw fetch, no SDK).
+ *
+ * API verified against the official OpenAPI at
+ * https://docs.granola.ai/api-reference/list-notes and
+ * https://docs.granola.ai/api-reference/get-note (fetched 2026-07-21):
+ *   - Base URL: https://public-api.granola.ai
+ *   - Auth: `Authorization: Bearer grn_<key>`
+ *   - `GET /v1/notes?created_after=&created_before=&cursor=&page_size=` →
+ *     `{ notes: NoteSummary[], hasMore, cursor }` (page_size 1..30, default 10);
+ *     `created_after`/`created_before` accept date or date-time. The list only
+ *     returns notes that already have an AI summary + transcript.
+ *   - `GET /v1/notes/{id}?include=transcript` → full Note with `calendar_event`
+ *     (`scheduled_start_time`/`scheduled_end_time`), `attendees`, `summary_text`,
+ *     `summary_markdown`, and `transcript` items
+ *     `{ speaker: { source, diarization_label? }, text, start_time, end_time }`.
+ *   - Rate limits: 5 req/s sustained, 25 burst → 429 on excess.
+ *
+ * A non-2xx or network failure throws GranolaApiError (a backend failure); an
+ * empty `notes` array is a real empty result, never conflated (AGENTS.md §22).
+ */
+
+export const GRANOLA_DEFAULT_BASE_URL = "https://public-api.granola.ai";
+
+/** Hard API maximum for `page_size` on the notes list. */
+export const NOTES_MAX_PAGE_SIZE = 30;
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 3;
+const MAX_RETRY_DELAY_MS = 30_000;
+
+export interface GranolaSpeaker {
+  source?: string | null;
+  diarization_label?: string | null;
+}
+
+export interface GranolaTranscriptItem {
+  speaker?: GranolaSpeaker | null;
+  text?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+}
+
+export interface GranolaCalendarEvent {
+  event_title?: string | null;
+  organiser?: string | null;
+  scheduled_start_time?: string | null;
+  scheduled_end_time?: string | null;
+}
+
+export interface GranolaUser {
+  name?: string | null;
+  email?: string | null;
+}
+
+export interface GranolaNote {
+  id: string;
+  title?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  calendar_event?: GranolaCalendarEvent | null;
+  attendees?: GranolaUser[] | null;
+  summary_text?: string | null;
+  summary_markdown?: string | null;
+  transcript?: GranolaTranscriptItem[] | null;
+}
+
+export interface NotesPage {
+  notes: GranolaNote[];
+  nextCursor: string | null;
+}
+
+export interface GranolaClientOptions {
+  apiKey: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export class GranolaApiError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "GranolaApiError";
+  }
+}
+
+/** Narrow unknown JSON to a plain object so field reads are actually checked. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export class GranolaClient {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(options: GranolaClientOptions) {
+    if (typeof options.apiKey !== "string" || options.apiKey.trim().length === 0) {
+      throw new GranolaApiError(
+        "Granola API key is missing. Set wearables.sources.granola.apiKey " +
+          "or the REMNIC_GRANOLA_API_KEY / GRANOLA_API_KEY environment variable " +
+          "(create a key under Settings → Connectors → API keys in the Granola app; " +
+          "requires a Business/Enterprise plan).",
+      );
+    }
+    this.apiKey = options.apiKey.trim();
+    this.baseUrl = stripTrailingSlashes(options.baseUrl ?? GRANOLA_DEFAULT_BASE_URL);
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.sleep = options.sleep ?? defaultSleep;
+  }
+
+  /** One page of note summaries in the half-open [createdAfter, createdBefore) window. */
+  async listNotes(params: {
+    createdAfter: string;
+    createdBefore: string;
+    cursor?: string | null;
+    signal?: AbortSignal;
+  }): Promise<NotesPage> {
+    const search = new URLSearchParams({
+      created_after: params.createdAfter,
+      created_before: params.createdBefore,
+      page_size: String(NOTES_MAX_PAGE_SIZE),
+    });
+    if (typeof params.cursor === "string" && params.cursor.length > 0) {
+      search.set("cursor", params.cursor);
+    }
+    const payload = await this.requestJson(`/v1/notes?${search.toString()}`, params.signal);
+    const notesRaw = isRecord(payload) ? payload.notes : undefined;
+    if (!Array.isArray(notesRaw)) {
+      throw new GranolaApiError("Granola API returned an unexpected /v1/notes shape (missing notes array)");
+    }
+    const notes = notesRaw.filter(
+      (entry): entry is GranolaNote => isRecord(entry) && typeof entry.id === "string",
+    );
+    const hasMore = isRecord(payload) && payload.hasMore === true;
+    const cursor = isRecord(payload) && typeof payload.cursor === "string" ? payload.cursor : null;
+    return { notes, nextCursor: hasMore ? cursor : null };
+  }
+
+  /** A single note with its transcript, calendar event, summary, and attendees. */
+  async getNote(id: string, signal?: AbortSignal): Promise<GranolaNote> {
+    const payload = await this.requestJson(
+      `/v1/notes/${encodeURIComponent(id)}?include=transcript`,
+      signal,
+    );
+    if (!isRecord(payload) || typeof payload.id !== "string") {
+      throw new GranolaApiError("Granola API returned an unexpected note shape (missing id)");
+    }
+    // Validated boundary: `id` is confirmed a string above; every other field
+    // is optional and the normalizer re-checks each. Cast through `unknown`
+    // because the external JSON shape can't be proven structurally here.
+    return payload as unknown as GranolaNote;
+  }
+
+  /** Cheap auth probe. */
+  async verifyAuth(signal?: AbortSignal): Promise<{ ok: boolean; detail?: string }> {
+    try {
+      await this.requestJson("/v1/notes?page_size=1", signal);
+      return { ok: true };
+    } catch (err) {
+      if (err instanceof GranolaApiError && (err.status === 401 || err.status === 403)) {
+        return {
+          ok: false,
+          detail: "Granola rejected the API key (401/403) — create a new key under Settings → Connectors → API keys",
+        };
+      }
+      return { ok: false, detail: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  private async requestJson(pathAndQuery: string, signal?: AbortSignal): Promise<unknown> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      signal?.throwIfAborted();
+      const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+      const combined = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+      let response: Response;
+      try {
+        response = await this.fetchImpl(`${this.baseUrl}${pathAndQuery}`, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            Accept: "application/json",
+          },
+          signal: combined,
+        });
+      } catch (err) {
+        if (signal?.aborted) throw err;
+        lastError = err;
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(backoffMs(attempt));
+          continue;
+        }
+        throw new GranolaApiError(
+          `Granola API request failed after ${MAX_RETRIES + 1} attempts: ${describeNetworkError(err)}`,
+        );
+      }
+
+      if (response.status === 429 || response.status >= 500) {
+        lastError = new GranolaApiError(`Granola API responded ${response.status}`, response.status);
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(await retryDelayMs(response, attempt));
+          continue;
+        }
+        throw lastError;
+      }
+      if (!response.ok) {
+        throw new GranolaApiError(
+          `Granola API responded ${response.status} for ${pathAndQuery.split("?")[0]}`,
+          response.status,
+        );
+      }
+      try {
+        return await response.json();
+      } catch {
+        throw new GranolaApiError("Granola API returned a non-JSON body");
+      }
+    }
+    throw lastError instanceof Error ? lastError : new GranolaApiError("Granola API request failed");
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, ms);
+  return promise;
+}
+
+function describeNetworkError(err: unknown): string {
+  if (isRecord(err)) {
+    const name = typeof err.name === "string" ? err.name : "Error";
+    const code = err.code;
+    return typeof code === "string" ? `${name} (${code})` : name;
+  }
+  return "network error";
+}
+
+/** Loop instead of `/\/+$/` — CodeQL js/polynomial-redos on user-set URLs. */
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
+  return value.slice(0, end);
+}
+
+function backoffMs(attempt: number): number {
+  return Math.min(MAX_RETRY_DELAY_MS, 1_000 * 2 ** attempt);
+}
+
+async function retryDelayMs(response: Response, attempt: number): Promise<number> {
+  const header = response.headers.get("retry-after");
+  if (header) {
+    const seconds = Number(header);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return Math.min(MAX_RETRY_DELAY_MS, seconds * 1_000);
+    }
+    const when = Date.parse(header);
+    if (Number.isFinite(when)) {
+      return Math.min(MAX_RETRY_DELAY_MS, Math.max(0, when - Date.now()));
+    }
+  }
+  return backoffMs(attempt);
+}

--- a/packages/connector-granola/src/client.ts
+++ b/packages/connector-granola/src/client.ts
@@ -141,6 +141,11 @@ export class GranolaClient {
     );
     const hasMore = isRecord(payload) && payload.hasMore === true;
     const cursor = isRecord(payload) && typeof payload.cursor === "string" ? payload.cursor : null;
+    if (hasMore && (cursor === null || cursor.length === 0)) {
+      // A `hasMore: true` page with no usable cursor is a malformed pagination
+      // response; fail loudly rather than silently sync a partial day (§22).
+      throw new GranolaApiError("Granola reported hasMore=true but returned no pagination cursor");
+    }
     return { notes, nextCursor: hasMore ? cursor : null };
   }
 
@@ -204,6 +209,7 @@ export class GranolaClient {
       }
 
       if (response.status === 429 || response.status >= 500) {
+        discardBody(response);
         lastError = new GranolaApiError(`Granola API responded ${response.status}`, response.status);
         if (attempt < MAX_RETRIES) {
           await this.sleep(await retryDelayMs(response, attempt));
@@ -212,6 +218,7 @@ export class GranolaClient {
         throw lastError;
       }
       if (!response.ok) {
+        discardBody(response);
         throw new GranolaApiError(
           `Granola API responded ${response.status} for ${pathAndQuery.split("?")[0]}`,
           response.status,
@@ -231,6 +238,14 @@ function defaultSleep(ms: number): Promise<void> {
   const { promise, resolve } = Promise.withResolvers<void>();
   setTimeout(resolve, ms);
   return promise;
+}
+
+/**
+ * Release the socket back to the pool on error paths: an unconsumed response
+ * body pins the undici connection (stability review note).
+ */
+function discardBody(response: Response): void {
+  void response.body?.cancel().catch(() => {});
 }
 
 function describeNetworkError(err: unknown): string {

--- a/packages/connector-granola/src/index.test.ts
+++ b/packages/connector-granola/src/index.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { getWearableConnector } from "@remnic/core";
+import type { WearableSourceSettings } from "@remnic/core";
+
+import {
+  createGranolaConnector,
+  ensureGranolaConnectorRegistered,
+  resolveGranolaApiKey,
+  wearableConnectorRegistration,
+} from "./index.js";
+
+function settings(overrides: Partial<WearableSourceSettings> = {}): WearableSourceSettings {
+  return {
+    enabled: true,
+    memoryMode: "smart",
+    sourceTrust: 0.85,
+    autoApproveTrust: 0.7,
+    reviewTrust: 0.45,
+    minConfidence: 0,
+    minImportance: "low",
+    maxMemoriesPerDay: 0,
+    importNativeMemories: "smart",
+    cleanup: {
+      mergeSameSpeaker: true,
+      stripFillers: true,
+      collapseRepeats: true,
+      dropLowQuality: true,
+    },
+    ...overrides,
+  };
+}
+
+/** Route a mocked fetch by URL: list vs single-note-detail. */
+function mockGranola(notes: Record<string, unknown>, detailByPath: Record<string, { body: unknown; status?: number }>): typeof fetch {
+  return (async (url: string | URL | Request) => {
+    const u = String(url);
+    const detailMatch = u.match(/\/v1\/notes\/([^?]+)\?include=transcript/);
+    if (detailMatch) {
+      const id = decodeURIComponent(detailMatch[1] ?? "");
+      const entry = detailByPath[id];
+      const status = entry?.status ?? (entry ? 200 : 404);
+      return new Response(JSON.stringify(entry?.body ?? { error: "not found" }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify(notes), { status: 200, headers: { "Content-Type": "application/json" } });
+  }) as typeof fetch;
+}
+
+test("importing the module registers the connector exactly once", () => {
+  assert.ok(getWearableConnector("granola"));
+  assert.equal(ensureGranolaConnectorRegistered(), false);
+  assert.equal(wearableConnectorRegistration.id, "granola");
+});
+
+test("resolveGranolaApiKey prefers config, then REMNIC_*, then provider env", () => {
+  assert.equal(resolveGranolaApiKey("from-config", {}), "from-config");
+  assert.equal(
+    resolveGranolaApiKey(undefined, { REMNIC_GRANOLA_API_KEY: "remnic-env", GRANOLA_API_KEY: "provider-env" }),
+    "remnic-env",
+  );
+  assert.equal(resolveGranolaApiKey(undefined, { GRANOLA_API_KEY: "provider-env" }), "provider-env");
+  assert.equal(resolveGranolaApiKey(undefined, {}), undefined);
+});
+
+test("fetchConversations lists notes then fetches each transcript", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = mockGranola(
+    { notes: [{ id: "not_a" }, { id: "not_b" }], hasMore: true, cursor: "next" },
+    {
+      not_a: {
+        body: {
+          id: "not_a",
+          calendar_event: { event_title: "A", scheduled_start_time: "2026-03-10T14:00:00.000Z" },
+          transcript: [{ speaker: { source: "microphone" }, text: "hi", start_time: "2026-03-10T14:00:01.000Z", end_time: "2026-03-10T14:00:02.000Z" }],
+        },
+      },
+      not_b: {
+        body: {
+          id: "not_b",
+          calendar_event: { event_title: "B", scheduled_start_time: "2026-03-10T16:00:00.000Z" },
+          summary_text: "note only",
+          transcript: [],
+        },
+      },
+    },
+  );
+  try {
+    const connector = createGranolaConnector({ settings: settings({ apiKey: "grn_k" }), timezone: "UTC" });
+    const page = await connector.fetchConversations({ date: "2026-03-10", timezone: "UTC" });
+    assert.equal(page.conversations.length, 2);
+    assert.equal(page.conversations[0]?.id, "not_a");
+    assert.equal(page.conversations[0]?.title, "A");
+    assert.equal(page.conversations[1]?.segments[0]?.speakerKey, "note");
+    assert.equal(page.nextCursor, "next");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a note that 404s on detail fetch is skipped, not fatal", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = mockGranola(
+    { notes: [{ id: "not_a" }, { id: "not_gone" }], hasMore: false, cursor: null },
+    {
+      not_a: {
+        body: {
+          id: "not_a",
+          calendar_event: { scheduled_start_time: "2026-03-10T14:00:00.000Z" },
+          transcript: [{ speaker: { source: "speaker" }, text: "hi", start_time: "2026-03-10T14:00:01.000Z", end_time: "2026-03-10T14:00:02.000Z" }],
+        },
+      },
+      // not_gone omitted → 404
+    },
+  );
+  try {
+    const connector = createGranolaConnector({ settings: settings({ apiKey: "grn_k" }), timezone: "UTC" });
+    const page = await connector.fetchConversations({ date: "2026-03-10", timezone: "UTC" });
+    assert.equal(page.conversations.length, 1);
+    assert.equal(page.conversations[0]?.id, "not_a");
+    assert.equal(page.nextCursor, null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("missing API key surfaces an actionable error at call time, not construction", async () => {
+  const connector = createGranolaConnector({ settings: settings({ apiKey: undefined }), timezone: "UTC" });
+  await assert.rejects(
+    connector.fetchConversations({ date: "2026-03-10", timezone: "UTC" }),
+    (err: unknown) => {
+      assert.ok(err instanceof Error);
+      assert.match(err.message, /REMNIC_GRANOLA_API_KEY/);
+      return true;
+    },
+  );
+});

--- a/packages/connector-granola/src/index.ts
+++ b/packages/connector-granola/src/index.ts
@@ -1,0 +1,134 @@
+/**
+ * @remnic/connector-granola — Granola meeting-notes connector.
+ *
+ * À-la-carte optional companion of @remnic/core: installing core alone
+ * never pulls this in; core discovers it at runtime via a
+ * computed-specifier dynamic import (see wearables/registry.ts) or via
+ * a direct import of this module, which self-registers idempotently.
+ *
+ * API key: `wearables.sources.granola.apiKey`, else the
+ * `REMNIC_GRANOLA_API_KEY` / `GRANOLA_API_KEY` environment variables
+ * (checked in that order). Create a key under Settings → Connectors →
+ * API keys in the Granola app (Business/Enterprise plans).
+ */
+
+import {
+  registerWearableConnector,
+  getWearableConnector,
+  type WearableConnectorFactoryOptions,
+  type WearableConnectorRegistration,
+  type WearableConversation,
+  type WearableFetchOptions,
+  type WearableFetchPage,
+  type WearableSourceConnector,
+} from "@remnic/core";
+
+import { GranolaApiError, GranolaClient, type GranolaNote } from "./client.js";
+import { GRANOLA_SOURCE_ID, granolaDayWindow, noteToConversation } from "./normalize.js";
+
+export {
+  GranolaClient,
+  GranolaApiError,
+  GRANOLA_DEFAULT_BASE_URL,
+  NOTES_MAX_PAGE_SIZE,
+} from "./client.js";
+export type {
+  GranolaNote,
+  GranolaTranscriptItem,
+  GranolaSpeaker,
+  GranolaCalendarEvent,
+  GranolaUser,
+  NotesPage,
+  GranolaClientOptions,
+} from "./client.js";
+export { GRANOLA_SOURCE_ID, granolaDayWindow, noteToConversation } from "./normalize.js";
+
+const GRANOLA_DISPLAY_NAME = "Granola";
+
+export function resolveGranolaApiKey(
+  configuredKey: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (typeof configuredKey === "string" && configuredKey.trim().length > 0) {
+    return configuredKey.trim();
+  }
+  for (const name of ["REMNIC_GRANOLA_API_KEY", "GRANOLA_API_KEY"]) {
+    const value = env[name];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+export function createGranolaConnector(
+  options: WearableConnectorFactoryOptions,
+): WearableSourceConnector {
+  let client: GranolaClient | null = null;
+  const getClient = (): GranolaClient => {
+    if (!client) {
+      client = new GranolaClient({
+        apiKey: resolveGranolaApiKey(options.settings.apiKey) ?? "",
+        baseUrl: options.settings.baseUrl,
+      });
+    }
+    return client;
+  };
+
+  return {
+    id: GRANOLA_SOURCE_ID,
+    displayName: GRANOLA_DISPLAY_NAME,
+    async verifyAuth(signal?: AbortSignal) {
+      return getClient().verifyAuth(signal);
+    },
+    async fetchConversations(opts: WearableFetchOptions): Promise<WearableFetchPage> {
+      const { createdAfter, createdBefore } = granolaDayWindow(opts.date, opts.timezone);
+      const activeClient = getClient();
+      const page = await activeClient.listNotes({
+        createdAfter,
+        createdBefore,
+        cursor: opts.cursor,
+        signal: opts.signal,
+      });
+      // The list returns summaries only; each note's transcript/summary/timing
+      // needs a per-note fetch. Fetch sequentially to respect the 5 req/s rate
+      // limit (the client also backs off on 429).
+      const conversations: WearableConversation[] = [];
+      for (const summary of page.notes) {
+        let full: GranolaNote;
+        try {
+          full = await activeClient.getNote(summary.id, opts.signal);
+        } catch (err) {
+          // A note that 404s (deleted / no longer summarized) is gone, not a
+          // backend outage — skip it. Any other failure is real; rethrow so it
+          // reads as a source failure, not a quiet day (AGENTS.md §22).
+          if (err instanceof GranolaApiError && err.status === 404) continue;
+          throw err;
+        }
+        const conversation = noteToConversation(full);
+        // Drop a record with no resolvable start rather than emit an empty
+        // startIso that fails downstream parsing silently.
+        if (conversation.startIso !== "") conversations.push(conversation);
+      }
+      return { conversations, nextCursor: page.nextCursor };
+    },
+  };
+}
+
+export const wearableConnectorRegistration: WearableConnectorRegistration = {
+  id: GRANOLA_SOURCE_ID,
+  displayName: GRANOLA_DISPLAY_NAME,
+  factory: createGranolaConnector,
+};
+
+/**
+ * Idempotently register the connector with the core registry. Importing this
+ * module registers it as a side effect; calling again is safe.
+ */
+export function ensureGranolaConnectorRegistered(): boolean {
+  if (getWearableConnector(GRANOLA_SOURCE_ID)) return false;
+  registerWearableConnector(wearableConnectorRegistration);
+  return true;
+}
+
+ensureGranolaConnectorRegistered();

--- a/packages/connector-granola/src/normalize.test.ts
+++ b/packages/connector-granola/src/normalize.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { GranolaNote } from "./client.js";
+import { GRANOLA_SOURCE_ID, granolaDayWindow, noteToConversation } from "./normalize.js";
+
+test("maps a macOS transcript: source→speakerKey, microphone→wearer, absolute times", () => {
+  const note: GranolaNote = {
+    id: "not_a",
+    title: "Fallback title",
+    created_at: "2026-03-10T13:00:00.000Z",
+    calendar_event: {
+      event_title: "Roadmap review",
+      scheduled_start_time: "2026-03-10T14:00:00.000Z",
+      scheduled_end_time: "2026-03-10T15:00:00.000Z",
+    },
+    summary_text: "Reviewed the roadmap.",
+    transcript: [
+      {
+        speaker: { source: "microphone" },
+        text: "Let's begin.",
+        start_time: "2026-03-10T14:00:05.000Z",
+        end_time: "2026-03-10T14:00:08.000Z",
+      },
+      {
+        speaker: { source: "speaker" },
+        text: "Sounds good.",
+        start_time: "2026-03-10T14:00:09.000Z",
+        end_time: "2026-03-10T14:00:12.000Z",
+      },
+    ],
+  };
+  const conv = noteToConversation(note);
+  assert.equal(conv.id, "not_a");
+  assert.equal(conv.source, GRANOLA_SOURCE_ID);
+  // Calendar event title/time win over the note's own fields.
+  assert.equal(conv.title, "Roadmap review");
+  assert.equal(conv.summary, "Reviewed the roadmap.");
+  assert.equal(conv.startIso, "2026-03-10T14:00:00.000Z");
+  assert.equal(conv.endIso, "2026-03-10T15:00:00.000Z");
+  assert.deepEqual(conv.segments[0], {
+    text: "Let's begin.",
+    speakerKey: "microphone",
+    isWearer: true,
+    startIso: "2026-03-10T14:00:05.000Z",
+    endIso: "2026-03-10T14:00:08.000Z",
+  });
+  // "speaker" source is other audio — not the wearer.
+  assert.equal(conv.segments[1]?.speakerKey, "speaker");
+  assert.equal(conv.segments[1]?.isWearer, undefined);
+});
+
+test("iOS diarization_label becomes the speakerKey and suppresses the wearer guess", () => {
+  const note: GranolaNote = {
+    id: "not_b",
+    created_at: "2026-03-10T09:00:00.000Z",
+    transcript: [
+      { speaker: { source: "microphone", diarization_label: "Speaker A" }, text: "Hi", start_time: "2026-03-10T09:00:01.000Z", end_time: "2026-03-10T09:00:02.000Z" },
+      { speaker: { source: "microphone", diarization_label: "Speaker B" }, text: "Yo", start_time: "2026-03-10T09:00:03.000Z", end_time: "2026-03-10T09:00:04.000Z" },
+    ],
+  };
+  const conv = noteToConversation(note);
+  assert.equal(conv.segments[0]?.speakerKey, "Speaker A");
+  assert.equal(conv.segments[0]?.isWearer, undefined);
+  assert.equal(conv.segments[1]?.speakerKey, "Speaker B");
+  // No calendar event → start falls back to the first transcript time.
+  assert.equal(conv.startIso, "2026-03-10T09:00:01.000Z");
+});
+
+test("degrades to a single note segment when a summary exists without a transcript", () => {
+  const note: GranolaNote = {
+    id: "not_c",
+    created_at: "2026-03-10T09:00:00.000Z",
+    summary_text: "Quick standup, nothing blocking.",
+    transcript: [],
+  };
+  const conv = noteToConversation(note);
+  assert.equal(conv.segments.length, 1);
+  assert.deepEqual(conv.segments[0], { text: "Quick standup, nothing blocking.", speakerKey: "note" });
+  // No calendar/transcript time → falls back to created_at.
+  assert.equal(conv.startIso, "2026-03-10T09:00:00.000Z");
+});
+
+test("falls back to summary_markdown when summary_text is absent", () => {
+  const conv = noteToConversation({
+    id: "not_d",
+    created_at: "2026-03-10T09:00:00.000Z",
+    summary_markdown: "## Notes\n- did a thing",
+    transcript: null,
+  });
+  assert.equal(conv.summary, "## Notes\n- did a thing");
+  assert.equal(conv.segments[0]?.text, "## Notes\n- did a thing");
+});
+
+test("a note with no resolvable time yields an empty startIso (caller drops it)", () => {
+  const conv = noteToConversation({ id: "not_e", transcript: [] });
+  assert.equal(conv.startIso, "");
+  assert.equal(conv.segments.length, 0);
+});
+
+test("granolaDayWindow returns half-open UTC bounds for a local day", () => {
+  const window = granolaDayWindow("2026-03-10", "America/Chicago");
+  assert.equal(window.createdAfter, "2026-03-10T05:00:00.000Z");
+  assert.equal(window.createdBefore, "2026-03-11T05:00:00.000Z");
+});
+
+test("granolaDayWindow handles the spring-forward DST boundary", () => {
+  const window = granolaDayWindow("2026-03-08", "America/Chicago");
+  assert.equal(window.createdAfter, "2026-03-08T06:00:00.000Z");
+  assert.equal(window.createdBefore, "2026-03-09T05:00:00.000Z");
+});
+
+test("granolaDayWindow rejects an invalid timezone instead of coercing to UTC", () => {
+  assert.throws(() => granolaDayWindow("2026-03-10", "Not/AZone"), RangeError);
+});

--- a/packages/connector-granola/src/normalize.ts
+++ b/packages/connector-granola/src/normalize.ts
@@ -1,0 +1,146 @@
+/**
+ * Normalize Granola notes into Remnic's provider-agnostic
+ * `WearableConversation` shape, plus the timezone-aware day-window helpers the
+ * Granola `created_after`/`created_before` filters need.
+ *
+ * Granola transcript items carry absolute `start_time`/`end_time` (ISO) and a
+ * `speaker.source` of `microphone` (the wearer's own captured audio) or
+ * `speaker` (other meeting audio); iOS adds a `diarization_label`
+ * (`Speaker A/B/...`). The wearables speaker registry owns final naming.
+ * Meeting timing prefers the linked calendar event; notes with a summary but no
+ * transcript degrade to a single `note` segment.
+ */
+
+import type {
+  WearableConversation,
+  WearableTranscriptSegment,
+} from "@remnic/core";
+
+import type { GranolaNote } from "./client.js";
+
+export const GRANOLA_SOURCE_ID = "granola";
+
+/** "GMT+05:30" → "+05:30"; plain "GMT" → "+00:00". */
+export function timezoneOffsetIso(instant: Date, timezone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "longOffset",
+    }).formatToParts(instant);
+    const name = parts.find((part) => part.type === "timeZoneName")?.value ?? "GMT";
+    const match = name.match(/GMT([+-]\d{2}:\d{2})?/);
+    return match?.[1] ?? "+00:00";
+  } catch {
+    return "+00:00";
+  }
+}
+
+/** ISO instant for local midnight of `date` in `timezone`. */
+export function zonedDayStartIso(date: string, timezone: string): string {
+  let offset = timezoneOffsetIso(new Date(`${date}T12:00:00Z`), timezone);
+  const candidate = new Date(`${date}T00:00:00${offset}`);
+  const refined = timezoneOffsetIso(candidate, timezone);
+  if (refined !== offset) {
+    offset = refined;
+  }
+  return `${date}T00:00:00${offset}`;
+}
+
+export function nextIsoDate(date: string): string {
+  const parsed = new Date(`${date}T00:00:00Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + 1);
+  return parsed.toISOString().slice(0, 10);
+}
+
+/**
+ * Reject an invalid/unsupported IANA timezone loudly instead of silently
+ * coercing to UTC and shifting every meeting's day window (AGENTS.md §39).
+ */
+function assertValidTimezone(timezone: string): void {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+  } catch {
+    throw new RangeError(
+      `Invalid IANA timezone "${timezone}" for the Granola connector — check wearables.timezone.`,
+    );
+  }
+}
+
+/**
+ * Half-open [createdAfter, createdBefore) UTC ISO bounds of a local day — the
+ * window the Granola notes list filters on.
+ */
+export function granolaDayWindow(
+  date: string,
+  timezone: string,
+): { createdAfter: string; createdBefore: string } {
+  assertValidTimezone(timezone);
+  return {
+    createdAfter: new Date(zonedDayStartIso(date, timezone)).toISOString(),
+    createdBefore: new Date(zonedDayStartIso(nextIsoDate(date), timezone)).toISOString(),
+  };
+}
+
+function trimmed(value: string | null | undefined): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function isoOrUndefined(value: string | null | undefined): string | undefined {
+  if (typeof value !== "string" || value.trim().length === 0) return undefined;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : undefined;
+}
+
+export function noteToConversation(note: GranolaNote): WearableConversation {
+  const event = note.calendar_event ?? undefined;
+  const items = note.transcript ?? [];
+
+  const segments: WearableTranscriptSegment[] = [];
+  for (const item of items) {
+    const text = trimmed(item.text);
+    if (text === undefined) continue;
+    const source = trimmed(item.speaker?.source);
+    const label = trimmed(item.speaker?.diarization_label);
+    const startIso = isoOrUndefined(item.start_time);
+    const endIso = isoOrUndefined(item.end_time);
+    // macOS marks the wearer's own audio as `microphone` (vs `speaker` for
+    // other meeting audio). When a diarization_label is present (iOS single
+    // stream) the source no longer distinguishes the wearer, so don't guess.
+    const isWearer = source === "microphone" && label === undefined;
+    segments.push({
+      text,
+      speakerKey: label ?? source ?? "unknown",
+      ...(isWearer ? { isWearer: true } : {}),
+      ...(startIso !== undefined ? { startIso } : {}),
+      ...(endIso !== undefined ? { endIso } : {}),
+    });
+  }
+
+  const summary = trimmed(note.summary_text) ?? trimmed(note.summary_markdown);
+
+  // Note-only fallback: a summarized meeting with no transcript still anchors
+  // recall for the day.
+  if (segments.length === 0 && summary !== undefined) {
+    segments.push({ text: summary, speakerKey: "note" });
+  }
+
+  const title = trimmed(event?.event_title) ?? trimmed(note.title);
+  const startIso =
+    isoOrUndefined(event?.scheduled_start_time) ??
+    segments.find((segment) => segment.startIso !== undefined)?.startIso ??
+    isoOrUndefined(note.created_at) ??
+    "";
+  const endIso =
+    isoOrUndefined(event?.scheduled_end_time) ??
+    [...segments].reverse().find((segment) => segment.endIso !== undefined)?.endIso;
+
+  return {
+    id: note.id,
+    source: GRANOLA_SOURCE_ID,
+    ...(title !== undefined ? { title } : {}),
+    ...(summary !== undefined ? { summary } : {}),
+    startIso,
+    ...(endIso !== undefined ? { endIso } : {}),
+    segments,
+  };
+}

--- a/packages/connector-granola/tsconfig.json
+++ b/packages/connector-granola/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2024"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-core/src/wearables/registry.ts
+++ b/packages/remnic-core/src/wearables/registry.ts
@@ -85,6 +85,7 @@ const BUILT_IN_CONNECTOR_PACKAGES: Array<{ id: string; suffix: string }> = [
   { id: "bee", suffix: "connector-bee" },
   { id: "omi", suffix: "connector-omi" },
   { id: "fireflies", suffix: "connector-fireflies" },
+  { id: "granola", suffix: "connector-granola" },
 ];
 
 const loadFailuresWarned = new Set<string>();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,21 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/connector-granola:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/connector-limitless:
     devDependencies:
       '@remnic/core':

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -526,7 +526,7 @@ tests/query-aware-prefilter.test.ts(262,27): TS7006
 tests/query-aware-prefilter.test.ts(299,38): TS2339
 tests/query-aware-prefilter.test.ts(304,34): TS2339
 tests/recall-no-recall-short-circuit.test.ts(15,3): TS2740
-tests/release-workflow-public-packages.test.ts(153,41): TS7016
+tests/release-workflow-public-packages.test.ts(154,41): TS7016
 tests/remnic-cli-service-candidates.test.ts(17,82): TS7006
 tests/remnic-plugin-register-migration.test.ts(66,12): TS2352
 tests/remnic-server-cli.test.ts(9,30): TS7016

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -25,6 +25,7 @@ const expectedPublishDirs = [
   "packages/connector-bee",
   "packages/connector-omi",
   "packages/connector-fireflies",
+  "packages/connector-granola",
   "packages/hermes-provider",
   "packages/belief-ledger",
   "packages/remnic-server",


### PR DESCRIPTION
Part of #1898 (Phase 2, epic #1896). Second cloud meeting connector, after Fireflies (#2087).

## API verification (mandatory per #1898)

Verified against the official Granola OpenAPI on **2026-07-21**:
- Base: `https://public-api.granola.ai`, auth `Authorization: Bearer grn_<key>` — https://docs.granola.ai/introduction
- `GET /v1/notes` — https://docs.granola.ai/api-reference/list-notes — params `created_after`/`created_before` (date or date-time), `cursor`, `page_size` (1–30). Response `{notes: NoteSummary[], hasMore, cursor}`. NoteSummary has `id`, `title`, `owner`, `created_at`, `updated_at` (no transcript/summary).
- `GET /v1/notes/{id}?include=transcript` — https://docs.granola.ai/api-reference/get-note — full Note with `calendar_event {scheduled_start_time, scheduled_end_time, event_title}`, `attendees`, `summary_text`, `summary_markdown`, and `transcript` items `{speaker: {source, diarization_label?}, text, start_time, end_time}` (absolute ISO). List returns only summarized+transcribed notes; unavailable → 404.
- Rate limits: 5 req/s sustained, 25 burst → 429.

## What this adds

New à-la-carte package `@remnic/connector-granola` implementing `WearableSourceConnector`.

- **client.ts** — REST client, retry/backoff on 429/5xx, injectable fetch; non-2xx/network → `GranolaApiError`, empty `notes[]` stays a real empty result (§22); `getNote` 404 preserved as status 404.
- **normalize.ts** — DST-aware half-open `[created_after, created_before)` day window; timing prefers `calendar_event`, then transcript, then `created_at`; `speaker.source`(`microphone`=wearer/`speaker`=other) or iOS `diarization_label` → `speakerKey`, no `isWearer` guess under diarization; summary-without-transcript → single `note` segment; invalid IANA timezone rejected (§39).
- **index.ts** — list → per-note transcript fetch (sequential, rate-limit-friendly); a 404'd note is skipped (not fatal), other errors rethrow; empty-start records dropped; env-first key resolution; idempotent self-registration.
- Registry discovery entry, release publish-dir allowlist entry, typecheck-baseline line shift, `docs/wearables.md` tables + section, package README.

## Charter / à-la-carte

`enabled` defaults `false`; enabling Granola neither enables nor syncs any other source. Optional peer dep on `@remnic/core`, computed-specifier dynamic import, auto-discovered in the topological publish order. Base installs unaffected.

## Verification

- 24 package tests (client transport incl. 404/empty-vs-failure/retry/malformed; normalize incl. macOS+iOS speaker mapping, calendar/transcript/created_at timing precedence, note fallback, DST bounds, invalid-tz throw; index list→detail flow, 404-skip, key precedence, lazy-key error).
- `check-types` clean, `build` OK, release-workflow-public-packages test green (10), `preflight:quick` OK. Fixtures synthetic (public-repo privacy).

## Not in this PR

Real-account fixture recording (needs an owner API key) — CI uses injected fetch mocks. Otter connector + Plaud investigation are the remaining #1898 slices.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated optional package and registry entry; no changes to auth, memory storage, or core sync logic beyond discovering the new connector.
> 
> **Overview**
> Adds an optional **`@remnic/connector-granola`** package so Granola cloud meeting notes and transcripts can flow through the same wearables pipeline as Fireflies and device connectors.
> 
> The connector lists notes for a DST-aware local day, fetches each note with `?include=transcript`, maps speakers and timing into `WearableConversation`, and registers as source **`granola`** (config/env API keys, `enabled` off by default). **Core** only gains built-in dynamic-import discovery in `registry.ts`; **docs/wearables.md**, package README, release publish allowlist, and lockfile follow the existing à-la-carte pattern.
> 
> Implementation highlights: REST client with retries on 429/5xx and strict pagination/empty-day handling; summary-only notes become a single `note` segment; per-note **404** is skipped without failing the sync; broad unit tests cover client, normalization, and integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3afcebc7361be98696ed4afa0450a5b7c002b8bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Granola connector for syncing meeting notes and transcripts into wearables, including API key configuration (with environment-variable fallback and precedence), pagination, speaker mapping, and meeting timing.
  * Gracefully handles missing notes/transcripts and skips unavailable detail records during sync.
  * Registers the connector automatically with built-in wearables connectors when available.

* **Documentation**
  * Updated wearables documentation to include Granola.
  * Added a dedicated Granola connector README with setup and verification steps.

* **Tests**
  * Added comprehensive client, connector, and normalization test coverage (auth, retries, pagination, and mapping behavior).


<!-- end of auto-generated comment: release notes by coderabbit.ai -->