### PR TITLE
test(cli): clean selector and import temp directories

### DIFF
--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -29,7 +29,7 @@
     "build": "tsup --config tsup.config.ts && node scripts/copy-bench-assets.mjs",
     "precheck-types": "node ../../scripts/ensure-cli-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
-    "test": "cd ../.. && tsx --test packages/remnic-cli/src/*.test.ts tests/remnic-cli-bin-wrapper.test.ts tests/evals-engram-adapter-buffering.test.ts tests/shim-openclaw-engram-package.test.ts tests/engram-access-bin-errors.test.ts tests/remnic-cli-bench-surface.test.ts tests/remnic-cli-bench-ui-surface.test.ts tests/bench-remnic-deterministic-runners.test.ts tests/bench-remnic-stateful-runners.test.ts",
+    "test": "cd ../.. && tsx --test packages/remnic-cli/src/*.test.ts packages/remnic-cli/src/testing/*.test.ts tests/remnic-cli-bin-wrapper.test.ts tests/evals-engram-adapter-buffering.test.ts tests/shim-openclaw-engram-package.test.ts tests/engram-access-bin-errors.test.ts tests/remnic-cli-bench-surface.test.ts tests/remnic-cli-bench-ui-surface.test.ts tests/bench-remnic-deterministic-runners.test.ts tests/bench-remnic-stateful-runners.test.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/remnic-cli/src/bench-task-selector.test.ts
+++ b/packages/remnic-cli/src/bench-task-selector.test.ts
@@ -1,19 +1,18 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import { __benchDatasetTestHooks } from "./index.js";
+import { withTempDir, withTempDirSync } from "./testing/tmp-dir.js";
 import { runCli } from "./run-cli.js";
 
 const DIGEST = "a".repeat(64);
 
 test("CLI loads an explicit LoCoMo selector and forwards no local path", () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-task-selector-"));
-  const selectorPath = path.join(dir, "task-ids.json");
-  fs.writeFileSync(selectorPath, JSON.stringify(["task-b", "task-a"]));
-  try {
+  withTempDirSync("task-selector", (dir) => {
+    const selectorPath = path.join(dir, "task-ids.json");
+    fs.writeFileSync(selectorPath, JSON.stringify(["task-b", "task-a"]));
     const selector = __benchDatasetTestHooks.loadPinnedLoCoMoTaskSelectorForTest({
       taskIdsFile: selectorPath,
       expectedTaskIdListSha256: DIGEST,
@@ -31,14 +30,11 @@ test("CLI loads an explicit LoCoMo selector and forwards no local path", () => {
     );
     assert.deepEqual(options?.taskSelector, selector);
     assert.equal(JSON.stringify(options).includes(selectorPath), false);
-  } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+  });
 });
 
 test("CLI rejects malformed or duplicate explicit LoCoMo selectors", () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-task-selector-"));
-  try {
+  withTempDirSync("task-selector", (dir) => {
     for (const [value, expected] of [
       [{ task: "task-a" }, /non-empty array of strings/],
       [[], /non-empty array of strings/],
@@ -55,9 +51,7 @@ test("CLI rejects malformed or duplicate explicit LoCoMo selectors", () => {
         expected,
       );
     }
-  } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+  });
 });
 
 test("CLI redacts the selector file path from persisted repro argv", () => {
@@ -131,34 +125,33 @@ test("LoCoMo published dry-run does not invoke the runner without a pinned selec
 });
 
 test("bench published LoCoMo dry-run rejects an unknown pinned task id", async () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-task-selector-cli-"));
-  const selectorPath = path.join(dir, "task-ids.json");
-  fs.writeFileSync(selectorPath, JSON.stringify(["unknown-task"]));
-  fs.writeFileSync(
-    path.join(dir, "locomo10.json"),
-    JSON.stringify([
-      {
-        sample_id: "selector-dry-run",
-        conversation: {
-          speaker_a: "Maya",
-          speaker_b: "Assistant",
-          session_1: [
-            { speaker: "Maya", dia_id: "D1:1", text: "I moved to Austin." },
+  await withTempDir("task-selector-cli", async (dir) => {
+    const selectorPath = path.join(dir, "task-ids.json");
+    fs.writeFileSync(selectorPath, JSON.stringify(["unknown-task"]));
+    fs.writeFileSync(
+      path.join(dir, "locomo10.json"),
+      JSON.stringify([
+        {
+          sample_id: "selector-dry-run",
+          conversation: {
+            speaker_a: "Maya",
+            speaker_b: "Assistant",
+            session_1: [
+              { speaker: "Maya", dia_id: "D1:1", text: "I moved to Austin." },
+            ],
+          },
+          qa: [
+            {
+              question: "Where did Maya move?",
+              answer: "Austin",
+              evidence: ["D1:1"],
+              category: 1,
+            },
           ],
         },
-        qa: [
-          {
-            question: "Where did Maya move?",
-            answer: "Austin",
-            evidence: ["D1:1"],
-            category: 1,
-          },
-        ],
-      },
-    ]),
-  );
+      ]),
+    );
 
-  try {
     const result = await runCli(
       [
         "bench",
@@ -184,7 +177,5 @@ test("bench published LoCoMo dry-run rejects an unknown pinned task id", async (
     assert.equal(result.exitCode, 1);
     assert.match(result.stdout, /\[dry-run\] locomo: source=dataset/);
     assert.match(result.stderr, /Unknown LoCoMo task id: unknown-task/);
-  } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+  });
 });

--- a/packages/remnic-cli/src/import-lossless-claw-cmd.test.ts
+++ b/packages/remnic-cli/src/import-lossless-claw-cmd.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
 
@@ -9,6 +8,7 @@ import {
   cmdImportLosslessClaw,
   type ImportLosslessClawModule,
 } from "./import-lossless-claw-cmd.js";
+import { withTempDir } from "./testing/tmp-dir.js";
 
 describe("parseImportLosslessClawArgs", () => {
   it("accepts --src and a relative path", () => {
@@ -107,10 +107,7 @@ describe("parseImportLosslessClawArgs", () => {
 
 describe("cmdImportLosslessClaw", () => {
   it("does not create destination state when opening the source database fails", async () => {
-    const tempDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "remnic-lossless-source-first-"),
-    );
-    try {
+    await withTempDir("lossless-source-first", async (tempDir) => {
       const sourcePath = path.join(tempDir, "corrupt-source.sqlite");
       const memoryDir = path.join(tempDir, "memory");
       const stdout: string[] = [];
@@ -164,8 +161,6 @@ describe("cmdImportLosslessClaw", () => {
       assert.equal(sourceClosed, true);
       assert.equal(destinationOpened, false);
       assert.equal(fs.existsSync(memoryDir), false);
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    });
   });
 });

--- a/packages/remnic-cli/src/testing/tmp-dir.test.ts
+++ b/packages/remnic-cli/src/testing/tmp-dir.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import test from "node:test";
+
+import { withTempDir, withTempDirSync } from "./tmp-dir.js";
+
+test("withTempDirSync removes the directory after a successful callback", () => {
+  let createdDir = "";
+
+  const result = withTempDirSync("success", (dir) => {
+    createdDir = dir;
+    return 42;
+  });
+
+  assert.equal(result, 42);
+  assert.equal(existsSync(createdDir), false);
+});
+
+test("withTempDirSync removes the directory after a failed callback", () => {
+  let createdDir = "";
+
+  assert.throws(() =>
+    withTempDirSync("failure", (dir) => {
+      createdDir = dir;
+      throw new Error("callback failed");
+    }),
+  /callback failed/);
+
+  assert.equal(existsSync(createdDir), false);
+});
+
+test("withTempDir removes the directory after a failed callback", async () => {
+  let createdDir = "";
+
+  await assert.rejects(
+    withTempDir("async-failure", async (dir) => {
+      createdDir = dir;
+      throw new Error("callback failed");
+    }),
+    /callback failed/,
+  );
+
+  assert.equal(existsSync(createdDir), false);
+});
+
+test("rejects path separators in temporary directory prefixes", async () => {
+  assert.throws(() => withTempDirSync("../escape", () => undefined), /path separator/);
+  await assert.rejects(withTempDir("nested/escape", async () => undefined), /path separator/);
+});

--- a/packages/remnic-cli/src/testing/tmp-dir.ts
+++ b/packages/remnic-cli/src/testing/tmp-dir.ts
@@ -1,0 +1,30 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+function assertSafePrefix(prefix: string): void {
+  if (/[\\/]/.test(prefix)) {
+    throw new Error("Temporary directory prefix must not contain a path separator");
+  }
+}
+
+export async function withTempDir<T>(prefix: string, fn: (dir: string) => Promise<T>): Promise<T> {
+  assertSafePrefix(prefix);
+  const dir = await mkdtemp(path.join(os.tmpdir(), `remnic-cli-${prefix}-`));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+export function withTempDirSync<T>(prefix: string, fn: (dir: string) => T): T {
+  assertSafePrefix(prefix);
+  const dir = mkdtempSync(path.join(os.tmpdir(), `remnic-cli-${prefix}-`));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary
- Add synchronous and asynchronous scoped temporary-directory helpers for CLI tests.
- Migrate the LoCoMo selector and Lossless Claw import tests to guaranteed cleanup.
- Register the helper contract test in the package test command.

Part of #2083.

## Verification
- `tsx --test src/testing/tmp-dir.test.ts src/import-lossless-claw-cmd.test.ts` (14 passing tests)
- The selector test and package type check are currently blocked by unrelated source-export mismatches in the worktree's dependency graph.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code paths; behavior under test is unchanged aside from more reliable temp cleanup.
> 
> **Overview**
> Introduces **`withTempDir`** and **`withTempDirSync`** under `packages/remnic-cli/src/testing/` so CLI tests get a temp directory under `os.tmpdir()` with **guaranteed recursive cleanup** in a `finally` block, including when callbacks throw. Prefixes are validated so they cannot contain path separators.
> 
> **LoCoMo bench task selector** and **Lossless Claw import** tests are refactored from manual `mkdtemp` + `try`/`finally` + `rmSync` to these helpers. New **`tmp-dir.test.ts`** covers success/failure cleanup and prefix validation. The **`@remnic/cli` `test` script** now includes `packages/remnic-cli/src/testing/*.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47bf9b627e9f4d7322f745cc5322ffac412a2e0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new tests for temporary-directory helpers, including success, error propagation, async behavior, and automatic cleanup.
  * Validated temporary-directory naming rules by rejecting prefixes with path separators.
  * Expanded the test runner to include CLI tests in the testing subdirectory and improved existing CLI tests to use consistent temp-directory lifecycle handling.

* **Chores**
  * Standardized temporary test resource management across the CLI test suite to reduce leftover files and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->