### PR TITLE
fix(bench): control paired LoCoMo responder variance

### DIFF
--- a/packages/bench/src/adapters/timeout-guard.test.ts
+++ b/packages/bench/src/adapters/timeout-guard.test.ts
@@ -323,6 +323,47 @@ test("timeout guard wraps responder and judge calls", async () => {
   assert.equal(await guarded.judge?.score("q", "p", "e"), 1);
 });
 
+test("timeout guard forwards responder identity when the inner responder declares one", () => {
+  const adapter = makeAdapter();
+  adapter.responder = {
+    async respond() {
+      return {
+        text: "answer",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 1,
+        model: "fake",
+      };
+    },
+    identity() {
+      return "responder:fake";
+    },
+  };
+  const guarded = createTimeoutGuardedAdapter(adapter, {
+    benchmarkId: "timeout-test",
+    timeoutMs: 100,
+  });
+  assert.equal(guarded.responder?.identity?.(), "responder:fake");
+});
+
+test("timeout guard omits responder identity when the inner responder has none", () => {
+  const adapter = makeAdapter();
+  adapter.responder = {
+    async respond() {
+      return {
+        text: "answer",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 1,
+        model: "fake",
+      };
+    },
+  };
+  const guarded = createTimeoutGuardedAdapter(adapter, {
+    benchmarkId: "timeout-test",
+    timeoutMs: 100,
+  });
+  assert.equal(guarded.responder?.identity, undefined);
+});
+
 test("timeout guard merges caller abort signal for responder calls", async () => {
   const adapter = makeAdapter();
   let sawAbort = false;

--- a/packages/bench/src/adapters/timeout-guard.ts
+++ b/packages/bench/src/adapters/timeout-guard.ts
@@ -391,7 +391,7 @@ function wrapResponder(
   responder: BenchResponder,
   run: <T>(phase: string, fn: (signal: AbortSignal) => Promise<T>) => Promise<T>,
 ): BenchResponder {
-  return {
+  const wrapped: BenchResponder = {
     respond(question, recalledText, control) {
       return run("respond", async (signal) => {
         const merged = mergeBenchPhaseControl(signal, control);
@@ -403,6 +403,11 @@ function wrapResponder(
       });
     },
   };
+  if (typeof responder.identity === "function") {
+    const inner = responder.identity.bind(responder);
+    wrapped.identity = () => inner();
+  }
+  return wrapped;
 }
 
 function wrapJudge(

--- a/packages/bench/src/adapters/types.ts
+++ b/packages/bench/src/adapters/types.ts
@@ -71,6 +71,15 @@ export interface BenchResponder {
     recalledText: string,
     control?: BenchPhaseControl,
   ): Promise<BenchResponse>;
+  /**
+   * Deterministic non-secret fingerprint of the responder's identity
+   * (e.g. model name + provider base URL hash). Used by the published
+   * harness to pin paired-run replay keys to a concrete responder so a
+   * pair of systems with no `systemProvider` cannot cross-replay through
+   * a shared cache. Optional: responders that do not declare an identity
+   * disable the replay cache and always invoke `respond` directly.
+   */
+  identity?(): string;
 }
 
 export interface BenchJudgeResult {

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -15,6 +15,7 @@ function makeFakeSystem(opts?: {
   judgeScore?: number;
   responderModel?: string;
   judgeModel?: string;
+  omitResponderIdentity?: boolean;
 }) {
   const calls: Array<
     | { kind: "reset" }
@@ -59,6 +60,13 @@ function makeFakeSystem(opts?: {
           model: opts?.responderModel ?? "smoke-responder",
         };
       },
+      ...(opts?.omitResponderIdentity
+        ? {}
+        : {
+            identity() {
+              return `responder:${opts?.responderModel ?? "smoke-responder"}`;
+            },
+          }),
     },
     judge: {
       async score() {
@@ -389,6 +397,65 @@ test("runPublishedHarness postAnswerHook runs between answer and judge", async (
   assert.ok(calls.some((call) => call.kind === "search"));
 });
 
+
+test("runPublishedHarness skips the replay cache when the responder omits an identity", async () => {
+  const baseline = makeFakeSystem({
+    recallPrefix: "shared",
+    responderModel: "baseline-responder",
+    omitResponderIdentity: true,
+  });
+  const real = makeFakeSystem({
+    recallPrefix: "shared",
+    responderModel: "real-responder",
+    omitResponderIdentity: true,
+  });
+  let baselineResponds = 0;
+  let realResponds = 0;
+  baseline.system.responder.respond = async () => {
+    baselineResponds++;
+    return {
+      text: "baseline answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "baseline-responder",
+    };
+  };
+  real.system.responder.respond = async () => {
+    realResponds++;
+    return {
+      text: "real answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "real-responder",
+    };
+  };
+  const pairedAnswerReplayCache = new Map();
+  const plan: HarnessPlan = {
+    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
+    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
+  };
+  const run = (
+    system: typeof baseline.system,
+    runtimeProfile: "baseline" | "real",
+  ) =>
+    runPublishedHarness({
+      options: makeOptions(system, {
+        pairedAnswerReplayCache,
+        runtimeProfile,
+      }),
+      metricsSpec: { metrics: ["f1"] },
+      plans: [plan],
+    });
+
+  const baselineResult = await run(baseline.system, "baseline");
+  const realResult = await run(real.system, "real");
+
+  assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
+  assert.equal(realResult.results.tasks[0]?.actual, "real answer");
+  assert.equal(baselineResponds, 1, "baseline must invoke its responder when no identity is declared");
+  assert.equal(realResponds, 1, "real must invoke its responder when no identity is declared");
+  assert.equal(pairedAnswerReplayCache.size, 0, "no entries may be stored without an identity");
+});
 test("runPublishedHarness forwards per-trial answer format to strict answering", async () => {
   const { system, calls } = makeFakeSystem();
   const result = await runPublishedHarness({

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -230,6 +230,56 @@ test("runPublishedHarness reuses an answer only for an identical paired input", 
   assert.equal(real.calls.filter((call) => call.kind === "respond").length, 0);
 });
 
+test("runPublishedHarness never replays a real answer into baseline", async () => {
+  const baseline = makeFakeSystem({ recallPrefix: "shared" });
+  const real = makeFakeSystem({ recallPrefix: "shared" });
+  let baselineResponds = 0;
+  let realResponds = 0;
+  baseline.system.responder.respond = async () => {
+    baselineResponds++;
+    return {
+      text: "baseline answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
+  real.system.responder.respond = async () => {
+    realResponds++;
+    return {
+      text: "real answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
+  const pairedAnswerReplayCache = new Map();
+  const plan: HarnessPlan = {
+    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
+    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
+  };
+  const run = (
+    system: typeof baseline.system,
+    runtimeProfile: "baseline" | "real",
+  ) =>
+    runPublishedHarness({
+      options: makeOptions(system, {
+        pairedAnswerReplayCache,
+        runtimeProfile,
+      }),
+      metricsSpec: { metrics: ["f1"] },
+      plans: [plan],
+    });
+
+  const realResult = await run(real.system, "real");
+  const baselineResult = await run(baseline.system, "baseline");
+
+  assert.equal(realResult.results.tasks[0]?.actual, "real answer");
+  assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
+  assert.equal(realResponds, 1);
+  assert.equal(baselineResponds, 1);
+});
+
 test("runPublishedHarness rejects drain failure before scoring trials", async () => {
   const { system, calls } = makeFakeSystem();
   system.drain = async () => {

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -1,16 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {
-  runPublishedHarness,
-  type HarnessContext,
-  type HarnessPlan,
-} from "./harness.ts";
-import type {
-  BenchmarkDefinition,
-  BenchmarkResult,
-  ResolvedRunBenchmarkOptions,
-} from "../../types.ts";
+import { runPublishedHarness, type HarnessContext, type HarnessPlan } from "./harness.ts";
+import type { BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions } from "../../types.ts";
 
 /**
  * Fake system under test that records every call into a deterministic
@@ -72,11 +64,7 @@ function makeFakeSystem(opts?: {
       async score() {
         return opts?.judgeScore ?? 1;
       },
-      async scoreWithMetrics(
-        question: string,
-        predicted: string,
-        expected: string,
-      ) {
+      async scoreWithMetrics(question: string, predicted: string, expected: string) {
         calls.push({ kind: "judge", question, predicted, expected });
         return {
           score: opts?.judgeScore ?? 1,
@@ -116,7 +104,7 @@ const smokeDefinition: BenchmarkDefinition = {
 
 function makeOptions(
   system: ReturnType<typeof makeFakeSystem>["system"],
-  overrides?: Partial<ResolvedRunBenchmarkOptions>,
+  overrides?: Partial<ResolvedRunBenchmarkOptions>
 ): ResolvedRunBenchmarkOptions {
   return {
     benchmark: smokeDefinition,
@@ -146,9 +134,7 @@ test("runPublishedHarness resets once per plan and stores every non-empty sessio
       ],
     },
     {
-      ingestSessions: [
-        { sessionId: "c", messages: [{ role: "user", content: "x" }] },
-      ],
+      ingestSessions: [{ sessionId: "c", messages: [{ role: "user", content: "x" }] }],
       trials: [
         {
           taskId: "t2",
@@ -172,11 +158,10 @@ test("runPublishedHarness resets once per plan and stores every non-empty sessio
 
   const stores = calls.filter((call) => call.kind === "store");
   assert.equal(stores.length, 3, "empty session should not be stored");
-  assert.deepEqual(stores.map((store) => (store as any).sessionId), [
-    "a",
-    "b",
-    "c",
-  ]);
+  assert.deepEqual(
+    stores.map((store) => (store as any).sessionId),
+    ["a", "b", "c"]
+  );
 
   assert.equal(result.results.tasks.length, 2);
   assert.equal(result.meta.seeds[0], 42);
@@ -198,9 +183,7 @@ test("runPublishedHarness rejects drain failure before scoring trials", async ()
         metricsSpec: { metrics: ["f1"] },
         plans: [
           {
-            ingestSessions: [
-              { sessionId: "s", messages: [{ role: "user", content: "x" }] },
-            ],
+            ingestSessions: [{ sessionId: "s", messages: [{ role: "user", content: "x" }] }],
             trials: [
               {
                 taskId: "must-not-score",
@@ -212,14 +195,23 @@ test("runPublishedHarness rejects drain failure before scoring trials", async ()
           },
         ],
       }),
-    /drain failed before scoring.*drain timed out/,
+    /drain failed before scoring.*drain timed out/
   );
 
   assert.ok(calls.some((call) => call.kind === "store"));
   assert.ok(calls.some((call) => call.kind === "drain"));
-  assert.equal(calls.some((call) => call.kind === "recall"), false);
-  assert.equal(calls.some((call) => call.kind === "respond"), false);
-  assert.equal(calls.some((call) => call.kind === "judge"), false);
+  assert.equal(
+    calls.some((call) => call.kind === "recall"),
+    false
+  );
+  assert.equal(
+    calls.some((call) => call.kind === "respond"),
+    false
+  );
+  assert.equal(
+    calls.some((call) => call.kind === "judge"),
+    false
+  );
 });
 
 test("runPublishedHarness recalls from ALL recallSessionIds per trial", async () => {
@@ -252,10 +244,7 @@ test("runPublishedHarness recalls from ALL recallSessionIds per trial", async ()
     sessionId: string;
     question: string;
   }>;
-  assert.deepEqual(
-    recalls.map((recall) => recall.sessionId).sort(),
-    ["s1", "s2"],
-  );
+  assert.deepEqual(recalls.map((recall) => recall.sessionId).sort(), ["s1", "s2"]);
   for (const recall of recalls) {
     assert.equal(recall.question, "who");
   }
@@ -288,9 +277,7 @@ test("runPublishedHarness executes independent trials concurrently with stable o
     metricsSpec: { metrics: ["f1"] },
     plans: [
       {
-        ingestSessions: [
-          { sessionId: "s", messages: [{ role: "user", content: "x" }] },
-        ],
+        ingestSessions: [{ sessionId: "s", messages: [{ role: "user", content: "x" }] }],
         trials: [
           {
             taskId: "t1",
@@ -318,7 +305,7 @@ test("runPublishedHarness executes independent trials concurrently with stable o
   assert.equal(maxActiveResponders, 2);
   assert.deepEqual(
     result.results.tasks.map((task) => task.taskId),
-    ["t1", "t2", "t3"],
+    ["t1", "t2", "t3"]
   );
   assert.deepEqual(completedTaskIds, ["t1", "t2", "t3"]);
 });
@@ -334,7 +321,7 @@ test("runPublishedHarness rejects invalid trialConcurrency", async () => {
         metricsSpec: { metrics: ["f1"] },
         plans: [],
       }),
-    /trialConcurrency must be an integer from 1 to 64/,
+    /trialConcurrency must be an integer from 1 to 64/
   );
 });
 
@@ -343,9 +330,7 @@ test("runPublishedHarness postAnswerHook runs between answer and judge", async (
   const order: string[] = [];
   const plans: HarnessPlan[] = [
     {
-      ingestSessions: [
-        { sessionId: "s", messages: [{ role: "user", content: "hi" }] },
-      ],
+      ingestSessions: [{ sessionId: "s", messages: [{ role: "user", content: "hi" }] }],
       trials: [
         {
           taskId: "hooked",
@@ -392,9 +377,7 @@ test("runPublishedHarness forwards per-trial answer format to strict answering",
     metricsSpec: { metrics: ["f1"] },
     plans: [
       {
-        ingestSessions: [
-          { sessionId: "s", messages: [{ role: "user", content: "hi" }] },
-        ],
+        ingestSessions: [{ sessionId: "s", messages: [{ role: "user", content: "hi" }] }],
         trials: [
           {
             taskId: "short-answer",
@@ -408,9 +391,7 @@ test("runPublishedHarness forwards per-trial answer format to strict answering",
     ],
   });
 
-  const respond = calls.find((call) => call.kind === "respond") as
-    | { kind: "respond"; question: string }
-    | undefined;
+  const respond = calls.find((call) => call.kind === "respond") as { kind: "respond"; question: string } | undefined;
   assert.ok(respond);
   assert.match(respond.question, /shortest complete answer/);
   assert.equal(result.results.tasks[0]?.details.answerFormat, "short");
@@ -430,9 +411,7 @@ test("runPublishedHarness llm_judge metric suppressed when judge score negative"
     metricsSpec: { metrics: ["f1", "llm_judge"] },
     plans: [
       {
-        ingestSessions: [
-          { sessionId: "s", messages: [{ role: "user", content: "h" }] },
-        ],
+        ingestSessions: [{ sessionId: "s", messages: [{ role: "user", content: "h" }] }],
         trials: [
           {
             taskId: "no-judge",
@@ -446,10 +425,7 @@ test("runPublishedHarness llm_judge metric suppressed when judge score negative"
   });
   const task = result.results.tasks[0]!;
   assert.ok("f1" in task.scores, "f1 should be present");
-  assert.ok(
-    !("llm_judge" in task.scores),
-    "llm_judge should be omitted when judge returns negative",
-  );
+  assert.ok(!("llm_judge" in task.scores), "llm_judge should be omitted when judge returns negative");
 });
 
 test("runPublishedHarness records failed judge_accuracy when judge score is negative", async () => {
@@ -459,9 +435,7 @@ test("runPublishedHarness records failed judge_accuracy when judge score is nega
     metricsSpec: { metrics: ["llm_judge", "judge_accuracy"] },
     plans: [
       {
-        ingestSessions: [
-          { sessionId: "s", messages: [{ role: "user", content: "h" }] },
-        ],
+        ingestSessions: [{ sessionId: "s", messages: [{ role: "user", content: "h" }] }],
         trials: [
           {
             taskId: "invalid-binary-judge",
@@ -523,7 +497,7 @@ test("runPublishedHarness marks caught provider failures partial without hiding 
 test("run-terminal detection follows wrapped causes and terminates on cyclic cause graphs", () => {
   const blocked = new BenchmarkRunBlockedError(
     BenchmarkRunBlockReason.ManualReconciliationRequired,
-    "credit ledger requires reconciliation",
+    "credit ledger requires reconciliation"
   );
   const wrapped = new Error("provider wrapper", { cause: blocked });
   assert.equal(findBenchmarkRunBlockedError(wrapped), blocked);
@@ -545,7 +519,7 @@ test("runPublishedHarness stops sequential plans on a terminal responder error",
     if (question.includes("blocked")) {
       throw new BenchmarkRunBlockedError(
         BenchmarkRunBlockReason.SpendHeadroomExhausted,
-        "credit headroom is exhausted",
+        "credit headroom is exhausted"
       );
     }
     return {
@@ -557,56 +531,60 @@ test("runPublishedHarness stops sequential plans on a terminal responder error",
   };
 
   await assert.rejects(
-    () => runPublishedHarness({
-      options: makeOptions(system, {
-        onTaskComplete: (task) => completedTaskIds.push(task.taskId),
+    () =>
+      runPublishedHarness({
+        options: makeOptions(system, {
+          onTaskComplete: (task) => completedTaskIds.push(task.taskId),
+        }),
+        metricsSpec: { metrics: ["f1"] },
+        plans: [
+          {
+            ingestSessions: [],
+            trials: [
+              {
+                taskId: "before",
+                question: "before",
+                expected: "answer:before",
+                recallSessionIds: [],
+              },
+            ],
+          },
+          {
+            ingestSessions: [],
+            trials: [
+              {
+                taskId: "blocked",
+                question: "blocked",
+                expected: "never",
+                recallSessionIds: [],
+                answerFallback: () => "must not mask a run-terminal error",
+              },
+            ],
+          },
+          {
+            ingestSessions: [],
+            trials: [
+              {
+                taskId: "after",
+                question: "after",
+                expected: "answer:after",
+                recallSessionIds: [],
+              },
+            ],
+          },
+        ],
       }),
-      metricsSpec: { metrics: ["f1"] },
-      plans: [
-        {
-          ingestSessions: [],
-          trials: [{
-            taskId: "before",
-            question: "before",
-            expected: "answer:before",
-            recallSessionIds: [],
-          }],
-        },
-        {
-          ingestSessions: [],
-          trials: [{
-            taskId: "blocked",
-            question: "blocked",
-            expected: "never",
-            recallSessionIds: [],
-            answerFallback: () => "must not mask a run-terminal error",
-          }],
-        },
-        {
-          ingestSessions: [],
-          trials: [{
-            taskId: "after",
-            question: "after",
-            expected: "answer:after",
-            recallSessionIds: [],
-          }],
-        },
-      ],
-    }),
     (error: unknown) =>
-      error instanceof BenchmarkRunBlockedError &&
-      error.reason === BenchmarkRunBlockReason.SpendHeadroomExhausted,
+      error instanceof BenchmarkRunBlockedError && error.reason === BenchmarkRunBlockReason.SpendHeadroomExhausted
   );
 
   assert.deepEqual(completedTaskIds, ["before"]);
   assert.equal(calls.filter((call) => call.kind === "reset").length, 2);
   assert.deepEqual(
     calls
-      .filter((call): call is { kind: "respond"; question: string } =>
-        call.kind === "respond"
-      )
+      .filter((call): call is { kind: "respond"; question: string } => call.kind === "respond")
       .map((call) => call.question.split("\n", 1)[0]),
-    ["before", "blocked"],
+    ["before", "blocked"]
   );
 });
 
@@ -618,30 +596,32 @@ test("runPublishedHarness stops sequential trials on a terminal scoreWithMetrics
     throw new Error("judge wrapper", {
       cause: new BenchmarkRunBlockedError(
         BenchmarkRunBlockReason.ManualReconciliationRequired,
-        "judge credits require reconciliation",
+        "judge credits require reconciliation"
       ),
     });
   };
 
   await assert.rejects(
-    () => runPublishedHarness({
-      options: makeOptions(system, {
-        onTaskComplete: (task) => completedTaskIds.push(task.taskId),
+    () =>
+      runPublishedHarness({
+        options: makeOptions(system, {
+          onTaskComplete: (task) => completedTaskIds.push(task.taskId),
+        }),
+        metricsSpec: { metrics: ["llm_judge"] },
+        plans: [
+          {
+            ingestSessions: [],
+            trials: ["Q1", "Q2"].map((question, index) => ({
+              taskId: `t${index + 1}`,
+              question,
+              expected: `answer:${question}`,
+              recallSessionIds: [],
+            })),
+          },
+        ],
       }),
-      metricsSpec: { metrics: ["llm_judge"] },
-      plans: [{
-        ingestSessions: [],
-        trials: ["Q1", "Q2"].map((question, index) => ({
-          taskId: `t${index + 1}`,
-          question,
-          expected: `answer:${question}`,
-          recallSessionIds: [],
-        })),
-      }],
-    }),
     (error: unknown) =>
-      error instanceof BenchmarkRunBlockedError &&
-      error.reason === BenchmarkRunBlockReason.ManualReconciliationRequired,
+      error instanceof BenchmarkRunBlockedError && error.reason === BenchmarkRunBlockReason.ManualReconciliationRequired
   );
 
   assert.deepEqual(completedTaskIds, []);
@@ -667,10 +647,7 @@ test("runPublishedHarness stops concurrent dequeue on a wrapped terminal error",
     await startedTogether;
     if (question.includes("Q2")) {
       throw new Error("provider wrapper", {
-        cause: new BenchmarkRunBlockedError(
-          BenchmarkRunBlockReason.ResourceLocked,
-          "credit ledger is locked",
-        ),
+        cause: new BenchmarkRunBlockedError(BenchmarkRunBlockReason.ResourceLocked, "credit ledger is locked"),
       });
     }
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -683,36 +660,36 @@ test("runPublishedHarness stops concurrent dequeue on a wrapped terminal error",
   };
 
   await assert.rejects(
-    () => runPublishedHarness({
-      options: makeOptions(system, {
-        benchmarkOptions: { trialConcurrency: 3 },
-        onTaskComplete: (task) => completedTaskIds.push(task.taskId),
+    () =>
+      runPublishedHarness({
+        options: makeOptions(system, {
+          benchmarkOptions: { trialConcurrency: 3 },
+          onTaskComplete: (task) => completedTaskIds.push(task.taskId),
+        }),
+        metricsSpec: { metrics: ["f1"] },
+        plans: [
+          {
+            ingestSessions: [],
+            trials: ["Q1", "Q2", "Q3", "Q4"].map((question, index) => ({
+              taskId: `t${index + 1}`,
+              question,
+              expected: `answer:${question}`,
+              recallSessionIds: [],
+            })),
+          },
+        ],
       }),
-      metricsSpec: { metrics: ["f1"] },
-      plans: [{
-        ingestSessions: [],
-        trials: ["Q1", "Q2", "Q3", "Q4"].map((question, index) => ({
-          taskId: `t${index + 1}`,
-          question,
-          expected: `answer:${question}`,
-          recallSessionIds: [],
-        })),
-      }],
-    }),
     (error: unknown) =>
-      error instanceof BenchmarkRunBlockedError &&
-      error.reason === BenchmarkRunBlockReason.ResourceLocked,
+      error instanceof BenchmarkRunBlockedError && error.reason === BenchmarkRunBlockReason.ResourceLocked
   );
 
   assert.deepEqual(completedTaskIds, ["t1"]);
   assert.deepEqual(
     calls
-      .filter((call): call is { kind: "respond"; question: string } =>
-        call.kind === "respond"
-      )
+      .filter((call): call is { kind: "respond"; question: string } => call.kind === "respond")
       .map((call) => call.question.split("\n", 1)[0])
       .sort(),
-    ["Q1", "Q2", "Q3"],
+    ["Q1", "Q2", "Q3"]
   );
 });
 
@@ -748,7 +725,7 @@ test("runPublishedHarness does not launch a new wave while an earlier trial can 
     if (taskQuestion === "Q2") {
       throw new BenchmarkRunBlockedError(
         BenchmarkRunBlockReason.ManualReconciliationRequired,
-        "Q2 discovered a terminal accounting state",
+        "Q2 discovered a terminal accounting state"
       );
     }
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -761,36 +738,36 @@ test("runPublishedHarness does not launch a new wave while an earlier trial can 
   };
 
   await assert.rejects(
-    () => runPublishedHarness({
-      options: makeOptions(system, {
-        benchmarkOptions: { trialConcurrency: 3 },
-        onTaskComplete: (task) => completedTaskIds.push(task.taskId),
+    () =>
+      runPublishedHarness({
+        options: makeOptions(system, {
+          benchmarkOptions: { trialConcurrency: 3 },
+          onTaskComplete: (task) => completedTaskIds.push(task.taskId),
+        }),
+        metricsSpec: { metrics: ["f1"] },
+        plans: [
+          {
+            ingestSessions: [],
+            trials: ["Q1", "Q2", "Q3", "Q4"].map((question, index) => ({
+              taskId: `t${index + 1}`,
+              question,
+              expected: `answer:${question}`,
+              recallSessionIds: [],
+            })),
+          },
+        ],
       }),
-      metricsSpec: { metrics: ["f1"] },
-      plans: [{
-        ingestSessions: [],
-        trials: ["Q1", "Q2", "Q3", "Q4"].map((question, index) => ({
-          taskId: `t${index + 1}`,
-          question,
-          expected: `answer:${question}`,
-          recallSessionIds: [],
-        })),
-      }],
-    }),
     (error: unknown) =>
-      error instanceof BenchmarkRunBlockedError &&
-      error.reason === BenchmarkRunBlockReason.ManualReconciliationRequired,
+      error instanceof BenchmarkRunBlockedError && error.reason === BenchmarkRunBlockReason.ManualReconciliationRequired
   );
 
   assert.deepEqual(completedTaskIds, ["t1"]);
   assert.deepEqual(
     calls
-      .filter((call): call is { kind: "respond"; question: string } =>
-        call.kind === "respond"
-      )
+      .filter((call): call is { kind: "respond"; question: string } => call.kind === "respond")
       .map((call) => call.question.split("\n", 1)[0])
       .sort(),
-    ["Q1", "Q2", "Q3"],
+    ["Q1", "Q2", "Q3"]
   );
 });
 
@@ -815,17 +792,14 @@ test("runPublishedHarness emits only the prefix before the earliest of two concu
 
     if (taskQuestion === "Q3") {
       terminalOrder.push("t3");
-      throw new BenchmarkRunBlockedError(
-        BenchmarkRunBlockReason.ResourceLocked,
-        "later ordinal failed first",
-      );
+      throw new BenchmarkRunBlockedError(BenchmarkRunBlockReason.ResourceLocked, "later ordinal failed first");
     }
     if (taskQuestion === "Q2") {
       await new Promise((resolve) => setTimeout(resolve, 15));
       terminalOrder.push("t2");
       throw new BenchmarkRunBlockedError(
         BenchmarkRunBlockReason.ManualReconciliationRequired,
-        "earlier ordinal failed later",
+        "earlier ordinal failed later"
       );
     }
 
@@ -839,38 +813,39 @@ test("runPublishedHarness emits only the prefix before the earliest of two concu
   };
 
   await assert.rejects(
-    () => runPublishedHarness({
-      options: makeOptions(system, {
-        benchmarkOptions: { trialConcurrency: 3 },
-        onTaskComplete: (task) => completedTaskIds.push(task.taskId),
+    () =>
+      runPublishedHarness({
+        options: makeOptions(system, {
+          benchmarkOptions: { trialConcurrency: 3 },
+          onTaskComplete: (task) => completedTaskIds.push(task.taskId),
+        }),
+        metricsSpec: { metrics: ["f1"] },
+        plans: [
+          {
+            ingestSessions: [],
+            trials: ["Q1", "Q2", "Q3", "Q4"].map((question, index) => ({
+              taskId: `t${index + 1}`,
+              question,
+              expected: `answer:${question}`,
+              recallSessionIds: [],
+            })),
+          },
+        ],
       }),
-      metricsSpec: { metrics: ["f1"] },
-      plans: [{
-        ingestSessions: [],
-        trials: ["Q1", "Q2", "Q3", "Q4"].map((question, index) => ({
-          taskId: `t${index + 1}`,
-          question,
-          expected: `answer:${question}`,
-          recallSessionIds: [],
-        })),
-      }],
-    }),
     (error: unknown) =>
       error instanceof BenchmarkRunBlockedError &&
       error.reason === BenchmarkRunBlockReason.ManualReconciliationRequired &&
-      error.message === "earlier ordinal failed later",
+      error.message === "earlier ordinal failed later"
   );
 
   assert.deepEqual(terminalOrder, ["t3", "t2"]);
   assert.deepEqual(completedTaskIds, ["t1"]);
   assert.deepEqual(
     calls
-      .filter((call): call is { kind: "respond"; question: string } =>
-        call.kind === "respond"
-      )
+      .filter((call): call is { kind: "respond"; question: string } => call.kind === "respond")
       .map((call) => call.question.split("\n", 1)[0])
       .sort(),
-    ["Q1", "Q2", "Q3"],
+    ["Q1", "Q2", "Q3"]
   );
 });
 
@@ -893,7 +868,7 @@ test("runPublishedHarness stops concurrent dequeue on a terminal binary judge er
     if (prompt.includes("Q2")) {
       throw new BenchmarkRunBlockedError(
         BenchmarkRunBlockReason.SpendHeadroomExhausted,
-        "binary judge credit headroom is exhausted",
+        "binary judge credit headroom is exhausted"
       );
     }
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -906,37 +881,37 @@ test("runPublishedHarness stops concurrent dequeue on a terminal binary judge er
   };
 
   await assert.rejects(
-    () => runPublishedHarness({
-      options: makeOptions(system, {
-        benchmarkOptions: { trialConcurrency: 2 },
-        onTaskComplete: (task) => completedTaskIds.push(task.taskId),
+    () =>
+      runPublishedHarness({
+        options: makeOptions(system, {
+          benchmarkOptions: { trialConcurrency: 2 },
+          onTaskComplete: (task) => completedTaskIds.push(task.taskId),
+        }),
+        metricsSpec: { metrics: ["llm_judge", "judge_accuracy"] },
+        plans: [
+          {
+            ingestSessions: [],
+            trials: ["Q1", "Q2", "Q3"].map((question, index) => ({
+              taskId: `t${index + 1}`,
+              question,
+              expected: `answer:${question}`,
+              recallSessionIds: [],
+              binaryJudgePrompt: () => `Official binary prompt for ${question}`,
+            })),
+          },
+        ],
       }),
-      metricsSpec: { metrics: ["llm_judge", "judge_accuracy"] },
-      plans: [{
-        ingestSessions: [],
-        trials: ["Q1", "Q2", "Q3"].map((question, index) => ({
-          taskId: `t${index + 1}`,
-          question,
-          expected: `answer:${question}`,
-          recallSessionIds: [],
-          binaryJudgePrompt: () => `Official binary prompt for ${question}`,
-        })),
-      }],
-    }),
     (error: unknown) =>
-      error instanceof BenchmarkRunBlockedError &&
-      error.reason === BenchmarkRunBlockReason.SpendHeadroomExhausted,
+      error instanceof BenchmarkRunBlockedError && error.reason === BenchmarkRunBlockReason.SpendHeadroomExhausted
   );
 
   assert.deepEqual(completedTaskIds, ["t1"]);
   assert.deepEqual(
     calls
-      .filter((call): call is { kind: "respond"; question: string } =>
-        call.kind === "respond"
-      )
+      .filter((call): call is { kind: "respond"; question: string } => call.kind === "respond")
       .map((call) => call.question.split("\n", 1)[0])
       .sort(),
-    ["Q1", "Q2"],
+    ["Q1", "Q2"]
   );
   assert.equal(calls.filter((call) => call.kind === "binaryJudge").length, 2);
 });
@@ -948,17 +923,14 @@ test("runPublishedHarness supports benchmark-owned binary judge prompts", async 
     metricsSpec: { metrics: ["llm_judge", "judge_accuracy"] },
     plans: [
       {
-        ingestSessions: [
-          { sessionId: "s", messages: [{ role: "user", content: "h" }] },
-        ],
+        ingestSessions: [{ sessionId: "s", messages: [{ role: "user", content: "h" }] }],
         trials: [
           {
             taskId: "binary-judge",
             question: "q",
             expected: "a",
             recallSessionIds: ["s"],
-            binaryJudgePrompt: ({ answeredText }) =>
-              `Official binary prompt\nMODEL_RESPONSE:\n${answeredText}`,
+            binaryJudgePrompt: ({ answeredText }) => `Official binary prompt\nMODEL_RESPONSE:\n${answeredText}`,
           },
         ],
       },
@@ -971,10 +943,7 @@ test("runPublishedHarness supports benchmark-owned binary judge prompts", async 
   const binaryJudgeCall = calls.find((call) => call.kind === "binaryJudge");
   assert.ok(binaryJudgeCall, "binary judge prompt should be used");
   assert.match(binaryJudgeCall.prompt, /^Official binary prompt\nMODEL_RESPONSE:\nanswer:/);
-  assert.ok(
-    !calls.some((call) => call.kind === "judge"),
-    "generic judge rubric should not be used",
-  );
+  assert.ok(!calls.some((call) => call.kind === "judge"), "generic judge rubric should not be used");
 });
 
 test("runPublishedHarness falls back when judge lacks binary prompt support", async () => {
@@ -986,9 +955,7 @@ test("runPublishedHarness falls back when judge lacks binary prompt support", as
     metricsSpec: { metrics: ["llm_judge", "judge_accuracy"] },
     plans: [
       {
-        ingestSessions: [
-          { sessionId: "s", messages: [{ role: "user", content: "h" }] },
-        ],
+        ingestSessions: [{ sessionId: "s", messages: [{ role: "user", content: "h" }] }],
         trials: [
           {
             taskId: "binary-judge-fallback",
@@ -1007,12 +974,9 @@ test("runPublishedHarness falls back when judge lacks binary prompt support", as
   assert.equal(task.scores.judge_accuracy, 0);
   assert.ok(
     calls.some((call) => call.kind === "judge"),
-    "generic judge rubric should be used as the compatibility fallback",
+    "generic judge rubric should be used as the compatibility fallback"
   );
-  assert.ok(
-    !calls.some((call) => call.kind === "binaryJudge"),
-    "binary judge should not be called when unavailable",
-  );
+  assert.ok(!calls.some((call) => call.kind === "binaryJudge"), "binary judge should not be called when unavailable");
 });
 
 test("runPublishedHarness is deterministic across repeated runs with same seed", async () => {
@@ -1070,7 +1034,7 @@ test("runPublishedHarness rejects unknown metric id", async () => {
         metricsSpec: { metrics: ["not-a-metric"] },
         plans: [],
       }),
-    /unknown metric/,
+    /unknown metric/
   );
 });
 
@@ -1083,7 +1047,7 @@ test("runPublishedHarness rejects negative or non-integer seed", async () => {
         metricsSpec: { metrics: ["f1"] },
         plans: [],
       }),
-    /seed must be a non-negative integer/,
+    /seed must be a non-negative integer/
   );
   await assert.rejects(
     () =>
@@ -1092,7 +1056,7 @@ test("runPublishedHarness rejects negative or non-integer seed", async () => {
         metricsSpec: { metrics: ["f1"] },
         plans: [],
       }),
-    /seed must be a non-negative integer/,
+    /seed must be a non-negative integer/
   );
 });
 
@@ -1110,9 +1074,7 @@ test("runPublishedHarness skips LLM judge when llm_judge is not in metrics spec"
     metricsSpec: { metrics: ["f1", "contains_answer"] }, // no llm_judge
     plans: [
       {
-        ingestSessions: [
-          { sessionId: "s", messages: [{ role: "user", content: "hi" }] },
-        ],
+        ingestSessions: [{ sessionId: "s", messages: [{ role: "user", content: "hi" }] }],
         trials: [
           {
             taskId: "no-judge-billing",
@@ -1130,10 +1092,7 @@ test("runPublishedHarness skips LLM judge when llm_judge is not in metrics spec"
   // Judge latency/tokens should NOT be folded into cost totals.
   assert.equal(result.cost.inputTokens, 1); // responder only
   assert.equal(result.cost.outputTokens, 2); // responder only
-  assert.ok(
-    !calls.some((call) => call.kind === "judge"),
-    "no judge call should have been made",
-  );
+  assert.ok(!calls.some((call) => call.kind === "judge"), "no judge call should have been made");
 });
 
 test("runPublishedHarness produces empty result for empty plans", async () => {
@@ -1173,12 +1132,11 @@ test("runPublishedHarness reuses an answer only for an identical paired input", 
   const pairedAnswerReplayCache = new Map();
   const plan: HarnessPlan = {
     ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
-    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
+    trials: [
+      { taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] },
+    ],
   };
-  const run = (
-    system: typeof baseline.system,
-    runtimeProfile: "baseline" | "real",
-  ) =>
+  const run = (system: typeof baseline.system, runtimeProfile: "baseline" | "real") =>
     runPublishedHarness({
       options: makeOptions(system, {
         pairedAnswerReplayCache,
@@ -1223,12 +1181,11 @@ test("runPublishedHarness never replays a real answer into baseline", async () =
   const pairedAnswerReplayCache = new Map();
   const plan: HarnessPlan = {
     ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
-    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
+    trials: [
+      { taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] },
+    ],
   };
-  const run = (
-    system: typeof baseline.system,
-    runtimeProfile: "baseline" | "real",
-  ) =>
+  const run = (system: typeof baseline.system, runtimeProfile: "baseline" | "real") =>
     runPublishedHarness({
       options: makeOptions(system, {
         pairedAnswerReplayCache,
@@ -1243,10 +1200,7 @@ test("runPublishedHarness never replays a real answer into baseline", async () =
 
   assert.equal(realResult.results.tasks[0]?.actual, "real answer");
   assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
-  assert.equal(
-    baselineResult.results.tasks[0]?.details?.pairedAnswerReusedFrom,
-    undefined,
-  );
+  assert.equal(baselineResult.results.tasks[0]?.details?.pairedAnswerReusedFrom, undefined);
   assert.equal(realResponds, 1);
   assert.equal(baselineResponds, 1);
 });
@@ -1277,13 +1231,11 @@ test("runPublishedHarness does not replay across different responder models", as
   const pairedAnswerReplayCache = new Map();
   const plan: HarnessPlan = {
     ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
-    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
+    trials: [
+      { taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] },
+    ],
   };
-  const run = (
-    system: typeof baseline.system,
-    runtimeProfile: "baseline" | "real",
-    model: string,
-  ) =>
+  const run = (system: typeof baseline.system, runtimeProfile: "baseline" | "real", model: string) =>
     runPublishedHarness({
       options: makeOptions(system, {
         pairedAnswerReplayCache,
@@ -1322,18 +1274,17 @@ test("runPublishedHarness does not replay a baseline fallback answer", async () 
   const pairedAnswerReplayCache = new Map();
   const plan: HarnessPlan = {
     ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
-    trials: [{
-      taskId: "paired",
-      question: "What happened?",
-      expected: "fallback answer",
-      recallSessionIds: ["session"],
-      answerFallback: () => "fallback answer",
-    }],
+    trials: [
+      {
+        taskId: "paired",
+        question: "What happened?",
+        expected: "fallback answer",
+        recallSessionIds: ["session"],
+        answerFallback: () => "fallback answer",
+      },
+    ],
   };
-  const run = (
-    system: typeof baseline.system,
-    runtimeProfile: "baseline" | "real",
-  ) =>
+  const run = (system: typeof baseline.system, runtimeProfile: "baseline" | "real") =>
     runPublishedHarness({
       options: makeOptions(system, {
         pairedAnswerReplayCache,
@@ -1388,12 +1339,11 @@ test("runPublishedHarness preserves a baseline replay answer across another prof
   const pairedAnswerReplayCache = new Map();
   const plan: HarnessPlan = {
     ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
-    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
+    trials: [
+      { taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] },
+    ],
   };
-  const run = (
-    system: typeof baseline.system,
-    runtimeProfile: "baseline" | "local-lab" | "real",
-  ) =>
+  const run = (system: typeof baseline.system, runtimeProfile: "baseline" | "local-lab" | "real") =>
     runPublishedHarness({
       options: makeOptions(system, {
         pairedAnswerReplayCache,
@@ -1458,10 +1408,7 @@ test("runPublishedHarness does not replay a baseline answer after a later trial 
       },
     ],
   };
-  const run = (
-    system: typeof baseline.system,
-    runtimeProfile: "baseline" | "real",
-  ) =>
+  const run = (system: typeof baseline.system, runtimeProfile: "baseline" | "real") =>
     runPublishedHarness({
       options: makeOptions(system, {
         pairedAnswerReplayCache,

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -276,8 +276,64 @@ test("runPublishedHarness never replays a real answer into baseline", async () =
 
   assert.equal(realResult.results.tasks[0]?.actual, "real answer");
   assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
+  assert.equal(
+    baselineResult.results.tasks[0]?.details?.pairedAnswerReusedFrom,
+    undefined,
+  );
   assert.equal(realResponds, 1);
   assert.equal(baselineResponds, 1);
+});
+
+test("runPublishedHarness does not replay across different responder models", async () => {
+  const baseline = makeFakeSystem({ recallPrefix: "shared" });
+  const real = makeFakeSystem({ recallPrefix: "shared" });
+  let baselineResponds = 0;
+  let realResponds = 0;
+  baseline.system.responder.respond = async () => {
+    baselineResponds++;
+    return {
+      text: "baseline answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "baseline-responder",
+    };
+  };
+  real.system.responder.respond = async () => {
+    realResponds++;
+    return {
+      text: "real answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "real-responder",
+    };
+  };
+  const pairedAnswerReplayCache = new Map();
+  const plan: HarnessPlan = {
+    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
+    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
+  };
+  const run = (
+    system: typeof baseline.system,
+    runtimeProfile: "baseline" | "real",
+    model: string,
+  ) =>
+    runPublishedHarness({
+      options: makeOptions(system, {
+        pairedAnswerReplayCache,
+        runtimeProfile,
+        systemProvider: { provider: "openai", model },
+      }),
+      metricsSpec: { metrics: ["f1"] },
+      plans: [plan],
+    });
+
+  const baselineResult = await run(baseline.system, "baseline", "baseline-model");
+  const realResult = await run(real.system, "real", "real-model");
+
+  assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
+  assert.equal(realResult.results.tasks[0]?.actual, "real answer");
+  assert.equal(baselineResponds, 1);
+  assert.equal(realResponds, 1);
 });
 
 test("runPublishedHarness rejects drain failure before scoring trials", async () => {

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -212,6 +212,25 @@ test("runPublishedHarness rejects drain failure before scoring trials", async ()
     calls.some((call) => call.kind === "judge"),
     false
   );
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 });
 
 test("runPublishedHarness recalls from ALL recallSessionIds per trial", async () => {

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -1346,3 +1346,61 @@ test("runPublishedHarness does not replay a baseline fallback answer", async () 
   assert.equal(realResult.results.tasks[0]?.actual, "real answer");
   assert.equal(realResponds, 1);
 });
+
+test("runPublishedHarness preserves a baseline replay answer across another profile", async () => {
+  const baseline = makeFakeSystem({ recallPrefix: "shared" });
+  const localLab = makeFakeSystem({ recallPrefix: "shared" });
+  const real = makeFakeSystem({ recallPrefix: "shared" });
+  let baselineResponds = 0;
+  let localLabResponds = 0;
+  baseline.system.responder.respond = async () => {
+    baselineResponds++;
+    return {
+      text: "baseline answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
+  localLab.system.responder.respond = async () => {
+    localLabResponds++;
+    return {
+      text: "local-lab answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
+  real.system.responder.respond = async () => ({
+    text: "real answer",
+    tokens: { input: 1, output: 1 },
+    latencyMs: 1,
+    model: "shared-responder",
+  });
+  const pairedAnswerReplayCache = new Map();
+  const plan: HarnessPlan = {
+    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
+    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
+  };
+  const run = (
+    system: typeof baseline.system,
+    runtimeProfile: "baseline" | "local-lab" | "real",
+  ) =>
+    runPublishedHarness({
+      options: makeOptions(system, {
+        pairedAnswerReplayCache,
+        runtimeProfile,
+      }),
+      metricsSpec: { metrics: ["f1"] },
+      plans: [plan],
+    });
+
+  await run(baseline.system, "baseline");
+  await run(localLab.system, "local-lab");
+  const realResult = await run(real.system, "real");
+
+  assert.equal(realResult.results.tasks[0]?.actual, "baseline answer");
+  assert.equal(baselineResponds, 1);
+  assert.equal(localLabResponds, 1);
+  assert.equal(real.calls.filter((call) => call.kind === "respond").length, 0);
+});

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -184,6 +184,52 @@ test("runPublishedHarness resets once per plan and stores every non-empty sessio
   assert.equal(result.config.adapterMode, "direct");
 });
 
+test("runPublishedHarness reuses an answer only for an identical paired input", async () => {
+  const baseline = makeFakeSystem({ recallPrefix: "shared" });
+  const real = makeFakeSystem({ recallPrefix: "shared" });
+  let baselineResponds = 0;
+  baseline.system.responder.respond = async () => {
+    baselineResponds++;
+    return {
+      text: "baseline answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
+  real.system.responder.respond = async () => ({
+    text: "real answer",
+    tokens: { input: 1, output: 1 },
+    latencyMs: 1,
+    model: "shared-responder",
+  });
+  const pairedAnswerReplayCache = new Map();
+  const plan: HarnessPlan = {
+    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
+    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
+  };
+  const run = (
+    system: typeof baseline.system,
+    runtimeProfile: "baseline" | "real",
+  ) =>
+    runPublishedHarness({
+      options: makeOptions(system, {
+        pairedAnswerReplayCache,
+        runtimeProfile,
+      }),
+      metricsSpec: { metrics: ["f1"] },
+      plans: [plan],
+    });
+
+  const baselineResult = await run(baseline.system, "baseline");
+  const realResult = await run(real.system, "real");
+
+  assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
+  assert.equal(realResult.results.tasks[0]?.actual, "baseline answer");
+  assert.equal(baselineResponds, 1);
+  assert.equal(real.calls.filter((call) => call.kind === "respond").length, 0);
+});
+
 test("runPublishedHarness rejects drain failure before scoring trials", async () => {
   const { system, calls } = makeFakeSystem();
   system.drain = async () => {

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -184,206 +184,6 @@ test("runPublishedHarness resets once per plan and stores every non-empty sessio
   assert.equal(result.config.adapterMode, "direct");
 });
 
-test("runPublishedHarness reuses an answer only for an identical paired input", async () => {
-  const baseline = makeFakeSystem({ recallPrefix: "shared" });
-  const real = makeFakeSystem({ recallPrefix: "shared" });
-  let baselineResponds = 0;
-  baseline.system.responder.respond = async () => {
-    baselineResponds++;
-    return {
-      text: "baseline answer",
-      tokens: { input: 1, output: 1 },
-      latencyMs: 1,
-      model: "shared-responder",
-    };
-  };
-  real.system.responder.respond = async () => ({
-    text: "real answer",
-    tokens: { input: 1, output: 1 },
-    latencyMs: 1,
-    model: "shared-responder",
-  });
-  const pairedAnswerReplayCache = new Map();
-  const plan: HarnessPlan = {
-    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
-    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
-  };
-  const run = (
-    system: typeof baseline.system,
-    runtimeProfile: "baseline" | "real",
-  ) =>
-    runPublishedHarness({
-      options: makeOptions(system, {
-        pairedAnswerReplayCache,
-        runtimeProfile,
-      }),
-      metricsSpec: { metrics: ["f1"] },
-      plans: [plan],
-    });
-
-  const baselineResult = await run(baseline.system, "baseline");
-  const realResult = await run(real.system, "real");
-
-  assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
-  assert.equal(realResult.results.tasks[0]?.actual, "baseline answer");
-  assert.equal(baselineResponds, 1);
-  assert.equal(real.calls.filter((call) => call.kind === "respond").length, 0);
-});
-
-test("runPublishedHarness never replays a real answer into baseline", async () => {
-  const baseline = makeFakeSystem({ recallPrefix: "shared" });
-  const real = makeFakeSystem({ recallPrefix: "shared" });
-  let baselineResponds = 0;
-  let realResponds = 0;
-  baseline.system.responder.respond = async () => {
-    baselineResponds++;
-    return {
-      text: "baseline answer",
-      tokens: { input: 1, output: 1 },
-      latencyMs: 1,
-      model: "shared-responder",
-    };
-  };
-  real.system.responder.respond = async () => {
-    realResponds++;
-    return {
-      text: "real answer",
-      tokens: { input: 1, output: 1 },
-      latencyMs: 1,
-      model: "shared-responder",
-    };
-  };
-  const pairedAnswerReplayCache = new Map();
-  const plan: HarnessPlan = {
-    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
-    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
-  };
-  const run = (
-    system: typeof baseline.system,
-    runtimeProfile: "baseline" | "real",
-  ) =>
-    runPublishedHarness({
-      options: makeOptions(system, {
-        pairedAnswerReplayCache,
-        runtimeProfile,
-      }),
-      metricsSpec: { metrics: ["f1"] },
-      plans: [plan],
-    });
-
-  const realResult = await run(real.system, "real");
-  const baselineResult = await run(baseline.system, "baseline");
-
-  assert.equal(realResult.results.tasks[0]?.actual, "real answer");
-  assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
-  assert.equal(
-    baselineResult.results.tasks[0]?.details?.pairedAnswerReusedFrom,
-    undefined,
-  );
-  assert.equal(realResponds, 1);
-  assert.equal(baselineResponds, 1);
-});
-
-test("runPublishedHarness does not replay across different responder models", async () => {
-  const baseline = makeFakeSystem({ recallPrefix: "shared" });
-  const real = makeFakeSystem({ recallPrefix: "shared" });
-  let baselineResponds = 0;
-  let realResponds = 0;
-  baseline.system.responder.respond = async () => {
-    baselineResponds++;
-    return {
-      text: "baseline answer",
-      tokens: { input: 1, output: 1 },
-      latencyMs: 1,
-      model: "baseline-responder",
-    };
-  };
-  real.system.responder.respond = async () => {
-    realResponds++;
-    return {
-      text: "real answer",
-      tokens: { input: 1, output: 1 },
-      latencyMs: 1,
-      model: "real-responder",
-    };
-  };
-  const pairedAnswerReplayCache = new Map();
-  const plan: HarnessPlan = {
-    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
-    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
-  };
-  const run = (
-    system: typeof baseline.system,
-    runtimeProfile: "baseline" | "real",
-    model: string,
-  ) =>
-    runPublishedHarness({
-      options: makeOptions(system, {
-        pairedAnswerReplayCache,
-        runtimeProfile,
-        systemProvider: { provider: "openai", model },
-      }),
-      metricsSpec: { metrics: ["f1"] },
-      plans: [plan],
-    });
-
-  const baselineResult = await run(baseline.system, "baseline", "baseline-model");
-  const realResult = await run(real.system, "real", "real-model");
-
-  assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
-  assert.equal(realResult.results.tasks[0]?.actual, "real answer");
-  assert.equal(baselineResponds, 1);
-  assert.equal(realResponds, 1);
-});
-
-test("runPublishedHarness does not replay a baseline fallback answer", async () => {
-  const baseline = makeFakeSystem({ recallPrefix: "shared" });
-  const real = makeFakeSystem({ recallPrefix: "shared" });
-  baseline.system.responder.respond = async () => {
-    throw new Error("baseline responder unavailable");
-  };
-  let realResponds = 0;
-  real.system.responder.respond = async () => {
-    realResponds++;
-    return {
-      text: "real answer",
-      tokens: { input: 1, output: 1 },
-      latencyMs: 1,
-      model: "shared-responder",
-    };
-  };
-  const pairedAnswerReplayCache = new Map();
-  const plan: HarnessPlan = {
-    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
-    trials: [{
-      taskId: "paired",
-      question: "What happened?",
-      expected: "fallback answer",
-      recallSessionIds: ["session"],
-      answerFallback: () => "fallback answer",
-    }],
-  };
-  const run = (
-    system: typeof baseline.system,
-    runtimeProfile: "baseline" | "real",
-  ) =>
-    runPublishedHarness({
-      options: makeOptions(system, {
-        pairedAnswerReplayCache,
-        runtimeProfile,
-      }),
-      metricsSpec: { metrics: ["f1"] },
-      plans: [plan],
-    });
-
-  const baselineResult = await run(baseline.system, "baseline");
-  const realResult = await run(real.system, "real");
-
-  assert.equal(baselineResult.results.tasks[0]?.actual, "fallback answer");
-  assert.equal(realResult.results.tasks[0]?.actual, "real answer");
-  assert.equal(realResponds, 1);
-});
-
 test("runPublishedHarness rejects drain failure before scoring trials", async () => {
   const { system, calls } = makeFakeSystem();
   system.drain = async () => {
@@ -1346,4 +1146,203 @@ test("runPublishedHarness produces empty result for empty plans", async () => {
   assert.equal(result.results.tasks.length, 0);
   assert.equal(result.cost.meanQueryLatencyMs, 0);
   assert.equal(result.meta.status, undefined, "an empty dataset is not a backend failure");
+});
+test("runPublishedHarness reuses an answer only for an identical paired input", async () => {
+  const baseline = makeFakeSystem({ recallPrefix: "shared" });
+  const real = makeFakeSystem({ recallPrefix: "shared" });
+  let baselineResponds = 0;
+  baseline.system.responder.respond = async () => {
+    baselineResponds++;
+    return {
+      text: "baseline answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
+  real.system.responder.respond = async () => ({
+    text: "real answer",
+    tokens: { input: 1, output: 1 },
+    latencyMs: 1,
+    model: "shared-responder",
+  });
+  const pairedAnswerReplayCache = new Map();
+  const plan: HarnessPlan = {
+    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
+    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
+  };
+  const run = (
+    system: typeof baseline.system,
+    runtimeProfile: "baseline" | "real",
+  ) =>
+    runPublishedHarness({
+      options: makeOptions(system, {
+        pairedAnswerReplayCache,
+        runtimeProfile,
+      }),
+      metricsSpec: { metrics: ["f1"] },
+      plans: [plan],
+    });
+
+  const baselineResult = await run(baseline.system, "baseline");
+  const realResult = await run(real.system, "real");
+
+  assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
+  assert.equal(realResult.results.tasks[0]?.actual, "baseline answer");
+  assert.equal(baselineResponds, 1);
+  assert.equal(real.calls.filter((call) => call.kind === "respond").length, 0);
+});
+
+test("runPublishedHarness never replays a real answer into baseline", async () => {
+  const baseline = makeFakeSystem({ recallPrefix: "shared" });
+  const real = makeFakeSystem({ recallPrefix: "shared" });
+  let baselineResponds = 0;
+  let realResponds = 0;
+  baseline.system.responder.respond = async () => {
+    baselineResponds++;
+    return {
+      text: "baseline answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
+  real.system.responder.respond = async () => {
+    realResponds++;
+    return {
+      text: "real answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
+  const pairedAnswerReplayCache = new Map();
+  const plan: HarnessPlan = {
+    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
+    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
+  };
+  const run = (
+    system: typeof baseline.system,
+    runtimeProfile: "baseline" | "real",
+  ) =>
+    runPublishedHarness({
+      options: makeOptions(system, {
+        pairedAnswerReplayCache,
+        runtimeProfile,
+      }),
+      metricsSpec: { metrics: ["f1"] },
+      plans: [plan],
+    });
+
+  const realResult = await run(real.system, "real");
+  const baselineResult = await run(baseline.system, "baseline");
+
+  assert.equal(realResult.results.tasks[0]?.actual, "real answer");
+  assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
+  assert.equal(
+    baselineResult.results.tasks[0]?.details?.pairedAnswerReusedFrom,
+    undefined,
+  );
+  assert.equal(realResponds, 1);
+  assert.equal(baselineResponds, 1);
+});
+
+test("runPublishedHarness does not replay across different responder models", async () => {
+  const baseline = makeFakeSystem({ recallPrefix: "shared" });
+  const real = makeFakeSystem({ recallPrefix: "shared" });
+  let baselineResponds = 0;
+  let realResponds = 0;
+  baseline.system.responder.respond = async () => {
+    baselineResponds++;
+    return {
+      text: "baseline answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "baseline-responder",
+    };
+  };
+  real.system.responder.respond = async () => {
+    realResponds++;
+    return {
+      text: "real answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "real-responder",
+    };
+  };
+  const pairedAnswerReplayCache = new Map();
+  const plan: HarnessPlan = {
+    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
+    trials: [{ taskId: "paired", question: "What happened?", expected: "baseline answer", recallSessionIds: ["session"] }],
+  };
+  const run = (
+    system: typeof baseline.system,
+    runtimeProfile: "baseline" | "real",
+    model: string,
+  ) =>
+    runPublishedHarness({
+      options: makeOptions(system, {
+        pairedAnswerReplayCache,
+        runtimeProfile,
+        systemProvider: { provider: "openai", model },
+      }),
+      metricsSpec: { metrics: ["f1"] },
+      plans: [plan],
+    });
+
+  const baselineResult = await run(baseline.system, "baseline", "baseline-model");
+  const realResult = await run(real.system, "real", "real-model");
+
+  assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
+  assert.equal(realResult.results.tasks[0]?.actual, "real answer");
+  assert.equal(baselineResponds, 1);
+  assert.equal(realResponds, 1);
+});
+
+test("runPublishedHarness does not replay a baseline fallback answer", async () => {
+  const baseline = makeFakeSystem({ recallPrefix: "shared" });
+  const real = makeFakeSystem({ recallPrefix: "shared" });
+  baseline.system.responder.respond = async () => {
+    throw new Error("baseline responder unavailable");
+  };
+  let realResponds = 0;
+  real.system.responder.respond = async () => {
+    realResponds++;
+    return {
+      text: "real answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
+  const pairedAnswerReplayCache = new Map();
+  const plan: HarnessPlan = {
+    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
+    trials: [{
+      taskId: "paired",
+      question: "What happened?",
+      expected: "fallback answer",
+      recallSessionIds: ["session"],
+      answerFallback: () => "fallback answer",
+    }],
+  };
+  const run = (
+    system: typeof baseline.system,
+    runtimeProfile: "baseline" | "real",
+  ) =>
+    runPublishedHarness({
+      options: makeOptions(system, {
+        pairedAnswerReplayCache,
+        runtimeProfile,
+      }),
+      metricsSpec: { metrics: ["f1"] },
+      plans: [plan],
+    });
+
+  const baselineResult = await run(baseline.system, "baseline");
+  const realResult = await run(real.system, "real");
+
+  assert.equal(baselineResult.results.tasks[0]?.actual, "fallback answer");
+  assert.equal(realResult.results.tasks[0]?.actual, "real answer");
+  assert.equal(realResponds, 1);
 });

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -1151,6 +1151,7 @@ test("runPublishedHarness reuses an answer only for an identical paired input", 
   const baseline = makeFakeSystem({ recallPrefix: "shared" });
   const real = makeFakeSystem({ recallPrefix: "shared" });
   let baselineResponds = 0;
+  let realResponds = 0;
   baseline.system.responder.respond = async () => {
     baselineResponds++;
     return {
@@ -1160,12 +1161,15 @@ test("runPublishedHarness reuses an answer only for an identical paired input", 
       model: "shared-responder",
     };
   };
-  real.system.responder.respond = async () => ({
-    text: "real answer",
-    tokens: { input: 1, output: 1 },
-    latencyMs: 1,
-    model: "shared-responder",
-  });
+  real.system.responder.respond = async () => {
+    realResponds++;
+    return {
+      text: "real answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
   const pairedAnswerReplayCache = new Map();
   const plan: HarnessPlan = {
     ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
@@ -1190,7 +1194,7 @@ test("runPublishedHarness reuses an answer only for an identical paired input", 
   assert.equal(baselineResult.results.tasks[0]?.actual, "baseline answer");
   assert.equal(realResult.results.tasks[0]?.actual, "baseline answer");
   assert.equal(baselineResponds, 1);
-  assert.equal(real.calls.filter((call) => call.kind === "respond").length, 0);
+  assert.equal(realResponds, 0);
 });
 
 test("runPublishedHarness never replays a real answer into baseline", async () => {
@@ -1353,6 +1357,7 @@ test("runPublishedHarness preserves a baseline replay answer across another prof
   const real = makeFakeSystem({ recallPrefix: "shared" });
   let baselineResponds = 0;
   let localLabResponds = 0;
+  let realResponds = 0;
   baseline.system.responder.respond = async () => {
     baselineResponds++;
     return {
@@ -1371,12 +1376,15 @@ test("runPublishedHarness preserves a baseline replay answer across another prof
       model: "shared-responder",
     };
   };
-  real.system.responder.respond = async () => ({
-    text: "real answer",
-    tokens: { input: 1, output: 1 },
-    latencyMs: 1,
-    model: "shared-responder",
-  });
+  real.system.responder.respond = async () => {
+    realResponds++;
+    return {
+      text: "real answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
   const pairedAnswerReplayCache = new Map();
   const plan: HarnessPlan = {
     ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
@@ -1402,5 +1410,62 @@ test("runPublishedHarness preserves a baseline replay answer across another prof
   assert.equal(realResult.results.tasks[0]?.actual, "baseline answer");
   assert.equal(baselineResponds, 1);
   assert.equal(localLabResponds, 1);
-  assert.equal(real.calls.filter((call) => call.kind === "respond").length, 0);
+  assert.equal(realResponds, 0);
+});
+
+test("runPublishedHarness does not replay a baseline answer after a later trial failure", async () => {
+  const baseline = makeFakeSystem({ recallPrefix: "shared" });
+  const real = makeFakeSystem({ recallPrefix: "shared" });
+  let realResponds = 0;
+  baseline.system.responder.respond = async () => ({
+    text: "baseline answer",
+    tokens: { input: 1, output: 1 },
+    latencyMs: 1,
+    model: "shared-responder",
+  });
+  real.system.responder.respond = async () => {
+    realResponds++;
+    return {
+      text: "real answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
+  let hookCalls = 0;
+  const pairedAnswerReplayCache = new Map();
+  const plan: HarnessPlan = {
+    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
+    trials: [{
+      taskId: "paired",
+      question: "What happened?",
+      expected: "baseline answer",
+      recallSessionIds: ["session"],
+      postAnswerHook: async () => {
+        if (hookCalls++ === 0) {
+          throw new Error("late trial failure");
+        }
+        return {};
+      },
+    }],
+  };
+  const run = (
+    system: typeof baseline.system,
+    runtimeProfile: "baseline" | "real",
+  ) =>
+    runPublishedHarness({
+      options: makeOptions(system, {
+        pairedAnswerReplayCache,
+        runtimeProfile,
+      }),
+      metricsSpec: { metrics: ["f1"] },
+      plans: [plan],
+    });
+
+  const baselineResult = await run(baseline.system, "baseline");
+  const realResult = await run(real.system, "real");
+
+  assert.match(baselineResult.results.tasks[0]?.actual ?? "", /late trial failure/);
+  assert.equal(realResult.results.tasks[0]?.actual, "real answer");
+  assert.equal(realResponds, 1);
 });

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -1444,3 +1444,48 @@ test("runPublishedHarness does not replay a baseline answer after a later trial 
   assert.equal(realResult.results.tasks[0]?.actual, "real answer");
   assert.equal(realResponds, 2);
 });
+
+test("pairedAnswerReplayKey hashes identical nested retryOptions regardless of property order", () => {
+  const baseSystemProvider = {
+    provider: "openai" as const,
+    model: "gpt-test",
+  };
+  const plan: HarnessPlan = {
+    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
+    trials: [{
+      taskId: "paired",
+      question: "What happened?",
+      expected: "baseline answer",
+      recallSessionIds: ["session"],
+    }],
+  };
+  const runWithRetry = (retryOptions: Record<string, unknown>) => {
+    const baseline = makeFakeSystem({ recallPrefix: "shared" });
+    baseline.system.responder.respond = async () => ({
+      text: "baseline answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    });
+    return runPublishedHarness({
+      options: makeOptions(baseline.system, {
+        runtimeProfile: "baseline",
+        systemProvider: {
+          ...baseSystemProvider,
+          retryOptions: retryOptions as never,
+        },
+      }),
+      metricsSpec: { metrics: ["f1"] },
+      plans: [plan],
+    });
+  };
+  const first = runWithRetry({ maxAttempts: 3, baseBackoffMs: 100 });
+  const second = runWithRetry({ baseBackoffMs: 100, maxAttempts: 3 });
+  return Promise.all([first, second]).then(([a, b]) => {
+    assert.equal(
+      a.results.tasks[0]?.actual,
+      b.results.tasks[0]?.actual,
+      "identical retryOptions must produce identical answers",
+    );
+  });
+});

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -1432,22 +1432,31 @@ test("runPublishedHarness does not replay a baseline answer after a later trial 
       model: "shared-responder",
     };
   };
-  let hookCalls = 0;
+  let shouldFail = true;
   const pairedAnswerReplayCache = new Map();
   const plan: HarnessPlan = {
     ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
-    trials: [{
-      taskId: "paired",
-      question: "What happened?",
-      expected: "baseline answer",
-      recallSessionIds: ["session"],
-      postAnswerHook: async () => {
-        if (hookCalls++ === 0) {
-          throw new Error("late trial failure");
-        }
-        return {};
+    trials: [
+      {
+        taskId: "accepted",
+        question: "What happened?",
+        expected: "baseline answer",
+        recallSessionIds: ["session"],
       },
-    }],
+      {
+        taskId: "failed",
+        question: "What failed?",
+        expected: "baseline answer",
+        recallSessionIds: ["session"],
+        postAnswerHook: async () => {
+          if (shouldFail) {
+            shouldFail = false;
+            throw new Error("late trial failure");
+          }
+          return {};
+        },
+      },
+    ],
   };
   const run = (
     system: typeof baseline.system,
@@ -1465,7 +1474,7 @@ test("runPublishedHarness does not replay a baseline answer after a later trial 
   const baselineResult = await run(baseline.system, "baseline");
   const realResult = await run(real.system, "real");
 
-  assert.match(baselineResult.results.tasks[0]?.actual ?? "", /late trial failure/);
+  assert.match(baselineResult.results.tasks[1]?.actual ?? "", /late trial failure/);
   assert.equal(realResult.results.tasks[0]?.actual, "real answer");
-  assert.equal(realResponds, 1);
+  assert.equal(realResponds, 2);
 });

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -336,6 +336,54 @@ test("runPublishedHarness does not replay across different responder models", as
   assert.equal(realResponds, 1);
 });
 
+test("runPublishedHarness does not replay a baseline fallback answer", async () => {
+  const baseline = makeFakeSystem({ recallPrefix: "shared" });
+  const real = makeFakeSystem({ recallPrefix: "shared" });
+  baseline.system.responder.respond = async () => {
+    throw new Error("baseline responder unavailable");
+  };
+  let realResponds = 0;
+  real.system.responder.respond = async () => {
+    realResponds++;
+    return {
+      text: "real answer",
+      tokens: { input: 1, output: 1 },
+      latencyMs: 1,
+      model: "shared-responder",
+    };
+  };
+  const pairedAnswerReplayCache = new Map();
+  const plan: HarnessPlan = {
+    ingestSessions: [{ sessionId: "session", messages: [{ role: "user", content: "memory" }] }],
+    trials: [{
+      taskId: "paired",
+      question: "What happened?",
+      expected: "fallback answer",
+      recallSessionIds: ["session"],
+      answerFallback: () => "fallback answer",
+    }],
+  };
+  const run = (
+    system: typeof baseline.system,
+    runtimeProfile: "baseline" | "real",
+  ) =>
+    runPublishedHarness({
+      options: makeOptions(system, {
+        pairedAnswerReplayCache,
+        runtimeProfile,
+      }),
+      metricsSpec: { metrics: ["f1"] },
+      plans: [plan],
+    });
+
+  const baselineResult = await run(baseline.system, "baseline");
+  const realResult = await run(real.system, "real");
+
+  assert.equal(baselineResult.results.tasks[0]?.actual, "fallback answer");
+  assert.equal(realResult.results.tasks[0]?.actual, "real answer");
+  assert.equal(realResponds, 1);
+});
+
 test("runPublishedHarness rejects drain failure before scoring trials", async () => {
   const { system, calls } = makeFakeSystem();
   system.drain = async () => {

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -24,7 +24,7 @@
  * permissible values rather than silently defaulting.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import type {
   BenchRecallSupportAssessment,
@@ -59,6 +59,7 @@ import { computeCategoryAggregates } from "./category-aggregates.js";
 import type {
   BenchmarkMode,
   BenchmarkResult,
+  PairedAnswerReplayEntry,
   ResolvedRunBenchmarkOptions,
   TaskResult,
 } from "../../types.js";
@@ -500,6 +501,45 @@ function resolveAnswerSupportGate(
   );
 }
 
+function pairedAnswerReplayKey(
+  trial: HarnessTrial,
+  recalledText: string,
+  recallSupport: BenchRecallSupportAssessment | undefined,
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        answerFormat: trial.answerFormat ?? null,
+        answerMode: "strict",
+        question: trial.question,
+        recalledText,
+        recallSupport: recallSupport
+          ? {
+              evidenceCount: recallSupport.evidenceCount ?? null,
+              maxScore: recallSupport.maxScore ?? null,
+              reason: recallSupport.reason ?? null,
+              status: recallSupport.status,
+              supportThreshold: recallSupport.supportThreshold ?? null,
+            }
+          : null,
+        taskId: trial.taskId,
+      }),
+    )
+    .digest("hex");
+}
+
+function pairedAnswerReplayEntry(
+  sourceRuntimeProfile: PairedAnswerReplayEntry["sourceRuntimeProfile"],
+  answer: HarnessAnswerResult,
+): PairedAnswerReplayEntry {
+  return {
+    sourceRuntimeProfile,
+    finalAnswer: answer.finalAnswer,
+    answeredText: answer.answeredText,
+    ...(answer.model === undefined ? {} : { model: answer.model }),
+  };
+}
+
 async function executeTrial(
   ctx: HarnessContext,
   trial: HarnessTrial,
@@ -527,8 +567,25 @@ async function executeTrial(
     return { recalledText, recallSupport };
   });
   const { recalledText, recallSupport } = recallResult;
-  let answered: HarnessAnswerResult =
-    await answerBenchmarkQuestion({
+  const answerReplayKey = ctx.options.pairedAnswerReplayCache
+    ? pairedAnswerReplayKey(trial, recalledText, recallSupport)
+    : undefined;
+  const cachedAnswer = answerReplayKey
+    ? ctx.options.pairedAnswerReplayCache?.get(answerReplayKey)
+    : undefined;
+  const currentProfile = ctx.options.runtimeProfile ?? null;
+  let answered: HarnessAnswerResult;
+  if (cachedAnswer && cachedAnswer.sourceRuntimeProfile !== currentProfile) {
+    answered = {
+      finalAnswer: cachedAnswer.finalAnswer,
+      recalledText,
+      answeredText: cachedAnswer.answeredText,
+      latencyMs: 0,
+      tokens: { input: 0, output: 0 },
+      model: cachedAnswer.model,
+    };
+  } else {
+    answered = await answerBenchmarkQuestion({
       question: trial.question,
       recalledText,
       responder: ctx.options.system.responder,
@@ -538,7 +595,14 @@ async function executeTrial(
     }).catch((error: unknown) =>
       answerWithTrialFallback(trial, recalledText, error),
     );
-  answered = refineTrialAnswer(trial, recalledText, answered);
+    answered = refineTrialAnswer(trial, recalledText, answered);
+    if (answerReplayKey) {
+      ctx.options.pairedAnswerReplayCache?.set(
+        answerReplayKey,
+        pairedAnswerReplayEntry(currentProfile, answered),
+      );
+    }
+  }
 
   // Post-answer hook runs before the judge so dataset-specific signals
   // (e.g. LongMemEval `search_hits`) are observed from the same
@@ -625,6 +689,9 @@ async function executeTrial(
     ...(trial.answerFormat ? { answerFormat: trial.answerFormat } : {}),
     ...(answerSupportGate
       ? { answerSupportGate: true, recallSupport }
+      : {}),
+    ...(cachedAnswer && cachedAnswer.sourceRuntimeProfile !== currentProfile
+      ? { pairedAnswerReusedFrom: cachedAnswer.sourceRuntimeProfile }
       : {}),
     responderModel: answered.model,
     judgeModel: judgeResult.model,

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -33,6 +33,7 @@ import type {
 } from "../../adapters/types.js";
 import {
   answerBenchmarkQuestion,
+  buildStrictBenchmarkQuestion,
   type BenchmarkAnswerResult,
   type BenchmarkAnswerFormat,
 } from "../../answering.js";
@@ -505,11 +506,19 @@ function pairedAnswerReplayKey(
   trial: HarnessTrial,
   recalledText: string,
   recallSupport: BenchRecallSupportAssessment | undefined,
+  systemProvider: ResolvedRunBenchmarkOptions["systemProvider"],
 ): string {
   return createHash("sha256")
     .update(
       JSON.stringify({
-        answerFormat: trial.answerFormat ?? null,
+        responder: {
+          model: systemProvider?.model ?? null,
+          provider: systemProvider?.provider ?? null,
+        },
+        responderPrompt: buildStrictBenchmarkQuestion(
+          trial.question,
+          trial.answerFormat ?? "auto",
+        ),
         answerMode: "strict",
         question: trial.question,
         recalledText,
@@ -568,25 +577,31 @@ async function executeTrial(
   });
   const { recalledText, recallSupport } = recallResult;
   const answerReplayKey = ctx.options.pairedAnswerReplayCache
-    ? pairedAnswerReplayKey(trial, recalledText, recallSupport)
+    ? pairedAnswerReplayKey(
+        trial,
+        recalledText,
+        recallSupport,
+        ctx.options.systemProvider,
+      )
     : undefined;
   const cachedAnswer = answerReplayKey
     ? ctx.options.pairedAnswerReplayCache?.get(answerReplayKey)
     : undefined;
   const currentProfile = ctx.options.runtimeProfile ?? null;
+  const pairedAnswerReusedFrom =
+    cachedAnswer?.sourceRuntimeProfile === "baseline" && currentProfile === "real"
+      ? "baseline"
+      : undefined;
   let answered: HarnessAnswerResult;
-  if (
-    cachedAnswer
-    && cachedAnswer.sourceRuntimeProfile === "baseline"
-    && currentProfile === "real"
-  ) {
+  if (pairedAnswerReusedFrom) {
+    const reusedAnswer = cachedAnswer!;
     answered = {
-      finalAnswer: cachedAnswer.finalAnswer,
+      finalAnswer: reusedAnswer.finalAnswer,
       recalledText,
-      answeredText: cachedAnswer.answeredText,
+      answeredText: reusedAnswer.answeredText,
       latencyMs: 0,
       tokens: { input: 0, output: 0 },
-      model: cachedAnswer.model,
+      model: reusedAnswer.model,
     };
   } else {
     answered = await answerBenchmarkQuestion({
@@ -694,9 +709,7 @@ async function executeTrial(
     ...(answerSupportGate
       ? { answerSupportGate: true, recallSupport }
       : {}),
-    ...(cachedAnswer && cachedAnswer.sourceRuntimeProfile !== currentProfile
-      ? { pairedAnswerReusedFrom: cachedAnswer.sourceRuntimeProfile }
-      : {}),
+    ...(pairedAnswerReusedFrom ? { pairedAnswerReusedFrom } : {}),
     responderModel: answered.model,
     judgeModel: judgeResult.model,
     ...(answered.fallbackReason

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -26,7 +26,7 @@
 
 import { createHash, randomUUID } from "node:crypto";
 
-import type { BenchRecallSupportAssessment, BenchRecallSupportStatus, Message } from "../../adapters/types.js";
+import type { BenchRecallSupportAssessment, BenchRecallSupportStatus, BenchResponder, Message } from "../../adapters/types.js";
 import {
   answerBenchmarkQuestion,
   buildStrictBenchmarkQuestion,
@@ -504,7 +504,8 @@ function pairedAnswerReplayKey(
   trial: HarnessTrial,
   recalledText: string,
   recallSupport: BenchRecallSupportAssessment | undefined,
-  systemProvider: ResolvedRunBenchmarkOptions["systemProvider"]
+  systemProvider: ResolvedRunBenchmarkOptions["systemProvider"],
+  responderIdentity: string | null
 ): string {
   return createHash("sha256")
     .update(
@@ -522,6 +523,7 @@ function pairedAnswerReplayKey(
           seed: systemProvider?.seed ?? null,
           temperature: systemProvider?.temperature ?? null,
         },
+        responderIdentity,
         responderPrompt: buildStrictBenchmarkQuestion(
           trial.question,
           trial.answerFormat ?? "auto"
@@ -556,6 +558,26 @@ function pairedAnswerReplayEntry(
   };
 }
 
+/**
+ * Resolve a non-secret responder fingerprint. Returns `null` when the
+ * responder does not declare an identity, signalling that the replay cache
+ * must be disabled for this trial (paired runs will invoke the responder
+ * directly every time instead of risking a cross-profile replay).
+ */
+function resolveResponderIdentity(responder: BenchResponder | undefined): string | null {
+  if (!responder || typeof responder.identity !== "function") {
+    return null;
+  }
+  let raw: string;
+  try {
+    raw = responder.identity();
+  } catch {
+    return null;
+  }
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 async function executeTrial(
   ctx: HarnessContext,
   trial: HarnessTrial,
@@ -578,9 +600,17 @@ async function executeTrial(
     return { recalledText, recallSupport };
   });
   const { recalledText, recallSupport } = recallResult;
-  const answerReplayKey = ctx.options.pairedAnswerReplayCache
-    ? pairedAnswerReplayKey(trial, recalledText, recallSupport, ctx.options.systemProvider)
-    : undefined;
+  const responderIdentity = resolveResponderIdentity(ctx.options.system.responder);
+  const answerReplayKey =
+    ctx.options.pairedAnswerReplayCache && responderIdentity !== null
+      ? pairedAnswerReplayKey(
+          trial,
+          recalledText,
+          recallSupport,
+          ctx.options.systemProvider,
+          responderIdentity,
+        )
+      : undefined;
   const cachedAnswer = answerReplayKey ? ctx.options.pairedAnswerReplayCache?.get(answerReplayKey) : undefined;
   const currentProfile = ctx.options.runtimeProfile ?? null;
   const pairedAnswerReusedFrom =

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -615,7 +615,11 @@ async function executeTrial(
       answerWithTrialFallback(trial, recalledText, error),
     );
     answered = refineTrialAnswer(trial, recalledText, answered);
-    if (answerReplayKey && answered.fallbackReason === undefined) {
+    if (
+      answerReplayKey
+      && currentProfile === "baseline"
+      && answered.fallbackReason === undefined
+    ) {
       ctx.options.pairedAnswerReplayCache?.set(
         answerReplayKey,
         pairedAnswerReplayEntry(currentProfile, answered),

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -206,6 +206,11 @@ export interface HarnessContext {
   totalCount?: number;
 }
 
+interface PendingPairedAnswerReplay {
+  key: string;
+  entry: PairedAnswerReplayEntry;
+}
+
 /** Convenience: guard an arbitrary iterable shape into an async iterator. */
 async function* toAsyncIterable<T>(
   iter: Iterable<T> | AsyncIterable<T>,
@@ -242,6 +247,7 @@ export async function runPublishedHarness(
     ctx.options.benchmarkOptions?.trialConcurrency,
   );
   const tasks: TaskResult[] = [];
+  const pendingPairedAnswerReplays = new Map<TaskResult, PendingPairedAnswerReplay>();
 
   for await (const plan of toAsyncIterable(ctx.plans)) {
     await ctx.options.system.reset();
@@ -266,6 +272,7 @@ export async function runPublishedHarness(
       tasks,
       trialConcurrency,
       answerSupportGate,
+      pendingPairedAnswerReplays,
     });
   }
 
@@ -280,6 +287,7 @@ async function executePlanTrials(
     tasks: TaskResult[];
     trialConcurrency: number;
     answerSupportGate: boolean;
+    pendingPairedAnswerReplays: Map<TaskResult, PendingPairedAnswerReplay>;
   },
 ): Promise<void> {
   if (options.trialConcurrency === 1 || trials.length <= 1) {
@@ -287,11 +295,13 @@ async function executePlanTrials(
       appendCompletedTask(
         ctx,
         options.tasks,
+        options.pendingPairedAnswerReplays,
         await executeTrialWithFailure(
           ctx,
           trial,
           options.planIndex,
           options.answerSupportGate,
+          options.pendingPairedAnswerReplays,
         ),
       );
     }
@@ -314,6 +324,7 @@ async function executePlanTrials(
           trial,
           options.planIndex,
           options.answerSupportGate,
+          options.pendingPairedAnswerReplays,
         ),
       ),
     );
@@ -340,7 +351,12 @@ async function executePlanTrials(
           `PublishedBenchmarkHarness: concurrent trial ${batchStart + offset} did not settle before canonical emission.`,
         );
       }
-      appendCompletedTask(ctx, options.tasks, result.value);
+      appendCompletedTask(
+        ctx,
+        options.tasks,
+        options.pendingPairedAnswerReplays,
+        result.value,
+      );
     }
 
     if (terminalOffset >= 0) {
@@ -361,8 +377,16 @@ async function executePlanTrials(
 function appendCompletedTask(
   ctx: HarnessContext,
   tasks: TaskResult[],
+  pendingPairedAnswerReplays: Map<TaskResult, PendingPairedAnswerReplay>,
   task: TaskResult,
 ): void {
+  const pendingReplay = pendingPairedAnswerReplays.get(task);
+  if (pendingReplay) {
+    ctx.options.pairedAnswerReplayCache?.set(
+      pendingReplay.key,
+      pendingReplay.entry,
+    );
+  }
   tasks.push(task);
   // Pass the GLOBAL total (ctx.totalCount), not a per-plan total —
   // `tasks.length` is cumulative across every plan in ctx.plans, so a
@@ -375,10 +399,16 @@ async function executeTrialWithFailure(
   trial: HarnessTrial,
   planIndex: number,
   answerSupportGate: boolean,
+  pendingPairedAnswerReplays: Map<TaskResult, PendingPairedAnswerReplay>,
 ): Promise<TaskResult> {
   const trialId = trial.taskId ?? trial.question.slice(0, 60);
   try {
-    return await executeTrial(ctx, trial, answerSupportGate);
+    return await executeTrial(
+      ctx,
+      trial,
+      answerSupportGate,
+      pendingPairedAnswerReplays,
+    );
   } catch (err) {
     const blocked = findBenchmarkRunBlockedError(err);
     if (blocked) {
@@ -553,6 +583,7 @@ async function executeTrial(
   ctx: HarnessContext,
   trial: HarnessTrial,
   answerSupportGate: boolean,
+  pendingPairedAnswerReplays: Map<TaskResult, PendingPairedAnswerReplay>,
 ): Promise<TaskResult> {
   const { result: recallResult, durationMs } = await timed(async () => {
     const recallBudget = benchmarkRecallBudgetForSessionCount(
@@ -615,16 +646,6 @@ async function executeTrial(
       answerWithTrialFallback(trial, recalledText, error),
     );
     answered = refineTrialAnswer(trial, recalledText, answered);
-    if (
-      answerReplayKey
-      && currentProfile === "baseline"
-      && answered.fallbackReason === undefined
-    ) {
-      ctx.options.pairedAnswerReplayCache?.set(
-        answerReplayKey,
-        pairedAnswerReplayEntry(currentProfile, answered),
-      );
-    }
   }
 
   // Post-answer hook runs before the judge so dataset-specific signals
@@ -734,7 +755,7 @@ async function executeTrial(
     Object.assign(details, hookResult.extraDetails);
   }
 
-  return {
+  const task: TaskResult = {
     taskId: trial.taskId,
     question: trial.question,
     expected: trial.expected,
@@ -747,6 +768,17 @@ async function executeTrial(
     },
     details,
   };
+  if (
+    answerReplayKey
+    && currentProfile === "baseline"
+    && answered.fallbackReason === undefined
+  ) {
+    pendingPairedAnswerReplays.set(task, {
+      key: answerReplayKey,
+      entry: pairedAnswerReplayEntry(currentProfile, answered),
+    });
+  }
+  return task;
 }
 
 async function assessRecallSupport(

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -487,6 +487,19 @@ function resolveAnswerSupportGate(options: ResolvedRunBenchmarkOptions): boolean
   );
 }
 
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  return `{${keys
+    .map((key) => `${JSON.stringify(key)}:${stableStringify((value as Record<string, unknown>)[key])}`)
+    .join(",")}}`;
+}
+
 function pairedAnswerReplayKey(
   trial: HarnessTrial,
   recalledText: string,
@@ -495,7 +508,7 @@ function pairedAnswerReplayKey(
 ): string {
   return createHash("sha256")
     .update(
-      JSON.stringify({
+      stableStringify({
         responder: {
           baseUrl: systemProvider?.baseUrl ?? null,
           disableThinking: systemProvider?.disableThinking ?? null,

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -276,7 +276,14 @@ export async function runPublishedHarness(
     });
   }
 
-  return buildBenchmarkResult(ctx, tasks, executionProvenance);
+  const result = await buildBenchmarkResult(ctx, tasks, executionProvenance);
+  if (
+    ctx.options.runtimeProfile === "baseline"
+    && result.meta.status === "partial"
+  ) {
+    ctx.options.pairedAnswerReplayCache?.clear();
+  }
+  return result;
 }
 
 async function executePlanTrials(
@@ -542,8 +549,16 @@ function pairedAnswerReplayKey(
     .update(
       JSON.stringify({
         responder: {
+          baseUrl: systemProvider?.baseUrl ?? null,
+          disableThinking: systemProvider?.disableThinking ?? null,
           model: systemProvider?.model ?? null,
           provider: systemProvider?.provider ?? null,
+          providerRequestTimeoutMs: systemProvider?.providerRequestTimeoutMs ?? null,
+          reasoningEffort: systemProvider?.reasoningEffort ?? null,
+          responderContextBudgetChars: systemProvider?.responderContextBudgetChars ?? null,
+          responderPromptBudgetChars: systemProvider?.responderPromptBudgetChars ?? null,
+          seed: systemProvider?.seed ?? null,
+          temperature: systemProvider?.temperature ?? null,
         },
         responderPrompt: buildStrictBenchmarkQuestion(
           trial.question,

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -575,7 +575,11 @@ async function executeTrial(
     : undefined;
   const currentProfile = ctx.options.runtimeProfile ?? null;
   let answered: HarnessAnswerResult;
-  if (cachedAnswer && cachedAnswer.sourceRuntimeProfile !== currentProfile) {
+  if (
+    cachedAnswer
+    && cachedAnswer.sourceRuntimeProfile === "baseline"
+    && currentProfile === "real"
+  ) {
     answered = {
       finalAnswer: cachedAnswer.finalAnswer,
       recalledText,

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -505,10 +505,14 @@ function pairedAnswerReplayKey(
           reasoningEffort: systemProvider?.reasoningEffort ?? null,
           responderContextBudgetChars: systemProvider?.responderContextBudgetChars ?? null,
           responderPromptBudgetChars: systemProvider?.responderPromptBudgetChars ?? null,
+          retryOptions: systemProvider?.retryOptions ?? null,
           seed: systemProvider?.seed ?? null,
           temperature: systemProvider?.temperature ?? null,
         },
-        responderPrompt: buildStrictBenchmarkQuestion(trial.question, trial.answerFormat ?? "auto"),
+        responderPrompt: buildStrictBenchmarkQuestion(
+          trial.question,
+          trial.answerFormat ?? "auto"
+        ),
         answerMode: "strict",
         question: trial.question,
         recalledText,

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -615,7 +615,7 @@ async function executeTrial(
       answerWithTrialFallback(trial, recalledText, error),
     );
     answered = refineTrialAnswer(trial, recalledText, answered);
-    if (answerReplayKey) {
+    if (answerReplayKey && answered.fallbackReason === undefined) {
       ctx.options.pairedAnswerReplayCache?.set(
         answerReplayKey,
         pairedAnswerReplayEntry(currentProfile, answered),

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -26,21 +26,14 @@
 
 import { createHash, randomUUID } from "node:crypto";
 
-import type {
-  BenchRecallSupportAssessment,
-  BenchRecallSupportStatus,
-  Message,
-} from "../../adapters/types.js";
+import type { BenchRecallSupportAssessment, BenchRecallSupportStatus, Message } from "../../adapters/types.js";
 import {
   answerBenchmarkQuestion,
   buildStrictBenchmarkQuestion,
   type BenchmarkAnswerResult,
   type BenchmarkAnswerFormat,
 } from "../../answering.js";
-import {
-  findBenchmarkRunBlockedError,
-  isBenchmarkRunBlockedError,
-} from "../../benchmark-run-blocked-error.js";
+import { findBenchmarkRunBlockedError, isBenchmarkRunBlockedError } from "../../benchmark-run-blocked-error.js";
 import { benchmarkRecallBudgetForSessionCount } from "../../recall-budget.js";
 import {
   captureBenchmarkExecutionProvenance,
@@ -175,12 +168,7 @@ export interface HarnessPlan {
  * Metrics the harness computes for every trial. Dataset-specific extra
  * metrics are merged on top via `HarnessTrial.extraScores`.
  */
-export type HarnessMetricId =
-  | "f1"
-  | "contains_answer"
-  | "rouge_l"
-  | "llm_judge"
-  | "judge_accuracy";
+export type HarnessMetricId = "f1" | "contains_answer" | "rouge_l" | "llm_judge" | "judge_accuracy";
 
 export interface HarnessMetricsSpec {
   /**
@@ -212,9 +200,7 @@ interface PendingPairedAnswerReplay {
 }
 
 /** Convenience: guard an arbitrary iterable shape into an async iterator. */
-async function* toAsyncIterable<T>(
-  iter: Iterable<T> | AsyncIterable<T>,
-): AsyncIterable<T> {
+async function* toAsyncIterable<T>(iter: Iterable<T> | AsyncIterable<T>): AsyncIterable<T> {
   for await (const value of iter as AsyncIterable<T>) {
     yield value;
   }
@@ -237,50 +223,50 @@ async function* toAsyncIterable<T>(
  *   - Every trial recalls from ALL `recallSessionIds` before calling
  *     the responder.
  */
-export async function runPublishedHarness(
-  ctx: HarnessContext,
-): Promise<BenchmarkResult> {
+export async function runPublishedHarness(ctx: HarnessContext): Promise<BenchmarkResult> {
   validateContext(ctx);
   const executionProvenance = captureBenchmarkExecutionProvenance();
   const answerSupportGate = resolveAnswerSupportGate(ctx.options);
-  const trialConcurrency = resolveTrialConcurrency(
-    ctx.options.benchmarkOptions?.trialConcurrency,
-  );
+  const trialConcurrency = resolveTrialConcurrency(ctx.options.benchmarkOptions?.trialConcurrency);
   const tasks: TaskResult[] = [];
   const pendingPairedAnswerReplays = new Map<TaskResult, PendingPairedAnswerReplay>();
 
-  for await (const plan of toAsyncIterable(ctx.plans)) {
-    await ctx.options.system.reset();
-    for (const session of plan.ingestSessions) {
-      if (session.messages.length > 0) {
-        await ctx.options.system.store(session.sessionId, session.messages);
+  try {
+    for await (const plan of toAsyncIterable(ctx.plans)) {
+      await ctx.options.system.reset();
+      for (const session of plan.ingestSessions) {
+        if (session.messages.length > 0) {
+          await ctx.options.system.store(session.sessionId, session.messages);
+        }
       }
+      try {
+        await ctx.options.system.drain?.();
+      } catch (drainErr) {
+        throw new Error(
+          `PublishedBenchmarkHarness: drain failed before scoring; public benchmark evidence would be incomplete: ${
+            drainErr instanceof Error ? drainErr.message : String(drainErr)
+          }`,
+          { cause: drainErr }
+        );
+      }
+      const planIndex = tasks.length;
+      await executePlanTrials(ctx, plan.trials, {
+        planIndex,
+        tasks,
+        trialConcurrency,
+        answerSupportGate,
+        pendingPairedAnswerReplays,
+      });
     }
-    try {
-      await ctx.options.system.drain?.();
-    } catch (drainErr) {
-      throw new Error(
-        `PublishedBenchmarkHarness: drain failed before scoring; public benchmark evidence would be incomplete: ${
-          drainErr instanceof Error ? drainErr.message : String(drainErr)
-        }`,
-        { cause: drainErr },
-      );
+  } catch (error) {
+    if (ctx.options.runtimeProfile === "baseline") {
+      ctx.options.pairedAnswerReplayCache?.clear();
     }
-    const planIndex = tasks.length;
-    await executePlanTrials(ctx, plan.trials, {
-      planIndex,
-      tasks,
-      trialConcurrency,
-      answerSupportGate,
-      pendingPairedAnswerReplays,
-    });
+    throw error;
   }
 
   const result = await buildBenchmarkResult(ctx, tasks, executionProvenance);
-  if (
-    ctx.options.runtimeProfile === "baseline"
-    && result.meta.status === "partial"
-  ) {
+  if (ctx.options.runtimeProfile === "baseline" && result.meta.status === "partial") {
     ctx.options.pairedAnswerReplayCache?.clear();
   }
   return result;
@@ -295,7 +281,7 @@ async function executePlanTrials(
     trialConcurrency: number;
     answerSupportGate: boolean;
     pendingPairedAnswerReplays: Map<TaskResult, PendingPairedAnswerReplay>;
-  },
+  }
 ): Promise<void> {
   if (options.trialConcurrency === 1 || trials.length <= 1) {
     for (const trial of trials) {
@@ -308,22 +294,15 @@ async function executePlanTrials(
           trial,
           options.planIndex,
           options.answerSupportGate,
-          options.pendingPairedAnswerReplays,
-        ),
+          options.pendingPairedAnswerReplays
+        )
       );
     }
     return;
   }
 
-  for (
-    let batchStart = 0;
-    batchStart < trials.length;
-    batchStart += options.trialConcurrency
-  ) {
-    const batch = trials.slice(
-      batchStart,
-      batchStart + options.trialConcurrency,
-    );
+  for (let batchStart = 0; batchStart < trials.length; batchStart += options.trialConcurrency) {
+    const batch = trials.slice(batchStart, batchStart + options.trialConcurrency);
     const settled = await Promise.allSettled(
       batch.map((trial) =>
         executeTrialWithFailure(
@@ -331,49 +310,40 @@ async function executePlanTrials(
           trial,
           options.planIndex,
           options.answerSupportGate,
-          options.pendingPairedAnswerReplays,
-        ),
-      ),
+          options.pendingPairedAnswerReplays
+        )
+      )
     );
 
     const unexpectedRejection = settled.find(
       (result): result is PromiseRejectedResult =>
-        result.status === "rejected" &&
-        findBenchmarkRunBlockedError(result.reason) === undefined,
+        result.status === "rejected" && findBenchmarkRunBlockedError(result.reason) === undefined
     );
     if (unexpectedRejection) {
       throw unexpectedRejection.reason;
     }
 
     const terminalOffset = settled.findIndex(
-      (result) =>
-        result.status === "rejected" &&
-        findBenchmarkRunBlockedError(result.reason) !== undefined,
+      (result) => result.status === "rejected" && findBenchmarkRunBlockedError(result.reason) !== undefined
     );
     const emitLimit = terminalOffset < 0 ? settled.length : terminalOffset;
     for (let offset = 0; offset < emitLimit; offset += 1) {
       const result = settled[offset];
       if (result?.status !== "fulfilled") {
         throw new Error(
-          `PublishedBenchmarkHarness: concurrent trial ${batchStart + offset} did not settle before canonical emission.`,
+          `PublishedBenchmarkHarness: concurrent trial ${batchStart + offset} did not settle before canonical emission.`
         );
       }
-      appendCompletedTask(
-        ctx,
-        options.tasks,
-        options.pendingPairedAnswerReplays,
-        result.value,
-      );
+      appendCompletedTask(ctx, options.tasks, options.pendingPairedAnswerReplays, result.value);
     }
 
     if (terminalOffset >= 0) {
       const terminalResult = settled[terminalOffset];
-      const terminalError = terminalResult?.status === "rejected"
-        ? findBenchmarkRunBlockedError(terminalResult.reason)
-        : undefined;
+      const terminalError =
+        terminalResult?.status === "rejected" ? findBenchmarkRunBlockedError(terminalResult.reason) : undefined;
       if (!terminalError) {
         throw new Error(
-          `PublishedBenchmarkHarness: concurrent trial ${batchStart + terminalOffset} lost its terminal error before canonical emission.`,
+          `PublishedBenchmarkHarness: concurrent trial ${batchStart + terminalOffset} lost its terminal error before canonical emission.`
         );
       }
       throw terminalError;
@@ -385,14 +355,11 @@ function appendCompletedTask(
   ctx: HarnessContext,
   tasks: TaskResult[],
   pendingPairedAnswerReplays: Map<TaskResult, PendingPairedAnswerReplay>,
-  task: TaskResult,
+  task: TaskResult
 ): void {
   const pendingReplay = pendingPairedAnswerReplays.get(task);
   if (pendingReplay) {
-    ctx.options.pairedAnswerReplayCache?.set(
-      pendingReplay.key,
-      pendingReplay.entry,
-    );
+    ctx.options.pairedAnswerReplayCache?.set(pendingReplay.key, pendingReplay.entry);
   }
   tasks.push(task);
   // Pass the GLOBAL total (ctx.totalCount), not a per-plan total —
@@ -406,16 +373,11 @@ async function executeTrialWithFailure(
   trial: HarnessTrial,
   planIndex: number,
   answerSupportGate: boolean,
-  pendingPairedAnswerReplays: Map<TaskResult, PendingPairedAnswerReplay>,
+  pendingPairedAnswerReplays: Map<TaskResult, PendingPairedAnswerReplay>
 ): Promise<TaskResult> {
   const trialId = trial.taskId ?? trial.question.slice(0, 60);
   try {
-    return await executeTrial(
-      ctx,
-      trial,
-      answerSupportGate,
-      pendingPairedAnswerReplays,
-    );
+    return await executeTrial(ctx, trial, answerSupportGate, pendingPairedAnswerReplays);
   } catch (err) {
     const blocked = findBenchmarkRunBlockedError(err);
     if (blocked) {
@@ -458,42 +420,33 @@ function validateContext(ctx: HarnessContext): void {
     throw new Error(
       "PublishedBenchmarkHarness requires a resolved options.system. " +
         "Valid shapes are created by the `benchmark-runner` CLI and the " +
-        "bench test doubles in packages/bench/src/adapters/.",
+        "bench test doubles in packages/bench/src/adapters/."
     );
   }
   if (!ctx.metricsSpec || !Array.isArray(ctx.metricsSpec.metrics)) {
     throw new Error(
       "PublishedBenchmarkHarness requires metricsSpec.metrics: one of " +
-        'f1, contains_answer, rouge_l, llm_judge, judge_accuracy.',
+        "f1, contains_answer, rouge_l, llm_judge, judge_accuracy."
     );
   }
-  const allowed: readonly HarnessMetricId[] = [
-    "f1",
-    "contains_answer",
-    "rouge_l",
-    "llm_judge",
-    "judge_accuracy",
-  ];
+  const allowed: readonly HarnessMetricId[] = ["f1", "contains_answer", "rouge_l", "llm_judge", "judge_accuracy"];
   for (const metric of ctx.metricsSpec.metrics) {
     if (!allowed.includes(metric)) {
       throw new Error(
-        `PublishedBenchmarkHarness: unknown metric "${String(metric)}". ` +
-          `Valid metrics: ${allowed.join(", ")}.`,
+        `PublishedBenchmarkHarness: unknown metric "${String(metric)}". ` + `Valid metrics: ${allowed.join(", ")}.`
       );
     }
   }
   if (ctx.options.seed !== undefined) {
     if (!Number.isInteger(ctx.options.seed) || ctx.options.seed < 0) {
       throw new Error(
-        `PublishedBenchmarkHarness: seed must be a non-negative integer; got ${String(ctx.options.seed)}.`,
+        `PublishedBenchmarkHarness: seed must be a non-negative integer; got ${String(ctx.options.seed)}.`
       );
     }
   }
 }
 
-function buildFailureScores(
-  metrics: readonly HarnessMetricId[],
-): Record<string, number> {
+function buildFailureScores(metrics: readonly HarnessMetricId[]): Record<string, number> {
   const scores: Record<string, number> = {};
   for (const metric of metrics) {
     scores[metric] = -1;
@@ -507,18 +460,13 @@ function resolveTrialConcurrency(raw: unknown): number {
   }
   const parsed = typeof raw === "number" ? raw : Number(raw);
   if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 64) {
-    throw new Error(
-      "PublishedBenchmarkHarness: benchmarkOptions.trialConcurrency must be an integer from 1 to 64.",
-    );
+    throw new Error("PublishedBenchmarkHarness: benchmarkOptions.trialConcurrency must be an integer from 1 to 64.");
   }
   return parsed;
 }
 
-function resolveAnswerSupportGate(
-  options: ResolvedRunBenchmarkOptions,
-): boolean {
-  const raw = options.benchmarkOptions?.answerSupportGate
-    ?? options.remnicConfig?.answerSupportGate;
+function resolveAnswerSupportGate(options: ResolvedRunBenchmarkOptions): boolean {
+  const raw = options.benchmarkOptions?.answerSupportGate ?? options.remnicConfig?.answerSupportGate;
   if (raw === undefined) {
     return false;
   }
@@ -535,7 +483,7 @@ function resolveAnswerSupportGate(
     }
   }
   throw new Error(
-    "PublishedBenchmarkHarness: answerSupportGate must be a boolean or one of true/false, 1/0, yes/no, on/off.",
+    "PublishedBenchmarkHarness: answerSupportGate must be a boolean or one of true/false, 1/0, yes/no, on/off."
   );
 }
 
@@ -543,7 +491,7 @@ function pairedAnswerReplayKey(
   trial: HarnessTrial,
   recalledText: string,
   recallSupport: BenchRecallSupportAssessment | undefined,
-  systemProvider: ResolvedRunBenchmarkOptions["systemProvider"],
+  systemProvider: ResolvedRunBenchmarkOptions["systemProvider"]
 ): string {
   return createHash("sha256")
     .update(
@@ -560,10 +508,7 @@ function pairedAnswerReplayKey(
           seed: systemProvider?.seed ?? null,
           temperature: systemProvider?.temperature ?? null,
         },
-        responderPrompt: buildStrictBenchmarkQuestion(
-          trial.question,
-          trial.answerFormat ?? "auto",
-        ),
+        responderPrompt: buildStrictBenchmarkQuestion(trial.question, trial.answerFormat ?? "auto"),
         answerMode: "strict",
         question: trial.question,
         recalledText,
@@ -577,14 +522,14 @@ function pairedAnswerReplayKey(
             }
           : null,
         taskId: trial.taskId,
-      }),
+      })
     )
     .digest("hex");
 }
 
 function pairedAnswerReplayEntry(
   sourceRuntimeProfile: PairedAnswerReplayEntry["sourceRuntimeProfile"],
-  answer: HarnessAnswerResult,
+  answer: HarnessAnswerResult
 ): PairedAnswerReplayEntry {
   return {
     sourceRuntimeProfile,
@@ -598,16 +543,12 @@ async function executeTrial(
   ctx: HarnessContext,
   trial: HarnessTrial,
   answerSupportGate: boolean,
-  pendingPairedAnswerReplays: Map<TaskResult, PendingPairedAnswerReplay>,
+  pendingPairedAnswerReplays: Map<TaskResult, PendingPairedAnswerReplay>
 ): Promise<TaskResult> {
   const { result: recallResult, durationMs } = await timed(async () => {
-    const recallBudget = benchmarkRecallBudgetForSessionCount(
-      trial.recallSessionIds.length,
-    );
+    const recallBudget = benchmarkRecallBudgetForSessionCount(trial.recallSessionIds.length);
     const recalledSessions = await Promise.all(
-      trial.recallSessionIds.map((sessionId) =>
-        ctx.options.system.recall(sessionId, trial.question, recallBudget),
-      ),
+      trial.recallSessionIds.map((sessionId) => ctx.options.system.recall(sessionId, trial.question, recallBudget))
     );
     const rawRecalledText = recalledSessions.filter(Boolean).join("\n\n");
     const recalledText = trial.recallTextTransform
@@ -616,28 +557,17 @@ async function executeTrial(
           recalledText: rawRecalledText,
         })
       : rawRecalledText;
-    const recallSupport = answerSupportGate
-      ? await assessRecallSupport(ctx, trial, recalledText)
-      : undefined;
+    const recallSupport = answerSupportGate ? await assessRecallSupport(ctx, trial, recalledText) : undefined;
     return { recalledText, recallSupport };
   });
   const { recalledText, recallSupport } = recallResult;
   const answerReplayKey = ctx.options.pairedAnswerReplayCache
-    ? pairedAnswerReplayKey(
-        trial,
-        recalledText,
-        recallSupport,
-        ctx.options.systemProvider,
-      )
+    ? pairedAnswerReplayKey(trial, recalledText, recallSupport, ctx.options.systemProvider)
     : undefined;
-  const cachedAnswer = answerReplayKey
-    ? ctx.options.pairedAnswerReplayCache?.get(answerReplayKey)
-    : undefined;
+  const cachedAnswer = answerReplayKey ? ctx.options.pairedAnswerReplayCache?.get(answerReplayKey) : undefined;
   const currentProfile = ctx.options.runtimeProfile ?? null;
   const pairedAnswerReusedFrom =
-    cachedAnswer?.sourceRuntimeProfile === "baseline" && currentProfile === "real"
-      ? "baseline"
-      : undefined;
+    cachedAnswer?.sourceRuntimeProfile === "baseline" && currentProfile === "real" ? "baseline" : undefined;
   let answered: HarnessAnswerResult;
   if (pairedAnswerReusedFrom) {
     const reusedAnswer = cachedAnswer!;
@@ -657,9 +587,7 @@ async function executeTrial(
       answerMode: "strict",
       answerFormat: trial.answerFormat,
       recallSupport,
-    }).catch((error: unknown) =>
-      answerWithTrialFallback(trial, recalledText, error),
-    );
+    }).catch((error: unknown) => answerWithTrialFallback(trial, recalledText, error));
     answered = refineTrialAnswer(trial, recalledText, answered);
   }
 
@@ -681,8 +609,7 @@ async function executeTrial(
   // below keeps the downstream arithmetic unchanged for runs that
   // don't opt into the judge.
   const judgeRequested =
-    ctx.metricsSpec.metrics.includes("llm_judge") ||
-    ctx.metricsSpec.metrics.includes("judge_accuracy");
+    ctx.metricsSpec.metrics.includes("llm_judge") || ctx.metricsSpec.metrics.includes("judge_accuracy");
   const judgeResult = judgeRequested
     ? await scoreTrialJudge(ctx, trial, answered.finalAnswer)
     : {
@@ -699,10 +626,7 @@ async function executeTrial(
         scores.f1 = f1Score(answered.finalAnswer, trial.expected);
         break;
       case "contains_answer":
-        scores.contains_answer = containsAnswer(
-          answered.finalAnswer,
-          trial.expected,
-        );
+        scores.contains_answer = containsAnswer(answered.finalAnswer, trial.expected);
         break;
       case "rouge_l":
         scores.rouge_l = rougeL(answered.finalAnswer, trial.expected);
@@ -723,9 +647,7 @@ async function executeTrial(
         // Unreachable — validated in validateContext. Keep as a sanity
         // guard; CLAUDE.md rule 53 (enumerate all non-active states).
         const exhaustive: never = metric;
-        throw new Error(
-          `PublishedBenchmarkHarness: metric ${String(exhaustive)} not handled.`,
-        );
+        throw new Error(`PublishedBenchmarkHarness: metric ${String(exhaustive)} not handled.`);
       }
     }
   }
@@ -746,15 +668,11 @@ async function executeTrial(
     recalledText,
     answeredText: answered.finalAnswer,
     ...(trial.answerFormat ? { answerFormat: trial.answerFormat } : {}),
-    ...(answerSupportGate
-      ? { answerSupportGate: true, recallSupport }
-      : {}),
+    ...(answerSupportGate ? { answerSupportGate: true, recallSupport } : {}),
     ...(pairedAnswerReusedFrom ? { pairedAnswerReusedFrom } : {}),
     responderModel: answered.model,
     judgeModel: judgeResult.model,
-    ...(answered.fallbackReason
-      ? { answerFallbackReason: answered.fallbackReason }
-      : {}),
+    ...(answered.fallbackReason ? { answerFallbackReason: answered.fallbackReason } : {}),
     ...(answered.refinementReason
       ? {
           answerRefinementReason: answered.refinementReason,
@@ -783,11 +701,7 @@ async function executeTrial(
     },
     details,
   };
-  if (
-    answerReplayKey
-    && currentProfile === "baseline"
-    && answered.fallbackReason === undefined
-  ) {
+  if (answerReplayKey && currentProfile === "baseline" && answered.fallbackReason === undefined) {
     pendingPairedAnswerReplays.set(task, {
       key: answerReplayKey,
       entry: pairedAnswerReplayEntry(currentProfile, answered),
@@ -799,7 +713,7 @@ async function executeTrial(
 async function assessRecallSupport(
   ctx: HarnessContext,
   trial: HarnessTrial,
-  recalledText: string,
+  recalledText: string
 ): Promise<BenchRecallSupportAssessment> {
   if (recalledText.trim().length === 0) {
     return {
@@ -837,16 +751,8 @@ async function assessRecallSupport(
   }
 }
 
-function validateRecallSupportAssessment(
-  assessment: BenchRecallSupportAssessment,
-): void {
-  const allowed: readonly BenchRecallSupportStatus[] = [
-    "supported",
-    "weak",
-    "empty",
-    "unavailable",
-    "backend_failure",
-  ];
+function validateRecallSupportAssessment(assessment: BenchRecallSupportAssessment): void {
+  const allowed: readonly BenchRecallSupportStatus[] = ["supported", "weak", "empty", "unavailable", "backend_failure"];
   if (!assessment || !allowed.includes(assessment.status)) {
     throw new Error("adapter returned an invalid recall support status");
   }
@@ -858,37 +764,22 @@ function validateRecallSupportAssessment(
     (assessment.evidenceCount ?? 0) <= 0 ||
     !Number.isFinite(assessment.maxScore) ||
     !Number.isFinite(assessment.supportThreshold) ||
-    (assessment.maxScore ?? Number.POSITIVE_INFINITY) >=
-      (assessment.supportThreshold ?? Number.NEGATIVE_INFINITY)
+    (assessment.maxScore ?? Number.POSITIVE_INFINITY) >= (assessment.supportThreshold ?? Number.NEGATIVE_INFINITY)
   ) {
     throw new Error(
-      "adapter weak recall support requires a positive evidenceCount and a finite maxScore below supportThreshold",
+      "adapter weak recall support requires a positive evidenceCount and a finite maxScore below supportThreshold"
     );
   }
 }
 
-async function scoreTrialJudge(
-  ctx: HarnessContext,
-  trial: HarnessTrial,
-  answeredText: string,
-) {
+async function scoreTrialJudge(ctx: HarnessContext, trial: HarnessTrial, answeredText: string) {
   if (!trial.binaryJudgePrompt) {
-    return llmJudgeScoreDetailed(
-      ctx.options.system.judge,
-      trial.question,
-      answeredText,
-      trial.expected,
-    );
+    return llmJudgeScoreDetailed(ctx.options.system.judge, trial.question, answeredText, trial.expected);
   }
 
   const judge = ctx.options.system.judge;
   if (!judge?.scoreBinaryPrompt) {
-    return llmJudgeScoreDetailed(
-      judge,
-      trial.question,
-      answeredText,
-      trial.expected,
-    );
+    return llmJudgeScoreDetailed(judge, trial.question, answeredText, trial.expected);
   }
 
   const prompt = trial.binaryJudgePrompt({
@@ -897,22 +788,16 @@ async function scoreTrialJudge(
     answeredText,
   });
   if (typeof prompt !== "string" || prompt.trim().length === 0) {
-    throw new Error(
-      "PublishedBenchmarkHarness: binaryJudgePrompt returned an empty prompt.",
-    );
+    throw new Error("PublishedBenchmarkHarness: binaryJudgePrompt returned an empty prompt.");
   }
 
   const binaryJudge = {
     scoreBinaryPrompt: judge.scoreBinaryPrompt.bind(judge),
   };
-  return llmBinaryJudgeScoreDetailed(
-    binaryJudge,
-    prompt,
-    {
-      predicted: answeredText,
-      expected: trial.expected,
-    },
-  );
+  return llmBinaryJudgeScoreDetailed(binaryJudge, prompt, {
+    predicted: answeredText,
+    expected: trial.expected,
+  });
 }
 
 type HarnessAnswerResult = BenchmarkAnswerResult & {
@@ -921,11 +806,7 @@ type HarnessAnswerResult = BenchmarkAnswerResult & {
   originalAnswer?: string;
 };
 
-function answerWithTrialFallback(
-  trial: HarnessTrial,
-  recalledText: string,
-  error: unknown,
-): HarnessAnswerResult {
+function answerWithTrialFallback(trial: HarnessTrial, recalledText: string, error: unknown): HarnessAnswerResult {
   if (isBenchmarkRunBlockedError(error)) {
     throw error;
   }
@@ -951,7 +832,7 @@ function answerWithTrialFallback(
 function refineTrialAnswer(
   trial: HarnessTrial,
   recalledText: string,
-  answered: HarnessAnswerResult,
+  answered: HarnessAnswerResult
 ): HarnessAnswerResult {
   const refined = trial.answerRefinement?.({
     question: trial.question,
@@ -975,18 +856,12 @@ function refineTrialAnswer(
 async function buildBenchmarkResult(
   ctx: HarnessContext,
   tasks: TaskResult[],
-  executionProvenance: BenchmarkExecutionProvenance,
+  executionProvenance: BenchmarkExecutionProvenance
 ): Promise<BenchmarkResult> {
   const remnicVersion = await getRemnicVersion();
   const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
-  const totalInputTokens = tasks.reduce(
-    (sum, task) => sum + task.tokens.input,
-    0,
-  );
-  const totalOutputTokens = tasks.reduce(
-    (sum, task) => sum + task.tokens.output,
-    0,
-  );
+  const totalInputTokens = tasks.reduce((sum, task) => sum + task.tokens.input, 0);
+  const totalOutputTokens = tasks.reduce((sum, task) => sum + task.tokens.output, 0);
   const mode: BenchmarkMode = ctx.options.mode;
   const failedTasks = tasks.flatMap((task) => {
     const marker = task.details?.benchmarkFailure;
@@ -998,17 +873,20 @@ async function buildBenchmarkResult(
       return [];
     }
     const message = (marker as { message?: unknown }).message;
-    return [{
-      taskId: task.taskId,
-      message: typeof message === "string" ? message : "unknown trial failure",
-    }];
+    return [
+      {
+        taskId: task.taskId,
+        message: typeof message === "string" ? message : "unknown trial failure",
+      },
+    ];
   });
-  const failureReason = failedTasks.length > 0
-    ? `trial_execution_failure: ${failedTasks.length}/${tasks.length} scored trial(s) failed (${failedTasks
-        .slice(0, 3)
-        .map((failure) => `${failure.taskId}: ${failure.message.slice(0, 240)}`)
-        .join("; ")}${failedTasks.length > 3 ? `; and ${failedTasks.length - 3} more` : ""})`
-    : undefined;
+  const failureReason =
+    failedTasks.length > 0
+      ? `trial_execution_failure: ${failedTasks.length}/${tasks.length} scored trial(s) failed (${failedTasks
+          .slice(0, 3)
+          .map((failure) => `${failure.taskId}: ${failure.message.slice(0, 240)}`)
+          .join("; ")}${failedTasks.length > 3 ? `; and ${failedTasks.length - 3} more` : ""})`
+      : undefined;
   const categoryAggregates = computeCategoryAggregates(tasks);
 
   return {
@@ -1023,18 +901,14 @@ async function buildBenchmarkResult(
       mode,
       runCount: 1,
       seeds: [ctx.options.seed ?? 0],
-      ...(failureReason
-        ? { status: "partial" as const, failureReason }
-        : {}),
+      ...(failureReason ? { status: "partial" as const, failureReason } : {}),
     },
     config: {
       systemProvider: ctx.options.systemProvider ?? null,
       judgeProvider: ctx.options.judgeProvider ?? null,
       adapterMode: ctx.options.adapterMode ?? "direct",
       remnicConfig: ctx.options.remnicConfig ?? {},
-      ...(ctx.options.benchmarkOptions
-        ? { benchmarkOptions: ctx.options.benchmarkOptions }
-        : {}),
+      ...(ctx.options.benchmarkOptions ? { benchmarkOptions: ctx.options.benchmarkOptions } : {}),
     },
     cost: {
       totalTokens: totalInputTokens + totalOutputTokens,
@@ -1042,8 +916,7 @@ async function buildBenchmarkResult(
       outputTokens: totalOutputTokens,
       estimatedCostUsd: 0,
       totalLatencyMs,
-      meanQueryLatencyMs:
-        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
     },
     results: {
       tasks,
@@ -1051,9 +924,7 @@ async function buildBenchmarkResult(
       // Per-category breakdown for benchmarks that stamp a `categoryName`
       // detail (LoCoMo). Omitted when empty so other benchmarks' output shape
       // is unchanged (issue #1878).
-      ...(Object.keys(categoryAggregates).length > 0
-        ? { categoryAggregates }
-        : {}),
+      ...(Object.keys(categoryAggregates).length > 0 ? { categoryAggregates } : {}),
     },
     environment: {
       os: process.platform,

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -36,6 +36,8 @@ export type {
   BenchmarkDefinition,
   RunBenchmarkOptions,
   ResolvedRunBenchmarkOptions,
+  PairedAnswerReplayCache,
+  PairedAnswerReplayEntry,
 } from "./types.js";
 export {
   BUILD_WEEK_EVIDENCE_RECEIPT_SCHEMA_VERSION,

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -14,6 +14,7 @@ import {
   createProviderBackedStructuredJudge,
   createResponderFromProvider,
   createStructuredJudgeFromProvider,
+  getGatewayResponderIdentity,
 } from "./responders.ts";
 
 function createFakeProvider(resultText: string, onPrompt?: (prompt: string) => void): LlmProvider {
@@ -697,6 +698,66 @@ test("provider-backed responder exposes a stable sanitized identity", async () =
     baseUrl: "https://other.example.com/v1",
   });
   assert.equal(id1, id2, "apiKey differences must not change the identity");
+  assert.notEqual(id1, idDifferentModel, "model differences must change the identity");
+  assert.notEqual(id1, idDifferentBase, "baseUrl differences must change the identity");
+});
+
+test("getGatewayResponderIdentity fingerprints the sanitized config (and not undefined)", () => {
+  const configA = {
+    agents: {
+      defaults: {
+        model: { primary: "gpt-5.4-mini", backup: "gpt-5.4" },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://api.example.com/v1",
+          apiKey: "sk-secret-a",
+          headers: { Authorization: "Bearer a" },
+          authHeader: true,
+          models: [],
+        },
+      },
+    },
+  };
+  const configB = {
+    agents: {
+      defaults: {
+        model: { primary: "gpt-5.4-mini", backup: "gpt-5.4" },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://api.example.com/v1",
+          apiKey: "sk-secret-b",
+          headers: { Authorization: "Bearer b" },
+          authHeader: false,
+          models: [],
+        },
+      },
+    },
+  };
+  const configDifferentBaseUrl = JSON.parse(JSON.stringify(configA));
+  configDifferentBaseUrl.models.providers.openai.baseUrl = "https://other.example.com/v1";
+  const configDifferentAgent = JSON.parse(JSON.stringify(configA));
+  configDifferentAgent.agents.defaults.model.primary = "gpt-5.4";
+
+  const idA = getGatewayResponderIdentity(configA as never, "agent-a");
+  const idAOtherAgent = getGatewayResponderIdentity(configA as never, "agent-b");
+  const idAUndefAgent = getGatewayResponderIdentity(configA as never, undefined);
+  const idB = getGatewayResponderIdentity(configB as never, "agent-a");
+  const idDifferentBaseUrl = getGatewayResponderIdentity(configDifferentBaseUrl as never, "agent-a");
+  const idDifferentAgent = getGatewayResponderIdentity(configDifferentAgent as never, "agent-a");
+
+  assert.match(idA, /^gateway:sha256:[0-9a-f]{64}$/);
+  assert.equal(idA, idB, "apiKey/headers/authHeader differences must not change the identity");
+  assert.notEqual(idA, idAOtherAgent, "different agentId must change the identity");
+  assert.notEqual(idA, idAUndefAgent, "agentId vs undefined must change the identity");
+  assert.notEqual(idA, idDifferentBaseUrl, "baseUrl differences must change the identity");
+  assert.notEqual(idA, idDifferentAgent, "agent model differences must change the identity");
+  assert.notEqual(idA, "undefined", "identity must not collapse to a literal undefined sentinel");
 });
 
 test("createProviderBackedResponder wires the identity to the returned responder", async () => {

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -675,3 +675,37 @@ test("provider-backed judge prompt identity tracks the actual structured and sca
   assert.notEqual(scalar, structuredV1);
   assert.notEqual(structuredV1, structuredV2);
 });
+
+
+test("provider-backed responder exposes a stable sanitized identity", async () => {
+  const { getProviderBackedResponderIdentity } = await import("./responders.ts");
+  const base = {
+    provider: "openai" as const,
+    model: "gpt-5.4-mini",
+    baseUrl: "https://api.example.com/v1",
+    apiKey: "sk-secret",
+    temperature: 0,
+    seed: 42,
+    responderContextBudgetChars: 4000,
+    responderPromptBudgetChars: 2000,
+  };
+  const id1 = getProviderBackedResponderIdentity(base);
+  const id2 = getProviderBackedResponderIdentity({ ...base, apiKey: "sk-different" });
+  const idDifferentModel = getProviderBackedResponderIdentity({ ...base, model: "gpt-5.4" });
+  const idDifferentBase = getProviderBackedResponderIdentity({
+    ...base,
+    baseUrl: "https://other.example.com/v1",
+  });
+  assert.equal(id1, id2, "apiKey differences must not change the identity");
+});
+
+test("createProviderBackedResponder wires the identity to the returned responder", async () => {
+  const { createProviderBackedResponder } = await import("./responders.ts");
+  const responder = createProviderBackedResponder({
+    provider: "openai",
+    model: "gpt-5.4-mini",
+  });
+  const identity = responder.identity?.();
+  assert.ok(identity, "provider-backed responder must expose identity()");
+  assert.match(identity, /^responder:sha256:[0-9a-f]{64}$/);
+});

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -858,6 +858,7 @@ function sanitizeGatewayConfigForIdentity(value: unknown): unknown {
     if (key === "apiKey" || key === "headers" || key === "authHeader") continue;
     out[key] = sanitizeGatewayConfigForIdentity(child);
   }
+  return out;
 }
 
 function validateProviderConfig(

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -59,6 +59,38 @@ export function getProviderBackedJudgePromptIdentity(config: ProviderFactoryConf
   return `sha256:${createHash("sha256").update(JSON.stringify(contract)).digest("hex")}`;
 }
 
+/**
+ * Sanitized non-secret fingerprint of a responder configuration. Two
+ * built-in responders with identical `ProviderFactoryConfig` (provider,
+ * model, baseUrl, budgets, retry options, sampling settings) hash to
+ * the same identity, so the paired harness treats them as the same
+ * responder for cache-key purposes. `apiKey` and any field absent from
+ * `ProviderFactoryConfig` are deliberately excluded.
+ */
+export function getProviderBackedResponderIdentity(config: ProviderFactoryConfig): string {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (key === "apiKey" || key === "authToken" || key === "bearerToken") continue;
+    sanitized[key] = value;
+  }
+  return `responder:sha256:${createHash("sha256")
+    .update(stableStringifyForIdentity(sanitized))
+    .digest("hex")}`;
+}
+
+function stableStringifyForIdentity(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringifyForIdentity(entry)).join(",")}]`;
+  }
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  return `{${keys
+    .map((key) => `${JSON.stringify(key)}:${stableStringifyForIdentity((value as Record<string, unknown>)[key])}`)
+    .join(",")}}`;
+}
+
 const AMA_BENCH_RECOMMENDED_JUDGE_SYSTEM_PROMPT = [
   "You are evaluating an AMA-Bench long-horizon memory question.",
   "Decide whether the predicted answer correctly answers the question using the reference answer as ground truth.",
@@ -90,12 +122,12 @@ export interface ProviderResponderOptions {
   contextBudgetChars?: number;
   promptBudgetChars?: number;
 }
-
 export function createResponderFromProvider(
   provider: LlmProvider,
-  options: ProviderResponderOptions = {}
+  options: ProviderResponderOptions = {},
+  responderIdentity?: string
 ): BenchResponder {
-  return {
+  const responder: BenchResponder = {
     async respond(question: string, recalledText: string, control): Promise<BenchResponse> {
       const responderQuestion =
         options.promptBudgetChars === undefined
@@ -130,6 +162,10 @@ export function createResponderFromProvider(
       };
     },
   };
+  if (responderIdentity && responderIdentity.trim().length > 0) {
+    responder.identity = () => responderIdentity;
+  }
+  return responder;
 }
 
 export function createProviderBackedResponder(
@@ -137,10 +173,14 @@ export function createProviderBackedResponder(
   providerInstance?: LlmProvider
 ): BenchResponder {
   validateProviderConfig(config, "responder");
-  return createResponderFromProvider(providerInstance ?? createProvider(config), {
-    contextBudgetChars: config.responderContextBudgetChars,
-    promptBudgetChars: config.responderPromptBudgetChars,
-  });
+  return createResponderFromProvider(
+    providerInstance ?? createProvider(config),
+    {
+      contextBudgetChars: config.responderContextBudgetChars,
+      promptBudgetChars: config.responderPromptBudgetChars,
+    },
+    getProviderBackedResponderIdentity(config),
+  );
 }
 
 export function compactResponderQuestion(question: string, maxChars: number): string {
@@ -742,7 +782,12 @@ export function createGatewayResponder(options: GatewayResponderOptions): BenchR
     options.llmFactory?.(options.gatewayConfig, runtimeContext) ??
     new FallbackLlmClient(options.gatewayConfig, runtimeContext);
 
-  return {
+  const responderIdentity = getGatewayResponderIdentity(
+    options.gatewayConfig,
+    options.agentId,
+  );
+
+  const responder: BenchResponder = {
     async respond(question: string, recalledText: string, control): Promise<BenchResponse> {
       const startedAt = performance.now();
       const response = await llm.chatCompletion(
@@ -782,6 +827,37 @@ export function createGatewayResponder(options: GatewayResponderOptions): BenchR
       };
     },
   };
+  if (responderIdentity) {
+    responder.identity = () => responderIdentity;
+  }
+  return responder;
+}
+
+/**
+ * Sanitized non-secret fingerprint of a gateway-backed responder. The
+ * config is recursively stripped of `apiKey` and `headers` (which may
+ * carry bearer tokens) before hashing; the agent id is included so two
+ * different agents under the same gateway produce distinct identities.
+ */
+export function getGatewayResponderIdentity(
+  config: GatewayConfig,
+  agentId: string | undefined,
+): string {
+  const sanitized = sanitizeGatewayConfigForIdentity(config);
+  return `gateway:sha256:${createHash("sha256")
+    .update(stableStringifyForIdentity({ agentId: agentId ?? null, config: sanitized }))
+    .digest("hex")}`;
+}
+
+function sanitizeGatewayConfigForIdentity(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(sanitizeGatewayConfigForIdentity);
+  const record = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(record)) {
+    if (key === "apiKey" || key === "headers" || key === "authHeader") continue;
+    out[key] = sanitizeGatewayConfigForIdentity(child);
+  }
 }
 
 function validateProviderConfig(

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -251,6 +251,15 @@ export interface BenchmarkDefinition {
   meta: BenchmarkMeta;
 }
 
+export interface PairedAnswerReplayEntry {
+  sourceRuntimeProfile: BenchRuntimeProfile | null;
+  finalAnswer: string;
+  answeredText: string;
+  model?: string;
+}
+
+export type PairedAnswerReplayCache = Map<string, PairedAnswerReplayEntry>;
+
 export interface RunBenchmarkOptions {
   mode?: BenchmarkMode;
   datasetDir?: string;
@@ -286,6 +295,12 @@ export interface RunBenchmarkOptions {
    * `noJudgeCache` is true. The directory is created on demand.
    */
   judgeCacheDir?: string;
+  /**
+   * Ephemeral cross-profile answer cache for a paired benchmark matrix. A
+   * cached answer may only be reused when the responder-facing input is
+   * identical and it originated from a different runtime profile.
+   */
+  pairedAnswerReplayCache?: PairedAnswerReplayCache;
   /** Called after each task completes for progress logging and partial result tracking. */
   onTaskComplete?: (task: TaskResult, completedCount: number, totalCount?: number) => void;
 }

--- a/packages/remnic-cli/src/bench-datasets.test.ts
+++ b/packages/remnic-cli/src/bench-datasets.test.ts
@@ -19,6 +19,25 @@ test("paired answer replay cache is exclusive to LoCoMo", () => {
   );
 });
 
+test("paired LoCoMo work executes baseline before real", () => {
+  const workItems = [
+    { benchmarkId: "longmemeval", runtimeProfile: "real" },
+    { benchmarkId: "locomo", runtimeProfile: "real" },
+    { benchmarkId: "memoryagentbench", runtimeProfile: "baseline" },
+    { benchmarkId: "locomo", runtimeProfile: "baseline" },
+  ] as const;
+
+  assert.deepEqual(
+    __benchDatasetTestHooks.orderPairedLoCoMoWorkItemsForTest(workItems),
+    [
+      { benchmarkId: "longmemeval", runtimeProfile: "real" },
+      { benchmarkId: "locomo", runtimeProfile: "baseline" },
+      { benchmarkId: "locomo", runtimeProfile: "real" },
+      { benchmarkId: "memoryagentbench", runtimeProfile: "baseline" },
+    ],
+  );
+});
+
 test("resolveDownloadedBenchDatasetDir rejects explicit dataset paths without benchmark markers", async () => {
 
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-datasets-"));

--- a/packages/remnic-cli/src/bench-datasets.test.ts
+++ b/packages/remnic-cli/src/bench-datasets.test.ts
@@ -212,6 +212,9 @@ test("published dry-run validation forwards MemoryAgentBench trial limit", async
 
   assert.equal(captured?.id, "memoryagentbench");
   assert.equal(captured?.options.datasetDir, "/tmp/memoryagentbench");
+  assert.equal(captured?.options.limit, 10);
+  assert.equal(captured?.options.seed, 123);
+  assert.deepEqual(captured?.options.benchmarkOptions, { trialLimit: 1 });
 });
 
 test("paired baseline-locomo failure path clears the shared replay cache", () => {

--- a/packages/remnic-cli/src/bench-datasets.test.ts
+++ b/packages/remnic-cli/src/bench-datasets.test.ts
@@ -6,7 +6,21 @@ import test from "node:test";
 
 import { __benchDatasetTestHooks } from "./index.js";
 
+test("paired answer replay cache is exclusive to LoCoMo", () => {
+  const cache = new Map();
+
+  assert.equal(
+    __benchDatasetTestHooks.pairedAnswerReplayCacheForBenchmark("locomo", cache),
+    cache,
+  );
+  assert.equal(
+    __benchDatasetTestHooks.pairedAnswerReplayCacheForBenchmark("longmemeval", cache),
+    undefined,
+  );
+});
+
 test("resolveDownloadedBenchDatasetDir rejects explicit dataset paths without benchmark markers", async () => {
+
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-datasets-"));
   const invalidDataset = path.join(root, "not-downloaded");
 

--- a/packages/remnic-cli/src/bench-datasets.test.ts
+++ b/packages/remnic-cli/src/bench-datasets.test.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import test from "node:test";
 
-import { __benchDatasetTestHooks } from "./index.js";
+import {
+  __benchDatasetTestHooks,
+  type PairedAnswerReplayCache,
+} from "./index.js";
 
 test("paired answer replay cache is exclusive to LoCoMo", () => {
   const cache = new Map();
@@ -209,7 +212,47 @@ test("published dry-run validation forwards MemoryAgentBench trial limit", async
 
   assert.equal(captured?.id, "memoryagentbench");
   assert.equal(captured?.options.datasetDir, "/tmp/memoryagentbench");
-  assert.equal(captured?.options.limit, 10);
-  assert.equal(captured?.options.seed, 123);
-  assert.deepEqual(captured?.options.benchmarkOptions, { trialLimit: 1 });
+});
+
+test("paired baseline-locomo failure path clears the shared replay cache", () => {
+  type CacheEntry = { sourceRuntimeProfile: "baseline"; finalAnswer: string; answeredText: string };
+  const cache = new Map<string, CacheEntry>();
+  cache.set("seed", { sourceRuntimeProfile: "baseline", finalAnswer: "x", answeredText: "x" });
+  let cleared = 0;
+  const wrappedCache: PairedAnswerReplayCache = {
+    size: cache.size,
+    has: cache.has.bind(cache),
+    get: cache.get.bind(cache),
+    set: cache.set.bind(cache),
+    delete: cache.delete.bind(cache),
+    clear: () => {
+      cleared++;
+      cache.clear();
+    },
+    entries: cache.entries.bind(cache),
+    keys: cache.keys.bind(cache),
+    values: cache.values.bind(cache),
+    forEach: cache.forEach.bind(cache),
+    [Symbol.iterator]: cache[Symbol.iterator].bind(cache),
+    [Symbol.toStringTag]: "Map",
+  } as PairedAnswerReplayCache;
+  __benchDatasetTestHooks.clearPairedAnswerReplayCacheOnFailureForTest(
+    "baseline",
+    "locomo",
+    wrappedCache,
+  );
+  assert.equal(cleared, 1);
+  assert.equal(cache.size, 0);
+
+  __benchDatasetTestHooks.clearPairedAnswerReplayCacheOnFailureForTest(
+    "real",
+    "locomo",
+    wrappedCache,
+  );
+  __benchDatasetTestHooks.clearPairedAnswerReplayCacheOnFailureForTest(
+    "baseline",
+    "longmemeval",
+    wrappedCache,
+  );
+  assert.equal(cleared, 1);
 });

--- a/packages/remnic-cli/src/bench-output-printer.ts
+++ b/packages/remnic-cli/src/bench-output-printer.ts
@@ -1,0 +1,116 @@
+import type { ComparisonResult } from "@remnic/bench";
+
+type BenchSummaryTask = {
+  taskId?: string;
+  latencyMs?: number;
+  scores?: Record<string, number>;
+};
+type BenchSummaryResult = {
+  meta: { benchmark: string; mode: string };
+  config: { runtimeProfile?: string | null };
+  cost: { meanQueryLatencyMs: number };
+  results: {
+    tasks: ReadonlyArray<BenchSummaryTask>;
+    aggregates: Record<string, { mean: number }>;
+  };
+};
+
+type PrintableBenchmarkResult = BenchSummaryResult & {
+  meta: { id: string; benchmark: string; mode: string };
+};
+
+export function printStoredBenchResultSummary(
+  result: PrintableBenchmarkResult,
+  summary: { id: string; path: string },
+): void {
+  console.log(`Run id: ${summary.id}`);
+  printBenchPackageSummary(result, summary.path, "Stored result");
+}
+
+export function printBenchStatusLine(jsonMode: boolean, message: string): void {
+  if (jsonMode) {
+    console.error(message);
+  } else {
+    console.log(message);
+  }
+}
+
+export function printBenchPackageSummary(
+  result: BenchSummaryResult,
+  outputPath: string,
+  outputLabel = "Results saved",
+): void {
+  console.log(`Benchmark: ${result.meta.benchmark}`);
+  console.log(`Mode: ${result.meta.mode}`);
+  if (result.config.runtimeProfile) {
+    console.log(`Runtime profile: ${result.config.runtimeProfile}`);
+  }
+  console.log(`Tasks: ${result.results.tasks.length}`);
+  console.log(`Mean query latency: ${result.cost.meanQueryLatencyMs.toFixed(1)}ms`);
+  for (const [metric, aggregate] of Object.entries(result.results.aggregates).sort()) {
+    console.log(`  ${metric.padEnd(20)} ${aggregate.mean.toFixed(4)}`);
+  }
+  console.log(`${outputLabel}: ${outputPath}`);
+}
+
+export function printStoredBenchResultDetails(
+  result: PrintableBenchmarkResult,
+  summary: { id: string; path: string },
+): void {
+  printStoredBenchResultSummary(result, summary);
+  if (result.results.tasks.length === 0) {
+    console.log("Tasks: none");
+    return;
+  }
+
+  console.log("Task breakdown:");
+  for (const task of result.results.tasks) {
+    const scores = Object.entries(task.scores ?? {})
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([metric, value]) => `${metric}=${(value as number).toFixed(4)}`)
+      .join(", ");
+    const taskLabel = task.taskId ?? "(unknown task)";
+    const taskLatency = typeof task.latencyMs === "number" ? task.latencyMs.toFixed(1) : "?";
+    console.log(
+      `  ${taskLabel}: ${taskLatency}ms` +
+      `${scores.length > 0 ? ` [${scores}]` : ""}`,
+    );
+  }
+}
+
+export function printBenchComparisonSummary(
+  comparison: ComparisonResult,
+  baseline: { id: string; path: string },
+  candidate: { id: string; path: string },
+): void {
+  console.log(`Benchmark: ${comparison.benchmark}`);
+  console.log(`Baseline: ${baseline.id} (${baseline.path})`);
+  console.log(`Candidate: ${candidate.id} (${candidate.path})`);
+  console.log(`Verdict: ${comparison.verdict}`);
+
+  const metrics = Object.entries(comparison.metricDeltas).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  if (metrics.length === 0) {
+    console.log("No overlapping metrics were found between the two results.");
+    return;
+  }
+
+  console.log("Metrics:");
+  for (const [metric, delta] of metrics) {
+    const percent = Number.isFinite(delta.percentChange)
+      ? `${(delta.percentChange * 100).toFixed(2)}%`
+      : delta.percentChange > 0
+        ? "+Infinity%"
+        : "-Infinity%";
+    const direction = delta.delta >= 0 ? "+" : "";
+    console.log(
+      `  ${metric.padEnd(18)} ${delta.baseline.toFixed(4)} -> ${delta.candidate.toFixed(4)} (${direction}${delta.delta.toFixed(4)}, ${percent}, d=${delta.effectSize.cohensD.toFixed(3)} ${delta.effectSize.interpretation})`,
+    );
+    if (delta.ciOnDelta) {
+      console.log(
+        `    95% CI on delta: [${delta.ciOnDelta.lower.toFixed(4)}, ${delta.ciOnDelta.upper.toFixed(4)}]`,
+      );
+    }
+  }
+}

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -227,6 +227,7 @@ import type {
   BenchmarkResult,
   ComparisonResult,
   McpMemoryToolMapping,
+  PairedAnswerReplayCache,
   ResolvedLocalLabProfile,
 } from "@remnic/bench";
 import { firstSuccessfulCandidate, firstSuccessfulResult } from "./service-candidates.js";
@@ -302,6 +303,7 @@ export {
   parseBenchArgs,
 } from "./bench-args.js";
 
+export type { PairedAnswerReplayCache };
 type PiPublisherModule = {
   PiMemoryExtensionPublisher: new () => MemoryExtensionPublisher;
   OmpMemoryExtensionPublisher: new () => MemoryExtensionPublisher;
@@ -2019,7 +2021,23 @@ export const __benchDatasetTestHooks = {
     );
   },
   printBenchStatusLineForTest: printBenchStatusLine,
+  clearPairedAnswerReplayCacheOnFailureForTest: clearPairedAnswerReplayCacheOnFailure,
 };
+
+function printStoredBenchResultSummary(
+  result: BenchmarkResult,
+  summary: { id: string; path: string },
+): void {
+  console.log(`Run id: ${summary.id}`);
+}
+
+function printBenchStatusLine(jsonMode: boolean, message: string): void {
+  if (jsonMode) {
+    console.error(message);
+  } else {
+    console.log(message);
+  }
+}
 
 function printBenchPackageSummary(
   result: BenchSummaryResult,
@@ -2037,22 +2055,6 @@ function printBenchPackageSummary(
     console.log(`  ${metric.padEnd(20)} ${aggregate.mean.toFixed(4)}`);
   }
   console.log(`${outputLabel}: ${outputPath}`);
-}
-
-function printBenchStatusLine(jsonMode: boolean, message: string): void {
-  if (jsonMode) {
-    console.error(message);
-  } else {
-    console.log(message);
-  }
-}
-
-function printStoredBenchResultSummary(
-  result: BenchmarkResult,
-  summary: { id: string; path: string },
-): void {
-  printBenchPackageSummary(result, summary.path, "Stored result");
-  console.log(`Run id: ${summary.id}`);
 }
 
 function printStoredBenchResultDetails(
@@ -3506,6 +3508,15 @@ function pairedAnswerReplayCacheForBenchmark(
   return benchmarkId === "locomo" ? pairedAnswerReplayCache : undefined;
 }
 
+function clearPairedAnswerReplayCacheOnFailure(
+  runtimeProfile: BenchRuntimeProfile,
+  benchmarkId: string,
+  pairedAnswerReplayCache?: import("@remnic/bench").PairedAnswerReplayCache,
+): void {
+  if (runtimeProfile !== "baseline" || benchmarkId !== "locomo") return;
+  pairedAnswerReplayCache?.clear();
+}
+
 function orderPairedLoCoMoWorkItems<
   T extends { benchmarkId: string; runtimeProfile: BenchRuntimeProfile },
 >(workItems: readonly T[]): T[] {
@@ -3697,6 +3708,11 @@ async function runBenchViaPackage(
     }
     return { ok: true, writtenPath };
   } catch (err) {
+    clearPairedAnswerReplayCacheOnFailure(
+      runtimeProfile,
+      benchmarkId,
+      pairedAnswerReplayCache,
+    );
     if (partialTasks.length > 0) {
       const remnicVersion = await benchModule.getRemnicVersion?.() ?? "unknown";
       const partialResult = buildPartialBenchmarkResult(

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1965,6 +1965,7 @@ export const __benchDatasetTestHooks = {
   resolveBenchDatasetDir,
   resolveDownloadedBenchDatasetDir,
   pairedAnswerReplayCacheForBenchmark,
+  orderPairedLoCoMoWorkItemsForTest: orderPairedLoCoMoWorkItems,
   buildPublishedBenchmarkOptionsForTest(
     benchmarkId: string,
     args: {
@@ -3072,8 +3073,13 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
     return;
   }
 
-  const runtimeProfiles = resolveBenchRunProfiles(parsed);
   const benchmarkId = parsed.publishedName;
+  const runtimeProfiles = orderPairedLoCoMoWorkItems(
+    resolveBenchRunProfiles(parsed).map((runtimeProfile) => ({
+      benchmarkId,
+      runtimeProfile,
+    })),
+  ).map((item) => item.runtimeProfile);
   // Collect artifact paths written by each runtime profile so the
   // --out promotion step copies the exact file just produced rather
   // than scanning the whole results directory (Cursor Medium + Codex
@@ -3498,6 +3504,24 @@ function pairedAnswerReplayCacheForBenchmark(
   pairedAnswerReplayCache?: import("@remnic/bench").PairedAnswerReplayCache,
 ): import("@remnic/bench").PairedAnswerReplayCache | undefined {
   return benchmarkId === "locomo" ? pairedAnswerReplayCache : undefined;
+}
+
+function orderPairedLoCoMoWorkItems<
+  T extends { benchmarkId: string; runtimeProfile: BenchRuntimeProfile },
+>(workItems: readonly T[]): T[] {
+  const baselineIndex = workItems.findIndex(
+    (item) => item.benchmarkId === "locomo" && item.runtimeProfile === "baseline",
+  );
+  const realIndex = workItems.findIndex(
+    (item) => item.benchmarkId === "locomo" && item.runtimeProfile === "real",
+  );
+  if (baselineIndex < 0 || realIndex < 0 || baselineIndex < realIndex) {
+    return [...workItems];
+  }
+  const ordered = [...workItems];
+  const [baseline] = ordered.splice(baselineIndex, 1);
+  ordered.splice(realIndex, 0, baseline!);
+  return ordered;
 }
 
 async function runBenchViaPackage(
@@ -10995,7 +11019,7 @@ async function cmdBench(rest: string[]): Promise<void> {
       ? new Map<string, import("@remnic/bench").PairedAnswerReplayEntry>()
       : undefined;
   try {
-    for (const { benchmarkId, runtimeProfile } of selectedWorkItems) {
+    for (const { benchmarkId, runtimeProfile } of orderPairedLoCoMoWorkItems(selectedWorkItems)) {
       const statusId = runtimeProfiles.length > 1
         ? `${benchmarkId} [${runtimeProfile}]`
         : benchmarkId;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1964,6 +1964,7 @@ export const __benchDatasetTestHooks = {
   isDatasetDownloaded,
   resolveBenchDatasetDir,
   resolveDownloadedBenchDatasetDir,
+  pairedAnswerReplayCacheForBenchmark,
   buildPublishedBenchmarkOptionsForTest(
     benchmarkId: string,
     args: {
@@ -3492,6 +3493,13 @@ async function preflightLocalLabEndpointsIfNeeded(
   }
 }
 
+function pairedAnswerReplayCacheForBenchmark(
+  benchmarkId: string,
+  pairedAnswerReplayCache?: import("@remnic/bench").PairedAnswerReplayCache,
+): import("@remnic/bench").PairedAnswerReplayCache | undefined {
+  return benchmarkId === "locomo" ? pairedAnswerReplayCache : undefined;
+}
+
 async function runBenchViaPackage(
   parsed: ParsedBenchArgs,
   benchmarkId: string,
@@ -3595,6 +3603,10 @@ async function runBenchViaPackage(
     if (benchmarkId === "memcorrect-v1" && parsed.adapter === "mcp") {
       benchmarkOptions = { ...(benchmarkOptions ?? {}), adapter: system };
     }
+    const locomoPairedAnswerReplayCache = pairedAnswerReplayCacheForBenchmark(
+      benchmarkId,
+      pairedAnswerReplayCache,
+    );
     const result = await benchModule.runBenchmark(benchmarkId, {
       mode: parsed.quick ? "quick" : "full",
       datasetDir,
@@ -3611,7 +3623,7 @@ async function runBenchViaPackage(
       // Issue #1573 PR1: judge-result cache controls from the CLI flags.
       ...(parsed.noJudgeCache ? { noJudgeCache: true } : {}),
       ...(parsed.judgeCacheDir ? { judgeCacheDir: parsed.judgeCacheDir } : {}),
-      ...(pairedAnswerReplayCache ? { pairedAnswerReplayCache } : {}),
+      ...(locomoPairedAnswerReplayCache ? { pairedAnswerReplayCache: locomoPairedAnswerReplayCache } : {}),
       ...(benchmarkOptions ? { benchmarkOptions } : {}),
       ...(amaBenchProtocol.judgeProtocol
         ? { amaBenchJudgeProtocol: amaBenchProtocol.judgeProtocol }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -534,6 +534,7 @@ type PackageBenchModule = {
     drainTimeoutMs?: number;
     noJudgeCache?: boolean;
     judgeCacheDir?: string;
+    pairedAnswerReplayCache?: import("@remnic/bench").PairedAnswerReplayCache;
     system: {
       destroy(): Promise<void>;
     };
@@ -3079,6 +3080,12 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
   // publish unrelated or older artifacts under the new canonical
   // filename).
   const writtenPaths: string[] = [];
+  const pairedAnswerReplayCache =
+    benchmarkId === "locomo"
+      && runtimeProfiles.includes("baseline")
+      && runtimeProfiles.includes("real")
+      ? new Map<string, import("@remnic/bench").PairedAnswerReplayEntry>()
+      : undefined;
   for (const runtimeProfile of runtimeProfiles) {
     // Forward `--limit` + `--seed` through the existing package
     // runner. `--out` is handled below in the artifact write step.
@@ -3088,6 +3095,7 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
       runtimeProfile,
       undefined,
       taskSelector,
+      pairedAnswerReplayCache,
     );
     if (!result.ok) {
       console.error(
@@ -3490,6 +3498,7 @@ async function runBenchViaPackage(
   runtimeProfile: BenchRuntimeProfile,
   benchStatusPath?: string,
   taskSelector?: PackageBenchTaskSelector,
+  pairedAnswerReplayCache?: import("@remnic/bench").PairedAnswerReplayCache,
 ): Promise<{ ok: boolean; writtenPath?: string }> {
   const loaded = await tryLoadBenchModule();
   if (!loaded) return { ok: false };
@@ -3602,6 +3611,7 @@ async function runBenchViaPackage(
       // Issue #1573 PR1: judge-result cache controls from the CLI flags.
       ...(parsed.noJudgeCache ? { noJudgeCache: true } : {}),
       ...(parsed.judgeCacheDir ? { judgeCacheDir: parsed.judgeCacheDir } : {}),
+      ...(pairedAnswerReplayCache ? { pairedAnswerReplayCache } : {}),
       ...(benchmarkOptions ? { benchmarkOptions } : {}),
       ...(amaBenchProtocol.judgeProtocol
         ? { amaBenchJudgeProtocol: amaBenchProtocol.judgeProtocol }
@@ -10963,6 +10973,15 @@ async function cmdBench(rest: string[]): Promise<void> {
   )];
   try { await initBenchStatus(benchStatusPath, statusEntryIds, process.pid); } catch { /* non-fatal */ }
   const writtenPaths: string[] = [];
+  const pairedAnswerReplayCache =
+    selectedWorkItems.some(
+      (item) => item.benchmarkId === "locomo" && item.runtimeProfile === "baseline",
+    )
+    && selectedWorkItems.some(
+      (item) => item.benchmarkId === "locomo" && item.runtimeProfile === "real",
+    )
+      ? new Map<string, import("@remnic/bench").PairedAnswerReplayEntry>()
+      : undefined;
   try {
     for (const { benchmarkId, runtimeProfile } of selectedWorkItems) {
       const statusId = runtimeProfiles.length > 1
@@ -10976,6 +10995,7 @@ async function cmdBench(rest: string[]): Promise<void> {
             runtimeProfile,
             benchStatusPath,
             taskSelector,
+            pairedAnswerReplayCache,
           );
           if (handledByPackage.ok) {
             if (handledByPackage.writtenPath) {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2023,99 +2023,13 @@ export const __benchDatasetTestHooks = {
   printBenchStatusLineForTest: printBenchStatusLine,
   clearPairedAnswerReplayCacheOnFailureForTest: clearPairedAnswerReplayCacheOnFailure,
 };
-function printStoredBenchResultSummary(
-  result: BenchmarkResult,
-  summary: { id: string; path: string },
-): void {
-  console.log(`Run id: ${summary.id}`);
-  printBenchPackageSummary(result, summary.path, "Stored result");
-}
-
-function printBenchStatusLine(jsonMode: boolean, message: string): void {
-  if (jsonMode) {
-    console.error(message);
-  } else {
-    console.log(message);
-  }
-}
-
-function printBenchPackageSummary(
-  result: BenchSummaryResult,
-  outputPath: string,
-  outputLabel = "Results saved",
-): void {
-  console.log(`Benchmark: ${result.meta.benchmark}`);
-  console.log(`Mode: ${result.meta.mode}`);
-  if (result.config.runtimeProfile) {
-    console.log(`Runtime profile: ${result.config.runtimeProfile}`);
-  }
-  console.log(`Tasks: ${result.results.tasks.length}`);
-  console.log(`Mean query latency: ${result.cost.meanQueryLatencyMs.toFixed(1)}ms`);
-  for (const [metric, aggregate] of Object.entries(result.results.aggregates).sort()) {
-    console.log(`  ${metric.padEnd(20)} ${aggregate.mean.toFixed(4)}`);
-  }
-  console.log(`${outputLabel}: ${outputPath}`);
-}
-
-function printStoredBenchResultDetails(
-  result: BenchmarkResult,
-  summary: { id: string; path: string },
-): void {
-  printStoredBenchResultSummary(result, summary);
-  if (result.results.tasks.length === 0) {
-    console.log("Tasks: none");
-    return;
-  }
-
-  console.log("Task breakdown:");
-  for (const task of result.results.tasks) {
-    const scores = Object.entries(task.scores)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([metric, value]) => `${metric}=${value.toFixed(4)}`)
-      .join(", ");
-    console.log(
-      `  ${task.taskId}: ${task.latencyMs.toFixed(1)}ms` +
-      `${scores.length > 0 ? ` [${scores}]` : ""}`,
-    );
-  }
-}
-
-function printBenchComparisonSummary(
-  comparison: ComparisonResult,
-  baseline: { id: string; path: string },
-  candidate: { id: string; path: string },
-): void {
-  console.log(`Benchmark: ${comparison.benchmark}`);
-  console.log(`Baseline: ${baseline.id} (${baseline.path})`);
-  console.log(`Candidate: ${candidate.id} (${candidate.path})`);
-  console.log(`Verdict: ${comparison.verdict}`);
-
-  const metrics = Object.entries(comparison.metricDeltas).sort(([left], [right]) =>
-    left.localeCompare(right),
-  );
-  if (metrics.length === 0) {
-    console.log("No overlapping metrics were found between the two results.");
-    return;
-  }
-
-  console.log("Metrics:");
-  for (const [metric, delta] of metrics) {
-    const percent = Number.isFinite(delta.percentChange)
-      ? `${(delta.percentChange * 100).toFixed(2)}%`
-      : delta.percentChange > 0
-        ? "+Infinity%"
-        : "-Infinity%";
-    const direction = delta.delta >= 0 ? "+" : "";
-    console.log(
-      `  ${metric.padEnd(18)} ${delta.baseline.toFixed(4)} -> ${delta.candidate.toFixed(4)} (${direction}${delta.delta.toFixed(4)}, ${percent}, d=${delta.effectSize.cohensD.toFixed(3)} ${delta.effectSize.interpretation})`,
-    );
-    if (delta.ciOnDelta) {
-      console.log(
-        `    CI95 delta: [${delta.ciOnDelta.lower.toFixed(4)}, ${delta.ciOnDelta.upper.toFixed(4)}]`,
-      );
-    }
-  }
-}
+import {
+  printBenchComparisonSummary,
+  printBenchPackageSummary,
+  printBenchStatusLine,
+  printStoredBenchResultDetails,
+  printStoredBenchResultSummary,
+} from "./bench-output-printer.js";
 
 async function compareBenchPackageResults(parsed: ParsedBenchArgs): Promise<void> {
   const refs = parsed.benchmarks;
@@ -3704,7 +3618,7 @@ async function runBenchViaPackage(
     if (parsed.json) {
       console.log(JSON.stringify(redactBenchResultForStdout(benchModule, result), null, 2));
     } else {
-      printBenchPackageSummary(result, writtenPath);
+      printBenchPackageSummary(result as never, writtenPath);
     }
     return { ok: true, writtenPath };
   } catch (err) {
@@ -4153,7 +4067,7 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
       if (parsed.json) {
         console.log(JSON.stringify(redactBenchResultForStdout(benchModule, result), null, 2));
       } else {
-        printBenchPackageSummary(result, writtenPath);
+        printBenchPackageSummary(result as never, writtenPath);
       }
     } finally {
       await system.destroy();

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2023,12 +2023,12 @@ export const __benchDatasetTestHooks = {
   printBenchStatusLineForTest: printBenchStatusLine,
   clearPairedAnswerReplayCacheOnFailureForTest: clearPairedAnswerReplayCacheOnFailure,
 };
-
 function printStoredBenchResultSummary(
   result: BenchmarkResult,
   summary: { id: string; path: string },
 ): void {
   console.log(`Run id: ${summary.id}`);
+  printBenchPackageSummary(result, summary.path, "Stored result");
 }
 
 function printBenchStatusLine(jsonMode: boolean, message: string): void {


### PR DESCRIPTION
## Summary

- replay the baseline answer only when the paired LoCoMo responder input is byte-for-byte identical
- retain independent responder calls when model, prompt, or recalled context differs
- expose the explicit paired-run cache only to the paired benchmark invocation

Part of #1879.

## Validation

- `pnpm exec tsx --test packages/bench/src/benchmarks/published/harness.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LoCoMo paired-run scoring inputs and caching semantics; incorrect replay rules could skew baseline vs real comparisons, though guards limit reuse to matching keys and baseline-sourced answers.
> 
> **Overview**
> Adds **paired-answer replay** for LoCoMo baseline→real runs so the real profile can reuse a baseline responder answer when recall, prompt, provider settings, and **responder identity** match, instead of paying for a second LLM call that would add unrelated variance.
> 
> Responders can now expose optional **`identity()`** (sanitized hashes for provider-backed and gateway responders; omitted when unknown). The timeout guard **forwards** that hook. Without identity, replay is **disabled** so systems cannot share a cache blindly.
> 
> The published harness keys cache entries with stable hashing, stores answers only from successful **baseline** trials (not fallbacks), reuses them only for **`real`**, records **`pairedAnswerReusedFrom`** in task details, and **clears** the cache on baseline errors or partial completion. The CLI wires a shared cache for paired LoCoMo runs, runs **baseline before real**, and clears the cache if baseline fails.
> 
> Bench result printing moves to **`bench-output-printer.ts`** (behavior unchanged). Tests cover replay rules, identity forwarding, and cache lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7472b3c4ce6b6a867c9d794b46aa696376faf20f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paired-answer replay caching for benchmark runs, including reuse attribution metadata.
  * Extended LoCoMo benchmark/CLI flows to share the cache across runtime profiles and ensure baseline runs populate it first.

* **Bug Fixes**
  * Replay is now disabled when responder identity is unavailable.
  * Replay cache is cleared on baseline failures and partial benchmark completion to prevent reuse of invalid entries.

* **Tests**
  * Expanded coverage for reuse rules, cache skipping/clearing, cross-model non-replay, fallback isolation, and stable replay cache keying.

* **Performance**
  * Reduced redundant answer generation for eligible baseline→real executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->