### PR TITLE
fix(access): resolve scoped namespace preflights

### DIFF
--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -2885,6 +2885,12 @@ test("HTTP namespace/writable preflight admits write-scoped tokens and rejects r
     assert.equal(await okOf(diag), false);
     // A read-only token cannot write, so it has nothing to preflight → 403.
     assert.equal((await request("read-only")).status, 403);
+    const invalidOp = await request("write-scoped", "memory_stroe");
+    assert.equal(invalidOp.status, 400);
+    assert.match(
+      JSON.stringify(await invalidOp.json()),
+      /unsupported namespace preflight operation: memory_stroe/,
+    );
   } finally {
     await server.stop();
   }

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -2727,6 +2727,10 @@ test("HTTP namespace/writable preflight returns the structured writability resul
   // is a valid 200 answer (read via `ok`), not an HTTP error.
   const service = {
     configRef: parseConfig({ memoryDir: "/tmp/remnic-http-preflight-test", defaultNamespace: "default" }),
+    namespaceWritablePreflight: async ({ namespace }: { namespace?: string }) =>
+      namespace && namespace !== "default"
+        ? { ok: false as const, reason: "not_writable" as const, namespace }
+        : { ok: true as const, namespace: "default" },
   } as unknown as EngramAccessService;
   const server = new EngramAccessHttpServer({
     service,
@@ -2757,9 +2761,90 @@ test("HTTP namespace/writable preflight returns the structured writability resul
   }
 });
 
+test("HTTP namespace/writable forwards project context to the scoped write preflight", async () => {
+  let received:
+    | {
+        namespace?: string;
+        sessionKey?: string;
+        projectTag?: string;
+        cwd?: string;
+      }
+    | undefined;
+  const service = {
+    configRef: parseConfig({ memoryDir: "/tmp/remnic-http-preflight-context", defaultNamespace: "default" }),
+    namespaceWritablePreflight: async (request: {
+      namespace?: string;
+      sessionKey?: string;
+      projectTag?: string;
+      cwd?: string;
+    }) => {
+      received = request;
+      return { ok: true as const, namespace: "derived-project-namespace" };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/namespace/writable?session=s-1&projectTag=Acme%2FWebshop&cwd=%2Ftmp%2Frepo`,
+      { headers: { authorization: "Bearer test-token" } },
+    );
+    assert.deepEqual(await response.json(), { ok: true, namespace: "derived-project-namespace" });
+    assert.deepEqual(received, {
+      namespace: undefined,
+      sessionKey: "s-1",
+      authenticatedPrincipal: undefined,
+      projectTag: "Acme/Webshop",
+      cwd: "/tmp/repo",
+    });
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP namespace/writable checks token scope against the effective scoped namespace", async () => {
+  const service = {
+    configRef: parseConfig({ memoryDir: "/tmp/remnic-http-preflight-effective", defaultNamespace: "default" }),
+    namespaceWritablePreflight: async () => ({
+      ok: true as const,
+      namespace: "principal-project-derived",
+    }),
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authTokenEntriesGetter: () => [
+      { token: "default-only", capabilities: { version: 1, ops: ["observe"], namespaces: ["default"] } },
+    ],
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/namespace/writable?session=s-1&projectTag=Acme%2FWebshop`,
+      { headers: { authorization: "Bearer default-only" } },
+    );
+    assert.deepEqual(await response.json(), {
+      ok: false,
+      reason: "not_writable",
+      namespace: "principal-project-derived",
+    });
+  } finally {
+    await server.stop();
+  }
+});
+
 test("HTTP namespace/writable preflight admits write-scoped tokens and rejects read-only ops", async () => {
   const service = {
     configRef: parseConfig({ memoryDir: "/tmp/remnic-http-preflight-ops-test", defaultNamespace: "default" }),
+    namespaceWritablePreflight: async () => ({ ok: true as const, namespace: "default" }),
   } as unknown as EngramAccessService;
   const server = new EngramAccessHttpServer({
     service,

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -37,7 +37,7 @@ import {
 import { expandTildePath } from "./utils/path.js";
 import { projectTagProjectId } from "./coding/coding-namespace.js";
 import { getOperation, type OperationName } from "./access-boundary.js";
-import { resolveNamespacePreflight } from "./scopes/scope-plan.js";
+import { resolveQueryNamespaceWritablePreflight } from "./access-namespace-preflight.js";
 import {
   assertOperationAllowed,
   capabilityAllowsOp,
@@ -1467,20 +1467,19 @@ export class EngramAccessHttpServer {
       return;
     }
 
-    // Namespace-writability preflight (issue #1888 part 3): would the client's
-    // enabled write (`?op=observe|memory_store`, default observe) to the
-    // requested namespace by THIS token succeed? Out-of-allow-list → 200
-    // {ok:false}; any allowedByOps token may run it (HTTP + batch admit alike).
     if (req.method === "GET" && pathname === "/engram/v1/namespace/writable") {
-      const preflightOp = getOperation("namespace_writable"); // boundary marker (catalog parity, issue #1888)
-      const caps = tokenCapabilityStore.getStore();
-      if (!(preflightOp?.spec.allowedByOps ?? []).some((op) => capabilityAllowsOp(caps, op))) {
-        throw new EngramAccessForbiddenError("token is not permitted to run the namespace preflight");
-      }
-      const ns = parsed.searchParams.get("namespace") || undefined;
-      const sk = parsed.searchParams.get("session") || undefined;
-      const writeOp = parsed.searchParams.get("op") === "memory_store" ? "memory_store" : "observe";
-      this.respondJson(res, 200, resolveNamespacePreflight(caps, ns, sk, this.resolveRequestPrincipal(req), this.service.configRef, writeOp));
+      if (!getOperation("namespace_writable")) throw new Error("namespace_writable operation is not registered");
+      this.respondJson(
+        res,
+        200,
+        await resolveQueryNamespaceWritablePreflight(
+          tokenCapabilityStore.getStore(),
+          parsed.searchParams,
+          this.resolveRequestPrincipal(req),
+          this.service.configRef.defaultNamespace,
+          (request) => this.service.namespaceWritablePreflight(request),
+        ),
+      );
       return;
     }
 

--- a/packages/remnic-core/src/access-namespace-preflight.test.ts
+++ b/packages/remnic-core/src/access-namespace-preflight.test.ts
@@ -4,7 +4,12 @@ import test from "node:test";
 import "./access-operations.js";
 import { getOperation } from "./access-boundary.js";
 import { tokenCapabilityStore, type TokenCapabilities } from "./access-token-capabilities.js";
-import type { EngramAccessNamespaceWritableRequest } from "./access-namespace-preflight.js";
+import {
+  assertNamespacePreflightPermitted,
+  resolveAuthorizedNamespaceWritablePreflight,
+  resolveQueryNamespaceWritablePreflight,
+  type EngramAccessNamespaceWritableRequest,
+} from "./access-namespace-preflight.js";
 import type { EngramAccessService } from "./access-service.js";
 
 test("namespace_writable forwards coding context through the batch boundary", async () => {
@@ -38,4 +43,59 @@ test("namespace_writable forwards coding context through the batch boundary", as
     cwd: "/workspace/project",
     projectTag: "project-tag",
   });
+});
+
+test("namespace_writable rejects unsupported write operations", async () => {
+  const operation = getOperation("namespace_writable");
+  assert.ok(operation);
+  const service = {
+    configRef: { defaultNamespace: "default" },
+    namespaceWritablePreflight: async () => ({ ok: true as const, namespace: "default" }),
+  } as unknown as EngramAccessService;
+
+  await assert.rejects(
+    () =>
+      tokenCapabilityStore.run({ version: 1, ops: ["observe"] }, () =>
+        operation.run({ op: "memory_stroe" }, { service }),
+      ),
+    /unsupported namespace preflight operation: memory_stroe/,
+  );
+  assert.throws(
+    () =>
+      resolveQueryNamespaceWritablePreflight(
+        { version: 1, ops: ["observe"] },
+        new URLSearchParams({ op: "memory_stroe" }),
+        undefined,
+        "default",
+        async () => ({ ok: true, namespace: "default" }),
+      ),
+    /unsupported namespace preflight operation: memory_stroe/,
+  );
+});
+
+test("namespace_writable rejects unavailable preflight and denied write scope", async () => {
+  assert.throws(
+    () => assertNamespacePreflightPermitted({ version: 1, ops: ["memory_get"] }),
+    /token is not permitted to run the namespace preflight/,
+  );
+  assert.deepEqual(
+    await resolveAuthorizedNamespaceWritablePreflight(
+      { version: 1, ops: ["observe"] },
+      { namespace: "default" },
+      "default",
+      "memory_store",
+      async () => ({ ok: true, namespace: "default" }),
+    ),
+    { ok: false, reason: "not_writable", namespace: "default" },
+  );
+  assert.deepEqual(
+    await resolveAuthorizedNamespaceWritablePreflight(
+      { version: 1, ops: ["observe"], namespaces: ["team-a"] },
+      {},
+      "default",
+      "observe",
+      async () => ({ ok: true, namespace: "default" }),
+    ),
+    { ok: false, reason: "not_writable", namespace: "default" },
+  );
 });

--- a/packages/remnic-core/src/access-namespace-preflight.test.ts
+++ b/packages/remnic-core/src/access-namespace-preflight.test.ts
@@ -98,4 +98,14 @@ test("namespace_writable rejects unavailable preflight and denied write scope", 
     ),
     { ok: false, reason: "not_writable", namespace: "default" },
   );
+  assert.deepEqual(
+    await resolveAuthorizedNamespaceWritablePreflight(
+      { version: 1, ops: ["observe"], namespaces: ["team-a"] },
+      { namespace: "outside-scope" },
+      "default",
+      "observe",
+      async () => ({ ok: false, reason: "unsupported", namespace: "outside-scope" }),
+    ),
+    { ok: false, reason: "not_writable", namespace: "outside-scope" },
+  );
 });

--- a/packages/remnic-core/src/access-namespace-preflight.test.ts
+++ b/packages/remnic-core/src/access-namespace-preflight.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import "./access-operations.js";
+import { getOperation } from "./access-boundary.js";
+import { tokenCapabilityStore, type TokenCapabilities } from "./access-token-capabilities.js";
+import type { EngramAccessNamespaceWritableRequest } from "./access-namespace-preflight.js";
+import type { EngramAccessService } from "./access-service.js";
+
+test("namespace_writable forwards coding context through the batch boundary", async () => {
+  let received: EngramAccessNamespaceWritableRequest | undefined;
+  const service = {
+    configRef: { defaultNamespace: "default" },
+    namespaceWritablePreflight: async (request: EngramAccessNamespaceWritableRequest) => {
+      received = request;
+      return { ok: true as const, namespace: "principal-project" };
+    },
+  } as unknown as EngramAccessService;
+  const operation = getOperation("namespace_writable");
+  assert.ok(operation);
+
+  const caps: TokenCapabilities = { version: 1, ops: ["observe"] };
+  const output = await tokenCapabilityStore.run(caps, () =>
+    operation.run(
+      {
+        sessionKey: "session-1",
+        cwd: "/workspace/project",
+        projectTag: "project-tag",
+      },
+      { service, authenticatedPrincipal: "principal" },
+    ),
+  );
+
+  assert.deepEqual(output, { result: { ok: true, namespace: "principal-project" } });
+  assert.deepEqual(received, {
+    sessionKey: "session-1",
+    authenticatedPrincipal: "principal",
+    cwd: "/workspace/project",
+    projectTag: "project-tag",
+  });
+});

--- a/packages/remnic-core/src/access-namespace-preflight.ts
+++ b/packages/remnic-core/src/access-namespace-preflight.ts
@@ -86,7 +86,7 @@ export async function resolveAuthorizedNamespaceWritablePreflight(
   }
 
   const result = await resolvePreflight(request);
-  if (result.ok && !isNamespaceAllowed(caps, result.namespace, defaultNamespace)) {
+  if (!isNamespaceAllowed(caps, result.namespace, defaultNamespace)) {
 
     return { ok: false, reason: "not_writable", namespace: result.namespace };
   }

--- a/packages/remnic-core/src/access-namespace-preflight.ts
+++ b/packages/remnic-core/src/access-namespace-preflight.ts
@@ -25,6 +25,14 @@ export function namespaceWritableRequest(
   };
 }
 
+export function parseNamespacePreflightWriteOp(
+  value: string | undefined,
+): "observe" | "memory_store" {
+  if (value === undefined || value === "observe") return "observe";
+  if (value === "memory_store") return "memory_store";
+  throw new EngramAccessInputError(`unsupported namespace preflight operation: ${value}`);
+}
+
 export function assertNamespacePreflightPermitted(
   caps: TokenCapabilities | undefined | null,
 ): void {
@@ -97,7 +105,7 @@ export function resolveQueryNamespaceWritablePreflight(
     caps,
     namespaceWritableRequest(params, authenticatedPrincipal),
     defaultNamespace,
-    params.get("op") === "memory_store" ? "memory_store" : "observe",
+    parseNamespacePreflightWriteOp(params.get("op") ?? undefined),
     resolvePreflight,
   );
 }

--- a/packages/remnic-core/src/access-namespace-preflight.ts
+++ b/packages/remnic-core/src/access-namespace-preflight.ts
@@ -1,0 +1,103 @@
+import { getOperation } from "./access-boundary.js";
+import { capabilityAllowsOp, isNamespaceAllowed, type TokenCapabilities } from "./access-token-capabilities.js";
+import { EngramAccessForbiddenError, EngramAccessInputError, NamespaceNotWritableError } from "./access-errors.js";
+import type { WritableNamespaceResult } from "./scopes/scope-plan.js";
+
+export interface EngramAccessNamespaceWritableRequest {
+  namespace?: string;
+  sessionKey?: string;
+  authenticatedPrincipal?: string;
+  cwd?: string;
+  projectTag?: string;
+}
+
+export function namespaceWritableRequest(
+  params: URLSearchParams,
+  authenticatedPrincipal?: string,
+): EngramAccessNamespaceWritableRequest {
+  const namespace = params.get("namespace") || undefined;
+  return {
+    namespace,
+    sessionKey: params.get("session") || undefined,
+    authenticatedPrincipal,
+    cwd: params.get("cwd") || undefined,
+    projectTag: params.get("projectTag") || undefined,
+  };
+}
+
+export function assertNamespacePreflightPermitted(
+  caps: TokenCapabilities | undefined | null,
+): void {
+  const allowedOps = getOperation("namespace_writable")?.spec.allowedByOps ?? [];
+  if (!allowedOps.some((op) => capabilityAllowsOp(caps, op))) {
+    throw new EngramAccessForbiddenError("token is not permitted to run the namespace preflight");
+  }
+}
+
+export type NamespaceWritableResolver = (
+  request: EngramAccessNamespaceWritableRequest,
+) => Promise<string>;
+export type NamespaceWritablePreflightResolver = (
+  request: EngramAccessNamespaceWritableRequest,
+) => Promise<WritableNamespaceResult>;
+
+export async function resolveNamespaceWritablePreflight(
+  request: EngramAccessNamespaceWritableRequest,
+  resolveWritable: NamespaceWritableResolver,
+): Promise<WritableNamespaceResult> {
+  try {
+    return { ok: true, namespace: await resolveWritable(request) };
+  } catch (error) {
+    if (error instanceof NamespaceNotWritableError) {
+      return { ok: false, reason: "not_writable", namespace: error.attemptedNamespace };
+    }
+    if (error instanceof EngramAccessInputError) {
+      return {
+        ok: false,
+        reason: "unsupported",
+        namespace: request.namespace?.trim() ?? "",
+      };
+    }
+    throw error;
+  }
+}
+
+export async function resolveAuthorizedNamespaceWritablePreflight(
+  caps: TokenCapabilities | undefined | null,
+  request: EngramAccessNamespaceWritableRequest,
+  defaultNamespace: string,
+  writeOp: "observe" | "memory_store",
+  resolvePreflight: NamespaceWritablePreflightResolver,
+): Promise<WritableNamespaceResult> {
+  if (!capabilityAllowsOp(caps, writeOp)) {
+    return {
+      ok: false,
+      reason: "not_writable",
+      namespace: request.namespace?.trim() || defaultNamespace,
+    };
+  }
+
+  const result = await resolvePreflight(request);
+  if (result.ok && !isNamespaceAllowed(caps, result.namespace, defaultNamespace)) {
+
+    return { ok: false, reason: "not_writable", namespace: result.namespace };
+  }
+  return result;
+}
+
+export function resolveQueryNamespaceWritablePreflight(
+  caps: TokenCapabilities | undefined | null,
+  params: URLSearchParams,
+  authenticatedPrincipal: string | undefined,
+  defaultNamespace: string,
+  resolvePreflight: NamespaceWritablePreflightResolver,
+): Promise<WritableNamespaceResult> {
+  assertNamespacePreflightPermitted(caps);
+  return resolveAuthorizedNamespaceWritablePreflight(
+    caps,
+    namespaceWritableRequest(params, authenticatedPrincipal),
+    defaultNamespace,
+    params.get("op") === "memory_store" ? "memory_store" : "observe",
+    resolvePreflight,
+  );
+}

--- a/packages/remnic-core/src/access-operations-batch.ts
+++ b/packages/remnic-core/src/access-operations-batch.ts
@@ -18,7 +18,10 @@ import { EngramAccessForbiddenError } from "./access-errors.js";
 import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
 import { enforceNamespaceAllowList, tokenCapabilityStore } from "./access-token-capabilities.js";
 import { projectTagProjectId } from "./coding/coding-namespace.js";
-import { resolveNamespacePreflight } from "./scopes/scope-plan.js";
+import {
+  resolveAuthorizedNamespaceWritablePreflight,
+  type EngramAccessNamespaceWritableRequest,
+} from "./access-namespace-preflight.js";
 import { expandTildePath } from "./utils/path.js";
 import { resolvePrincipal } from "./namespaces/principal.js";
 import { getRecallTimingStatus, isRecallTimingsOperator } from "./recall-timings.js";
@@ -114,7 +117,26 @@ defineOperation({ name: "recall_xray", description: "X-ray recall.", schema: str
     return { result: await ctx.service.recallXray({ query: defStr(input.query, ""), sessionKey: optStr(input.sessionKey), namespace: optStr(input.namespace), budget, authenticatedPrincipal: ctx.authenticatedPrincipal, ...(dr && dr !== "" ? { disclosure: dr as RecallDisclosure } : {}), ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}) }) };
   },
 });
-defineOperation({ name: "namespace_writable", description: "Read-only preflight: is a namespace writable for the caller's principal?", allowedByOps: ["namespace_writable", "observe", "memory_store"], schema: strictSchema({ namespace: S.str, sessionKey: S.str, op: S.str }), handler: async (input, ctx) => { const ns = optStr(input.namespace); const sk = optStr(input.sessionKey); const writeOp = optStr(input.op) === "memory_store" ? "memory_store" : "observe"; return { result: resolveNamespacePreflight(tokenCapabilityStore.getStore(), ns && ns.length > 0 ? ns : undefined, sk && sk.length > 0 ? sk : undefined, ctx.authenticatedPrincipal, ctx.service.configRef, writeOp) }; } });
+defineOperation({ name: "namespace_writable", description: "Read-only preflight: is a namespace writable for the caller's principal?", allowedByOps: ["namespace_writable", "observe", "memory_store"], schema: strictSchema({ namespace: S.str, sessionKey: S.str, op: S.str, cwd: S.str, projectTag: S.str }), handler: async (input, ctx) => {
+  const writeOp = optStr(input.op) === "memory_store" ? "memory_store" : "observe";
+  const namespace = optStr(input.namespace);
+  const request: EngramAccessNamespaceWritableRequest = {
+    sessionKey: optStr(input.sessionKey),
+    authenticatedPrincipal: ctx.authenticatedPrincipal,
+    cwd: optStr(input.cwd),
+    projectTag: optStr(input.projectTag),
+    ...(namespace ? { namespace } : {}),
+  };
+  return {
+    result: await resolveAuthorizedNamespaceWritablePreflight(
+      tokenCapabilityStore.getStore(),
+      request,
+      ctx.service.configRef.defaultNamespace,
+      writeOp,
+      (preflightRequest) => ctx.service.namespaceWritablePreflight(preflightRequest),
+    ),
+  };
+} });
 
 // === WEARABLES ===
 defineOperation({ name: "wearables_status", description: "Wearables status.", schema: strictSchema({}), handler: async (_i, ctx) => ({ result: await ctx.service.wearablesStatus() }) });

--- a/packages/remnic-core/src/access-operations-batch.ts
+++ b/packages/remnic-core/src/access-operations-batch.ts
@@ -19,6 +19,7 @@ import { EngramAccessInputError, type EngramAccessService } from "./access-servi
 import { enforceNamespaceAllowList, tokenCapabilityStore } from "./access-token-capabilities.js";
 import { projectTagProjectId } from "./coding/coding-namespace.js";
 import {
+  parseNamespacePreflightWriteOp,
   resolveAuthorizedNamespaceWritablePreflight,
   type EngramAccessNamespaceWritableRequest,
 } from "./access-namespace-preflight.js";
@@ -118,7 +119,7 @@ defineOperation({ name: "recall_xray", description: "X-ray recall.", schema: str
   },
 });
 defineOperation({ name: "namespace_writable", description: "Read-only preflight: is a namespace writable for the caller's principal?", allowedByOps: ["namespace_writable", "observe", "memory_store"], schema: strictSchema({ namespace: S.str, sessionKey: S.str, op: S.str, cwd: S.str, projectTag: S.str }), handler: async (input, ctx) => {
-  const writeOp = optStr(input.op) === "memory_store" ? "memory_store" : "observe";
+  const writeOp = parseNamespacePreflightWriteOp(optStr(input.op));
   const namespace = optStr(input.namespace);
   const request: EngramAccessNamespaceWritableRequest = {
     sessionKey: optStr(input.sessionKey),

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -33,6 +33,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { EngramAccessService } from "./access-service.js";
+import { tokenCapabilityStore } from "./access-token-capabilities.js";
 import { Orchestrator } from "./orchestrator.js";
 import type { StorageManager } from "./storage.js";
 import type { EngramAccessObserveRequest } from "./access-service.js";
@@ -633,6 +634,38 @@ test("#2080 preflight resolves an implicit project scope through the observe wri
   });
 
   assert.deepEqual(result, { ok: true, namespace: expected });
+  await assert.rejects(
+    () =>
+      tokenCapabilityStore.run({ version: 1, namespaces: ["default"] }, () =>
+        (
+          service as unknown as {
+            resolveCodingScopedWriteNamespace: (request: {
+              sessionKey: string;
+              authenticatedPrincipal: string;
+              projectTag: string;
+            }) => Promise<string>;
+          }
+        ).resolveCodingScopedWriteNamespace({
+          sessionKey: "pi-geek:abc123",
+          authenticatedPrincipal: "pi-geek",
+          projectTag: "Acme/Webshop",
+        }),
+      ),
+    /not permitted/,
+  );
+  await assert.rejects(
+    () =>
+      tokenCapabilityStore.run({ version: 1, namespaces: ["default"] }, () =>
+        service.observe(
+          observeRequest({
+            sessionKey: "pi-geek:abc123",
+            authenticatedPrincipal: "pi-geek",
+            projectTag: "Acme/Webshop",
+          }),
+        ),
+      ),
+    /not permitted/,
+  );
 });
 
 test("#1495 the scope plan's writeNamespace matches resolveCodingScopedWriteNamespace (memory_store / suggestion_submit parity, rule 39)", async () => {

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -34,6 +34,7 @@ import test from "node:test";
 
 import { EngramAccessService } from "./access-service.js";
 import { tokenCapabilityStore } from "./access-token-capabilities.js";
+import { resolveAuthorizedNamespaceWritablePreflight } from "./access-namespace-preflight.js";
 import { Orchestrator } from "./orchestrator.js";
 import type { StorageManager } from "./storage.js";
 import type { EngramAccessObserveRequest } from "./access-service.js";
@@ -653,6 +654,22 @@ test("#2080 preflight resolves an implicit project scope through the observe wri
       ),
     /not permitted/,
   );
+  const deniedPreflight = await tokenCapabilityStore.run(
+    { version: 1, ops: ["observe"], namespaces: ["default"] },
+    () =>
+      resolveAuthorizedNamespaceWritablePreflight(
+        tokenCapabilityStore.getStore(),
+        {
+          sessionKey: "pi-geek:abc123",
+          authenticatedPrincipal: "pi-geek",
+          projectTag: "Acme/Webshop",
+        },
+        "default",
+        "observe",
+        (request) => service.namespaceWritablePreflight(request),
+      ),
+  );
+  assert.deepEqual(deniedPreflight, { ok: false, reason: "not_writable", namespace: expected });
   await assert.rejects(
     () =>
       tokenCapabilityStore.run({ version: 1, namespaces: ["default"] }, () =>

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -604,6 +604,37 @@ test("#1505 (cursor hAp) scopeDebug.baseNamespace reports the principal self bas
   );
 });
 
+test("#2080 preflight resolves an implicit project scope through the observe write resolver", async () => {
+  const probe = makeObserveProbe({
+    ...withSelfPolicyPrefix("pi-geek"),
+    namespacePolicies: [
+      { name: "default", readPrincipals: ["admin"], writePrincipals: ["admin"] },
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+  });
+  const service = new EngramAccessService(probe.orch);
+  const expected = combineNamespaces(
+    "pi-geek",
+    projectNamespaceName(projectTagProjectId("Acme/Webshop")),
+  );
+
+  const result = await (
+    service as unknown as {
+      namespaceWritablePreflight: (request: {
+        sessionKey: string;
+        authenticatedPrincipal: string;
+        projectTag: string;
+      }) => Promise<{ ok: boolean; namespace: string }>;
+    }
+  ).namespaceWritablePreflight({
+    sessionKey: "pi-geek:abc123",
+    authenticatedPrincipal: "pi-geek",
+    projectTag: "Acme/Webshop",
+  });
+
+  assert.deepEqual(result, { ok: true, namespace: expected });
+});
+
 test("#1495 the scope plan's writeNamespace matches resolveCodingScopedWriteNamespace (memory_store / suggestion_submit parity, rule 39)", async () => {
   // Regression guard: observe's effective scope MUST be identical to what the
   // explicit-write tools (memory_store / suggestion_submit) resolve via

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -6,6 +6,7 @@ import { readdirSync, unlinkSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { ZodError } from "zod";
 import { AccessIdempotencyStore, hashAccessIdempotencyPayload } from "./access-idempotency.js";
+import { enforceNamespaceAllowList, tokenCapabilityStore } from "./access-token-capabilities.js";
 import {
   recordCitationUsage as recordCitationUsageForAccess,
   type CitationUsageRequest,
@@ -1591,6 +1592,14 @@ export class EngramAccessService {
     return { principal, codingContext, overlay, profilePlan };
   }
 
+  private assertTokenCanWriteNamespace(namespace: string): void {
+    enforceNamespaceAllowList(
+      tokenCapabilityStore.getStore(),
+      namespace,
+      this.orchestrator.config.defaultNamespace,
+    );
+  }
+
   /**
    * Resolve the write namespace for explicit-write tools (memory_store /
    * suggestion_submit), project-scoping the write the same way recall does so a
@@ -1609,11 +1618,13 @@ export class EngramAccessService {
   ): Promise<string> {
     const requested = request.namespace?.trim();
     if (requested) {
-      return this.writableNamespaceFor(
+      const namespace = this.writableNamespaceFor(
         requested,
         request.sessionKey,
         request.authenticatedPrincipal,
       );
+      this.assertTokenCanWriteNamespace(namespace);
+      return namespace;
     }
 
     const { principal, overlay, profilePlan } = await this.resolveCodingScopeInputs(request);
@@ -1625,7 +1636,10 @@ export class EngramAccessService {
       scopeProfile: profilePlan,
       config: this.orchestrator.config,
     });
-    if (result.ok) return result.namespace;
+    if (result.ok) {
+      this.assertTokenCanWriteNamespace(result.namespace);
+      return result.namespace;
+    }
     if (profilePlan && result.namespace === profilePlan.writeNamespace) {
       throw new NamespaceNotWritableError(
         result.namespace,
@@ -1752,6 +1766,7 @@ export class EngramAccessService {
         request.sessionKey,
         request.authenticatedPrincipal,
       );
+      this.assertTokenCanWriteNamespace(writeNamespace);
       return {
         principal,
         explicitNamespace: request.namespace!.trim(),
@@ -1829,6 +1844,15 @@ export class EngramAccessService {
         this.orchestrator.setCodingContextForSession(request.sessionKey!, null);
       }
     };
+    const assertWriteNamespaceAllowed = (namespace: string): void => {
+      try {
+        this.assertTokenCanWriteNamespace(namespace);
+      } catch (error) {
+        clearSeededContext();
+        throw error;
+      }
+    };
+
 
     const overlaidBase = this.orchestrator.applyCodingNamespaceOverlay(
       request.sessionKey,
@@ -1880,6 +1904,7 @@ export class EngramAccessService {
               readNamespaces.includes(layer.namespace),
           ),
       );
+      assertWriteNamespaceAllowed(profilePlan.writeNamespace);
       return {
         principal,
         baseNamespace: profilePlan.baseNamespace,
@@ -1932,6 +1957,7 @@ export class EngramAccessService {
         clearSeededContext();
         throw new NamespaceNotWritableError(baseNamespace, principal);
       }
+      assertWriteNamespaceAllowed(writeNamespace);
       return {
         principal,
         // scopeDebug.baseNamespace must report the principal SELF base
@@ -1969,6 +1995,7 @@ export class EngramAccessService {
       const ns = combineNamespaces(baseNamespace, fallback);
       if (!readNamespaces.includes(ns)) readNamespaces.push(ns);
     }
+    assertWriteNamespaceAllowed(writeNamespace);
     return {
       principal,
       baseNamespace,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -130,8 +130,11 @@ import {
 import {
   type ScopePlan,
   resolveScopePlan,
+  resolveScopedWritableNamespaceValue,
   resolveWritableNamespaceValue,
+  type WritableNamespaceResult,
 } from "./scopes/scope-plan.js";
+import { resolveNamespaceWritablePreflight, type EngramAccessNamespaceWritableRequest } from "./access-namespace-preflight.js";
 import { namespaceIdentityFromToken } from "./namespaces/identity.js";
 import { namespaceCollectionName } from "./namespaces/search.js";
 import { SecureStoreLockedError } from "./secure-store/index.js";
@@ -958,7 +961,7 @@ export interface CodingScopedWriteInput {
   cwd?: string;
   projectTag?: string;
 }
-
+export type { EngramAccessNamespaceWritableRequest } from "./access-namespace-preflight.js";
 /**
  * Internal, single-resolution plan describing the effective memory scope for a
  * write-producing access request (#1495, seed for epic #1494). One plan is
@@ -1604,48 +1607,49 @@ export class EngramAccessService {
       authenticatedPrincipal?: string;
     },
   ): Promise<string> {
-    const hasExplicitNamespace =
-      typeof request.namespace === "string" && request.namespace.trim().length > 0;
-    if (hasExplicitNamespace) {
+    const requested = request.namespace?.trim();
+    if (requested) {
       return this.writableNamespaceFor(
-        request.namespace,
+        requested,
         request.sessionKey,
         request.authenticatedPrincipal,
       );
     }
+
     const { principal, overlay, profilePlan } = await this.resolveCodingScopeInputs(request);
-    if (profilePlan) {
-      const selectedLayer = profilePlan.layers.find((layer) => layer.id === profilePlan.writeLayer);
-      const writeNamespaceReadable =
-        profilePlan.writeNamespace.length > 0 &&
-        profilePlan.readNamespaces.includes(profilePlan.writeNamespace);
-      if (!selectedLayer?.writable || !writeNamespaceReadable) {
-        throw new NamespaceNotWritableError(profilePlan.writeNamespace, principal,
-          `scope profile ${profilePlan.profileId} has no writable layer for principal ${principal ?? "anonymous"}`);
-      }
-      return profilePlan.writeNamespace;
-    }
-    if (!overlay) {
-      // No coding overlay → unqualified write stays on config.defaultNamespace,
-      // exactly the pre-#1434 behavior (auth-checked, like the legacy path).
-      return this.writableNamespaceFor(
-        undefined,
-        request.sessionKey,
-        request.authenticatedPrincipal,
+    const result = resolveScopedWritableNamespaceValue({
+      sessionKey: request.sessionKey,
+      authenticatedPrincipal: request.authenticatedPrincipal,
+      principal,
+      codingOverlay: overlay,
+      scopeProfile: profilePlan,
+      config: this.orchestrator.config,
+    });
+    if (result.ok) return result.namespace;
+    if (profilePlan && result.namespace === profilePlan.writeNamespace) {
+      throw new NamespaceNotWritableError(
+        result.namespace,
+        principal,
+        `scope profile ${profilePlan.profileId} has no writable layer for principal ${principal ?? "anonymous"}`,
       );
     }
-    // Coding overlay → overlay onto the principal self base, the SAME namespace
-    // recall/observe/buffer-flush use. The result is a principal-owned
-    // `project-*` sub-namespace derived from this authorized base, so it needs
-    // no separate write policy.
-    const base = defaultNamespaceForPrincipal(principal, this.orchestrator.config);
-    if (!canWriteNamespace(principal, base, this.orchestrator.config)) {
-      throw new NamespaceNotWritableError(base, principal);
+
+    if (result.reason === "unsupported") {
+      throw new EngramAccessInputError(`unsupported namespace: ${result.namespace}`);
     }
-    return combineNamespaces(base, overlay.namespace);
+    throw new NamespaceNotWritableError(result.namespace, principal);
   }
 
-  /** Read-side mirror of {@link resolveCodingScopedWriteNamespace}. Decision
+  async namespaceWritablePreflight(
+    request: EngramAccessNamespaceWritableRequest,
+  ): Promise<WritableNamespaceResult> {
+    return resolveNamespaceWritablePreflight(
+      request,
+      (preflightRequest) => this.resolveCodingScopedWriteNamespace(preflightRequest),
+    );
+  }
+
+  /**
    *  `list`/`get` use this so a record written by a project-scoped session is
    *  listable/fetchable by the SAME session without manually supplying the
    *  overlaid namespace (review P2). Derivation is IDENTICAL to the write path

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1615,6 +1615,7 @@ export class EngramAccessService {
       sessionKey?: string;
       authenticatedPrincipal?: string;
     },
+    enforceToken: boolean = true,
   ): Promise<string> {
     const requested = request.namespace?.trim();
     if (requested) {
@@ -1623,7 +1624,7 @@ export class EngramAccessService {
         request.sessionKey,
         request.authenticatedPrincipal,
       );
-      this.assertTokenCanWriteNamespace(namespace);
+      if (enforceToken) this.assertTokenCanWriteNamespace(namespace);
       return namespace;
     }
 
@@ -1637,7 +1638,7 @@ export class EngramAccessService {
       config: this.orchestrator.config,
     });
     if (result.ok) {
-      this.assertTokenCanWriteNamespace(result.namespace);
+      if (enforceToken) this.assertTokenCanWriteNamespace(result.namespace);
       return result.namespace;
     }
     if (profilePlan && result.namespace === profilePlan.writeNamespace) {
@@ -1659,7 +1660,7 @@ export class EngramAccessService {
   ): Promise<WritableNamespaceResult> {
     return resolveNamespaceWritablePreflight(
       request,
-      (preflightRequest) => this.resolveCodingScopedWriteNamespace(preflightRequest),
+      (preflightRequest) => this.resolveCodingScopedWriteNamespace(preflightRequest, false),
     );
   }
 

--- a/packages/remnic-core/src/scopes/scope-plan.ts
+++ b/packages/remnic-core/src/scopes/scope-plan.ts
@@ -490,6 +490,72 @@ export function resolveWritableNamespaceValue(
 }
 
 /**
+ * Inputs already derived by the access-service's read-only coding-context
+ * resolver. Keeping context discovery outside this pure function lets writes
+ * and preflight checks apply identical namespace and ACL rules.
+ */
+export interface ScopedWritableNamespaceInput {
+  readonly namespace?: string;
+  readonly sessionKey?: string;
+  readonly authenticatedPrincipal?: string;
+  readonly principal: string | undefined;
+  readonly codingOverlay: CodingNamespaceOverlay | null;
+  readonly scopeProfile: ResolvedScopeProfilePlan | null;
+  readonly config: PluginConfig;
+}
+
+/**
+ * Resolve the namespace an explicit write or implicit coding-scoped write
+ * would use. The caller supplies the same derived coding inputs for the real
+ * write and the read-only preflight.
+ */
+export function resolveScopedWritableNamespaceValue(
+  input: ScopedWritableNamespaceInput,
+): WritableNamespaceResult {
+  const requested = input.namespace?.trim();
+  if (requested) {
+    return resolveWritableNamespaceValue(
+      requested,
+      input.sessionKey,
+      input.authenticatedPrincipal,
+      input.config,
+    );
+  }
+  if (input.scopeProfile) {
+    const selectedLayer = input.scopeProfile.layers.find(
+      (layer) => layer.id === input.scopeProfile?.writeLayer,
+    );
+    const writeNamespaceReadable =
+      input.scopeProfile.writeNamespace.length > 0 &&
+      input.scopeProfile.readNamespaces.includes(input.scopeProfile.writeNamespace);
+    if (!selectedLayer?.writable || !writeNamespaceReadable) {
+      return {
+        ok: false,
+        reason: "not_writable",
+        namespace: input.scopeProfile.writeNamespace,
+      };
+    }
+    return { ok: true, namespace: input.scopeProfile.writeNamespace };
+  }
+  if (!input.codingOverlay) {
+    return resolveWritableNamespaceValue(
+      undefined,
+      input.sessionKey,
+      input.authenticatedPrincipal,
+      input.config,
+    );
+  }
+  const baseNamespace = defaultNamespaceForPrincipal(input.principal, input.config);
+  if (!canWriteNamespace(input.principal, baseNamespace, input.config)) {
+    return { ok: false, reason: "not_writable", namespace: baseNamespace };
+  }
+  return {
+    ok: true,
+    namespace: combineNamespaces(baseNamespace, input.codingOverlay.namespace),
+  };
+}
+
+/**
  * Namespace preflight (issue #1888 part 3): would a write to `namespace` by a
  * caller carrying `caps` succeed? Combines the token's write-op scope, its
  * namespace allow-list, and policy writability so one call answers the real


### PR DESCRIPTION
## Summary
- resolve namespace preflight through the same scoped write plan as observe and memory-store
- carry session, project, and working-directory context through HTTP and operation surfaces
- cover coding-scope and profile-layer preflight parity

## Verification
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication and namespace write gating across HTTP, batch ops, observe, and explicit writes; mis-scoping could allow writes to wrong tenants or deny legitimate project-scoped access.
> 
> **Overview**
> **Namespace writable preflight** is refactored into `access-namespace-preflight` and wired through HTTP `GET /engram/v1/namespace/writable` and the batch `namespace_writable` operation. Both surfaces now pass **session**, **projectTag**, **cwd**, and principal into `EngramAccessService.namespaceWritablePreflight`, which resolves writability via the same **coding-scoped write path** as `observe` / `memory_store` (using new pure helper `resolveScopedWritableNamespaceValue` in `scope-plan`).
> 
> **Authorization behavior changes:** token **namespace allow-lists** are enforced against the **effective** namespace returned by that scoped resolver (not only an explicit `?namespace=`), and real writes / observe scope planning call **`assertTokenCanWriteNamespace`** on the resolved write namespace. Invalid preflight `?op=` values return **HTTP 400** with an unsupported-operation message instead of being treated as observe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbf22981ded31e19346fc06df244bd9deda20a75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added coding-scoped, profile-aware `namespace_writable` preflight resolution for `observe` and `memory_store`.
  - Introduced a dedicated `namespaceWritablePreflight` service API that determines the effective writable namespace using session key, project tag, working directory, and the authenticated principal.
- **Bug Fixes**
  - Authorization is now enforced against the effective, preflight-resolved namespace.
  - Unsupported `namespace_writable` preflight `op` values now fail with HTTP 400 and a clear “unsupported namespace preflight operation” error.
- **Tests**
  - Expanded coverage for context forwarding, scoped namespace derivation, denial behavior, and unsupported `op` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->