### PR TITLE
fix(core): route LCM summarization through the fast local-LLM lane

### DIFF
--- a/.changeset/lcm-summarize-fast-lane.md
+++ b/.changeset/lcm-summarize-fast-lane.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+LCM summarization now uses the fast local-LLM lane (localLlmFastUrl/localLlmFastModel) instead of the main extraction model. The summarize closure's local branch called the heavy main client, so on deployments where the main model is a large remote model, every lcm-summarize call inherited multi-minute prefill latency — blowing pre-compaction flush budgets (session_before_compact handler timeouts on effectively every compaction) and holding main-lane slots that extraction needed. The gateway branch already used its fast counterpart; the local branch now matches. When the fast lane is disabled, behavior is unchanged (fastLlm falls back to the main client).

--- a/packages/remnic-core/src/lcm-summarize-lane.test.ts
+++ b/packages/remnic-core/src/lcm-summarize-lane.test.ts
@@ -14,12 +14,18 @@ interface LcmEngineTestSurface {
   summarizeFn: SummarizeFn;
 }
 
+interface ChatStub {
+  url: string;
+  hits: () => number;
+  close: () => Promise<void>;
+}
+
 /**
  * Minimal OpenAI-compatible chat stub that records how often it served a
  * completion. Both lanes get one so the test can observe which client the
  * LCM summarize closure actually uses.
  */
-async function startChatStub(label: string): Promise<{ url: string; hits: () => number; close: () => Promise<void> }> {
+async function startChatStub(label: string): Promise<ChatStub> {
   let hits = 0;
   const server = http.createServer((req, res) => {
     let body = "";
@@ -44,10 +50,19 @@ async function startChatStub(label: string): Promise<{ url: string; hits: () => 
     });
   });
   const listening = Promise.withResolvers<void>();
+  server.once("error", listening.reject);
   server.listen(0, "127.0.0.1", listening.resolve);
-  await listening.promise;
+  try {
+    await listening.promise;
+  } catch (err) {
+    server.close();
+    throw err;
+  }
   const address = server.address();
-  if (address === null || typeof address !== "object") throw new Error("stub did not bind");
+  if (address === null || typeof address !== "object") {
+    server.close();
+    throw new Error("stub did not bind");
+  }
   return {
     url: `http://127.0.0.1:${address.port}/v1`,
     hits: () => hits,
@@ -61,9 +76,11 @@ async function startChatStub(label: string): Promise<{ url: string; hits: () => 
 
 test("LCM summarize uses the fast local-LLM lane when configured (latency contract)", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lcm-lane-"));
-  const mainStub = await startChatStub("main");
-  const fastStub = await startChatStub("fast");
+  let mainStub: ChatStub | null = null;
+  let fastStub: ChatStub | null = null;
   try {
+    mainStub = await startChatStub("main");
+    fastStub = await startChatStub("fast");
     const config = parseConfig({
       memoryDir,
       qmdEnabled: false,
@@ -85,16 +102,17 @@ test("LCM summarize uses the fast local-LLM lane when configured (latency contra
     assert.equal(fastStub.hits(), 1, "fast lane serves the LCM summarize call");
     assert.equal(mainStub.hits(), 0, "the heavy main extraction lane must not serve lcm-summarize");
   } finally {
-    await mainStub.close();
-    await fastStub.close();
+    await mainStub?.close();
+    await fastStub?.close();
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
 
 test("LCM summarize falls back to the main client when the fast lane is disabled", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lcm-lane-fallback-"));
-  const mainStub = await startChatStub("main");
+  let mainStub: ChatStub | null = null;
   try {
+    mainStub = await startChatStub("main");
     const config = parseConfig({
       memoryDir,
       qmdEnabled: false,
@@ -113,7 +131,7 @@ test("LCM summarize falls back to the main client when the fast lane is disabled
     assert.equal(result, "summary from main", "with no fast lane the main client serves the call");
     assert.equal(mainStub.hits(), 1);
   } finally {
-    await mainStub.close();
+    await mainStub?.close();
     await rm(memoryDir, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/lcm-summarize-lane.test.ts
+++ b/packages/remnic-core/src/lcm-summarize-lane.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import http from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { parseConfig } from "./config.js";
+import { Orchestrator } from "./orchestrator.js";
+
+type SummarizeFn = (text: string, targetTokens: number, aggressive: boolean) => Promise<string | null>;
+
+interface LcmEngineTestSurface {
+  summarizeFn: SummarizeFn;
+}
+
+/**
+ * Minimal OpenAI-compatible chat stub that records how often it served a
+ * completion. Both lanes get one so the test can observe which client the
+ * LCM summarize closure actually uses.
+ */
+async function startChatStub(label: string): Promise<{ url: string; hits: () => number; close: () => Promise<void> }> {
+  let hits = 0;
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      if (req.url?.endsWith("/chat/completions")) {
+        hits += 1;
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            choices: [{ message: { role: "assistant", content: `summary from ${label}` }, finish_reason: "stop" }],
+            usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14 },
+          }),
+        );
+        return;
+      }
+      // Model detection / health probes: report a single model per lane.
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ data: [{ id: `${label}-model` }], object: "list" }));
+    });
+  });
+  const listening = Promise.withResolvers<void>();
+  server.listen(0, "127.0.0.1", listening.resolve);
+  await listening.promise;
+  const address = server.address();
+  if (address === null || typeof address !== "object") throw new Error("stub did not bind");
+  return {
+    url: `http://127.0.0.1:${address.port}/v1`,
+    hits: () => hits,
+    close: () => {
+      const closed = Promise.withResolvers<void>();
+      server.close(() => closed.resolve());
+      return closed.promise;
+    },
+  };
+}
+
+test("LCM summarize uses the fast local-LLM lane when configured (latency contract)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lcm-lane-"));
+  const mainStub = await startChatStub("main");
+  const fastStub = await startChatStub("fast");
+  try {
+    const config = parseConfig({
+      memoryDir,
+      qmdEnabled: false,
+      lcmEnabled: true,
+      localLlmEnabled: true,
+      localLlmUrl: mainStub.url,
+      localLlmModel: "main-model",
+      localLlmFastEnabled: true,
+      localLlmFastUrl: fastStub.url,
+      localLlmFastModel: "fast-model",
+    });
+    const orchestrator = new Orchestrator(config);
+    assert.ok(orchestrator.lcmEngine, "LCM engine must exist with lcmEnabled");
+    const summarizeFn = (orchestrator.lcmEngine as unknown as LcmEngineTestSurface).summarizeFn;
+
+    const result = await summarizeFn("A conversation segment worth compressing.", 64, false);
+
+    assert.equal(result, "summary from fast", "the summary must come from the fast lane");
+    assert.equal(fastStub.hits(), 1, "fast lane serves the LCM summarize call");
+    assert.equal(mainStub.hits(), 0, "the heavy main extraction lane must not serve lcm-summarize");
+  } finally {
+    await mainStub.close();
+    await fastStub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("LCM summarize falls back to the main client when the fast lane is disabled", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lcm-lane-fallback-"));
+  const mainStub = await startChatStub("main");
+  try {
+    const config = parseConfig({
+      memoryDir,
+      qmdEnabled: false,
+      lcmEnabled: true,
+      localLlmEnabled: true,
+      localLlmUrl: mainStub.url,
+      localLlmModel: "main-model",
+      localLlmFastEnabled: false,
+    });
+    const orchestrator = new Orchestrator(config);
+    assert.ok(orchestrator.lcmEngine, "LCM engine must exist with lcmEnabled");
+    const summarizeFn = (orchestrator.lcmEngine as unknown as LcmEngineTestSurface).summarizeFn;
+
+    const result = await summarizeFn("A conversation segment worth compressing.", 64, false);
+
+    assert.equal(result, "summary from main", "with no fast lane the main client serves the call");
+    assert.equal(mainStub.hits(), 1);
+  } finally {
+    await mainStub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1724,7 +1724,7 @@ export class Orchestrator {
                   ? { agentId: this.config.fastGatewayAgentId }
                   : gatewayTaskChainOptions(this.config)),
               })
-            : await this.localLlm.chatCompletion(messages, {
+            : await this.fastLlm.chatCompletion(messages, {
                 maxTokens: targetTokens * 2,
                 operation: "lcm-summarize",
                 priority: "background",


### PR DESCRIPTION
Part of #2117.

## Problem
The LCM `summarizeFn`'s local branch calls `this.localLlm` (heavy main extraction client) while the gateway branch already routes to its fast counterpart. Where the main model is large/remote, every `op=lcm-summarize` inherits multi-minute prefill: host `session_before_compact` handlers hit their 30s caps on essentially every compaction (pre-compaction flushes lost), `lcm_compaction_flush` RPCs blow 60s client timeouts, and lcm traffic occupies main-lane capacity extraction needs.

## Fix
One-line lane change: the local branch now uses `this.fastLlm` ("low latency at all costs" contract, thinking suppressed). `fastLlm` falls back to the main client when the fast lane is disabled, so disabled-lane deployments are byte-for-byte unchanged.

## Tests
New `lcm-summarize-lane.test.ts` (two recording OpenAI-compatible stubs, one per lane, real `Orchestrator` over a temp memoryDir):
- fast lane configured → summary served by the fast stub, main stub 0 hits (**fails without the fix**: 'summary from main')
- fast lane disabled → main client serves it (fallback contract, passes before and after)

Red/green verified by stashing the orchestrator change: 1 fail / 1 pass without it, 2/2 with it. `npm run test:entity-hardening` green (orchestrator touched).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line routing change in the LCM summarize closure with explicit fallback behavior and new integration tests; no auth or data-model changes.
> 
> **Overview**
> **LCM summarization** on the local model path now calls **`fastLlm`** instead of **`localLlm`**, aligning with the gateway branch that already used the fast tier. That keeps `op=lcm-summarize` off the heavy extraction model so pre-compaction flushes and compaction RPCs are less likely to hit multi-minute prefill and timeout budgets.
> 
> When **`localLlmFastEnabled`** is off, **`fastLlm`** still points at the main client, so behavior stays the same as before.
> 
> Adds **`lcm-summarize-lane.test.ts`** with dual HTTP stubs to assert the fast stub serves summarize when the fast lane is configured and the main stub serves it when the fast lane is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f5859582d3a18ebf49ab0cd7b152d825e4bb064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * LCM summarization now uses the fast local language-model lane when enabled, reducing delays for deployments using large primary models.
  * Automatically falls back to the primary model when the fast lane is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->