### PR TITLE
feat(capture-audio): add local transcription building blocks

### DIFF
--- a/packages/capture-audio/package.json
+++ b/packages/capture-audio/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsup src/index.ts src/cli-bin.ts --format esm --dts",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts src/model.test.ts src/janitor.test.ts",
+    "test": "tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts src/model.test.ts src/janitor.test.ts src/vad.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {
@@ -35,6 +35,14 @@
     "tsup": "^8.0.0",
     "typescript": "^5.7.0",
     "tsx": "^4.0.0"
+  },
+  "peerDependencies": {
+    "sherpa-onnx-node": "*"
+  },
+  "peerDependenciesMeta": {
+    "sherpa-onnx-node": {
+      "optional": true
+    }
   },
   "license": "MIT",
   "repository": {

--- a/packages/capture-audio/package.json
+++ b/packages/capture-audio/package.json
@@ -19,6 +19,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts src/cli-bin.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts src/model.test.ts src/janitor.test.ts src/vad.test.ts src/dedup.test.ts src/assembly.test.ts src/diarization.test.ts src/connector.test.ts src/e2e.test.ts",
     "prepublishOnly": "npm run build"

--- a/packages/capture-audio/package.json
+++ b/packages/capture-audio/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsup src/index.ts src/cli-bin.ts --format esm --dts",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts src/model.test.ts",
+    "test": "tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts src/model.test.ts src/janitor.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/capture-audio/package.json
+++ b/packages/capture-audio/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsup src/index.ts src/cli-bin.ts --format esm --dts",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts",
+    "test": "tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts src/model.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/capture-audio/package.json
+++ b/packages/capture-audio/package.json
@@ -39,7 +39,7 @@
     "tsx": "^4.0.0"
   },
   "peerDependencies": {
-    "@remnic/core": "^9.14.0",
+    "@remnic/core": "^9.22.0",
     "sherpa-onnx-node": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/capture-audio/package.json
+++ b/packages/capture-audio/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsup src/index.ts src/cli-bin.ts --format esm --dts",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts src/model.test.ts src/janitor.test.ts src/vad.test.ts",
+    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts src/model.test.ts src/janitor.test.ts src/vad.test.ts src/dedup.test.ts src/assembly.test.ts src/diarization.test.ts src/connector.test.ts src/e2e.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {
@@ -31,12 +31,14 @@
     "node": ">=22.13.0"
   },
   "devDependencies": {
+    "@remnic/core": "workspace:*",
     "@types/node": "^22.10.0",
     "tsup": "^8.0.0",
     "typescript": "^5.7.0",
     "tsx": "^4.0.0"
   },
   "peerDependencies": {
+    "@remnic/core": "^9.14.0",
     "sherpa-onnx-node": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/capture-audio/package.json
+++ b/packages/capture-audio/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsup src/index.ts src/cli-bin.ts --format esm --dts",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts",
+    "test": "tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/capture-audio/src/assembly.test.ts
+++ b/packages/capture-audio/src/assembly.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assembleConversations } from "./assembly.js";
+import type { SegmentInput } from "./spool.js";
+
+function seg(startUtc: string, endUtc: string, text = "hi"): SegmentInput {
+  return { channel: "mic", text, startUtc, endUtc };
+}
+
+test("segments within the gap join one conversation", () => {
+  const convs = assembleConversations(
+    [
+      seg("2026-07-20T15:00:00.000Z", "2026-07-20T15:00:05.000Z"),
+      seg("2026-07-20T15:02:00.000Z", "2026-07-20T15:02:05.000Z"),
+    ],
+    10,
+  );
+  assert.equal(convs.length, 1);
+  assert.equal(convs[0].segments.length, 2);
+  assert.equal(convs[0].startedAtUtc, "2026-07-20T15:00:00.000Z");
+  assert.equal(convs[0].endedAtUtc, "2026-07-20T15:02:05.000Z");
+});
+
+test("a gap larger than the threshold splits into two conversations", () => {
+  const convs = assembleConversations(
+    [
+      seg("2026-07-20T15:00:00.000Z", "2026-07-20T15:00:05.000Z"),
+      seg("2026-07-20T15:20:00.000Z", "2026-07-20T15:20:05.000Z"),
+    ],
+    10,
+  );
+  assert.equal(convs.length, 2);
+});
+
+test("a gap exactly equal to the threshold splits (join rule is strictly gap < threshold)", () => {
+  const convs = assembleConversations(
+    [
+      seg("2026-07-20T15:00:00.000Z", "2026-07-20T15:00:00.000Z"),
+      // next starts exactly 10 minutes after the previous end
+      seg("2026-07-20T15:10:00.000Z", "2026-07-20T15:10:05.000Z"),
+    ],
+    10,
+  );
+  assert.equal(convs.length, 2);
+});
+
+test("state defaults to final and is applied to every conversation", () => {
+  const convs = assembleConversations([seg("2026-07-20T15:00:00.000Z", "2026-07-20T15:00:01.000Z")], 10);
+  assert.equal(convs[0].state, "final");
+  const capturing = assembleConversations([seg("2026-07-20T15:00:00.000Z", "2026-07-20T15:00:01.000Z")], 10, "capturing");
+  assert.equal(capturing[0].state, "capturing");
+});
+
+test("empty input yields no conversations", () => {
+  assert.deepEqual(assembleConversations([], 10), []);
+});

--- a/packages/capture-audio/src/assembly.ts
+++ b/packages/capture-audio/src/assembly.ts
@@ -1,0 +1,59 @@
+/**
+ * Conversation assembly (issue #1897, component 2.5).
+ *
+ * A conversation is a maximal run of consecutive speech segments whose
+ * inter-segment gap stays below `conversationGapMinutes`. A gap greater
+ * than OR EQUAL to the threshold starts a new conversation (the join rule
+ * is strictly `gap < threshold`, per the issue). Pure over ordered
+ * segments so the daemon pipeline and unit tests share one implementation;
+ * output rows map 1:1 to Spool.insertConversation input.
+ */
+
+import type { ConversationInput, ConversationState, SegmentInput } from "./spool.js";
+
+/** A segment as it enters assembly (post dedup + diarization). */
+export type AssemblySegment = SegmentInput;
+
+/**
+ * Group ordered segments into conversations. Segments MUST already be in
+ * chronological order (the pipeline emits them that way). Each returned
+ * row omits `id` so Spool.insertConversation mints a `conv_<ulid>`.
+ *
+ * `gapMinutes` is the max silence that keeps two segments in the same
+ * conversation; `state` is applied to every produced conversation
+ * (default "final" — the API only serves final; callers pass "capturing"
+ * for the still-open tail).
+ */
+export function assembleConversations(
+  segments: readonly AssemblySegment[],
+  gapMinutes: number,
+  state: ConversationState = "final",
+): ConversationInput[] {
+  if (!Number.isFinite(gapMinutes) || gapMinutes < 0) {
+    throw new Error("assembleConversations: gapMinutes must be a non-negative number");
+  }
+  const gapMs = gapMinutes * 60_000;
+  const conversations: ConversationInput[] = [];
+  let current: AssemblySegment[] = [];
+  let prevEndMs = Number.NaN;
+
+  const flush = (): void => {
+    if (current.length === 0) return;
+    const startedAtUtc = current[0].startUtc;
+    const endedAtUtc = current[current.length - 1].endUtc;
+    conversations.push({ startedAtUtc, endedAtUtc, state, segments: current });
+    current = [];
+  };
+
+  for (const seg of segments) {
+    const startMs = Date.parse(seg.startUtc);
+    if (current.length > 0 && Number.isFinite(prevEndMs) && Number.isFinite(startMs) && startMs - prevEndMs >= gapMs) {
+      flush();
+    }
+    current.push(seg);
+    const endMs = Date.parse(seg.endUtc);
+    prevEndMs = Number.isFinite(endMs) ? endMs : startMs;
+  }
+  flush();
+  return conversations;
+}

--- a/packages/capture-audio/src/cli.test.ts
+++ b/packages/capture-audio/src/cli.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os, { tmpdir } from "node:os";
 import path from "node:path";
 import { once } from "node:events";
@@ -751,4 +751,18 @@ test("download-model downloads a named model beneath the capture directory", asy
 
   assert.equal(code, 0);
   assert.deepEqual(output, [`downloaded small to ${path.join(baseDir, "models", "ggml-small.bin")}`]);
+});
+
+test("janitor applies configured raw-audio retention", async () => {
+  const baseDir = await mkdtemp(path.join(tmpdir(), "cap-cli-"));
+  const rawDirectory = path.join(baseDir, "raw");
+  await mkdir(rawDirectory);
+  await writeFile(path.join(rawDirectory, "expired.wav"), "audio");
+  const output: string[] = [];
+
+  const code = await runCapture({ argv: ["janitor", "--base-dir", baseDir], stdout: (line) => output.push(line) });
+
+  assert.equal(code, 0);
+  assert.deepEqual(output, ["janitor: removed 1 expired raw audio file(s)"]);
+  assert.equal(existsSync(path.join(rawDirectory, "expired.wav")), false);
 });

--- a/packages/capture-audio/src/cli.test.ts
+++ b/packages/capture-audio/src/cli.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import os, { tmpdir } from "node:os";
 import path from "node:path";
 import { once } from "node:events";
@@ -757,14 +757,18 @@ test("janitor applies configured raw-audio retention", async () => {
   const baseDir = await mkdtemp(path.join(tmpdir(), "cap-cli-"));
   const rawDirectory = path.join(baseDir, "raw");
   await mkdir(rawDirectory);
-  await writeFile(path.join(rawDirectory, "expired.wav"), "audio");
+  const expired = path.join(rawDirectory, "expired.wav");
+  await writeFile(expired, "audio");
+  // Pin the mtime firmly in the past so zero-hour retention deletes it
+  // deterministically, without racing the janitor's wall-clock cutoff.
+  await utimes(expired, new Date(0), new Date(0));
   const output: string[] = [];
 
   const code = await runCapture({ argv: ["janitor", "--base-dir", baseDir], stdout: (line) => output.push(line) });
 
   assert.equal(code, 0);
   assert.deepEqual(output, ["janitor: removed 1 expired raw audio file(s)"]);
-  assert.equal(existsSync(path.join(rawDirectory, "expired.wav")), false);
+  assert.equal(existsSync(expired), false);
 });
 
 test("logs honors a valued --lines flag", async () => {

--- a/packages/capture-audio/src/cli.test.ts
+++ b/packages/capture-audio/src/cli.test.ts
@@ -766,3 +766,19 @@ test("janitor applies configured raw-audio retention", async () => {
   assert.deepEqual(output, ["janitor: removed 1 expired raw audio file(s)"]);
   assert.equal(existsSync(path.join(rawDirectory, "expired.wav")), false);
 });
+
+test("logs honors a valued --lines flag", async () => {
+  const baseDir = await mkdtemp(path.join(tmpdir(), "cap-cli-"));
+  const paths = capturePaths(baseDir);
+  await writeFile(paths.logPath, "first\nsecond\nthird\n", "utf8");
+  const output: string[] = [];
+
+  const code = await runCapture({
+    argv: ["logs", "--base-dir", baseDir, "--lines", "2"],
+    stdout: (line) => output.push(line),
+    stderr: () => undefined,
+  });
+
+  assert.equal(code, 0);
+  assert.deepEqual(output, ["third\n"]);
+});

--- a/packages/capture-audio/src/cli.test.ts
+++ b/packages/capture-audio/src/cli.test.ts
@@ -734,3 +734,21 @@ test("stop waits (bounded) for the daemon to exit before returning", async () =>
     }
   });
 });
+
+test("download-model downloads a named model beneath the capture directory", async () => {
+  const baseDir = await mkdtemp(path.join(tmpdir(), "cap-cli-"));
+  const output: string[] = [];
+
+  const code = await runCapture({
+    argv: ["download-model", "--model", "small", "--base-dir", baseDir],
+    stdout: (line) => output.push(line),
+    downloadModel: async (input) => {
+      assert.equal(input.model, "small");
+      assert.equal(input.directory, path.join(baseDir, "models"));
+      return { path: path.join(input.directory, "ggml-small.bin"), downloaded: true };
+    },
+  });
+
+  assert.equal(code, 0);
+  assert.deepEqual(output, [`downloaded small to ${path.join(baseDir, "models", "ggml-small.bin")}`]);
+});

--- a/packages/capture-audio/src/cli.test.ts
+++ b/packages/capture-audio/src/cli.test.ts
@@ -771,6 +771,30 @@ test("janitor applies configured raw-audio retention", async () => {
   assert.equal(existsSync(expired), false);
 });
 
+test("janitor rejects a flag it does not accept instead of silently ignoring it", async () => {
+  const baseDir = await mkdtemp(path.join(tmpdir(), "cap-cli-"));
+  const errs: string[] = [];
+  const code = await runCapture({
+    argv: ["janitor", "--port", "5555", "--base-dir", baseDir],
+    stdout: () => undefined,
+    stderr: (l) => errs.push(l),
+  });
+  assert.equal(code, 2);
+  assert.match(errs.join("\n"), /flag --port is not valid for command 'janitor'/);
+});
+
+test("download-model rejects a flag it does not accept", async () => {
+  const baseDir = await mkdtemp(path.join(tmpdir(), "cap-cli-"));
+  const errs: string[] = [];
+  const code = await runCapture({
+    argv: ["download-model", "--model", "small", "--replay", "fixtures", "--base-dir", baseDir],
+    stdout: () => undefined,
+    stderr: (l) => errs.push(l),
+  });
+  assert.equal(code, 2);
+  assert.match(errs.join("\n"), /flag --replay is not valid for command 'download-model'/);
+});
+
 test("logs honors a valued --lines flag", async () => {
   const baseDir = await mkdtemp(path.join(tmpdir(), "cap-cli-"));
   const paths = capturePaths(baseDir);

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -8,6 +8,7 @@
 
 import { spawn } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
 import { CAPTURE_AUDIO_VERSION } from "./constants.js";
@@ -30,6 +31,7 @@ import { startDaemon, type DaemonHandle } from "./daemon.js";
 import { CaptureConfigError, CaptureInputError } from "./errors.js";
 import { capturePaths, captureBaseDir, expandTilde, type CapturePaths } from "./paths.js";
 import { ingestReplayDirResponsive } from "./replay.js";
+import { downloadWhisperModel, type ModelDownloadInput, type ModelDownloadResult } from "./model.js";
 import { Spool } from "./spool.js";
 import { loadOrCreateToken } from "./token.js";
 import { formatHostForUrl, isLoopbackHost, stripIpv6Brackets } from "./util.js";
@@ -38,6 +40,7 @@ export interface CliIo {
   argv: string[];
   env?: NodeJS.ProcessEnv;
   stdout?: (line: string) => void;
+  downloadModel?: (input: ModelDownloadInput) => Promise<ModelDownloadResult>;
   stderr?: (line: string) => void;
 }
 
@@ -54,7 +57,7 @@ const VALUE_FLAGS: Record<string, true> = {
   port: true,
   listen: true,
   "base-dir": true,
-  lines: true,
+  model: true,
 };
 
 /** Standalone boolean flags. Any other `--flag` is rejected loudly. */
@@ -325,6 +328,18 @@ function cmdInit(paths: CapturePaths, flags: Record<string, string | boolean>, s
   const token = loadOrCreateToken(paths.tokenPath);
   stdout(`token ready at ${paths.tokenPath} (${token.length} chars, mode 0600)`);
   stdout(`spool will be created at ${paths.spoolPath} on first start`);
+  return 0;
+}
+
+async function cmdDownloadModel(
+  paths: CapturePaths,
+  flags: Record<string, string | boolean>,
+  stdout: (line: string) => void,
+  downloadModel: (input: ModelDownloadInput) => Promise<ModelDownloadResult>,
+): Promise<number> {
+  if (typeof flags.model !== "string") throw new CaptureInputError("flag --model requires a value");
+  const result = await downloadModel({ model: flags.model, directory: path.join(paths.baseDir, "models") });
+  stdout(`${result.downloaded ? "downloaded" : "model already present"} ${flags.model} to ${result.path}`);
   return 0;
 }
 
@@ -609,8 +624,9 @@ function usage(stdout: (l: string) => void): number {
     [
       `remnic-capture-audio v${CAPTURE_AUDIO_VERSION}`,
       "usage: remnic-capture-audio <command> [flags]",
-      "commands: init | start | stop | status | devices | logs",
+      "commands: init | start | stop | status | devices | logs | download-model",
       "start flags: --foreground --replay <dir> --host <h> --port <n> --listen <host:port> --base-dir <dir>",
+      "download-model flags: --model <base|small|large-v3-turbo-q5_0> --base-dir <dir>",
     ].join("\n"),
   );
   return 0;
@@ -654,6 +670,8 @@ export async function runCapture(io: CliIo): Promise<number> {
         return cmdDevices(stdout);
       case "logs":
         return cmdLogs(paths, parsed.flags, stdout);
+      case "download-model":
+        return await cmdDownloadModel(paths, parsed.flags, stdout, io.downloadModel ?? downloadWhisperModel);
       case "help":
       case "--help":
       case "-h":

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -32,6 +32,7 @@ import { CaptureConfigError, CaptureInputError } from "./errors.js";
 import { capturePaths, captureBaseDir, expandTilde, type CapturePaths } from "./paths.js";
 import { ingestReplayDirResponsive } from "./replay.js";
 import { downloadWhisperModel, type ModelDownloadInput, type ModelDownloadResult } from "./model.js";
+import { pruneExpiredRawAudio } from "./janitor.js";
 import { Spool } from "./spool.js";
 import { loadOrCreateToken } from "./token.js";
 import { formatHostForUrl, isLoopbackHost, stripIpv6Brackets } from "./util.js";
@@ -343,6 +344,17 @@ async function cmdDownloadModel(
   return 0;
 }
 
+async function cmdJanitor(
+  paths: CapturePaths,
+  stdout: (line: string) => void,
+  stderr: (line: string) => void,
+): Promise<number> {
+  const config = loadConfigOrDefault(paths, stderr);
+  const removed = await pruneExpiredRawAudio(path.join(paths.baseDir, "raw"), config.rawRetentionHours * 60 * 60 * 1000);
+  stdout(`janitor: removed ${removed.length} expired raw audio file(s)`);
+  return 0;
+}
+
 async function cmdStart(
   paths: CapturePaths,
   flags: Record<string, string | boolean>,
@@ -624,9 +636,10 @@ function usage(stdout: (l: string) => void): number {
     [
       `remnic-capture-audio v${CAPTURE_AUDIO_VERSION}`,
       "usage: remnic-capture-audio <command> [flags]",
-      "commands: init | start | stop | status | devices | logs | download-model",
+      "commands: init | start | stop | status | devices | logs | download-model | janitor",
       "start flags: --foreground --replay <dir> --host <h> --port <n> --listen <host:port> --base-dir <dir>",
       "download-model flags: --model <base|small|large-v3-turbo-q5_0> --base-dir <dir>",
+      "janitor uses rawRetentionHours from audio.json to remove expired files under raw/",
     ].join("\n"),
   );
   return 0;
@@ -672,6 +685,8 @@ export async function runCapture(io: CliIo): Promise<number> {
         return cmdLogs(paths, parsed.flags, stdout);
       case "download-model":
         return await cmdDownloadModel(paths, parsed.flags, stdout, io.downloadModel ?? downloadWhisperModel);
+      case "janitor":
+        return await cmdJanitor(paths, stdout, stderr);
       case "help":
       case "--help":
       case "-h":

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -59,6 +59,7 @@ const VALUE_FLAGS: Record<string, true> = {
   listen: true,
   "base-dir": true,
   model: true,
+  lines: true,
 };
 
 /** Standalone boolean flags. Any other `--flag` is rejected loudly. */

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -43,6 +43,15 @@ export interface CliIo {
   stdout?: (line: string) => void;
   downloadModel?: (input: ModelDownloadInput) => Promise<ModelDownloadResult>;
   stderr?: (line: string) => void;
+  /**
+   * argv tokens (after the node executable) that re-launch THIS CLI, used
+   * when the daemon backgrounds itself into `--foreground`. Defaults to
+   * [process.argv[1]] (direct `remnic-capture-audio` invocation). The
+   * `remnic capture audio` passthrough supplies [remnicBin, "capture",
+   * "audio"] so the detached child is `remnic capture audio start
+   * --foreground`, not `remnic start --foreground`.
+   */
+  spawnArgvPrefix?: string[];
 }
 
 interface ParsedArgs {
@@ -364,6 +373,7 @@ async function cmdStart(
   env: NodeJS.ProcessEnv,
   stdout: (l: string) => void,
   stderr: (l: string) => void,
+  spawnArgvPrefix: readonly string[],
 ): Promise<number> {
   const config = applyBindingOverrides(loadConfigOrDefault(paths, stderr), flags);
   if (!isLoopbackHost(config.host)) {
@@ -389,7 +399,7 @@ async function cmdStart(
   }
 
   if (flags.foreground !== true) {
-    const entry = process.argv[1];
+    const relaunch = spawnArgvPrefix.length > 0 ? [...spawnArgvPrefix] : [process.argv[1]];
     const forwarded = ["start", "--foreground"];
     if (replayDir) forwarded.push("--replay", replayDir);
     if (typeof flags["base-dir"] === "string") forwarded.push("--base-dir", flags["base-dir"]);
@@ -398,7 +408,7 @@ async function cmdStart(
     if (typeof flags.listen === "string") forwarded.push("--listen", flags.listen);
     ensurePrivateDir(paths.baseDir);
     const logFd = openSync(paths.logPath, "a");
-    const child = spawn(process.execPath, [entry, ...forwarded], {
+    const child = spawn(process.execPath, [...relaunch, ...forwarded], {
       detached: true,
       stdio: ["ignore", logFd, logFd],
       env: { ...process.env, ...env },
@@ -677,7 +687,7 @@ export async function runCapture(io: CliIo): Promise<number> {
       case "init":
         return cmdInit(paths, parsed.flags, stdout);
       case "start":
-        return await cmdStart(paths, parsed.flags, env, stdout, stderr);
+        return await cmdStart(paths, parsed.flags, env, stdout, stderr, io.spawnArgvPrefix ?? [process.argv[1]]);
       case "stop":
         return await cmdStop(paths, parsed.flags, stdout, stderr);
       case "status":

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -77,6 +77,8 @@ const COMMAND_FLAGS: Record<string, Record<string, true>> = {
   status: {},
   devices: {},
   logs: { lines: true },
+  "download-model": { model: true },
+  janitor: {},
   help: {},
 };
 

--- a/packages/capture-audio/src/config.test.ts
+++ b/packages/capture-audio/src/config.test.ts
@@ -76,8 +76,11 @@ test("unknown stt engine is rejected", () => {
   );
 });
 
-test("similarityThreshold out of [0,1] is rejected", () => {
+test("similarityThreshold outside exclusive (0,1) is rejected, matching the clusterer", () => {
   assert.throws(() => parseDaemonConfig({ diarization: { similarityThreshold: 1.5 } }), CaptureConfigError);
+  assert.throws(() => parseDaemonConfig({ diarization: { similarityThreshold: 0 } }), CaptureConfigError);
+  assert.throws(() => parseDaemonConfig({ diarization: { similarityThreshold: 1 } }), CaptureConfigError);
+  assert.equal(parseDaemonConfig({ diarization: { similarityThreshold: 0.6 } }).diarization.similarityThreshold, 0.6);
 });
 
 test("wrong types for structured fields are rejected", () => {

--- a/packages/capture-audio/src/config.test.ts
+++ b/packages/capture-audio/src/config.test.ts
@@ -28,6 +28,29 @@ test("valid overrides parse and boolean-like coercion applies to numbers", () =>
   assert.deepEqual(cfg.denyApps, ["Zoom", "Slack"]);
 });
 
+test("VAD options use the same valid ranges as the runtime adapter", () => {
+  const cfg = parseDaemonConfig({
+    vad: {
+      modelPath: "/models/silero_vad.onnx",
+      minSpeechMs: 500,
+      minSilenceMs: 400,
+      maxSpeechMs: 20_000,
+      threshold: 0.7,
+      threads: 2,
+    },
+  });
+  assert.deepEqual(cfg.vad, {
+    modelPath: "/models/silero_vad.onnx",
+    minSpeechMs: 500,
+    minSilenceMs: 400,
+    maxSpeechMs: 20_000,
+    threshold: 0.7,
+    threads: 2,
+  });
+  assert.throws(() => parseDaemonConfig({ vad: { minSpeechMs: 0 } }), CaptureConfigError);
+  assert.throws(() => parseDaemonConfig({ vad: { threshold: 1 } }), CaptureConfigError);
+});
+
 test("non-integer / out-of-range port is rejected loudly", () => {
   assert.throws(() => parseDaemonConfig({ port: 70000 }), CaptureConfigError);
   assert.throws(() => parseDaemonConfig({ port: 4340.5 }), CaptureConfigError);

--- a/packages/capture-audio/src/config.test.ts
+++ b/packages/capture-audio/src/config.test.ts
@@ -28,6 +28,10 @@ test("valid overrides parse and boolean-like coercion applies to numbers", () =>
   assert.deepEqual(cfg.denyApps, ["Zoom", "Slack"]);
 });
 
+test("an empty STT model path uses the default model", () => {
+  assert.equal(parseDaemonConfig({ stt: { modelPath: "" } }).stt.modelPath, null);
+});
+
 test("VAD options use the same valid ranges as the runtime adapter", () => {
   const cfg = parseDaemonConfig({
     vad: {
@@ -49,6 +53,8 @@ test("VAD options use the same valid ranges as the runtime adapter", () => {
   });
   assert.throws(() => parseDaemonConfig({ vad: { minSpeechMs: 0 } }), CaptureConfigError);
   assert.throws(() => parseDaemonConfig({ vad: { threshold: 1 } }), CaptureConfigError);
+  assert.throws(() => parseDaemonConfig({ vad: { threshold: 0 } }), CaptureConfigError);
+  assert.equal(parseDaemonConfig({ vad: { modelPath: null } }).vad.modelPath, null);
 });
 
 test("non-integer / out-of-range port is rejected loudly", () => {

--- a/packages/capture-audio/src/config.test.ts
+++ b/packages/capture-audio/src/config.test.ts
@@ -55,6 +55,7 @@ test("VAD options use the same valid ranges as the runtime adapter", () => {
   assert.throws(() => parseDaemonConfig({ vad: { threshold: 1 } }), CaptureConfigError);
   assert.throws(() => parseDaemonConfig({ vad: { threshold: 0 } }), CaptureConfigError);
   assert.equal(parseDaemonConfig({ vad: { modelPath: null } }).vad.modelPath, null);
+  assert.throws(() => parseDaemonConfig({ vad: { minSpeechMs: 40_000, maxSpeechMs: 30_000 } }), CaptureConfigError);
 });
 
 test("non-integer / out-of-range port is rejected loudly", () => {

--- a/packages/capture-audio/src/config.ts
+++ b/packages/capture-audio/src/config.ts
@@ -176,10 +176,11 @@ export function parseDaemonConfig(raw: unknown): DaemonConfig {
     const dia = asObject(obj.diarization, "diarization");
     warnUnknownKeys(dia, { similarityThreshold: true }, "diarization");
     if (dia.similarityThreshold !== undefined) {
-      cfg.diarization.similarityThreshold = coerceNumber(dia.similarityThreshold, "diarization.similarityThreshold", {
-        min: 0,
-        max: 1,
-      });
+      const threshold = coerceNumber(dia.similarityThreshold, "diarization.similarityThreshold", { max: 1 });
+      if (threshold <= 0 || threshold >= 1) {
+        throw new CaptureConfigError("diarization.similarityThreshold must be between 0 and 1");
+      }
+      cfg.diarization.similarityThreshold = threshold;
     }
   }
 

--- a/packages/capture-audio/src/config.ts
+++ b/packages/capture-audio/src/config.ts
@@ -146,7 +146,7 @@ export function parseDaemonConfig(raw: unknown): DaemonConfig {
       "vad",
     );
     if (vad.modelPath !== undefined) {
-      cfg.vad.modelPath = requireString(vad.modelPath, "vad.modelPath");
+      cfg.vad.modelPath = vad.modelPath === null ? null : requireString(vad.modelPath, "vad.modelPath");
     }
     if (vad.minSpeechMs !== undefined) {
       cfg.vad.minSpeechMs = coerceNumber(vad.minSpeechMs, "vad.minSpeechMs", { integer: true, min: 1 });
@@ -158,10 +158,11 @@ export function parseDaemonConfig(raw: unknown): DaemonConfig {
       cfg.vad.maxSpeechMs = coerceNumber(vad.maxSpeechMs, "vad.maxSpeechMs", { integer: true, min: 1 });
     }
     if (vad.threshold !== undefined) {
-      cfg.vad.threshold = coerceNumber(vad.threshold, "vad.threshold", {
-        min: Number.MIN_VALUE,
-        max: 1 - Number.EPSILON,
-      });
+      const threshold = coerceNumber(vad.threshold, "vad.threshold", { max: 1 });
+      if (threshold <= 0 || threshold >= 1) {
+        throw new CaptureConfigError("vad.threshold must be between 0 and 1");
+      }
+      cfg.vad.threshold = threshold;
     }
     if (vad.threads !== undefined) {
       cfg.vad.threads = coerceNumber(vad.threads, "vad.threads", { integer: true, min: 1, max: 256 });
@@ -189,7 +190,7 @@ export function parseDaemonConfig(raw: unknown): DaemonConfig {
       if (typeof stt.modelPath !== "string") {
         throw new CaptureConfigError(`stt.modelPath: expected a string, got ${describeValue(stt.modelPath)}`);
       }
-      cfg.stt.modelPath = stt.modelPath;
+      cfg.stt.modelPath = stt.modelPath.trim() || null;
     }
     if (stt.threads !== undefined && stt.threads !== null) {
       cfg.stt.threads = coerceNumber(stt.threads, "stt.threads", { integer: true, min: 1, max: 256 });

--- a/packages/capture-audio/src/config.ts
+++ b/packages/capture-audio/src/config.ts
@@ -167,6 +167,9 @@ export function parseDaemonConfig(raw: unknown): DaemonConfig {
     if (vad.threads !== undefined) {
       cfg.vad.threads = coerceNumber(vad.threads, "vad.threads", { integer: true, min: 1, max: 256 });
     }
+    if (cfg.vad.minSpeechMs > cfg.vad.maxSpeechMs) {
+      throw new CaptureConfigError("vad.maxSpeechMs must be greater than or equal to vad.minSpeechMs");
+    }
   }
 
   if (obj.diarization !== undefined) {

--- a/packages/capture-audio/src/config.ts
+++ b/packages/capture-audio/src/config.ts
@@ -5,9 +5,8 @@
  * CaptureConfigError (rule 39 — no silent defaulting). Ports are integers
  * in [1, 65535] (rule 17); booleans coerce boolean-like strings (rule 24).
  *
- * Only the STT engine `whisper-cpp` is accepted; capture/VAD/STT/
- * diarization are not implemented in this checklist item, but the config
- * surface is validated now so later stages read a trustworthy shape.
+ * Only `whisper-cpp` is currently accepted for STT. VAD configuration maps
+ * directly to the optional Sherpa Silero runtime adapter.
  */
 
 import { readFileSync } from "node:fs";
@@ -23,7 +22,12 @@ export interface SttConfig {
   threads: number | null;
 }
 export interface VadConfig {
+  modelPath: string | null;
   minSpeechMs: number;
+  minSilenceMs: number;
+  maxSpeechMs: number;
+  threshold: number;
+  threads: number;
 }
 export interface DiarizationConfig {
   similarityThreshold: number;
@@ -54,7 +58,14 @@ export function defaultDaemonConfig(): DaemonConfig {
     conversationGapMinutes: 10,
     rawRetentionHours: 0,
     spoolRetentionDays: 30,
-    vad: { minSpeechMs: 500 },
+    vad: {
+      modelPath: null,
+      minSpeechMs: 500,
+      minSilenceMs: 500,
+      maxSpeechMs: 30_000,
+      threshold: 0.5,
+      threads: 1,
+    },
     diarization: { similarityThreshold: 0.4 },
     stt: { engine: "whisper-cpp", modelPath: null, threads: null },
     denyApps: [],
@@ -122,9 +133,38 @@ export function parseDaemonConfig(raw: unknown): DaemonConfig {
 
   if (obj.vad !== undefined) {
     const vad = asObject(obj.vad, "vad");
-    warnUnknownKeys(vad, { minSpeechMs: true }, "vad");
+    warnUnknownKeys(
+      vad,
+      {
+        modelPath: true,
+        minSpeechMs: true,
+        minSilenceMs: true,
+        maxSpeechMs: true,
+        threshold: true,
+        threads: true,
+      },
+      "vad",
+    );
+    if (vad.modelPath !== undefined) {
+      cfg.vad.modelPath = requireString(vad.modelPath, "vad.modelPath");
+    }
     if (vad.minSpeechMs !== undefined) {
-      cfg.vad.minSpeechMs = coerceNumber(vad.minSpeechMs, "vad.minSpeechMs", { integer: true, min: 0 });
+      cfg.vad.minSpeechMs = coerceNumber(vad.minSpeechMs, "vad.minSpeechMs", { integer: true, min: 1 });
+    }
+    if (vad.minSilenceMs !== undefined) {
+      cfg.vad.minSilenceMs = coerceNumber(vad.minSilenceMs, "vad.minSilenceMs", { integer: true, min: 0 });
+    }
+    if (vad.maxSpeechMs !== undefined) {
+      cfg.vad.maxSpeechMs = coerceNumber(vad.maxSpeechMs, "vad.maxSpeechMs", { integer: true, min: 1 });
+    }
+    if (vad.threshold !== undefined) {
+      cfg.vad.threshold = coerceNumber(vad.threshold, "vad.threshold", {
+        min: Number.MIN_VALUE,
+        max: 1 - Number.EPSILON,
+      });
+    }
+    if (vad.threads !== undefined) {
+      cfg.vad.threads = coerceNumber(vad.threads, "vad.threads", { integer: true, min: 1, max: 256 });
     }
   }
 

--- a/packages/capture-audio/src/connector.test.ts
+++ b/packages/capture-audio/src/connector.test.ts
@@ -81,10 +81,10 @@ test("daemonConversationToWearable maps daemon shape to the wearable contract", 
 });
 
 test("resolveCaptureAudioToken prefers config, then env; skips the local file for non-loopback", () => {
-  assert.equal(resolveCaptureAudioToken("cfg", "http://192.168.1.9:4340", { REMNIC_CAPTURE_AUDIO_TOKEN: "env" }), "cfg");
-  assert.equal(resolveCaptureAudioToken(undefined, "http://192.168.1.9:4340", { REMNIC_CAPTURE_AUDIO_TOKEN: "env" }), "env");
+  assert.equal(resolveCaptureAudioToken("cfg", "http://192.0.2.9:4340", { REMNIC_CAPTURE_AUDIO_TOKEN: "env" }), "cfg");
+  assert.equal(resolveCaptureAudioToken(undefined, "http://192.0.2.9:4340", { REMNIC_CAPTURE_AUDIO_TOKEN: "env" }), "env");
   // Non-loopback + no config/env -> never reads the local token file.
-  assert.equal(resolveCaptureAudioToken(undefined, "http://192.168.1.9:4340", {}), undefined);
+  assert.equal(resolveCaptureAudioToken(undefined, "http://192.0.2.9:4340", {}), undefined);
 });
 
 test("verifyAuth: ok on 200, unauthorized on 401, unreachable never throws", async () => {
@@ -196,6 +196,7 @@ test("the bearer token is resolved per request, so env rotation applies without 
     res.writeHead(url.pathname === "/v1/health" ? 200 : 404, { "content-type": "application/json" });
     res.end(JSON.stringify({ ok: true, version: "9.14.0" }));
   });
+  const previousToken = process.env.REMNIC_CAPTURE_AUDIO_TOKEN;
   try {
     // No config apiKey + non-loopback would skip the token file; use a
     // loopback daemon but resolve the token from env, rotating between calls.
@@ -220,10 +221,35 @@ test("the bearer token is resolved per request, so env rotation applies without 
     await connector.verifyAuth();
     process.env.REMNIC_CAPTURE_AUDIO_TOKEN = "second";
     await connector.verifyAuth();
-    delete process.env.REMNIC_CAPTURE_AUDIO_TOKEN;
     const auths = daemon.requests.filter((r) => r.path === "/v1/health").map((r) => r.auth);
     assert.deepEqual(auths, ["Bearer first", "Bearer second"]);
   } finally {
+    if (previousToken === undefined) delete process.env.REMNIC_CAPTURE_AUDIO_TOKEN;
+    else process.env.REMNIC_CAPTURE_AUDIO_TOKEN = previousToken;
     await daemon.close();
   }
+});
+
+test("fetchConversations honors caller cancellation instead of reporting unreachable", async () => {
+  const daemon = await startMockDaemon((_url, res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ conversations: [], nextCursor: null }));
+  });
+  try {
+    const controller = new AbortController();
+    controller.abort();
+    await assert.rejects(
+      connectorFor(daemon.url).fetchConversations({ date: "2026-07-20", timezone: "UTC", signal: controller.signal }),
+      (err: Error) => err.name === "AbortError",
+    );
+  } finally {
+    await daemon.close();
+  }
+});
+
+test("fetchConversations rejects a malformed baseUrl as a daemon error, not a raw TypeError", async () => {
+  await assert.rejects(
+    connectorFor("notaurl").fetchConversations({ date: "2026-07-20", timezone: "UTC" }),
+    DesktopDaemonError,
+  );
 });

--- a/packages/capture-audio/src/connector.test.ts
+++ b/packages/capture-audio/src/connector.test.ts
@@ -253,3 +253,26 @@ test("fetchConversations rejects a malformed baseUrl as a daemon error, not a ra
     DesktopDaemonError,
   );
 });
+
+test("fetchConversations honors a caller abort during the request, never mislabeling it", async () => {
+  // The server flushes headers 200 OK but withholds the body, so the caller's
+  // abort lands while the request/body read is still pending.
+  const { promise: requestReceived, resolve: onRequest } = Promise.withResolvers<void>();
+  const daemon = await startMockDaemon((_url, res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    onRequest();
+  });
+  try {
+    const controller = new AbortController();
+    const pending = connectorFor(daemon.url).fetchConversations({
+      date: "2026-07-20",
+      timezone: "UTC",
+      signal: controller.signal,
+    });
+    await requestReceived;
+    controller.abort();
+    await assert.rejects(pending, (err: Error) => err.name === "AbortError");
+  } finally {
+    await daemon.close();
+  }
+});

--- a/packages/capture-audio/src/connector.test.ts
+++ b/packages/capture-audio/src/connector.test.ts
@@ -170,3 +170,60 @@ test("fetchConversations throws (not empty) on a backend 500 — empty vs failur
     await daemon.close();
   }
 });
+
+test("fetchConversations throws (not empty) when a 200 body is not valid JSON", async () => {
+  const daemon = await startMockDaemon((url, res) => {
+    if (url.pathname !== "/v1/conversations") {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end("not json <<<");
+  });
+  try {
+    await assert.rejects(
+      connectorFor(daemon.url).fetchConversations({ date: "2026-07-20", timezone: "UTC" }),
+      DesktopDaemonError,
+    );
+  } finally {
+    await daemon.close();
+  }
+});
+
+test("the bearer token is resolved per request, so env rotation applies without a rebuild", async () => {
+  const daemon = await startMockDaemon((url, res) => {
+    res.writeHead(url.pathname === "/v1/health" ? 200 : 404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true, version: "9.14.0" }));
+  });
+  try {
+    // No config apiKey + non-loopback would skip the token file; use a
+    // loopback daemon but resolve the token from env, rotating between calls.
+    const opts: WearableConnectorFactoryOptions = {
+      settings: {
+        enabled: true,
+        baseUrl: daemon.url,
+        memoryMode: "smart",
+        sourceTrust: 0.85,
+        autoApproveTrust: 0.9,
+        reviewTrust: 0.5,
+        minConfidence: 0,
+        minImportance: "low",
+        maxMemoriesPerDay: 0,
+        importNativeMemories: "off",
+        cleanup: {} as never,
+      },
+      timezone: "UTC",
+    };
+    const connector = createDesktopConnector(opts);
+    process.env.REMNIC_CAPTURE_AUDIO_TOKEN = "first";
+    await connector.verifyAuth();
+    process.env.REMNIC_CAPTURE_AUDIO_TOKEN = "second";
+    await connector.verifyAuth();
+    delete process.env.REMNIC_CAPTURE_AUDIO_TOKEN;
+    const auths = daemon.requests.filter((r) => r.path === "/v1/health").map((r) => r.auth);
+    assert.deepEqual(auths, ["Bearer first", "Bearer second"]);
+  } finally {
+    await daemon.close();
+  }
+});

--- a/packages/capture-audio/src/connector.test.ts
+++ b/packages/capture-audio/src/connector.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+import {
+  createDesktopConnector,
+  daemonConversationToWearable,
+  DesktopDaemonError,
+  resolveCaptureAudioToken,
+} from "./connector.js";
+import type { WearableConnectorFactoryOptions, WearableSourceConnector } from "@remnic/core";
+
+interface MockDaemon {
+  url: string;
+  close: () => Promise<void>;
+  requests: Array<{ path: string; auth: string | undefined }>;
+}
+
+async function startMockDaemon(handler: (url: URL, res: http.ServerResponse) => void): Promise<MockDaemon> {
+  const requests: MockDaemon["requests"] = [];
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    requests.push({ path: url.pathname, auth: req.headers.authorization });
+    handler(url, res);
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const addr = server.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+function connectorFor(baseUrl: string, apiKey = "tok"): WearableSourceConnector {
+  const options: WearableConnectorFactoryOptions = {
+    settings: {
+      enabled: true,
+      baseUrl,
+      apiKey,
+      memoryMode: "smart",
+      sourceTrust: 0.85,
+      autoApproveTrust: 0.9,
+      reviewTrust: 0.5,
+      minConfidence: 0,
+      minImportance: "low",
+      maxMemoriesPerDay: 0,
+      importNativeMemories: "off",
+      cleanup: {} as never,
+    },
+    timezone: "UTC",
+  };
+  return createDesktopConnector(options);
+}
+
+test("daemonConversationToWearable maps daemon shape to the wearable contract", () => {
+  const wc = daemonConversationToWearable({
+    id: "conv_1",
+    startedAtUtc: "2026-07-20T15:00:00.000Z",
+    endedAtUtc: "2026-07-20T15:05:00.000Z",
+    state: "final",
+    segmentCount: 2,
+    segments: [
+      { textRaw: "hi there", speakerKey: "spk_1", isWearer: false, channel: "system", startUtc: "2026-07-20T15:00:00.000Z", endUtc: "2026-07-20T15:00:02.000Z" },
+      { textRaw: "hello", speakerKey: null, isWearer: true, channel: "mic", startUtc: "2026-07-20T15:00:03.000Z", endUtc: "2026-07-20T15:00:04.000Z" },
+    ],
+  });
+  assert.equal(wc.id, "conv_1");
+  assert.equal(wc.source, "desktop");
+  assert.equal(wc.startIso, "2026-07-20T15:00:00.000Z");
+  assert.equal(wc.endIso, "2026-07-20T15:05:00.000Z");
+  assert.deepEqual(wc.segments[0], { text: "hi there", speakerKey: "spk_1", isWearer: false, startIso: "2026-07-20T15:00:00.000Z", endIso: "2026-07-20T15:00:02.000Z" });
+  assert.equal(wc.segments[1].speakerKey, "unknown"); // null -> "unknown"
+  assert.equal(wc.segments[1].isWearer, true);
+});
+
+test("resolveCaptureAudioToken prefers config, then env; skips the local file for non-loopback", () => {
+  assert.equal(resolveCaptureAudioToken("cfg", "http://192.168.1.9:4340", { REMNIC_CAPTURE_AUDIO_TOKEN: "env" }), "cfg");
+  assert.equal(resolveCaptureAudioToken(undefined, "http://192.168.1.9:4340", { REMNIC_CAPTURE_AUDIO_TOKEN: "env" }), "env");
+  // Non-loopback + no config/env -> never reads the local token file.
+  assert.equal(resolveCaptureAudioToken(undefined, "http://192.168.1.9:4340", {}), undefined);
+});
+
+test("verifyAuth: ok on 200, unauthorized on 401, unreachable never throws", async () => {
+  const daemon = await startMockDaemon((url, res) => {
+    if (url.pathname === "/v1/health") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, version: "9.14.0" }));
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  try {
+    const okCheck = await connectorFor(daemon.url).verifyAuth();
+    assert.equal(okCheck.ok, true);
+    assert.match(okCheck.detail ?? "", /capture-audio/);
+  } finally {
+    await daemon.close();
+  }
+
+  const unauth = await startMockDaemon((_url, res) => {
+    res.writeHead(401);
+    res.end();
+  });
+  try {
+    assert.deepEqual(await connectorFor(unauth.url).verifyAuth(), { ok: false, detail: "unauthorized" });
+  } finally {
+    await unauth.close();
+  }
+
+  // Closed port -> unreachable, not a throw (AC2).
+  const check = await connectorFor("http://127.0.0.1:1").verifyAuth();
+  assert.deepEqual(check, { ok: false, detail: "unreachable" });
+});
+
+test("fetchConversations maps a page, sends the bearer token, and treats an empty day as an empty page", async () => {
+  const daemon = await startMockDaemon((url, res) => {
+    if (url.pathname !== "/v1/conversations") {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const empty = url.searchParams.get("date") === "2026-07-21";
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify(
+        empty
+          ? { conversations: [], nextCursor: null }
+          : {
+              conversations: [
+                { id: "conv_1", startedAtUtc: "2026-07-20T15:00:00.000Z", endedAtUtc: null, state: "final", segmentCount: 1, segments: [{ textRaw: "hi", speakerKey: "spk_1", isWearer: false, channel: "mic", startUtc: "2026-07-20T15:00:00.000Z", endUtc: "2026-07-20T15:00:01.000Z" }] },
+              ],
+              nextCursor: "c2",
+            },
+      ),
+    );
+  });
+  try {
+    const page = await connectorFor(daemon.url).fetchConversations({ date: "2026-07-20", timezone: "UTC" });
+    assert.equal(page.conversations.length, 1);
+    assert.equal(page.conversations[0].source, "desktop");
+    assert.equal(page.nextCursor, "c2");
+    assert.ok(daemon.requests.some((r) => r.auth === "Bearer tok"));
+
+    const emptyPage = await connectorFor(daemon.url).fetchConversations({ date: "2026-07-21", timezone: "UTC" });
+    assert.deepEqual(emptyPage, { conversations: [], nextCursor: null });
+  } finally {
+    await daemon.close();
+  }
+});
+
+test("fetchConversations throws (not empty) on a backend 500 — empty vs failure are distinct", async () => {
+  const daemon = await startMockDaemon((_url, res) => {
+    res.writeHead(500);
+    res.end();
+  });
+  try {
+    await assert.rejects(
+      connectorFor(daemon.url).fetchConversations({ date: "2026-07-20", timezone: "UTC" }),
+      DesktopDaemonError,
+    );
+  } finally {
+    await daemon.close();
+  }
+});

--- a/packages/capture-audio/src/connector.test.ts
+++ b/packages/capture-audio/src/connector.test.ts
@@ -278,3 +278,22 @@ test("fetchConversations honors a caller abort during the request, never mislabe
     await daemon.close();
   }
 });
+
+test("verifyAuth honors a caller abort during the request, never reporting a false status", async () => {
+  // Headers flushed, body withheld; abort lands during the health JSON read.
+  const arrival = new EventEmitter();
+  const requestReceived = once(arrival, "request");
+  const daemon = await startMockDaemon((_url, res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    arrival.emit("request");
+  });
+  try {
+    const controller = new AbortController();
+    const pending = connectorFor(daemon.url).verifyAuth(controller.signal);
+    await requestReceived;
+    controller.abort();
+    await assert.rejects(pending, (err: Error) => err.name === "AbortError");
+  } finally {
+    await daemon.close();
+  }
+});

--- a/packages/capture-audio/src/connector.test.ts
+++ b/packages/capture-audio/src/connector.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import http from "node:http";
-import { once } from "node:events";
+import { EventEmitter, once } from "node:events";
 import test from "node:test";
 
 import {
@@ -256,11 +256,13 @@ test("fetchConversations rejects a malformed baseUrl as a daemon error, not a ra
 
 test("fetchConversations honors a caller abort during the request, never mislabeling it", async () => {
   // The server flushes headers 200 OK but withholds the body, so the caller's
-  // abort lands while the request/body read is still pending.
-  const { promise: requestReceived, resolve: onRequest } = Promise.withResolvers<void>();
+  // abort lands while the request/body read is still pending. The listener is
+  // attached before the request is sent, so there is no race and no timer.
+  const arrival = new EventEmitter();
+  const requestReceived = once(arrival, "request");
   const daemon = await startMockDaemon((_url, res) => {
     res.writeHead(200, { "content-type": "application/json" });
-    onRequest();
+    arrival.emit("request");
   });
   try {
     const controller = new AbortController();

--- a/packages/capture-audio/src/connector.ts
+++ b/packages/capture-audio/src/connector.ts
@@ -143,9 +143,11 @@ class DesktopClient {
     let res: Response;
     try {
       res = await fetch(`${this.#baseUrl}/v1/health`, { headers: this.#headers(), signal: withTimeout(signal) });
-    } catch {
-      // Connection refused / DNS / offline: the daemon isn't running.
-      // This is NOT an auth failure and must never throw (AC2).
+    } catch (err) {
+      // Honor caller cancellation; do not mislabel a deliberate abort.
+      if (signal?.aborted) throw err;
+      // Timeout / connection refused / DNS / offline: the daemon isn't
+      // reachable. This is NOT an auth failure and must never throw (AC2).
       return { ok: false, detail: "unreachable" };
     }
     if (res.status === 401) return { ok: false, detail: "unauthorized" };
@@ -158,14 +160,18 @@ class DesktopClient {
   }
 
   async fetchConversations(opts: WearableFetchOptions): Promise<WearableFetchPage> {
-    const url = new URL(`${this.#baseUrl}/v1/conversations`);
-    url.searchParams.set("date", opts.date);
-    url.searchParams.set("timezone", opts.timezone);
-    if (opts.cursor) url.searchParams.set("cursor", opts.cursor);
     let res: Response;
     try {
+      const url = new URL(`${this.#baseUrl}/v1/conversations`);
+      url.searchParams.set("date", opts.date);
+      url.searchParams.set("timezone", opts.timezone);
+      if (opts.cursor) url.searchParams.set("cursor", opts.cursor);
       res = await fetch(url, { headers: this.#headers(), signal: withTimeout(opts.signal) });
-    } catch {
+    } catch (err) {
+      // Honor caller cancellation instead of reporting a daemon fault.
+      if (opts.signal?.aborted) throw err;
+      // Timeout, offline daemon, or a malformed configured baseUrl all
+      // surface consistently as unreachable (never a raw TypeError).
       throw new DesktopDaemonError(
         `desktop capture daemon unreachable at ${this.#baseUrl} (is remnic-capture-audio running?)`,
       );

--- a/packages/capture-audio/src/connector.ts
+++ b/packages/capture-audio/src/connector.ts
@@ -42,6 +42,14 @@ export const DESKTOP_SOURCE_ID = "desktop";
 export const DESKTOP_DISPLAY_NAME = "Desktop audio";
 const DEFAULT_BASE_URL = `http://${DEFAULT_HOST}:${DEFAULT_PORT}`;
 
+/** Bounded probe timeout so a wedged daemon reports unreachable instead of hanging. */
+const PROBE_TIMEOUT_MS = 15_000;
+
+function withTimeout(signal: AbortSignal | undefined): AbortSignal {
+  const timeout = AbortSignal.timeout(PROBE_TIMEOUT_MS);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
 /** Error raised for a genuine backend failure (never for an empty day). */
 export class DesktopDaemonError extends Error {
   constructor(message: string) {
@@ -134,7 +142,7 @@ class DesktopClient {
   async verifyAuth(signal?: AbortSignal): Promise<WearableAuthCheck> {
     let res: Response;
     try {
-      res = await fetch(`${this.#baseUrl}/v1/health`, { headers: this.#headers(), signal });
+      res = await fetch(`${this.#baseUrl}/v1/health`, { headers: this.#headers(), signal: withTimeout(signal) });
     } catch {
       // Connection refused / DNS / offline: the daemon isn't running.
       // This is NOT an auth failure and must never throw (AC2).
@@ -156,7 +164,7 @@ class DesktopClient {
     if (opts.cursor) url.searchParams.set("cursor", opts.cursor);
     let res: Response;
     try {
-      res = await fetch(url, { headers: this.#headers(), signal: opts.signal });
+      res = await fetch(url, { headers: this.#headers(), signal: withTimeout(opts.signal) });
     } catch {
       throw new DesktopDaemonError(
         `desktop capture daemon unreachable at ${this.#baseUrl} (is remnic-capture-audio running?)`,

--- a/packages/capture-audio/src/connector.ts
+++ b/packages/capture-audio/src/connector.ts
@@ -106,20 +106,29 @@ export function daemonConversationToWearable(conv: DaemonConversation): Wearable
 
 interface DesktopClientOptions {
   baseUrl: string;
-  token: string | undefined;
+  /** Resolved per request so env / token-file rotation applies without a rebuild. */
+  getToken: () => string | undefined;
+}
+
+/** Linear trailing-slash trim (avoids a backtracking regex on the base URL). */
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47 /* "/" */) end--;
+  return value.slice(0, end);
 }
 
 class DesktopClient {
   #baseUrl: string;
-  #token: string | undefined;
+  #getToken: () => string | undefined;
 
   constructor(options: DesktopClientOptions) {
-    this.#baseUrl = options.baseUrl.replace(/\/+$/, "");
-    this.#token = options.token;
+    this.#baseUrl = trimTrailingSlashes(options.baseUrl);
+    this.#getToken = options.getToken;
   }
 
   #headers(): Record<string, string> {
-    return this.#token ? { authorization: `Bearer ${this.#token}` } : {};
+    const token = this.#getToken();
+    return token ? { authorization: `Bearer ${token}` } : {};
   }
 
   async verifyAuth(signal?: AbortSignal): Promise<WearableAuthCheck> {
@@ -157,7 +166,13 @@ class DesktopClient {
       // A non-2xx is a backend/auth failure, distinct from an empty day.
       throw new DesktopDaemonError(`desktop capture daemon returned HTTP ${res.status}`);
     }
-    const page = (await res.json()) as ConversationPage;
+    let page: ConversationPage;
+    try {
+      page = (await res.json()) as ConversationPage;
+    } catch {
+      // A 200 with an empty/non-JSON body is a backend fault, not an empty day.
+      throw new DesktopDaemonError("desktop capture daemon returned a non-JSON conversations response");
+    }
     if (!page || !Array.isArray(page.conversations)) {
       throw new DesktopDaemonError("desktop capture daemon returned a malformed conversations page");
     }
@@ -170,12 +185,12 @@ class DesktopClient {
 
 export function createDesktopConnector(options: WearableConnectorFactoryOptions): WearableSourceConnector {
   const baseUrl = options.settings.baseUrl?.trim() || DEFAULT_BASE_URL;
-  // Token resolved lazily so `wearables status` works without a token and
-  // env/file changes take effect without a connector rebuild.
+  // One client per connector, but the token is resolved per request (below)
+  // so env / on-disk token rotation takes effect without a rebuild.
   let client: DesktopClient | null = null;
   const getClient = (): DesktopClient => {
     if (!client) {
-      client = new DesktopClient({ baseUrl, token: resolveCaptureAudioToken(options.settings.apiKey, baseUrl) });
+      client = new DesktopClient({ baseUrl, getToken: () => resolveCaptureAudioToken(options.settings.apiKey, baseUrl) });
     }
     return client;
   };

--- a/packages/capture-audio/src/connector.ts
+++ b/packages/capture-audio/src/connector.ts
@@ -1,0 +1,203 @@
+/**
+ * `desktop` wearable source connector (issue #1897, component 4).
+ *
+ * À-la-carte optional companion of @remnic/core: installing core alone
+ * never pulls this in; core discovers it at runtime via a
+ * computed-specifier dynamic import (registry entry {id:"desktop",
+ * suffix:"capture-audio"}) or via a direct import of @remnic/capture-audio,
+ * which self-registers idempotently.
+ *
+ * The connector is a pure API client + normalizer over the capture-audio
+ * daemon's loopback HTTP API: no file IO beyond reading the local token,
+ * no memory writes, no pipeline behavior (all of that stays in core so
+ * desktop audio gets the same cleanup/corrections/trust gating as every
+ * other wearable source).
+ *
+ * Token resolution (in order): settings.apiKey (config) ->
+ * REMNIC_CAPTURE_AUDIO_TOKEN env -> the daemon's local token file
+ * (~/.remnic/capture/token) when the base URL is loopback.
+ */
+
+import { readFileSync } from "node:fs";
+
+import {
+  registerWearableConnector,
+  getWearableConnector,
+  type WearableAuthCheck,
+  type WearableConnectorFactoryOptions,
+  type WearableConnectorRegistration,
+  type WearableConversation,
+  type WearableFetchOptions,
+  type WearableFetchPage,
+  type WearableSourceConnector,
+  type WearableTranscriptSegment,
+} from "@remnic/core";
+
+import { DEFAULT_HOST, DEFAULT_PORT } from "./constants.js";
+import { capturePaths } from "./paths.js";
+import { isLoopbackHost } from "./util.js";
+import type { ConversationPage, DaemonConversation, DaemonSegment } from "./spool.js";
+
+export const DESKTOP_SOURCE_ID = "desktop";
+export const DESKTOP_DISPLAY_NAME = "Desktop audio";
+const DEFAULT_BASE_URL = `http://${DEFAULT_HOST}:${DEFAULT_PORT}`;
+
+/** Error raised for a genuine backend failure (never for an empty day). */
+export class DesktopDaemonError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DesktopDaemonError";
+  }
+}
+
+function baseUrlIsLoopback(baseUrl: string): boolean {
+  try {
+    return isLoopbackHost(new URL(baseUrl).hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the daemon bearer token. The local token file is read ONLY for
+ * a loopback base URL — a remote reader must supply the token explicitly
+ * (config/env), never inherit this machine's local token.
+ */
+export function resolveCaptureAudioToken(
+  configured: string | undefined,
+  baseUrl: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (typeof configured === "string" && configured.trim().length > 0) return configured.trim();
+  const fromEnv = env.REMNIC_CAPTURE_AUDIO_TOKEN;
+  if (typeof fromEnv === "string" && fromEnv.trim().length > 0) return fromEnv.trim();
+  if (baseUrlIsLoopback(baseUrl)) {
+    try {
+      const token = readFileSync(capturePaths().tokenPath, "utf8").trim();
+      if (token.length > 0) return token;
+    } catch {
+      // no local token file — treat as unauthenticated (health will 401)
+    }
+  }
+  return undefined;
+}
+
+function daemonSegmentToWearable(seg: DaemonSegment): WearableTranscriptSegment {
+  return {
+    text: seg.textRaw,
+    // The wearables speaker registry owns naming; the connector only
+    // supplies the stable per-source key (spk_<n> | self | "unknown").
+    speakerKey: seg.speakerKey ?? "unknown",
+    isWearer: seg.isWearer,
+    startIso: seg.startUtc,
+    endIso: seg.endUtc,
+  };
+}
+
+export function daemonConversationToWearable(conv: DaemonConversation): WearableConversation {
+  return {
+    id: conv.id,
+    source: DESKTOP_SOURCE_ID,
+    startIso: conv.startedAtUtc,
+    endIso: conv.endedAtUtc ?? undefined,
+    segments: conv.segments.map(daemonSegmentToWearable),
+  };
+}
+
+interface DesktopClientOptions {
+  baseUrl: string;
+  token: string | undefined;
+}
+
+class DesktopClient {
+  #baseUrl: string;
+  #token: string | undefined;
+
+  constructor(options: DesktopClientOptions) {
+    this.#baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.#token = options.token;
+  }
+
+  #headers(): Record<string, string> {
+    return this.#token ? { authorization: `Bearer ${this.#token}` } : {};
+  }
+
+  async verifyAuth(signal?: AbortSignal): Promise<WearableAuthCheck> {
+    let res: Response;
+    try {
+      res = await fetch(`${this.#baseUrl}/v1/health`, { headers: this.#headers(), signal });
+    } catch {
+      // Connection refused / DNS / offline: the daemon isn't running.
+      // This is NOT an auth failure and must never throw (AC2).
+      return { ok: false, detail: "unreachable" };
+    }
+    if (res.status === 401) return { ok: false, detail: "unauthorized" };
+    if (!res.ok) return { ok: false, detail: `HTTP ${res.status}` };
+    const body = (await res.json().catch(() => ({}))) as { ok?: unknown; version?: unknown };
+    if (body.ok === true) {
+      return { ok: true, detail: typeof body.version === "string" ? `capture-audio ${body.version}` : undefined };
+    }
+    return { ok: false, detail: "unhealthy" };
+  }
+
+  async fetchConversations(opts: WearableFetchOptions): Promise<WearableFetchPage> {
+    const url = new URL(`${this.#baseUrl}/v1/conversations`);
+    url.searchParams.set("date", opts.date);
+    url.searchParams.set("timezone", opts.timezone);
+    if (opts.cursor) url.searchParams.set("cursor", opts.cursor);
+    let res: Response;
+    try {
+      res = await fetch(url, { headers: this.#headers(), signal: opts.signal });
+    } catch {
+      throw new DesktopDaemonError(
+        `desktop capture daemon unreachable at ${this.#baseUrl} (is remnic-capture-audio running?)`,
+      );
+    }
+    if (!res.ok) {
+      // A non-2xx is a backend/auth failure, distinct from an empty day.
+      throw new DesktopDaemonError(`desktop capture daemon returned HTTP ${res.status}`);
+    }
+    const page = (await res.json()) as ConversationPage;
+    if (!page || !Array.isArray(page.conversations)) {
+      throw new DesktopDaemonError("desktop capture daemon returned a malformed conversations page");
+    }
+    return {
+      conversations: page.conversations.map(daemonConversationToWearable),
+      nextCursor: page.nextCursor ?? null,
+    };
+  }
+}
+
+export function createDesktopConnector(options: WearableConnectorFactoryOptions): WearableSourceConnector {
+  const baseUrl = options.settings.baseUrl?.trim() || DEFAULT_BASE_URL;
+  // Token resolved lazily so `wearables status` works without a token and
+  // env/file changes take effect without a connector rebuild.
+  let client: DesktopClient | null = null;
+  const getClient = (): DesktopClient => {
+    if (!client) {
+      client = new DesktopClient({ baseUrl, token: resolveCaptureAudioToken(options.settings.apiKey, baseUrl) });
+    }
+    return client;
+  };
+  return {
+    id: DESKTOP_SOURCE_ID,
+    displayName: DESKTOP_DISPLAY_NAME,
+    verifyAuth: (signal?: AbortSignal) => getClient().verifyAuth(signal),
+    fetchConversations: (opts: WearableFetchOptions) => getClient().fetchConversations(opts),
+  };
+}
+
+export const wearableConnectorRegistration: WearableConnectorRegistration = {
+  id: DESKTOP_SOURCE_ID,
+  displayName: DESKTOP_DISPLAY_NAME,
+  factory: createDesktopConnector,
+};
+
+/** Idempotently register the desktop connector with the core registry. */
+export function ensureDesktopConnectorRegistered(): boolean {
+  if (getWearableConnector(DESKTOP_SOURCE_ID) !== undefined) return false;
+  registerWearableConnector(wearableConnectorRegistration);
+  return true;
+}
+
+ensureDesktopConnectorRegistered();

--- a/packages/capture-audio/src/connector.ts
+++ b/packages/capture-audio/src/connector.ts
@@ -152,7 +152,15 @@ class DesktopClient {
     }
     if (res.status === 401) return { ok: false, detail: "unauthorized" };
     if (!res.ok) return { ok: false, detail: `HTTP ${res.status}` };
-    const body = (await res.json().catch(() => ({}))) as { ok?: unknown; version?: unknown };
+    let body: { ok?: unknown; version?: unknown };
+    try {
+      body = (await res.json()) as { ok?: unknown; version?: unknown };
+    } catch (err) {
+      // Honor caller cancellation during the body read; a non-JSON body
+      // otherwise just reads as unhealthy (never throws for that, AC2).
+      if (signal?.aborted) throw err;
+      body = {};
+    }
     if (body.ok === true) {
       return { ok: true, detail: typeof body.version === "string" ? `capture-audio ${body.version}` : undefined };
     }

--- a/packages/capture-audio/src/connector.ts
+++ b/packages/capture-audio/src/connector.ts
@@ -183,7 +183,9 @@ class DesktopClient {
     let page: ConversationPage;
     try {
       page = (await res.json()) as ConversationPage;
-    } catch {
+    } catch (err) {
+      // Honor caller cancellation that lands mid-body-read.
+      if (opts.signal?.aborted) throw err;
       // A 200 with an empty/non-JSON body is a backend fault, not an empty day.
       throw new DesktopDaemonError("desktop capture daemon returned a non-JSON conversations response");
     }

--- a/packages/capture-audio/src/dedup.test.ts
+++ b/packages/capture-audio/src/dedup.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { dedupeCrossChannel, wordJaccard } from "./dedup.js";
+
+test("wordJaccard scores word overlap ignoring case and punctuation", () => {
+  assert.equal(wordJaccard("Hello there, world!", "hello there world"), 1);
+  assert.equal(wordJaccard("a b c d", "a b c e"), 3 / 5);
+  assert.equal(wordJaccard("totally different", "nothing shared"), 0);
+  assert.equal(wordJaccard("", ""), 1);
+  assert.equal(wordJaccard("words", ""), 0);
+});
+
+test("dedupeCrossChannel drops the mic copy of an overlapping near-identical system segment", () => {
+  const segments = [
+    { channel: "mic", text: "let us schedule the review for friday", startUtc: "2026-07-20T15:00:00.000Z", endUtc: "2026-07-20T15:00:04.000Z" },
+    { channel: "system", text: "let us schedule the review for friday", startUtc: "2026-07-20T15:00:01.000Z", endUtc: "2026-07-20T15:00:05.000Z" },
+  ];
+  const kept = dedupeCrossChannel(segments);
+  assert.equal(kept.length, 1);
+  assert.equal(kept[0].channel, "system");
+});
+
+test("dedupeCrossChannel keeps mic when text differs below threshold", () => {
+  const segments = [
+    { channel: "mic", text: "the weather is nice today outside", startUtc: "2026-07-20T15:00:00.000Z", endUtc: "2026-07-20T15:00:04.000Z" },
+    { channel: "system", text: "quarterly revenue numbers look strong", startUtc: "2026-07-20T15:00:01.000Z", endUtc: "2026-07-20T15:00:05.000Z" },
+  ];
+  assert.equal(dedupeCrossChannel(segments).length, 2);
+});
+
+test("dedupeCrossChannel keeps mic when the system copy is outside the time tolerance", () => {
+  const segments = [
+    { channel: "mic", text: "same exact words here", startUtc: "2026-07-20T15:00:00.000Z", endUtc: "2026-07-20T15:00:02.000Z" },
+    { channel: "system", text: "same exact words here", startUtc: "2026-07-20T15:00:30.000Z", endUtc: "2026-07-20T15:00:32.000Z" },
+  ];
+  assert.equal(dedupeCrossChannel(segments).length, 2);
+});
+
+test("dedupeCrossChannel never drops system segments", () => {
+  const segments = [
+    { channel: "system", text: "one", startUtc: "2026-07-20T15:00:00.000Z", endUtc: "2026-07-20T15:00:01.000Z" },
+    { channel: "system", text: "one", startUtc: "2026-07-20T15:00:00.500Z", endUtc: "2026-07-20T15:00:01.500Z" },
+  ];
+  assert.equal(dedupeCrossChannel(segments).length, 2);
+});

--- a/packages/capture-audio/src/dedup.ts
+++ b/packages/capture-audio/src/dedup.ts
@@ -1,0 +1,78 @@
+/**
+ * Cross-channel dedup (issue #1897, component 2.4).
+ *
+ * A speakerphone is heard twice: once on the mic and once on the system
+ * (loopback) channel. When the mic and system channels transcribe
+ * near-identical text in overlapping time, keep the SYSTEM copy (the
+ * cleaner far-end signal) and drop the mic copy. Match rule: word-level
+ * Jaccard >= 0.8 within +-5 s. Pure over segment arrays so the pipeline
+ * and the unit tests share one implementation.
+ */
+
+/** Minimum shape needed to dedup; the pipeline's richer segments satisfy it. */
+export interface DedupSegment {
+  channel: string;
+  text: string;
+  startUtc: string;
+  endUtc: string;
+}
+
+/** Default temporal tolerance for "overlapping time" (ms). */
+const OVERLAP_TOLERANCE_MS = 5_000;
+/** Default word-level Jaccard threshold for "near-identical text". */
+const JACCARD_THRESHOLD = 0.8;
+
+function wordSet(text: string): Set<string> {
+  const words = text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 0);
+  return new Set(words);
+}
+
+export function wordJaccard(a: string, b: string): number {
+  const setA = wordSet(a);
+  const setB = wordSet(b);
+  if (setA.size === 0 && setB.size === 0) return 1;
+  if (setA.size === 0 || setB.size === 0) return 0;
+  let intersection = 0;
+  for (const w of setA) {
+    if (setB.has(w)) intersection++;
+  }
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/** True when two segments overlap in time, expanded by `toleranceMs` on each side. */
+function overlapsWithin(a: DedupSegment, b: DedupSegment, toleranceMs: number): boolean {
+  const aStart = Date.parse(a.startUtc);
+  const aEnd = Date.parse(a.endUtc);
+  const bStart = Date.parse(b.startUtc);
+  const bEnd = Date.parse(b.endUtc);
+  if (!Number.isFinite(aStart) || !Number.isFinite(aEnd) || !Number.isFinite(bStart) || !Number.isFinite(bEnd)) {
+    return false;
+  }
+  return aStart <= bEnd + toleranceMs && bStart <= aEnd + toleranceMs;
+}
+
+/**
+ * Drop mic segments that duplicate a system segment (overlapping time +
+ * Jaccard >= threshold). System segments and non-duplicate mic segments
+ * are preserved in input order. Generic so callers keep their richer type.
+ */
+export function dedupeCrossChannel<T extends DedupSegment>(
+  segments: readonly T[],
+  options: { toleranceMs?: number; jaccardThreshold?: number } = {},
+): T[] {
+  const toleranceMs = options.toleranceMs ?? OVERLAP_TOLERANCE_MS;
+  const threshold = options.jaccardThreshold ?? JACCARD_THRESHOLD;
+  const systemSegments = segments.filter((s) => s.channel === "system");
+  return segments.filter((seg) => {
+    if (seg.channel !== "mic") return true;
+    const duplicated = systemSegments.some(
+      (sys) => overlapsWithin(seg, sys, toleranceMs) && wordJaccard(seg.text, sys.text) >= threshold,
+    );
+    return !duplicated;
+  });
+}

--- a/packages/capture-audio/src/diarization.test.ts
+++ b/packages/capture-audio/src/diarization.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { cosineSimilarity, SpeakerClusterer } from "./diarization.js";
+import { SpeakerClusterer, cosineSimilarity } from "./diarization.js";
+import { Spool } from "./spool.js";
 
 /** Deterministic pseudo-embedding near a base vector (same speaker) with jitter. */
 function nearVoice(base: number[], seed: number, jitter = 0.02): number[] {
@@ -53,4 +54,28 @@ test("enrolled self voice is labeled `self`", () => {
 test("constructor rejects an out-of-range threshold", () => {
   assert.throws(() => new SpeakerClusterer(0));
   assert.throws(() => new SpeakerClusterer(1));
+});
+
+test("a clusters() snapshot persists its embeddingCount through the spool (no reset to 0)", () => {
+  const clusterer = new SpeakerClusterer(0.5);
+  const voice = [0.9, 0.1, 0.2, 0.0];
+  clusterer.assign(voice);
+  clusterer.assign(nearVoice(voice, 1)); // merges -> embeddingCount 2
+  const [snapshot] = clusterer.clusters();
+  assert.equal(snapshot.embeddingCount, 2);
+
+  const spool = new Spool(":memory:");
+  try {
+    // Persist the snapshot object directly, as daemon/library wiring would;
+    // the field names must line up or the count is silently stored as 0.
+    for (const c of clusterer.clusters()) spool.upsertSpeaker(c);
+    const rows = spool.readSpeakerClusters();
+    assert.equal(rows[0].embeddingCount, 2);
+    // Seeding a fresh clusterer from the persisted rows keeps the sample
+    // count, so established speakers are not treated as fresh on restart.
+    const seeded = new SpeakerClusterer(0.5, rows);
+    assert.equal(seeded.clusters()[0].embeddingCount, 2);
+  } finally {
+    spool.close();
+  }
 });

--- a/packages/capture-audio/src/diarization.test.ts
+++ b/packages/capture-audio/src/diarization.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { cosineSimilarity, decodeEmbedding, encodeEmbedding, SpeakerClusterer } from "./diarization.js";
+import { cosineSimilarity, SpeakerClusterer } from "./diarization.js";
 
 /** Deterministic pseudo-embedding near a base vector (same speaker) with jitter. */
 function nearVoice(base: number[], seed: number, jitter = 0.02): number[] {
@@ -12,14 +12,6 @@ test("cosineSimilarity: identical=1, orthogonal=0", () => {
   assert.equal(cosineSimilarity([1, 0, 0], [1, 0, 0]), 1);
   assert.equal(cosineSimilarity([1, 0], [0, 1]), 0);
   assert.equal(cosineSimilarity([], [1]), 0);
-});
-
-test("encode/decode embedding round-trips through a Float32 BLOB", () => {
-  const emb = [0.1, -0.5, 0.9, 0.25];
-  const decoded = decodeEmbedding(encodeEmbedding(emb));
-  assert.equal(decoded.length, 4);
-  for (let i = 0; i < emb.length; i++) assert.ok(Math.abs(decoded[i] - emb[i]) < 1e-6);
-  assert.deepEqual(decodeEmbedding(null), []);
 });
 
 test("fragmentation regression: one synthetic voice across 50 segments stays one cluster", () => {

--- a/packages/capture-audio/src/diarization.test.ts
+++ b/packages/capture-audio/src/diarization.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { cosineSimilarity, decodeEmbedding, encodeEmbedding, SpeakerClusterer } from "./diarization.js";
+
+/** Deterministic pseudo-embedding near a base vector (same speaker) with jitter. */
+function nearVoice(base: number[], seed: number, jitter = 0.02): number[] {
+  return base.map((v, i) => v + jitter * Math.sin(seed * 7 + i));
+}
+
+test("cosineSimilarity: identical=1, orthogonal=0", () => {
+  assert.equal(cosineSimilarity([1, 0, 0], [1, 0, 0]), 1);
+  assert.equal(cosineSimilarity([1, 0], [0, 1]), 0);
+  assert.equal(cosineSimilarity([], [1]), 0);
+});
+
+test("encode/decode embedding round-trips through a Float32 BLOB", () => {
+  const emb = [0.1, -0.5, 0.9, 0.25];
+  const decoded = decodeEmbedding(encodeEmbedding(emb));
+  assert.equal(decoded.length, 4);
+  for (let i = 0; i < emb.length; i++) assert.ok(Math.abs(decoded[i] - emb[i]) < 1e-6);
+  assert.deepEqual(decodeEmbedding(null), []);
+});
+
+test("fragmentation regression: one synthetic voice across 50 segments stays one cluster", () => {
+  const clusterer = new SpeakerClusterer(0.4);
+  const base = [0.9, 0.1, 0.4, 0.2, 0.7];
+  const ids = new Set<string>();
+  for (let i = 0; i < 50; i++) ids.add(clusterer.assign(nearVoice(base, i)));
+  assert.equal(ids.size, 1, `expected 1 cluster, got ${[...ids].join(",")}`);
+});
+
+test("two distinct voices form two clusters", () => {
+  const clusterer = new SpeakerClusterer(0.5);
+  const voiceA = [0.9, 0.1, 0.1, 0.0];
+  const voiceB = [0.0, 0.1, 0.1, 0.9];
+  const a = clusterer.assign(voiceA);
+  const b = clusterer.assign(voiceB);
+  assert.notEqual(a, b);
+  // A third sample close to A rejoins A, not B.
+  assert.equal(clusterer.assign(nearVoice(voiceA, 3)), a);
+});
+
+test("cluster ids are stable across a restart when seeded from persisted clusters", () => {
+  const first = new SpeakerClusterer(0.5);
+  const voice = [0.2, 0.8, 0.1, 0.3];
+  const id = first.assign(voice);
+  const seeded = new SpeakerClusterer(0.5, first.clusters());
+  assert.equal(seeded.assign(nearVoice(voice, 1)), id);
+  // A new distinct voice does not reuse the seeded id.
+  assert.notEqual(seeded.assign([0.9, 0.0, 0.0, 0.1]), id);
+});
+
+test("enrolled self voice is labeled `self`", () => {
+  const clusterer = new SpeakerClusterer(0.5);
+  const selfVoice = [0.5, 0.5, 0.5, 0.5];
+  clusterer.enrollSelf(selfVoice);
+  assert.equal(clusterer.assign(nearVoice(selfVoice, 2)), "self");
+});
+
+test("constructor rejects an out-of-range threshold", () => {
+  assert.throws(() => new SpeakerClusterer(0));
+  assert.throws(() => new SpeakerClusterer(1));
+});

--- a/packages/capture-audio/src/diarization.ts
+++ b/packages/capture-audio/src/diarization.ts
@@ -1,0 +1,181 @@
+/**
+ * Speaker diarization clustering (issue #1897, component 2.3).
+ *
+ * The daemon computes one speaker embedding per VAD speech segment (via
+ * the optional sherpa-onnx speaker-id model, wired with the native
+ * capture layer). This module owns the CPU-cheap, hardware-free half:
+ * matching an embedding to a stable speaker cluster and maintaining the
+ * cluster's running centroid + a bounded diverse example set. It is pure
+ * over embedding vectors so the fragmentation regression (one synthetic
+ * voice across many segments -> one cluster) runs in CI without models.
+ *
+ * Match score = best cosine similarity against BOTH the cluster centroid
+ * and up to `maxExamples` stored examples (issue: "take the best score").
+ */
+
+import { Buffer } from "node:buffer";
+
+import { CaptureConfigError } from "./errors.js";
+
+export type Embedding = readonly number[];
+
+export interface SpeakerCluster {
+  id: string;
+  centroid: number[];
+  examples: number[][];
+  count: number;
+  isSelf: boolean;
+  label: string | null;
+}
+
+const MAX_EXAMPLES = 10;
+const SELF_ID = "self";
+
+export function cosineSimilarity(a: Embedding, b: Embedding): number {
+  if (a.length === 0 || a.length !== b.length) return 0;
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+/** Encode an embedding as a little-endian Float32 BLOB for the spool. */
+export function encodeEmbedding(embedding: Embedding): Buffer {
+  const arr = Float32Array.from(embedding);
+  return Buffer.from(arr.buffer, arr.byteOffset, arr.byteLength);
+}
+
+/** Decode a Float32 BLOB back into a number[]; empty/odd buffers -> []. */
+export function decodeEmbedding(blob: Buffer | null | undefined): number[] {
+  if (!blob || blob.byteLength < 4 || blob.byteLength % 4 !== 0) return [];
+  const arr = new Float32Array(blob.buffer, blob.byteOffset, blob.byteLength / 4);
+  return Array.from(arr);
+}
+
+/**
+ * Assigns embeddings to stable speaker clusters. Ids are `spk_<n>` (or
+ * `self` for the enrolled wearer). Seed with persisted clusters so ids
+ * survive daemon restarts.
+ */
+export class SpeakerClusterer {
+  #clusters: SpeakerCluster[] = [];
+  #threshold: number;
+  #next = 1;
+
+  constructor(threshold: number, seed: readonly SpeakerCluster[] = []) {
+    if (!Number.isFinite(threshold) || threshold <= 0 || threshold >= 1) {
+      throw new CaptureConfigError("diarization.similarityThreshold must be between 0 and 1");
+    }
+    this.#threshold = threshold;
+    for (const c of seed) {
+      this.#clusters.push({
+        id: c.id,
+        centroid: [...c.centroid],
+        examples: c.examples.map((e) => [...e]),
+        count: c.count,
+        isSelf: c.isSelf,
+        label: c.label,
+      });
+      const n = /^spk_(\d+)$/.exec(c.id);
+      if (n) this.#next = Math.max(this.#next, Number(n[1]) + 1);
+    }
+  }
+
+  /** Register an enrolled self profile (its embedding seeds the `self` cluster). */
+  enrollSelf(embedding: Embedding): void {
+    const existing = this.#clusters.find((c) => c.id === SELF_ID);
+    if (existing) {
+      this.#update(existing, embedding);
+      existing.isSelf = true;
+      return;
+    }
+    this.#clusters.unshift({
+      id: SELF_ID,
+      centroid: [...embedding],
+      examples: [[...embedding]],
+      count: 1,
+      isSelf: true,
+      label: null,
+    });
+  }
+
+  /** Best cosine over a cluster's centroid + examples. */
+  #score(cluster: SpeakerCluster, embedding: Embedding): number {
+    let best = cosineSimilarity(cluster.centroid, embedding);
+    for (const ex of cluster.examples) {
+      const s = cosineSimilarity(ex, embedding);
+      if (s > best) best = s;
+    }
+    return best;
+  }
+
+  #update(cluster: SpeakerCluster, embedding: Embedding): void {
+    // Running mean centroid.
+    const n = cluster.count;
+    for (let i = 0; i < cluster.centroid.length && i < embedding.length; i++) {
+      cluster.centroid[i] = (cluster.centroid[i] * n + embedding[i]) / (n + 1);
+    }
+    cluster.count = n + 1;
+    if (cluster.examples.length < MAX_EXAMPLES) {
+      cluster.examples.push([...embedding]);
+    } else {
+      // Keep the set diverse: replace the example most similar to the
+      // incoming one, so the cluster spans more of the speaker's range.
+      let mostSimilar = 0;
+      let mostSimilarScore = -Infinity;
+      for (let i = 0; i < cluster.examples.length; i++) {
+        const s = cosineSimilarity(cluster.examples[i], embedding);
+        if (s > mostSimilarScore) {
+          mostSimilarScore = s;
+          mostSimilar = i;
+        }
+      }
+      cluster.examples[mostSimilar] = [...embedding];
+    }
+  }
+
+  /** Match `embedding` to an existing cluster or create a new `spk_<n>`. */
+  assign(embedding: Embedding): string {
+    let best: SpeakerCluster | null = null;
+    let bestScore = -Infinity;
+    for (const cluster of this.#clusters) {
+      const s = this.#score(cluster, embedding);
+      if (s > bestScore) {
+        bestScore = s;
+        best = cluster;
+      }
+    }
+    if (best && bestScore >= this.#threshold) {
+      this.#update(best, embedding);
+      return best.id;
+    }
+    const cluster: SpeakerCluster = {
+      id: `spk_${this.#next++}`,
+      centroid: [...embedding],
+      examples: [[...embedding]],
+      count: 1,
+      isSelf: false,
+      label: null,
+    };
+    this.#clusters.push(cluster);
+    return cluster.id;
+  }
+
+  /** Snapshot for persistence. */
+  clusters(): SpeakerCluster[] {
+    return this.#clusters.map((c) => ({
+      id: c.id,
+      centroid: [...c.centroid],
+      examples: c.examples.map((e) => [...e]),
+      count: c.count,
+      isSelf: c.isSelf,
+      label: c.label,
+    }));
+  }
+}

--- a/packages/capture-audio/src/diarization.ts
+++ b/packages/capture-audio/src/diarization.ts
@@ -21,7 +21,7 @@ export interface SpeakerCluster {
   id: string;
   centroid: number[];
   examples: number[][];
-  count: number;
+  embeddingCount: number;
   isSelf: boolean;
   label: string | null;
 }
@@ -63,7 +63,7 @@ export class SpeakerClusterer {
         id: c.id,
         centroid: [...c.centroid],
         examples: c.examples.map((e) => [...e]),
-        count: c.count,
+        embeddingCount: c.embeddingCount,
         isSelf: c.isSelf,
         label: c.label,
       });
@@ -84,7 +84,7 @@ export class SpeakerClusterer {
       id: SELF_ID,
       centroid: [...embedding],
       examples: [[...embedding]],
-      count: 1,
+      embeddingCount: 1,
       isSelf: true,
       label: null,
     });
@@ -102,11 +102,11 @@ export class SpeakerClusterer {
 
   #update(cluster: SpeakerCluster, embedding: Embedding): void {
     // Running mean centroid.
-    const n = cluster.count;
+    const n = cluster.embeddingCount;
     for (let i = 0; i < cluster.centroid.length && i < embedding.length; i++) {
       cluster.centroid[i] = (cluster.centroid[i] * n + embedding[i]) / (n + 1);
     }
-    cluster.count = n + 1;
+    cluster.embeddingCount = n + 1;
     if (cluster.examples.length < MAX_EXAMPLES) {
       cluster.examples.push([...embedding]);
     } else {
@@ -144,7 +144,7 @@ export class SpeakerClusterer {
       id: `spk_${this.#next++}`,
       centroid: [...embedding],
       examples: [[...embedding]],
-      count: 1,
+      embeddingCount: 1,
       isSelf: false,
       label: null,
     };
@@ -158,7 +158,7 @@ export class SpeakerClusterer {
       id: c.id,
       centroid: [...c.centroid],
       examples: c.examples.map((e) => [...e]),
-      count: c.count,
+      embeddingCount: c.embeddingCount,
       isSelf: c.isSelf,
       label: c.label,
     }));

--- a/packages/capture-audio/src/diarization.ts
+++ b/packages/capture-audio/src/diarization.ts
@@ -13,8 +13,6 @@
  * and up to `maxExamples` stored examples (issue: "take the best score").
  */
 
-import { Buffer } from "node:buffer";
-
 import { CaptureConfigError } from "./errors.js";
 
 export type Embedding = readonly number[];
@@ -43,19 +41,6 @@ export function cosineSimilarity(a: Embedding, b: Embedding): number {
   }
   if (normA === 0 || normB === 0) return 0;
   return dot / (Math.sqrt(normA) * Math.sqrt(normB));
-}
-
-/** Encode an embedding as a little-endian Float32 BLOB for the spool. */
-export function encodeEmbedding(embedding: Embedding): Buffer {
-  const arr = Float32Array.from(embedding);
-  return Buffer.from(arr.buffer, arr.byteOffset, arr.byteLength);
-}
-
-/** Decode a Float32 BLOB back into a number[]; empty/odd buffers -> []. */
-export function decodeEmbedding(blob: Buffer | null | undefined): number[] {
-  if (!blob || blob.byteLength < 4 || blob.byteLength % 4 !== 0) return [];
-  const arr = new Float32Array(blob.buffer, blob.byteOffset, blob.byteLength / 4);
-  return Array.from(arr);
 }
 
 /**

--- a/packages/capture-audio/src/e2e.test.ts
+++ b/packages/capture-audio/src/e2e.test.ts
@@ -1,0 +1,130 @@
+/**
+ * End-to-end acceptance (issue #1897): a real capture-audio daemon serving
+ * synthetic fixture conversations -> the real `desktop` connector over
+ * loopback HTTP -> the UNCHANGED core wearables pipeline (syncWearableSource)
+ * -> a day-transcript in the memory dir. No hardware, no network, no models:
+ * the daemon spool is seeded directly (the same rows `--replay` would write).
+ *
+ * Proves: default-off (AC2), replay->sync->day store with source `desktop`
+ * + content-hash no-op re-run (AC3), and connector discovery/registration.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  defaultWearableSourceSettings,
+  defaultWearablesConfig,
+  getWearableConnector,
+  parseDayTranscript,
+  syncWearableSource,
+  type WearableSyncDeps,
+} from "@remnic/core";
+
+import { defaultDaemonConfig } from "./config.js";
+import { createDesktopConnector, DESKTOP_SOURCE_ID } from "./connector.js";
+import { startDaemon } from "./daemon.js";
+import { Spool } from "./spool.js";
+
+const DATE = "2026-07-20";
+
+function fileBackedDeps(memoryDir: string): { deps: WearableSyncDeps; written: Map<string, string> } {
+  const written = new Map<string, string>();
+  const deps: WearableSyncDeps = {
+    memoryDir,
+    async readDayContentHash(sourceId, date) {
+      const raw = written.get(`${sourceId}/${date}`);
+      return raw === undefined ? null : (parseDayTranscript(raw)?.meta.contentHash ?? null);
+    },
+    async writeDayTranscript(sourceId, date, serialized) {
+      written.set(`${sourceId}/${date}`, serialized);
+    },
+    memoryGen: null, // transcripts-only: memoryMode "off" wants no extraction
+  };
+  return { deps, written };
+}
+
+async function seededDaemon(): Promise<{ url: string; close: () => Promise<void>; spool: Spool }> {
+  const spool = new Spool(":memory:");
+  spool.insertConversation({
+    id: "conv_e2e_1",
+    startedAtUtc: `${DATE}T15:00:00.000Z`,
+    endedAtUtc: `${DATE}T15:02:00.000Z`,
+    state: "final",
+    segments: [
+      { channel: "system", speakerCluster: "spk_1", text: "Let us ship the desktop capture connector on Friday.", startUtc: `${DATE}T15:00:00.000Z`, endUtc: `${DATE}T15:00:05.000Z` },
+      { channel: "mic", speakerCluster: "self", isWearer: true, text: "Agreed, I will prepare the release notes.", startUtc: `${DATE}T15:00:06.000Z`, endUtc: `${DATE}T15:00:10.000Z` },
+    ],
+  });
+  // A still-capturing conversation MUST NOT be served (final-only pagination).
+  spool.insertConversation({
+    id: "conv_e2e_open",
+    startedAtUtc: `${DATE}T18:00:00.000Z`,
+    state: "capturing",
+    segments: [{ channel: "mic", text: "half a meeting", startUtc: `${DATE}T18:00:00.000Z`, endUtc: `${DATE}T18:00:02.000Z` }],
+  });
+  const handle = await startDaemon({ spool, config: { ...defaultDaemonConfig(), host: "127.0.0.1", port: 0 }, token: "tok" });
+  return { url: handle.url, close: () => handle.close().finally(() => spool.close()), spool };
+}
+
+function desktopSettings(baseUrl: string, overrides = {}) {
+  return { ...defaultWearableSourceSettings(), enabled: true, baseUrl, apiKey: "tok", memoryMode: "off" as const, ...overrides };
+}
+
+function wearablesConfig() {
+  return { ...defaultWearablesConfig(), enabled: true, timezone: "UTC", digestEnabled: false, offTheRecordEnabled: false };
+}
+
+test("importing the connector registers `desktop` for core discovery", () => {
+  assert.equal(getWearableConnector(DESKTOP_SOURCE_ID)?.id, DESKTOP_SOURCE_ID);
+});
+
+test("replay->desktop connector->core sync writes a desktop day transcript (final-only), re-run is a content-hash no-op", async () => {
+  const daemon = await seededDaemon();
+  const memoryDir = mkdtempSync(path.join(tmpdir(), "cap-e2e-"));
+  try {
+    const connector = createDesktopConnector({ settings: desktopSettings(daemon.url), timezone: "UTC" });
+    const { deps, written } = fileBackedDeps(memoryDir);
+
+    const first = await syncWearableSource(connector, desktopSettings(daemon.url), wearablesConfig(), { date: DATE }, deps);
+    assert.equal(first.source, "desktop");
+    assert.equal(first.transcriptsWritten.length, 1);
+
+    const serialized = written.get(`desktop/${DATE}`);
+    assert.ok(serialized, "a desktop day transcript was written");
+    const parsed = parseDayTranscript(serialized as string);
+    assert.equal(parsed?.meta.source, "desktop");
+    assert.match(serialized as string, /desktop capture connector on Friday/);
+    // final-only: the capturing conversation's text never reaches the day store.
+    assert.doesNotMatch(serialized as string, /half a meeting/);
+
+    // Re-sync the same day: identical content hash => no new transcript write.
+    const second = await syncWearableSource(connector, desktopSettings(daemon.url), wearablesConfig(), { date: DATE }, deps);
+    assert.equal(second.transcriptsWritten.length, 0, "re-run is a content-hash no-op");
+  } finally {
+    await daemon.close();
+    rmSync(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("default-off: a disabled desktop source with the daemon running syncs nothing", async () => {
+  const daemon = await seededDaemon();
+  const memoryDir = mkdtempSync(path.join(tmpdir(), "cap-e2e-"));
+  try {
+    const connector = createDesktopConnector({ settings: desktopSettings(daemon.url), timezone: "UTC" });
+    const { deps, written } = fileBackedDeps(memoryDir);
+    // A caller that respects `enabled:false` never invokes sync; assert the
+    // gate value the pipeline/service reads is off by default.
+    assert.equal(defaultWearableSourceSettings().enabled, false);
+    // And even if sync is called for a day with no final conversations, it
+    // writes nothing (empty page is not an error).
+    await syncWearableSource(connector, desktopSettings(daemon.url), wearablesConfig(), { date: "2026-07-21" }, deps);
+    assert.equal(written.size, 0);
+  } finally {
+    await daemon.close();
+    rmSync(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/capture-audio/src/index.ts
+++ b/packages/capture-audio/src/index.ts
@@ -52,6 +52,8 @@ export { buildWhisperArgs, parseWhisperJson, resolveModelPath, runWhisperCli, tr
 export { downloadWhisperModel, whisperModelUrl } from "./model.js";
 export type { ModelDownloadInput, ModelDownloadResult } from "./model.js";
 export { pruneExpiredRawAudio } from "./janitor.js";
+export { createSileroVad, loadSherpaOnnx, sileroVadConfig } from "./vad.js";
+export type { SherpaOnnxModule, SileroVadInput } from "./vad.js";
 export type { TranscribedSegment, WhisperRunResult, WhisperTranscriptionInput } from "./stt.js";
 export type { ReplayResult } from "./replay.js";
 export { createRequestHandler, startDaemon } from "./daemon.js";

--- a/packages/capture-audio/src/index.ts
+++ b/packages/capture-audio/src/index.ts
@@ -44,6 +44,7 @@ export type {
   DaemonSegment,
   QueryFinalOptions,
   SegmentInput,
+  SpeakerClusterRow,
   SpeakerInput,
   SpeakerRow,
 } from "./spool.js";
@@ -69,3 +70,18 @@ export {
 export type { PidRecord } from "./control.js";
 export { runCapture, superviseReplay } from "./cli.js";
 export type { CliIo } from "./cli.js";
+export {
+  createDesktopConnector,
+  daemonConversationToWearable,
+  DesktopDaemonError,
+  DESKTOP_SOURCE_ID,
+  ensureDesktopConnectorRegistered,
+  resolveCaptureAudioToken,
+  wearableConnectorRegistration,
+} from "./connector.js";
+export { dedupeCrossChannel, wordJaccard } from "./dedup.js";
+export type { DedupSegment } from "./dedup.js";
+export { assembleConversations } from "./assembly.js";
+export type { AssemblySegment } from "./assembly.js";
+export { cosineSimilarity, decodeEmbedding, encodeEmbedding, SpeakerClusterer } from "./diarization.js";
+export type { Embedding, SpeakerCluster } from "./diarization.js";

--- a/packages/capture-audio/src/index.ts
+++ b/packages/capture-audio/src/index.ts
@@ -48,8 +48,8 @@ export type {
   SpeakerRow,
 } from "./spool.js";
 export { ingestReplayDir, ingestReplayDirResponsive, REPLAY_COMMIT_BATCH } from "./replay.js";
-export { buildWhisperArgs, parseWhisperJson, resolveModelPath } from "./stt.js";
-export type { TranscribedSegment } from "./stt.js";
+export { buildWhisperArgs, parseWhisperJson, resolveModelPath, transcribeWithWhisper } from "./stt.js";
+export type { TranscribedSegment, WhisperRunResult, WhisperTranscriptionInput } from "./stt.js";
 export type { ReplayResult } from "./replay.js";
 export { createRequestHandler, startDaemon } from "./daemon.js";
 export type { DaemonDeps, DaemonHandle } from "./daemon.js";

--- a/packages/capture-audio/src/index.ts
+++ b/packages/capture-audio/src/index.ts
@@ -48,7 +48,7 @@ export type {
   SpeakerRow,
 } from "./spool.js";
 export { ingestReplayDir, ingestReplayDirResponsive, REPLAY_COMMIT_BATCH } from "./replay.js";
-export { parseWhisperJson, resolveModelPath } from "./stt.js";
+export { buildWhisperArgs, parseWhisperJson, resolveModelPath } from "./stt.js";
 export type { TranscribedSegment } from "./stt.js";
 export type { ReplayResult } from "./replay.js";
 export { createRequestHandler, startDaemon } from "./daemon.js";

--- a/packages/capture-audio/src/index.ts
+++ b/packages/capture-audio/src/index.ts
@@ -48,7 +48,7 @@ export type {
   SpeakerRow,
 } from "./spool.js";
 export { ingestReplayDir, ingestReplayDirResponsive, REPLAY_COMMIT_BATCH } from "./replay.js";
-export { buildWhisperArgs, parseWhisperJson, resolveModelPath, transcribeWithWhisper } from "./stt.js";
+export { buildWhisperArgs, parseWhisperJson, resolveModelPath, runWhisperCli, transcribeWithWhisper } from "./stt.js";
 export type { TranscribedSegment, WhisperRunResult, WhisperTranscriptionInput } from "./stt.js";
 export type { ReplayResult } from "./replay.js";
 export { createRequestHandler, startDaemon } from "./daemon.js";

--- a/packages/capture-audio/src/index.ts
+++ b/packages/capture-audio/src/index.ts
@@ -48,6 +48,8 @@ export type {
   SpeakerRow,
 } from "./spool.js";
 export { ingestReplayDir, ingestReplayDirResponsive, REPLAY_COMMIT_BATCH } from "./replay.js";
+export { parseWhisperJson, resolveModelPath } from "./stt.js";
+export type { TranscribedSegment } from "./stt.js";
 export type { ReplayResult } from "./replay.js";
 export { createRequestHandler, startDaemon } from "./daemon.js";
 export type { DaemonDeps, DaemonHandle } from "./daemon.js";

--- a/packages/capture-audio/src/index.ts
+++ b/packages/capture-audio/src/index.ts
@@ -49,6 +49,8 @@ export type {
 } from "./spool.js";
 export { ingestReplayDir, ingestReplayDirResponsive, REPLAY_COMMIT_BATCH } from "./replay.js";
 export { buildWhisperArgs, parseWhisperJson, resolveModelPath, runWhisperCli, transcribeWithWhisper } from "./stt.js";
+export { downloadWhisperModel, whisperModelUrl } from "./model.js";
+export type { ModelDownloadInput, ModelDownloadResult } from "./model.js";
 export type { TranscribedSegment, WhisperRunResult, WhisperTranscriptionInput } from "./stt.js";
 export type { ReplayResult } from "./replay.js";
 export { createRequestHandler, startDaemon } from "./daemon.js";

--- a/packages/capture-audio/src/index.ts
+++ b/packages/capture-audio/src/index.ts
@@ -51,6 +51,7 @@ export { ingestReplayDir, ingestReplayDirResponsive, REPLAY_COMMIT_BATCH } from 
 export { buildWhisperArgs, parseWhisperJson, resolveModelPath, runWhisperCli, transcribeWithWhisper } from "./stt.js";
 export { downloadWhisperModel, whisperModelUrl } from "./model.js";
 export type { ModelDownloadInput, ModelDownloadResult } from "./model.js";
+export { pruneExpiredRawAudio } from "./janitor.js";
 export type { TranscribedSegment, WhisperRunResult, WhisperTranscriptionInput } from "./stt.js";
 export type { ReplayResult } from "./replay.js";
 export { createRequestHandler, startDaemon } from "./daemon.js";

--- a/packages/capture-audio/src/index.ts
+++ b/packages/capture-audio/src/index.ts
@@ -83,5 +83,5 @@ export { dedupeCrossChannel, wordJaccard } from "./dedup.js";
 export type { DedupSegment } from "./dedup.js";
 export { assembleConversations } from "./assembly.js";
 export type { AssemblySegment } from "./assembly.js";
-export { cosineSimilarity, decodeEmbedding, encodeEmbedding, SpeakerClusterer } from "./diarization.js";
+export { cosineSimilarity, SpeakerClusterer } from "./diarization.js";
 export type { Embedding, SpeakerCluster } from "./diarization.js";

--- a/packages/capture-audio/src/janitor.test.ts
+++ b/packages/capture-audio/src/janitor.test.ts
@@ -24,6 +24,20 @@ test("pruneExpiredRawAudio removes only expired regular files", async () => {
   assert.equal(await readFile(outside, "utf8"), "outside");
 });
 
+test("pruneExpiredRawAudio removes a file whose age exactly equals the retention boundary", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "capture-janitor-"));
+  const raw = path.join(root, "raw");
+  const boundaryFile = path.join(raw, "boundary.wav");
+  await mkdir(raw);
+  await writeFile(boundaryFile, "boundary");
+  // now=2000, retention=1000 -> cutoff=1000; set mtime exactly at the cutoff.
+  await utimes(boundaryFile, new Date(1_000), new Date(1_000));
+
+  const removed = await pruneExpiredRawAudio(raw, 1_000, 2_000);
+
+  assert.deepEqual(removed, [boundaryFile]);
+});
+
 test("pruneExpiredRawAudio rejects a symlinked raw root", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "capture-janitor-"));
   const target = path.join(root, "target");

--- a/packages/capture-audio/src/janitor.test.ts
+++ b/packages/capture-audio/src/janitor.test.ts
@@ -23,3 +23,13 @@ test("pruneExpiredRawAudio removes only expired regular files", async () => {
   assert.equal(await readFile(freshFile, "utf8"), "fresh");
   assert.equal(await readFile(outside, "utf8"), "outside");
 });
+
+test("pruneExpiredRawAudio rejects a symlinked raw root", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "capture-janitor-"));
+  const target = path.join(root, "target");
+  const raw = path.join(root, "raw");
+  await mkdir(target);
+  await symlink(target, raw);
+
+  await assert.rejects(pruneExpiredRawAudio(raw, 1_000, 2_000), /non-symlink/);
+});

--- a/packages/capture-audio/src/janitor.test.ts
+++ b/packages/capture-audio/src/janitor.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, symlink, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { pruneExpiredRawAudio } from "./janitor.js";
+
+test("pruneExpiredRawAudio removes only expired regular files", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "capture-janitor-"));
+  const raw = path.join(root, "raw");
+  const outside = path.join(root, "outside.wav");
+  const oldFile = path.join(raw, "old.wav");
+  const freshFile = path.join(raw, "fresh.wav");
+  await mkdir(raw);
+  await Promise.all([writeFile(oldFile, "old"), writeFile(freshFile, "fresh"), writeFile(outside, "outside")]);
+  await utimes(oldFile, new Date(0), new Date(0));
+  await symlink(outside, path.join(raw, "linked.wav"));
+
+  const removed = await pruneExpiredRawAudio(raw, 1_000, 2_000);
+
+  assert.deepEqual(removed, [oldFile]);
+  assert.equal(await readFile(freshFile, "utf8"), "fresh");
+  assert.equal(await readFile(outside, "utf8"), "outside");
+});

--- a/packages/capture-audio/src/janitor.ts
+++ b/packages/capture-audio/src/janitor.ts
@@ -1,0 +1,32 @@
+import { lstat, readdir, rm } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import path from "node:path";
+
+import { CaptureConfigError } from "./errors.js";
+
+export async function pruneExpiredRawAudio(rawDirectory: string, retentionMs: number, nowMs: number = Date.now()): Promise<string[]> {
+  if (!Number.isFinite(retentionMs) || retentionMs < 0) {
+    throw new CaptureConfigError("raw audio retention must be a non-negative duration");
+  }
+  const cutoffMs = nowMs - retentionMs;
+  let entries: Dirent<string>[];
+  try {
+    entries = await readdir(rawDirectory, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+
+  const removed: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const location = path.join(rawDirectory, entry.name);
+    const stat = await lstat(location);
+    if (!stat.isFile()) continue;
+    if (stat.mtimeMs < cutoffMs) {
+      await rm(location);
+      removed.push(location);
+    }
+  }
+  return removed.sort();
+}

--- a/packages/capture-audio/src/janitor.ts
+++ b/packages/capture-audio/src/janitor.ts
@@ -9,14 +9,18 @@ export async function pruneExpiredRawAudio(rawDirectory: string, retentionMs: nu
     throw new CaptureConfigError("raw audio retention must be a non-negative duration");
   }
   const cutoffMs = nowMs - retentionMs;
-  let entries: Dirent<string>[];
+  let root;
   try {
-    entries = await readdir(rawDirectory, { withFileTypes: true });
+    root = await lstat(rawDirectory);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
     throw error;
   }
+  if (root.isSymbolicLink() || !root.isDirectory()) {
+    throw new CaptureConfigError("raw audio directory must be a non-symlink directory");
+  }
 
+  const entries = await readdir(rawDirectory, { withFileTypes: true });
   const removed: string[] = [];
   for (const entry of entries) {
     if (!entry.isFile()) continue;

--- a/packages/capture-audio/src/janitor.ts
+++ b/packages/capture-audio/src/janitor.ts
@@ -27,7 +27,7 @@ export async function pruneExpiredRawAudio(rawDirectory: string, retentionMs: nu
     const location = path.join(rawDirectory, entry.name);
     const stat = await lstat(location);
     if (!stat.isFile()) continue;
-    if (stat.mtimeMs < cutoffMs) {
+    if (stat.mtimeMs <= cutoffMs) {
       await rm(location);
       removed.push(location);
     }

--- a/packages/capture-audio/src/janitor.ts
+++ b/packages/capture-audio/src/janitor.ts
@@ -25,11 +25,19 @@ export async function pruneExpiredRawAudio(rawDirectory: string, retentionMs: nu
   for (const entry of entries) {
     if (!entry.isFile()) continue;
     const location = path.join(rawDirectory, entry.name);
-    const stat = await lstat(location);
-    if (!stat.isFile()) continue;
-    if (stat.mtimeMs <= cutoffMs) {
-      await rm(location);
-      removed.push(location);
+    try {
+      const stat = await lstat(location);
+      if (!stat.isFile()) continue;
+      if (stat.mtimeMs <= cutoffMs) {
+        await rm(location);
+        removed.push(location);
+      }
+    } catch (error) {
+      // A concurrent capture/cleanup can delete a chunk between readdir and
+      // lstat/rm; a vanished file is already pruned, so skip it and continue
+      // instead of aborting the whole janitor run with a generic FS error.
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw error;
     }
   }
   return removed.sort();

--- a/packages/capture-audio/src/model.test.ts
+++ b/packages/capture-audio/src/model.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { CaptureConfigError } from "./errors.js";
+import { downloadWhisperModel, whisperModelUrl } from "./model.js";
+
+test("whisperModelUrl maps supported model identifiers to official model files", () => {
+  assert.equal(
+    whisperModelUrl("large-v3-turbo-q5_0"),
+    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin",
+  );
+  assert.throws(() => whisperModelUrl("unknown"), CaptureConfigError);
+});
+
+test("downloadWhisperModel streams to an atomic destination", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "capture-model-"));
+  try {
+    const result = await downloadWhisperModel({
+      model: "small",
+      directory,
+      fetch: async () => new Response("model-bytes"),
+    });
+
+    assert.equal(result.downloaded, true);
+    assert.equal(await readFile(result.path, "utf8"), "model-bytes");
+    assert.deepEqual(await readdir(directory), ["ggml-small.bin"]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("downloadWhisperModel rejects failed responses without writing a model", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "capture-model-"));
+  try {
+    await assert.rejects(
+      downloadWhisperModel({
+        model: "base",
+        directory,
+        fetch: async () => new Response("unavailable", { status: 503 }),
+      }),
+      CaptureConfigError,
+    );
+    assert.deepEqual(await readdir(directory), []);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/capture-audio/src/model.test.ts
+++ b/packages/capture-audio/src/model.test.ts
@@ -52,6 +52,51 @@ test("downloadWhisperModel rejects failed responses without writing a model", as
   }
 });
 
+test("downloadWhisperModel wraps a fetch rejection in a config error", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "capture-model-"));
+  try {
+    await assert.rejects(
+      downloadWhisperModel({
+        model: "base",
+        directory,
+        fetch: async () => {
+          throw new TypeError("fetch failed");
+        },
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof CaptureConfigError);
+        assert.match(error.message, /network request to Hugging Face failed/);
+        return true;
+      },
+    );
+    assert.deepEqual(await readdir(directory), []);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("downloadWhisperModel rejects a dangling symlink destination before fetching", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "capture-model-"));
+  try {
+    await symlink(path.join(directory, "missing-target.bin"), path.join(directory, "ggml-small.bin"));
+    let fetched = false;
+    await assert.rejects(
+      downloadWhisperModel({
+        model: "small",
+        directory,
+        fetch: async () => {
+          fetched = true;
+          return new Response("bytes");
+        },
+      }),
+      /broken symlink/,
+    );
+    assert.equal(fetched, false);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("downloadWhisperModel rejects an existing non-file destination", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "capture-model-"));
   try {

--- a/packages/capture-audio/src/model.test.ts
+++ b/packages/capture-audio/src/model.test.ts
@@ -13,6 +13,9 @@ test("whisperModelUrl maps supported model identifiers to official model files",
     "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin",
   );
   assert.throws(() => whisperModelUrl("unknown"), CaptureConfigError);
+  for (const key of ["toString", "constructor", "__proto__", "hasOwnProperty"]) {
+    assert.throws(() => whisperModelUrl(key), CaptureConfigError, `prototype key ${key} must be rejected`);
+  }
 });
 
 test("downloadWhisperModel streams to an atomic destination", async () => {

--- a/packages/capture-audio/src/model.test.ts
+++ b/packages/capture-audio/src/model.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -54,6 +54,28 @@ test("downloadWhisperModel rejects an existing non-file destination", async () =
   try {
     await mkdir(path.join(directory, "ggml-small.bin"));
     await assert.rejects(downloadWhisperModel({ model: "small", directory }), /regular file/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("downloadWhisperModel treats a symlink to an existing model file as already present", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "capture-model-"));
+  try {
+    const realModel = path.join(directory, "real-model.bin");
+    await writeFile(realModel, "model-bytes");
+    await symlink(realModel, path.join(directory, "ggml-small.bin"));
+    let fetched = false;
+    const result = await downloadWhisperModel({
+      model: "small",
+      directory,
+      fetch: async () => {
+        fetched = true;
+        return new Response("should-not-download");
+      },
+    });
+    assert.equal(result.downloaded, false);
+    assert.equal(fetched, false);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/packages/capture-audio/src/model.test.ts
+++ b/packages/capture-audio/src/model.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -44,6 +44,16 @@ test("downloadWhisperModel rejects failed responses without writing a model", as
       CaptureConfigError,
     );
     assert.deepEqual(await readdir(directory), []);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("downloadWhisperModel rejects an existing non-file destination", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "capture-model-"));
+  try {
+    await mkdir(path.join(directory, "ggml-small.bin"));
+    await assert.rejects(downloadWhisperModel({ model: "small", directory }), /regular file/);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/packages/capture-audio/src/model.ts
+++ b/packages/capture-audio/src/model.ts
@@ -1,0 +1,77 @@
+import { createWriteStream, existsSync } from "node:fs";
+import { link, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+import { CaptureConfigError } from "./errors.js";
+
+const MODEL_FILES: Record<string, string> = {
+  base: "ggml-base.bin",
+  small: "ggml-small.bin",
+  "large-v3-turbo-q5_0": "ggml-large-v3-turbo-q5_0.bin",
+};
+
+const MODEL_REPOSITORY = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main";
+
+type ModelFetch = (url: string) => Promise<Response>;
+
+export interface ModelDownloadInput {
+  model: string;
+  directory: string;
+  fetch?: ModelFetch;
+}
+
+export interface ModelDownloadResult {
+  path: string;
+  downloaded: boolean;
+}
+
+function responseBodyToReadable(body: ReadableStream<Uint8Array>): Readable {
+  const reader = body.getReader();
+  return new Readable({
+    read() {
+      void reader
+        .read()
+        .then(({ done, value }) => this.push(done ? null : Buffer.from(value)))
+        .catch((error: unknown) => this.destroy(error as Error));
+    },
+  });
+}
+
+export function whisperModelUrl(model: string): string {
+  const file = MODEL_FILES[model];
+  if (!file) {
+    throw new CaptureConfigError(`unknown Whisper model '${model}'; expected one of ${Object.keys(MODEL_FILES).join(", ")}`);
+  }
+  return `${MODEL_REPOSITORY}/${file}`;
+}
+
+export async function downloadWhisperModel(input: ModelDownloadInput): Promise<ModelDownloadResult> {
+  const url = whisperModelUrl(input.model);
+  const filename = new URL(url).pathname.split("/").at(-1);
+  if (!filename) throw new CaptureConfigError("Whisper model URL has no filename");
+
+  await mkdir(input.directory, { recursive: true });
+  const destination = path.join(input.directory, filename);
+  if (existsSync(destination)) return { path: destination, downloaded: false };
+
+  const response = await (input.fetch ?? ((value) => fetch(value)))(url);
+  if (!response.ok || !response.body) {
+    throw new CaptureConfigError(`failed to download ${input.model}: HTTP ${response.status}`);
+  }
+
+  const temporary = path.join(input.directory, `.${filename}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  try {
+    await pipeline(responseBodyToReadable(response.body), createWriteStream(temporary, { flags: "wx", mode: 0o600 }));
+    await link(temporary, destination);
+    await rm(temporary);
+    return { path: destination, downloaded: true };
+  } catch (error) {
+    await rm(temporary, { force: true });
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return { path: destination, downloaded: false };
+    }
+    throw error;
+  }
+}

--- a/packages/capture-audio/src/model.ts
+++ b/packages/capture-audio/src/model.ts
@@ -1,4 +1,4 @@
-import { createWriteStream, existsSync } from "node:fs";
+import { createWriteStream, lstatSync } from "node:fs";
 import { link, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
@@ -39,6 +39,19 @@ function responseBodyToReadable(body: ReadableStream<Uint8Array>): Readable {
   });
 }
 
+function existingFile(destination: string): boolean {
+  try {
+    const entry = lstatSync(destination);
+    if (!entry.isFile()) {
+      throw new CaptureConfigError(`Whisper model path exists but is not a regular file: ${destination}`);
+    }
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
 export function whisperModelUrl(model: string): string {
   const file = MODEL_FILES[model];
   if (!file) {
@@ -54,7 +67,7 @@ export async function downloadWhisperModel(input: ModelDownloadInput): Promise<M
 
   await mkdir(input.directory, { recursive: true });
   const destination = path.join(input.directory, filename);
-  if (existsSync(destination)) return { path: destination, downloaded: false };
+  if (existingFile(destination)) return { path: destination, downloaded: false };
 
   const response = await (input.fetch ?? ((value) => fetch(value)))(url);
   if (!response.ok || !response.body) {
@@ -69,7 +82,7 @@ export async function downloadWhisperModel(input: ModelDownloadInput): Promise<M
     return { path: destination, downloaded: true };
   } catch (error) {
     await rm(temporary, { force: true });
-    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST" && existingFile(destination)) {
       return { path: destination, downloaded: false };
     }
     throw error;

--- a/packages/capture-audio/src/model.ts
+++ b/packages/capture-audio/src/model.ts
@@ -1,4 +1,4 @@
-import { createWriteStream, lstatSync } from "node:fs";
+import { createWriteStream, statSync } from "node:fs";
 import { link, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
@@ -41,7 +41,7 @@ function responseBodyToReadable(body: ReadableStream<Uint8Array>): Readable {
 
 function existingFile(destination: string): boolean {
   try {
-    const entry = lstatSync(destination);
+    const entry = statSync(destination);
     if (!entry.isFile()) {
       throw new CaptureConfigError(`Whisper model path exists but is not a regular file: ${destination}`);
     }

--- a/packages/capture-audio/src/model.ts
+++ b/packages/capture-audio/src/model.ts
@@ -1,5 +1,5 @@
-import { createWriteStream, statSync } from "node:fs";
-import { link, mkdir, rm } from "node:fs/promises";
+import { createWriteStream, lstatSync, statSync } from "node:fs";
+import { mkdir, rename, rm } from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -40,16 +40,27 @@ function responseBodyToReadable(body: ReadableStream<Uint8Array>): Readable {
 }
 
 function existingFile(destination: string): boolean {
+  let entry;
   try {
-    const entry = statSync(destination);
-    if (!entry.isFile()) {
-      throw new CaptureConfigError(`Whisper model path exists but is not a regular file: ${destination}`);
-    }
-    return true;
+    entry = statSync(destination);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
-    throw error;
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    // statSync follows symlinks, so ENOENT is either no directory entry at
+    // all or a dangling symlink. lstatSync tells them apart: if it succeeds,
+    // a broken symlink occupies the path and must be cleared, not silently
+    // treated as absent (a later rename/link would fail on it).
+    try {
+      lstatSync(destination);
+    } catch (linkError) {
+      if ((linkError as NodeJS.ErrnoException).code === "ENOENT") return false;
+      throw linkError;
+    }
+    throw new CaptureConfigError(`Whisper model path is a broken symlink: ${destination}; remove it and retry`);
   }
+  if (!entry.isFile()) {
+    throw new CaptureConfigError(`Whisper model path exists but is not a regular file: ${destination}`);
+  }
+  return true;
 }
 
 export function whisperModelUrl(model: string): string {
@@ -69,7 +80,14 @@ export async function downloadWhisperModel(input: ModelDownloadInput): Promise<M
   const destination = path.join(input.directory, filename);
   if (existingFile(destination)) return { path: destination, downloaded: false };
 
-  const response = await (input.fetch ?? ((value) => fetch(value)))(url);
+  let response;
+  try {
+    response = await (input.fetch ?? ((value) => fetch(value)))(url);
+  } catch {
+    throw new CaptureConfigError(
+      `failed to download ${input.model}: the network request to Hugging Face failed (check connectivity/proxy/DNS)`,
+    );
+  }
   if (!response.ok || !response.body) {
     throw new CaptureConfigError(`failed to download ${input.model}: HTTP ${response.status}`);
   }
@@ -77,14 +95,12 @@ export async function downloadWhisperModel(input: ModelDownloadInput): Promise<M
   const temporary = path.join(input.directory, `.${filename}.${process.pid}.${crypto.randomUUID()}.tmp`);
   try {
     await pipeline(responseBodyToReadable(response.body), createWriteStream(temporary, { flags: "wx", mode: 0o600 }));
-    await link(temporary, destination);
-    await rm(temporary);
+    // Atomic same-directory rename: works on filesystems without hard-link
+    // support (FAT32/exFAT, some network mounts), unlike link()+rm().
+    await rename(temporary, destination);
     return { path: destination, downloaded: true };
   } catch (error) {
     await rm(temporary, { force: true });
-    if ((error as NodeJS.ErrnoException).code === "EEXIST" && existingFile(destination)) {
-      return { path: destination, downloaded: false };
-    }
     throw error;
   }
 }

--- a/packages/capture-audio/src/model.ts
+++ b/packages/capture-audio/src/model.ts
@@ -53,10 +53,10 @@ function existingFile(destination: string): boolean {
 }
 
 export function whisperModelUrl(model: string): string {
-  const file = MODEL_FILES[model];
-  if (!file) {
+  if (!Object.hasOwn(MODEL_FILES, model)) {
     throw new CaptureConfigError(`unknown Whisper model '${model}'; expected one of ${Object.keys(MODEL_FILES).join(", ")}`);
   }
+  const file = MODEL_FILES[model];
   return `${MODEL_REPOSITORY}/${file}`;
 }
 

--- a/packages/capture-audio/src/paths.ts
+++ b/packages/capture-audio/src/paths.ts
@@ -12,17 +12,17 @@ export interface CapturePaths {
   logPath: string;
 }
 
+export function expandTilde(value: string): string {
+  if (value === "~") return os.homedir();
+  if (value.startsWith("~/")) return path.join(os.homedir(), value.slice(2));
+  return value;
+}
+
 /**
  * Root of the capture working directory. `REMNIC_CAPTURE_DIR` overrides
  * the default `~/.remnic/capture` (tests and multi-instance setups point
  * it at a scratch dir). A leading `~` expands to the home directory.
  */
-/** Expand a leading `~` / `~/` to the home directory; other paths pass through. */
-export function expandTilde(p: string): string {
-  if (p === "~") return os.homedir();
-  if (p.startsWith("~/")) return path.join(os.homedir(), p.slice(2));
-  return p;
-}
 
 export function captureBaseDir(env: NodeJS.ProcessEnv = process.env): string {
   const override = env.REMNIC_CAPTURE_DIR?.trim();

--- a/packages/capture-audio/src/spool.test.ts
+++ b/packages/capture-audio/src/spool.test.ts
@@ -312,3 +312,46 @@ test("insertConversation normalizes offset instants to UTC Z so the keyset order
   );
   spool.close();
 });
+
+test("upsertSpeaker persists centroid + examples and readSpeakerClusters round-trips them", () => {
+  const spool = new Spool(":memory:");
+  try {
+    spool.upsertSpeaker({
+      id: "spk_1",
+      label: "Jane",
+      isSelf: false,
+      embeddingCount: 3,
+      centroid: [0.1, 0.2, 0.3],
+      examples: [
+        [0.1, 0.2, 0.3],
+        [0.11, 0.19, 0.31],
+      ],
+    });
+    spool.upsertSpeaker({ id: "self", isSelf: true, embeddingCount: 1, centroid: [0.5, 0.5], examples: [[0.5, 0.5]] });
+    const clusters = spool.readSpeakerClusters();
+    assert.equal(clusters.length, 2);
+    const jane = clusters.find((c) => c.id === "spk_1");
+    assert.equal(jane?.label, "Jane");
+    assert.equal(jane?.embeddingCount, 3);
+    assert.deepEqual(jane?.centroid, [0.1, 0.2, 0.3]);
+    assert.equal(jane?.examples.length, 2);
+    const self = clusters.find((c) => c.id === "self");
+    assert.equal(self?.isSelf, true);
+    assert.deepEqual(self?.centroid, [0.5, 0.5]);
+  } finally {
+    spool.close();
+  }
+});
+
+test("upsertSpeaker preserves an existing centroid when the field is omitted", () => {
+  const spool = new Spool(":memory:");
+  try {
+    spool.upsertSpeaker({ id: "spk_1", centroid: [1, 2, 3], examples: [[1, 2, 3]] });
+    spool.upsertSpeaker({ id: "spk_1", label: "renamed" }); // no centroid field
+    const c = spool.readSpeakerClusters()[0];
+    assert.equal(c.label, "renamed");
+    assert.deepEqual(c.centroid, [1, 2, 3]);
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -53,6 +53,18 @@ export interface SpeakerInput {
   label?: string | null;
   isSelf?: boolean;
   embeddingCount?: number;
+  /** Speaker embedding centroid; persisted as a JSON BLOB for restart-stable ids. */
+  centroid?: readonly number[] | null;
+  /** Bounded diverse example embeddings; persisted as a JSON BLOB. */
+  examples?: readonly (readonly number[])[] | null;
+}
+export interface SpeakerClusterRow {
+  id: string;
+  label: string | null;
+  isSelf: boolean;
+  embeddingCount: number;
+  centroid: number[];
+  examples: number[][];
 }
 export interface DaemonSegment {
   textRaw: string;
@@ -327,19 +339,70 @@ export class Spool {
 
   upsertSpeaker(input: SpeakerInput): void {
     const current = this.#db
-      .prepare("SELECT label, embedding_count AS embeddingCount, is_self AS isSelf FROM speaker_clusters WHERE id = ?")
-      .get(input.id) as { label: string | null; embeddingCount: number; isSelf: number } | undefined;
+      .prepare(
+        "SELECT label, embedding_count AS embeddingCount, is_self AS isSelf, centroid, example_embeddings AS examples FROM speaker_clusters WHERE id = ?",
+      )
+      .get(input.id) as
+      | { label: string | null; embeddingCount: number; isSelf: number; centroid: Buffer | null; examples: Buffer | null }
+      | undefined;
     const label = Object.hasOwn(input, "label") ? (input.label ?? null) : (current?.label ?? null);
     const embeddingCount = Object.hasOwn(input, "embeddingCount")
       ? (input.embeddingCount ?? 0)
       : (current?.embeddingCount ?? 0);
     const isSelf = Object.hasOwn(input, "isSelf") ? (input.isSelf ? 1 : 0) : (current?.isSelf ?? 0);
+    const centroid = Object.hasOwn(input, "centroid")
+      ? input.centroid
+        ? Buffer.from(JSON.stringify(input.centroid))
+        : null
+      : (current?.centroid ?? null);
+    const examples = Object.hasOwn(input, "examples")
+      ? input.examples
+        ? Buffer.from(JSON.stringify(input.examples))
+        : null
+      : (current?.examples ?? null);
     this.#db
       .prepare(
-        "INSERT INTO speaker_clusters(id, label, embedding_count, is_self) VALUES (?,?,?,?) " +
-          "ON CONFLICT(id) DO UPDATE SET label = excluded.label, is_self = excluded.is_self, embedding_count = excluded.embedding_count",
+        "INSERT INTO speaker_clusters(id, label, embedding_count, is_self, centroid, example_embeddings) VALUES (?,?,?,?,?,?) " +
+          "ON CONFLICT(id) DO UPDATE SET label = excluded.label, is_self = excluded.is_self, embedding_count = excluded.embedding_count, " +
+          "centroid = excluded.centroid, example_embeddings = excluded.example_embeddings",
       )
-      .run(input.id, label, embeddingCount, isSelf);
+      .run(input.id, label, embeddingCount, isSelf, centroid, examples);
+  }
+
+  /** Read every speaker cluster with decoded centroid + examples (diarization restart seed). */
+  readSpeakerClusters(): SpeakerClusterRow[] {
+    const rows = this.#db
+      .prepare(
+        "SELECT id, label, is_self AS isSelf, embedding_count AS embeddingCount, centroid, example_embeddings AS examples FROM speaker_clusters ORDER BY id ASC",
+      )
+      .all() as Array<{
+      id: string;
+      label: string | null;
+      isSelf: number;
+      embeddingCount: number;
+      centroid: Buffer | null;
+      examples: Buffer | null;
+    }>;
+    const decode = (blob: Buffer | Uint8Array | null): unknown => {
+      if (!blob || blob.byteLength === 0) return null;
+      try {
+        return JSON.parse(Buffer.from(blob).toString("utf8"));
+      } catch {
+        return null;
+      }
+    };
+    return rows.map((r) => {
+      const centroid = decode(r.centroid);
+      const examples = decode(r.examples);
+      return {
+        id: r.id,
+        label: r.label,
+        isSelf: r.isSelf === 1,
+        embeddingCount: r.embeddingCount,
+        centroid: Array.isArray(centroid) ? (centroid as number[]) : [],
+        examples: Array.isArray(examples) ? (examples as number[][]) : [],
+      };
+    });
   }
 
   listSpeakers(): SpeakerRow[] {

--- a/packages/capture-audio/src/stt.test.ts
+++ b/packages/capture-audio/src/stt.test.ts
@@ -41,6 +41,14 @@ test("parseWhisperJson rejects malformed output", () => {
       ),
     CaptureConfigError,
   );
+  assert.throws(
+    () =>
+      parseWhisperJson(
+        JSON.stringify({ transcription: [{ text: "Hello", offsets: { from: 8.64e15, to: 8.64e15 } }] }),
+        "2026-07-22T12:00:00.000Z",
+      ),
+    CaptureConfigError,
+  );
   assert.throws(() => parseWhisperJson(JSON.stringify({ transcription: [{}] }), "2026-07-22T12:00:00.000Z"), CaptureConfigError);
 });
 
@@ -67,6 +75,7 @@ test("buildWhisperArgs requests JSON output without shell interpolation", () => 
     "/models/model.bin",
     "-f",
     "/audio/chunk.wav",
+    "--no-prints",
     "--output-json",
     "--output-file",
     "-",

--- a/packages/capture-audio/src/stt.test.ts
+++ b/packages/capture-audio/src/stt.test.ts
@@ -60,6 +60,7 @@ test("resolveModelPath prefers a configured readable model", () => {
     resolveModelPath("~/configured.bin", "/default.bin", (file) => file === path.join(process.env.HOME!, "configured.bin")),
     path.join(process.env.HOME!, "configured.bin"),
   );
+
   assert.throws(() => resolveModelPath("/directory", "/default.bin", () => false), /not found/);
   assert.throws(() => resolveModelPath(process.cwd(), "/default.bin"), /not found/);
 });
@@ -67,6 +68,11 @@ test("resolveModelPath prefers a configured readable model", () => {
 test("resolveModelPath uses the default model only when no explicit model is configured", () => {
   const exists = (file: string) => file === "/default.bin";
   assert.equal(resolveModelPath(undefined, "/default.bin", exists), "/default.bin");
+});
+
+test("resolveModelPath uses the default model for an empty configured path", () => {
+  const exists = (file: string) => file === "/default.bin";
+  assert.equal(resolveModelPath("", "/default.bin", exists), "/default.bin");
 });
 
 test("buildWhisperArgs requests JSON output without shell interpolation", () => {

--- a/packages/capture-audio/src/stt.test.ts
+++ b/packages/capture-audio/src/stt.test.ts
@@ -56,6 +56,7 @@ test("resolveModelPath prefers a configured readable model", () => {
   const exists = (file: string) => file === "/configured.bin";
   assert.equal(resolveModelPath("/configured.bin", "/default.bin", exists), "/configured.bin");
   assert.throws(() => resolveModelPath("/missing.bin", "/default.bin", exists), /not found/);
+  assert.throws(() => resolveModelPath("/missing.bin", "/default.bin", exists), /download-model --model base/);
   assert.equal(
     resolveModelPath("~/configured.bin", "/default.bin", (file) => file === path.join(process.env.HOME!, "configured.bin")),
     path.join(process.env.HOME!, "configured.bin"),

--- a/packages/capture-audio/src/stt.test.ts
+++ b/packages/capture-audio/src/stt.test.ts
@@ -150,3 +150,14 @@ test("runWhisperCli returns stdout and stderr from an argv-only subprocess", asy
 
   assert.deepEqual(result, { code: 0, stdout: "out", stderr: "err" });
 });
+
+test("runWhisperCli translates a missing executable into an actionable config error", async () => {
+  await assert.rejects(
+    runWhisperCli("remnic-nonexistent-whisper-cli", ["-h"]),
+    (error: unknown) => {
+      assert.ok(error instanceof CaptureConfigError);
+      assert.match(error.message, /not found on PATH/);
+      return true;
+    },
+  );
+});

--- a/packages/capture-audio/src/stt.test.ts
+++ b/packages/capture-audio/src/stt.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { CaptureConfigError } from "./errors.js";
+import { parseWhisperJson, resolveModelPath } from "./stt.js";
+
+test("parseWhisperJson converts segment offsets into chunk timestamps", () => {
+  const result = parseWhisperJson(
+    JSON.stringify({ transcription: [{ text: "Hello", offsets: { from: 500, to: 1500 } }] }),
+    "2026-07-22T12:00:00.000Z",
+  );
+
+  assert.deepEqual(result, [{ text: "Hello", startUtc: "2026-07-22T12:00:00.500Z", endUtc: "2026-07-22T12:00:01.500Z" }]);
+});
+
+test("parseWhisperJson rejects malformed output", () => {
+  assert.throws(() => parseWhisperJson("not JSON", "2026-07-22T12:00:00.000Z"), CaptureConfigError);
+  assert.throws(() => parseWhisperJson(JSON.stringify({ transcription: [{}] }), "2026-07-22T12:00:00.000Z"), CaptureConfigError);
+});
+
+test("resolveModelPath prefers a configured readable model", () => {
+  const exists = (file: string) => file === "/configured.bin";
+  assert.equal(resolveModelPath("/configured.bin", "/default.bin", exists), "/configured.bin");
+  assert.throws(() => resolveModelPath("/missing.bin", "/default.bin", exists), /not found/);
+});
+
+test("resolveModelPath uses the default model only when no explicit model is configured", () => {
+  const exists = (file: string) => file === "/default.bin";
+  assert.equal(resolveModelPath(undefined, "/default.bin", exists), "/default.bin");
+});

--- a/packages/capture-audio/src/stt.test.ts
+++ b/packages/capture-audio/src/stt.test.ts
@@ -17,6 +17,13 @@ test("parseWhisperJson converts segment offsets into chunk timestamps", () => {
     "2026-07-22T12:00:00.000Z",
   );
 
+  assert.deepEqual(
+    parseWhisperJson(
+      JSON.stringify({ transcription: [{ text: "Hello", offsets: { from: 0, to: 1 } }] }),
+      "2026-07-22T1:00:00Z",
+    ),
+    [{ text: "Hello", startUtc: "2026-07-22T01:00:00.000Z", endUtc: "2026-07-22T01:00:00.001Z" }],
+  );
   assert.deepEqual(result, [{ text: "Hello", startUtc: "2026-07-22T12:00:00.500Z", endUtc: "2026-07-22T12:00:01.500Z" }]);
 });
 

--- a/packages/capture-audio/src/stt.test.ts
+++ b/packages/capture-audio/src/stt.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { CaptureConfigError } from "./errors.js";
-import { buildWhisperArgs, parseWhisperJson, resolveModelPath } from "./stt.js";
+import { buildWhisperArgs, parseWhisperJson, resolveModelPath, transcribeWithWhisper } from "./stt.js";
 
 test("parseWhisperJson converts segment offsets into chunk timestamps", () => {
   const result = parseWhisperJson(
@@ -37,4 +37,36 @@ test("buildWhisperArgs requests JSON output without shell interpolation", () => 
     "/audio/chunk.wav",
     "--output-json",
   ]);
+});
+
+test("transcribeWithWhisper parses successful subprocess output", async () => {
+  const segments = await transcribeWithWhisper({
+    wavPath: "/audio/chunk.wav",
+    modelPath: "/models/model.bin",
+    chunkStartedAtUtc: "2026-07-22T12:00:00.000Z",
+    run: async (command, args) => {
+      assert.equal(command, "whisper-cli");
+      assert.deepEqual(args, buildWhisperArgs("/audio/chunk.wav", "/models/model.bin"));
+      return {
+        code: 0,
+        stdout: JSON.stringify({ transcription: [{ text: "Ready", offsets: { from: 0, to: 250 } }] }),
+        stderr: "",
+      };
+    },
+  });
+
+  assert.deepEqual(segments, [{ text: "Ready", startUtc: "2026-07-22T12:00:00.000Z", endUtc: "2026-07-22T12:00:00.250Z" }]);
+});
+
+test("transcribeWithWhisper makes a failed subprocess actionable", async () => {
+  await assert.rejects(
+    () =>
+      transcribeWithWhisper({
+        wavPath: "/audio/chunk.wav",
+        modelPath: "/models/model.bin",
+        chunkStartedAtUtc: "2026-07-22T12:00:00.000Z",
+        run: async () => ({ code: 1, stdout: "", stderr: "model unavailable" }),
+      }),
+    /whisper-cli failed: model unavailable/,
+  );
 });

--- a/packages/capture-audio/src/stt.test.ts
+++ b/packages/capture-audio/src/stt.test.ts
@@ -88,6 +88,28 @@ test("buildWhisperArgs requests JSON output without shell interpolation", () => 
   ]);
 });
 
+test("buildWhisperArgs appends -t only when a positive thread count is configured", () => {
+  assert.deepEqual(buildWhisperArgs("/a.wav", "/m.bin", 4).slice(-2), ["-t", "4"]);
+  for (const value of [null, undefined, 0, -1, 1.5, Number.NaN]) {
+    assert.equal(buildWhisperArgs("/a.wav", "/m.bin", value as number | null).includes("-t"), false);
+  }
+});
+
+test("transcribeWithWhisper forwards the configured thread count to whisper-cli", async () => {
+  let seenArgs: string[] = [];
+  await transcribeWithWhisper({
+    wavPath: "/audio/chunk.wav",
+    modelPath: "/models/model.bin",
+    chunkStartedAtUtc: "2026-07-22T12:00:00.000Z",
+    threads: 8,
+    run: async (_command, args) => {
+      seenArgs = args;
+      return { code: 0, stdout: JSON.stringify({ transcription: [] }), stderr: "" };
+    },
+  });
+  assert.deepEqual(seenArgs.slice(-2), ["-t", "8"]);
+});
+
 test("transcribeWithWhisper parses successful subprocess output", async () => {
   const segments = await transcribeWithWhisper({
     wavPath: "/audio/chunk.wav",

--- a/packages/capture-audio/src/stt.test.ts
+++ b/packages/capture-audio/src/stt.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import path from "node:path";
 
 import { CaptureConfigError } from "./errors.js";
 import {
@@ -21,6 +22,18 @@ test("parseWhisperJson converts segment offsets into chunk timestamps", () => {
 
 test("parseWhisperJson rejects malformed output", () => {
   assert.throws(() => parseWhisperJson("not JSON", "2026-07-22T12:00:00.000Z"), CaptureConfigError);
+  assert.throws(
+    () => parseWhisperJson(JSON.stringify({ transcription: [null] }), "2026-07-22T12:00:00.000Z"),
+    CaptureConfigError,
+  );
+  assert.throws(
+    () =>
+      parseWhisperJson(
+        JSON.stringify({ transcription: [{ text: "Hello", offsets: { from: 0, to: 1 } }] }),
+        "2026-02-31T00:00:00.000Z",
+      ),
+    CaptureConfigError,
+  );
   assert.throws(() => parseWhisperJson(JSON.stringify({ transcription: [{}] }), "2026-07-22T12:00:00.000Z"), CaptureConfigError);
 });
 
@@ -28,6 +41,12 @@ test("resolveModelPath prefers a configured readable model", () => {
   const exists = (file: string) => file === "/configured.bin";
   assert.equal(resolveModelPath("/configured.bin", "/default.bin", exists), "/configured.bin");
   assert.throws(() => resolveModelPath("/missing.bin", "/default.bin", exists), /not found/);
+  assert.equal(
+    resolveModelPath("~/configured.bin", "/default.bin", (file) => file === path.join(process.env.HOME!, "configured.bin")),
+    path.join(process.env.HOME!, "configured.bin"),
+  );
+  assert.throws(() => resolveModelPath("/directory", "/default.bin", () => false), /not found/);
+  assert.throws(() => resolveModelPath(process.cwd(), "/default.bin"), /not found/);
 });
 
 test("resolveModelPath uses the default model only when no explicit model is configured", () => {
@@ -42,6 +61,8 @@ test("buildWhisperArgs requests JSON output without shell interpolation", () => 
     "-f",
     "/audio/chunk.wav",
     "--output-json",
+    "--output-file",
+    "-",
   ]);
 });
 
@@ -73,7 +94,7 @@ test("transcribeWithWhisper makes a failed subprocess actionable", async () => {
         chunkStartedAtUtc: "2026-07-22T12:00:00.000Z",
         run: async () => ({ code: 1, stdout: "", stderr: "model unavailable" }),
       }),
-    /whisper-cli failed: model unavailable/,
+    /whisper-cli failed with exit code 1/,
   );
 });
 

--- a/packages/capture-audio/src/stt.test.ts
+++ b/packages/capture-audio/src/stt.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { CaptureConfigError } from "./errors.js";
-import { parseWhisperJson, resolveModelPath } from "./stt.js";
+import { buildWhisperArgs, parseWhisperJson, resolveModelPath } from "./stt.js";
 
 test("parseWhisperJson converts segment offsets into chunk timestamps", () => {
   const result = parseWhisperJson(
@@ -27,4 +27,14 @@ test("resolveModelPath prefers a configured readable model", () => {
 test("resolveModelPath uses the default model only when no explicit model is configured", () => {
   const exists = (file: string) => file === "/default.bin";
   assert.equal(resolveModelPath(undefined, "/default.bin", exists), "/default.bin");
+});
+
+test("buildWhisperArgs requests JSON output without shell interpolation", () => {
+  assert.deepEqual(buildWhisperArgs("/audio/chunk.wav", "/models/model.bin"), [
+    "-m",
+    "/models/model.bin",
+    "-f",
+    "/audio/chunk.wav",
+    "--output-json",
+  ]);
 });

--- a/packages/capture-audio/src/stt.test.ts
+++ b/packages/capture-audio/src/stt.test.ts
@@ -2,7 +2,13 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { CaptureConfigError } from "./errors.js";
-import { buildWhisperArgs, parseWhisperJson, resolveModelPath, transcribeWithWhisper } from "./stt.js";
+import {
+  buildWhisperArgs,
+  parseWhisperJson,
+  resolveModelPath,
+  runWhisperCli,
+  transcribeWithWhisper,
+} from "./stt.js";
 
 test("parseWhisperJson converts segment offsets into chunk timestamps", () => {
   const result = parseWhisperJson(
@@ -69,4 +75,13 @@ test("transcribeWithWhisper makes a failed subprocess actionable", async () => {
       }),
     /whisper-cli failed: model unavailable/,
   );
+});
+
+test("runWhisperCli returns stdout and stderr from an argv-only subprocess", async () => {
+  const result = await runWhisperCli(process.execPath, [
+    "-e",
+    'process.stdout.write("out"); process.stderr.write("err")',
+  ]);
+
+  assert.deepEqual(result, { code: 0, stdout: "out", stderr: "err" });
 });

--- a/packages/capture-audio/src/stt.ts
+++ b/packages/capture-audio/src/stt.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
 
 import { CaptureConfigError } from "./errors.js";
 
@@ -92,4 +93,22 @@ export async function transcribeWithWhisper(input: WhisperTranscriptionInput): P
     throw new CaptureConfigError(`whisper-cli failed: ${detail}`);
   }
   return parseWhisperJson(result.stdout, input.chunkStartedAtUtc);
+}
+
+export function runWhisperCli(command: string, args: string[]): Promise<WhisperRunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { shell: false, stdio: ["ignore", "pipe", "pipe"] });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.once("error", reject);
+    child.once("close", (code) => {
+      resolve({
+        code: code ?? 1,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    });
+  });
 }

--- a/packages/capture-audio/src/stt.ts
+++ b/packages/capture-audio/src/stt.ts
@@ -145,7 +145,18 @@ export function runWhisperCli(command: string, args: string[]): Promise<WhisperR
     const stderr: Buffer[] = [];
     child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
     child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
-    child.once("error", reject);
+    child.once("error", (error) => {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        reject(
+          new CaptureConfigError(
+            `whisper-cli executable '${command}' not found on PATH; install whisper.cpp or configure its path before transcribing`,
+          ),
+        );
+        return;
+      }
+      reject(new CaptureConfigError(`failed to launch whisper-cli '${command}'${code ? ` (${code})` : ""}`));
+    });
     child.once("close", (code) => {
       resolve({
         code: code ?? 1,

--- a/packages/capture-audio/src/stt.ts
+++ b/packages/capture-audio/src/stt.ts
@@ -116,7 +116,7 @@ export function resolveModelPath(
   const modelPath = expandTilde(configuredPath?.trim() || defaultPath);
   if (!exists(modelPath)) {
     throw new CaptureConfigError(
-      `whisper model not found at ${modelPath}; run remnic-capture-audio download-model or set stt.modelPath`,
+      `whisper model not found at ${modelPath}; run 'remnic-capture-audio download-model --model base' or set stt.modelPath`,
     );
   }
   return modelPath;

--- a/packages/capture-audio/src/stt.ts
+++ b/packages/capture-audio/src/stt.ts
@@ -8,6 +8,19 @@ export interface TranscribedSegment {
   endUtc: string;
 }
 
+export interface WhisperRunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface WhisperTranscriptionInput {
+  wavPath: string;
+  modelPath: string;
+  chunkStartedAtUtc: string;
+  run: (command: string, args: string[]) => Promise<WhisperRunResult>;
+}
+
 interface WhisperSegment {
   text?: unknown;
   offsets?: { from?: unknown; to?: unknown };
@@ -70,4 +83,13 @@ export function resolveModelPath(
 
 export function buildWhisperArgs(wavPath: string, modelPath: string): string[] {
   return ["-m", modelPath, "-f", wavPath, "--output-json"];
+}
+
+export async function transcribeWithWhisper(input: WhisperTranscriptionInput): Promise<TranscribedSegment[]> {
+  const result = await input.run("whisper-cli", buildWhisperArgs(input.wavPath, input.modelPath));
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new CaptureConfigError(`whisper-cli failed: ${detail}`);
+  }
+  return parseWhisperJson(result.stdout, input.chunkStartedAtUtc);
 }

--- a/packages/capture-audio/src/stt.ts
+++ b/packages/capture-audio/src/stt.ts
@@ -1,0 +1,69 @@
+import { existsSync } from "node:fs";
+
+import { CaptureConfigError } from "./errors.js";
+
+export interface TranscribedSegment {
+  text: string;
+  startUtc: string;
+  endUtc: string;
+}
+
+interface WhisperSegment {
+  text?: unknown;
+  offsets?: { from?: unknown; to?: unknown };
+}
+
+function timestampAt(chunkStartedAtUtc: string, offsetMs: number): string {
+  const startMs = Date.parse(chunkStartedAtUtc);
+  if (!Number.isFinite(startMs)) {
+    throw new CaptureConfigError("chunk start timestamp is invalid");
+  }
+  return new Date(startMs + offsetMs).toISOString();
+}
+
+export function parseWhisperJson(output: string, chunkStartedAtUtc: string): TranscribedSegment[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    throw new CaptureConfigError("whisper-cli returned malformed JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || !Array.isArray((parsed as { transcription?: unknown }).transcription)) {
+    throw new CaptureConfigError("whisper-cli JSON must contain a transcription array");
+  }
+
+  return (parsed as { transcription: WhisperSegment[] }).transcription.map((segment, index) => {
+    if (
+      typeof segment.text !== "string" ||
+      segment.text.trim() === "" ||
+      !segment.offsets ||
+      typeof segment.offsets.from !== "number" ||
+      typeof segment.offsets.to !== "number" ||
+      !Number.isFinite(segment.offsets.from) ||
+      !Number.isFinite(segment.offsets.to) ||
+      segment.offsets.from < 0 ||
+      segment.offsets.to < segment.offsets.from
+    ) {
+      throw new CaptureConfigError(`whisper-cli transcription[${index}] is invalid`);
+    }
+    return {
+      text: segment.text.trim(),
+      startUtc: timestampAt(chunkStartedAtUtc, segment.offsets.from),
+      endUtc: timestampAt(chunkStartedAtUtc, segment.offsets.to),
+    };
+  });
+}
+
+export function resolveModelPath(
+  configuredPath: string | undefined,
+  defaultPath: string,
+  exists: (path: string) => boolean = existsSync,
+): string {
+  const path = configuredPath ?? defaultPath;
+  if (!exists(path)) {
+    throw new CaptureConfigError(
+      `whisper model not found at ${path}; run remnic-capture-audio download-model or set stt.modelPath`,
+    );
+  }
+  return path;
+}

--- a/packages/capture-audio/src/stt.ts
+++ b/packages/capture-audio/src/stt.ts
@@ -112,7 +112,7 @@ export function resolveModelPath(
   defaultPath: string,
   exists: (path: string) => boolean = isRegularFile,
 ): string {
-  const modelPath = expandTilde(configuredPath ?? defaultPath);
+  const modelPath = expandTilde(configuredPath?.trim() || defaultPath);
   if (!exists(modelPath)) {
     throw new CaptureConfigError(
       `whisper model not found at ${modelPath}; run remnic-capture-audio download-model or set stt.modelPath`,

--- a/packages/capture-audio/src/stt.ts
+++ b/packages/capture-audio/src/stt.ts
@@ -1,6 +1,7 @@
-import { existsSync } from "node:fs";
+import { statSync } from "node:fs";
 import { spawn } from "node:child_process";
 
+import { expandTilde } from "./paths.js";
 import { CaptureConfigError } from "./errors.js";
 
 export interface TranscribedSegment {
@@ -27,9 +28,17 @@ interface WhisperSegment {
   offsets?: { from?: unknown; to?: unknown };
 }
 
+function isRegularFile(filePath: string): boolean {
+  try {
+    return statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
 function timestampAt(chunkStartedAtUtc: string, offsetMs: number): string {
   const startMs = Date.parse(chunkStartedAtUtc);
-  if (!Number.isFinite(startMs)) {
+  if (!Number.isFinite(startMs) || new Date(startMs).toISOString() !== chunkStartedAtUtc) {
     throw new CaptureConfigError("chunk start timestamp is invalid");
   }
   return new Date(startMs + offsetMs).toISOString();
@@ -46,7 +55,11 @@ export function parseWhisperJson(output: string, chunkStartedAtUtc: string): Tra
     throw new CaptureConfigError("whisper-cli JSON must contain a transcription array");
   }
 
-  return (parsed as { transcription: WhisperSegment[] }).transcription.map((segment, index) => {
+  return (parsed as { transcription: unknown[] }).transcription.map((value, index) => {
+    if (!value || typeof value !== "object") {
+      throw new CaptureConfigError(`whisper-cli transcription[${index}] is invalid`);
+    }
+    const segment = value as WhisperSegment;
     if (
       typeof segment.text !== "string" ||
       segment.text.trim() === "" ||
@@ -71,26 +84,25 @@ export function parseWhisperJson(output: string, chunkStartedAtUtc: string): Tra
 export function resolveModelPath(
   configuredPath: string | undefined,
   defaultPath: string,
-  exists: (path: string) => boolean = existsSync,
+  exists: (path: string) => boolean = isRegularFile,
 ): string {
-  const path = configuredPath ?? defaultPath;
-  if (!exists(path)) {
+  const modelPath = expandTilde(configuredPath ?? defaultPath);
+  if (!exists(modelPath)) {
     throw new CaptureConfigError(
-      `whisper model not found at ${path}; run remnic-capture-audio download-model or set stt.modelPath`,
+      `whisper model not found at ${modelPath}; run remnic-capture-audio download-model or set stt.modelPath`,
     );
   }
-  return path;
+  return modelPath;
 }
 
 export function buildWhisperArgs(wavPath: string, modelPath: string): string[] {
-  return ["-m", modelPath, "-f", wavPath, "--output-json"];
+  return ["-m", modelPath, "-f", wavPath, "--output-json", "--output-file", "-"];
 }
 
 export async function transcribeWithWhisper(input: WhisperTranscriptionInput): Promise<TranscribedSegment[]> {
   const result = await input.run("whisper-cli", buildWhisperArgs(input.wavPath, input.modelPath));
   if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new CaptureConfigError(`whisper-cli failed: ${detail}`);
+    throw new CaptureConfigError(`whisper-cli failed with exit code ${result.code}`);
   }
   return parseWhisperJson(result.stdout, input.chunkStartedAtUtc);
 }

--- a/packages/capture-audio/src/stt.ts
+++ b/packages/capture-audio/src/stt.ts
@@ -63,7 +63,11 @@ function timestampAt(chunkStartedAtUtc: string, offsetMs: number): string {
   ) {
     throw new CaptureConfigError("chunk start timestamp is invalid");
   }
-  return new Date(startMs + offsetMs).toISOString();
+  const timestampMs = startMs + offsetMs;
+  if (!Number.isFinite(timestampMs) || Math.abs(timestampMs) > 8.64e15) {
+    throw new CaptureConfigError("whisper-cli segment offset produces an invalid timestamp");
+  }
+  return new Date(timestampMs).toISOString();
 }
 
 export function parseWhisperJson(output: string, chunkStartedAtUtc: string): TranscribedSegment[] {
@@ -118,7 +122,7 @@ export function resolveModelPath(
 }
 
 export function buildWhisperArgs(wavPath: string, modelPath: string): string[] {
-  return ["-m", modelPath, "-f", wavPath, "--output-json", "--output-file", "-"];
+  return ["-m", modelPath, "-f", wavPath, "--no-prints", "--output-json", "--output-file", "-"];
 }
 
 export async function transcribeWithWhisper(input: WhisperTranscriptionInput): Promise<TranscribedSegment[]> {

--- a/packages/capture-audio/src/stt.ts
+++ b/packages/capture-audio/src/stt.ts
@@ -67,3 +67,7 @@ export function resolveModelPath(
   }
   return path;
 }
+
+export function buildWhisperArgs(wavPath: string, modelPath: string): string[] {
+  return ["-m", modelPath, "-f", wavPath, "--output-json"];
+}

--- a/packages/capture-audio/src/stt.ts
+++ b/packages/capture-audio/src/stt.ts
@@ -37,8 +37,30 @@ function isRegularFile(filePath: string): boolean {
 }
 
 function timestampAt(chunkStartedAtUtc: string, offsetMs: number): string {
-  const startMs = Date.parse(chunkStartedAtUtc);
-  if (!Number.isFinite(startMs) || new Date(startMs).toISOString() !== chunkStartedAtUtc) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{1,2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z$/.exec(chunkStartedAtUtc);
+  if (!match) {
+    throw new CaptureConfigError("chunk start timestamp is invalid");
+  }
+  const [, year, month, day, hour, minute, second, millisecond = "0"] = match;
+  const startMs = Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second),
+    Number(millisecond.padEnd(3, "0")),
+  );
+  const start = new Date(startMs);
+  if (
+    start.getUTCFullYear() !== Number(year) ||
+    start.getUTCMonth() !== Number(month) - 1 ||
+    start.getUTCDate() !== Number(day) ||
+    start.getUTCHours() !== Number(hour) ||
+    start.getUTCMinutes() !== Number(minute) ||
+    start.getUTCSeconds() !== Number(second) ||
+    start.getUTCMilliseconds() !== Number(millisecond.padEnd(3, "0"))
+  ) {
     throw new CaptureConfigError("chunk start timestamp is invalid");
   }
   return new Date(startMs + offsetMs).toISOString();

--- a/packages/capture-audio/src/stt.ts
+++ b/packages/capture-audio/src/stt.ts
@@ -20,6 +20,7 @@ export interface WhisperTranscriptionInput {
   wavPath: string;
   modelPath: string;
   chunkStartedAtUtc: string;
+  threads?: number | null;
   run: (command: string, args: string[]) => Promise<WhisperRunResult>;
 }
 
@@ -121,12 +122,16 @@ export function resolveModelPath(
   return modelPath;
 }
 
-export function buildWhisperArgs(wavPath: string, modelPath: string): string[] {
-  return ["-m", modelPath, "-f", wavPath, "--no-prints", "--output-json", "--output-file", "-"];
+export function buildWhisperArgs(wavPath: string, modelPath: string, threads?: number | null): string[] {
+  const args = ["-m", modelPath, "-f", wavPath, "--no-prints", "--output-json", "--output-file", "-"];
+  if (typeof threads === "number" && Number.isInteger(threads) && threads > 0) {
+    args.push("-t", String(threads));
+  }
+  return args;
 }
 
 export async function transcribeWithWhisper(input: WhisperTranscriptionInput): Promise<TranscribedSegment[]> {
-  const result = await input.run("whisper-cli", buildWhisperArgs(input.wavPath, input.modelPath));
+  const result = await input.run("whisper-cli", buildWhisperArgs(input.wavPath, input.modelPath, input.threads));
   if (result.code !== 0) {
     throw new CaptureConfigError(`whisper-cli failed with exit code ${result.code}`);
   }

--- a/packages/capture-audio/src/vad.test.ts
+++ b/packages/capture-audio/src/vad.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import test from "node:test";
 
-import { createSileroVad } from "./vad.js";
+import { createSileroVad, resolveSherpaExport } from "./vad.js";
 
 test("createSileroVad configures the optional Sherpa runtime with audio-safe defaults", async () => {
   let received: unknown;
@@ -53,4 +53,21 @@ test("createSileroVad expands a tilde model path", async () => {
 
 test("createSileroVad requires a positive speech threshold", async () => {
   await assert.rejects(createSileroVad({ modelPath: "/models/vad.onnx", minSpeechMs: 0 }), /positive/);
+});
+
+test("resolveSherpaExport unwraps a CommonJS default export", () => {
+  class FakeVad {}
+  const cjs = { default: { Vad: FakeVad } };
+  assert.equal(resolveSherpaExport(cjs), cjs.default);
+});
+
+test("resolveSherpaExport accepts an ES namespace that exposes Vad directly", () => {
+  class FakeVad {}
+  const esm = { Vad: FakeVad };
+  assert.equal(resolveSherpaExport(esm), esm);
+});
+
+test("resolveSherpaExport returns null when no Vad constructor is present", () => {
+  assert.equal(resolveSherpaExport({ default: { notVad: 1 } }), null);
+  assert.equal(resolveSherpaExport(null), null);
 });

--- a/packages/capture-audio/src/vad.test.ts
+++ b/packages/capture-audio/src/vad.test.ts
@@ -55,6 +55,13 @@ test("createSileroVad requires a positive speech threshold", async () => {
   await assert.rejects(createSileroVad({ modelPath: "/models/vad.onnx", minSpeechMs: 0 }), /positive/);
 });
 
+test("createSileroVad rejects a max speech window shorter than the min", async () => {
+  await assert.rejects(
+    createSileroVad({ modelPath: "/models/vad.onnx", minSpeechMs: 40_000, maxSpeechMs: 30_000 }),
+    /maxSpeechMs must be greater than or equal to minSpeechMs/,
+  );
+});
+
 test("resolveSherpaExport unwraps a CommonJS default export", () => {
   class FakeVad {}
   const cjs = { default: { Vad: FakeVad } };
@@ -85,7 +92,7 @@ test("loadSherpaOnnx reports the install hint only when the package itself is mi
 });
 
 test("loadSherpaOnnx surfaces a broken installed native addon without leaking paths or an install hint", async () => {
-  const dlopenFailure = Object.assign(new Error("dlopen failed: /home/user/node_modules/sherpa-onnx-node/build/Release/x.node"), {
+  const dlopenFailure = Object.assign(new Error("dlopen failed: /app/node_modules/sherpa-onnx-node/build/Release/x.node"), {
     code: "ERR_DLOPEN_FAILED",
   });
   await assert.rejects(loadSherpaOnnx(async () => {

--- a/packages/capture-audio/src/vad.test.ts
+++ b/packages/capture-audio/src/vad.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import test from "node:test";
 
-import { createSileroVad, resolveSherpaExport } from "./vad.js";
+import { createSileroVad, loadSherpaOnnx, resolveSherpaExport } from "./vad.js";
 
 test("createSileroVad configures the optional Sherpa runtime with audio-safe defaults", async () => {
   let received: unknown;
@@ -70,4 +70,37 @@ test("resolveSherpaExport accepts an ES namespace that exposes Vad directly", ()
 test("resolveSherpaExport returns null when no Vad constructor is present", () => {
   assert.equal(resolveSherpaExport({ default: { notVad: 1 } }), null);
   assert.equal(resolveSherpaExport(null), null);
+});
+
+test("loadSherpaOnnx reports the install hint only when the package itself is missing", async () => {
+  const notFound = Object.assign(new Error("Cannot find package 'sherpa-onnx-node' imported from vad.js"), {
+    code: "ERR_MODULE_NOT_FOUND",
+  });
+  await assert.rejects(
+    loadSherpaOnnx(async () => {
+      throw notFound;
+    }),
+    /install it before enabling VAD/,
+  );
+});
+
+test("loadSherpaOnnx surfaces a broken installed native addon instead of an install hint", async () => {
+  const dlopenFailure = Object.assign(new Error("dlopen failed: libonnxruntime.so: cannot open shared object file"), {
+    code: "ERR_DLOPEN_FAILED",
+  });
+  await assert.rejects(loadSherpaOnnx(async () => {
+    throw dlopenFailure;
+  }), (error: unknown) => {
+    assert.ok(error instanceof Error);
+    assert.match(error.message, /failed to load sherpa-onnx-node/);
+    assert.match(error.message, /dlopen failed/);
+    assert.doesNotMatch(error.message, /install it before enabling VAD/);
+    return true;
+  });
+});
+
+test("loadSherpaOnnx unwraps a CommonJS module returned by the importer", async () => {
+  class FakeVad {}
+  const resolved = await loadSherpaOnnx(async () => ({ default: { Vad: FakeVad } }));
+  assert.equal(resolved.Vad, FakeVad);
 });

--- a/packages/capture-audio/src/vad.test.ts
+++ b/packages/capture-audio/src/vad.test.ts
@@ -17,6 +17,7 @@ test("createSileroVad configures the optional Sherpa runtime with audio-safe def
   const vad = await createSileroVad(
     { modelPath: "/models/silero_vad.onnx", minSpeechMs: 500 },
     async () => ({ Vad: FakeVad }),
+    () => true,
   );
 
   assert.ok(vad instanceof FakeVad);
@@ -46,9 +47,20 @@ test("createSileroVad expands a tilde model path", async () => {
     }
   }
 
-  await createSileroVad({ modelPath: "~/models/silero_vad.onnx", minSpeechMs: 500 }, async () => ({ Vad: FakeVad }));
+  await createSileroVad({ modelPath: "~/models/silero_vad.onnx", minSpeechMs: 500 }, async () => ({ Vad: FakeVad }), () => true);
 
   assert.equal(received?.config.sileroVad.model, path.join(os.homedir(), "models/silero_vad.onnx"));
+});
+
+test("createSileroVad rejects a model path that is not a readable file", async () => {
+  await assert.rejects(
+    createSileroVad(
+      { modelPath: "/models/missing_vad.onnx", minSpeechMs: 500 },
+      async () => ({ Vad: class {} }),
+      () => false,
+    ),
+    /Silero VAD model not found/,
+  );
 });
 
 test("createSileroVad requires a positive speech threshold", async () => {

--- a/packages/capture-audio/src/vad.test.ts
+++ b/packages/capture-audio/src/vad.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+
 import test from "node:test";
 
 import { createSileroVad } from "./vad.js";
@@ -33,6 +36,19 @@ test("createSileroVad configures the optional Sherpa runtime with audio-safe def
     },
     bufferSeconds: 60,
   });
+});
+
+test("createSileroVad expands a tilde model path", async () => {
+  let received: { config: { sileroVad: { model: string } } } | undefined;
+  class FakeVad {
+    constructor(config: unknown, _bufferSeconds: number) {
+      received = { config: config as { sileroVad: { model: string } } };
+    }
+  }
+
+  await createSileroVad({ modelPath: "~/models/silero_vad.onnx", minSpeechMs: 500 }, async () => ({ Vad: FakeVad }));
+
+  assert.equal(received?.config.sileroVad.model, path.join(os.homedir(), "models/silero_vad.onnx"));
 });
 
 test("createSileroVad requires a positive speech threshold", async () => {

--- a/packages/capture-audio/src/vad.test.ts
+++ b/packages/capture-audio/src/vad.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createSileroVad } from "./vad.js";
+
+test("createSileroVad configures the optional Sherpa runtime with audio-safe defaults", async () => {
+  let received: unknown;
+  class FakeVad {
+    constructor(config: unknown, bufferSeconds: number) {
+      received = { config, bufferSeconds };
+    }
+  }
+
+  const vad = await createSileroVad(
+    { modelPath: "/models/silero_vad.onnx", minSpeechMs: 500 },
+    async () => ({ Vad: FakeVad }),
+  );
+
+  assert.ok(vad instanceof FakeVad);
+  assert.deepEqual(received, {
+    config: {
+      sileroVad: {
+        model: "/models/silero_vad.onnx",
+        threshold: 0.5,
+        minSpeechDuration: 0.5,
+        minSilenceDuration: 0.5,
+        maxSpeechDuration: 30,
+        windowSize: 512,
+      },
+      sampleRate: 16_000,
+      debug: false,
+      numThreads: 1,
+    },
+    bufferSeconds: 60,
+  });
+});
+
+test("createSileroVad requires a positive speech threshold", async () => {
+  await assert.rejects(createSileroVad({ modelPath: "/models/vad.onnx", minSpeechMs: 0 }), /positive/);
+});

--- a/packages/capture-audio/src/vad.test.ts
+++ b/packages/capture-audio/src/vad.test.ts
@@ -84,16 +84,31 @@ test("loadSherpaOnnx reports the install hint only when the package itself is mi
   );
 });
 
-test("loadSherpaOnnx surfaces a broken installed native addon instead of an install hint", async () => {
-  const dlopenFailure = Object.assign(new Error("dlopen failed: libonnxruntime.so: cannot open shared object file"), {
+test("loadSherpaOnnx surfaces a broken installed native addon without leaking paths or an install hint", async () => {
+  const dlopenFailure = Object.assign(new Error("dlopen failed: /home/user/node_modules/sherpa-onnx-node/build/Release/x.node"), {
     code: "ERR_DLOPEN_FAILED",
   });
   await assert.rejects(loadSherpaOnnx(async () => {
     throw dlopenFailure;
   }), (error: unknown) => {
     assert.ok(error instanceof Error);
-    assert.match(error.message, /failed to load sherpa-onnx-node/);
-    assert.match(error.message, /dlopen failed/);
+    assert.match(error.message, /could not load the installed sherpa-onnx-node native runtime/);
+    assert.doesNotMatch(error.message, /install it before enabling VAD/);
+    assert.doesNotMatch(error.message, /dlopen|\.node|node_modules/);
+    return true;
+  });
+});
+
+test("loadSherpaOnnx treats an installed package with a missing native module (require stack) as broken, not absent", async () => {
+  const nativeMissing = Object.assign(
+    new Error("Cannot find module '/app/node_modules/sherpa-onnx-node/build/Release/sherpa-onnx-node.node'"),
+    { code: "MODULE_NOT_FOUND", requireStack: ["/app/node_modules/sherpa-onnx-node/index.js"] },
+  );
+  await assert.rejects(loadSherpaOnnx(async () => {
+    throw nativeMissing;
+  }), (error: unknown) => {
+    assert.ok(error instanceof Error);
+    assert.match(error.message, /could not load the installed sherpa-onnx-node native runtime/);
     assert.doesNotMatch(error.message, /install it before enabling VAD/);
     return true;
   });

--- a/packages/capture-audio/src/vad.ts
+++ b/packages/capture-audio/src/vad.ts
@@ -73,18 +73,27 @@ export async function loadSherpaOnnx(
   try {
     module = await importModule(specifier);
   } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    const missing =
-      (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") &&
-      error instanceof Error &&
-      error.message.includes(specifier);
-    if (missing) {
+    // A genuinely absent package surfaces as ERR_MODULE_NOT_FOUND naming the
+    // specifier as a package, with no require stack. An installed-but-broken
+    // package (missing native .node, dlopen failure) has a different code
+    // and/or a require stack, so it must NOT be reported as "not installed".
+    const err = error as NodeJS.ErrnoException & { requireStack?: unknown };
+    const message = error instanceof Error ? error.message : "";
+    const packageMissing =
+      err.code === "ERR_MODULE_NOT_FOUND" &&
+      err.requireStack === undefined &&
+      message.includes(`package '${specifier}'`);
+    if (packageMissing) {
       throw new CaptureConfigError(
         "Silero VAD requires optional dependency sherpa-onnx-node; install it before enabling VAD",
       );
     }
-    const detail = error instanceof Error ? error.message : String(error);
-    throw new CaptureConfigError(`Silero VAD failed to load sherpa-onnx-node: ${detail}`);
+    // Installed but unusable. Report that distinctly, but keep the message
+    // operator-safe: never echo the raw error (it can leak absolute native
+    // library paths), per the CaptureConfigError contract.
+    throw new CaptureConfigError(
+      "Silero VAD could not load the installed sherpa-onnx-node native runtime; verify its native build and shared-library dependencies",
+    );
   }
   const resolved = resolveSherpaExport(module);
   if (!resolved) {

--- a/packages/capture-audio/src/vad.ts
+++ b/packages/capture-audio/src/vad.ts
@@ -1,4 +1,6 @@
 import { CaptureConfigError } from "./errors.js";
+import { expandTilde } from "./paths.js";
+
 
 export interface SileroVadInput {
   modelPath: string;
@@ -36,7 +38,7 @@ export function sileroVadConfig(input: SileroVadInput): { config: object; buffer
   return {
     config: {
       sileroVad: {
-        model: input.modelPath,
+        model: expandTilde(input.modelPath),
         threshold,
         minSpeechDuration: input.minSpeechMs / 1_000,
         minSilenceDuration: minSilenceMs / 1_000,

--- a/packages/capture-audio/src/vad.ts
+++ b/packages/capture-audio/src/vad.ts
@@ -63,15 +63,28 @@ export function resolveSherpaExport(module: unknown): SherpaOnnxModule | null {
   return null;
 }
 
-export async function loadSherpaOnnx(): Promise<SherpaOnnxModule> {
+export async function loadSherpaOnnx(
+  importModule: (specifier: string) => Promise<unknown> = (specifier) => import(specifier),
+): Promise<SherpaOnnxModule> {
   // Computed specifier keeps the optional sherpa-onnx-node peer out of the static
   // dependency graph so the package builds and runs without it installed.
   const specifier = "sherpa-onnx-" + "node";
   let module: unknown;
   try {
-    module = await import(specifier);
-  } catch {
-    throw new CaptureConfigError("Silero VAD requires optional dependency sherpa-onnx-node; install it before enabling VAD");
+    module = await importModule(specifier);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    const missing =
+      (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") &&
+      error instanceof Error &&
+      error.message.includes(specifier);
+    if (missing) {
+      throw new CaptureConfigError(
+        "Silero VAD requires optional dependency sherpa-onnx-node; install it before enabling VAD",
+      );
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new CaptureConfigError(`Silero VAD failed to load sherpa-onnx-node: ${detail}`);
   }
   const resolved = resolveSherpaExport(module);
   if (!resolved) {

--- a/packages/capture-audio/src/vad.ts
+++ b/packages/capture-audio/src/vad.ts
@@ -53,7 +53,19 @@ export function sileroVadConfig(input: SileroVadInput): { config: object; buffer
   };
 }
 
+export function resolveSherpaExport(module: unknown): SherpaOnnxModule | null {
+  const candidates = [module, (module as { default?: unknown } | null)?.default];
+  for (const candidate of candidates) {
+    if (candidate && typeof candidate === "object" && typeof (candidate as SherpaOnnxModule).Vad === "function") {
+      return candidate as SherpaOnnxModule;
+    }
+  }
+  return null;
+}
+
 export async function loadSherpaOnnx(): Promise<SherpaOnnxModule> {
+  // Computed specifier keeps the optional sherpa-onnx-node peer out of the static
+  // dependency graph so the package builds and runs without it installed.
   const specifier = "sherpa-onnx-" + "node";
   let module: unknown;
   try {
@@ -61,10 +73,11 @@ export async function loadSherpaOnnx(): Promise<SherpaOnnxModule> {
   } catch {
     throw new CaptureConfigError("Silero VAD requires optional dependency sherpa-onnx-node; install it before enabling VAD");
   }
-  if (!module || typeof module !== "object" || typeof (module as SherpaOnnxModule).Vad !== "function") {
+  const resolved = resolveSherpaExport(module);
+  if (!resolved) {
     throw new CaptureConfigError("sherpa-onnx-node does not expose the Vad API required by capture-audio");
   }
-  return module as SherpaOnnxModule;
+  return resolved;
 }
 
 export async function createSileroVad(

--- a/packages/capture-audio/src/vad.ts
+++ b/packages/capture-audio/src/vad.ts
@@ -1,0 +1,75 @@
+import { CaptureConfigError } from "./errors.js";
+
+export interface SileroVadInput {
+  modelPath: string;
+  minSpeechMs: number;
+  minSilenceMs?: number;
+  maxSpeechMs?: number;
+  threshold?: number;
+  threads?: number;
+}
+
+export interface SherpaOnnxModule {
+  Vad: new (config: unknown, bufferSeconds: number) => unknown;
+}
+
+export function sileroVadConfig(input: SileroVadInput): { config: object; bufferSeconds: number } {
+  if (typeof input.modelPath !== "string" || input.modelPath.trim() === "") {
+    throw new CaptureConfigError("Silero VAD modelPath must be a non-empty string");
+  }
+  if (!Number.isFinite(input.minSpeechMs) || input.minSpeechMs <= 0) {
+    throw new CaptureConfigError("Silero VAD minSpeechMs must be positive");
+  }
+  const minSilenceMs = input.minSilenceMs ?? 500;
+  const maxSpeechMs = input.maxSpeechMs ?? 30_000;
+  const threshold = input.threshold ?? 0.5;
+  const threads = input.threads ?? 1;
+  if (!Number.isFinite(minSilenceMs) || minSilenceMs < 0 || !Number.isFinite(maxSpeechMs) || maxSpeechMs <= 0) {
+    throw new CaptureConfigError("Silero VAD duration settings are invalid");
+  }
+  if (!Number.isFinite(threshold) || threshold <= 0 || threshold >= 1) {
+    throw new CaptureConfigError("Silero VAD threshold must be between 0 and 1");
+  }
+  if (!Number.isInteger(threads) || threads <= 0) {
+    throw new CaptureConfigError("Silero VAD threads must be a positive integer");
+  }
+  return {
+    config: {
+      sileroVad: {
+        model: input.modelPath,
+        threshold,
+        minSpeechDuration: input.minSpeechMs / 1_000,
+        minSilenceDuration: minSilenceMs / 1_000,
+        maxSpeechDuration: maxSpeechMs / 1_000,
+        windowSize: 512,
+      },
+      sampleRate: 16_000,
+      debug: false,
+      numThreads: threads,
+    },
+    bufferSeconds: 60,
+  };
+}
+
+export async function loadSherpaOnnx(): Promise<SherpaOnnxModule> {
+  const specifier = "sherpa-onnx-" + "node";
+  let module: unknown;
+  try {
+    module = await import(specifier);
+  } catch {
+    throw new CaptureConfigError("Silero VAD requires optional dependency sherpa-onnx-node; install it before enabling VAD");
+  }
+  if (!module || typeof module !== "object" || typeof (module as SherpaOnnxModule).Vad !== "function") {
+    throw new CaptureConfigError("sherpa-onnx-node does not expose the Vad API required by capture-audio");
+  }
+  return module as SherpaOnnxModule;
+}
+
+export async function createSileroVad(
+  input: SileroVadInput,
+  load: () => Promise<SherpaOnnxModule> = loadSherpaOnnx,
+): Promise<unknown> {
+  const { config, bufferSeconds } = sileroVadConfig(input);
+  const { Vad } = await load();
+  return new Vad(config, bufferSeconds);
+}

--- a/packages/capture-audio/src/vad.ts
+++ b/packages/capture-audio/src/vad.ts
@@ -29,6 +29,9 @@ export function sileroVadConfig(input: SileroVadInput): { config: object; buffer
   if (!Number.isFinite(minSilenceMs) || minSilenceMs < 0 || !Number.isFinite(maxSpeechMs) || maxSpeechMs <= 0) {
     throw new CaptureConfigError("Silero VAD duration settings are invalid");
   }
+  if (maxSpeechMs < input.minSpeechMs) {
+    throw new CaptureConfigError("Silero VAD maxSpeechMs must be greater than or equal to minSpeechMs");
+  }
   if (!Number.isFinite(threshold) || threshold <= 0 || threshold >= 1) {
     throw new CaptureConfigError("Silero VAD threshold must be between 0 and 1");
   }

--- a/packages/capture-audio/src/vad.ts
+++ b/packages/capture-audio/src/vad.ts
@@ -1,3 +1,5 @@
+import { statSync } from "node:fs";
+
 import { CaptureConfigError } from "./errors.js";
 import { expandTilde } from "./paths.js";
 
@@ -105,11 +107,24 @@ export async function loadSherpaOnnx(
   return resolved;
 }
 
+function isRegularFile(filePath: string): boolean {
+  try {
+    return statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
 export async function createSileroVad(
   input: SileroVadInput,
   load: () => Promise<SherpaOnnxModule> = loadSherpaOnnx,
+  exists: (path: string) => boolean = isRegularFile,
 ): Promise<unknown> {
   const { config, bufferSeconds } = sileroVadConfig(input);
+  const modelPath = expandTilde(input.modelPath);
+  if (!exists(modelPath)) {
+    throw new CaptureConfigError(`Silero VAD model not found at ${modelPath}; set vad.modelPath to a readable model file`);
+  }
   const { Vad } = await load();
   return new Vad(config, bufferSeconds);
 }

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -50,7 +50,8 @@
     "@remnic/import-supermemory": "^9.22.0",
     "@remnic/connector-limitless": "^9.22.0",
     "@remnic/connector-bee": "^9.22.0",
-    "@remnic/connector-omi": "^9.22.0"
+    "@remnic/connector-omi": "^9.22.0",
+    "@remnic/capture-audio": "^9.22.0"
   },
   "peerDependenciesMeta": {
     "@remnic/bench": {
@@ -87,6 +88,9 @@
       "optional": true
     },
     "@remnic/connector-omi": {
+      "optional": true
+    },
+    "@remnic/capture-audio": {
       "optional": true
     }
   },

--- a/packages/remnic-cli/src/capture-dispatch.test.ts
+++ b/packages/remnic-cli/src/capture-dispatch.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { cmdCapture, INSTALL_HINT, translateCaptureLoadError, type CaptureAudioModule } from "./capture-dispatch.js";
+
+function io(): { stdout: (l: string) => void; stderr: (l: string) => void; out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { out, err, stdout: (l) => out.push(l), stderr: (l) => err.push(l) };
+}
+
+test("cmdCapture forwards `audio <sub...>` argv to the loaded package runCapture", async () => {
+  let seenArgv: string[] | undefined;
+  const mod: CaptureAudioModule = {
+    async runCapture({ argv }) {
+      seenArgv = argv;
+      return 0;
+    },
+  };
+  const sink = io();
+  const code = await cmdCapture(["audio", "status", "--base-dir", "/tmp/x"], {
+    stdout: sink.stdout,
+    stderr: sink.stderr,
+    loadCaptureAudio: async () => mod,
+  });
+  assert.equal(code, 0);
+  assert.deepEqual(seenArgv, ["status", "--base-dir", "/tmp/x"]);
+});
+
+test("cmdCapture surfaces a loader install-hint failure to stderr with a non-zero code", async () => {
+  const sink = io();
+  const code = await cmdCapture(["audio", "status"], {
+    stdout: sink.stdout,
+    stderr: sink.stderr,
+    loadCaptureAudio: async () => {
+      throw new Error(INSTALL_HINT);
+    },
+  });
+  assert.equal(code, 2);
+  assert.ok(sink.err.some((l) => l.includes("npm install @remnic/capture-audio")), sink.err.join("|"));
+});
+
+test("cmdCapture rejects an unknown subgroup and prints usage; bare `capture` shows usage", async () => {
+  const a = io();
+  assert.equal(await cmdCapture(["screen"], { stdout: a.stdout, stderr: a.stderr }), 2);
+  assert.ok(a.err.join(" ").includes("unknown capture subgroup"));
+
+  const b = io();
+  assert.equal(await cmdCapture([], { stdout: b.stdout, stderr: b.stderr }), 2);
+  assert.ok(b.out.join(" ").includes("remnic capture audio"));
+});
+
+test("translateCaptureLoadError maps a missing-package error to the install hint, rethrows others", () => {
+  const notFound = Object.assign(new Error("Cannot find package '@remnic/capture-audio' imported from cli"), {
+    code: "ERR_MODULE_NOT_FOUND",
+  });
+  assert.equal(translateCaptureLoadError(notFound).message, INSTALL_HINT);
+
+  // A broken transitive dep (different specifier) is NOT the install-hint case.
+  const innerMiss = Object.assign(new Error("Cannot find package 'some-inner-dep' imported from capture-audio"), {
+    code: "ERR_MODULE_NOT_FOUND",
+  });
+  assert.notEqual(translateCaptureLoadError(innerMiss).message, INSTALL_HINT);
+  assert.equal(translateCaptureLoadError(innerMiss), innerMiss);
+
+  const other = new Error("boom");
+  assert.equal(translateCaptureLoadError(other), other);
+});

--- a/packages/remnic-cli/src/capture-dispatch.ts
+++ b/packages/remnic-cli/src/capture-dispatch.ts
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------------
+// `remnic capture audio <subcommand>` passthrough (issue #1897)
+// ---------------------------------------------------------------------------
+//
+// `@remnic/capture-audio` is an à-la-carte optional package: installing the
+// CLI alone never pulls it in. This dispatcher forwards
+// `remnic capture audio <sub> [args...]` to the package's `runCapture`,
+// loaded lazily via a computed-specifier dynamic import so the bundler
+// leaves it as a runtime call. When the package is absent we surface a
+// clean install hint (AGENTS.md §44 / #1897 AC), never a bare
+// MODULE_NOT_FOUND.
+
+import { isSpecifierNotFoundError } from "./optional-module-loader.js";
+
+const SPECIFIER = "@remnic/" + "capture-audio";
+
+export const INSTALL_HINT =
+  "`remnic capture audio` requires the optional @remnic/capture-audio package. " +
+  "Install it with: npm install @remnic/capture-audio";
+
+const USAGE =
+  "usage: remnic capture audio <init|start|stop|status|devices|logs|download-model|janitor|enroll-self> [options]";
+
+/** Shape of the optional package this dispatcher forwards to. */
+export interface CaptureAudioModule {
+  runCapture(io: {
+    argv: string[];
+    env?: NodeJS.ProcessEnv;
+    stdout?: (line: string) => void;
+    stderr?: (line: string) => void;
+  }): Promise<number>;
+}
+
+export interface CaptureDispatchIO {
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+  /** Injectable loader (tests supply present/absent modules). */
+  loadCaptureAudio?: () => Promise<CaptureAudioModule>;
+}
+
+/** Map a dynamic-import failure to the install hint (missing package) or rethrow. */
+export function translateCaptureLoadError(err: unknown): Error {
+  if (isSpecifierNotFoundError(err, SPECIFIER)) return new Error(INSTALL_HINT);
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+async function defaultLoadCaptureAudio(): Promise<CaptureAudioModule> {
+  try {
+    return (await import(SPECIFIER)) as unknown as CaptureAudioModule;
+  } catch (err) {
+    throw translateCaptureLoadError(err);
+  }
+}
+
+/**
+ * `remnic capture <rest...>`. Only the `audio` subgroup exists today; it
+ * forwards the remaining argv to the capture-audio CLI. Returns a process
+ * exit code (0 success, 2 usage/install error).
+ */
+export async function cmdCapture(rest: string[], io: CaptureDispatchIO): Promise<number> {
+  if (rest.length === 0 || rest[0] === "--help" || rest[0] === "-h") {
+    io.stdout(USAGE);
+    return rest.length === 0 ? 2 : 0;
+  }
+  if (rest[0] !== "audio") {
+    io.stderr(`unknown capture subgroup '${rest[0]}'. ${USAGE}`);
+    return 2;
+  }
+  const forwarded = rest.slice(1);
+  let mod: CaptureAudioModule;
+  try {
+    mod = await (io.loadCaptureAudio ?? defaultLoadCaptureAudio)();
+  } catch (err) {
+    io.stderr(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+  return mod.runCapture({ argv: forwarded, stdout: io.stdout, stderr: io.stderr });
+}

--- a/packages/remnic-cli/src/capture-dispatch.ts
+++ b/packages/remnic-cli/src/capture-dispatch.ts
@@ -28,6 +28,7 @@ export interface CaptureAudioModule {
     env?: NodeJS.ProcessEnv;
     stdout?: (line: string) => void;
     stderr?: (line: string) => void;
+    spawnArgvPrefix?: string[];
   }): Promise<number>;
 }
 
@@ -74,5 +75,13 @@ export async function cmdCapture(rest: string[], io: CaptureDispatchIO): Promise
     io.stderr(err instanceof Error ? err.message : String(err));
     return 2;
   }
-  return mod.runCapture({ argv: forwarded, stdout: io.stdout, stderr: io.stderr });
+  // Tell the daemon how to re-launch itself when it backgrounds into
+  // --foreground: as `remnic capture audio ...`, not the bare `remnic` bin
+  // (process.argv[1] here is the remnic CLI entrypoint).
+  return mod.runCapture({
+    argv: forwarded,
+    stdout: io.stdout,
+    stderr: io.stderr,
+    spawnArgvPrefix: [process.argv[1], "capture", "audio"],
+  });
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -293,6 +293,7 @@ import { parseConnectorConfig, stripConfigArgv } from "./parse-connector-config.
 // import; slice 1 ships only the dispatcher and surfaces a clean install hint
 // when an adapter package is absent.
 import { cmdImport, IMPORT_USAGE } from "./import-dispatch.js";
+import { cmdCapture } from "./capture-dispatch.js";
 import { cmdImportLosslessClaw } from "./import-lossless-claw-cmd.js";
 
 export { parseConnectorConfig, stripConfigArgv };
@@ -403,6 +404,7 @@ type CommandName =
   | "wearables"
   | "capsule"
   | "offline"
+  | "capture"
   | "oauth";
 
 type DaemonAction = "start" | "stop" | "restart" | "install" | "uninstall" | "status";
@@ -13387,6 +13389,18 @@ Other:
       // and the destination is the LCM SQLite store, not the orchestrator.
       const exitCode = await cmdImportLosslessClaw(rest, {
         resolveMemoryDir,
+        stdout: (line) => console.log(line),
+        stderr: (line) => console.error(line),
+      });
+      if (exitCode !== 0) process.exit(exitCode);
+      break;
+    }
+
+    case "capture": {
+      // `remnic capture audio <sub>` forwards to the optional
+      // @remnic/capture-audio CLI (loaded via computed-specifier dynamic
+      // import; clean install hint when absent — issue #1897).
+      const exitCode = await cmdCapture(rest, {
         stdout: (line) => console.log(line),
         stderr: (line) => console.error(line),
       });

--- a/packages/remnic-core/src/wearables/cli.ts
+++ b/packages/remnic-core/src/wearables/cli.ts
@@ -9,6 +9,7 @@
  */
 
 import { WearablesInputError } from "./errors.js";
+import { builtInConnectorPackageSpecifier } from "./registry.js";
 import type { WearablesService } from "./service.js";
 import type { WearableSyncSummary } from "./types.js";
 
@@ -182,7 +183,7 @@ export async function runWearablesCliCommand(
         for (const source of status.sources) {
           io.stdout.write(
             `  ${source.source} (${source.displayName}): ${source.enabled ? "enabled" : "disabled"}, ` +
-              `connector ${source.connectorInstalled ? "installed" : `MISSING — npm install @remnic/connector-${source.source}`}, ` +
+              `connector ${source.connectorInstalled ? "installed" : `MISSING — npm install ${builtInConnectorPackageSpecifier(source.source)}`}, ` +
               `memoryMode ${source.memoryMode}, ` +
               `${source.transcriptDays} transcript day${source.transcriptDays === 1 ? "" : "s"}, ` +
               `last sync ${source.lastSyncAt ?? "never"}\n`,

--- a/packages/remnic-core/src/wearables/index.ts
+++ b/packages/remnic-core/src/wearables/index.ts
@@ -16,6 +16,7 @@ export {
   parseWearablesConfig,
 } from "./config.js";
 export {
+  builtInConnectorPackageSpecifier,
   registerWearableConnector,
   getWearableConnector,
   listWearableConnectors,

--- a/packages/remnic-core/src/wearables/registry.test.ts
+++ b/packages/remnic-core/src/wearables/registry.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
 
 import {
+  builtInConnectorPackageSpecifier,
   clearWearableConnectors,
   ensureBuiltInWearableConnectors,
   getWearableConnector,
@@ -59,4 +60,14 @@ test("ensureBuiltInWearableConnectors tolerates absent optional packages", async
   await ensureBuiltInWearableConnectors();
   await ensureBuiltInWearableConnectors();
   assert.ok(Array.isArray(listWearableConnectors()));
+});
+
+test("builtInConnectorPackageSpecifier maps a source to its real optional package (AC9 install hint)", () => {
+  // desktop ships in @remnic/capture-audio, NOT the nonexistent
+  // @remnic/connector-desktop — the missing-package hint must be installable.
+  assert.equal(builtInConnectorPackageSpecifier("desktop"), "@remnic/capture-audio");
+  assert.equal(builtInConnectorPackageSpecifier("limitless"), "@remnic/connector-limitless");
+  assert.equal(builtInConnectorPackageSpecifier("bee"), "@remnic/connector-bee");
+  // An unknown id keeps the connector-<id> convention.
+  assert.equal(builtInConnectorPackageSpecifier("acme"), "@remnic/connector-acme");
 });

--- a/packages/remnic-core/src/wearables/registry.ts
+++ b/packages/remnic-core/src/wearables/registry.ts
@@ -89,6 +89,18 @@ const BUILT_IN_CONNECTOR_PACKAGES: Array<{ id: string; suffix: string }> = [
   { id: "desktop", suffix: "capture-audio" },
 ];
 
+/**
+ * npm specifier of the optional package that provides a source's connector.
+ * Built-in sources map to their real package (e.g. `desktop` ->
+ * `@remnic/capture-audio`, not the nonexistent `@remnic/connector-desktop`);
+ * unknown ids fall back to the `connector-<id>` convention. Used by
+ * missing-connector install hints so they name the exact install command.
+ */
+export function builtInConnectorPackageSpecifier(id: string): string {
+  const entry = BUILT_IN_CONNECTOR_PACKAGES.find((e) => e.id === id);
+  return `@remnic/${entry ? entry.suffix : `connector-${id}`}`;
+}
+
 const loadFailuresWarned = new Set<string>();
 
 export async function ensureBuiltInWearableConnectors(): Promise<void> {

--- a/packages/remnic-core/src/wearables/registry.ts
+++ b/packages/remnic-core/src/wearables/registry.ts
@@ -86,6 +86,7 @@ const BUILT_IN_CONNECTOR_PACKAGES: Array<{ id: string; suffix: string }> = [
   { id: "omi", suffix: "connector-omi" },
   { id: "fireflies", suffix: "connector-fireflies" },
   { id: "granola", suffix: "connector-granola" },
+  { id: "desktop", suffix: "capture-audio" },
 ];
 
 const loadFailuresWarned = new Set<string>();

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -41,6 +41,7 @@ import {
   type WearableSyncOptions,
 } from "./pipeline.js";
 import {
+  builtInConnectorPackageSpecifier,
   ensureBuiltInWearableConnectors,
   getWearableConnector,
   listWearableConnectors,
@@ -326,7 +327,7 @@ export class WearablesService {
       if (!registration) {
         throw new WearablesInputError(
           `wearable source '${sourceId}' is enabled but its connector package is not installed.\n` +
-            `Install it alongside Remnic:\n  npm install @remnic/connector-${sourceId}`,
+            `Install it alongside Remnic:\n  npm install ${builtInConnectorPackageSpecifier(sourceId)}`,
         );
       }
       const connector = registration.factory({
@@ -414,7 +415,7 @@ export class WearablesService {
     if (!registration) {
       return {
         ok: false,
-        detail: `connector package @remnic/connector-${sourceId} is not installed`,
+        detail: `connector package ${builtInConnectorPackageSpecifier(sourceId)} is not installed`,
       };
     }
     const connector = registration.factory({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
 
   packages/capture-audio:
     devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
       '@types/node':
         specifier: ^22.10.0
         version: 22.20.0


### PR DESCRIPTION
## Summary
- add replayable SQLite spool storage, a local HTTP read API, and validated fixture ingestion
- add argv-only whisper.cpp transcription, atomic local model downloads, raw-audio retention, and an optional Sherpa Silero VAD adapter
- keep native capture, continuous VAD segmentation, diarization, and conversation assembly out of this boundary-only slice

## Verification
- `pnpm --filter @remnic/capture-audio run test` - 55 passing
- `pnpm --filter @remnic/capture-audio run check-types`
- `pnpm --filter @remnic/capture-audio run build`

Part of #1897

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive surface (auth token rules, optional native sherpa/whisper deps, spool schema for speaker embeddings) with strong test coverage; misconfiguration or token handling on non-loopback URLs is the main operational concern.
> 
> **Overview**
> Extends **@remnic/capture-audio** with the processing and integration pieces for desktop audio as a wearable source: **whisper.cpp** STT helpers, atomic **Whisper model downloads**, optional **Sherpa Silero VAD**, **raw-audio janitor**, **speaker clustering** with spool persistence, **cross-channel dedup**, and **conversation assembly** by gap—mostly as shared library code plus broad tests (daemon wiring for live capture may still be out of scope for this slice).
> 
> Adds a **`desktop` wearable connector** that talks to the loopback daemon HTTP API (auth, health, paginated conversations), registers with **@remnic/core**, and includes an **e2e** path through `syncWearableSource` to day transcripts (final-only, content-hash re-sync).
> 
> **CLI / packaging:** new **`download-model`** and **`janitor`** subcommands; **`remnic capture audio`** lazy-loads the optional package with install hints; background **`start`** can relaunch via **`spawnArgvPrefix`** so the detached daemon matches the `remnic` entrypoint. **Config** gains full **VAD** fields and tighter validation (exclusive similarity thresholds, empty STT model path → default).
> 
> **Core** maps the `desktop` source to **`@remnic/capture-audio`** for discovery and missing-package hints via **`builtInConnectorPackageSpecifier`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c9f6991e0842a0c06c5ce8fc2dbc583f3f8426. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a desktop audio wearable connector with token resolution, auth checking, and conversation syncing.
  * Added Whisper-based transcription plus configurable VAD, speaker diarization, cross-channel deduplication, and conversation assembly.
  * Extended capture CLI with `audio download-model` and `audio janitor`, and added a `capture` dispatcher for forwarding capture-audio runs.
* **Bug Fixes**
  * Strengthened configuration validation/normalization (VAD fields and bounds, similarity-threshold exclusivity, model path trimming, and stricter conversation gap rules).
  * Improved raw-audio cleanup correctness at the retention boundary.
* **Tests**
  * Expanded unit/integration coverage for transcription, connector syncing, diarization, deduplication, assembly, janitor cleanup, model download, and CLI dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->