### PR TITLE
test(extraction): cover four-case thinking matrix

### DIFF
--- a/packages/remnic-core/src/extraction-thinking.test.ts
+++ b/packages/remnic-core/src/extraction-thinking.test.ts
@@ -25,3 +25,20 @@ test("disabled threshold and explicit global opt-out preserve existing behavior 
   assert.equal(shouldEnableLocalExtractionThinking(config({ localLlmThinkingThresholdChars: 0 }), 1), false);
   assert.equal(shouldEnableLocalExtractionThinking(config({ localLlmDisableThinking: false }), 1), false);
 });
+
+test("four-transcript selection matrix keeps short sparse cases in thinking mode (#1997)", () => {
+  const cases = [
+    { name: "sparse commitment", transcript: "A".repeat(750), thinking: true },
+    { name: "sparse correction", transcript: "B".repeat(1_600), thinking: true },
+    { name: "dense technical discussion", transcript: "C".repeat(3_000), thinking: false },
+    { name: "dense multi-turn discussion", transcript: "D".repeat(6_000), thinking: false },
+  ];
+
+  for (const scenario of cases) {
+    assert.equal(
+      shouldEnableLocalExtractionThinking(config(), scenario.transcript.length),
+      scenario.thinking,
+      scenario.name,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add a deterministic four-transcript matrix for the length-aware local-extraction thinking decision
- retain thinking for short sparse cases and suppress it at or above the dense-transcript threshold

## Verification
- `pnpm --filter @remnic/core run check-types`
- `pnpm exec tsx --test packages/remnic-core/src/extraction-thinking.test.ts packages/remnic-core/src/local-llm-thinking.test.ts packages/remnic-core/src/config.test.ts`

Part of #1997.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production logic modified.
> 
> **Overview**
> Adds a single parameterized test in `extraction-thinking.test.ts` that exercises `shouldEnableLocalExtractionThinking` across four transcript lengths (750, 1_600, 3_000, 6_000 chars) with named scenarios, locking in that thinking stays on below the 3_000-char threshold and off at or above it.
> 
> No runtime or config behavior changes—only expanded test coverage for #1997.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2347ada28a3c34eae1c02271e2162e31d5a5bcd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for local extraction thinking behavior across transcript scenarios, including varying lengths, density, technical content, and conversation turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->