### PR TITLE
feat(extraction): enable thinking for short local transcripts

### DIFF
--- a/.changeset/length-aware-local-thinking.md
+++ b/.changeset/length-aware-local-thinking.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": patch
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Enable local extraction thinking for short transcripts with the configurable `localLlmThinkingThresholdChars` threshold.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -669,7 +669,8 @@ Set `modelSource` to `plugin` (or remove it) to restore the original behavior wh
 | `localLlmFastModel` | `""` | Optional model id for the fast local tier |
 | `localLlmFastUrl` | `http://localhost:1234/v1` | Optional dedicated base URL for the fast local tier |
 | `localLlmFastTimeoutMs` | `15000` | Timeout for the fast local tier |
-| `localLlmDisableThinking` | `true` | Suppress chain-of-thought / thinking mode on the main local LLM by sending `chat_template_kwargs: { enable_thinking: false }` (issue #548). Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens; thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) commonly blow the 60s timeout before emitting content. Set to `false` to restore thinking for narrative tasks. The fast-tier client always disables thinking regardless of this flag. |
+| `localLlmDisableThinking` | `true` | Suppress thinking on supported local backends for extraction and other terse structured operations. Short extraction can opt back in through `localLlmThinkingThresholdChars`. Consolidation and the fast tier are unaffected. |
+| `localLlmThinkingThresholdChars` | `3000` | Enable thinking for local extraction only when the transcript is shorter than this length. Set to `0` to keep thinking suppressed for every extraction. Consolidation is unaffected. |
 | `localLlmHomeDir` | `(unset)` | Optional home-dir override used when resolving local helper binaries |
 | `localLmsCliPath` | `(auto)` | Path to `lms` CLI (LM Studio) |
 | `localLmsBinDir` | `(auto)` | LM Studio binary directory |
@@ -1494,7 +1495,8 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `localLlmFastModel` | `""` | `""` |
 | `localLlmFastUrl` | `http://localhost:1234/v1` | `http://localhost:1234/v1` |
 | `localLlmFastTimeoutMs` | `15000` | `15000` |
-| `localLlmDisableThinking` | `true` | `true` (skip reasoning tokens on structured extraction); set `false` if you want thinking on narrative tasks |
+| `localLlmDisableThinking` | `true` | `true` (suppress thinking except short extraction selected by `localLlmThinkingThresholdChars`) |
+| `localLlmThinkingThresholdChars` | `3000` | `3000`; set `0` to keep thinking suppressed for every extraction |
 | `hourlySummaryCronAutoRegister` | `false` | `false` |
 | `hourlySummariesExtendedEnabled` | `false` | `false` unless structured hourly summaries are useful |
 | `hourlySummariesIncludeToolStats` | `false` | `false` |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3033,7 +3033,13 @@
       "localLlmDisableThinking": {
         "type": "boolean",
         "default": true,
-        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is sent only when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+        "description": "When true (default), suppress thinking on supported local backends for extraction and other terse structured operations. `localLlmThinkingThresholdChars` re-enables thinking for short extractions. Consolidation and the fast tier are unaffected."
+      },
+      "localLlmThinkingThresholdChars": {
+        "type": "integer",
+        "minimum": 0,
+        "default": 3000,
+        "description": "Enable thinking for local extraction when the transcript is shorter than this many characters. Set to 0 to keep thinking suppressed for every extraction. Consolidation is unaffected."
       },
       "localLlmEnabled": {
         "type": "boolean",
@@ -6673,7 +6679,12 @@
     "localLlmDisableThinking": {
       "label": "Disable Local LLM Thinking Mode",
       "advanced": true,
-      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. The suppression field (chat_template_kwargs) is only sent when the backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
+      "help": "Suppress thinking for supported local extraction operations. Short extractions can opt back in with Local LLM Thinking Threshold. Consolidation and the fast tier are unaffected."
+    },
+    "localLlmThinkingThresholdChars": {
+      "label": "Local LLM Thinking Threshold (chars)",
+      "advanced": true,
+      "help": "Enable thinking only for local extraction transcripts shorter than this length. Set to 0 to suppress thinking for every extraction. Consolidation is unaffected."
     },
     "evalHarnessEnabled": {
       "label": "Evaluation Harness",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3033,7 +3033,13 @@
       "localLlmDisableThinking": {
         "type": "boolean",
         "default": true,
-        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is sent only when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+        "description": "When true (default), suppress thinking on supported local backends for extraction and other terse structured operations. `localLlmThinkingThresholdChars` re-enables thinking for short extractions. Consolidation and the fast tier are unaffected."
+      },
+      "localLlmThinkingThresholdChars": {
+        "type": "integer",
+        "minimum": 0,
+        "default": 3000,
+        "description": "Enable thinking for local extraction when the transcript is shorter than this many characters. Set to 0 to keep thinking suppressed for every extraction. Consolidation is unaffected."
       },
       "localLlmEnabled": {
         "type": "boolean",
@@ -6673,7 +6679,12 @@
     "localLlmDisableThinking": {
       "label": "Disable Local LLM Thinking Mode",
       "advanced": true,
-      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. The suppression field (chat_template_kwargs) is only sent when the backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
+      "help": "Suppress thinking for supported local extraction operations. Short extractions can opt back in with Local LLM Thinking Threshold. Consolidation and the fast tier are unaffected."
+    },
+    "localLlmThinkingThresholdChars": {
+      "label": "Local LLM Thinking Threshold (chars)",
+      "advanced": true,
+      "help": "Enable thinking only for local extraction transcripts shorter than this length. Set to 0 to suppress thinking for every extraction. Consolidation is unaffected."
     },
     "evalHarnessEnabled": {
       "label": "Evaluation Harness",

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -1179,6 +1179,13 @@ test('parseConfig localLlmDisableThinking "0"/"no"/"off" all coerce to false', (
   assert.equal(parseConfig({ localLlmDisableThinking: "off" }).localLlmDisableThinking, false);
 });
 
+test("parseConfig localLlmThinkingThresholdChars defaults conservatively and accepts zero to disable (#1997)", () => {
+  assert.equal(parseConfig({}).localLlmThinkingThresholdChars, 3_000);
+  assert.equal(parseConfig({ localLlmThinkingThresholdChars: 0 }).localLlmThinkingThresholdChars, 0);
+  assert.equal(parseConfig({ localLlmThinkingThresholdChars: "3000" }).localLlmThinkingThresholdChars, 3_000);
+  assert.equal(parseConfig({ localLlmThinkingThresholdChars: 3_000 }).localLlmThinkingThresholdChars, 3_000);
+});
+
 test("parseConfig procedural numeric fields coerce from CLI-style strings (issue #519)", () => {
   const result = parseConfig({
     openaiApiKey: "sk-test",

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2856,6 +2856,12 @@ export function parseConfig(
       ["", "none", "low", "medium", "high", "max"].includes(cfg.localLlmReasoningEffort)
         ? cfg.localLlmReasoningEffort
         : "none",
+    localLlmThinkingThresholdChars: (() => {
+      const threshold = coerceNumber(cfg.localLlmThinkingThresholdChars);
+      return threshold !== undefined && Number.isInteger(threshold) && threshold >= 0
+        ? threshold
+        : 3_000;
+    })(),
     // Extraction retry/backoff + circuit breaker (extraction hot-loop hardening)
     extractionRetryEnabled: coerceBooleanLike(cfg.extractionRetryEnabled) ?? true,
     extractionRetryScheduleMs:

--- a/packages/remnic-core/src/extraction-thinking.test.ts
+++ b/packages/remnic-core/src/extraction-thinking.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldEnableLocalExtractionThinking } from "./extraction.js";
+import type { PluginConfig } from "./types.js";
+
+function config(overrides: Partial<PluginConfig> = {}): PluginConfig {
+  return {
+    localLlmDisableThinking: true,
+    localLlmThinkingThresholdChars: 3_000,
+    ...overrides,
+  } as PluginConfig;
+}
+
+test("short local extraction enables thinking when configured (#1997)", () => {
+  assert.equal(shouldEnableLocalExtractionThinking(config(), 2_999), true);
+});
+
+test("length-aware local thinking stays disabled at the threshold and above (#1997)", () => {
+  assert.equal(shouldEnableLocalExtractionThinking(config(), 3_000), false);
+  assert.equal(shouldEnableLocalExtractionThinking(config(), 3_001), false);
+});
+
+test("disabled threshold and explicit global opt-out preserve existing behavior (#1997)", () => {
+  assert.equal(shouldEnableLocalExtractionThinking(config({ localLlmThinkingThresholdChars: 0 }), 1), false);
+  assert.equal(shouldEnableLocalExtractionThinking(config({ localLlmDisableThinking: false }), 1), false);
+});

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -147,6 +147,15 @@ function normalizeProfileUpdateKey(update: string): string {
   return update.trim().toLowerCase();
 }
 
+export function shouldEnableLocalExtractionThinking(
+  config: Pick<PluginConfig, "localLlmDisableThinking" | "localLlmThinkingThresholdChars">,
+  conversationChars: number,
+): boolean {
+  return config.localLlmDisableThinking &&
+    config.localLlmThinkingThresholdChars > 0 &&
+    conversationChars < config.localLlmThinkingThresholdChars;
+}
+
 export class ExtractionEngine {
   private client: OpenAI | null;
   private localLlm: LocalLlmClient;
@@ -1523,6 +1532,9 @@ ${truncatedConversation}`;
         temperature: 0.1,
         maxTokens: contextSizes.maxOutputTokens,
         operation: "extraction",
+        disableThinking: shouldEnableLocalExtractionThinking(this.config, conversation.length)
+          ? false
+          : undefined,
         priority: "background",
       },
     );

--- a/packages/remnic-core/src/local-llm-thinking.test.ts
+++ b/packages/remnic-core/src/local-llm-thinking.test.ts
@@ -83,7 +83,7 @@ function captureFetchBodies(): {
 async function runOneChatCompletion(
   client: LocalLlmClient,
   operation: string | null = "extraction",
-  options: { forceDisableThinking?: boolean } = {},
+  options: { forceDisableThinking?: boolean; disableThinking?: boolean } = {},
 ): Promise<void> {
   await client.chatCompletion(
     [{ role: "user", content: "hello" }],
@@ -343,4 +343,16 @@ test("disableThinking=false never injects chat_template_kwargs, regardless of ba
     restore();
   }
   assert.equal("chat_template_kwargs" in (bodies[0] ?? {}), false);
+});
+
+test("request-level thinking override leaves short extraction thinking enabled (#1997)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "ollama" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client, "extraction", { disableThinking: false });
+  } finally {
+    restore();
+  }
+  assert.equal("reasoning_effort" in (bodies[0] ?? {}), false);
 });

--- a/packages/remnic-core/src/local-llm.ts
+++ b/packages/remnic-core/src/local-llm.ts
@@ -220,6 +220,7 @@ interface LocalLlmChatCompletionOptions {
   timeoutMs?: number;
   operation?: string;
   forceDisableThinking?: boolean;
+  disableThinking?: boolean;
   priority?: LocalLlmRequestPriority;
 }
 
@@ -989,7 +990,7 @@ export class LocalLlmClient {
       // backend hasn't been positively identified as thinking-capable.
       const shouldSuppressThinking =
         options.forceDisableThinking === true ||
-        (this._disableThinking &&
+        ((options.disableThinking ?? this._disableThinking) &&
           THINKING_SUPPRESSED_OPERATIONS.has(operation));
       if (
         shouldSuppressThinking &&

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1624,6 +1624,12 @@ export interface PluginConfig extends BoundedJsonlStateConfig {
    *  `chat_template_kwargs`, so this is the only think-off dialect it honors.
    *  Issue #1996. */
   localLlmReasoningEffort: string;
+  /**
+   * Maximum transcript length that re-enables thinking for local extraction.
+   * Set to `0` to keep thinking suppressed for every extraction. Default:
+   * `3000`. Consolidation is unaffected.
+   */
+  localLlmThinkingThresholdChars: number;
   // Extraction retry/backoff + circuit breaker (extraction hot-loop hardening)
   /** Master gate. When false, restores pre-change behavior (extractor called on every triggered observe; no gate). */
   extractionRetryEnabled: boolean;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -3033,7 +3033,13 @@
       "localLlmDisableThinking": {
         "type": "boolean",
         "default": true,
-        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is sent only when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+        "description": "When true (default), suppress thinking on supported local backends for extraction and other terse structured operations. `localLlmThinkingThresholdChars` re-enables thinking for short extractions. Consolidation and the fast tier are unaffected."
+      },
+      "localLlmThinkingThresholdChars": {
+        "type": "integer",
+        "minimum": 0,
+        "default": 3000,
+        "description": "Enable thinking for local extraction when the transcript is shorter than this many characters. Set to 0 to keep thinking suppressed for every extraction. Consolidation is unaffected."
       },
       "localLlmEnabled": {
         "type": "boolean",
@@ -6673,7 +6679,12 @@
     "localLlmDisableThinking": {
       "label": "Disable Local LLM Thinking Mode",
       "advanced": true,
-      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. The suppression field (chat_template_kwargs) is only sent when the backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
+      "help": "Suppress thinking for supported local extraction operations. Short extractions can opt back in with Local LLM Thinking Threshold. Consolidation and the fast tier are unaffected."
+    },
+    "localLlmThinkingThresholdChars": {
+      "label": "Local LLM Thinking Threshold (chars)",
+      "advanced": true,
+      "help": "Enable thinking only for local extraction transcripts shorter than this length. Set to 0 to suppress thinking for every extraction. Consolidation is unaffected."
     },
     "evalHarnessEnabled": {
       "label": "Evaluation Harness",


### PR DESCRIPTION
## Summary
- select local extraction thinking only below a configurable transcript-length threshold
- expose the threshold in both plugin manifests and config documentation
- cover threshold boundaries, opt-out behavior, config coercion, and request propagation

## Verification
- `pnpm run sync:openclaw-plugin`
- `pnpm run check:openclaw-plugin-sync`
- `pnpm run check-config-contract`
- `pnpm exec tsx --test packages/remnic-core/src/local-llm-thinking.test.ts packages/remnic-core/src/extraction-thinking.test.ts packages/remnic-core/src/config.test.ts`
- `pnpm --filter @remnic/core run check-types`

Part of #1997.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes local extraction LLM request parameters (thinking on/off) based on transcript size; scope is limited to extraction and defaults preserve prior behavior for long transcripts, but short-buffer extraction quality and latency may shift.
> 
> **Overview**
> Adds **`localLlmThinkingThresholdChars`** (default `3000`) so local **extraction** can turn thinking back on for short transcripts while keeping it suppressed for longer ones when `localLlmDisableThinking` stays `true`. **`0`** keeps thinking off for every extraction; consolidation and the fast local tier are unchanged.
> 
> **`shouldEnableLocalExtractionThinking`** drives the rule: thinking is allowed only when global disable-thinking is on, the threshold is positive, and transcript length is **strictly below** the threshold. Local extraction passes **`disableThinking: false`** on those calls; otherwise it leaves the request unset so existing global suppression still applies.
> 
> **`LocalLlmClient`** now honors a per-request **`disableThinking`** override (`options.disableThinking ??` global flag) so short extractions can skip suppression without changing other operations. Config parsing, types, plugin manifests, and docs describe the new knob; tests cover threshold edges, opt-out, coercion, and request propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95cc62c98f7d7490c7696bd2ba6cafc250c70364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable threshold that enables local LLM thinking for shorter extraction transcripts.
  * Added configuration and UI guidance for controlling this behavior.
  * Preserved existing suppression behavior when the threshold is set to `0`.

* **Documentation**
  * Updated configuration references and recommended settings to explain the new threshold and its effect.

* **Bug Fixes**
  * Improved per-request handling of local LLM thinking preferences during extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->