### PR TITLE
fix(offline-sync): decode canonical token dirs in namespace enumeration

### DIFF
--- a/.changeset/2125-offline-sync-token-dir-enumeration.md
+++ b/.changeset/2125-offline-sync-token-dir-enumeration.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Fix offline-sync root snapshot-stream 500 (`unsafe namespace`) on canonical token directories. `listOfflineSyncNamespaces` now decodes `ns-<hex>` canonical token dirs back to their namespace name (matching the catalog rebuild scanner) and skips any filesystem-derived name the router would reject, so a namespace stored in a token dir whose basename exceeds the 64-char `isSafeRouteNamespace` cap (e.g. a `project-origin-<hash>` scope) no longer aborts the whole `GET /remnic/v1/offline-sync/snapshot-stream`. The root-snapshot lifecycle-drain fanout also degrades to draining the remaining namespaces instead of failing the snapshot when one namespace cannot be resolved. Part of #2125.

--- a/packages/remnic-core/src/offline-sync-impression-drain.test.ts
+++ b/packages/remnic-core/src/offline-sync-impression-drain.test.ts
@@ -326,7 +326,12 @@ test("listOfflineSyncNamespaces decodes canonical token dirs and skips names the
     const longName = "generalist-project-origin-6d1ad1f2";
     const longToken = namespaceIdentityToken(longName); // ns-<hex>, 71 chars
     assert.ok(longToken.length > 64, "token dir must exceed the route-namespace cap");
-    for (const dir of [longToken, "blend"]) {
+    // A namespace whose DECODED name itself exceeds the 64-char route cap:
+    // decoding succeeds but isSafeRouteNamespace must still reject it.
+    const overCapName = `generalist-project-tag-${"x".repeat(60)}`;
+    const overCapToken = namespaceIdentityToken(overCapName);
+    assert.ok(overCapName.length > 64, "decoded name must exceed the route cap");
+    for (const dir of [longToken, overCapToken, "blend", "ns-default"]) {
       await mkdir(path.join(root, "namespaces", dir, "state"), { recursive: true });
       await writeFile(
         path.join(root, "namespaces", dir, LIFECYCLE_LEDGER_REL),
@@ -350,8 +355,15 @@ test("listOfflineSyncNamespaces decodes canonical token dirs and skips names the
     assert.ok(names.has(longName), "canonical token dir must be decoded to its namespace name");
     // ...never surfaced as the raw >64-char token that getStorage would reject.
     assert.ok(!names.has(longToken), "raw over-cap token must never be enumerated as a namespace");
+    // A decoded name that is ITSELF over the route cap is skipped entirely
+    // (the isSafeRouteNamespace rejection branch).
+    assert.ok(!names.has(overCapName), "over-cap decoded name must be skipped");
+    assert.ok(!names.has(overCapToken), "over-cap raw token must be skipped");
     // A raw plain-named dir is used verbatim.
     assert.ok(names.has("blend"), "plain namespace dir must be enumerated verbatim");
+    // The literal ns-default token decodes to the EMPTY default identity and
+    // must map to the configured default namespace, not be skipped as "".
+    assert.ok(names.has("generalist"), "ns-default dir maps to the configured default namespace");
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/offline-sync-impression-drain.test.ts
+++ b/packages/remnic-core/src/offline-sync-impression-drain.test.ts
@@ -8,7 +8,9 @@ import {
   drainPendingImpressionsForOfflineSync,
   drainPendingLifecycleForOfflineSync,
   getOfflineSyncStorage,
+  listOfflineSyncNamespaces,
 } from "./offline-sync-impression-drain.js";
+import { namespaceIdentityToken } from "./namespaces/identity.js";
 import { isEncryptedFile } from "./secure-store/secure-fs.js";
 import { StorageManager } from "./storage.js";
 
@@ -313,4 +315,44 @@ test("getOfflineSyncStorage never double-folds the root ledger when it is listed
   await getOfflineSyncStorage(orchestrator, "root");
 
   assert.deepEqual(lifecycleDrains, ["root", "team"], "root ledger is folded exactly once");
+});
+
+test("listOfflineSyncNamespaces decodes canonical token dirs and skips names the router would reject", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-offline-ns-enum-"));
+  try {
+    // A project namespace whose canonical token dir `ns-<hex>` exceeds the
+    // 64-char route-namespace cap: `getStorage` on the RAW basename throws
+    // `unsafe namespace` and 500s the whole root snapshot-stream (the regression).
+    const longName = "generalist-project-origin-6d1ad1f2";
+    const longToken = namespaceIdentityToken(longName); // ns-<hex>, 71 chars
+    assert.ok(longToken.length > 64, "token dir must exceed the route-namespace cap");
+    for (const dir of [longToken, "blend"]) {
+      await mkdir(path.join(root, "namespaces", dir, "state"), { recursive: true });
+      await writeFile(
+        path.join(root, "namespaces", dir, LIFECYCLE_LEDGER_REL),
+        "",
+        "utf-8",
+      );
+    }
+    const host = {
+      config: {
+        memoryDir: root,
+        defaultNamespace: "generalist",
+        sharedNamespace: "shared",
+        namespacePolicies: [],
+      },
+      namespaceCatalog: { listNamespaces: async () => [] },
+    } as unknown as Parameters<typeof listOfflineSyncNamespaces>[0];
+
+    const names = new Set(await listOfflineSyncNamespaces(host));
+
+    // The canonical token dir is decoded back to its namespace NAME...
+    assert.ok(names.has(longName), "canonical token dir must be decoded to its namespace name");
+    // ...never surfaced as the raw >64-char token that getStorage would reject.
+    assert.ok(!names.has(longToken), "raw over-cap token must never be enumerated as a namespace");
+    // A raw plain-named dir is used verbatim.
+    assert.ok(names.has("blend"), "plain namespace dir must be enumerated verbatim");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-core/src/offline-sync-impression-drain.ts
+++ b/packages/remnic-core/src/offline-sync-impression-drain.ts
@@ -136,7 +136,16 @@ export async function listOfflineSyncNamespaces(host: OfflineSyncNamespaceHost):
       // 64-char cap — because getStorage() would throw `unsafe namespace` and 500
       // the whole root snapshot-stream (the offline-sync regression this fixes).
       const dirName = path.basename(namespaceDir);
-      const name = namespaceIdentityFromToken(dirName) ?? dirName;
+      // namespaceIdentityFromToken returns "" for the ns-default token (the
+      // default-namespace identity) — map that to the configured default
+      // namespace instead of skipping the directory as an unsafe empty name.
+      const decoded = namespaceIdentityFromToken(dirName);
+      const name =
+        decoded === null
+          ? dirName
+          : decoded.length > 0
+            ? decoded
+            : host.config.defaultNamespace;
       if (isSafeRouteNamespace(name)) {
         names.add(name);
       }

--- a/packages/remnic-core/src/offline-sync-impression-drain.ts
+++ b/packages/remnic-core/src/offline-sync-impression-drain.ts
@@ -12,6 +12,8 @@ import { isErrnoCode } from "./utils/errno.js";
 import { assertPathInsideRoot, pathIsInside } from "./utils/path-containment.js";
 import { displayErrorDetail } from "./runtime/better-sqlite.js";
 import { getConfiguredNamespaces } from "./scopes/scope-plan.js";
+import { isSafeRouteNamespace } from "./routing/engine.js";
+import { namespaceIdentityFromToken } from "./namespaces/identity.js";
 import type { PluginConfig } from "./types.js";
 
 type PendingImpressionDrain = () => Promise<{ pendingDeferred: boolean }>;
@@ -89,7 +91,17 @@ export async function getOfflineSyncStorage<T extends PendingLifecycleDrain & { 
   if (path.resolve(storage.dir) === memoryRoot && orchestrator.listOfflineSyncNamespaces) {
     const drained = new Set<string>([memoryRoot]);
     for (const ns of await orchestrator.listOfflineSyncNamespaces()) {
-      const nsStorage = await orchestrator.getStorage(ns);
+      // A single unresolvable namespace (e.g. a legacy canonical token dir whose
+      // name exceeds the route-namespace length cap) must not abort the whole root
+      // snapshot — degrade to draining the rest. listOfflineSyncNamespaces already
+      // normalizes token dirs, so this is defense-in-depth.
+      let nsStorage: T;
+      try {
+        nsStorage = await orchestrator.getStorage(ns);
+      } catch (err) {
+        log.debug(`offline-sync root drain: skipping namespace ${ns} (non-fatal): ${err}`);
+        continue;
+      }
       const nsDir = path.resolve(nsStorage.dir);
       if (drained.has(nsDir)) continue;
       drained.add(nsDir);
@@ -114,8 +126,19 @@ export async function listOfflineSyncNamespaces(host: OfflineSyncNamespaceHost):
   try {
     for (const ledgerPath of await offlineSyncLifecycleLedgerPaths(host.config.memoryDir)) {
       const namespaceDir = path.dirname(path.dirname(ledgerPath));
-      if (path.basename(path.dirname(namespaceDir)) === "namespaces") {
-        names.add(path.basename(namespaceDir));
+      if (path.basename(path.dirname(namespaceDir)) !== "namespaces") continue;
+      // A namespace is stored under its canonical token dir `ns-<hex>`. Decode the
+      // token back to the namespace NAME so the drain fanout resolves the SAME
+      // storage the token dir belongs to (the catalog rebuild scanner decodes the
+      // same way, catalog.ts finishRebuild). A raw dir already named as a plain
+      // namespace is used verbatim. Skip any name the router would reject — e.g. a
+      // canonical token dir whose decoded-or-raw name exceeds isSafeRouteNamespace's
+      // 64-char cap — because getStorage() would throw `unsafe namespace` and 500
+      // the whole root snapshot-stream (the offline-sync regression this fixes).
+      const dirName = path.basename(namespaceDir);
+      const name = namespaceIdentityFromToken(dirName) ?? dirName;
+      if (isSafeRouteNamespace(name)) {
+        names.add(name);
       }
     }
   } catch {


### PR DESCRIPTION
## What

Fixes the offline-sync `GET /remnic/v1/offline-sync/snapshot-stream` 500 (`unsafe namespace: ns-<hex>`) that breaks pulling the default (root) namespace when the memory root stores a namespace in its canonical token dir `namespaces/ns-<hex>` whose basename exceeds the 64-char `isSafeRouteNamespace` cap (a `project-origin-<hash>`/`project-tag-<name>` scope tokenizes to `ns-` + 68+ hex chars = 71+ chars).

## Root cause

`packages/remnic-core/src/offline-sync-impression-drain.ts`

- `listOfflineSyncNamespaces` derived namespace **names** from raw `namespaces/<dir>` basenames, without decoding canonical `ns-<hex>` tokens or validating them.
- The default namespace resolves `storage.dir === memoryRoot`, so `getOfflineSyncStorage` fans out the per-namespace lifecycle-ledger drain and calls `getStorage(rawBasename)`.
- `getStorage` -> `storage.ts` `isSafeRouteNamespace` rejects the 71-char raw token -> throw -> whole snapshot-stream 500s every loop.

The catalog rebuild scanner already decodes these tokens (`namespaces/catalog.ts` finishRebuild via `namespaceIdentityFromToken`); the offline-sync drain did not.

## Change

- Decode `ns-<hex>` basenames via `namespaceIdentityFromToken` (same as the catalog scanner); use plain-named dirs verbatim; skip any name that is not a safe route namespace.
- Defense-in-depth: the root-snapshot drain fanout now degrades to draining the remaining namespaces (logged at debug) instead of aborting the whole snapshot when one namespace cannot be resolved.
- Pure bug fix -> no config gate (default-on is the correct behavior); no new config keys, so no manifest/parsed-keys changes.

## Tests

- New regression test `listOfflineSyncNamespaces decodes canonical token dirs and skips names the router would reject` (fails on the old code: raw >64-char token enumerated, decoded name absent).
- `tsx --test src/offline-sync-impression-drain.test.ts` -> 13/13 pass.
- `npm run test:entity-hardening` -> 259/259 pass.
- `tsc -p packages/remnic-core/tsconfig.json --noEmit` -> clean.

Part of #2125.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offline-sync root snapshot namespace discovery and multi-namespace lifecycle draining; behavior is more permissive (skip bad entries) but affects sync completeness for edge-case namespaces.
> 
> **Overview**
> Fixes **root offline-sync snapshot-stream** failures (`unsafe namespace`) when namespaces live under canonical `ns-<hex>` directories whose raw basename exceeds the 64-character route cap.
> 
> **`listOfflineSyncNamespaces`** no longer treats `namespaces/<dir>` basenames as namespace names verbatim. It decodes `ns-<hex>` dirs via `namespaceIdentityFromToken` (aligned with the catalog rebuild scanner), keeps plain dir names as-is, maps `ns-default` to the configured default namespace, and only adds names that pass **`isSafeRouteNamespace`**—so over-cap raw tokens or decoded names are omitted instead of being passed to `getStorage`.
> 
> For **root snapshot lifecycle drain fanout**, a single namespace that still fails `getStorage` is skipped with a debug log and the drain continues for the rest, rather than aborting the whole snapshot.
> 
> Adds a regression test covering long token dirs, over-cap decoded names, plain dirs, and `ns-default` → default namespace mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fcf8f4d51a73ff5029b985bac6dfe5dcf95c5dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed offline sync root snapshot failures caused by namespaces stored in canonical token directories.
  * Correctly restores namespace names from encoded directory names while ignoring invalid or unsafe entries.
  * Root snapshot processing now continues draining other namespaces when one cannot be resolved, preventing the entire operation from failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->