### PR TITLE
fix(test-runner): sandbox TMPDIR per run to stop temp-dir inode leak (#2083)

### DIFF
--- a/scripts/run-root-tests.mjs
+++ b/scripts/run-root-tests.mjs
@@ -56,21 +56,38 @@ process.env.NODE_OPTIONS = appendNodeOption(
 // Sandbox TMPDIR for this run (#2083). os.tmpdir() reads TMPDIR/TMP/TEMP on
 // each call and child test processes inherit process.env, so pointing all
 // three at one per-run scratch dir makes every test's temp directory land
-// inside it. A single cleanup on exit then reclaims them all, so leaked
-// per-test dirs cannot accumulate in the shared /tmp across runs and exhaust
-// inodes on long-lived (self-hosted) runners. The scratch dir is created via
-// the current tmpdir() BEFORE the override so it is not nested under itself.
-const testRunScratchDir = mkdtempSync(join(tmpdir(), "remnic-test-run-"));
+// inside it. A single cleanup then reclaims them all, so leaked per-test dirs
+// cannot accumulate in the shared /tmp across runs and exhaust inodes on
+// long-lived (self-hosted) runners. The scratch dir is created via the current
+// tmpdir() BEFORE the override so it is not nested under itself. The prefix is
+// deliberately short: one test binds an AF_UNIX socket under os.tmpdir(), and
+// its path must stay within the ~107-byte sun_path limit even with this extra
+// nesting level.
+const testRunScratchDir = mkdtempSync(join(tmpdir(), "rt-"));
 process.env.TMPDIR = testRunScratchDir;
 process.env.TMP = testRunScratchDir;
 process.env.TEMP = testRunScratchDir;
-process.on("exit", () => {
+let testRunScratchCleaned = false;
+function cleanupTestRunScratchDir() {
+  if (testRunScratchCleaned) return;
+  testRunScratchCleaned = true;
   try {
     rmSync(testRunScratchDir, { recursive: true, force: true });
   } catch {
     // Best-effort cleanup — never mask the run's real exit status.
   }
-});
+}
+// Normal termination emits `exit`; a signal (CI cancel/timeout, Ctrl-C) does
+// NOT, so clean up in the signal handler too, then re-raise with the default
+// disposition so the parent still observes the real signal termination.
+process.on("exit", cleanupTestRunScratchDir);
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  process.on(signal, () => {
+    cleanupTestRunScratchDir();
+    process.removeAllListeners(signal);
+    process.kill(process.pid, signal);
+  });
+}
 
 let selectedGroups;
 let selectedPatterns;

--- a/scripts/run-root-tests.mjs
+++ b/scripts/run-root-tests.mjs
@@ -22,6 +22,8 @@ import path from "node:path";
 import process from "node:process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 import { ensurePackageBuild } from "./build-staleness.mjs";
 import { appendNodeOption } from "./root-test-runner-env.mjs";
@@ -50,6 +52,25 @@ process.env.NODE_OPTIONS = appendNodeOption(
   process.env.NODE_OPTIONS,
   "--conditions=remnic-source",
 );
+
+// Sandbox TMPDIR for this run (#2083). os.tmpdir() reads TMPDIR/TMP/TEMP on
+// each call and child test processes inherit process.env, so pointing all
+// three at one per-run scratch dir makes every test's temp directory land
+// inside it. A single cleanup on exit then reclaims them all, so leaked
+// per-test dirs cannot accumulate in the shared /tmp across runs and exhaust
+// inodes on long-lived (self-hosted) runners. The scratch dir is created via
+// the current tmpdir() BEFORE the override so it is not nested under itself.
+const testRunScratchDir = mkdtempSync(join(tmpdir(), "remnic-test-run-"));
+process.env.TMPDIR = testRunScratchDir;
+process.env.TMP = testRunScratchDir;
+process.env.TEMP = testRunScratchDir;
+process.on("exit", () => {
+  try {
+    rmSync(testRunScratchDir, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup — never mask the run's real exit status.
+  }
+});
 
 let selectedGroups;
 let selectedPatterns;


### PR DESCRIPTION
## Summary

Part of #2083 (Tier 1 — the load-bearing fix). Small single-file change to the root test runner.

Per-test temp dirs created under `os.tmpdir()` that lack cleanup accumulated in the shared `/tmp` across runs on the long-lived self-hosted CI runner, eventually exhausting **inodes** — later jobs then failed at setup with `ENOSPC: no space left on device` despite low block usage, in a way that looks unrelated to the change under test.

CI runs both test shards (`tests (root)` = `--group root --group misc`, `tests (packages)` = `--group packages`) through `scripts/run-root-tests.mjs` on the self-hosted `remnic` runner (`ci.yml`), so sandboxing there covers the entire accumulation surface in one place.

## Change

- Before spawning tests, create one per-run scratch dir and point `TMPDIR`/`TMP`/`TEMP` at it; remove it on exit via `process.on("exit")` (fires on every exit path, including early errors).
- `os.tmpdir()` reads those env vars on each call and child test processes inherit `process.env`, so every test's temp dir lands inside the scratch dir and a single cleanup reclaims them all — resilient to tests that forget their own cleanup. All three vars are set for cross-platform coverage (Windows honors `TEMP`/`TMP`).

## Verification

- Mechanism probe: a child process's `os.tmpdir()` resolves to the scratch dir, a leaky `mkdtemp` lands inside it, and the exit cleanup removes the whole tree.
- Ran the edited runner on an early-exit path (unknown group): loads cleanly, errors correctly, and leaves **no** `remnic-test-run-*` dir behind.
- `npm run preflight:quick`: OK (incl. `root-test-build-contract` and `build-staleness` tests).

## Follow-up

Tier 2 (a shared `tmpDir(t)` helper + migrating the ~136 non-cleaning test files and folding the duplicated local helpers) removes the root-cause duplication and is tracked as a separate PR; it is independent of this stop-gap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only change; no production paths, with cleanup designed not to mask real exit codes.
> 
> **Overview**
> **Root test runner** now creates a short-prefixed per-run scratch directory under the system temp **before** overriding env, then sets **`TMPDIR`**, **`TMP`**, and **`TEMP`** so every child test’s `os.tmpdir()` resolves inside that sandbox.
> 
> On **`exit`** and on **`SIGINT`/`SIGTERM`/`SIGHUP`**, the runner **best-effort removes** the whole tree so leaked per-test temp dirs no longer pile up in shared **`/tmp`** on long-lived CI runners (inode exhaustion / false **`ENOSPC`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482724d1e0ce5acd9a9ba4a184f1f8ea3f795cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by executing each test run in a dedicated temporary “scratch” workspace under the system temp directory.
  * Ensures consistent temporary storage for both the runner and spawned test processes by redirecting standard temp environment variables to the same workspace.
  * Adds best-effort cleanup on normal completion and on common termination signals (e.g., Ctrl+C), while still preserving the original test outcome even if cleanup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->