### PR TITLE
test(ledger): clean temporary test directories

### DIFF
--- a/packages/belief-ledger/package.json
+++ b/packages/belief-ledger/package.json
@@ -20,7 +20,7 @@
     "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "pretest": "node ../../scripts/ensure-bench-build-deps.mjs",
-    "test": "tsx --test src/*.test.ts",
+    "test": "tsx --test src/*.test.ts src/testing/*.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/belief-ledger/src/remnic-store.test.ts
+++ b/packages/belief-ledger/src/remnic-store.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, it } from "node:test";
 
@@ -12,18 +11,16 @@ import { RemnicLedgerStore } from "./remnic-store.js";
 // for published consumers that catch it via instanceof (#1645 review).
 import { RemnicLedgerTombstoneBlockedError } from "./index.js";
 import { normalizeClaimDraft } from "./schema.js";
+import { withTempDir } from "./testing/tmp-dir.js";
 
 async function withStore<T>(fn: (store: RemnicLedgerStore, storage: StorageManager) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-belief-ledger-"));
-  try {
+  return await withTempDir("store", async (dir) => {
     const storage = new StorageManager(dir);
     const store = new RemnicLedgerStore(storage, {
       now: () => new Date("2026-06-03T12:00:00Z"),
     });
     return await fn(store, storage);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
+  });
 }
 
 describe("RemnicLedgerStore", () => {
@@ -488,8 +485,7 @@ describe("RemnicLedgerStore", () => {
   });
 
   it("can reach public core page-versioning from an external package", async () => {
-    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-belief-ledger-versioning-"));
-    try {
+    await withTempDir("versioning", async (dir) => {
       const pagePath = path.join(dir, "facts", "belief-ledger.md");
       await mkdir(path.dirname(pagePath), { recursive: true });
       await writeFile(pagePath, "first version\n", "utf-8");
@@ -501,26 +497,23 @@ describe("RemnicLedgerStore", () => {
         { enabled: true, maxVersionsPerPage: 5, sidecarDir: ".versions" },
         undefined,
         "belief ledger external consumer smoke test",
-        dir
+        dir,
       );
       const versions = await listVersions(
         pagePath,
         { enabled: true, maxVersionsPerPage: 5, sidecarDir: ".versions" },
-        dir
+        dir,
       );
 
       assert.equal(version.versionId, "1");
       assert.equal(versions.versions.length, 1);
       assert.equal(versions.versions[0]?.trigger, "manual");
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
+    });
   });
 
 
   it("#1645: createClaim throws a distinct tombstone_blocked error (not readback failure)", async () => {
-    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-belief-ledger-"));
-    try {
+    await withTempDir("tombstone", async (dir) => {
       const storage = new StorageManager(dir);
       await storage.ensureDirectories();
       // Wire the tombstone invariant exactly as the orchestrator does — without
@@ -569,16 +562,13 @@ describe("RemnicLedgerStore", () => {
           err.message.includes("tombstone-blocked"),
         "createClaim must throw a distinct tombstone_blocked error before the readback",
       );
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("#1645: the tombstone_blocked error is instanceof-catchable from the package root (review)", async () => {
     // Published consumers import from @remnic/belief-ledger (the package barrel);
     // the error class must be re-exported so they can catch it via instanceof.
-    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-belief-ledger-"));
-    try {
+    await withTempDir("tombstone-catch", async (dir) => {
       const storage = new StorageManager(dir);
       await storage.ensureDirectories();
       storage.setTombstonesConfig({
@@ -617,12 +607,12 @@ describe("RemnicLedgerStore", () => {
       } catch (err) {
         caught = err;
       }
-      assert.ok(caught instanceof RemnicLedgerTombstoneBlockedError,
-        "a tombstone-blocked createClaim must be instanceof the package-root RemnicLedgerTombstoneBlockedError");
+      assert.ok(
+        caught instanceof RemnicLedgerTombstoneBlockedError,
+        "a tombstone-blocked createClaim must be instanceof the package-root RemnicLedgerTombstoneBlockedError",
+      );
       assert.equal((caught as RemnicLedgerTombstoneBlockedError).code, "tombstone_blocked");
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
+    });
   });
 
 });

--- a/packages/belief-ledger/src/testing/tmp-dir.test.ts
+++ b/packages/belief-ledger/src/testing/tmp-dir.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import test from "node:test";
+
+import { withTempDir } from "./tmp-dir.js";
+
+test("withTempDir removes the directory after a failed callback", async () => {
+  let createdDir = "";
+
+  await assert.rejects(
+    withTempDir("failure", async (dir) => {
+      createdDir = dir;
+      throw new Error("callback failed");
+    }),
+    /callback failed/,
+  );
+
+  assert.equal(existsSync(createdDir), false);
+});
+
+test("rejects path separators in a temporary directory prefix", async () => {
+  await assert.rejects(withTempDir("../escape", async () => undefined), /path separator/);
+});

--- a/packages/belief-ledger/src/testing/tmp-dir.ts
+++ b/packages/belief-ledger/src/testing/tmp-dir.ts
@@ -1,0 +1,19 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+function assertSafePrefix(prefix: string): void {
+  if (/[\\/]/.test(prefix)) {
+    throw new Error("Temporary directory prefix must not contain a path separator");
+  }
+}
+
+export async function withTempDir<T>(prefix: string, fn: (dir: string) => Promise<T>): Promise<T> {
+  assertSafePrefix(prefix);
+  const dir = await mkdtemp(path.join(os.tmpdir(), `remnic-belief-ledger-${prefix}-`));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary
- Add a scoped asynchronous temporary-directory helper for belief-ledger tests.
- Migrate ledger store tests from manual `try`/`finally` cleanup.
- Register the helper cleanup contract in the package test command.

Part of #2083.

## Verification
- `pnpm --filter @remnic/belief-ledger test` - 56 passing tests
- `pnpm install --prefer-offline && npm test && npm run check-types` - completed successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor and helper utilities; no runtime or published API changes.
> 
> **Overview**
> Introduces a shared **`withTempDir`** helper under `src/testing/` that creates a scoped temp directory under `os.tmpdir()`, runs an async callback, and always removes the directory in `finally` (including when the callback throws). Prefixes are validated so they cannot contain path separators.
> 
> **`remnic-store.test.ts`** is refactored to use this helper for `withStore` and for the versioning and tombstone tests, replacing repeated `mkdtemp` / `try` / `finally` / `rm` blocks.
> 
> The package **`test`** script now also runs `src/testing/*.test.ts`, with new tests that assert cleanup on failure and rejection of unsafe prefixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e24caf431e6f59255dd951f6ad2e35dca9afba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated test coverage to run all relevant test files across the package’s test directories.
  * Added and adopted a shared temporary-directory helper to ensure cleanup happens even when callbacks fail.
  * Improved temp-dir safety validation (including rejection on unsafe prefixes).
  * Strengthened tombstone-related assertions to verify the correct error type and details.

* **Chores**
  * Updated the package test script to include the additional test directory for execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->