### PR TITLE
test: migrate remaining root temp-dir helpers onto shared helper (#2083)

### DIFF
--- a/tests/cli/peer-forget.test.ts
+++ b/tests/cli/peer-forget.test.ts
@@ -16,11 +16,12 @@
 
 import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
+
+import { makeTempDir as managedTempDir } from "../helpers/tmp-dir.mjs";
 
 import {
   writePeer,
@@ -41,9 +42,7 @@ const repoRoot = path.resolve(__dirname, "..", "..");
 // Fixtures
 // ──────────────────────────────────────────────────────────────────────
 
-async function makeTempDir(): Promise<string> {
-  return fs.mkdtemp(path.join(os.tmpdir(), "peer-forget-test-"));
-}
+const makeTempDir = (): Promise<string> => managedTempDir("peer-forget-test-");
 
 function syntheticPeer(overrides: Partial<Peer> = {}): Peer {
   return {

--- a/tests/cli/peers.test.ts
+++ b/tests/cli/peers.test.ts
@@ -18,9 +18,9 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { rm } from "node:fs/promises";
+
+import { makeTempDir as managedTempDir } from "../helpers/tmp-dir.mjs";
 
 import {
   assertValidPeerId,
@@ -36,9 +36,7 @@ import type { Peer, PeerProfile } from "../../packages/remnic-core/src/peers/typ
 // Helpers
 // ──────────────────────────────────────────────────────────────────────
 
-async function makeTempDir(): Promise<string> {
-  return mkdtemp(join(tmpdir(), "remnic-peers-test-"));
-}
+const makeTempDir = (): Promise<string> => managedTempDir("remnic-peers-test-");
 
 async function removeTempDir(dir: string): Promise<void> {
   await rm(dir, { recursive: true, force: true });

--- a/tests/codex-materialize-config-resolution.test.ts
+++ b/tests/codex-materialize-config-resolution.test.ts
@@ -1,10 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { withTempDirSync as sharedWithTempDirSync } from "./helpers/tmp-dir.mjs";
 
 import {
   loadRawConfig as loadDevRawConfig,
@@ -39,14 +40,7 @@ const loaders: Array<[string, Loader]> = [
   ],
 ];
 
-function withTempDir<T>(fn: (dir: string) => T): T {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "codex-materialize-config-"));
-  try {
-    return fn(dir);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-}
+const withTempDir = <T>(fn: (dir: string) => T): T => sharedWithTempDirSync(fn, "codex-materialize-config-");
 
 function writeJson(file: string, value: unknown): void {
   writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);

--- a/tests/codex-materialize-runner.test.ts
+++ b/tests/codex-materialize-runner.test.ts
@@ -18,9 +18,10 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, existsSync, readdirSync, rmSync } from "node:fs";
-import os from "node:os";
+import { mkdirSync, existsSync, readdirSync, rmSync } from "node:fs";
 import path from "node:path";
+
+import { makeTempDirSync as managedTempDirSync } from "./helpers/tmp-dir.mjs";
 
 import {
   runCodexMaterialize,
@@ -37,9 +38,7 @@ import { StorageManager } from "@remnic/core/storage";
 const isSecureStoreLockedError = (error: unknown): boolean =>
   error instanceof SecureStoreLockedError;
 
-function makeTempDir(prefix: string): string {
-  return mkdtempSync(path.join(os.tmpdir(), prefix));
-}
+const makeTempDir = (prefix: string): string => managedTempDirSync(prefix);
 
 function makeCodexHome(): { root: string; memoriesDir: string } {
   const root = makeTempDir("codex-materialize-runner-home-");

--- a/tests/peers/multi-peer-integration.test.ts
+++ b/tests/peers/multi-peer-integration.test.ts
@@ -17,11 +17,12 @@
 
 import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
+
+import { makeTempDir as managedTempDir } from "../helpers/tmp-dir.mjs";
 
 import {
   writePeer,
@@ -49,9 +50,7 @@ const repoRoot = path.resolve(__dirname, "..", "..");
 // Fixtures
 // ──────────────────────────────────────────────────────────────────────
 
-async function makeTempDir(): Promise<string> {
-  return fs.mkdtemp(path.join(os.tmpdir(), "multi-peer-intg-"));
-}
+const makeTempDir = (): Promise<string> => managedTempDir("multi-peer-intg-");
 
 /** Returns three synthetic peers with distinct kinds */
 function threeFixturePeers(): [Peer, Peer, Peer] {

--- a/tests/peers/profile-reasoner.test.ts
+++ b/tests/peers/profile-reasoner.test.ts
@@ -17,9 +17,10 @@
 
 import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+
+import { makeTempDir as managedTempDir } from "../helpers/tmp-dir.mjs";
 
 import {
   appendInteractionLog,
@@ -38,9 +39,7 @@ import {
 // Fixtures + helpers
 // ──────────────────────────────────────────────────────────────────────
 
-async function makeTempDir(): Promise<string> {
-  return await fs.mkdtemp(path.join(os.tmpdir(), "peer-reasoner-test-"));
-}
+const makeTempDir = (): Promise<string> => managedTempDir("peer-reasoner-test-");
 
 function syntheticPeer(overrides: Partial<Peer> = {}): Peer {
   return {

--- a/tests/peers/recall-integration.test.ts
+++ b/tests/peers/recall-integration.test.ts
@@ -13,12 +13,12 @@
  */
 
 import assert from "node:assert/strict";
-import { promises as fs } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+
+import { makeTempDir as managedTempDir } from "../helpers/tmp-dir.mjs";
 
 import {
   writePeer,
@@ -35,9 +35,7 @@ const repoRoot = path.resolve(__dirname, "..", "..");
 // Fixtures
 // ──────────────────────────────────────────────────────────────────────
 
-async function makeTempDir(): Promise<string> {
-  return fs.mkdtemp(path.join(os.tmpdir(), "peer-recall-test-"));
-}
+const makeTempDir = (): Promise<string> => managedTempDir("peer-recall-test-");
 
 function syntheticPeer(overrides: Partial<Peer> = {}): Peer {
   return {


### PR DESCRIPTION
## Summary

Part of #2083 (Tier 2). Folds the 7 remaining root `tests/` files that still defined their own temp-dir helper onto the shared `tests/helpers/tmp-dir.mjs` (added in #2094), completing the root-scope dedup.

## Change

Each file's **local** helper definition is replaced with a thin wrapper delegating to the shared helper, **preserving the original prefix** and leaving all call sites unchanged; now-unused local `os`/`mkdtemp` imports are removed:

- `cli/peer-forget` (`peer-forget-test-`), `cli/peers` (`remnic-peers-test-`; its existing `removeTempDir` left intact — redundant with auto-clean but harmless), `codex-materialize-config-resolution` (sync `withTempDir`), `codex-materialize-runner` (prefix-arg `makeTempDirSync`), `peers/multi-peer-integration`, `peers/profile-reasoner`, `peers/recall-integration`.

The three `makeTempDir` files that previously **leaked** (no cleanup) are now self-cleaning via the shared helper's file-scoped `after()` hook.

## Verification

- The 7 migrated suites: 105 tests, 0 fail (run under a sandboxed `TMPDIR`).
- `npm run preflight:quick`: OK (lint / check-types / test-typecheck all clean).

## Follow-up

Package-scope helper dedup (`@remnic/core`, `bench`) and the inline-`mkdtemp` tail are separate PRs (in progress).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production or runtime behavior changes; risk is limited to test isolation and cleanup timing.
> 
> **Overview**
> Finishes **Tier 2** of #2083 by routing the last seven root `tests/` suites through **`tests/helpers/tmp-dir.mjs`** instead of copy-pasted `mkdtemp` helpers.
> 
> Each file keeps its **original prefix** and call sites via a thin wrapper (`makeTempDir`, `withTempDir`, or sync variants). Unused `os` / `mkdtemp` imports are dropped. Suites that previously **never tore down** temp dirs now get **file-scoped cleanup** from the shared helper’s `after()` hook; explicit `rmSync`/`removeTempDir` in some tests is unchanged (redundant but harmless).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe8b58cd111e499ae3b969edd3cbfe422317ba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized temporary-directory handling across CLI, configuration, runner, and peer integration tests.
  * Improved test cleanup consistency and reduced duplicated setup logic.
  * Existing test coverage and validation behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->