### PR TITLE
test(core): shared src/testing/tmp-dir helper + migrate core temp-dir helpers (#2083)

### DIFF
--- a/packages/remnic-core/src/admin/admin-surfaces.test.ts
+++ b/packages/remnic-core/src/admin/admin-surfaces.test.ts
@@ -7,10 +7,11 @@
  * hold by construction rather than by mock.
  */
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
+
+import { makeTempDir as managedMakeTempDir } from "../testing/tmp-dir.js";
 
 import { NamespaceCatalog } from "../namespaces/catalog.js";
 import { resolveScopeProfilePlan } from "../namespaces/scope-profiles.js";
@@ -41,9 +42,7 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
   });
 }
 
-async function makeTempDir(): Promise<string> {
-  return mkdtemp(path.join(os.tmpdir(), "remnic-admin-test-"));
-}
+const makeTempDir = (): Promise<string> => managedMakeTempDir("remnic-admin-test-");
 
 // ---------------------------------------------------------------------------
 // redactSensitive

--- a/packages/remnic-core/src/chat/chat-cli.test.ts
+++ b/packages/remnic-core/src/chat/chat-cli.test.ts
@@ -8,10 +8,9 @@
  */
 
 import { strict as assert } from "node:assert";
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { test } from "node:test";
+
+import { withTempDir as managedWithTempDir } from "../testing/tmp-dir.js";
 
 import type { EngramAccessService } from "../access-service.js";
 import { parseConfig } from "../config.js";
@@ -54,10 +53,8 @@ function makeService(overrides: Partial<EngramAccessService> = {}): EngramAccess
   } as unknown as EngramAccessService;
 }
 
-async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(join(tmpdir(), "chat-cli-"));
-  try { return await fn(dir); } finally { await rm(dir, { recursive: true, force: true }); }
-}
+const withTempDir = <T>(fn: (dir: string) => Promise<T>): Promise<T> =>
+  managedWithTempDir(fn, "chat-cli-");
 
 test("CLI --once mode: prints the assistant reply and session id", async () => {
   await withTempDir(async (memoryDir) => {

--- a/packages/remnic-core/src/chat/chat-engine.test.ts
+++ b/packages/remnic-core/src/chat/chat-engine.test.ts
@@ -7,10 +7,10 @@
  */
 
 import { strict as assert } from "node:assert";
-import { mkdir, rm, readFile, utimes, unlink, appendFile } from "node:fs/promises";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { readFile, utimes, unlink, appendFile } from "node:fs/promises";
 import { test } from "node:test";
+
+import { makeTempDir as managedMakeTempDir } from "../testing/tmp-dir.js";
 
 import { ChatEngine } from "./chat-engine.js";
 import { StubChatLlmAdapter, NullChatLlmAdapter } from "./chat-llm.js";
@@ -62,11 +62,7 @@ function makeEngine(
   });
 }
 
-async function makeTempDir(): Promise<string> {
-  const dir = join(tmpdir(), `chat-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-  await mkdir(dir, { recursive: true });
-  return dir;
-}
+const makeTempDir = (): Promise<string> => managedMakeTempDir("chat-test-");
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/packages/remnic-core/src/chat/chat-http.test.ts
+++ b/packages/remnic-core/src/chat/chat-http.test.ts
@@ -9,10 +9,9 @@
 
 import { strict as assert } from "node:assert";
 import { EventEmitter } from "node:events";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { test } from "node:test";
+
+import { withTempDir as managedWithTempDir } from "../testing/tmp-dir.js";
 
 import type { EngramAccessService } from "../access-service.js";
 import { parseConfig } from "../config.js";
@@ -66,10 +65,8 @@ function makeService(overrides: Partial<EngramAccessService> = {}): EngramAccess
   } as unknown as EngramAccessService;
 }
 
-async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(join(tmpdir(), "chat-http-"));
-  try { return await fn(dir); } finally { await rm(dir, { recursive: true, force: true }); }
-}
+const withTempDir = <T>(fn: (dir: string) => Promise<T>): Promise<T> =>
+  managedWithTempDir(fn, "chat-http-");
 
 test("HTTP chat/message: 404 when chat is disabled", async () => {
   await withTempDir(async (memoryDir) => {

--- a/packages/remnic-core/src/chat/chat-security.test.ts
+++ b/packages/remnic-core/src/chat/chat-security.test.ts
@@ -14,10 +14,10 @@
  */
 
 import { strict as assert } from "node:assert";
-import { mkdtemp, rm, readFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { rm, readFile } from "node:fs/promises";
 import { test } from "node:test";
+
+import { makeTempDir as managedMakeTempDir } from "../testing/tmp-dir.js";
 
 import { ChatEngine } from "./chat-engine.js";
 import { StubChatLlmAdapter } from "./chat-llm.js";
@@ -70,9 +70,7 @@ function makeEngine(
   });
 }
 
-async function makeTempDir(): Promise<string> {
-  return mkdtemp(join(tmpdir(), "chat-sec-"));
-}
+const makeTempDir = (): Promise<string> => managedMakeTempDir("chat-sec-");
 
 // ---------------------------------------------------------------------------
 // P1 — Path traversal (chat-session.ts)

--- a/packages/remnic-core/src/console/trace.test.ts
+++ b/packages/remnic-core/src/console/trace.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { promises as fs } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { Writable } from "node:stream";
+
+import { withTempDir as managedWithTempDir } from "../testing/tmp-dir.js";
 
 import {
   openTraceRecorder,
@@ -52,14 +53,8 @@ function makeSnapshot(
   };
 }
 
-async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-trace-"));
-  try {
-    return await fn(dir);
-  } finally {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
-}
+const withTempDir = <T>(fn: (dir: string) => Promise<T>): Promise<T> =>
+  managedWithTempDir(fn, "remnic-trace-");
 
 test("openTraceRecorder writes one parseable JSON object per line", async () => {
   await withTempDir(async (dir) => {

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
+
+import { makeTempDir as managedMakeTempDir } from "../testing/tmp-dir.js";
 
 import {
   computePairId,
@@ -35,7 +36,7 @@ async function makeTempDir(prefix = "contradiction-test-"): Promise<{
   dir: string;
   cleanup: () => Promise<void>;
 }> {
-  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  const dir = await managedMakeTempDir(prefix);
   return { dir, cleanup: () => rm(dir, { recursive: true, force: true }) };
 }
 

--- a/packages/remnic-core/src/correction/correction-executor.test.ts
+++ b/packages/remnic-core/src/correction/correction-executor.test.ts
@@ -16,10 +16,10 @@
  */
 
 import { strict as assert } from "node:assert";
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
+
+import { withTempDir as managedWithTempDir } from "../testing/tmp-dir.js";
 import {
   CorrectionContractError,
   type CorrectionAction,
@@ -157,14 +157,8 @@ function makeExecutorDeps(state: FakeState, opts: { biTemporalEnabled?: boolean;
   };
 }
 
-async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(path.join(tmpdir(), "remnic-corr-exec-"));
-  try {
-    return await fn(dir);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-}
+const withTempDir = <T>(fn: (dir: string) => Promise<T>): Promise<T> =>
+  managedWithTempDir(fn, "remnic-corr-exec-");
 
 /** Build a persisted plan via the planner, then hand it to the executor. */
 async function makePlan(

--- a/packages/remnic-core/src/correction/correction-planner.test.ts
+++ b/packages/remnic-core/src/correction/correction-planner.test.ts
@@ -12,10 +12,11 @@
  */
 
 import { strict as assert } from "node:assert";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { test } from "node:test";
+
+import { withTempDir as managedWithTempDir } from "../testing/tmp-dir.js";
 import {
   CorrectionContractError,
   MEMORY_CATEGORIES,
@@ -88,14 +89,8 @@ function makeDeps(stateDir: string, state: StubState, opts: { maxAffected?: numb
   };
 }
 
-async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(path.join(tmpdir(), "remnic-corr-plan-"));
-  try {
-    return await fn(dir);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-}
+const withTempDir = <T>(fn: (dir: string) => Promise<T>): Promise<T> =>
+  managedWithTempDir(fn, "remnic-corr-plan-");
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/packages/remnic-core/src/extraction-redaction-rules.test.ts
+++ b/packages/remnic-core/src/extraction-redaction-rules.test.ts
@@ -7,10 +7,11 @@
  * correction actually blocks future extraction of matching content.
  */
 import { strict as assert } from "node:assert";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { tmpdir } from "node:os";
 import { test } from "node:test";
+
+import { withTempDir as managedWithTempDir } from "./testing/tmp-dir.js";
 import {
   REDACTION_RULES_SUBDIR,
   compileRedactionPattern,
@@ -20,14 +21,8 @@ import {
 } from "./extraction-redaction-rules.js";
 import { validateRedactionPattern } from "./correction/correction-contract.js";
 
-async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(path.join(tmpdir(), "remnic-redact-"));
-  try {
-    return await fn(dir);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-}
+const withTempDir = <T>(fn: (dir: string) => Promise<T>): Promise<T> =>
+  managedWithTempDir(fn, "remnic-redact-");
 
 async function writeRule(stateDir: string, pattern: string): Promise<void> {
   const dir = path.join(stateDir, REDACTION_RULES_SUBDIR);

--- a/packages/remnic-core/src/maintenance/graph-edge-decay.test.ts
+++ b/packages/remnic-core/src/maintenance/graph-edge-decay.test.ts
@@ -3,10 +3,11 @@
  */
 
 import assert from "node:assert/strict";
-import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+
+import { withTempDir as managedWithTempDir } from "../testing/tmp-dir.js";
 
 import { appendEdge, graphFilePath, graphsDir, type GraphEdge } from "../graph.js";
 import {
@@ -85,14 +86,8 @@ async function readEdgesFile(memoryDir: string): Promise<GraphEdge[]> {
     .map((l) => JSON.parse(l) as GraphEdge);
 }
 
-async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
-  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-graph-decay-test-"));
-  try {
-    await fn(dir);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-}
+const withTempDir = (fn: (dir: string) => Promise<void>): Promise<void> =>
+  managedWithTempDir(fn, "remnic-graph-decay-test-");
 
 test("runs end-to-end on a fixture graph with fresh, mid-decay, stale edges", async () => {
   await withTempDir(async (memoryDir) => {

--- a/packages/remnic-core/src/peers/migrate-from-identity-anchor.test.ts
+++ b/packages/remnic-core/src/peers/migrate-from-identity-anchor.test.ts
@@ -6,9 +6,10 @@
 
 import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+
+import { makeTempDir as managedMakeTempDir } from "../testing/tmp-dir.js";
 
 import { readPeer } from "./storage.js";
 import { migrateFromIdentityAnchor } from "./migrate-from-identity-anchor.js";
@@ -17,9 +18,7 @@ import { migrateFromIdentityAnchor } from "./migrate-from-identity-anchor.js";
 // Helpers
 // ──────────────────────────────────────────────────────────────────────────────
 
-async function makeTempDir(): Promise<string> {
-  return fs.mkdtemp(path.join(os.tmpdir(), "peer-migrate-test-"));
-}
+const makeTempDir = (): Promise<string> => managedMakeTempDir("peer-migrate-test-");
 
 /** Write a file, creating intermediate directories as needed. */
 async function writeFixture(filePath: string, content: string): Promise<void> {

--- a/packages/remnic-core/src/peers/peers.test.ts
+++ b/packages/remnic-core/src/peers/peers.test.ts
@@ -7,9 +7,10 @@
 
 import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+
+import { makeTempDir as managedMakeTempDir } from "../testing/tmp-dir.js";
 
 import {
   appendInteractionLog,
@@ -33,9 +34,7 @@ import {
 // Fixtures
 // ──────────────────────────────────────────────────────────────────────
 
-async function makeTempDir(): Promise<string> {
-  return await fs.mkdtemp(path.join(os.tmpdir(), "peers-test-"));
-}
+const makeTempDir = (): Promise<string> => managedMakeTempDir("peers-test-");
 
 function samplePeer(overrides: Partial<Peer> = {}): Peer {
   return {

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -4,16 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { withTempDir as managedWithTempDir } from "../testing/tmp-dir.js";
+
 import { collectLocalSessionSummaries, compileRedactionRules, runLocalSessionSummaryCliCommand } from "./index.js";
 
-async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-session-summary-"));
-  try {
-    return await fn(dir);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-}
+const withTempDir = <T>(fn: (dir: string) => Promise<T>): Promise<T> =>
+  managedWithTempDir(fn, "remnic-session-summary-");
 
 test("collectLocalSessionSummaries produces metadata-only drafts without local paths or raw session keys", async () => {
   await withTempDir(async (dir) => {

--- a/packages/remnic-core/src/testing/tmp-dir.ts
+++ b/packages/remnic-core/src/testing/tmp-dir.ts
@@ -1,0 +1,68 @@
+import { after } from "node:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Shared temp-dir lifecycle for `@remnic/core` tests (#2083). The single source
+ * of truth within this package, so its tests are self-cleaning rather than
+ * relying solely on the run-level TMPDIR sandbox (Tier 1).
+ *
+ * `makeTempDir` / `makeTempDirSync` register the created directory for cleanup
+ * via a single file-scoped `after()` hook (registered at import time, before
+ * any test runs), so a bare `const dir = await makeTempDir()` call site needs
+ * no per-test teardown wiring. `withTempDir` scopes the directory to a callback
+ * and removes it in `finally`.
+ */
+const pendingCleanup = new Set<string>();
+
+// Registered at module load — importing this module from a test file installs
+// one file-scoped after-all hook that removes every managed temp dir. Doing it
+// here (not lazily inside a test) guarantees the hook binds to the file root
+// rather than whichever test happened to allocate the first dir.
+after(async () => {
+  const dirs = [...pendingCleanup];
+  pendingCleanup.clear();
+  // Surface cleanup failures (do not swallow): a dir that cannot be removed is
+  // a real signal. `force: true` already ignores a missing dir, so a rejection
+  // here means an actual teardown problem and should fail the file loudly.
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+/** Create a temp dir that is removed automatically after the file's tests. */
+export async function makeTempDir(prefix = "remnic-test-"): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  pendingCleanup.add(dir);
+  return dir;
+}
+
+/** Synchronous {@link makeTempDir}. */
+export function makeTempDirSync(prefix = "remnic-test-"): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  pendingCleanup.add(dir);
+  return dir;
+}
+
+/** Run `fn` with a fresh temp dir, removing it in `finally`. */
+export async function withTempDir<T>(
+  fn: (dir: string) => T | Promise<T>,
+  prefix = "remnic-test-",
+): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/** Synchronous {@link withTempDir}. */
+export function withTempDirSync<T>(fn: (dir: string) => T, prefix = "remnic-test-"): T {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/remnic-core/src/transfer/capsule-encrypt.test.ts
+++ b/packages/remnic-core/src/transfer/capsule-encrypt.test.ts
@@ -22,10 +22,11 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtemp, rm, writeFile, readFile, mkdir, stat, readdir } from "node:fs/promises";
+import { rm, writeFile, readFile, mkdir, stat, readdir } from "node:fs/promises";
 import path from "node:path";
-import { tmpdir } from "node:os";
 import { gzipSync, gunzipSync } from "node:zlib";
+
+import { makeTempDir as managedMakeTempDir } from "../testing/tmp-dir.js";
 
 import { exportCapsule } from "./capsule-export.js";
 import { importCapsule } from "./capsule-import.js";
@@ -53,9 +54,7 @@ const FAST_SCRYPT: ScryptParams = {
 
 const TEST_PASSPHRASE = "hunter2-test-passphrase";
 
-async function makeTempDir(): Promise<string> {
-  return mkdtemp(path.join(tmpdir(), "capsule-enc-test-"));
-}
+const makeTempDir = (): Promise<string> => managedMakeTempDir("capsule-enc-test-");
 
 /**
  * Initialize a secure-store header in `memoryDir` and unlock the keyring.

--- a/packages/remnic-core/src/write-quarantine.test.ts
+++ b/packages/remnic-core/src/write-quarantine.test.ts
@@ -4,16 +4,12 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { withTempDir as managedWithTempDir } from "./testing/tmp-dir.js";
+
 import { WriteQuarantineStore } from "./write-quarantine.js";
 
-async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
-  const dir = await mkdtemp(path.join(tmpdir(), "remnic-quarantine-"));
-  try {
-    await fn(dir);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-}
+const withTempDir = (fn: (dir: string) => Promise<void>): Promise<void> =>
+  managedWithTempDir(fn, "remnic-quarantine-");
 
 function isInside(root: string, child: string): boolean {
   const rel = path.relative(path.resolve(root), path.resolve(child));


### PR DESCRIPTION
## Summary

Part of #2083 (Tier 2, package scope for `@remnic/core`). Adds `packages/remnic-core/src/testing/tmp-dir.ts` as the intra-package source of truth for test temp-dir lifecycle, colocated with the existing `src/testing/` utilities (`lifecycle-matrix`). Package tests can't import the root `tests/helpers/` module, so this gives core its own shared helper **without** a new workspace package or any published-manifest/publish-surface change.

## Change

- New `src/testing/tmp-dir.ts`: `makeTempDir`/`makeTempDirSync` (auto-clean via a file-scoped `after()` hook), `withTempDir`/`withTempDirSync` (scope + clean in `finally`). Cleanup failures are surfaced (not swallowed); `force:true` handles the benign missing-dir case.
- Migrates the 16 core test files that defined their own temp-dir helper onto it, **preserving each file's prefix** and leaving call sites unchanged. Now-unused local `os`/`mkdtemp` imports removed. Two files (`session-summaries` tilde-expansion, `write-quarantine`) keep `mkdtemp`/`os` because they use them elsewhere — only the helper body is swapped.

## Verification

- The 16 migrated suites: 411 tests, 0 fail (run under a sandboxed `TMPDIR`).
- `npm run preflight:quick`: OK (lint, check-types incl. the new helper, test-typecheck all clean).

## Follow-up

`@remnic/bench` + `@remnic/remnic-cli` helper/inline dedup and the root inline-`mkdtemp` tail are separate PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no runtime behavior changes; risk is limited to test teardown semantics (e.g. file-scoped `after()` vs per-test `finally`).
> 
> **Overview**
> Adds **`packages/remnic-core/src/testing/tmp-dir.ts`** as the in-package test utility for temp directories (#2083 Tier 2). It exposes **`makeTempDir` / `makeTempDirSync`** (dirs tracked and removed in a file-scoped **`after()`** hook at import time) and **`withTempDir` / `withTempDirSync`** (callback-scoped create + **`finally`** cleanup). Cleanup errors are not swallowed.
> 
> **Sixteen** core test suites drop their local **`mkdtemp`/`withTempDir`** copies and import the shared helper instead, keeping each file’s **prefix** and existing call sites. Redundant **`os`/`mkdtemp`** imports are removed where they were only used for those helpers.
> 
> No production or published API changes—test infrastructure only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a1542850d4677b74dff6a2407be6a5ee53dbdfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added shared utilities for creating and cleaning up temporary test directories.
  * Updated filesystem-based tests to use consistent, automatic temporary-directory cleanup.
  * Preserved existing test scenarios and behavior while simplifying test setup and teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->