### PR TITLE
fix(bench): make answer support opt-in

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -91,26 +91,24 @@ At 7B-Q4 single-seed no cell moves any metric outside the run-to-run noise
 band, so no shipped default is changed by that ablation.
 
 The July 14 Tier-F `real` versus LCM-only `baseline` LoCoMo comparison and its
-July 16 current-main follow-up are diagnosed in
+current-main follow-ups are diagnosed in
 [`docs/benchmarks/locomo-profile-diagnosis.md`](./benchmarks/locomo-profile-diagnosis.md).
 The historical regression was concentrated in multi-hop questions and present
-on judge-independent F1. Current main's provider-free paired capture found no
-retrieval-structure delta across those 321 tasks, and the scored GPT-5.6 pair
-reduced the historical gap to -0.0067 `llm_judge` and -0.0044 F1 while moving
-`contains_answer` +0.0031. That result does not establish parity or a causal
-retrieval mechanism. The old `baseline` recommendation is therefore only
-historical reproduction guidance for the July 14 configuration, not current-
-main or production guidance, and no shipped default changes on this evidence.
+on judge-independent F1. A fresh current-main paired capture of the same 321
+tasks with the same model, judge, seed, and recall budget yielded
+`llm_judge` -0.0025 (14 real wins, 13 losses, 294 ties). The differing
+answers reused the same recalled evidence in sampled records, so the result
+does not establish a retrieval-side regression or causal mechanism. The old
+`baseline` recommendation is therefore historical reproduction guidance for
+the July 14 configuration, not current-main or production guidance, and no
+shipped default changes on this evidence.
 
-An answer-time support gate is available as a read-time faithfulness control.
-It defaults to `true` for the full-feature `real` profile and remains disabled
-for the stripped `baseline` profile. To disable it for an ablation, put the
-following top-level setting in the JSON passed to the existing
-`--remnic-config` option (a nested `remnic` object is also accepted):
+An answer-time support gate is available as an opt-in read-time faithfulness
+control. It must be enabled explicitly for either runtime profile:
 
 ```json
 {
-  "answerSupportGate": false
+  "answerSupportGate": true
 }
 ```
 

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -117,9 +117,8 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
   assert.equal(resolved.remnicConfig.authtoken, "[redacted]");
   assert.equal(resolved.remnicConfig.clientsecret, "[redacted]");
   assert.equal(resolved.remnicConfig.oauthToken, "[redacted]");
-  assert.equal(resolved.remnicConfig.sessionTokenCount, 3);
-  assert.equal(resolved.remnicConfig.answerSupportGate, true);
-  assert.equal(resolved.effectiveRemnicConfig.answerSupportGate, true);
+  assert.equal(resolved.remnicConfig.answerSupportGate, undefined);
+  assert.equal(resolved.effectiveRemnicConfig.answerSupportGate, undefined);
   assert.equal(resolved.effectiveRemnicConfig.openaiApiKey, "super-secret");
   assert.equal(resolved.effectiveRemnicConfig.secretKey, "secondary-secret");
   assert.equal(resolved.effectiveRemnicConfig.refreshToken, "oauth-refresh-token");

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -277,12 +277,6 @@ export async function resolveBenchRuntimeProfile(
       : {};
     const realProfileOverrides = {
       lcmEnabled: true,
-      // Read-time faithfulness is on by default for the full-feature profile.
-      // An explicit config value (including false-like strings) remains
-      // authoritative so benchmark operators can perform reversible ablations.
-      ...(fileConfig.answerSupportGate === undefined
-        ? { answerSupportGate: true }
-        : {}),
       ...(options.modelSource ? { modelSource: options.modelSource } : {}),
       ...(options.gatewayAgentId ? { gatewayAgentId: options.gatewayAgentId } : {}),
       ...(options.fastGatewayAgentId


### PR DESCRIPTION
## Summary
- stop enabling `answerSupportGate` implicitly for the real benchmark profile
- retain explicit support-gate configuration and document the opt-in contract
- record the fresh paired LoCoMo diagnosis: 321 matched tasks had a -0.0025 judge delta with 294 ties; sampled changes shared recalled evidence, so this does not establish a recall-side cause

## Verification
- `pnpm exec tsx --test packages/bench/src/runtime-profiles.test.ts`
- `pnpm --filter @remnic/bench check-types`
- paired 321-task LoCoMo run on the same commit, model, judge, seed, and task selector

Part of #1879.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to bench `real` profile defaults and benchmark documentation; explicit config and harness gate logic remain unchanged.
> 
> **Overview**
> **`answerSupportGate` is no longer turned on by default** for the bench `real` runtime profile. The harness only applies the read-time faithfulness gate when `answerSupportGate` is set explicitly in `--remnic-config` (or equivalent); explicit false-like values still win for ablations.
> 
> **Docs** now describe the gate as **opt-in for both profiles**, show `answerSupportGate: true` in the example, and refresh the LoCoMo `real` vs historical `baseline` narrative with a new 321-task paired run (`llm_judge` **-0.0025**, mostly ties) and the conclusion that sampled answer deltas reused the same recalled evidence—so no retrieval-side regression is claimed and no shipped defaults change on that evidence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf27c87a2cbeac055f13dbc9037091faf874139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the answer-support gate is an opt-in read-time faithfulness control.
  * Updated configuration examples and baseline comparisons to reflect the revised behavior.

* **Bug Fixes**
  * The real runtime profile now preserves the configured answer-support gate setting instead of enabling it automatically when unspecified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->