### PR TITLE
fix(plugin-openclaw): ship minified manifest to fit OpenClaw's 256 KiB cap

### DIFF
--- a/.changeset/openclaw-manifest-size-cap.md
+++ b/.changeset/openclaw-manifest-size-cap.md
@@ -1,0 +1,6 @@
+---
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Published packages now ship a minified openclaw.plugin.json: OpenClaw rejects plugin manifests at or above 256 KiB (MAX_PLUGIN_MANIFEST_BYTES) with "unsafe plugin manifest path (validation)", and the pretty-printed manifest crossed that cap, breaking every install on current hosts. A shared prepack/postpack script packs the compact form (with a 250,000-byte early-fail guard) while the committed manifest stays pretty-printed, and verify-openclaw-clawpack asserts the packed size stays under the host cap.

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -74,7 +74,9 @@
     "check-types": "tsc -p tsconfig.check.json",
     "plugin:inspect": "plugin-inspector check --config plugin-inspector.config.json --no-openclaw",
     "plugin:inspect:runtime": "pnpm run build && PLUGIN_INSPECTOR_EXECUTE_ISOLATED=1 plugin-inspector check --config plugin-inspector.config.json --no-openclaw --runtime --mock-sdk",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "prepack": "node ../../scripts/openclaw-manifest-pack.mjs minify",
+    "postpack": "node ../../scripts/openclaw-manifest-pack.mjs restore"
   },
   "dependencies": {
     "@remnic/core": "workspace:^",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -55,8 +55,9 @@
     "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "postinstall": "node ./scripts/postinstall-banner.mjs",
-    "prepack": "npm run build",
-    "prepublishOnly": "npm run build"
+    "prepack": "node ../../scripts/openclaw-manifest-pack.mjs minify",
+    "prepublishOnly": "npm run build",
+    "postpack": "node ../../scripts/openclaw-manifest-pack.mjs restore"
   },
   "dependencies": {
     "@remnic/core": "workspace:^",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -55,7 +55,7 @@
     "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "postinstall": "node ./scripts/postinstall-banner.mjs",
-    "prepack": "node ../../scripts/openclaw-manifest-pack.mjs minify",
+    "prepack": "npm run build && node ../../scripts/openclaw-manifest-pack.mjs minify",
     "prepublishOnly": "npm run build",
     "postpack": "node ../../scripts/openclaw-manifest-pack.mjs restore"
   },

--- a/scripts/openclaw-manifest-pack.mjs
+++ b/scripts/openclaw-manifest-pack.mjs
@@ -1,0 +1,47 @@
+/**
+ * Pack-time manifest minifier (issue: OpenClaw caps openclaw.plugin.json at
+ * 256 KiB via MAX_PLUGIN_MANIFEST_BYTES; the pretty-printed manifest crossed
+ * that cap at 9.15.x, so every install on current hosts failed with
+ * "unsafe plugin manifest path: ... (validation)").
+ *
+ * `prepack` swaps the committed pretty manifest for a compact serialization
+ * of the same document; `postpack` restores the pretty original so the git
+ * tree stays clean. The committed file remains pretty-printed for review.
+ */
+import { copyFileSync, readFileSync, renameSync, writeFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+const packageDir = process.cwd();
+const manifestPath = path.join(packageDir, "openclaw.plugin.json");
+const backupPath = path.join(packageDir, ".openclaw.plugin.json.prepack");
+
+// OpenClaw's MAX_PLUGIN_MANIFEST_BYTES is 256 KiB; fail earlier so schema
+// growth surfaces in CI before it breaks installs on real hosts.
+const HARD_CAP_BYTES = 256 * 1024;
+const FAIL_AT_BYTES = 250_000;
+
+const command = process.argv[2];
+
+if (command === "minify") {
+  const raw = readFileSync(manifestPath, "utf8");
+  const compact = `${JSON.stringify(JSON.parse(raw))}\n`;
+  const bytes = Buffer.byteLength(compact, "utf8");
+  if (bytes >= FAIL_AT_BYTES) {
+    console.error(
+      `openclaw.plugin.json is ${bytes} bytes even minified — OpenClaw rejects manifests >= ${HARD_CAP_BYTES} bytes ` +
+        `and this build fails at ${FAIL_AT_BYTES} to leave headroom. Shrink configSchema/uiHints before releasing.`,
+    );
+    process.exit(1);
+  }
+  copyFileSync(manifestPath, backupPath);
+  writeFileSync(manifestPath, compact);
+  console.log(`openclaw.plugin.json minified for pack: ${bytes} bytes (cap ${HARD_CAP_BYTES}).`);
+} else if (command === "restore") {
+  if (existsSync(backupPath)) {
+    renameSync(backupPath, manifestPath);
+    console.log("openclaw.plugin.json restored to the committed pretty form.");
+  }
+} else {
+  console.error("usage: manifest-pack.mjs <minify|restore>");
+  process.exit(1);
+}

--- a/scripts/openclaw-manifest-pack.mjs
+++ b/scripts/openclaw-manifest-pack.mjs
@@ -8,7 +8,7 @@
  * of the same document; `postpack` restores the pretty original so the git
  * tree stays clean. The committed file remains pretty-printed for review.
  */
-import { copyFileSync, readFileSync, renameSync, writeFileSync, existsSync } from "node:fs";
+import { copyFileSync, readFileSync, unlinkSync, writeFileSync, existsSync } from "node:fs";
 import path from "node:path";
 
 const packageDir = process.cwd();
@@ -33,13 +33,21 @@ if (command === "minify") {
     );
     process.exit(1);
   }
-  copyFileSync(manifestPath, backupPath);
+  // A leftover backup from a crashed pack holds the authoritative pretty
+  // form — never clobber it with a possibly already-minified manifest.
+  if (!existsSync(backupPath)) {
+    copyFileSync(manifestPath, backupPath);
+  }
   writeFileSync(manifestPath, compact);
   console.log(`openclaw.plugin.json minified for pack: ${bytes} bytes (cap ${HARD_CAP_BYTES}).`);
 } else if (command === "restore") {
   if (existsSync(backupPath)) {
-    renameSync(backupPath, manifestPath);
-    console.log("openclaw.plugin.json restored to the committed pretty form.");
+    // copy+unlink instead of rename: fs.renameSync cannot overwrite an
+    // existing destination on Windows (EEXIST) and the destination always
+    // exists here (it is the minified manifest).
+    copyFileSync(backupPath, manifestPath);
+    unlinkSync(backupPath);
+    console.log("openclaw.plugin.json reset to the committed pretty form.");
   }
 } else {
   console.error("usage: manifest-pack.mjs <minify|restore>");

--- a/scripts/verify-openclaw-clawpack.mjs
+++ b/scripts/verify-openclaw-clawpack.mjs
@@ -87,6 +87,21 @@ if (distFiles.length < 2) {
   fail(`${packageJson.name}@${packageJson.version} packlist only includes ${distFiles.length} dist file(s)`);
 }
 
+// OpenClaw rejects plugin manifests >= 256 KiB (MAX_PLUGIN_MANIFEST_BYTES) with
+// "unsafe plugin manifest path (validation)". The prepack minifier must keep the
+// packed manifest under that cap or every install on current hosts fails.
+const MANIFEST_CAP_BYTES = 256 * 1024;
+const manifestEntry = entries.find((entry) => entry.path === "openclaw.plugin.json");
+if (!manifestEntry || typeof manifestEntry.size !== "number") {
+  fail("npm pack output has no size for openclaw.plugin.json");
+}
+if (manifestEntry.size >= MANIFEST_CAP_BYTES) {
+  fail(
+    `packed openclaw.plugin.json is ${manifestEntry.size} bytes — OpenClaw rejects manifests >= ${MANIFEST_CAP_BYTES} bytes. ` +
+      "Ensure the prepack minifier ran and shrink configSchema/uiHints if the compact form still exceeds the cap.",
+  );
+}
+
 console.log(
   `Verified ${packageJson.name}@${packageJson.version} ClawPack packlist: ${files.size} files, ${distFiles.length} dist files.`,
 );


### PR DESCRIPTION
Part of #2115.

## Problem
OpenClaw enforces `MAX_PLUGIN_MANIFEST_BYTES = 256 * 1024` when safe-opening `openclaw.plugin.json`; anything larger fails as `unsafe plugin manifest path (validation)`. The committed pretty-printed manifest is ~289 KB, so **every ClawHub and npm install of the latest published plugin fails on current hosts**. Compact-serialized, the same document is ~212 KB — the overage is indentation.

## Fix
- Shared `scripts/openclaw-manifest-pack.mjs`: `prepack` swaps in the compact serialization (failing at 250,000 bytes so configSchema/uiHints growth surfaces in CI before it breaks real installs), `postpack` puts the committed pretty form back — the git tree stays clean and reviewable.
- Wired into **both** `@remnic/plugin-openclaw` and `packages/shim-openclaw-engram` (ships the same manifest at the same size).
- `verify-openclaw-clawpack.mjs` now asserts the packed manifest entry stays under the host cap (npm pack --dry-run runs the prepack lifecycle, so the assert exercises the minifier).

## Verification
- `node scripts/verify-openclaw-clawpack.mjs` → `Verified @remnic/plugin-openclaw@9.15.3 ClawPack packlist: 7 files, 2 dist files.` with the new size assert active (pretty form would fail it at 288,765 bytes; packed form passes at ~212 KB).
- Shim `npm pack --dry-run --json` → packed `openclaw.plugin.json` 213,406 bytes.
- Clean `git status` after packing (postpack round-trip verified).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pack-time JSON minification and verify-only size checks; no runtime or manifest schema semantics changed.
> 
> **Overview**
> Fixes **broken installs** on current OpenClaw hosts: pretty-printed `openclaw.plugin.json` exceeded the host **256 KiB** manifest limit, so validation failed on every ClawHub/npm install.
> 
> Adds **`scripts/openclaw-manifest-pack.mjs`**, wired via **`prepack` / `postpack`** on `@remnic/plugin-openclaw` and `@joshuaswarren/openclaw-engram`: pack swaps in compact JSON (same document), then restores the pretty file so git stays reviewable. Minify **fails at 250,000 bytes** so schema growth is caught in CI before it hits the host cap.
> 
> **`verify-openclaw-clawpack.mjs`** now asserts the packed manifest entry stays under 256 KiB (dry-run pack runs prepack, so CI exercises the minifier).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f74dafaff5e138fba40d614cad1cb8eedc4c9e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenClaw plugin packaging to prevent installation failures caused by oversized manifests.
  * Published plugin manifests are now compacted and verified to remain below the 256 KiB limit.
  * Added safeguards to detect packaging issues before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->