### PR TITLE
test(bench-ui): clean temporary result directories

### DIFF
--- a/packages/bench-ui/src/results.test.ts
+++ b/packages/bench-ui/src/results.test.ts
@@ -1,17 +1,15 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 
 import { loadBenchResultSummaries } from "./results";
+import { withTempDir } from "./testing/tmp-dir";
 
 test("loadBenchResultSummaries reports malformed result files as skipped warnings", async () => {
-  const resultsDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ui-results-"));
-  const validPath = path.join(resultsDir, "valid.json");
-  const malformedPath = path.join(resultsDir, "malformed.json");
-
-  try {
+  await withTempDir("results", async (resultsDir) => {
+    const validPath = path.join(resultsDir, "valid.json");
+    const malformedPath = path.join(resultsDir, "malformed.json");
     await writeFile(
       validPath,
       JSON.stringify({
@@ -33,16 +31,12 @@ test("loadBenchResultSummaries reports malformed result files as skipped warning
     assert.equal(payload.skippedFiles?.length, 1);
     assert.equal(payload.skippedFiles?.[0]?.filePath, malformedPath);
     assert.match(payload.skippedFiles?.[0]?.reason ?? "", /JSON|Expected|property/i);
-  } finally {
-    await rm(resultsDir, { recursive: true, force: true });
-  }
+  });
 });
 
 test("loadBenchResultSummaries preserves non-standard result modes", async () => {
-  const resultsDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ui-results-"));
-  const resultPath = path.join(resultsDir, "eval.json");
-
-  try {
+  await withTempDir("results", async (resultsDir) => {
+    const resultPath = path.join(resultsDir, "eval.json");
     await writeFile(
       resultPath,
       JSON.stringify({
@@ -60,7 +54,5 @@ test("loadBenchResultSummaries preserves non-standard result modes", async () =>
     const payload = await loadBenchResultSummaries(resultsDir);
 
     assert.equal(payload.summaries[0]?.mode, "eval");
-  } finally {
-    await rm(resultsDir, { recursive: true, force: true });
-  }
+  });
 });

--- a/packages/bench-ui/src/testing/tmp-dir.test.ts
+++ b/packages/bench-ui/src/testing/tmp-dir.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { withTempDir } from "./tmp-dir";
+
+test("withTempDir removes the directory after a successful callback", async () => {
+  let createdDir = "";
+
+  await withTempDir("contract", async (dir) => {
+    createdDir = dir;
+    assert.equal(path.basename(dir).startsWith("remnic-bench-ui-contract-"), true);
+    assert.equal(existsSync(dir), true);
+  });
+
+  assert.equal(existsSync(createdDir), false);
+});
+
+test("withTempDir removes the directory after a rejected callback", async () => {
+  let createdDir = "";
+
+  await assert.rejects(
+    withTempDir("failure", async (dir) => {
+      createdDir = dir;
+      throw new Error("callback failed");
+    }),
+    /callback failed/,
+  );
+
+  assert.equal(existsSync(createdDir), false);
+});

--- a/packages/bench-ui/src/testing/tmp-dir.ts
+++ b/packages/bench-ui/src/testing/tmp-dir.ts
@@ -1,0 +1,12 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export async function withTempDir<T>(prefix: string, fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), `remnic-bench-ui-${prefix}-`));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/bench-ui/vite.config.test.ts
+++ b/packages/bench-ui/vite.config.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 
@@ -9,6 +8,7 @@ import {
   createBenchResultsHandler,
   resolveResultsDir,
 } from "./vite.config";
+import { withTempDir } from "./src/testing/tmp-dir";
 
 test("resolveResultsDir expands exact home-relative bench results paths", () => {
   const home = path.join(path.sep, "tmp", "remnic-home");
@@ -42,9 +42,8 @@ test("resolveResultsDir preserves relative, absolute, and unsupported tilde-user
 });
 
 test("bench results handler serves JSON for dev and preview middleware", async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ui-vite-"));
-  const resultsDir = path.join(tempRoot, "results");
-  try {
+  await withTempDir("vite", async (tempRoot) => {
+    const resultsDir = path.join(tempRoot, "results");
     await mkdir(resultsDir, { recursive: true });
     await writeFile(
       path.join(resultsDir, "run.json"),
@@ -92,16 +91,13 @@ test("bench results handler serves JSON for dev and preview middleware", async (
     assert.deepEqual(previewRoutes, ["/api/results"]);
     assert.equal(typeof devHandlers[0], "function");
     assert.equal(typeof previewHandlers[0], "function");
-  } finally {
-    await rm(tempRoot, { recursive: true, force: true });
-  }
+  });
 });
 
 test("bench results plugin emits static /api/results asset during build", async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ui-static-"));
-  const resultsDir = path.join(tempRoot, "results");
-  const outDir = path.join(tempRoot, "dist");
-  try {
+  await withTempDir("static", async (tempRoot) => {
+    const resultsDir = path.join(tempRoot, "results");
+    const outDir = path.join(tempRoot, "dist");
     await mkdir(resultsDir, { recursive: true });
     await writeFile(
       path.join(resultsDir, "run.json"),
@@ -130,9 +126,7 @@ test("bench results plugin emits static /api/results asset during build", async 
       summaries?: Array<{ id?: string }>;
     };
     assert.equal(payload.summaries?.[0]?.id, "run-static");
-  } finally {
-    await rm(tempRoot, { recursive: true, force: true });
-  }
+  });
 });
 
 async function invokeHandler(


### PR DESCRIPTION
## Summary
- Add a scoped temporary-directory helper for bench UI tests.
- Migrate result and Vite configuration tests to clean their directories in `finally`.
- Cover cleanup after successful and failed callbacks.

Part of #2083.

## Verification
- `pnpm --filter @remnic/bench-ui test`
- `pnpm --filter @remnic/bench-ui check-types`
- `pnpm exec tsx --test vite.config.test.ts`
- `npm run preflight:quick` is blocked by an existing orchestrator structural-ratchet baseline mismatch on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code paths; behavior under test is preserved.
> 
> **Overview**
> Introduces **`withTempDir`** in `packages/bench-ui/src/testing/tmp-dir.ts` to create `remnic-bench-ui-{prefix}-*` directories under the OS temp folder and **always** remove them in a `finally` block, including when the callback throws.
> 
> **`results.test.ts`** and **`vite.config.test.ts`** drop inline `mkdtemp` / `rm` / `try/finally` setup and run their filesystem scenarios inside `withTempDir` instead. Assertions are unchanged.
> 
> Adds **`tmp-dir.test.ts`** to lock in naming, cleanup on success, and cleanup after a rejected callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe00ff4f9745d9493e03100e7e30e3ecd7f97866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify temporary test directories are created with the expected naming pattern and cleaned up after both successful and failed operations.
  - Updated filesystem-related tests to use consistent temporary directory handling.
  - Preserved validation for malformed result files and non-standard result permissions.

- **Refactor**
  - Centralized temporary directory creation and cleanup to improve test reliability and reduce duplicated setup logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->