### PR TITLE
feat(capture): @remnic/capture-screen daemon + unified macOS capture helper (#1899)

### DIFF
--- a/.github/workflows/capture-native-helper.yml
+++ b/.github/workflows/capture-native-helper.yml
@@ -1,0 +1,137 @@
+name: capture-native-helper
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'packages/capture-native-darwin-helper/**'
+      - 'packages/capture-native-darwin-arm64/**'
+      - 'packages/capture-native-darwin-x64/**'
+      - 'packages/capture-screen/**'
+      - '.github/workflows/capture-native-helper.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/capture-native-darwin-helper/**'
+      - 'packages/capture-native-darwin-arm64/**'
+      - 'packages/capture-native-darwin-x64/**'
+      - 'packages/capture-screen/**'
+      - '.github/workflows/capture-native-helper.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: capture-native-helper-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # Compile + unit-test the unified Swift helper on real macOS runners, one per
+  # target arch, then stage the built binary into its platform package and run
+  # that package's Node test. Swift cannot be built or run on Linux, so this
+  # job is the only place the native helper is actually proven.
+  swift:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            arch: arm64
+            platformPackage: packages/capture-native-darwin-arm64
+          - runner: macos-13
+            arch: x64
+            platformPackage: packages/capture-native-darwin-x64
+    name: swift (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Pin a toolchain that provides Swift 5.10 (swift-tools-version in
+      # Package.swift). latest-stable satisfies this on both runner images.
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Swift version
+        run: swift --version
+
+      - name: Build helper (release)
+        working-directory: packages/capture-native-darwin-helper
+        run: swift build -c release
+
+      - name: Test helper
+        working-directory: packages/capture-native-darwin-helper
+        run: swift test
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+
+      - name: Stage built binary into platform package
+        run: |
+          set -euo pipefail
+          bin_dir="$(cd packages/capture-native-darwin-helper && swift build -c release --show-bin-path)"
+          mkdir -p "${{ matrix.platformPackage }}/bin"
+          cp "${bin_dir}/remnic-capture-helper" "${{ matrix.platformPackage }}/bin/remnic-capture-helper"
+          chmod +x "${{ matrix.platformPackage }}/bin/remnic-capture-helper"
+
+      - name: Platform package test
+        working-directory: ${{ matrix.platformPackage }}
+        run: node test.mjs
+
+      - name: Smoke-test helper CLI surface
+        working-directory: ${{ matrix.platformPackage }}
+        run: |
+          set -euo pipefail
+          ./bin/remnic-capture-helper --help
+          # device-enumerate needs no TCC grant and must emit one JSON line.
+          ./bin/remnic-capture-helper device-enumerate | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const o=JSON.parse(s);if(!Array.isArray(o.devices))throw new Error("device-enumerate did not emit a devices array");console.log("device-enumerate ok:",o.devices.length,"entries")})'
+
+      - name: Upload helper binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: remnic-capture-helper-${{ matrix.arch }}
+          path: ${{ matrix.platformPackage }}/bin/remnic-capture-helper
+          if-no-files-found: error
+
+  # The screen-activity daemon (@remnic/capture-screen) is TypeScript and is
+  # proven on Linux like the rest of the workspace.
+  screen-linux:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    name: screen (linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # capture-screen's check-types resolves @remnic/core types.
+      - name: Build core
+        run: pnpm --filter @remnic/core build
+
+      - name: Typecheck capture-screen
+        run: pnpm --filter @remnic/capture-screen run check-types
+
+      - name: Test capture-screen
+        run: pnpm --filter @remnic/capture-screen run test

--- a/.github/workflows/capture-native-helper.yml
+++ b/.github/workflows/capture-native-helper.yml
@@ -40,7 +40,7 @@ jobs:
           - runner: macos-14
             arch: arm64
             platformPackage: packages/capture-native-darwin-arm64
-          - runner: macos-13
+          - runner: macos-15-intel
             arch: x64
             platformPackage: packages/capture-native-darwin-x64
     name: swift (${{ matrix.arch }})
@@ -52,6 +52,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Pin a toolchain that provides Swift 5.10 (swift-tools-version in
       # Package.swift). latest-stable satisfies this on both runner images.
@@ -113,6 +115,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -561,16 +561,6 @@ jobs:
               echo "::notice::Skipping private package: $pkg_dir"
               continue
             fi
-            # Platform-specific native packages (declaring an `os` allow-list,
-            # e.g. the darwin capture-helper binaries whose prebuilt binary only
-            # exists on its own platform) cannot be packed intact on this Ubuntu
-            # runner; each carries a prepack guard that fails loudly without it.
-            # They publish from their dedicated platform CI job — skip here.
-            pkg_os="$(node -p "JSON.stringify(require('./$pkg_json').os || [])")"
-            if [ "$pkg_os" != "[]" ] && ! node -e "process.exit((require('./$pkg_json').os||[]).includes(process.platform)?0:1)"; then
-              echo "::notice::Skipping platform-specific package on $(node -p 'process.platform'): $pkg_dir (published from its platform CI job)"
-              continue
-            fi
             pkg_name="$(node -p "require('./$pkg_json').name")"
             pkg_version="$(node -p "require('./$pkg_json').version")"
             pkg_exists="false"

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -561,6 +561,16 @@ jobs:
               echo "::notice::Skipping private package: $pkg_dir"
               continue
             fi
+            # Platform-specific native packages (declaring an `os` allow-list,
+            # e.g. the darwin capture-helper binaries whose prebuilt binary only
+            # exists on its own platform) cannot be packed intact on this Ubuntu
+            # runner; each carries a prepack guard that fails loudly without it.
+            # They publish from their dedicated platform CI job — skip here.
+            pkg_os="$(node -p "JSON.stringify(require('./$pkg_json').os || [])")"
+            if [ "$pkg_os" != "[]" ] && ! node -e "process.exit((require('./$pkg_json').os||[]).includes(process.platform)?0:1)"; then
+              echo "::notice::Skipping platform-specific package on $(node -p 'process.platform'): $pkg_dir (published from its platform CI job)"
+              continue
+            fi
             pkg_name="$(node -p "require('./$pkg_json').name")"
             pkg_version="$(node -p "require('./$pkg_json').version")"
             pkg_exists="false"

--- a/packages/capture-native-darwin-arm64/README.md
+++ b/packages/capture-native-darwin-arm64/README.md
@@ -4,6 +4,12 @@ macOS Apple Silicon (arm64) platform package for the unified Remnic native
 capture helper, `remnic-capture-helper`. One binary serves both the audio
 capture pipeline (#1897) and the screen-activity pipeline (#1899).
 
+> **Not yet published.** This package is currently `private` and not on npm.
+> Runtime distribution via npm is tracked in
+> https://github.com/joshuaswarren/remnic/issues/2139. Until then, build the
+> helper from source (`packages/capture-native-darwin-helper`) and point
+> `REMNIC_CAPTURE_HELPER_BIN` at the binary.
+
 ## What this package provides
 
 - `helperBinaryPath` — an absolute path to the packaged `bin/remnic-capture-helper`

--- a/packages/capture-native-darwin-arm64/README.md
+++ b/packages/capture-native-darwin-arm64/README.md
@@ -1,0 +1,34 @@
+# @remnic/capture-native-darwin-arm64
+
+macOS Apple Silicon (arm64) platform package for the unified Remnic native
+capture helper, `remnic-capture-helper`. One binary serves both the audio
+capture pipeline (#1897) and the screen-activity pipeline (#1899).
+
+## What this package provides
+
+- `helperBinaryPath` — an absolute path to the packaged `bin/remnic-capture-helper`
+  binary, resolved relative to the installed package:
+
+  ```js
+  import { helperBinaryPath } from "@remnic/capture-native-darwin-arm64";
+  ```
+
+## The binary is built by CI, not committed
+
+`bin/remnic-capture-helper` is a compiled macOS Mach-O executable produced by
+the `capture-native-helper` GitHub Actions workflow on a real macOS arm64
+runner (`swift build -c release` against `packages/capture-native-darwin-helper`).
+It is **not** committed to the repository and is **not** buildable on Linux.
+
+Until CI stages the binary into `bin/`, `helperBinaryPath` still resolves to the
+path it *will* occupy; the package `test` script tolerates its absence and skips
+the executable check with a note.
+
+## Subcommands
+
+```
+remnic-capture-helper audio-capture --channel mic|system|both --chunk-seconds N --out <dir> [--device <id>]
+remnic-capture-helper device-enumerate
+remnic-capture-helper ax-snapshot [--frontmost | --pid <n>] [--max-nodes N]
+remnic-capture-helper ocr-window [--frontmost | --window <id>]
+```

--- a/packages/capture-native-darwin-arm64/index.d.ts
+++ b/packages/capture-native-darwin-arm64/index.d.ts
@@ -1,0 +1,2 @@
+/** Absolute path to the packaged `remnic-capture-helper` native binary. */
+export declare const helperBinaryPath: string;

--- a/packages/capture-native-darwin-arm64/index.js
+++ b/packages/capture-native-darwin-arm64/index.js
@@ -1,0 +1,9 @@
+import { fileURLToPath } from "node:url";
+
+/**
+ * Absolute path to the packaged `remnic-capture-helper` native binary for
+ * macOS arm64. The binary is produced by macOS CI (see README.md) and staged
+ * into `bin/`; this export resolves its path relative to the installed
+ * package, whether the binary is present yet or not.
+ */
+export const helperBinaryPath = fileURLToPath(new URL("./bin/remnic-capture-helper", import.meta.url));

--- a/packages/capture-native-darwin-arm64/package.json
+++ b/packages/capture-native-darwin-arm64/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@remnic/capture-native-darwin-arm64",
+  "version": "9.14.0",
+  "description": "macOS Apple Silicon native capture helper for Remnic — audio, screen accessibility (AX), and window OCR",
+  "type": "module",
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js"
+    }
+  },
+  "bin": {
+    "remnic-capture-helper": "bin/remnic-capture-helper"
+  },
+  "files": ["index.js", "index.d.ts", "bin/remnic-capture-helper", "README.md"],
+  "scripts": {
+    "test": "node test.mjs"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/capture-native-darwin-arm64"
+  },
+  "keywords": ["remnic", "audio", "screen", "ax", "ocr", "capture", "macos", "darwin", "arm64"]
+}

--- a/packages/capture-native-darwin-arm64/package.json
+++ b/packages/capture-native-darwin-arm64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@remnic/capture-native-darwin-arm64",
   "version": "9.14.0",
+  "private": true,
   "description": "macOS Apple Silicon native capture helper for Remnic — audio, screen accessibility (AX), and window OCR",
   "type": "module",
   "os": ["darwin"],

--- a/packages/capture-native-darwin-arm64/package.json
+++ b/packages/capture-native-darwin-arm64/package.json
@@ -18,6 +18,7 @@
   },
   "files": ["index.js", "index.d.ts", "bin/remnic-capture-helper", "README.md"],
   "scripts": {
+    "prepack": "node -e \"require('node:fs').accessSync('bin/remnic-capture-helper')\"",
     "test": "node test.mjs"
   },
   "publishConfig": {

--- a/packages/capture-native-darwin-arm64/test.mjs
+++ b/packages/capture-native-darwin-arm64/test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { access, constants } from "node:fs/promises";
+
+import { helperBinaryPath } from "./index.js";
+
+assert.equal(typeof helperBinaryPath, "string");
+assert.ok(helperBinaryPath.length > 0, "helperBinaryPath must be non-empty");
+assert.ok(
+  helperBinaryPath.endsWith("bin/remnic-capture-helper"),
+  "helperBinaryPath must point at the packaged binary",
+);
+
+try {
+  await access(helperBinaryPath, constants.X_OK);
+  console.log(`ok: ${helperBinaryPath} present and executable`);
+} catch {
+  // The real binary is produced by macOS CI (swift build -c release) and
+  // staged into bin/. On Linux and any pre-build checkout it is absent; the
+  // -x check is skipped with a note so the Linux release-workflow test passes.
+  console.log(`note: CI-built binary absent at ${helperBinaryPath}; skipping -x check`);
+}

--- a/packages/capture-native-darwin-arm64/test.mjs
+++ b/packages/capture-native-darwin-arm64/test.mjs
@@ -13,9 +13,10 @@ assert.ok(
 try {
   await access(helperBinaryPath, constants.X_OK);
   console.log(`ok: ${helperBinaryPath} present and executable`);
-} catch {
-  // The real binary is produced by macOS CI (swift build -c release) and
-  // staged into bin/. On Linux and any pre-build checkout it is absent; the
-  // -x check is skipped with a note so the Linux release-workflow test passes.
+} catch (err) {
+  // The real binary is produced by macOS CI (swift build -c release) and staged
+  // into bin/. Only its ABSENCE (ENOENT) on Linux / pre-build checkouts is a
+  // benign skip; a present-but-not-executable binary (EACCES) is a real failure.
+  if (err?.code !== "ENOENT") throw err;
   console.log(`note: CI-built binary absent at ${helperBinaryPath}; skipping -x check`);
 }

--- a/packages/capture-native-darwin-helper/Package.swift
+++ b/packages/capture-native-darwin-helper/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "RemnicCaptureHelper",
+    platforms: [.macOS(.v13)],
+    products: [
+        .executable(name: "remnic-capture-helper", targets: ["RemnicCaptureHelper"]),
+    ],
+    targets: [
+        .executableTarget(name: "RemnicCaptureHelper"),
+        .testTarget(name: "RemnicCaptureHelperTests", dependencies: ["RemnicCaptureHelper"]),
+    ]
+)

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/AXSnapshot.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/AXSnapshot.swift
@@ -138,11 +138,13 @@ enum AXSnapshotReader {
         visited += 1
 
         let role = string(element, kAXRoleAttribute)
+        let subrole = string(element, kAXSubroleAttribute)
 
-        // Never read secure input, and never descend into it — the value is a
-        // password. Emit the role only so the daemon still sees the node exists.
-        if role == (kAXSecureTextFieldRole as String) {
-            return AxNode(role: role, value: nil, title: nil, description: nil, offScreen: nil, children: nil)
+        // Secure text field (subrole AXSecureTextField): never read its value and
+        // never descend — it is a password. Emit the secure role marker only, so
+        // the daemon still sees the node exists but no secret leaves the helper.
+        if subrole == "AXSecureTextField" {
+            return AxNode(role: "AXSecureTextField", value: nil, title: nil, description: nil, offScreen: nil, children: nil)
         }
 
         let onScreen = isOnScreen(element, within: screenBounds)

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/AXSnapshot.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/AXSnapshot.swift
@@ -1,0 +1,256 @@
+import AppKit
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+/// Parsed flags for `ax-snapshot`:
+/// `[--frontmost | --pid <n>] [--max-nodes N]`. `pid == nil` targets the
+/// frontmost application.
+struct AXSnapshotOptions {
+    let pid: pid_t?
+    let maxNodes: Int
+
+    static func parse(_ arguments: [String]) throws -> AXSnapshotOptions {
+        var pid: pid_t?
+        var frontmost = false
+        var maxNodes = 4000
+        var index = 0
+
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--frontmost":
+                frontmost = true
+            case "--pid":
+                index += 1
+                guard index < arguments.count, let value = Int32(arguments[index]), value > 0 else {
+                    throw HelperError(message: "--pid requires a positive integer", exitCode: 2)
+                }
+                pid = value
+            case "--max-nodes":
+                index += 1
+                guard index < arguments.count, let value = Int(arguments[index]), value > 0 else {
+                    throw HelperError(message: "--max-nodes requires a positive integer", exitCode: 2)
+                }
+                maxNodes = value
+            default:
+                throw HelperError(message: "unknown argument: \(argument)", exitCode: 2)
+            }
+            index += 1
+        }
+
+        if pid != nil, frontmost {
+            throw HelperError(message: "--pid and --frontmost are mutually exclusive", exitCode: 2)
+        }
+
+        return AXSnapshotOptions(pid: pid, maxNodes: maxNodes)
+    }
+}
+
+/// One accessibility node. Deliberately permissive and RAW — the helper does
+/// NOT filter secure/off-screen text; it serializes the tree and the daemon
+/// (`@remnic/capture-screen` axtree.ts) applies the security filters, so that
+/// logic stays unit-testable off-macOS. Matches the daemon's `AxNode`.
+/// A secure-text node is emitted with its role only (never its value/children),
+/// as defense-in-depth so a password never leaves the helper.
+struct AxNode: Codable {
+    let role: String?
+    let value: String?
+    let title: String?
+    let description: String?
+    let offScreen: Bool?
+    let children: [AxNode]?
+}
+
+/// `ax-snapshot` payload: window context + the raw AX tree.
+/// `{"app","windowTitle","browserUrl"?,"tree":AxNode}`.
+struct AXSnapshotResult: Codable {
+    let app: String
+    let windowTitle: String
+    let browserUrl: String?
+    let tree: AxNode
+
+    func jsonLine() throws -> Data {
+        // A nil `browserUrl` is omitted (synthesized encodeIfPresent), matching
+        // the optional-key contract the daemon expects.
+        var line = try JSONEncoder().encode(self)
+        line.append(0x0A)
+        return line
+    }
+}
+
+enum AXSnapshotReader {
+    static func snapshot(options: AXSnapshotOptions) throws -> AXSnapshotResult {
+        guard AXIsProcessTrusted() else {
+            throw HelperError(
+                message: "Accessibility permission required — grant remnic-capture-helper access in "
+                    + "System Settings > Privacy & Security > Accessibility",
+                exitCode: 3
+            )
+        }
+
+        let (pid, appName) = try resolveTarget(options: options)
+        let application = AXUIElementCreateApplication(pid)
+        let window = try focusedWindow(of: application)
+        let windowTitle = string(window, kAXTitleAttribute) ?? ""
+        let browserUrl = url(of: window)
+
+        let screenBounds = combinedScreenBounds()
+        var visited = 0
+        let tree = serialize(window, maxNodes: options.maxNodes, screenBounds: screenBounds, visited: &visited)
+
+        return AXSnapshotResult(app: appName, windowTitle: windowTitle, browserUrl: browserUrl, tree: tree)
+    }
+
+    private static func resolveTarget(options: AXSnapshotOptions) throws -> (pid_t, String) {
+        if let pid = options.pid {
+            let name = NSRunningApplication(processIdentifier: pid)?.localizedName ?? "pid \(pid)"
+            return (pid, name)
+        }
+        guard let front = NSWorkspace.shared.frontmostApplication else {
+            throw HelperError(message: "no frontmost application", exitCode: 1)
+        }
+        return (front.processIdentifier, front.localizedName ?? "unknown app")
+    }
+
+    private static func focusedWindow(of application: AXUIElement) throws -> AXUIElement {
+        if let window = element(application, kAXFocusedWindowAttribute) {
+            return window
+        }
+        if let window = element(application, kAXMainWindowAttribute) {
+            return window
+        }
+        if let windows = elements(application, kAXWindowsAttribute), let first = windows.first {
+            return first
+        }
+        throw HelperError(message: "target application has no accessible window", exitCode: 1)
+    }
+
+    /// Serialize an element (and, bounded by `maxNodes`, its subtree) into a raw
+    /// AxNode. No text filtering here — the daemon does secure/off-screen/cap
+    /// filtering on the emitted tree.
+    private static func serialize(
+        _ element: AXUIElement,
+        maxNodes: Int,
+        screenBounds: CGRect,
+        visited: inout Int
+    ) -> AxNode {
+        visited += 1
+
+        let role = string(element, kAXRoleAttribute)
+
+        // Never read secure input, and never descend into it — the value is a
+        // password. Emit the role only so the daemon still sees the node exists.
+        if role == (kAXSecureTextFieldRole as String) {
+            return AxNode(role: role, value: nil, title: nil, description: nil, offScreen: nil, children: nil)
+        }
+
+        let onScreen = isOnScreen(element, within: screenBounds)
+
+        var children: [AxNode]?
+        if let kids = elements(element, kAXChildrenAttribute), !kids.isEmpty {
+            var out: [AxNode] = []
+            for child in kids {
+                if visited >= maxNodes { break }
+                out.append(serialize(child, maxNodes: maxNodes, screenBounds: screenBounds, visited: &visited))
+            }
+            if !out.isEmpty { children = out }
+        }
+
+        return AxNode(
+            role: role,
+            value: string(element, kAXValueAttribute),
+            title: string(element, kAXTitleAttribute),
+            description: string(element, kAXDescriptionAttribute),
+            offScreen: onScreen ? nil : true,
+            children: children
+        )
+    }
+
+    // MARK: attribute helpers
+
+    private static func attribute(_ element: AXUIElement, _ name: String) -> CFTypeRef? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, name as CFString, &value) == .success else {
+            return nil
+        }
+        return value
+    }
+
+    private static func string(_ element: AXUIElement, _ name: String) -> String? {
+        guard let value = attribute(element, name), CFGetTypeID(value) == CFStringGetTypeID() else {
+            return nil
+        }
+        // swiftlint:disable:next force_cast
+        return (value as! CFString) as String
+    }
+
+    private static func element(_ element: AXUIElement, _ name: String) -> AXUIElement? {
+        guard let value = attribute(element, name), CFGetTypeID(value) == AXUIElementGetTypeID() else {
+            return nil
+        }
+        // swiftlint:disable:next force_cast
+        return (value as! AXUIElement)
+    }
+
+    private static func elements(_ element: AXUIElement, _ name: String) -> [AXUIElement]? {
+        guard let value = attribute(element, name), CFGetTypeID(value) == CFArrayGetTypeID() else {
+            return nil
+        }
+        return value as? [AXUIElement]
+    }
+
+    private static func url(of element: AXUIElement) -> String? {
+        guard let value = attribute(element, kAXURLAttribute as String) else { return nil }
+        if let url = value as? URL {
+            return url.absoluteString
+        }
+        return nil
+    }
+
+    private static func isOnScreen(_ element: AXUIElement, within screenBounds: CGRect) -> Bool {
+        guard let frame = frame(of: element) else {
+            // Position/size unavailable: keep it rather than over-excluding.
+            return true
+        }
+        if frame.width <= 0 || frame.height <= 0 {
+            return false
+        }
+        if screenBounds.isNull || screenBounds.isEmpty {
+            return true
+        }
+        return screenBounds.intersects(frame)
+    }
+
+    private static func frame(of element: AXUIElement) -> CGRect? {
+        guard let positionValue = attribute(element, kAXPositionAttribute),
+              CFGetTypeID(positionValue) == AXValueGetTypeID(),
+              let sizeValue = attribute(element, kAXSizeAttribute),
+              CFGetTypeID(sizeValue) == AXValueGetTypeID() else {
+            return nil
+        }
+        var point = CGPoint.zero
+        var size = CGSize.zero
+        // swiftlint:disable force_cast
+        guard AXValueGetValue(positionValue as! AXValue, .cgPoint, &point),
+              AXValueGetValue(sizeValue as! AXValue, .cgSize, &size) else {
+            return nil
+        }
+        // swiftlint:enable force_cast
+        return CGRect(origin: point, size: size)
+    }
+
+    /// Union of active display bounds. `CGDisplayBounds` uses the global
+    /// top-left origin space, matching `kAXPositionAttribute`.
+    private static func combinedScreenBounds() -> CGRect {
+        var count: UInt32 = 0
+        guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else { return .null }
+        var displays = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetActiveDisplayList(count, &displays, &count) == .success else { return .null }
+        var bounds = CGRect.null
+        for display in displays {
+            bounds = bounds.union(CGDisplayBounds(display))
+        }
+        return bounds
+    }
+}

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/AudioCapture.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/AudioCapture.swift
@@ -20,7 +20,12 @@ final class AudioCaptureController {
     }
 
     func start() async throws {
-        try micCapture?.start()
+        do {
+            try micCapture?.start()
+        } catch {
+            await systemCapture?.stop()
+            throw error
+        }
         do {
             try await systemCapture?.start()
         } catch {
@@ -100,6 +105,9 @@ private final class MicrophoneCapture {
 private final class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate {
     private let writer: ChunkWriter
     private var stream: SCStream?
+    // Serial delivery: SCStream may otherwise call didOutputSampleBuffer
+    // concurrently, and ChunkWriter mutates file/converter state without locking.
+    private let sampleQueue = DispatchQueue(label: "com.remnic.capture-helper.system-audio")
 
     init(configuration: CaptureConfiguration) throws {
         writer = try ChunkWriter(
@@ -123,7 +131,7 @@ private final class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelega
         configuration.excludesCurrentProcessAudio = false
 
         let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
-        try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: .global(qos: .userInitiated))
+        try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: sampleQueue)
         try await stream.startCapture()
         self.stream = stream
     }

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/AudioCapture.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/AudioCapture.swift
@@ -1,0 +1,208 @@
+import AudioToolbox
+import AVFoundation
+import CoreAudio
+import CoreMedia
+import Dispatch
+import Foundation
+import ScreenCaptureKit
+
+final class AudioCaptureController {
+    private let micCapture: MicrophoneCapture?
+    private let systemCapture: SystemAudioCapture?
+
+    init(configuration: CaptureConfiguration) throws {
+        micCapture = configuration.channel.capturesMic
+            ? try MicrophoneCapture(configuration: configuration)
+            : nil
+        systemCapture = configuration.channel.capturesSystem
+            ? try SystemAudioCapture(configuration: configuration)
+            : nil
+    }
+
+    func start() async throws {
+        try micCapture?.start()
+        do {
+            try await systemCapture?.start()
+        } catch {
+            micCapture?.stop()
+            throw error
+        }
+    }
+
+    func stop() async {
+        micCapture?.stop()
+        await systemCapture?.stop()
+    }
+}
+
+private final class MicrophoneCapture {
+    private let writer: ChunkWriter
+    private let engine = AVAudioEngine()
+
+    init(configuration: CaptureConfiguration) throws {
+        let deviceName: String
+        if let deviceId = configuration.deviceId,
+           let audioDeviceID = CoreAudioDevices.deviceID(forUID: deviceId) {
+            try Self.selectInputDevice(audioDeviceID, on: engine)
+            deviceName = CoreAudioDevices.name(audioDeviceID) ?? deviceId
+        } else {
+            deviceName = AVCaptureDevice.default(for: .audio)?.localizedName ?? "default microphone"
+        }
+        writer = try ChunkWriter(
+            outDirectory: configuration.outDirectory,
+            channel: .mic,
+            device: deviceName,
+            chunkSeconds: configuration.chunkSeconds
+        )
+    }
+
+    func start() throws {
+        let input = engine.inputNode
+        let format = input.inputFormat(forBus: 0)
+        input.installTap(onBus: 0, bufferSize: 4_096, format: format) { [writer] buffer, _ in
+            if let event = writer.append(buffer, at: Date()) {
+                emit(event)
+            }
+        }
+        engine.prepare()
+        try engine.start()
+    }
+
+    func stop() {
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        finish(writer)
+    }
+
+    /// Bind the AVAudioEngine input to a specific CoreAudio device.
+    private static func selectInputDevice(_ deviceID: AudioDeviceID, on engine: AVAudioEngine) throws {
+        guard let audioUnit = engine.inputNode.audioUnit else { return }
+        var mutableID = deviceID
+        let status = AudioUnitSetProperty(
+            audioUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &mutableID,
+            UInt32(MemoryLayout<AudioDeviceID>.size)
+        )
+        guard status == noErr else {
+            throw HelperError(message: "unable to select input device (status \(status))", exitCode: 1)
+        }
+    }
+}
+
+private final class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate {
+    private let writer: ChunkWriter
+    private var stream: SCStream?
+
+    init(configuration: CaptureConfiguration) throws {
+        writer = try ChunkWriter(
+            outDirectory: configuration.outDirectory,
+            channel: .system,
+            device: "system audio",
+            chunkSeconds: configuration.chunkSeconds
+        )
+    }
+
+    func start() async throws {
+        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        guard let display = content.displays.first else {
+            throw AudioCaptureError.noDisplay
+        }
+        let filter = SCContentFilter(display: display, excludingWindows: [])
+        let configuration = SCStreamConfiguration()
+        configuration.capturesAudio = true
+        configuration.channelCount = 1
+        configuration.sampleRate = 16_000
+        configuration.excludesCurrentProcessAudio = false
+
+        let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
+        try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: .global(qos: .userInitiated))
+        try await stream.startCapture()
+        self.stream = stream
+    }
+
+    func stop() async {
+        if let stream {
+            try? await stream.stopCapture()
+        }
+        self.stream = nil
+        finish(writer)
+    }
+
+    func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of outputType: SCStreamOutputType) {
+        guard outputType == .audio, sampleBuffer.isValid else {
+            return
+        }
+        withPCMBuffer(from: sampleBuffer) { buffer in
+            if let event = writer.append(buffer, at: Date()) {
+                emit(event)
+            }
+        }
+    }
+
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        FileHandle.standardError.write(
+            Data("remnic-capture-helper: system audio capture stopped: \(error.localizedDescription)\n".utf8)
+        )
+    }
+
+    private func withPCMBuffer(from sampleBuffer: CMSampleBuffer, consume: (AVAudioPCMBuffer) -> Void) {
+        guard let description = sampleBuffer.formatDescription else {
+            return
+        }
+        let format = AVAudioFormat(cmAudioFormatDescription: description)
+        let list = UnsafeMutablePointer<AudioBufferList>.allocate(capacity: 1)
+        defer { list.deallocate() }
+        var blockBuffer: CMBlockBuffer?
+        let status = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+            sampleBuffer,
+            bufferListSizeNeededOut: nil,
+            bufferListOut: list,
+            bufferListSize: MemoryLayout<AudioBufferList>.size,
+            blockBufferAllocator: kCFAllocatorDefault,
+            blockBufferMemoryAllocator: kCFAllocatorDefault,
+            flags: kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment,
+            blockBufferOut: &blockBuffer
+        )
+        guard status == noErr,
+              let buffer = AVAudioPCMBuffer(pcmFormat: format, bufferListNoCopy: list, deallocator: nil) else {
+            return
+        }
+        consume(buffer)
+    }
+}
+
+private enum AudioCaptureError: LocalizedError {
+    case noDisplay
+
+    var errorDescription: String? {
+        switch self {
+        case .noDisplay: "no display is available for system-audio capture"
+        }
+    }
+}
+
+private func finish(_ writer: ChunkWriter) {
+    do {
+        emit(try writer.finish(at: Date()))
+    } catch ChunkWriterError.noOpenChunk {
+    } catch {
+        FileHandle.standardError.write(Data("remnic-capture-helper: \(error.localizedDescription)\n".utf8))
+    }
+}
+
+private let eventOutputQueue = DispatchQueue(label: "com.remnic.capture-helper.event-output")
+
+private func emit(_ event: ChunkEvent) {
+    eventOutputQueue.sync {
+        do {
+            FileHandle.standardOutput.write(try event.jsonLine())
+        } catch {
+            FileHandle.standardError.write(
+                Data("remnic-capture-helper: unable to emit chunk event: \(error.localizedDescription)\n".utf8)
+            )
+        }
+    }
+}

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/AudioCapture.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/AudioCapture.swift
@@ -41,8 +41,13 @@ private final class MicrophoneCapture {
 
     init(configuration: CaptureConfiguration) throws {
         let deviceName: String
-        if let deviceId = configuration.deviceId,
-           let audioDeviceID = CoreAudioDevices.deviceID(forUID: deviceId) {
+        if let deviceId = configuration.deviceId {
+            guard let audioDeviceID = CoreAudioDevices.deviceID(forUID: deviceId) else {
+                throw HelperError(
+                    message: "requested --device '\(deviceId)' is not a known CoreAudio input; run device-enumerate to list valid UIDs",
+                    exitCode: 2
+                )
+            }
             try Self.selectInputDevice(audioDeviceID, on: engine)
             deviceName = CoreAudioDevices.name(audioDeviceID) ?? deviceId
         } else {

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/AudioCapture.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/AudioCapture.swift
@@ -86,7 +86,9 @@ private final class MicrophoneCapture {
 
     /// Bind the AVAudioEngine input to a specific CoreAudio device.
     private static func selectInputDevice(_ deviceID: AudioDeviceID, on engine: AVAudioEngine) throws {
-        guard let audioUnit = engine.inputNode.audioUnit else { return }
+        guard let audioUnit = engine.inputNode.audioUnit else {
+            throw HelperError(message: "cannot bind --device: input node exposes no audio unit", exitCode: 1)
+        }
         var mutableID = deviceID
         let status = AudioUnitSetProperty(
             audioUnit,

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/CaptureConfiguration.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/CaptureConfiguration.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Which capture channels the `audio-capture` subcommand should run.
+enum ChannelSelection: String {
+    case mic
+    case system
+    case both
+
+    var capturesMic: Bool { self == .mic || self == .both }
+    var capturesSystem: Bool { self == .system || self == .both }
+}
+
+/// Parsed flags for `audio-capture`:
+/// `--channel mic|system|both --chunk-seconds N --out <dir> [--device <id>]`.
+struct CaptureConfiguration {
+    let outDirectory: URL
+    let chunkSeconds: Int
+    let channel: ChannelSelection
+    /// Optional CoreAudio device UID selecting a specific microphone input.
+    let deviceId: String?
+
+    static func parse(_ arguments: [String]) throws -> CaptureConfiguration {
+        var outDirectory: URL?
+        var chunkSeconds = 30
+        var channel: ChannelSelection?
+        var deviceId: String?
+        var index = 0
+
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--out":
+                outDirectory = URL(fileURLWithPath: try value(arguments, &index, argument))
+            case "--chunk-seconds":
+                let raw = try value(arguments, &index, argument)
+                guard let seconds = Int(raw), seconds > 0 else {
+                    throw CaptureConfigurationError.invalidChunkSeconds
+                }
+                chunkSeconds = seconds
+            case "--channel":
+                let raw = try value(arguments, &index, argument)
+                guard let parsed = ChannelSelection(rawValue: raw) else {
+                    throw CaptureConfigurationError.invalidChannel(raw)
+                }
+                channel = parsed
+            case "--device":
+                deviceId = try value(arguments, &index, argument)
+            default:
+                throw CaptureConfigurationError.unknownArgument(argument)
+            }
+            index += 1
+        }
+
+        guard let channel else {
+            throw CaptureConfigurationError.missingChannel
+        }
+        guard let outDirectory else {
+            throw CaptureConfigurationError.missingOutDirectory
+        }
+
+        return CaptureConfiguration(
+            outDirectory: outDirectory,
+            chunkSeconds: chunkSeconds,
+            channel: channel,
+            deviceId: deviceId
+        )
+    }
+
+    /// Consume the value that follows a flag, advancing the parse index.
+    private static func value(_ arguments: [String], _ index: inout Int, _ flag: String) throws -> String {
+        index += 1
+        guard index < arguments.count else {
+            throw CaptureConfigurationError.missingValue(flag)
+        }
+        return arguments[index]
+    }
+}
+
+enum CaptureConfigurationError: LocalizedError {
+    case missingOutDirectory
+    case missingChannel
+    case invalidChunkSeconds
+    case invalidChannel(String)
+    case missingValue(String)
+    case unknownArgument(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingOutDirectory:
+            "--out is required"
+        case .missingChannel:
+            "--channel is required (mic|system|both)"
+        case .invalidChunkSeconds:
+            "--chunk-seconds must be a positive integer"
+        case let .invalidChannel(value):
+            "--channel must be mic|system|both, got: \(value)"
+        case let .missingValue(flag):
+            "\(flag) requires a value"
+        case let .unknownArgument(argument):
+            "unknown argument: \(argument)"
+        }
+    }
+}

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/ChunkEvent.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/ChunkEvent.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum CaptureChannel: String, Codable {
+    case mic
+    case system
+}
+
+struct ChunkEvent: Codable {
+    let path: String
+    let channel: CaptureChannel
+    let startedAtUtc: Date
+    let endedAtUtc: Date
+    let device: String
+
+    func jsonLine() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode(Self.timestampFormatter.string(from: date))
+        }
+        var line = try encoder.encode(self)
+        line.append(0x0A)
+        return line
+    }
+
+    private static let timestampFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/ChunkWriter.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/ChunkWriter.swift
@@ -32,7 +32,11 @@ final class ChunkWriter {
             throw ChunkWriterError.unavailableFormat
         }
         destinationFormat = format
-        try FileManager.default.createDirectory(at: outDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: outDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
     }
 
     func append(_ buffer: AVAudioPCMBuffer, at timestamp: Date) -> ChunkEvent? {
@@ -80,6 +84,9 @@ final class ChunkWriter {
             commonFormat: .pcmFormatInt16,
             interleaved: true
         )
+        // Captured audio is sensitive — restrict the WAV to owner-only before any
+        // path is emitted (parity with the 0600 spool DB).
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: chunkURL.path)
         self.chunkURL = chunkURL
         startedAtUtc = timestamp
     }

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/ChunkWriter.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/ChunkWriter.swift
@@ -1,0 +1,145 @@
+import AVFoundation
+import Foundation
+
+final class ChunkWriter {
+    private let outDirectory: URL
+    private let channel: CaptureChannel
+    private let device: String
+    private let chunkSeconds: Int
+    private let destinationFormat: AVAudioFormat
+    private var file: AVAudioFile?
+    private var chunkURL: URL?
+    private var converter: AVAudioConverter?
+    private var converterInputFormat: AVAudioFormat?
+    private var startedAtUtc: Date?
+
+    init(
+        outDirectory: URL,
+        channel: CaptureChannel,
+        device: String,
+        chunkSeconds: Int
+    ) throws {
+        self.outDirectory = outDirectory
+        self.channel = channel
+        self.device = device
+        self.chunkSeconds = chunkSeconds
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: true
+        ) else {
+            throw ChunkWriterError.unavailableFormat
+        }
+        destinationFormat = format
+        try FileManager.default.createDirectory(at: outDirectory, withIntermediateDirectories: true)
+    }
+
+    func append(_ buffer: AVAudioPCMBuffer, at timestamp: Date) -> ChunkEvent? {
+        var completed: ChunkEvent?
+        do {
+            if let startedAtUtc, timestamp.timeIntervalSince(startedAtUtc) >= TimeInterval(chunkSeconds) {
+                completed = try finish(at: timestamp)
+            }
+            if file == nil {
+                try openChunk(at: timestamp)
+            }
+            try write(buffer)
+        } catch {
+            FileHandle.standardError.write(Data("remnic-capture-helper: \(error.localizedDescription)\n".utf8))
+        }
+        return completed
+    }
+
+    func finish(at endedAtUtc: Date) throws -> ChunkEvent {
+        guard let chunkURL, let startedAtUtc else {
+            throw ChunkWriterError.noOpenChunk
+        }
+        var completedFile = file
+        file = nil
+        self.chunkURL = nil
+        self.startedAtUtc = nil
+        if #available(macOS 15.0, *) {
+            completedFile?.close()
+        }
+        completedFile = nil
+        return ChunkEvent(
+            path: chunkURL.path,
+            channel: channel,
+            startedAtUtc: startedAtUtc,
+            endedAtUtc: endedAtUtc,
+            device: device
+        )
+    }
+
+    private func openChunk(at timestamp: Date) throws {
+        let chunkURL = outDirectory.appendingPathComponent("\(channel.rawValue)-\(UUID().uuidString).wav")
+        file = try AVAudioFile(
+            forWriting: chunkURL,
+            settings: destinationFormat.settings,
+            commonFormat: .pcmFormatInt16,
+            interleaved: true
+        )
+        self.chunkURL = chunkURL
+        startedAtUtc = timestamp
+    }
+
+    private func write(_ buffer: AVAudioPCMBuffer) throws {
+        guard let file else {
+            throw ChunkWriterError.noOpenChunk
+        }
+        if buffer.format.sampleRate == destinationFormat.sampleRate,
+           buffer.format.channelCount == destinationFormat.channelCount,
+           buffer.format.commonFormat == destinationFormat.commonFormat {
+            try file.write(from: buffer)
+            return
+        }
+
+        if converter == nil || converterInputFormat?.isEqual(buffer.format) != true {
+            converter = AVAudioConverter(from: buffer.format, to: destinationFormat)
+            converterInputFormat = buffer.format
+        }
+        guard let converter else {
+            throw ChunkWriterError.unavailableConverter
+        }
+        let capacity = AVAudioFrameCount(
+            ceil(Double(buffer.frameLength) * destinationFormat.sampleRate / buffer.format.sampleRate)
+        )
+        guard let converted = AVAudioPCMBuffer(pcmFormat: destinationFormat, frameCapacity: capacity) else {
+            throw ChunkWriterError.unavailableBuffer
+        }
+        var consumed = false
+        var conversionError: NSError?
+        let status = converter.convert(to: converted, error: &conversionError) { _, inputStatus in
+            if consumed {
+                inputStatus.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            inputStatus.pointee = .haveData
+            return buffer
+        }
+        if status == .error {
+            throw conversionError ?? ChunkWriterError.conversionFailed
+        }
+        try file.write(from: converted)
+    }
+}
+
+enum ChunkWriterError: LocalizedError {
+    case unavailableFormat
+    case unavailableConverter
+    case unavailableBuffer
+    case conversionFailed
+    case noOpenChunk
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailableFormat: "unable to create 16 kHz mono PCM format"
+        case .unavailableConverter: "unable to convert captured audio to 16 kHz mono PCM"
+        case .unavailableBuffer: "unable to allocate converted audio buffer"
+        case .conversionFailed: "audio conversion failed"
+        case .noOpenChunk: "no audio chunk is open"
+        }
+    }
+}

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/CoreAudioDevices.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/CoreAudioDevices.swift
@@ -1,0 +1,94 @@
+import CoreAudio
+import Foundation
+
+/// Thin CoreAudio accessors shared by `device-enumerate` and microphone
+/// device selection in `audio-capture`.
+enum CoreAudioDevices {
+    static func allDeviceIDs() -> [AudioDeviceID] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        var status = AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize
+        )
+        guard status == noErr, dataSize > 0 else { return [] }
+        let count = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
+        var ids = [AudioDeviceID](repeating: 0, count: count)
+        status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize, &ids
+        )
+        guard status == noErr else { return [] }
+        return ids
+    }
+
+    static func name(_ id: AudioDeviceID) -> String? {
+        stringProperty(id, kAudioObjectPropertyName)
+    }
+
+    static func uid(_ id: AudioDeviceID) -> String? {
+        stringProperty(id, kAudioDevicePropertyDeviceUID)
+    }
+
+    static func hasStreams(_ id: AudioDeviceID, scope: AudioObjectPropertyScope) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: scope,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        var status = AudioObjectGetPropertyDataSize(id, &address, 0, nil, &dataSize)
+        guard status == noErr, dataSize > 0 else { return false }
+        let raw = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(dataSize),
+            alignment: MemoryLayout<AudioBufferList>.alignment
+        )
+        defer { raw.deallocate() }
+        status = AudioObjectGetPropertyData(id, &address, 0, nil, &dataSize, raw)
+        guard status == noErr else { return false }
+        let bufferList = UnsafeMutableAudioBufferListPointer(raw.assumingMemoryBound(to: AudioBufferList.self))
+        for buffer in bufferList where buffer.mNumberChannels > 0 {
+            return true
+        }
+        return false
+    }
+
+    static func defaultDeviceID(_ selector: AudioObjectPropertySelector) -> AudioDeviceID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceID = AudioDeviceID(0)
+        var dataSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize, &deviceID
+        )
+        guard status == noErr, deviceID != 0 else { return nil }
+        return deviceID
+    }
+
+    static func deviceID(forUID uid: String) -> AudioDeviceID? {
+        for id in allDeviceIDs() where self.uid(id) == uid {
+            return id
+        }
+        return nil
+    }
+
+    private static func stringProperty(_ id: AudioDeviceID, _ selector: AudioObjectPropertySelector) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize = UInt32(MemoryLayout<CFString?>.size)
+        var value: CFString?
+        let status = withUnsafeMutablePointer(to: &value) { pointer in
+            AudioObjectGetPropertyData(id, &address, 0, nil, &dataSize, pointer)
+        }
+        guard status == noErr, let value else { return nil }
+        return value as String
+    }
+}

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/DeviceEnumerate.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/DeviceEnumerate.swift
@@ -1,0 +1,48 @@
+import CoreAudio
+import Foundation
+
+enum DeviceKind: String, Codable {
+    case input
+    case output
+}
+
+struct DeviceInfo: Codable {
+    let id: String
+    let name: String
+    let kind: DeviceKind
+    let isDefault: Bool
+}
+
+/// `device-enumerate` payload: `{"devices":[{"id","name","kind","isDefault"}]}`.
+struct DeviceList: Codable {
+    let devices: [DeviceInfo]
+
+    func jsonLine() throws -> Data {
+        var line = try JSONEncoder().encode(self)
+        line.append(0x0A)
+        return line
+    }
+}
+
+enum DeviceEnumerator {
+    /// A device that carries both input and output streams appears once per
+    /// direction so each entry has a single, honest `kind` and default flag.
+    static func enumerate() throws -> DeviceList {
+        let defaultInput = CoreAudioDevices.defaultDeviceID(kAudioHardwarePropertyDefaultInputDevice)
+        let defaultOutput = CoreAudioDevices.defaultDeviceID(kAudioHardwarePropertyDefaultOutputDevice)
+        var devices: [DeviceInfo] = []
+
+        for deviceID in CoreAudioDevices.allDeviceIDs() {
+            let id = CoreAudioDevices.uid(deviceID) ?? String(deviceID)
+            let name = CoreAudioDevices.name(deviceID) ?? "unknown device"
+            if CoreAudioDevices.hasStreams(deviceID, scope: kAudioObjectPropertyScopeInput) {
+                devices.append(DeviceInfo(id: id, name: name, kind: .input, isDefault: deviceID == defaultInput))
+            }
+            if CoreAudioDevices.hasStreams(deviceID, scope: kAudioObjectPropertyScopeOutput) {
+                devices.append(DeviceInfo(id: id, name: name, kind: .output, isDefault: deviceID == defaultOutput))
+            }
+        }
+
+        return DeviceList(devices: devices)
+    }
+}

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/OCRWindow.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/OCRWindow.swift
@@ -1,0 +1,178 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+import Vision
+
+/// Parsed flags for `ocr-window`: `[--frontmost | --window <id>]`.
+/// `windowId == nil` targets the frontmost application's front window.
+struct OCRWindowOptions {
+    let windowId: CGWindowID?
+
+    static func parse(_ arguments: [String]) throws -> OCRWindowOptions {
+        var windowId: CGWindowID?
+        var frontmost = false
+        var index = 0
+
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--frontmost":
+                frontmost = true
+            case "--window":
+                index += 1
+                guard index < arguments.count, let value = UInt32(arguments[index]) else {
+                    throw HelperError(message: "--window requires a numeric window id", exitCode: 2)
+                }
+                windowId = value
+            default:
+                throw HelperError(message: "unknown argument: \(argument)", exitCode: 2)
+            }
+            index += 1
+        }
+
+        if windowId != nil, frontmost {
+            throw HelperError(message: "--window and --frontmost are mutually exclusive", exitCode: 2)
+        }
+
+        return OCRWindowOptions(windowId: windowId)
+    }
+}
+
+/// `ocr-window` payload: `{"app","windowTitle","text","textSource":"ocr"}`.
+struct OCRWindowResult: Codable {
+    let app: String
+    let windowTitle: String
+    let text: String
+    let textSource: String
+
+    init(app: String, windowTitle: String, text: String) {
+        self.app = app
+        self.windowTitle = windowTitle
+        self.text = text
+        self.textSource = "ocr"
+    }
+
+    func jsonLine() throws -> Data {
+        var line = try JSONEncoder().encode(self)
+        line.append(0x0A)
+        return line
+    }
+}
+
+enum OCRWindowReader {
+    private struct TargetWindow {
+        let windowId: CGWindowID
+        let app: String
+        let windowTitle: String
+    }
+
+    static func recognize(options: OCRWindowOptions) async throws -> OCRWindowResult {
+        guard CGPreflightScreenCaptureAccess() else {
+            throw HelperError(
+                message: "Screen Recording permission required — grant remnic-capture-helper access in "
+                    + "System Settings > Privacy & Security > Screen Recording",
+                exitCode: 3
+            )
+        }
+
+        let target = try resolveWindow(options: options)
+        // The captured image lives only for the duration of recognition and is
+        // never written to disk.
+        let image = try await captureImage(windowId: target.windowId)
+        let text = try recognizeText(in: image)
+        return OCRWindowResult(app: target.app, windowTitle: target.windowTitle, text: text)
+    }
+
+    private static func resolveWindow(options: OCRWindowOptions) throws -> TargetWindow {
+        let listOption: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let infoList = CGWindowListCopyWindowInfo(listOption, kCGNullWindowID) as? [[String: Any]] else {
+            throw HelperError(message: "unable to enumerate windows", exitCode: 1)
+        }
+
+        if let windowId = options.windowId {
+            guard let info = infoList.first(where: { ($0[kCGWindowNumber as String] as? CGWindowID) == windowId }) else {
+                throw HelperError(message: "window \(windowId) not found", exitCode: 1)
+            }
+            return target(from: info, fallbackId: windowId)
+        }
+
+        guard let front = NSWorkspace.shared.frontmostApplication else {
+            throw HelperError(message: "no frontmost application", exitCode: 1)
+        }
+        let pid = front.processIdentifier
+        let candidate = infoList.first { info in
+            (info[kCGWindowOwnerPID as String] as? pid_t) == pid
+                && (info[kCGWindowLayer as String] as? Int) == 0
+        }
+        guard let info = candidate, let windowId = info[kCGWindowNumber as String] as? CGWindowID else {
+            throw HelperError(message: "frontmost application has no capturable window", exitCode: 1)
+        }
+        return target(from: info, fallbackId: windowId)
+    }
+
+    private static func target(from info: [String: Any], fallbackId: CGWindowID) -> TargetWindow {
+        let windowId = (info[kCGWindowNumber as String] as? CGWindowID) ?? fallbackId
+        let app = (info[kCGWindowOwnerName as String] as? String) ?? "unknown app"
+        let title = (info[kCGWindowName as String] as? String) ?? ""
+        return TargetWindow(windowId: windowId, app: app, windowTitle: title)
+    }
+
+    private static func captureImage(windowId: CGWindowID) async throws -> CGImage {
+        if #available(macOS 14.0, *) {
+            if let image = try? await captureWithScreenCaptureKit(windowId: windowId) {
+                return image
+            }
+        }
+        guard let image = captureWithCoreGraphics(windowId: windowId) else {
+            throw HelperError(message: "unable to capture window image", exitCode: 1)
+        }
+        return image
+    }
+
+    @available(macOS 14.0, *)
+    private static func captureWithScreenCaptureKit(windowId: CGWindowID) async throws -> CGImage {
+        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        guard let window = content.windows.first(where: { $0.windowID == windowId }) else {
+            throw HelperError(message: "window \(windowId) not shareable", exitCode: 1)
+        }
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        let configuration = SCStreamConfiguration()
+        configuration.width = max(1, Int(window.frame.width))
+        configuration.height = max(1, Int(window.frame.height))
+        configuration.scalesToFit = true
+        configuration.showsCursor = false
+        return try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: configuration)
+    }
+
+    private static func captureWithCoreGraphics(windowId: CGWindowID) -> CGImage? {
+        CGWindowListCreateImage(
+            .null,
+            .optionIncludingWindow,
+            windowId,
+            [.boundsIgnoreFraming, .bestResolution]
+        )
+    }
+
+    private static func recognizeText(in image: CGImage) throws -> String {
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+
+        let handler = VNImageRequestHandler(cgImage: image, options: [:])
+        try handler.perform([request])
+
+        guard let observations = request.results else { return "" }
+        // Reading order: top-to-bottom (Vision's normalized boundingBox origin is
+        // bottom-left, so a larger y is higher on screen), then left-to-right.
+        return observations
+            .sorted { lhs, rhs in
+                if abs(lhs.boundingBox.origin.y - rhs.boundingBox.origin.y) > 0.01 {
+                    return lhs.boundingBox.origin.y > rhs.boundingBox.origin.y
+                }
+                return lhs.boundingBox.origin.x < rhs.boundingBox.origin.x
+            }
+            .compactMap { $0.topCandidates(1).first?.string }
+            .joined(separator: "\n")
+    }
+}

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/RemnicCaptureHelper.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/RemnicCaptureHelper.swift
@@ -18,6 +18,9 @@ struct RemnicCaptureHelper {
     static let programName = "remnic-capture-helper"
 
     static func main() async {
+        // Writing chunk events to a closed stdout pipe must not SIGPIPE-kill the
+        // helper before controller.stop()/finish() can flush; ignore it here too.
+        Darwin.signal(SIGPIPE, SIG_IGN)
         let arguments = Array(CommandLine.arguments.dropFirst())
         guard let subcommand = arguments.first else {
             fail("missing subcommand (audio-capture|device-enumerate|ax-snapshot|ocr-window)", code: 2)

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/RemnicCaptureHelper.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/RemnicCaptureHelper.swift
@@ -1,0 +1,125 @@
+import Dispatch
+import Foundation
+
+/// Unified Remnic macOS native capture helper.
+///
+/// One binary serves both the audio-capture pipeline (#1897) and the
+/// screen-activity pipeline (#1899). The subcommand is `argv[1]`:
+///
+///   audio-capture    long-running PCM WAV chunk writer (mic / system / both)
+///   device-enumerate one-shot audio device list
+///   ax-snapshot      one-shot accessibility text snapshot of a window
+///   ocr-window       one-shot Vision OCR of a window image (image never persisted)
+///
+/// Every one-shot subcommand prints exactly one JSON line to stdout. Missing
+/// TCC permissions exit non-zero with a one-line stderr instruction.
+@main
+struct RemnicCaptureHelper {
+    static let programName = "remnic-capture-helper"
+
+    static func main() async {
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        guard let subcommand = arguments.first else {
+            fail("missing subcommand (audio-capture|device-enumerate|ax-snapshot|ocr-window)", code: 2)
+        }
+        let rest = Array(arguments.dropFirst())
+
+        do {
+            switch subcommand {
+            case "audio-capture":
+                try await runAudioCapture(rest)
+            case "device-enumerate":
+                try runDeviceEnumerate(rest)
+            case "ax-snapshot":
+                try runAxSnapshot(rest)
+            case "ocr-window":
+                try await runOcrWindow(rest)
+            case "--help", "-h", "help":
+                printUsage()
+            default:
+                fail("unknown subcommand: \(subcommand)", code: 2)
+            }
+        } catch let error as HelperError {
+            fail(error.message, code: error.exitCode)
+        } catch {
+            fail(error.localizedDescription, code: 1)
+        }
+    }
+
+    // MARK: audio-capture
+
+    private static func runAudioCapture(_ arguments: [String]) async throws {
+        let configuration = try CaptureConfiguration.parse(arguments)
+        let controller = try AudioCaptureController(configuration: configuration)
+        try await controller.start()
+        await waitForTermination(controller: controller)
+    }
+
+    private static func waitForTermination(controller: AudioCaptureController) async {
+        let source = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+        Darwin.signal(SIGTERM, SIG_IGN)
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            source.setEventHandler {
+                source.cancel()
+                continuation.resume()
+            }
+            source.resume()
+        }
+        await controller.stop()
+    }
+
+    // MARK: device-enumerate
+
+    private static func runDeviceEnumerate(_ arguments: [String]) throws {
+        guard arguments.isEmpty else {
+            throw HelperError(message: "device-enumerate takes no arguments", exitCode: 2)
+        }
+        let list = try DeviceEnumerator.enumerate()
+        writeLine(try list.jsonLine())
+    }
+
+    // MARK: ax-snapshot
+
+    private static func runAxSnapshot(_ arguments: [String]) throws {
+        let options = try AXSnapshotOptions.parse(arguments)
+        let result = try AXSnapshotReader.snapshot(options: options)
+        writeLine(try result.jsonLine())
+    }
+
+    // MARK: ocr-window
+
+    private static func runOcrWindow(_ arguments: [String]) async throws {
+        let options = try OCRWindowOptions.parse(arguments)
+        let result = try await OCRWindowReader.recognize(options: options)
+        writeLine(try result.jsonLine())
+    }
+
+    // MARK: output helpers
+
+    private static func printUsage() {
+        let usage = """
+        usage: \(programName) <subcommand> [options]
+          audio-capture --channel mic|system|both --chunk-seconds N --out <dir> [--device <id>]
+          device-enumerate
+          ax-snapshot [--frontmost | --pid <n>] [--max-nodes N]
+          ocr-window [--frontmost | --window <id>]
+        """
+        FileHandle.standardOutput.write(Data((usage + "\n").utf8))
+    }
+
+    private static func writeLine(_ data: Data) {
+        FileHandle.standardOutput.write(data)
+    }
+
+    private static func fail(_ message: String, code: Int32) -> Never {
+        FileHandle.standardError.write(Data("\(programName): \(message)\n".utf8))
+        Foundation.exit(code)
+    }
+}
+
+/// A domain error that carries an explicit process exit code. Missing-TCC
+/// failures use this to exit non-zero with a clear one-line message.
+struct HelperError: Error {
+    let message: String
+    let exitCode: Int32
+}

--- a/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/RemnicCaptureHelper.swift
+++ b/packages/capture-native-darwin-helper/Sources/RemnicCaptureHelper/RemnicCaptureHelper.swift
@@ -59,14 +59,25 @@ struct RemnicCaptureHelper {
     }
 
     private static func waitForTermination(controller: AudioCaptureController) async {
-        let source = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
-        Darwin.signal(SIGTERM, SIG_IGN)
+        // Honor both SIGTERM (supervisors) and SIGINT (Ctrl-C) so a foreground
+        // stop still runs controller.stop()/finish() and flushes the open chunk.
+        let handled: [Int32] = [SIGTERM, SIGINT]
+        let sources = handled.map { sig -> DispatchSourceSignal in
+            Darwin.signal(sig, SIG_IGN)
+            return DispatchSource.makeSignalSource(signal: sig, queue: .main)
+        }
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            source.setEventHandler {
-                source.cancel()
-                continuation.resume()
+            var resumed = false
+            for source in sources {
+                source.setEventHandler {
+                    for other in sources { other.cancel() }
+                    if !resumed {
+                        resumed = true
+                        continuation.resume()
+                    }
+                }
+                source.resume()
             }
-            source.resume()
         }
         await controller.stop()
     }

--- a/packages/capture-native-darwin-helper/Tests/RemnicCaptureHelperTests/AXSnapshotTests.swift
+++ b/packages/capture-native-darwin-helper/Tests/RemnicCaptureHelperTests/AXSnapshotTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import RemnicCaptureHelper
+
+final class AXSnapshotTests: XCTestCase {
+    func testDefaultsToFrontmostAndMaxNodes() throws {
+        let options = try AXSnapshotOptions.parse([])
+        XCTAssertNil(options.pid)
+        XCTAssertEqual(options.maxNodes, 4000)
+    }
+
+    func testParsesPidAndMaxNodes() throws {
+        let options = try AXSnapshotOptions.parse(["--pid", "1234", "--max-nodes", "500"])
+        XCTAssertEqual(options.pid, 1234)
+        XCTAssertEqual(options.maxNodes, 500)
+    }
+
+    func testFrontmostFlagKeepsPidNil() throws {
+        let options = try AXSnapshotOptions.parse(["--frontmost", "--max-nodes", "10"])
+        XCTAssertNil(options.pid)
+        XCTAssertEqual(options.maxNodes, 10)
+    }
+
+    func testRejectsPidAndFrontmostTogether() {
+        XCTAssertThrowsError(try AXSnapshotOptions.parse(["--pid", "1", "--frontmost"]))
+    }
+
+    func testRejectsNonPositivePid() {
+        XCTAssertThrowsError(try AXSnapshotOptions.parse(["--pid", "0"]))
+    }
+
+    func testRejectsUnknownArgument() {
+        XCTAssertThrowsError(try AXSnapshotOptions.parse(["--bogus"]))
+    }
+
+    func testEncodesResultWithBrowserUrlAndRawTree() throws {
+        let tree = AxNode(
+            role: "AXWindow",
+            value: nil,
+            title: "Example",
+            description: nil,
+            offScreen: nil,
+            children: [
+                AxNode(role: "AXStaticText", value: "Hello", title: nil, description: nil, offScreen: nil, children: nil),
+                AxNode(role: "AXSecureTextField", value: nil, title: nil, description: nil, offScreen: nil, children: nil),
+            ]
+        )
+        let result = AXSnapshotResult(
+            app: "Safari",
+            windowTitle: "Example",
+            browserUrl: "https://example.com/",
+            tree: tree
+        )
+
+        let json = try result.jsonLine()
+        XCTAssertEqual(json.last, 0x0A)
+        let object = try JSONSerialization.jsonObject(with: json.dropLast()) as? [String: Any]
+        XCTAssertEqual(object?["app"] as? String, "Safari")
+        XCTAssertEqual(object?["windowTitle"] as? String, "Example")
+        XCTAssertEqual(object?["browserUrl"] as? String, "https://example.com/")
+
+        let treeObject = object?["tree"] as? [String: Any]
+        XCTAssertEqual(treeObject?["role"] as? String, "AXWindow")
+        XCTAssertEqual(treeObject?["title"] as? String, "Example")
+        let children = treeObject?["children"] as? [[String: Any]]
+        XCTAssertEqual(children?.count, 2)
+        XCTAssertEqual(children?[0]["role"] as? String, "AXStaticText")
+        XCTAssertEqual(children?[0]["value"] as? String, "Hello")
+        // The secure node carries its role only — never a value key.
+        XCTAssertEqual(children?[1]["role"] as? String, "AXSecureTextField")
+        XCTAssertFalse((children?[1].keys.contains("value")) ?? true)
+    }
+
+    func testOmitsBrowserUrlWhenNil() throws {
+        let tree = AxNode(role: "AXWindow", value: nil, title: "bash", description: nil, offScreen: nil, children: nil)
+        let result = AXSnapshotResult(app: "Terminal", windowTitle: "bash", browserUrl: nil, tree: tree)
+
+        let json = try result.jsonLine()
+        let object = try JSONSerialization.jsonObject(with: json.dropLast()) as? [String: Any]
+        XCTAssertFalse(object?.keys.contains("browserUrl") ?? true)
+        XCTAssertNotNil(object?["tree"])
+    }
+}

--- a/packages/capture-native-darwin-helper/Tests/RemnicCaptureHelperTests/CaptureConfigurationTests.swift
+++ b/packages/capture-native-darwin-helper/Tests/RemnicCaptureHelperTests/CaptureConfigurationTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import RemnicCaptureHelper
+
+final class CaptureConfigurationTests: XCTestCase {
+    func testParsesChannelOutChunkSecondsAndDevice() throws {
+        let configuration = try CaptureConfiguration.parse([
+            "--channel", "both",
+            "--chunk-seconds", "45",
+            "--out", "/tmp/remnic-audio",
+            "--device", "BuiltInMicrophoneDevice",
+        ])
+
+        XCTAssertEqual(configuration.channel, .both)
+        XCTAssertTrue(configuration.channel.capturesMic)
+        XCTAssertTrue(configuration.channel.capturesSystem)
+        XCTAssertEqual(configuration.chunkSeconds, 45)
+        XCTAssertEqual(configuration.outDirectory.path, "/tmp/remnic-audio")
+        XCTAssertEqual(configuration.deviceId, "BuiltInMicrophoneDevice")
+    }
+
+    func testDefaultsChunkSecondsAndOmitsDevice() throws {
+        let configuration = try CaptureConfiguration.parse([
+            "--channel", "mic",
+            "--out", "/tmp/remnic-audio",
+        ])
+
+        XCTAssertEqual(configuration.channel, .mic)
+        XCTAssertTrue(configuration.channel.capturesMic)
+        XCTAssertFalse(configuration.channel.capturesSystem)
+        XCTAssertEqual(configuration.chunkSeconds, 30)
+        XCTAssertNil(configuration.deviceId)
+    }
+
+    func testSystemChannelCapturesSystemOnly() throws {
+        let configuration = try CaptureConfiguration.parse(["--channel", "system", "--out", "/tmp/x"])
+
+        XCTAssertFalse(configuration.channel.capturesMic)
+        XCTAssertTrue(configuration.channel.capturesSystem)
+    }
+
+    func testRejectsNonPositiveChunkSeconds() {
+        XCTAssertThrowsError(
+            try CaptureConfiguration.parse(["--channel", "mic", "--out", "/tmp/x", "--chunk-seconds", "0"])
+        ) { error in
+            XCTAssertEqual(error.localizedDescription, "--chunk-seconds must be a positive integer")
+        }
+    }
+
+    func testRejectsInvalidChannel() {
+        XCTAssertThrowsError(
+            try CaptureConfiguration.parse(["--channel", "sideband", "--out", "/tmp/x"])
+        ) { error in
+            XCTAssertEqual(error.localizedDescription, "--channel must be mic|system|both, got: sideband")
+        }
+    }
+
+    func testRejectsMissingChannel() {
+        XCTAssertThrowsError(try CaptureConfiguration.parse(["--out", "/tmp/x"])) { error in
+            XCTAssertEqual(error.localizedDescription, "--channel is required (mic|system|both)")
+        }
+    }
+
+    func testRejectsMissingOutDirectory() {
+        XCTAssertThrowsError(try CaptureConfiguration.parse(["--channel", "mic"])) { error in
+            XCTAssertEqual(error.localizedDescription, "--out is required")
+        }
+    }
+
+    func testRejectsFlagWithoutValue() {
+        XCTAssertThrowsError(try CaptureConfiguration.parse(["--channel"])) { error in
+            XCTAssertEqual(error.localizedDescription, "--channel requires a value")
+        }
+    }
+
+    func testRejectsUnknownArgument() {
+        XCTAssertThrowsError(
+            try CaptureConfiguration.parse(["--channel", "mic", "--out", "/tmp/x", "--bogus"])
+        ) { error in
+            XCTAssertEqual(error.localizedDescription, "unknown argument: --bogus")
+        }
+    }
+}

--- a/packages/capture-native-darwin-helper/Tests/RemnicCaptureHelperTests/ChunkEventTests.swift
+++ b/packages/capture-native-darwin-helper/Tests/RemnicCaptureHelperTests/ChunkEventTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import RemnicCaptureHelper
+
+final class ChunkEventTests: XCTestCase {
+    func testEncodesACompletedMicChunkAsOneJsonLine() throws {
+        let event = ChunkEvent(
+            path: "/tmp/remnic-audio/mic-1.wav",
+            channel: .mic,
+            startedAtUtc: Date(timeIntervalSince1970: 0),
+            endedAtUtc: Date(timeIntervalSince1970: 30),
+            device: "Built-in Microphone"
+        )
+
+        let json = try event.jsonLine()
+
+        XCTAssertEqual(json.last, 0x0A)
+        let object = try JSONSerialization.jsonObject(with: json.dropLast()) as? [String: String]
+        XCTAssertEqual(
+            object,
+            [
+                "path": "/tmp/remnic-audio/mic-1.wav",
+                "channel": "mic",
+                "startedAtUtc": "1970-01-01T00:00:00.000Z",
+                "endedAtUtc": "1970-01-01T00:00:30.000Z",
+                "device": "Built-in Microphone",
+            ]
+        )
+    }
+}

--- a/packages/capture-native-darwin-helper/Tests/RemnicCaptureHelperTests/ChunkWriterTests.swift
+++ b/packages/capture-native-darwin-helper/Tests/RemnicCaptureHelperTests/ChunkWriterTests.swift
@@ -1,0 +1,55 @@
+import AVFoundation
+import XCTest
+@testable import RemnicCaptureHelper
+
+final class ChunkWriterTests: XCTestCase {
+    func testFinishesMicChunkAs16KhzMonoWav() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let format = AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 16_000)!
+        buffer.frameLength = 16_000
+
+        let writer = try ChunkWriter(
+            outDirectory: directory,
+            channel: .mic,
+            device: "Built-in Microphone",
+            chunkSeconds: 30
+        )
+        _ = writer.append(buffer, at: Date(timeIntervalSince1970: 0))
+        let event = try writer.finish(at: Date(timeIntervalSince1970: 1))
+
+        XCTAssertEqual(event.channel, .mic)
+        XCTAssertEqual(event.device, "Built-in Microphone")
+        XCTAssertEqual(event.startedAtUtc, Date(timeIntervalSince1970: 0))
+        XCTAssertEqual(event.endedAtUtc, Date(timeIntervalSince1970: 1))
+        let attributes = try FileManager.default.attributesOfItem(atPath: event.path)
+        XCTAssertEqual(URL(fileURLWithPath: event.path).pathExtension, "wav")
+        XCTAssertEqual(try Data(contentsOf: URL(fileURLWithPath: event.path)).prefix(4), Data("RIFF".utf8))
+        XCTAssertEqual((attributes[.size] as? NSNumber)?.intValue ?? 0 > 44, true)
+        let file = try AVAudioFile(forReading: URL(fileURLWithPath: event.path))
+        XCTAssertEqual(file.processingFormat.sampleRate, 16_000)
+        XCTAssertEqual(file.processingFormat.channelCount, 1)
+    }
+
+    func testReturnsCompletedChunkWhenNewAudioCrossesChunkBoundary() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let format = AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 16_000)!
+        buffer.frameLength = 16_000
+        let writer = try ChunkWriter(
+            outDirectory: directory,
+            channel: .system,
+            device: "system audio",
+            chunkSeconds: 30
+        )
+
+        XCTAssertNil(writer.append(buffer, at: Date(timeIntervalSince1970: 0)))
+        let completed = writer.append(buffer, at: Date(timeIntervalSince1970: 30))
+
+        XCTAssertEqual(completed?.channel, .system)
+        XCTAssertEqual(completed?.startedAtUtc, Date(timeIntervalSince1970: 0))
+        XCTAssertEqual(completed?.endedAtUtc, Date(timeIntervalSince1970: 30))
+    }
+}

--- a/packages/capture-native-darwin-helper/Tests/RemnicCaptureHelperTests/DeviceEnumerateTests.swift
+++ b/packages/capture-native-darwin-helper/Tests/RemnicCaptureHelperTests/DeviceEnumerateTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import RemnicCaptureHelper
+
+final class DeviceEnumerateTests: XCTestCase {
+    func testEncodesDeviceListAsOneJsonLine() throws {
+        let list = DeviceList(devices: [
+            DeviceInfo(id: "BuiltInMic", name: "MacBook Pro Microphone", kind: .input, isDefault: true),
+            DeviceInfo(id: "BuiltInSpeaker", name: "MacBook Pro Speakers", kind: .output, isDefault: false),
+        ])
+
+        let json = try list.jsonLine()
+
+        XCTAssertEqual(json.last, 0x0A)
+        let object = try JSONSerialization.jsonObject(with: json.dropLast()) as? [String: Any]
+        let devices = try XCTUnwrap(object?["devices"] as? [[String: Any]])
+        XCTAssertEqual(devices.count, 2)
+        XCTAssertEqual(devices[0]["id"] as? String, "BuiltInMic")
+        XCTAssertEqual(devices[0]["name"] as? String, "MacBook Pro Microphone")
+        XCTAssertEqual(devices[0]["kind"] as? String, "input")
+        XCTAssertEqual(devices[0]["isDefault"] as? Bool, true)
+        XCTAssertEqual(devices[1]["kind"] as? String, "output")
+        XCTAssertEqual(devices[1]["isDefault"] as? Bool, false)
+    }
+
+    func testEncodesEmptyDeviceList() throws {
+        let json = try DeviceList(devices: []).jsonLine()
+        let object = try JSONSerialization.jsonObject(with: json.dropLast()) as? [String: Any]
+        XCTAssertEqual((object?["devices"] as? [[String: Any]])?.count, 0)
+    }
+}

--- a/packages/capture-native-darwin-helper/Tests/RemnicCaptureHelperTests/OCRWindowTests.swift
+++ b/packages/capture-native-darwin-helper/Tests/RemnicCaptureHelperTests/OCRWindowTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import RemnicCaptureHelper
+
+final class OCRWindowTests: XCTestCase {
+    func testDefaultsToFrontmost() throws {
+        let options = try OCRWindowOptions.parse([])
+        XCTAssertNil(options.windowId)
+    }
+
+    func testParsesWindowId() throws {
+        let options = try OCRWindowOptions.parse(["--window", "42"])
+        XCTAssertEqual(options.windowId, 42)
+    }
+
+    func testFrontmostFlagKeepsWindowIdNil() throws {
+        let options = try OCRWindowOptions.parse(["--frontmost"])
+        XCTAssertNil(options.windowId)
+    }
+
+    func testRejectsWindowAndFrontmostTogether() {
+        XCTAssertThrowsError(try OCRWindowOptions.parse(["--window", "42", "--frontmost"]))
+    }
+
+    func testRejectsNonNumericWindowId() {
+        XCTAssertThrowsError(try OCRWindowOptions.parse(["--window", "abc"]))
+    }
+
+    func testRejectsUnknownArgument() {
+        XCTAssertThrowsError(try OCRWindowOptions.parse(["--bogus"]))
+    }
+
+    func testEncodesResultAsOneJsonLine() throws {
+        let result = OCRWindowResult(app: "Notes", windowTitle: "Grocery", text: "milk\neggs")
+
+        let json = try result.jsonLine()
+        XCTAssertEqual(json.last, 0x0A)
+        let object = try JSONSerialization.jsonObject(with: json.dropLast()) as? [String: Any]
+        XCTAssertEqual(object?["app"] as? String, "Notes")
+        XCTAssertEqual(object?["windowTitle"] as? String, "Grocery")
+        XCTAssertEqual(object?["text"] as? String, "milk\neggs")
+        XCTAssertEqual(object?["textSource"] as? String, "ocr")
+    }
+}

--- a/packages/capture-native-darwin-x64/README.md
+++ b/packages/capture-native-darwin-x64/README.md
@@ -1,0 +1,34 @@
+# @remnic/capture-native-darwin-x64
+
+macOS Intel (x64) platform package for the unified Remnic native capture
+helper, `remnic-capture-helper`. One binary serves both the audio capture
+pipeline (#1897) and the screen-activity pipeline (#1899).
+
+## What this package provides
+
+- `helperBinaryPath` — an absolute path to the packaged `bin/remnic-capture-helper`
+  binary, resolved relative to the installed package:
+
+  ```js
+  import { helperBinaryPath } from "@remnic/capture-native-darwin-x64";
+  ```
+
+## The binary is built by CI, not committed
+
+`bin/remnic-capture-helper` is a compiled macOS Mach-O executable produced by
+the `capture-native-helper` GitHub Actions workflow on a real macOS x64 runner
+(`swift build -c release` against `packages/capture-native-darwin-helper`).
+It is **not** committed to the repository and is **not** buildable on Linux.
+
+Until CI stages the binary into `bin/`, `helperBinaryPath` still resolves to the
+path it *will* occupy; the package `test` script tolerates its absence and skips
+the executable check with a note.
+
+## Subcommands
+
+```
+remnic-capture-helper audio-capture --channel mic|system|both --chunk-seconds N --out <dir> [--device <id>]
+remnic-capture-helper device-enumerate
+remnic-capture-helper ax-snapshot [--frontmost | --pid <n>] [--max-nodes N]
+remnic-capture-helper ocr-window [--frontmost | --window <id>]
+```

--- a/packages/capture-native-darwin-x64/README.md
+++ b/packages/capture-native-darwin-x64/README.md
@@ -4,6 +4,12 @@ macOS Intel (x64) platform package for the unified Remnic native capture
 helper, `remnic-capture-helper`. One binary serves both the audio capture
 pipeline (#1897) and the screen-activity pipeline (#1899).
 
+> **Not yet published.** This package is currently `private` and not on npm.
+> Runtime distribution via npm is tracked in
+> https://github.com/joshuaswarren/remnic/issues/2139. Until then, build the
+> helper from source (`packages/capture-native-darwin-helper`) and point
+> `REMNIC_CAPTURE_HELPER_BIN` at the binary.
+
 ## What this package provides
 
 - `helperBinaryPath` — an absolute path to the packaged `bin/remnic-capture-helper`

--- a/packages/capture-native-darwin-x64/index.d.ts
+++ b/packages/capture-native-darwin-x64/index.d.ts
@@ -1,0 +1,2 @@
+/** Absolute path to the packaged `remnic-capture-helper` native binary. */
+export declare const helperBinaryPath: string;

--- a/packages/capture-native-darwin-x64/index.js
+++ b/packages/capture-native-darwin-x64/index.js
@@ -1,0 +1,9 @@
+import { fileURLToPath } from "node:url";
+
+/**
+ * Absolute path to the packaged `remnic-capture-helper` native binary for
+ * macOS x64. The binary is produced by macOS CI (see README.md) and staged
+ * into `bin/`; this export resolves its path relative to the installed
+ * package, whether the binary is present yet or not.
+ */
+export const helperBinaryPath = fileURLToPath(new URL("./bin/remnic-capture-helper", import.meta.url));

--- a/packages/capture-native-darwin-x64/package.json
+++ b/packages/capture-native-darwin-x64/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@remnic/capture-native-darwin-x64",
+  "version": "9.14.0",
+  "description": "macOS Intel native capture helper for Remnic — audio, screen accessibility (AX), and window OCR",
+  "type": "module",
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js"
+    }
+  },
+  "bin": {
+    "remnic-capture-helper": "bin/remnic-capture-helper"
+  },
+  "files": ["index.js", "index.d.ts", "bin/remnic-capture-helper", "README.md"],
+  "scripts": {
+    "test": "node test.mjs"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/capture-native-darwin-x64"
+  },
+  "keywords": ["remnic", "audio", "screen", "ax", "ocr", "capture", "macos", "darwin", "x64"]
+}

--- a/packages/capture-native-darwin-x64/package.json
+++ b/packages/capture-native-darwin-x64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@remnic/capture-native-darwin-x64",
   "version": "9.14.0",
+  "private": true,
   "description": "macOS Intel native capture helper for Remnic — audio, screen accessibility (AX), and window OCR",
   "type": "module",
   "os": ["darwin"],

--- a/packages/capture-native-darwin-x64/package.json
+++ b/packages/capture-native-darwin-x64/package.json
@@ -18,6 +18,7 @@
   },
   "files": ["index.js", "index.d.ts", "bin/remnic-capture-helper", "README.md"],
   "scripts": {
+    "prepack": "node -e \"require('node:fs').accessSync('bin/remnic-capture-helper')\"",
     "test": "node test.mjs"
   },
   "publishConfig": {

--- a/packages/capture-native-darwin-x64/test.mjs
+++ b/packages/capture-native-darwin-x64/test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { access, constants } from "node:fs/promises";
+
+import { helperBinaryPath } from "./index.js";
+
+assert.equal(typeof helperBinaryPath, "string");
+assert.ok(helperBinaryPath.length > 0, "helperBinaryPath must be non-empty");
+assert.ok(
+  helperBinaryPath.endsWith("bin/remnic-capture-helper"),
+  "helperBinaryPath must point at the packaged binary",
+);
+
+try {
+  await access(helperBinaryPath, constants.X_OK);
+  console.log(`ok: ${helperBinaryPath} present and executable`);
+} catch {
+  // The real binary is produced by macOS CI (swift build -c release) and
+  // staged into bin/. On Linux and any pre-build checkout it is absent; the
+  // -x check is skipped with a note so the Linux release-workflow test passes.
+  console.log(`note: CI-built binary absent at ${helperBinaryPath}; skipping -x check`);
+}

--- a/packages/capture-native-darwin-x64/test.mjs
+++ b/packages/capture-native-darwin-x64/test.mjs
@@ -13,9 +13,10 @@ assert.ok(
 try {
   await access(helperBinaryPath, constants.X_OK);
   console.log(`ok: ${helperBinaryPath} present and executable`);
-} catch {
-  // The real binary is produced by macOS CI (swift build -c release) and
-  // staged into bin/. On Linux and any pre-build checkout it is absent; the
-  // -x check is skipped with a note so the Linux release-workflow test passes.
+} catch (err) {
+  // The real binary is produced by macOS CI (swift build -c release) and staged
+  // into bin/. Only its ABSENCE (ENOENT) on Linux / pre-build checkouts is a
+  // benign skip; a present-but-not-executable binary (EACCES) is a real failure.
+  if (err?.code !== "ENOENT") throw err;
   console.log(`note: CI-built binary absent at ${helperBinaryPath}; skipping -x check`);
 }

--- a/packages/capture-screen/README.md
+++ b/packages/capture-screen/README.md
@@ -14,15 +14,15 @@ The daemon binds only to `127.0.0.1`, `::1`, or `localhost`.
 
 ```sh
 export REMNIC_CAPTURE_TOKEN="…"   # bearer token, read from the environment
-remnic-capture-screen \
-  --spool ./capture.sqlite \
-  --replay ./snapshots.json
+remnic-capture-screen start \
+  --spool ~/.local/state/remnic/capture/spool.sqlite \
+  --replay ./snapshots/            # a directory of *.json fixture files
 ```
 
 The bearer token is read from the `REMNIC_CAPTURE_TOKEN` environment variable (legacy `ENGRAM_CAPTURE_TOKEN` also accepted), never a CLI flag: a long-lived daemon's argv is world-readable via `ps` / `/proc` on a multi-user host. Passing `--auth-token` is rejected.
 
-`snapshots.json` contains an array of objects with `capturedAtUtc` (ISO-8601 UTC), `app`, `windowTitle`, `text`, and `textSource` (`"ax"` or `"ocr"`) fields. Each served snapshot also carries the stored `contentHash`, so the core activity client can ingest it. Exact replays deduplicate by the complete snapshot payload.
+Each `*.json` file in the `--replay` directory holds a snapshot object (or an array of them) with `capturedAtUtc` (ISO-8601 UTC), `app`, `windowTitle`, one of `text` or `ax`, and `textSource` (`"ax"` or `"ocr"`). Each served snapshot also carries the stored `contentHash`, so the core activity client can ingest it. Exact replays deduplicate by the complete snapshot payload.
 
 The daemon does not acquire native screenshots. Native platform helpers send redacted text snapshots to this daemon over its loopback API.
 
-The `--spool` file must live in an owner-only directory: the daemon requires its parent to be a non-symlink directory you own with mode `0700` (no group/other access) and creates it `0700` when absent, so no other local user can plant a symlink at the spool path. The SQLite file itself is created `0600`. Point `--spool` at a dedicated directory such as `~/.local/state/remnic/capture/`.
+The `--spool` file must live in an owner-only directory. The daemon creates the directory `0700` when absent; if it already exists, the daemon refuses to open the spool under a symlinked or group/other-accessible directory and never changes an existing directory's permissions. The SQLite file itself is created `0600`. Point `--spool` at a dedicated directory such as `~/.local/state/remnic/capture/`.

--- a/packages/capture-screen/README.md
+++ b/packages/capture-screen/README.md
@@ -5,7 +5,8 @@ Local loopback daemon for replaying and serving screen-text snapshots to Remnic 
 It stores snapshots in SQLite and exposes authenticated, cursor-paginated HTTP endpoints:
 
 - `GET /v1/health`
-- `GET /v1/snapshots?cursor=<id>&limit=<1-500>`
+- `GET /v1/snapshots?date=<YYYY-MM-DD>&timezone=<IANA>&cursor=<token>&limit=<1-500>` — `date` and `timezone` are required; `cursor` is the opaque keyset token returned by the previous page (not a raw row id).
+- `GET /v1/stats?date=<YYYY-MM-DD>&timezone=<IANA>` — per-app time attribution for the day.
 
 The daemon binds only to `127.0.0.1`, `::1`, or `localhost`.
 

--- a/packages/capture-screen/README.md
+++ b/packages/capture-screen/README.md
@@ -1,0 +1,27 @@
+# @remnic/capture-screen
+
+Local loopback daemon for replaying and serving screen-text snapshots to Remnic activity sources.
+
+It stores snapshots in SQLite and exposes authenticated, cursor-paginated HTTP endpoints:
+
+- `GET /v1/health`
+- `GET /v1/snapshots?cursor=<id>&limit=<1-500>`
+
+The daemon binds only to `127.0.0.1`, `::1`, or `localhost`.
+
+## Run a replay fixture
+
+```sh
+export REMNIC_CAPTURE_TOKEN="…"   # bearer token, read from the environment
+remnic-capture-screen \
+  --spool ./capture.sqlite \
+  --replay ./snapshots.json
+```
+
+The bearer token is read from the `REMNIC_CAPTURE_TOKEN` environment variable (legacy `ENGRAM_CAPTURE_TOKEN` also accepted), never a CLI flag: a long-lived daemon's argv is world-readable via `ps` / `/proc` on a multi-user host. Passing `--auth-token` is rejected.
+
+`snapshots.json` contains an array of objects with `capturedAtUtc` (ISO-8601 UTC), `app`, `windowTitle`, `text`, and `textSource` (`"ax"` or `"ocr"`) fields. Each served snapshot also carries the stored `contentHash`, so the core activity client can ingest it. Exact replays deduplicate by the complete snapshot payload.
+
+The daemon does not acquire native screenshots. Native platform helpers send redacted text snapshots to this daemon over its loopback API.
+
+The `--spool` file must live in an owner-only directory: the daemon requires its parent to be a non-symlink directory you own with mode `0700` (no group/other access) and creates it `0700` when absent, so no other local user can plant a symlink at the spool path. The SQLite file itself is created `0600`. Point `--spool` at a dedicated directory such as `~/.local/state/remnic/capture/`.

--- a/packages/capture-screen/package.json
+++ b/packages/capture-screen/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@remnic/capture-screen",
+  "version": "9.14.0",
+  "description": "Desktop screen-activity capture daemon for Remnic \u2014 local spool, loopback HTTP API, and replay ingestion for the activity source `screen` (\u00e0-la-carte)",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "remnic-capture-screen": "./dist/cli-bin.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts src/cli-bin.ts --format esm --dts",
+    "check-types": "tsc --noEmit",
+    "test": "tsx --test src/simhash.test.ts src/dedup.test.ts src/daywindow.test.ts src/denylist.test.ts src/axtree.test.ts src/redact.test.ts src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/capture.test.ts src/helper.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "tsx": "^4.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/capture-screen"
+  },
+  "keywords": [
+    "remnic",
+    "memory",
+    "activity",
+    "desktop",
+    "screen",
+    "capture",
+    "accessibility"
+  ]
+}

--- a/packages/capture-screen/package.json
+++ b/packages/capture-screen/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsup src/index.ts src/cli-bin.ts --format esm --dts",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/simhash.test.ts src/dedup.test.ts src/daywindow.test.ts src/denylist.test.ts src/axtree.test.ts src/redact.test.ts src/config.test.ts src/validate.test.ts src/util.test.ts src/token.test.ts src/spool.test.ts src/capture.test.ts src/helper.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts",
+    "test": "tsx --test src/simhash.test.ts src/dedup.test.ts src/daywindow.test.ts src/denylist.test.ts src/axtree.test.ts src/redact.test.ts src/config.test.ts src/validate.test.ts src/util.test.ts src/token.test.ts src/spool.test.ts src/capture.test.ts src/helper.test.ts src/replay.test.ts src/scheduler.test.ts src/daemon.test.ts src/cli.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/capture-screen/package.json
+++ b/packages/capture-screen/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsup src/index.ts src/cli-bin.ts --format esm --dts",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/simhash.test.ts src/dedup.test.ts src/daywindow.test.ts src/denylist.test.ts src/axtree.test.ts src/redact.test.ts src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/capture.test.ts src/helper.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts",
+    "test": "tsx --test src/simhash.test.ts src/dedup.test.ts src/daywindow.test.ts src/denylist.test.ts src/axtree.test.ts src/redact.test.ts src/config.test.ts src/validate.test.ts src/util.test.ts src/token.test.ts src/spool.test.ts src/capture.test.ts src/helper.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {
@@ -29,6 +29,14 @@
   },
   "engines": {
     "node": ">=22.13.0"
+  },
+  "peerDependencies": {
+    "@remnic/capture-native-darwin-arm64": "*",
+    "@remnic/capture-native-darwin-x64": "*"
+  },
+  "peerDependenciesMeta": {
+    "@remnic/capture-native-darwin-arm64": { "optional": true },
+    "@remnic/capture-native-darwin-x64": { "optional": true }
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/capture-screen/src/axtree.test.ts
+++ b/packages/capture-screen/src/axtree.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { extractAxText, SECURE_ROLE, type AxNode } from "./axtree.js";
+
+const tree: AxNode = {
+  role: "AXWindow",
+  title: "Login",
+  children: [
+    { role: "AXStaticText", value: "Username" },
+    { role: "AXTextField", value: "alice@example.com" },
+    { role: "AXStaticText", value: "Password" },
+    { role: SECURE_ROLE, value: "hunter2-should-never-appear", children: [{ role: "AXStaticText", value: "leak?" }] },
+    { role: "AXGroup", offScreen: true, children: [{ role: "AXStaticText", value: "offscreen-should-not-appear" }] },
+    { role: "AXButton", description: "Sign In" },
+  ],
+};
+
+test("extracts visible text from value/title/description across the tree", () => {
+  const { text } = extractAxText(tree, 4000);
+  assert.match(text, /Login/);
+  assert.match(text, /Username/);
+  assert.match(text, /alice@example\.com/);
+  assert.match(text, /Sign In/);
+});
+
+test("AXSecureTextField text and its subtree are never extracted", () => {
+  const { text } = extractAxText(tree, 4000);
+  assert.doesNotMatch(text, /hunter2/);
+  assert.doesNotMatch(text, /leak/);
+});
+
+test("off-screen nodes and their subtree are excluded", () => {
+  const { text } = extractAxText(tree, 4000);
+  assert.doesNotMatch(text, /offscreen-should-not-appear/);
+});
+
+test("traversal is bounded by maxNodes and flags truncation", () => {
+  const wide: AxNode = { role: "AXWindow", children: Array.from({ length: 50 }, (_, i) => ({ value: `n${i}` })) };
+  const capped = extractAxText(wide, 10);
+  assert.equal(capped.nodes, 10);
+  assert.equal(capped.truncated, true);
+  const full = extractAxText(wide, 4000);
+  assert.equal(full.truncated, false);
+  assert.equal(full.nodes, 51);
+});
+
+test("document order is preserved in the extracted text", () => {
+  const { text } = extractAxText(tree, 4000);
+  assert.ok(text.indexOf("Username") < text.indexOf("Password"), "children read in order");
+});

--- a/packages/capture-screen/src/axtree.ts
+++ b/packages/capture-screen/src/axtree.ts
@@ -1,0 +1,73 @@
+/**
+ * Accessibility-tree text extraction. Walks a macOS AX-tree JSON snapshot and
+ * concatenates the visible text, with three safety filters baked in:
+ *
+ *   - AXSecureTextField nodes are skipped entirely (never read a password box),
+ *     including their subtree.
+ *   - Off-screen nodes (`offScreen: true`) are skipped with their subtree — text
+ *     the user cannot see is not "on screen".
+ *   - Traversal is bounded to `maxNodes` visited nodes, so a pathological tree
+ *     cannot exhaust memory/CPU; the result is flagged `truncated` when the cap
+ *     is hit.
+ *
+ * The shape is intentionally permissive: real AX dumps carry many roles and the
+ * text can live on any of value/title/description/label. Unknown fields are
+ * ignored.
+ */
+
+export const SECURE_ROLE = "AXSecureTextField";
+
+export interface AxNode {
+  role?: string;
+  value?: string;
+  title?: string;
+  description?: string;
+  label?: string;
+  offScreen?: boolean;
+  children?: AxNode[];
+}
+
+export interface AxExtractResult {
+  text: string;
+  /** Nodes actually visited (bounded by maxNodes). */
+  nodes: number;
+  /** True when the maxNodes cap stopped traversal before the tree was exhausted. */
+  truncated: boolean;
+}
+
+function nodeText(node: AxNode): string {
+  const pieces: string[] = [];
+  for (const field of [node.value, node.title, node.description, node.label]) {
+    if (typeof field === "string" && field.trim().length > 0) pieces.push(field.trim());
+  }
+  return pieces.join(" ");
+}
+
+/**
+ * Extract visible, non-secure text from an AX tree. Iterative DFS with an
+ * explicit stack so a deep tree cannot overflow the call stack, and a visited
+ * counter that enforces the node cap.
+ */
+export function extractAxText(root: AxNode, maxNodes: number): AxExtractResult {
+  const lines: string[] = [];
+  const stack: AxNode[] = [root];
+  let visited = 0;
+  let truncated = false;
+  while (stack.length > 0) {
+    if (visited >= maxNodes) {
+      truncated = true;
+      break;
+    }
+    const node = stack.pop() as AxNode;
+    visited += 1;
+    if (node.offScreen === true) continue;
+    if (node.role === SECURE_ROLE) continue;
+    const text = nodeText(node);
+    if (text.length > 0) lines.push(text);
+    if (Array.isArray(node.children)) {
+      // Push in reverse so children are visited in document order.
+      for (let i = node.children.length - 1; i >= 0; i--) stack.push(node.children[i]);
+    }
+  }
+  return { text: lines.join("\n"), nodes: visited, truncated };
+}

--- a/packages/capture-screen/src/capture.test.ts
+++ b/packages/capture-screen/src/capture.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  CaptureProcessor,
+  computeStats,
+  contentHash,
+  isTerminalApp,
+  type CaptureCandidate,
+  type OcrFn,
+} from "./capture.js";
+import { defaultDaemonConfig, type DaemonConfig } from "./config.js";
+import type { AxNode } from "./axtree.js";
+import type { DaemonSnapshot } from "./spool.js";
+
+function proc(overrides: Partial<DaemonConfig> = {}, ocr?: OcrFn): CaptureProcessor {
+  return new CaptureProcessor({ ...defaultDaemonConfig(), ...overrides }, ocr);
+}
+
+const at = (s: string) => `2026-07-20T10:00:${s}.000Z`;
+
+test("a deny-listed app records nothing and names the rule", () => {
+  const decision = proc().process({ capturedAtUtc: at("00"), app: "1Password 8", windowTitle: "Vault", text: "secrets" });
+  assert.deepEqual(decision, { action: "denied", rule: "app:1Password*" });
+});
+
+test("a normal AX candidate is stored with extracted, redacted text", () => {
+  const ax: AxNode = {
+    role: "AXWindow",
+    children: [
+      { role: "AXStaticText", value: "Order total" },
+      { role: "AXTextField", value: "card 4242 4242 4242 4242" },
+    ],
+  };
+  const decision = proc().process({ capturedAtUtc: at("00"), app: "Safari", windowTitle: "Checkout", ax });
+  assert.equal(decision.action, "store");
+  if (decision.action !== "store") return;
+  assert.equal(decision.snapshot.textSource, "ax");
+  assert.match(decision.snapshot.text, /Order total/);
+  assert.match(decision.snapshot.text, /\[REDACTED\]/, "payment card redacted before storage");
+  assert.doesNotMatch(decision.snapshot.text, /4242 4242/);
+  assert.equal(decision.snapshot.contentHash.length, 64);
+  assert.equal(decision.snapshot.simhash.length, 16);
+});
+
+test("secure-field text never reaches the stored snapshot", () => {
+  const ax: AxNode = {
+    role: "AXWindow",
+    children: [
+      { role: "AXStaticText", value: "Password" },
+      { role: "AXSecureTextField", value: "hunter2-secret" },
+    ],
+  };
+  const decision = proc().process({ capturedAtUtc: at("00"), app: "Login", windowTitle: "Sign in", ax });
+  assert.equal(decision.action, "store");
+  if (decision.action !== "store") return;
+  assert.doesNotMatch(decision.snapshot.text, /hunter2/);
+});
+
+test("dedup: an identical follow-up within TTL is skipped", () => {
+  const processor = proc();
+  const candidate: CaptureCandidate = { capturedAtUtc: at("00"), app: "Editor", windowTitle: "a.ts", text: "line one" };
+  assert.equal(processor.process(candidate).action, "store");
+  const skipped = processor.process({ ...candidate, capturedAtUtc: at("05") });
+  assert.deepEqual(skipped, { action: "skipped", reason: "dedup" });
+});
+
+test("terminal-class window with no AX text routes to OCR; skips when OCR unavailable", () => {
+  const empty: AxNode = { role: "AXWindow" };
+  const noOcr = proc().process({ capturedAtUtc: at("00"), app: "iTerm2", windowTitle: "zsh", ax: empty });
+  assert.deepEqual(noOcr, { action: "skipped", reason: "ocr-unavailable" });
+
+  const ocr: OcrFn = () => "user@host ~ % ls -la";
+  const withOcr = proc({}, ocr).process({ capturedAtUtc: at("00"), app: "iTerm2", windowTitle: "zsh", ax: empty });
+  assert.equal(withOcr.action, "store");
+  if (withOcr.action !== "store") return;
+  assert.equal(withOcr.snapshot.textSource, "ocr");
+  assert.match(withOcr.snapshot.text, /ls -la/);
+});
+
+test("an AX-empty non-terminal window also routes to OCR", () => {
+  const ocr: OcrFn = () => "rendered canvas text";
+  const decision = proc({}, ocr).process({
+    capturedAtUtc: at("00"),
+    app: "Figma",
+    windowTitle: "Board",
+    ax: { role: "AXWindow", children: [{ role: "AXGroup" }] },
+  });
+  assert.equal(decision.action, "store");
+  if (decision.action !== "store") return;
+  assert.equal(decision.snapshot.textSource, "ocr");
+});
+
+test("isTerminalApp matches defaults and merged config globs", () => {
+  assert.equal(isTerminalApp("Alacritty", []), true);
+  assert.equal(isTerminalApp("Safari", []), false);
+  assert.equal(isTerminalApp("MyTerm", ["MyTerm"]), true);
+});
+
+test("contentHash length-prefixes fields so a split can't collide", () => {
+  const a = contentHash({ capturedAtUtc: at("00"), app: "ab", windowTitle: "c", browserUrl: null, text: "t", textSource: "ax" });
+  const b = contentHash({ capturedAtUtc: at("00"), app: "a", windowTitle: "bc", browserUrl: null, text: "t", textSource: "ax" });
+  assert.notEqual(a, b);
+});
+
+function daySnap(id: number, app: string, sec: number): DaemonSnapshot {
+  return {
+    id,
+    capturedAtUtc: new Date(Date.parse("2026-07-20T10:00:00.000Z") + sec * 1000).toISOString(),
+    app,
+    windowTitle: "w",
+    browserUrl: null,
+    text: "t",
+    textSource: "ax",
+    contentHash: `h${id}`,
+    simhash: "0000000000000000",
+    supersededBy: null,
+  };
+}
+
+test("computeStats attributes capped per-app dwell from snapshot spans", () => {
+  const snaps = [daySnap(1, "AppA", 0), daySnap(2, "AppA", 30), daySnap(3, "AppB", 60)];
+  const stats = computeStats(snaps, "2026-07-20", "UTC", 300);
+  assert.equal(stats.snapshotCount, 3);
+  assert.equal(stats.totalSeconds, 60);
+  assert.deepEqual(stats.apps, [
+    { app: "AppA", seconds: 60, snapshotCount: 2 },
+    { app: "AppB", seconds: 0, snapshotCount: 1 },
+  ]);
+});
+
+test("computeStats caps a long idle gap at maxDwellSeconds", () => {
+  const snaps = [daySnap(1, "AppA", 0), daySnap(2, "AppB", 59)];
+  // 59s gap, cap 10 → AppA credited 10s only.
+  const stats = computeStats(snaps, "2026-07-20", "UTC", 10);
+  assert.equal(stats.apps.find((a) => a.app === "AppA")?.seconds, 10);
+});

--- a/packages/capture-screen/src/capture.ts
+++ b/packages/capture-screen/src/capture.ts
@@ -1,0 +1,228 @@
+/**
+ * Capture-time processing pipeline (pure, hardware-free). A raw candidate —
+ * frontmost app/window plus either an AX tree or pre-extracted text — is turned
+ * into a decision: dropped by a deny rule, skipped (OCR unavailable / deduped),
+ * or a fully-formed spool snapshot. The steps, in order:
+ *
+ *   1. Deny-lists FIRST — a match records NOTHING (not even metadata).
+ *   2. Text: pre-extracted text is used as-is; otherwise the AX tree is walked
+ *      (secure fields + off-screen nodes excluded, bounded to maxNodes). A
+ *      terminal-class window, or an AX tree with no visible text, routes to the
+ *      OCR seam; when OCR is unavailable the snapshot is skipped (reflected in
+ *      health) rather than crashing.
+ *   3. Redaction — SSN/card + user patterns, before hashing or storage.
+ *   4. Dedup — per-window SimHash gate (threshold / TTL).
+ *   5. Content hash — length-prefixed SHA-256 so control chars can't collide.
+ *
+ * The OCR step is a seam (an injected callback), so the daemon wires the native
+ * helper while tests inject a fake without any macOS binary.
+ */
+
+import { createHash } from "node:crypto";
+
+import { extractAxText, type AxNode } from "./axtree.js";
+import { DedupCache } from "./dedup.js";
+import { matchDenyRule, matchesAnyGlob } from "./denylist.js";
+import { compileRedactionPatterns, redactText } from "./redact.js";
+import { simhash, simhashToHex } from "./simhash.js";
+import type { DaemonConfig } from "./config.js";
+import type { DaemonSnapshot, SnapshotInput, TextSource } from "./spool.js";
+
+/** Terminal-class apps whose windows expose no useful AX text (route to OCR). */
+export const DEFAULT_TERMINAL_APPS: readonly string[] = [
+  "Terminal",
+  "iTerm2",
+  "iTerm",
+  "Alacritty",
+  "kitty",
+  "WezTerm",
+  "Warp",
+  "Hyper",
+  "Konsole",
+  "gnome-terminal*",
+];
+
+/**
+ * True when `app` is a terminal-class window (routes to OCR — terminals expose
+ * no useful AX text). `includeDefaults` prepends DEFAULT_TERMINAL_APPS; pass
+ * false when `terminalApps` is already the merged list.
+ */
+export function isTerminalApp(app: string, terminalApps: readonly string[], includeDefaults = true): boolean {
+  const patterns = includeDefaults ? [...DEFAULT_TERMINAL_APPS, ...terminalApps] : terminalApps;
+  return matchesAnyGlob(patterns, app);
+}
+
+/** A raw capture candidate before processing. Provide `text` OR `ax`. */
+export interface CaptureCandidate {
+  capturedAtUtc: string;
+  app: string;
+  windowTitle: string;
+  browserUrl?: string | null;
+  /** Pre-extracted text (skips AX walking); source defaults to "ax". */
+  text?: string;
+  textSource?: TextSource;
+  /** Accessibility tree to extract from when `text` is absent. */
+  ax?: AxNode;
+}
+
+export type CaptureDecision =
+  | { action: "denied"; rule: string }
+  | { action: "skipped"; reason: "ocr-unavailable" | "dedup" }
+  | { action: "store"; snapshot: SnapshotInput };
+
+/** OCR seam: returns extracted text for a candidate, or null when unavailable. */
+export type OcrFn = (candidate: CaptureCandidate) => string | null;
+
+interface ContentHashFields {
+  capturedAtUtc: string;
+  app: string;
+  windowTitle: string;
+  browserUrl: string | null;
+  text: string;
+  textSource: string;
+}
+
+/**
+ * SHA-256 over length-prefixed fields so control characters (incl. NUL) in the
+ * captured text cannot make two distinct snapshots collide — a collision would
+ * silently drop a valid capture via the UNIQUE content_hash + INSERT OR IGNORE.
+ */
+export function contentHash(fields: ContentHashFields): string {
+  const hash = createHash("sha256");
+  const parts = [fields.capturedAtUtc, fields.app, fields.windowTitle, fields.browserUrl ?? "", fields.text, fields.textSource];
+  for (const field of parts) {
+    hash.update(`${Buffer.byteLength(field)}:`).update(field);
+  }
+  return hash.digest("hex");
+}
+
+export class CaptureProcessor {
+  readonly #denyApps: string[];
+  readonly #denyTitles: string[];
+  readonly #denyUrls: string[];
+  readonly #terminalApps: string[];
+  readonly #maxNodes: number;
+  readonly #redaction: RegExp[];
+  readonly #cache: DedupCache;
+  readonly #ocr: OcrFn | undefined;
+
+  constructor(config: DaemonConfig, ocr?: OcrFn) {
+    this.#denyApps = config.denyApps;
+    this.#denyTitles = config.denyTitles;
+    this.#denyUrls = config.denyUrls;
+    this.#terminalApps = [...DEFAULT_TERMINAL_APPS, ...config.terminalApps];
+    this.#maxNodes = config.maxNodes;
+    this.#redaction = compileRedactionPatterns(config.redactionPatterns);
+    this.#cache = new DedupCache(config.simhashThreshold, config.dedupTtlSeconds);
+    this.#ocr = ocr;
+  }
+
+  /** Seed the dedup cache from prior spool state so restarts don't re-store. */
+  seed(app: string, windowTitle: string, simhashHex: string, capturedAtUtc: string): void {
+    this.#cache.seed(app, windowTitle, BigInt(`0x${simhashHex}`), Date.parse(capturedAtUtc));
+  }
+
+  process(candidate: CaptureCandidate): CaptureDecision {
+    const denyRule = matchDenyRule(
+      { app: candidate.app, windowTitle: candidate.windowTitle, browserUrl: candidate.browserUrl },
+      { apps: this.#denyApps, titles: this.#denyTitles, urls: this.#denyUrls },
+    );
+    if (denyRule !== null) return { action: "denied", rule: denyRule };
+
+    const extracted = this.#extractText(candidate);
+    if (extracted === null) return { action: "skipped", reason: "ocr-unavailable" };
+    const { source } = extracted;
+    const text = redactText(extracted.text, this.#redaction);
+
+    const fingerprint = simhash(text);
+    const atMs = Date.parse(candidate.capturedAtUtc);
+    if (!this.#cache.shouldStore(candidate.app, candidate.windowTitle, fingerprint, atMs)) {
+      return { action: "skipped", reason: "dedup" };
+    }
+
+    const browserUrl = candidate.browserUrl ?? null;
+    return {
+      action: "store",
+      snapshot: {
+        capturedAtUtc: candidate.capturedAtUtc,
+        app: candidate.app,
+        windowTitle: candidate.windowTitle,
+        browserUrl,
+        text,
+        textSource: source,
+        contentHash: contentHash({
+          capturedAtUtc: candidate.capturedAtUtc,
+          app: candidate.app,
+          windowTitle: candidate.windowTitle,
+          browserUrl,
+          text,
+          textSource: source,
+        }),
+        simhash: simhashToHex(fingerprint),
+      },
+    };
+  }
+
+  /** Resolve visible text + its source, or null when OCR was needed but unavailable. */
+  #extractText(candidate: CaptureCandidate): { text: string; source: TextSource } | null {
+    if (typeof candidate.text === "string") {
+      return { text: candidate.text, source: candidate.textSource ?? "ax" };
+    }
+    const axText = candidate.ax === undefined ? "" : extractAxText(candidate.ax, this.#maxNodes).text;
+    const needsOcr = isTerminalApp(candidate.app, this.#terminalApps, false) || axText.trim() === "";
+    if (!needsOcr) return { text: axText, source: "ax" };
+    const ocrText = this.#ocr === undefined ? null : this.#ocr(candidate);
+    if (ocrText !== null && ocrText.trim() !== "") return { text: ocrText, source: "ocr" };
+    return null;
+  }
+}
+
+export interface AppStat {
+  app: string;
+  seconds: number;
+  snapshotCount: number;
+}
+
+export interface DayStats {
+  date: string;
+  timezone: string;
+  snapshotCount: number;
+  totalSeconds: number;
+  apps: AppStat[];
+}
+
+/**
+ * Per-app time attribution for a day. Each snapshot is credited the gap to the
+ * next snapshot (capped at maxDwellSeconds); the final snapshot contributes no
+ * dwell (no following instant to bound it). Apps sort by seconds desc, then name.
+ */
+export function computeStats(
+  snapshots: DaemonSnapshot[],
+  date: string,
+  timezone: string,
+  maxDwellSeconds: number,
+): DayStats {
+  const ordered = [...snapshots].sort((a, b) => {
+    const at = Date.parse(a.capturedAtUtc);
+    const bt = Date.parse(b.capturedAtUtc);
+    if (at !== bt) return at - bt;
+    return a.id - b.id;
+  });
+  const seconds = new Map<string, number>();
+  const counts = new Map<string, number>();
+  let totalSeconds = 0;
+  for (let i = 0; i < ordered.length; i++) {
+    const snap = ordered[i];
+    counts.set(snap.app, (counts.get(snap.app) ?? 0) + 1);
+    if (i + 1 < ordered.length) {
+      const gap = (Date.parse(ordered[i + 1].capturedAtUtc) - Date.parse(snap.capturedAtUtc)) / 1000;
+      const dwell = Math.max(0, Math.min(gap, maxDwellSeconds));
+      seconds.set(snap.app, (seconds.get(snap.app) ?? 0) + dwell);
+      totalSeconds += dwell;
+    }
+  }
+  const apps: AppStat[] = [...counts.keys()]
+    .map((app) => ({ app, seconds: seconds.get(app) ?? 0, snapshotCount: counts.get(app) ?? 0 }))
+    .sort((a, b) => (b.seconds !== a.seconds ? b.seconds - a.seconds : a.app < b.app ? -1 : a.app > b.app ? 1 : 0));
+  return { date, timezone, snapshotCount: ordered.length, totalSeconds, apps };
+}

--- a/packages/capture-screen/src/cli-bin.ts
+++ b/packages/capture-screen/src/cli-bin.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { runCapture } from "./cli.js";
+
+runCapture({ argv: process.argv.slice(2) })
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err) => {
+    // Last-resort handler (runCapture already sanitizes its own errors). Print
+    // only an errno code / error name — never raw message text that could embed
+    // absolute paths or loader stacks.
+    const detail = (err as NodeJS.ErrnoException).code ?? (err instanceof Error ? err.name : "unknown error");
+    console.error(`remnic-capture-screen: ${detail}`);
+    process.exitCode = 1;
+  });

--- a/packages/capture-screen/src/cli.test.ts
+++ b/packages/capture-screen/src/cli.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { chmodSync, existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { runCapture } from "./cli.js";
+import { ensurePrivateDir, resolveToken, runCapture } from "./cli.js";
+import { CaptureInputError } from "./errors.js";
+import { capturePaths } from "./paths.js";
 
 const helperDir = mkdtempSync(path.join(tmpdir(), "csr-cli-helper-"));
 function fakeHelper(name: string, body: string): string {
@@ -135,4 +137,41 @@ test("test-snapshot names the deny rule that fires", async () => {
   const body = JSON.parse(r.out.join("\n")) as { action: string; rule: string };
   assert.equal(body.action, "denied");
   assert.equal(body.rule, "app:1Password*");
+});
+
+const AX_EMPTY_BLANK_OCR = fakeHelper(
+  "blankocr.js",
+  `const cmd = process.argv[2];
+if (cmd === "ax-snapshot") process.stdout.write(JSON.stringify({ app: "Notes", windowTitle: "Untitled", tree: { role: "AXWindow" } }));
+else if (cmd === "ocr-window") process.stdout.write(JSON.stringify({ text: "   " }));
+else process.exit(2);`,
+);
+
+test("test-snapshot skips (ocr-unavailable) instead of storing blank OCR text", async () => {
+  const r = await run(["test-snapshot"], { REMNIC_CAPTURE_HELPER_BIN: AX_EMPTY_BLANK_OCR });
+  assert.equal(r.code, 0);
+  const body = JSON.parse(r.out.join("\n")) as { action: string; reason?: string };
+  assert.equal(body.action, "skipped");
+  assert.equal(body.reason, "ocr-unavailable");
+});
+
+test("resolveToken honors the legacy ENGRAM_CAPTURE_TOKEN alias; REMNIC takes precedence", () => {
+  const paths = capturePaths(mkdtempSync(path.join(tmpdir(), "csr-tok-")));
+  assert.equal(resolveToken(paths, { ENGRAM_CAPTURE_TOKEN: "legacy" }, false), "legacy");
+  assert.equal(
+    resolveToken(paths, { REMNIC_CAPTURE_TOKEN: "primary", ENGRAM_CAPTURE_TOKEN: "legacy" }, false),
+    "primary",
+  );
+});
+
+test("ensurePrivateDir refuses a symlinked private directory and creates a real one 0700", () => {
+  const base = mkdtempSync(path.join(tmpdir(), "csr-priv-"));
+  const realTarget = path.join(base, "real");
+  mkdirSync(realTarget);
+  const link = path.join(base, "link");
+  symlinkSync(realTarget, link);
+  assert.throws(() => ensurePrivateDir(link), CaptureInputError);
+  const fresh = path.join(base, "fresh");
+  ensurePrivateDir(fresh);
+  assert.equal(existsSync(fresh), true);
 });

--- a/packages/capture-screen/src/cli.test.ts
+++ b/packages/capture-screen/src/cli.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { ensurePrivateDir, resolveToken, runCapture } from "./cli.js";
+import { ensurePrivateDir, ensureSpoolParentDir, resolveToken, runCapture } from "./cli.js";
 import { CaptureInputError } from "./errors.js";
 import { capturePaths } from "./paths.js";
 
@@ -174,4 +174,29 @@ test("ensurePrivateDir refuses a symlinked private directory and creates a real 
   const fresh = path.join(base, "fresh");
   ensurePrivateDir(fresh);
   assert.equal(existsSync(fresh), true);
+});
+
+test("ensureSpoolParentDir creates absent 0700, rejects symlink/non-private, never chmods existing", () => {
+  const base = mkdtempSync(path.join(tmpdir(), "csr-spoolp-"));
+  // Absent parent → created 0700.
+  ensureSpoolParentDir(path.join(base, "fresh", "spool.sqlite"));
+  assert.equal(existsSync(path.join(base, "fresh")), true);
+  if (process.platform !== "win32") {
+    assert.equal(statSync(path.join(base, "fresh")).mode & 0o777, 0o700);
+  }
+  // Existing private parent → accepted (idempotent, no throw).
+  ensureSpoolParentDir(path.join(base, "fresh", "spool.sqlite"));
+  // Symlinked parent → rejected.
+  const realDir = path.join(base, "real");
+  mkdirSync(realDir, { mode: 0o700 });
+  symlinkSync(realDir, path.join(base, "link"));
+  assert.throws(() => ensureSpoolParentDir(path.join(base, "link", "spool.sqlite")), CaptureInputError);
+  // Existing group/other-accessible parent → rejected AND left untouched (not chmod'd).
+  if (process.platform !== "win32") {
+    const shared = path.join(base, "shared");
+    mkdirSync(shared);
+    chmodSync(shared, 0o755);
+    assert.throws(() => ensureSpoolParentDir(path.join(shared, "spool.sqlite")), CaptureInputError);
+    assert.equal(statSync(shared).mode & 0o777, 0o755, "must not chmod an existing shared dir");
+  }
 });

--- a/packages/capture-screen/src/cli.test.ts
+++ b/packages/capture-screen/src/cli.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { chmodSync, existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { runCapture } from "./cli.js";
+
+const helperDir = mkdtempSync(path.join(tmpdir(), "csr-cli-helper-"));
+function fakeHelper(name: string, body: string): string {
+  const file = path.join(helperDir, name);
+  writeFileSync(file, `#!/usr/bin/env node\n${body}\n`, "utf8");
+  chmodSync(file, 0o755);
+  return file;
+}
+const OK_HELPER = fakeHelper(
+  "ok.js",
+  `if (process.argv[2] === "ax-snapshot") process.stdout.write(JSON.stringify({ app: "Safari", windowTitle: "Docs", tree: { role: "AXWindow", children: [{ role: "AXStaticText", value: "visible page text here" }] } }));
+else process.exit(2);`,
+);
+const DENY_HELPER = fakeHelper(
+  "deny.js",
+  `if (process.argv[2] === "ax-snapshot") process.stdout.write(JSON.stringify({ app: "1Password 8", windowTitle: "Vault", tree: { role: "AXWindow" } }));
+else process.exit(2);`,
+);
+
+interface Captured {
+  code: number;
+  out: string[];
+  err: string[];
+}
+async function run(argv: string[], env: NodeJS.ProcessEnv = {}): Promise<Captured> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const scratch = mkdtempSync(path.join(tmpdir(), "csr-cli-"));
+  const code = await runCapture({
+    argv,
+    env: { REMNIC_CAPTURE_SCREEN_DIR: scratch, REMNIC_CAPTURE_TOKEN: "cli-token", ...env },
+    stdout: (l) => out.push(l),
+    stderr: (l) => err.push(l),
+  });
+  return { code, out, err };
+}
+
+// A stable scratch dir shared by the init round-trip test.
+const initDir = mkdtempSync(path.join(tmpdir(), "csr-cli-init-"));
+function runIn(dir: string, argv: string[], env: NodeJS.ProcessEnv = {}): Promise<Captured> {
+  const out: string[] = [];
+  const err: string[] = [];
+  return runCapture({
+    argv,
+    env: { REMNIC_CAPTURE_SCREEN_DIR: dir, REMNIC_CAPTURE_TOKEN: "cli-token", ...env },
+    stdout: (l) => out.push(l),
+    stderr: (l) => err.push(l),
+  }).then((code) => ({ code, out, err }));
+}
+
+test("init writes config + token and is idempotent without --force", async () => {
+  const first = await runIn(initDir, ["init"]);
+  assert.equal(first.code, 0);
+  assert.ok(existsSync(path.join(initDir, "screen.json")));
+  assert.ok(existsSync(path.join(initDir, "token")));
+  assert.ok(first.out.some((l) => /wrote default config/.test(l)));
+
+  const second = await runIn(initDir, ["init"]);
+  assert.equal(second.code, 0);
+  assert.ok(second.out.some((l) => /already exists/.test(l)));
+});
+
+test("--auth-token on argv is rejected with an env instruction", async () => {
+  const r = await run(["start", "--auth-token", "leaked"]);
+  assert.equal(r.code, 2);
+  assert.ok(r.err.some((l) => /REMNIC_CAPTURE_TOKEN/.test(l)));
+});
+
+test("unknown flags and commands are rejected", async () => {
+  assert.equal((await run(["start", "--bogus", "x"])).code, 2);
+  assert.equal((await run(["frobnicate"])).code, 2);
+  assert.equal((await run(["logs", "--foreground"])).code, 2, "flag not valid for command");
+});
+
+test("status reports not-running against a fresh dir", async () => {
+  const r = await run(["status"]);
+  assert.equal(r.code, 0);
+  assert.ok(r.out.some((l) => /not running/.test(l)));
+});
+
+test("install-service is honest: it installs nothing and says so", async () => {
+  const r = await run(["install-service"]);
+  assert.equal(r.code, 0);
+  assert.ok(r.out.some((l) => /No service was installed/.test(l)));
+  assert.ok(!r.out.some((l) => /installed successfully|service installed/i.test(l)));
+});
+
+test("logs reports absence of a log file cleanly", async () => {
+  const r = await run(["logs"]);
+  assert.equal(r.code, 0);
+  assert.ok(r.out.some((l) => /no log file/.test(l)));
+});
+
+test("start refuses a non-loopback host without binding", async () => {
+  const r = await run(["start", "--foreground", "--host", "0.0.0.0"]);
+  assert.equal(r.code, 1);
+  assert.ok(r.err.some((l) => /non-loopback/.test(l)));
+});
+
+test("start rejects an out-of-range port", async () => {
+  // coerceNumber raises a config error (exit 1), matching the capture-audio CLI.
+  const r = await run(["start", "--foreground", "--port", "99999"]);
+  assert.equal(r.code, 1);
+});
+
+test("test-snapshot is honest when the native helper is unavailable", async () => {
+  const r = await run(["test-snapshot"]);
+  assert.equal(r.code, 0);
+  const body = JSON.parse(r.out.join("\n")) as { axAvailable: boolean; ocrAvailable: boolean; helperHint: string };
+  assert.equal(body.axAvailable, false);
+  assert.equal(body.ocrAvailable, false);
+  assert.match(body.helperHint, /capture-native/);
+});
+
+test("test-snapshot with a fake helper reports what would be captured", async () => {
+  const r = await run(["test-snapshot"], { REMNIC_CAPTURE_HELPER_BIN: OK_HELPER });
+  assert.equal(r.code, 0);
+  const body = JSON.parse(r.out.join("\n")) as { action: string; app: string; textSource: string; textPreview: string };
+  assert.equal(body.action, "would-store");
+  assert.equal(body.app, "Safari");
+  assert.equal(body.textSource, "ax");
+  assert.match(body.textPreview, /visible page text/);
+});
+
+test("test-snapshot names the deny rule that fires", async () => {
+  const r = await run(["test-snapshot"], { REMNIC_CAPTURE_HELPER_BIN: DENY_HELPER });
+  assert.equal(r.code, 0);
+  const body = JSON.parse(r.out.join("\n")) as { action: string; rule: string };
+  assert.equal(body.action, "denied");
+  assert.equal(body.rule, "app:1Password*");
+});

--- a/packages/capture-screen/src/cli.ts
+++ b/packages/capture-screen/src/cli.ts
@@ -1,0 +1,663 @@
+/**
+ * `remnic-capture-screen` CLI. Subcommands:
+ *   init | start | stop | status | install-service | logs | test-snapshot
+ *
+ * `start --replay <dir>` feeds synthetic fixtures through the full capture
+ * pipeline + HTTP API (the CI-friendly, hardware-free path). Live capture needs
+ * the native helper (@remnic/capture-native-*); where it is absent the daemon
+ * still serves the spool and reports axAvailable/ocrAvailable = false.
+ *
+ * The bearer token comes from the environment (REMNIC_CAPTURE_TOKEN), never
+ * argv: a long-lived daemon's argv is world-readable via `ps`/`/proc`, so a
+ * token on the command line would let any local account read captured screen
+ * text. `--auth-token` is rejected. When the env var is unset, the token file
+ * created by `init` is used instead.
+ */
+
+import { spawn } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { CaptureProcessor } from "./capture.js";
+import { coerceNumber } from "./coerce.js";
+import { CAPTURE_SCREEN_VERSION } from "./constants.js";
+import {
+  defaultDaemonConfig,
+  loadDaemonConfig,
+  serializeDaemonConfig,
+  type DaemonConfig,
+} from "./config.js";
+import {
+  isProcessAlive,
+  readPidRecord,
+  removePidFile,
+  removePidFileIfOwner,
+  writePidFile,
+  type PidRecord,
+} from "./control.js";
+import { startDaemon, type DaemonHandle } from "./daemon.js";
+import { CaptureConfigError, CaptureInputError } from "./errors.js";
+import { NativeHelper, resolveHelperBinaryPath } from "./helper.js";
+import { captureViaHelper } from "./live.js";
+import { capturePaths, captureBaseDir, expandTilde, type CapturePaths } from "./paths.js";
+import { ingestReplayDirResponsive } from "./replay.js";
+import { Spool } from "./spool.js";
+import { loadOrCreateToken } from "./token.js";
+import { formatHostForUrl, isLoopbackHost, sanitizeError, stripIpv6Brackets } from "./util.js";
+
+export interface CliIo {
+  argv: string[];
+  env?: NodeJS.ProcessEnv;
+  stdout?: (line: string) => void;
+  stderr?: (line: string) => void;
+}
+
+interface ParsedArgs {
+  command: string;
+  positionals: string[];
+  flags: Record<string, string | boolean>;
+}
+
+const CAPTURE_TOKEN_ENV = "REMNIC_CAPTURE_TOKEN";
+
+/** Flags that consume the next argv token as their value. */
+const VALUE_FLAGS: Record<string, true> = {
+  replay: true,
+  host: true,
+  port: true,
+  listen: true,
+  "base-dir": true,
+  spool: true,
+  lines: true,
+};
+
+/** Standalone boolean flags. */
+const BOOLEAN_FLAGS: Record<string, true> = {
+  foreground: true,
+  force: true,
+  help: true,
+};
+
+/** Non-global flags each subcommand accepts; anything else is rejected. */
+const COMMAND_FLAGS: Record<string, Record<string, true>> = {
+  init: { force: true },
+  start: { foreground: true, replay: true, host: true, port: true, listen: true, spool: true },
+  stop: { force: true },
+  status: {},
+  "install-service": {},
+  logs: { lines: true },
+  "test-snapshot": {},
+  help: {},
+};
+
+/** Flags accepted regardless of subcommand. */
+const GLOBAL_FLAGS: Record<string, true> = { "base-dir": true, spool: true, help: true };
+
+const READINESS_TIMEOUT_MS = 10_000;
+const STOP_TIMEOUT_MS = 10_000;
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const tokens: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      if (key === "auth-token") {
+        throw new CaptureInputError(
+          `--auth-token is not accepted; set the ${CAPTURE_TOKEN_ENV} environment variable instead`,
+        );
+      }
+      if (Object.hasOwn(VALUE_FLAGS, key)) {
+        const next = argv[i + 1];
+        if (next === undefined || next.startsWith("--")) throw new CaptureInputError(`flag --${key} requires a value`);
+        flags[key] = next;
+        i += 1;
+      } else if (Object.hasOwn(BOOLEAN_FLAGS, key)) {
+        flags[key] = true;
+      } else {
+        throw new CaptureInputError(`unknown flag --${key}`);
+      }
+    } else {
+      tokens.push(arg);
+    }
+  }
+  const command = tokens.length > 0 ? tokens[0] : "help";
+  return { command, positionals: tokens.slice(1), flags };
+}
+
+function resolvePaths(flags: Record<string, string | boolean>, env: NodeJS.ProcessEnv): CapturePaths {
+  const baseDir =
+    typeof flags["base-dir"] === "string"
+      ? captureBaseDir({ ...env, REMNIC_CAPTURE_SCREEN_DIR: flags["base-dir"] })
+      : captureBaseDir(env);
+  const paths = capturePaths(baseDir);
+  if (typeof flags.spool === "string") return { ...paths, spoolPath: expandTilde(flags.spool) };
+  return paths;
+}
+
+function loadConfigOrDefault(paths: CapturePaths, stderr: (line: string) => void): DaemonConfig {
+  if (existsSync(paths.configPath)) return loadDaemonConfig(paths.configPath);
+  stderr(`no config at ${paths.configPath}; using defaults (run \`init\` to customize)`);
+  return defaultDaemonConfig();
+}
+
+function applyBindingOverrides(config: DaemonConfig, flags: Record<string, string | boolean>): DaemonConfig {
+  const next = { ...config };
+  if (typeof flags.listen === "string") {
+    const idx = flags.listen.lastIndexOf(":");
+    if (idx <= 0) throw new CaptureInputError(`--listen expects host:port, got '${flags.listen}'`);
+    next.host = flags.listen.slice(0, idx);
+    next.port = coerceNumber(flags.listen.slice(idx + 1), "--listen port", { integer: true, min: 1, max: 65535 });
+  }
+  if (typeof flags.host === "string") next.host = flags.host;
+  if (typeof flags.port === "string") next.port = coerceNumber(flags.port, "--port", { integer: true, min: 1, max: 65535 });
+  next.host = stripIpv6Brackets(next.host);
+  return next;
+}
+
+function healthUrlFor(host: string, port: number): string {
+  return `http://${formatHostForUrl(host)}:${port}/v1/health`;
+}
+
+function recordHealthUrl(record: PidRecord, paths: CapturePaths, stderr: (l: string) => void): string {
+  if (record.host !== null && record.port !== null) return healthUrlFor(record.host, record.port);
+  const config = loadConfigOrDefault(paths, stderr);
+  return healthUrlFor(config.host, config.port);
+}
+
+/** Token for probes/serving: env override first, then the on-disk token file. */
+function resolveToken(paths: CapturePaths, env: NodeJS.ProcessEnv, create: boolean): string {
+  const fromEnv = env[CAPTURE_TOKEN_ENV]?.trim();
+  if (fromEnv) return fromEnv;
+  if (create) return loadOrCreateToken(paths.tokenPath);
+  if (existsSync(paths.tokenPath)) return readFileSync(paths.tokenPath, "utf8").trim();
+  return "";
+}
+
+function tokenHeader(paths: CapturePaths, env: NodeJS.ProcessEnv): Record<string, string> {
+  const token = resolveToken(paths, env, false);
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+function ensurePrivateDir(dir: string): void {
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(dir, 0o700);
+  } catch {
+    // filesystem without POSIX perms
+  }
+}
+
+interface DaemonIdentity {
+  instanceId: string;
+  pid: number;
+}
+
+async function probeIdentity(paths: CapturePaths, env: NodeJS.ProcessEnv, url: string): Promise<DaemonIdentity | null> {
+  try {
+    const res = await fetch(url, { headers: tokenHeader(paths, env), signal: AbortSignal.timeout(2000) });
+    if (!res.ok) return null;
+    const body: unknown = await res.json();
+    if (body !== null && typeof body === "object" && "instanceId" in body && "pid" in body) {
+      const instanceId: unknown = body.instanceId;
+      const pid: unknown = body.pid;
+      if (typeof instanceId === "string" && typeof pid === "number") return { instanceId, pid };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function recordChildPidOrTerminate(
+  pid: number,
+  paths: CapturePaths,
+  binding: { host: string; port: number },
+  stderr: (l: string) => void,
+): boolean {
+  const existing = readPidRecord(paths.pidPath);
+  if (existing !== null && existing.pid === pid && existing.instanceId !== null) return true;
+  try {
+    writePidFile(paths.pidPath, pid, binding);
+    return true;
+  } catch (err) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // already gone
+    }
+    stderr(`failed to record daemon pid: ${sanitizeError(err)}; terminated child pid ${pid}`);
+    return false;
+  }
+}
+
+async function isOwnRunningDaemon(record: PidRecord, paths: CapturePaths, env: NodeJS.ProcessEnv, stderr: (l: string) => void): Promise<boolean> {
+  if (record.instanceId === null) return true;
+  const live = await probeIdentity(paths, env, recordHealthUrl(record, paths, stderr));
+  if (live === null) return true;
+  return live.instanceId === record.instanceId && live.pid === record.pid;
+}
+
+export async function recordedDaemonIsRunning(record: PidRecord, paths: CapturePaths, env: NodeJS.ProcessEnv, stderr: (l: string) => void): Promise<boolean> {
+  if (record.pid === process.pid) return false;
+  if (!isProcessAlive(record.pid)) return false;
+  return isOwnRunningDaemon(record, paths, env, stderr);
+}
+
+/**
+ * Run replay ingestion as a supervised task AFTER the daemon is ready. Never
+ * throws: success/failure is surfaced via the spool's `replay_status` meta
+ * (also on /v1/health) and the daemon log, so a slow/failed replay never kills
+ * the daemon or retracts its readiness.
+ */
+export async function superviseReplay(
+  spool: Spool,
+  replayDir: string,
+  config: DaemonConfig,
+  io: { stdout: (l: string) => void; stderr: (l: string) => void },
+  signal?: AbortSignal,
+): Promise<void> {
+  await Promise.resolve();
+  spool.setMeta("replay_status", "running");
+  try {
+    const summary = await ingestReplayDirResponsive(spool, replayDir, config, { signal });
+    if (summary.aborted) {
+      spool.setMeta("replay_status", "cancelled");
+      io.stdout(`replay: cancelled after ${summary.stored} snapshot(s)`);
+    } else {
+      spool.setMeta("replay_status", "ok");
+      io.stdout(
+        `replay: stored ${summary.stored} of ${summary.candidates} candidate(s) ` +
+          `(denied ${summary.denied}, deduped ${summary.deduped}, ocr-skipped ${summary.ocrSkipped}) ` +
+          `from ${summary.files} fixture file(s)`,
+      );
+    }
+  } catch (err) {
+    const message = err instanceof CaptureConfigError || err instanceof CaptureInputError ? err.message : sanitizeError(err);
+    const sanitized = message.replace(/\/\S+/g, "<path>");
+    spool.setMeta("replay_status", `failed: ${sanitized}`);
+    io.stderr(`replay ingestion failed: ${message}`);
+  }
+}
+
+function cmdInit(paths: CapturePaths, flags: Record<string, string | boolean>, stdout: (l: string) => void): number {
+  ensurePrivateDir(paths.baseDir);
+  if (existsSync(paths.configPath) && flags.force !== true) {
+    stdout(`config already exists at ${paths.configPath} (use --force to overwrite)`);
+  } else {
+    writeFileSync(paths.configPath, serializeDaemonConfig(defaultDaemonConfig()), "utf8");
+    stdout(`wrote default config to ${paths.configPath}`);
+  }
+  const token = loadOrCreateToken(paths.tokenPath);
+  stdout(`token ready at ${paths.tokenPath} (${token.length} chars, mode 0600)`);
+  stdout(`set ${CAPTURE_TOKEN_ENV} to override the token file when starting the daemon`);
+  stdout(`spool will be created at ${paths.spoolPath} on first start`);
+  return 0;
+}
+
+async function cmdStart(
+  paths: CapturePaths,
+  flags: Record<string, string | boolean>,
+  env: NodeJS.ProcessEnv,
+  stdout: (l: string) => void,
+  stderr: (l: string) => void,
+): Promise<number> {
+  const config = applyBindingOverrides(loadConfigOrDefault(paths, stderr), flags);
+  if (!isLoopbackHost(config.host)) {
+    stderr(
+      `refusing to bind non-loopback host '${config.host}': capture-screen serves plain HTTP with no TLS contract; ` +
+        "use a loopback address (127.0.0.1 or ::1)",
+    );
+    return 1;
+  }
+  const replayDir = typeof flags.replay === "string" ? expandTilde(flags.replay) : null;
+  const previousRecord = readPidRecord(paths.pidPath);
+  if (previousRecord !== null) {
+    if (await recordedDaemonIsRunning(previousRecord, paths, env, stderr)) {
+      stdout(`daemon already running (pid ${previousRecord.pid})`);
+      return 0;
+    }
+    if (previousRecord.pid !== process.pid) removePidFile(paths.pidPath);
+  }
+
+  if (flags.foreground !== true) {
+    const entry = process.argv[1];
+    const forwarded = ["start", "--foreground"];
+    if (replayDir) forwarded.push("--replay", replayDir);
+    if (typeof flags["base-dir"] === "string") forwarded.push("--base-dir", flags["base-dir"]);
+    if (typeof flags.spool === "string") forwarded.push("--spool", flags.spool);
+    if (typeof flags.host === "string") forwarded.push("--host", flags.host);
+    if (typeof flags.port === "string") forwarded.push("--port", flags.port);
+    if (typeof flags.listen === "string") forwarded.push("--listen", flags.listen);
+    ensurePrivateDir(paths.baseDir);
+    const logFd = openSync(paths.logPath, "a");
+    const child = spawn(process.execPath, [entry, ...forwarded], {
+      detached: true,
+      stdio: ["ignore", logFd, logFd],
+      env: { ...process.env, ...env },
+    });
+    child.on("error", (err) => stderr(`daemon failed to launch: ${sanitizeError(err)}`));
+    child.unref();
+    if (typeof child.pid !== "number") {
+      stderr("failed to spawn daemon process");
+      return 1;
+    }
+    if (!recordChildPidOrTerminate(child.pid, paths, { host: config.host, port: config.port }, stderr)) return 1;
+    const deadline = Date.now() + READINESS_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      if (!isProcessAlive(child.pid)) {
+        removePidFileIfOwner(paths.pidPath, child.pid);
+        stderr(`daemon exited during startup; see ${paths.logPath}`);
+        return 1;
+      }
+      if (readPidRecord(paths.pidPath)?.instanceId) {
+        stdout(`started daemon (pid ${child.pid}); listening; logs at ${paths.logPath}`);
+        return 0;
+      }
+      await delay(100);
+    }
+    try {
+      process.kill(child.pid, "SIGTERM");
+    } catch {
+      // already gone
+    }
+    removePidFileIfOwner(paths.pidPath, child.pid);
+    stderr(`daemon did not become ready within ${READINESS_TIMEOUT_MS / 1000}s; terminated pid ${child.pid}. See ${paths.logPath}.`);
+    return 1;
+  }
+
+  ensurePrivateDir(paths.baseDir);
+  const token = resolveToken(paths, env, true);
+  const helperRes = await resolveHelperBinaryPath(env);
+  const axAvailable = helperRes.binaryPath !== null;
+  const spool = new Spool(paths.spoolPath);
+  // Retention janitor: prune expired rows once on start so a long-idle spool is
+  // trimmed even if the (native) capture loop never runs on this platform.
+  spool.pruneOlderThan(config.spoolRetentionDays);
+  let handle: DaemonHandle;
+  try {
+    handle = await startDaemon({
+      spool,
+      config,
+      token,
+      capturing: false,
+      axAvailable,
+      ocrAvailable: axAvailable,
+      helperHint: helperRes.hint,
+    });
+  } catch (err) {
+    spool.close();
+    throw err;
+  }
+  try {
+    writePidFile(paths.pidPath, process.pid, {
+      instanceId: spool.meta("instance_id"),
+      host: handle.host,
+      port: handle.port,
+    });
+  } catch (err) {
+    await handle.close();
+    spool.close();
+    throw err;
+  }
+  stdout(`listening on ${handle.url}`);
+  if (helperRes.hint) stdout(`note: ${helperRes.hint}`);
+  const replayAbort = new AbortController();
+  const replayTask: Promise<void> = replayDir
+    ? superviseReplay(spool, replayDir, config, { stdout, stderr }, replayAbort.signal)
+    : Promise.resolve();
+
+  return await new Promise<number>((resolve) => {
+    let closing = false;
+    const shutdown = () => {
+      if (closing) return;
+      closing = true;
+      // Cancel any in-flight replay and drain it before closing the spool so no
+      // ingestion write can ever hit a closed database.
+      replayAbort.abort();
+      void replayTask
+        .catch(() => undefined)
+        .then(() => handle.close().catch(() => undefined))
+        .finally(() => {
+          spool.close();
+          removePidFileIfOwner(paths.pidPath, process.pid);
+          resolve(0);
+        });
+    };
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+  });
+}
+
+async function cmdStop(
+  paths: CapturePaths,
+  flags: Record<string, string | boolean>,
+  env: NodeJS.ProcessEnv,
+  stdout: (l: string) => void,
+  stderr: (l: string) => void,
+): Promise<number> {
+  const record = readPidRecord(paths.pidPath);
+  if (record === null || !isProcessAlive(record.pid)) {
+    removePidFile(paths.pidPath);
+    stdout("daemon not running");
+    return 0;
+  }
+  if (record.instanceId !== null) {
+    const live = await probeIdentity(paths, env, recordHealthUrl(record, paths, stderr));
+    if (live !== null && (live.instanceId !== record.instanceId || live.pid !== record.pid)) {
+      stderr(
+        `recorded pid ${record.pid} does not match the daemon serving this endpoint (identity/pid mismatch); ` +
+          `not signalling and preserving ${paths.pidPath}.`,
+      );
+      return 1;
+    }
+    if (live === null && flags.force !== true) {
+      stderr(
+        `cannot confirm daemon identity for pid ${record.pid} (health unreachable); not signalling. ` +
+          `Re-run \`stop --force\` to stop it anyway, or remove ${paths.pidPath}.`,
+      );
+      return 1;
+    }
+  } else if (flags.force !== true) {
+    stderr(
+      `cannot verify daemon identity for pid ${record.pid} (no recorded instance id); not signalling. ` +
+        `Re-run \`stop --force\` to stop it anyway, or remove ${paths.pidPath}.`,
+    );
+    return 1;
+  }
+  try {
+    process.kill(record.pid, "SIGTERM");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") {
+      removePidFile(paths.pidPath);
+      stdout("daemon not running");
+      return 0;
+    }
+    if (code === "EPERM") {
+      stderr(`daemon (pid ${record.pid}) is running but not controllable from this user`);
+      return 1;
+    }
+    throw err;
+  }
+  const deadline = Date.now() + STOP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(record.pid) || readPidRecord(paths.pidPath) === null) {
+      stdout(`daemon (pid ${record.pid}) stopped`);
+      return 0;
+    }
+    await delay(100);
+  }
+  stdout(`sent SIGTERM to daemon (pid ${record.pid}); still shutting down after ${STOP_TIMEOUT_MS / 1000}s`);
+  return 0;
+}
+
+async function cmdStatus(paths: CapturePaths, env: NodeJS.ProcessEnv, stdout: (l: string) => void, stderr: (l: string) => void): Promise<number> {
+  const record = readPidRecord(paths.pidPath);
+  if (record === null || !isProcessAlive(record.pid)) {
+    stdout("status: not running");
+    return 0;
+  }
+  try {
+    const res = await fetch(recordHealthUrl(record, paths, stderr), {
+      headers: tokenHeader(paths, env),
+      signal: AbortSignal.timeout(2000),
+    });
+    const body = await res.text();
+    stdout(`status: running (pid ${record.pid}) — HTTP ${res.status} ${body}`);
+  } catch (err) {
+    stdout(`status: process alive (pid ${record.pid}) but health check failed (${sanitizeError(err)})`);
+  }
+  return 0;
+}
+
+function cmdInstallService(stdout: (l: string) => void): number {
+  stdout(
+    `install-service is not yet implemented for platform '${process.platform}'. ` +
+      "No service was installed. Run `remnic-capture-screen start` under your process manager " +
+      "(launchd on macOS, systemd --user on Linux) once the native capture helper is installed.",
+  );
+  return 0;
+}
+
+function cmdLogs(paths: CapturePaths, flags: Record<string, string | boolean>, stdout: (l: string) => void): number {
+  if (!existsSync(paths.logPath)) {
+    stdout(`no log file at ${paths.logPath}`);
+    return 0;
+  }
+  const lines = typeof flags.lines === "string" ? coerceNumber(flags.lines, "--lines", { integer: true, min: 1 }) : 200;
+  const all = readFileSync(paths.logPath, "utf8").split("\n");
+  stdout(all.slice(Math.max(0, all.length - lines)).join("\n"));
+  return 0;
+}
+
+/**
+ * `test-snapshot`: report what WOULD be captured now and which deny rule (if
+ * any) fired — WITHOUT storing. Honest about degradation: with no native helper
+ * it reports the unavailable capabilities + install hint and captures nothing.
+ */
+async function cmdTestSnapshot(
+  paths: CapturePaths,
+  env: NodeJS.ProcessEnv,
+  stdout: (l: string) => void,
+  stderr: (l: string) => void,
+): Promise<number> {
+  const config = loadConfigOrDefault(paths, stderr);
+  const helperRes = await resolveHelperBinaryPath(env);
+  if (helperRes.binaryPath === null) {
+    stdout(
+      JSON.stringify(
+        {
+          capturing: false,
+          axAvailable: false,
+          ocrAvailable: false,
+          helperHint: helperRes.hint,
+          note: "no live snapshot: native capture helper unavailable",
+        },
+        null,
+        2,
+      ),
+    );
+    return 0;
+  }
+  const helper = new NativeHelper(helperRes.binaryPath);
+  const processor = new CaptureProcessor(config);
+  const decision = await captureViaHelper(helper, processor, config, new Date().toISOString());
+  if (decision.action === "denied") {
+    stdout(JSON.stringify({ action: "denied", rule: decision.rule }, null, 2));
+  } else if (decision.action === "skipped") {
+    stdout(JSON.stringify({ action: "skipped", reason: decision.reason }, null, 2));
+  } else {
+    const snap = decision.snapshot;
+    stdout(
+      JSON.stringify(
+        {
+          action: "would-store",
+          app: snap.app,
+          windowTitle: snap.windowTitle,
+          textSource: snap.textSource,
+          textPreview: snap.text.slice(0, 200),
+          contentHash: snap.contentHash,
+          simhash: snap.simhash,
+          denyRule: null,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+  return 0;
+}
+
+function usage(stdout: (l: string) => void): number {
+  stdout(
+    [
+      `remnic-capture-screen v${CAPTURE_SCREEN_VERSION}`,
+      "usage: remnic-capture-screen <command> [flags]",
+      "commands: init | start | stop | status | install-service | logs | test-snapshot",
+      "start flags: --foreground --replay <dir> --host <h> --port <n> --listen <host:port> --spool <path> --base-dir <dir>",
+      `token: set ${CAPTURE_TOKEN_ENV} (never --auth-token)`,
+    ].join("\n"),
+  );
+  return 0;
+}
+
+export async function runCapture(io: CliIo): Promise<number> {
+  const env = io.env ?? process.env;
+  const stdout = io.stdout ?? ((line: string) => console.log(line));
+  const stderr = io.stderr ?? ((line: string) => console.error(line));
+  try {
+    const parsed = parseArgs(io.argv);
+    const paths = resolvePaths(parsed.flags, env);
+    if (parsed.flags.help === true || parsed.positionals.includes("-h") || parsed.positionals.includes("--help")) {
+      return usage(stdout);
+    }
+    if (parsed.positionals.length > 0) {
+      stderr(`unexpected argument(s): ${parsed.positionals.join(" ")}`);
+      usage(stderr);
+      return 2;
+    }
+    const allowedFlags = COMMAND_FLAGS[parsed.command];
+    if (allowedFlags !== undefined) {
+      for (const key of Object.keys(parsed.flags)) {
+        if (!Object.hasOwn(GLOBAL_FLAGS, key) && !Object.hasOwn(allowedFlags, key)) {
+          stderr(`flag --${key} is not valid for command '${parsed.command}'`);
+          usage(stderr);
+          return 2;
+        }
+      }
+    }
+    switch (parsed.command) {
+      case "init":
+        return cmdInit(paths, parsed.flags, stdout);
+      case "start":
+        return await cmdStart(paths, parsed.flags, env, stdout, stderr);
+      case "stop":
+        return await cmdStop(paths, parsed.flags, env, stdout, stderr);
+      case "status":
+        return await cmdStatus(paths, env, stdout, stderr);
+      case "install-service":
+        return cmdInstallService(stdout);
+      case "logs":
+        return cmdLogs(paths, parsed.flags, stdout);
+      case "test-snapshot":
+        return await cmdTestSnapshot(paths, env, stdout, stderr);
+      case "help":
+      case "--help":
+      case "-h":
+        return usage(stdout);
+      default:
+        stderr(`unknown command '${parsed.command}'`);
+        usage(stderr);
+        return 2;
+    }
+  } catch (err) {
+    if (err instanceof CaptureConfigError || err instanceof CaptureInputError) {
+      stderr(`error: ${err.message}`);
+      return err instanceof CaptureInputError ? 2 : 1;
+    }
+    stderr(`error: ${sanitizeError(err)}`);
+    return 1;
+  }
+}

--- a/packages/capture-screen/src/cli.ts
+++ b/packages/capture-screen/src/cli.ts
@@ -15,8 +15,9 @@
  */
 
 import { spawn } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
 import { setTimeout as delay } from "node:timers/promises";
+import { dirname } from "node:path";
 
 import { CaptureProcessor } from "./capture.js";
 import { coerceNumber } from "./coerce.js";
@@ -59,6 +60,8 @@ interface ParsedArgs {
 }
 
 const CAPTURE_TOKEN_ENV = "REMNIC_CAPTURE_TOKEN";
+/** Legacy alias honored across Remnic (formerly Engram); see README auth note. */
+const LEGACY_CAPTURE_TOKEN_ENV = "ENGRAM_CAPTURE_TOKEN";
 
 /** Flags that consume the next argv token as their value. */
 const VALUE_FLAGS: Record<string, true> = {
@@ -167,8 +170,8 @@ function recordHealthUrl(record: PidRecord, paths: CapturePaths, stderr: (l: str
 }
 
 /** Token for probes/serving: env override first, then the on-disk token file. */
-function resolveToken(paths: CapturePaths, env: NodeJS.ProcessEnv, create: boolean): string {
-  const fromEnv = env[CAPTURE_TOKEN_ENV]?.trim();
+export function resolveToken(paths: CapturePaths, env: NodeJS.ProcessEnv, create: boolean): string {
+  const fromEnv = (env[CAPTURE_TOKEN_ENV] ?? env[LEGACY_CAPTURE_TOKEN_ENV])?.trim();
   if (fromEnv) return fromEnv;
   if (create) return loadOrCreateToken(paths.tokenPath);
   if (existsSync(paths.tokenPath)) return readFileSync(paths.tokenPath, "utf8").trim();
@@ -180,7 +183,16 @@ function tokenHeader(paths: CapturePaths, env: NodeJS.ProcessEnv): Record<string
   return token ? { authorization: `Bearer ${token}` } : {};
 }
 
-function ensurePrivateDir(dir: string): void {
+export function ensurePrivateDir(dir: string): void {
+  let isLink = false;
+  try {
+    isLink = lstatSync(dir).isSymbolicLink();
+  } catch {
+    // not present yet — mkdir below creates it
+  }
+  if (isLink) {
+    throw new CaptureInputError(`refusing to use symlinked private directory '${dir}'`);
+  }
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   try {
     chmodSync(dir, 0o700);
@@ -371,6 +383,10 @@ async function cmdStart(
   const token = resolveToken(paths, env, true);
   const helperRes = await resolveHelperBinaryPath(env);
   const axAvailable = helperRes.binaryPath !== null;
+  // A custom --spool may live outside base-dir; ensure its parent exists and is
+  // owner-only (0700, non-symlink) before opening, matching the README spool
+  // safety contract. Idempotent when the spool is the default in-base path.
+  ensurePrivateDir(dirname(paths.spoolPath));
   const spool = new Spool(paths.spoolPath);
   // Retention janitor: prune expired rows once on start so a long-idle spool is
   // trimmed even if the (native) capture loop never runs on this platform.

--- a/packages/capture-screen/src/cli.ts
+++ b/packages/capture-screen/src/cli.ts
@@ -41,6 +41,7 @@ import { CaptureConfigError, CaptureInputError } from "./errors.js";
 import { NativeHelper, resolveHelperBinaryPath } from "./helper.js";
 import { captureViaHelper } from "./live.js";
 import { capturePaths, captureBaseDir, expandTilde, type CapturePaths } from "./paths.js";
+import { CaptureScheduler } from "./scheduler.js";
 import { ingestReplayDirResponsive } from "./replay.js";
 import { Spool } from "./spool.js";
 import { loadOrCreateToken } from "./token.js";
@@ -198,6 +199,35 @@ export function ensurePrivateDir(dir: string): void {
     chmodSync(dir, 0o700);
   } catch {
     // filesystem without POSIX perms
+  }
+}
+
+/**
+ * Prepare a custom --spool parent WITHOUT clobbering an existing directory's
+ * mode. Absent → create a dedicated 0700 dir. Present → refuse a symlink or a
+ * non-owner-only dir, but never chmod it, so `--spool ./x.sqlite` can't tighten
+ * the caller's cwd. The daemon's own base-dir is handled by ensurePrivateDir.
+ */
+export function ensureSpoolParentDir(spoolPath: string): void {
+  const dir = dirname(spoolPath);
+  let stat: ReturnType<typeof lstatSync>;
+  try {
+    stat = lstatSync(dir);
+  } catch {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    return;
+  }
+  if (stat.isSymbolicLink()) {
+    throw new CaptureInputError(`refusing to open the capture spool under symlinked directory '${dir}'`);
+  }
+  if (!stat.isDirectory()) {
+    throw new CaptureInputError(`capture spool parent '${dir}' exists but is not a directory`);
+  }
+  if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) {
+    throw new CaptureInputError(
+      `capture spool directory '${dir}' is not owner-only (mode ${(stat.mode & 0o777).toString(8)}); ` +
+        "point --spool at a private 0700 directory (the daemon creates one when absent)",
+    );
   }
 }
 
@@ -383,10 +413,10 @@ async function cmdStart(
   const token = resolveToken(paths, env, true);
   const helperRes = await resolveHelperBinaryPath(env);
   const axAvailable = helperRes.binaryPath !== null;
-  // A custom --spool may live outside base-dir; ensure its parent exists and is
-  // owner-only (0700, non-symlink) before opening, matching the README spool
-  // safety contract. Idempotent when the spool is the default in-base path.
-  ensurePrivateDir(dirname(paths.spoolPath));
+  // A custom --spool may live outside base-dir; prepare its parent (create 0700
+  // if absent; refuse a symlinked or non-owner-only existing dir) without ever
+  // chmod-ing an existing directory.
+  ensureSpoolParentDir(paths.spoolPath);
   const spool = new Spool(paths.spoolPath);
   // Retention janitor: prune expired rows once on start so a long-idle spool is
   // trimmed even if the (native) capture loop never runs on this platform.
@@ -397,7 +427,7 @@ async function cmdStart(
       spool,
       config,
       token,
-      capturing: false,
+      capturing: axAvailable,
       axAvailable,
       ocrAvailable: axAvailable,
       helperHint: helperRes.hint,
@@ -424,11 +454,27 @@ async function cmdStart(
     ? superviseReplay(spool, replayDir, config, { stdout, stderr }, replayAbort.signal)
     : Promise.resolve();
 
+  // Live capture loop (#1899 Part 1): when the native helper is available, poll
+  // the frontmost window and store on change/settle/idle through the same
+  // pipeline as replay. On Linux (no helper) the daemon serves + replays only.
+  let scheduler: CaptureScheduler | null = null;
+  if (helperRes.binaryPath !== null) {
+    const processor = new CaptureProcessor(config);
+    for (const fp of spool.latestFingerprints()) {
+      processor.seed(fp.app, fp.windowTitle, fp.simhash, fp.capturedAtUtc);
+    }
+    scheduler = new CaptureScheduler(new NativeHelper(helperRes.binaryPath), processor, spool, config, {
+      onError: (err) => stderr(`capture loop error: ${sanitizeError(err)}`),
+    });
+    scheduler.start();
+  }
+
   return await new Promise<number>((resolve) => {
     let closing = false;
     const shutdown = () => {
       if (closing) return;
       closing = true;
+      scheduler?.stop();
       // Cancel any in-flight replay and drain it before closing the spool so no
       // ingestion write can ever hit a closed database.
       replayAbort.abort();

--- a/packages/capture-screen/src/cli.ts
+++ b/packages/capture-screen/src/cli.ts
@@ -474,12 +474,12 @@ async function cmdStart(
     const shutdown = () => {
       if (closing) return;
       closing = true;
-      scheduler?.stop();
-      // Cancel any in-flight replay and drain it before closing the spool so no
-      // ingestion write can ever hit a closed database.
+      // Stop the capture loop and cancel replay, then drain BOTH before closing
+      // the spool so no capture/ingestion write can ever hit a closed database.
       replayAbort.abort();
-      void replayTask
+      void Promise.resolve(scheduler?.stop())
         .catch(() => undefined)
+        .then(() => replayTask.catch(() => undefined))
         .then(() => handle.close().catch(() => undefined))
         .finally(() => {
           spool.close();

--- a/packages/capture-screen/src/coerce.ts
+++ b/packages/capture-screen/src/coerce.ts
@@ -1,0 +1,70 @@
+/**
+ * Config-layer coercion. Every helper THROWS on an unrecognized value (never
+ * silently defaults); callers apply defaults only when a field is absent.
+ * Boolean-ish strings coerce per the shared connector convention:
+ * true/1/yes/on and false/0/no/off.
+ */
+
+import { CaptureConfigError } from "./errors.js";
+import { describeValue } from "./util.js";
+
+const BOOL_TOKENS: Record<string, boolean> = {
+  true: true,
+  "1": true,
+  yes: true,
+  on: true,
+  false: false,
+  "0": false,
+  no: false,
+  off: false,
+};
+
+export function coerceBool(value: unknown, label: string): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number" && (value === 0 || value === 1)) return value === 1;
+  if (typeof value === "string") {
+    const token = value.trim().toLowerCase();
+    if (Object.hasOwn(BOOL_TOKENS, token)) return BOOL_TOKENS[token];
+  }
+  throw new CaptureConfigError(
+    `${label}: expected a boolean (true/false/1/0/yes/no/on/off), got ${describeValue(value)}`,
+  );
+}
+
+export interface NumberBounds {
+  min?: number;
+  max?: number;
+  integer?: boolean;
+}
+
+export function coerceNumber(value: unknown, label: string, bounds: NumberBounds = {}): number {
+  let n: number;
+  if (typeof value === "number") {
+    n = value;
+  } else if (typeof value === "string" && value.trim() !== "") {
+    n = Number(value);
+  } else {
+    throw new CaptureConfigError(`${label}: expected a number, got ${describeValue(value)}`);
+  }
+  if (!Number.isFinite(n)) {
+    throw new CaptureConfigError(`${label}: '${String(value)}' is not a finite number`);
+  }
+  if (bounds.integer && !Number.isInteger(n)) {
+    throw new CaptureConfigError(`${label}: expected an integer, got ${n}`);
+  }
+  if (bounds.min !== undefined && n < bounds.min) {
+    throw new CaptureConfigError(`${label}: must be >= ${bounds.min}, got ${n}`);
+  }
+  if (bounds.max !== undefined && n > bounds.max) {
+    throw new CaptureConfigError(`${label}: must be <= ${bounds.max}, got ${n}`);
+  }
+  return n;
+}
+
+/** Coerce an unknown to a `string[]`, rejecting non-arrays and non-string members. */
+export function coerceStringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw new CaptureConfigError(`${label}: expected an array of strings, got ${describeValue(value)}`);
+  }
+  return [...(value as string[])];
+}

--- a/packages/capture-screen/src/config.test.ts
+++ b/packages/capture-screen/src/config.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { defaultDaemonConfig, parseDaemonConfig, serializeDaemonConfig } from "./config.js";
+import { CaptureConfigError } from "./errors.js";
+
+test("defaults are the documented à-la-carte knobs", () => {
+  const cfg = defaultDaemonConfig();
+  assert.equal(cfg.host, "127.0.0.1");
+  assert.equal(cfg.port, 4341);
+  assert.equal(cfg.spoolRetentionDays, 14);
+  assert.equal(cfg.simhashThreshold, 10);
+  assert.equal(cfg.dedupTtlSeconds, 60);
+  assert.equal(cfg.maxNodes, 4000);
+  assert.deepEqual(cfg.denyApps, []);
+});
+
+test("valid overrides parse; string-boolean-like numbers coerce at the boundary", () => {
+  const cfg = parseDaemonConfig({
+    port: "5000",
+    spoolRetentionDays: 7,
+    simhashThreshold: 4,
+    denyApps: ["Foo*"],
+    terminalApps: ["MyTerm"],
+    redactionPatterns: ["\\bsecret\\b"],
+  });
+  assert.equal(cfg.port, 5000);
+  assert.equal(cfg.spoolRetentionDays, 7);
+  assert.equal(cfg.simhashThreshold, 4);
+  assert.deepEqual(cfg.denyApps, ["Foo*"]);
+  assert.deepEqual(cfg.terminalApps, ["MyTerm"]);
+});
+
+test("invalid values throw loudly (no silent defaulting)", () => {
+  assert.throws(() => parseDaemonConfig({ port: 0 }), CaptureConfigError);
+  assert.throws(() => parseDaemonConfig({ port: 70000 }), CaptureConfigError);
+  assert.throws(() => parseDaemonConfig({ simhashThreshold: 65 }), CaptureConfigError);
+  assert.throws(() => parseDaemonConfig({ denyApps: "nope" }), CaptureConfigError);
+  assert.throws(() => parseDaemonConfig({ denyApps: [1, 2] }), CaptureConfigError);
+  assert.throws(() => parseDaemonConfig("not an object"), CaptureConfigError);
+});
+
+test("serialize round-trips through parse", () => {
+  const cfg = parseDaemonConfig({ port: 5001, denyTitles: ["*secret*"] });
+  const reparsed = parseDaemonConfig(JSON.parse(serializeDaemonConfig(cfg)));
+  assert.deepEqual(reparsed, cfg);
+});

--- a/packages/capture-screen/src/config.ts
+++ b/packages/capture-screen/src/config.ts
@@ -1,0 +1,154 @@
+/**
+ * Daemon config (`~/.remnic/capture-screen/screen.json`), created by
+ * `remnic-capture-screen init`. Strict and loud: an absent field takes the
+ * documented default, but a present-but-invalid value throws CaptureConfigError
+ * (no silent defaulting). Ports are integers in [1, 65535]; string arrays
+ * (deny-lists, terminal-app globs, redaction patterns) reject non-string
+ * members.
+ *
+ * Deny-lists, terminal-app globs, and redaction patterns here are ADDITIVE to
+ * the built-in defaults (see denylist.ts / redact.ts / capture.ts).
+ */
+
+import { readFileSync } from "node:fs";
+
+import { coerceNumber, coerceStringArray } from "./coerce.js";
+import {
+  DEFAULT_DEDUP_TTL_SECONDS,
+  DEFAULT_HOST,
+  DEFAULT_MAX_DWELL_SECONDS,
+  DEFAULT_MAX_NODES,
+  DEFAULT_PORT,
+  DEFAULT_SESSION_GAP_SECONDS,
+  DEFAULT_SIMHASH_THRESHOLD,
+  DEFAULT_SPOOL_RETENTION_DAYS,
+} from "./constants.js";
+import { CaptureConfigError } from "./errors.js";
+import { describeValue } from "./util.js";
+
+export interface DaemonConfig {
+  host: string;
+  port: number;
+  spoolRetentionDays: number;
+  simhashThreshold: number;
+  dedupTtlSeconds: number;
+  sessionGapSeconds: number;
+  maxNodes: number;
+  maxDwellSeconds: number;
+  /** Additive deny-list globs (checked in addition to the built-in defaults). */
+  denyApps: string[];
+  denyTitles: string[];
+  denyUrls: string[];
+  /** Additive terminal-class app globs (route to OCR). */
+  terminalApps: string[];
+  /** Additive user redaction regex source strings. */
+  redactionPatterns: string[];
+}
+
+export function defaultDaemonConfig(): DaemonConfig {
+  return {
+    host: DEFAULT_HOST,
+    port: DEFAULT_PORT,
+    spoolRetentionDays: DEFAULT_SPOOL_RETENTION_DAYS,
+    simhashThreshold: DEFAULT_SIMHASH_THRESHOLD,
+    dedupTtlSeconds: DEFAULT_DEDUP_TTL_SECONDS,
+    sessionGapSeconds: DEFAULT_SESSION_GAP_SECONDS,
+    maxNodes: DEFAULT_MAX_NODES,
+    maxDwellSeconds: DEFAULT_MAX_DWELL_SECONDS,
+    denyApps: [],
+    denyTitles: [],
+    denyUrls: [],
+    terminalApps: [],
+    redactionPatterns: [],
+  };
+}
+
+const KNOWN_TOP_KEYS: Record<string, true> = {
+  host: true,
+  port: true,
+  spoolRetentionDays: true,
+  simhashThreshold: true,
+  dedupTtlSeconds: true,
+  sessionGapSeconds: true,
+  maxNodes: true,
+  maxDwellSeconds: true,
+  denyApps: true,
+  denyTitles: true,
+  denyUrls: true,
+  terminalApps: true,
+  redactionPatterns: true,
+};
+
+function asObject(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new CaptureConfigError(`${label}: expected an object, got ${describeValue(value)}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new CaptureConfigError(`${label}: expected a non-empty string, got ${describeValue(value)}`);
+  }
+  return value.trim();
+}
+
+export function parseDaemonConfig(raw: unknown): DaemonConfig {
+  const cfg = defaultDaemonConfig();
+  const obj = asObject(raw, "config");
+  for (const key of Object.keys(obj)) {
+    if (!Object.hasOwn(KNOWN_TOP_KEYS, key)) {
+      console.warn(`remnic-capture-screen: config: ignoring unknown key '${key}'`);
+    }
+  }
+
+  if (obj.host !== undefined) cfg.host = requireString(obj.host, "host");
+  if (obj.port !== undefined) cfg.port = coerceNumber(obj.port, "port", { integer: true, min: 1, max: 65535 });
+  if (obj.spoolRetentionDays !== undefined) {
+    cfg.spoolRetentionDays = coerceNumber(obj.spoolRetentionDays, "spoolRetentionDays", { integer: true, min: 1 });
+  }
+  if (obj.simhashThreshold !== undefined) {
+    cfg.simhashThreshold = coerceNumber(obj.simhashThreshold, "simhashThreshold", { integer: true, min: 0, max: 64 });
+  }
+  if (obj.dedupTtlSeconds !== undefined) {
+    cfg.dedupTtlSeconds = coerceNumber(obj.dedupTtlSeconds, "dedupTtlSeconds", { min: 0 });
+  }
+  if (obj.sessionGapSeconds !== undefined) {
+    cfg.sessionGapSeconds = coerceNumber(obj.sessionGapSeconds, "sessionGapSeconds", { min: 0 });
+  }
+  if (obj.maxNodes !== undefined) {
+    cfg.maxNodes = coerceNumber(obj.maxNodes, "maxNodes", { integer: true, min: 1 });
+  }
+  if (obj.maxDwellSeconds !== undefined) {
+    cfg.maxDwellSeconds = coerceNumber(obj.maxDwellSeconds, "maxDwellSeconds", { min: 1 });
+  }
+  if (obj.denyApps !== undefined) cfg.denyApps = coerceStringArray(obj.denyApps, "denyApps");
+  if (obj.denyTitles !== undefined) cfg.denyTitles = coerceStringArray(obj.denyTitles, "denyTitles");
+  if (obj.denyUrls !== undefined) cfg.denyUrls = coerceStringArray(obj.denyUrls, "denyUrls");
+  if (obj.terminalApps !== undefined) cfg.terminalApps = coerceStringArray(obj.terminalApps, "terminalApps");
+  if (obj.redactionPatterns !== undefined) {
+    cfg.redactionPatterns = coerceStringArray(obj.redactionPatterns, "redactionPatterns");
+  }
+
+  return cfg;
+}
+
+export function loadDaemonConfig(configPath: string): DaemonConfig {
+  let text: string;
+  try {
+    text = readFileSync(configPath, "utf8");
+  } catch {
+    throw new CaptureConfigError(`config not found at ${configPath} — run \`remnic-capture-screen init\` first`);
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    throw new CaptureConfigError(`config at ${configPath} is not valid JSON: ${(err as Error).message}`);
+  }
+  return parseDaemonConfig(raw);
+}
+
+export function serializeDaemonConfig(cfg: DaemonConfig): string {
+  return `${JSON.stringify(cfg, null, 2)}\n`;
+}

--- a/packages/capture-screen/src/config.ts
+++ b/packages/capture-screen/src/config.ts
@@ -14,6 +14,9 @@ import { readFileSync } from "node:fs";
 
 import { coerceNumber, coerceStringArray } from "./coerce.js";
 import {
+  DEFAULT_IDLE_FALLBACK_SECONDS,
+  DEFAULT_POLL_INTERVAL_MS,
+  DEFAULT_SETTLE_MS,
   DEFAULT_DEDUP_TTL_SECONDS,
   DEFAULT_HOST,
   DEFAULT_MAX_DWELL_SECONDS,
@@ -35,6 +38,12 @@ export interface DaemonConfig {
   sessionGapSeconds: number;
   maxNodes: number;
   maxDwellSeconds: number;
+  /** Live capture loop: poll interval (ms) for foreground-change detection. */
+  pollIntervalMs: number;
+  /** Live capture loop: settle window (ms) after a foreground change. */
+  settleMs: number;
+  /** Live capture loop: idle re-sample cadence (seconds). */
+  idleFallbackSeconds: number;
   /** Additive deny-list globs (checked in addition to the built-in defaults). */
   denyApps: string[];
   denyTitles: string[];
@@ -55,6 +64,9 @@ export function defaultDaemonConfig(): DaemonConfig {
     sessionGapSeconds: DEFAULT_SESSION_GAP_SECONDS,
     maxNodes: DEFAULT_MAX_NODES,
     maxDwellSeconds: DEFAULT_MAX_DWELL_SECONDS,
+    pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+    settleMs: DEFAULT_SETTLE_MS,
+    idleFallbackSeconds: DEFAULT_IDLE_FALLBACK_SECONDS,
     denyApps: [],
     denyTitles: [],
     denyUrls: [],
@@ -72,6 +84,9 @@ const KNOWN_TOP_KEYS: Record<string, true> = {
   sessionGapSeconds: true,
   maxNodes: true,
   maxDwellSeconds: true,
+  pollIntervalMs: true,
+  settleMs: true,
+  idleFallbackSeconds: true,
   denyApps: true,
   denyTitles: true,
   denyUrls: true,
@@ -121,6 +136,15 @@ export function parseDaemonConfig(raw: unknown): DaemonConfig {
   }
   if (obj.maxDwellSeconds !== undefined) {
     cfg.maxDwellSeconds = coerceNumber(obj.maxDwellSeconds, "maxDwellSeconds", { min: 1 });
+  }
+  if (obj.pollIntervalMs !== undefined) {
+    cfg.pollIntervalMs = coerceNumber(obj.pollIntervalMs, "pollIntervalMs", { integer: true, min: 100 });
+  }
+  if (obj.settleMs !== undefined) {
+    cfg.settleMs = coerceNumber(obj.settleMs, "settleMs", { integer: true, min: 0 });
+  }
+  if (obj.idleFallbackSeconds !== undefined) {
+    cfg.idleFallbackSeconds = coerceNumber(obj.idleFallbackSeconds, "idleFallbackSeconds", { min: 1 });
   }
   if (obj.denyApps !== undefined) cfg.denyApps = coerceStringArray(obj.denyApps, "denyApps");
   if (obj.denyTitles !== undefined) cfg.denyTitles = coerceStringArray(obj.denyTitles, "denyTitles");

--- a/packages/capture-screen/src/constants.ts
+++ b/packages/capture-screen/src/constants.ts
@@ -1,0 +1,31 @@
+/** Package-wide constants for @remnic/capture-screen. */
+
+/**
+ * Reported by GET /v1/health. Kept in sync with package.json by the release
+ * tooling; the health endpoint tolerates drift because the connector never
+ * gates on an exact match (it reads `ok`).
+ */
+export const CAPTURE_SCREEN_VERSION = "9.14.0";
+
+/** Loopback default; capture is local-first (charter). */
+export const DEFAULT_HOST = "127.0.0.1";
+export const DEFAULT_PORT = 4341;
+
+/** Spool schema version, persisted in the `meta` table. */
+export const SPOOL_SCHEMA_VERSION = 1;
+
+/** Upper bound for the snapshots `limit` query parameter. */
+export const MAX_SNAPSHOTS_LIMIT = 500;
+/** Default page size when `limit` is omitted. */
+export const DEFAULT_SNAPSHOTS_LIMIT = 100;
+
+/** Default capture-time processing knobs (all overridable in config). */
+export const DEFAULT_SPOOL_RETENTION_DAYS = 14;
+export const DEFAULT_SIMHASH_THRESHOLD = 10;
+export const DEFAULT_DEDUP_TTL_SECONDS = 60;
+/** Two snapshots of the same window within this gap belong to one session. */
+export const DEFAULT_SESSION_GAP_SECONDS = 300;
+/** AX-tree traversal cap (nodes) — bounds pathological accessibility trees. */
+export const DEFAULT_MAX_NODES = 4000;
+/** Per-snapshot dwell cap for /v1/stats time attribution. */
+export const DEFAULT_MAX_DWELL_SECONDS = 300;

--- a/packages/capture-screen/src/constants.ts
+++ b/packages/capture-screen/src/constants.ts
@@ -29,3 +29,10 @@ export const DEFAULT_SESSION_GAP_SECONDS = 300;
 export const DEFAULT_MAX_NODES = 4000;
 /** Per-snapshot dwell cap for /v1/stats time attribution. */
 export const DEFAULT_MAX_DWELL_SECONDS = 300;
+/** Live capture loop cadence (#1899 Part 1; all overridable in config). */
+/** How often the loop polls the frontmost AX snapshot for a change. */
+export const DEFAULT_POLL_INTERVAL_MS = 1000;
+/** Foreground must be stable this long after a change before a snapshot is stored. */
+export const DEFAULT_SETTLE_MS = 500;
+/** Re-sample an unchanging foreground at least this often (dedup drops repeats). */
+export const DEFAULT_IDLE_FALLBACK_SECONDS = 30;

--- a/packages/capture-screen/src/control.ts
+++ b/packages/capture-screen/src/control.ts
@@ -1,0 +1,109 @@
+/**
+ * Daemon process control: an atomic, identity-bearing pid file plus liveness
+ * probing.
+ *
+ * The pid file is JSON `{ pid, instanceId, startedAtIso, host, port }` written
+ * via a temp-file + rename so a reader never sees a partial write, and reads
+ * are tolerant of a concurrent delete. `instanceId` (the spool instance id)
+ * lets `stop`/`status` confirm — over the authenticated health endpoint — that
+ * the recorded pid really is our daemon before signalling it, which guards
+ * against PID reuse. Removal is owner-checked so a late shutdown can't delete a
+ * newer daemon's control file.
+ */
+
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import path from "node:path";
+
+export interface PidRecord {
+  pid: number;
+  /** Daemon instance id (spool instance_id) for cross-process identity; null when unknown. */
+  instanceId: string | null;
+  /** ISO timestamp the record was written. */
+  startedAtIso: string;
+  /** Effective bound host, when known (so status/stop reach the daemon the CLI actually started). */
+  host: string | null;
+  /** Effective bound port, when known. */
+  port: number | null;
+}
+
+export interface PidWriteOptions {
+  instanceId?: string | null;
+  startedAtIso?: string;
+  host?: string | null;
+  port?: number | null;
+}
+
+/** Atomically write the pid record (temp file + rename) — no partial reads. */
+export function writePidFile(pidPath: string, pid: number, options: PidWriteOptions = {}): void {
+  mkdirSync(path.dirname(pidPath), { recursive: true });
+  const record: PidRecord = {
+    pid,
+    instanceId: options.instanceId ?? null,
+    startedAtIso: options.startedAtIso ?? new Date().toISOString(),
+    host: options.host ?? null,
+    port: options.port ?? null,
+  };
+  const tmp = `${pidPath}.${process.pid}.${randomBytes(4).toString("hex")}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(record)}\n`, "utf8");
+  renameSync(tmp, pidPath);
+}
+
+/** Read the pid record; a missing file or a partial/concurrent write returns null. */
+export function readPidRecord(pidPath: string): PidRecord | null {
+  let text: string;
+  try {
+    text = readFileSync(pidPath, "utf8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const record = parsed as Record<string, unknown>;
+  const pid = typeof record.pid === "number" ? record.pid : Number.NaN;
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  const port =
+    typeof record.port === "number" && Number.isInteger(record.port) && record.port > 0 ? record.port : null;
+  return {
+    pid,
+    instanceId: typeof record.instanceId === "string" ? record.instanceId : null,
+    startedAtIso: typeof record.startedAtIso === "string" ? record.startedAtIso : "",
+    host: typeof record.host === "string" && record.host !== "" ? record.host : null,
+    port,
+  };
+}
+
+/** Convenience accessor: the recorded pid, or null. */
+export function readPidFile(pidPath: string): number | null {
+  return readPidRecord(pidPath)?.pid ?? null;
+}
+
+/** Liveness via signal 0. ESRCH → gone; EPERM → alive but owned by another user. */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/** Remove the pid file unconditionally (stale reclaim). */
+export function removePidFile(pidPath: string): void {
+  rmSync(pidPath, { force: true });
+}
+
+/**
+ * Remove the pid file only when it still records `pid`. Prevents a late
+ * shutdown or `stop` from deleting a NEWER daemon's control file after a
+ * restart or PID reuse.
+ */
+export function removePidFileIfOwner(pidPath: string, pid: number): void {
+  const record = readPidRecord(pidPath);
+  if (record && record.pid === pid) rmSync(pidPath, { force: true });
+}

--- a/packages/capture-screen/src/daemon.test.ts
+++ b/packages/capture-screen/src/daemon.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+
+import { contentHash } from "./capture.js";
+import { defaultDaemonConfig } from "./config.js";
+import { CaptureConfigError } from "./errors.js";
+import { simhash, simhashToHex } from "./simhash.js";
+import { startDaemon, type DaemonHandle } from "./daemon.js";
+import { Spool, type SnapshotInput } from "./spool.js";
+import { formatHostForUrl } from "./util.js";
+
+const TOKEN = "loopback-token";
+const open: DaemonHandle[] = [];
+const spools: Spool[] = [];
+after(async () => {
+  for (const h of open) await h.close();
+  for (const s of spools) s.close();
+});
+
+function snap(over: Partial<SnapshotInput> & { capturedAtUtc: string }): SnapshotInput {
+  const base = { app: "Editor", windowTitle: "a.ts", browserUrl: null as string | null, text: "code", textSource: "ax" as const, ...over };
+  return { ...base, contentHash: contentHash(base), simhash: simhashToHex(simhash(base.text)) };
+}
+
+function seededSpool(): Spool {
+  const spool = new Spool(":memory:");
+  spools.push(spool);
+  spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T09:00:00.000Z", app: "Safari", text: "one" }), 300);
+  spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z", app: "Safari", text: "two" }), 300);
+  spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T11:00:00.000Z", app: "Editor", text: "three" }), 300);
+  return spool;
+}
+
+async function startLoopback(axAvailable = false): Promise<DaemonHandle> {
+  const config = { ...defaultDaemonConfig(), host: "127.0.0.1", port: 0 };
+  const handle = await startDaemon({ spool: seededSpool(), config, token: TOKEN, axAvailable, ocrAvailable: axAvailable, helperHint: axAvailable ? null : "install helper" });
+  open.push(handle);
+  return handle;
+}
+
+function authFetch(url: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(url, { ...init, headers: { authorization: `Bearer ${TOKEN}`, ...(init.headers ?? {}) } });
+}
+
+test("GET /v1/health returns the rich health shape", async () => {
+  const h = await startLoopback(false);
+  const res = await authFetch(`${h.url}/v1/health`);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Record<string, unknown>;
+  assert.equal(body.ok, true);
+  assert.equal(body.capturing, false);
+  assert.equal(body.axAvailable, false);
+  assert.equal(body.ocrAvailable, false);
+  assert.equal(typeof body.version, "string");
+  assert.equal(typeof body.platform, "string");
+  assert.equal(body.pendingCount, 3);
+  assert.equal(typeof body.instanceId, "string");
+  assert.equal(body.helperHint, "install helper");
+});
+
+test("GET /v1/snapshots serves a keyset-paged local day", async () => {
+  const h = await startLoopback();
+  const res = await authFetch(`${h.url}/v1/snapshots?date=2026-07-20&timezone=UTC&limit=2`);
+  assert.equal(res.status, 200);
+  const page = (await res.json()) as { snapshots: Array<Record<string, unknown>>; nextCursor: string | null };
+  assert.deepEqual(page.snapshots.map((s) => s.text), ["one", "two"]);
+  assert.ok(page.nextCursor);
+  // Wire shape: app/windowTitle/text/textSource/contentHash present, no null browserUrl key.
+  assert.equal(page.snapshots[0].textSource, "ax");
+  assert.equal(typeof page.snapshots[0].contentHash, "string");
+  assert.ok(!("browserUrl" in page.snapshots[0]), "null browserUrl omitted from the wire");
+
+  const res2 = await authFetch(
+    `${h.url}/v1/snapshots?date=2026-07-20&timezone=UTC&limit=2&cursor=${encodeURIComponent(page.nextCursor as string)}`,
+  );
+  const page2 = (await res2.json()) as { snapshots: Array<{ text: string }>; nextCursor: string | null };
+  assert.deepEqual(page2.snapshots.map((s) => s.text), ["three"]);
+  assert.equal(page2.nextCursor, null);
+});
+
+test("GET /v1/stats attributes per-app time for the day", async () => {
+  const h = await startLoopback();
+  const res = await authFetch(`${h.url}/v1/stats?date=2026-07-20&timezone=UTC`);
+  assert.equal(res.status, 200);
+  const stats = (await res.json()) as { snapshotCount: number; apps: Array<{ app: string; seconds: number }> };
+  assert.equal(stats.snapshotCount, 3);
+  const safari = stats.apps.find((a) => a.app === "Safari");
+  assert.ok(safari && safari.seconds > 0, "Safari accrues dwell across its two snapshots");
+});
+
+test("invalid date/timezone/limit/cursor each return 400", async () => {
+  const h = await startLoopback();
+  const bad = [
+    "/v1/snapshots?timezone=UTC",
+    "/v1/snapshots?date=2026-13-40&timezone=UTC",
+    "/v1/snapshots?date=2026-07-20",
+    "/v1/snapshots?date=2026-07-20&timezone=Not/AZone",
+    "/v1/snapshots?date=2026-07-20&timezone=UTC&limit=0",
+    "/v1/snapshots?date=2026-07-20&timezone=UTC&cursor=%21%21%21bad",
+    "/v1/stats?date=2026-07-20",
+  ];
+  for (const p of bad) {
+    const res = await authFetch(`${h.url}${p}`);
+    assert.equal(res.status, 400, `expected 400 for ${p}, got ${res.status}`);
+  }
+});
+
+test("unknown route 404; authed non-GET 405; unauth 401 (authorize first)", async () => {
+  const h = await startLoopback();
+  assert.equal((await authFetch(`${h.url}/v1/nope`)).status, 404);
+  assert.equal((await authFetch(`${h.url}/v1/health`, { method: "POST" })).status, 405);
+  assert.equal((await fetch(`${h.url}/v1/health`, { method: "POST" })).status, 401);
+});
+
+test("every request requires a valid bearer token (loopback included)", async () => {
+  const h = await startLoopback();
+  assert.equal((await fetch(`${h.url}/v1/health`)).status, 401);
+  assert.equal((await fetch(`${h.url}/v1/health`, { headers: { authorization: "Bearer wrong" } })).status, 401);
+  assert.equal((await authFetch(`${h.url}/v1/health`)).status, 200);
+});
+
+test("startDaemon refuses a non-loopback host and an empty token", async () => {
+  await assert.rejects(
+    startDaemon({ spool: seededSpool(), config: { ...defaultDaemonConfig(), host: "0.0.0.0", port: 0 }, token: TOKEN }),
+    CaptureConfigError,
+  );
+  await assert.rejects(
+    startDaemon({ spool: seededSpool(), config: { ...defaultDaemonConfig(), host: "127.0.0.1", port: 0 }, token: "" }),
+    CaptureConfigError,
+  );
+});
+
+test("formatHostForUrl brackets IPv6 hosts only", () => {
+  assert.equal(formatHostForUrl("127.0.0.1"), "127.0.0.1");
+  assert.equal(formatHostForUrl("::1"), "[::1]");
+});

--- a/packages/capture-screen/src/daemon.ts
+++ b/packages/capture-screen/src/daemon.ts
@@ -1,0 +1,186 @@
+/**
+ * Loopback-only HTTP daemon. Serves the spool over three read-only routes:
+ *
+ *   GET /v1/health     → liveness + capture status + AX/OCR availability
+ *   GET /v1/snapshots  → snapshots for a local day (keyset paged; wire shape
+ *                        consumed by @remnic/core's ActivityHttpSourceClient)
+ *   GET /v1/stats      → per-app time attribution for a local day
+ *
+ * Security: capture-screen serves PLAIN HTTP and has no TLS contract, so it
+ * refuses to bind a non-loopback host — captured screen text must never cross
+ * the network in cleartext. Every request MUST carry `Authorization: Bearer
+ * <token>` matching the daemon token, even on loopback, so another local user
+ * cannot read snapshots off 127.0.0.1. Input errors are 400; anything
+ * unexpected is 500 with no foreign text.
+ */
+
+import http from "node:http";
+import { Buffer } from "node:buffer";
+
+import { computeStats } from "./capture.js";
+import { CAPTURE_SCREEN_VERSION } from "./constants.js";
+import { CaptureConfigError, CaptureInputError } from "./errors.js";
+import { bearerFromHeader, tokensMatch } from "./token.js";
+import { formatHostForUrl, isLoopbackHost } from "./util.js";
+import { assertValidTimezone, parseLimit, parseSnapshotDate } from "./validate.js";
+import type { DaemonConfig } from "./config.js";
+import type { DaemonSnapshot, Spool } from "./spool.js";
+
+export interface DaemonDeps {
+  spool: Spool;
+  config: DaemonConfig;
+  token: string;
+  /** Live capture status for /v1/health; false until the capture layer runs. */
+  capturing?: boolean;
+  /** Native-helper capabilities (false when the helper is unavailable). */
+  axAvailable?: boolean;
+  ocrAvailable?: boolean;
+  /** Operator-facing hint surfaced on /v1/health when the helper is missing. */
+  helperHint?: string | null;
+}
+
+export interface DaemonHandle {
+  server: http.Server;
+  host: string;
+  port: number;
+  url: string;
+  close(): Promise<void>;
+}
+
+/** Wire shape consumed by ActivityHttpSourceClient. browserUrl omitted when null. */
+function snapshotToWire(snap: DaemonSnapshot): Record<string, unknown> {
+  const wire: Record<string, unknown> = {
+    capturedAtUtc: snap.capturedAtUtc,
+    app: snap.app,
+    windowTitle: snap.windowTitle,
+    text: snap.text,
+    textSource: snap.textSource,
+    contentHash: snap.contentHash,
+    simhash: snap.simhash,
+  };
+  if (snap.browserUrl !== null) wire.browserUrl = snap.browserUrl;
+  return wire;
+}
+
+function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(payload),
+    "cache-control": "no-store",
+  });
+  res.end(payload);
+}
+
+function handleHealth(deps: DaemonDeps, res: http.ServerResponse): void {
+  const body: Record<string, unknown> = {
+    ok: true,
+    version: CAPTURE_SCREEN_VERSION,
+    platform: process.platform,
+    capturing: deps.capturing ?? false,
+    axAvailable: deps.axAvailable ?? false,
+    ocrAvailable: deps.ocrAvailable ?? false,
+    pendingCount: deps.spool.countSnapshots(),
+    instanceId: deps.spool.meta("instance_id"),
+    replayStatus: deps.spool.meta("replay_status"),
+    pid: process.pid,
+  };
+  if (deps.helperHint) body.helperHint = deps.helperHint;
+  sendJson(res, 200, body);
+}
+
+function handleSnapshots(deps: DaemonDeps, url: URL, res: http.ServerResponse): void {
+  const date = parseSnapshotDate(url.searchParams.get("date"));
+  const timezone = assertValidTimezone(url.searchParams.get("timezone"));
+  const limit = parseLimit(url.searchParams.get("limit"));
+  const cursor = url.searchParams.get("cursor");
+  const page = deps.spool.querySnapshots({ date, timezone, cursor, limit });
+  sendJson(res, 200, { snapshots: page.snapshots.map(snapshotToWire), nextCursor: page.nextCursor });
+}
+
+function handleStats(deps: DaemonDeps, url: URL, res: http.ServerResponse): void {
+  const date = parseSnapshotDate(url.searchParams.get("date"));
+  const timezone = assertValidTimezone(url.searchParams.get("timezone"));
+  const stats = computeStats(deps.spool.daySnapshots(date, timezone), date, timezone, deps.config.maxDwellSeconds);
+  sendJson(res, 200, stats);
+}
+
+export function createRequestHandler(deps: DaemonDeps): http.RequestListener {
+  if (!isLoopbackHost(deps.config.host)) {
+    throw new CaptureConfigError(
+      `refusing to bind non-loopback host '${deps.config.host}': capture-screen serves plain HTTP with no TLS contract; ` +
+        "bind a loopback address (127.0.0.1 or ::1) only",
+    );
+  }
+  if (!deps.token) {
+    throw new CaptureConfigError("daemon requires a bearer token");
+  }
+  return (req, res) => {
+    try {
+      const presented = bearerFromHeader(req.headers["authorization"]);
+      if (!presented || !tokensMatch(deps.token, presented)) {
+        res.setHeader("www-authenticate", "Bearer");
+        sendJson(res, 401, { error: "unauthorized" });
+        return;
+      }
+      if (req.method !== "GET") {
+        sendJson(res, 405, { error: "method not allowed" });
+        return;
+      }
+      const url = new URL(req.url ?? "/", "http://localhost");
+      switch (url.pathname) {
+        case "/v1/health":
+          handleHealth(deps, res);
+          return;
+        case "/v1/snapshots":
+          handleSnapshots(deps, url, res);
+          return;
+        case "/v1/stats":
+          handleStats(deps, url, res);
+          return;
+        default:
+          sendJson(res, 404, { error: "not found" });
+      }
+    } catch (err) {
+      if (err instanceof CaptureInputError) {
+        sendJson(res, 400, { error: err.message });
+        return;
+      }
+      sendJson(res, 500, { error: "internal error" });
+    }
+  };
+}
+
+export function startDaemon(deps: DaemonDeps): Promise<DaemonHandle> {
+  return new Promise((resolve, reject) => {
+    let handler: http.RequestListener;
+    try {
+      handler = createRequestHandler(deps);
+    } catch (err) {
+      reject(err as Error);
+      return;
+    }
+    const server = http.createServer(handler);
+    const onError = (err: Error) => reject(err);
+    server.once("error", onError);
+    server.listen(deps.config.port, deps.config.host, () => {
+      server.removeListener("error", onError);
+      server.on("error", (err: NodeJS.ErrnoException) => {
+        process.stderr.write(`capture-screen daemon server error: ${err.code ?? err.name}\n`);
+      });
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : deps.config.port;
+      const host = deps.config.host;
+      resolve({
+        server,
+        host,
+        port,
+        url: `http://${formatHostForUrl(host)}:${port}`,
+        close: () =>
+          new Promise<void>((res2, rej2) => {
+            server.close((closeErr) => (closeErr ? rej2(closeErr) : res2()));
+          }),
+      });
+    });
+  });
+}

--- a/packages/capture-screen/src/daywindow.test.ts
+++ b/packages/capture-screen/src/daywindow.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { activityDayWindow } from "./daywindow.js";
+import { CaptureInputError } from "./errors.js";
+
+const hours = (a: string, b: string) => (Date.parse(b) - Date.parse(a)) / 3_600_000;
+
+test("a UTC day is a plain [00:00, next 00:00) window", () => {
+  const w = activityDayWindow("2026-07-20", "UTC");
+  assert.equal(w.startUtc, "2026-07-20T00:00:00.000Z");
+  assert.equal(w.endUtc, "2026-07-21T00:00:00.000Z");
+  assert.equal(hours(w.startUtc, w.endUtc), 24);
+});
+
+test("the window is half-open: end equals the next day's start", () => {
+  const day = activityDayWindow("2026-07-20", "America/New_York");
+  const next = activityDayWindow("2026-07-21", "America/New_York");
+  assert.equal(day.endUtc, next.startUtc);
+});
+
+test("spring-forward local day is 23 hours (DST begins)", () => {
+  const w = activityDayWindow("2026-03-08", "America/New_York");
+  assert.equal(w.startUtc, "2026-03-08T05:00:00.000Z");
+  assert.equal(w.endUtc, "2026-03-09T04:00:00.000Z");
+  assert.equal(hours(w.startUtc, w.endUtc), 23);
+});
+
+test("fall-back local day is 25 hours (DST ends)", () => {
+  const w = activityDayWindow("2026-11-01", "America/New_York");
+  assert.equal(w.startUtc, "2026-11-01T04:00:00.000Z");
+  assert.equal(w.endUtc, "2026-11-02T05:00:00.000Z");
+  assert.equal(hours(w.startUtc, w.endUtc), 25);
+});
+
+test("a positive-offset zone shifts the window east of UTC", () => {
+  const w = activityDayWindow("2026-07-20", "Asia/Tokyo");
+  assert.equal(w.startUtc, "2026-07-19T15:00:00.000Z");
+  assert.equal(w.endUtc, "2026-07-20T15:00:00.000Z");
+});
+
+test("invalid date and timezone are rejected", () => {
+  assert.throws(() => activityDayWindow("2026-02-30", "UTC"), CaptureInputError);
+  assert.throws(() => activityDayWindow("2026-07-20", "Not/AZone"), CaptureInputError);
+});

--- a/packages/capture-screen/src/daywindow.ts
+++ b/packages/capture-screen/src/daywindow.ts
@@ -1,0 +1,104 @@
+/**
+ * DST-aware local-day window. Inlined from @remnic/core's activity digest
+ * (capture-screen is à-la-carte and depends on nothing at runtime). Returns the
+ * half-open [startUtc, endUtc) UTC instants bounding a local calendar day in an
+ * IANA timezone, correct across spring-forward (skipped midnight) and fall-back
+ * (repeated midnight) transitions.
+ */
+
+import { CaptureInputError } from "./errors.js";
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidDate(date: string): boolean {
+  if (typeof date !== "string" || !DATE_PATTERN.test(date)) return false;
+  // Reject impossible calendar days (2026-02-30, 2026-13-01): the UTC round-trip
+  // must reproduce the same Y-M-D, else Date normalized an overflow.
+  const parsed = new Date(`${date}T00:00:00Z`);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === date;
+}
+
+function timezoneOffsetIso(instant: Date, timezone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    timeZoneName: "longOffset",
+  }).formatToParts(instant);
+  const name = parts.find((part) => part.type === "timeZoneName")?.value ?? "GMT";
+  const match = name.match(/GMT([+-]\d{2}:\d{2})?/);
+  return match?.[1] ?? "+00:00";
+}
+
+function shiftIsoDate(date: string, days: number): string {
+  const parsed = new Date(`${date}T00:00:00Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+}
+
+/**
+ * First UTC instant whose local wall-clock is `date` at 00:00. Probe several
+ * instants across the day (and the prior UTC day, for zones east of UTC) to
+ * collect every offset in play; keep an offset only if constructing local
+ * midnight with it lands back on that same offset, then take the EARLIEST such
+ * instant — the FIRST 00:00 across a fall-back that repeats local midnight.
+ */
+function zonedDayStartIso(date: string, timezone: string): string {
+  const prevDate = shiftIsoDate(date, -1);
+  const probeOffsets = new Set(
+    [
+      `${prevDate}T12:00:00Z`,
+      `${prevDate}T23:00:00Z`,
+      `${date}T00:00:00Z`,
+      `${date}T12:00:00Z`,
+      `${date}T23:00:00Z`,
+    ].map((iso) => timezoneOffsetIso(new Date(iso), timezone)),
+  );
+  let best: number | null = null;
+  for (const offset of probeOffsets) {
+    const candidate = Date.parse(`${date}T00:00:00${offset}`);
+    if (!Number.isFinite(candidate)) continue;
+    // Reject an offset whose local midnight does not actually occur (spring
+    // forward skipped the wall clock): the offset in effect at the candidate
+    // instant must equal the offset we used to build it.
+    if (timezoneOffsetIso(new Date(candidate), timezone) !== offset) continue;
+    if (best === null || candidate < best) best = candidate;
+  }
+  if (best === null) {
+    // Local midnight was skipped by a spring-forward at 00:00. Advance to the
+    // first local wall-clock minute on this date that actually exists, scanning
+    // forward up to 3h.
+    for (let minute = 1; minute <= 180 && best === null; minute++) {
+      const hh = String(Math.floor(minute / 60)).padStart(2, "0");
+      const mm = String(minute % 60).padStart(2, "0");
+      for (const offset of probeOffsets) {
+        const candidate = Date.parse(`${date}T${hh}:${mm}:00${offset}`);
+        if (!Number.isFinite(candidate)) continue;
+        if (timezoneOffsetIso(new Date(candidate), timezone) !== offset) continue;
+        if (best === null || candidate < best) best = candidate;
+      }
+    }
+  }
+  if (best === null) {
+    const noon = timezoneOffsetIso(new Date(`${date}T12:00:00Z`), timezone);
+    best = Date.parse(`${date}T00:00:00${noon}`);
+  }
+  if (best === null || !Number.isFinite(best)) {
+    throw new CaptureInputError(`could not resolve a local day start for '${date}' in '${timezone}'`);
+  }
+  return new Date(best).toISOString();
+}
+
+/** Half-open [startUtc, endUtc) UTC ISO bounds of a local day. */
+export function activityDayWindow(date: string, timezone: string): { startUtc: string; endUtc: string } {
+  if (!isValidDate(date)) {
+    throw new CaptureInputError(`invalid date '${date}' — expected a real YYYY-MM-DD day`);
+  }
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+  } catch {
+    throw new CaptureInputError(`invalid timezone '${timezone}' — not a known IANA timezone`);
+  }
+  return {
+    startUtc: new Date(zonedDayStartIso(date, timezone)).toISOString(),
+    endUtc: new Date(zonedDayStartIso(shiftIsoDate(date, 1), timezone)).toISOString(),
+  };
+}

--- a/packages/capture-screen/src/dedup.test.ts
+++ b/packages/capture-screen/src/dedup.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { DedupCache } from "./dedup.js";
+import { simhash } from "./simhash.js";
+
+const A = simhash("window content one two three four five six seven eight nine ten");
+const A_NEAR = simhash("window content one two three four five six seven eight nine XYZ"); // 1-word edit → small
+const B = simhash("completely unrelated payload about compilers linkers and assembly directives everywhere");
+
+const t0 = Date.parse("2026-07-20T10:00:00.000Z");
+const sec = (n: number) => t0 + n * 1000;
+
+test("first snapshot of a window always stores", () => {
+  const cache = new DedupCache(10, 60);
+  assert.equal(cache.shouldStore("App", "Win", A, t0), true);
+});
+
+test("a near-identical snapshot within TTL is deduped (distance <= threshold)", () => {
+  const cache = new DedupCache(10, 60);
+  cache.shouldStore("App", "Win", A, t0);
+  assert.equal(cache.shouldStore("App", "Win", A, sec(5)), false, "exact repeat");
+  assert.equal(cache.shouldStore("App", "Win", A_NEAR, sec(10)), false, "near-duplicate");
+});
+
+test("a sufficiently different snapshot stores even within TTL", () => {
+  const cache = new DedupCache(10, 60);
+  cache.shouldStore("App", "Win", A, t0);
+  assert.equal(cache.shouldStore("App", "Win", B, sec(5)), true);
+});
+
+test("TTL elapsed forces a refresh even for identical content", () => {
+  const cache = new DedupCache(10, 60);
+  cache.shouldStore("App", "Win", A, t0);
+  assert.equal(cache.shouldStore("App", "Win", A, sec(59)), false, "before TTL");
+  assert.equal(cache.shouldStore("App", "Win", A, sec(60)), true, "at TTL boundary");
+});
+
+test("distinct windows never dedup against each other", () => {
+  const cache = new DedupCache(10, 60);
+  assert.equal(cache.shouldStore("App", "Win1", A, t0), true);
+  assert.equal(cache.shouldStore("App", "Win2", A, sec(1)), true, "same hash, different window");
+  assert.equal(cache.shouldStore("Other", "Win1", A, sec(1)), true, "same window title, different app");
+});
+
+test("100 near-identical scroll states collapse to a handful of stored rows", () => {
+  const cache = new DedupCache(10, 60);
+  let stored = 0;
+  for (let i = 0; i < 100; i++) {
+    // A static reader window: the same visible text on every frame (pure scroll
+    // captures the same content), one second apart. Only the TTL should refresh.
+    const h = simhash("a long document whose visible text does not change while the user scrolls slowly");
+    if (cache.shouldStore("Reader", "Doc", h, sec(i))) stored += 1;
+  }
+  assert.ok(stored <= 5, `expected <= 5 stored, got ${stored}`);
+});
+
+test("seed primes the last fingerprint so a restart does not re-store", () => {
+  const cache = new DedupCache(10, 60);
+  cache.seed("App", "Win", A, t0);
+  assert.equal(cache.shouldStore("App", "Win", A, sec(5)), false);
+});

--- a/packages/capture-screen/src/dedup.ts
+++ b/packages/capture-screen/src/dedup.ts
@@ -1,0 +1,63 @@
+/**
+ * Per-window near-duplicate suppression. Keyed by (app, windowTitle): for each
+ * window we remember the last STORED snapshot's SimHash and capture instant. A
+ * new snapshot of the same window is stored only when it is meaningfully
+ * different (Hamming distance > threshold) OR enough time has elapsed since the
+ * last store (ttlSeconds), so a long unchanging window is refreshed periodically
+ * while a stream of near-identical scroll states collapses to a few rows.
+ * Distinct windows never dedup against each other (independent cache entries).
+ *
+ * The clock is the snapshot's own capturedAt (passed in as ms), never a
+ * wall-clock read — so replay/fixtures are deterministic.
+ */
+
+import { hammingDistance } from "./simhash.js";
+
+interface Entry {
+  hash: bigint;
+  atMs: number;
+}
+
+export class DedupCache {
+  #last = new Map<string, Entry>();
+  readonly #threshold: number;
+  readonly #ttlSeconds: number;
+
+  constructor(threshold: number, ttlSeconds: number) {
+    this.#threshold = threshold;
+    this.#ttlSeconds = ttlSeconds;
+  }
+
+  static #key(app: string, windowTitle: string): string {
+    // NUL separator: app/title are arbitrary text, so a printable delimiter
+    // could be forged by a title to alias a different (app,title) pair.
+    return `${app}\u0000${windowTitle}`;
+  }
+
+  /** Seed the last-stored fingerprint for a window (used to prime from the spool). */
+  seed(app: string, windowTitle: string, hash: bigint, atMs: number): void {
+    this.#last.set(DedupCache.#key(app, windowTitle), { hash, atMs });
+  }
+
+  /**
+   * Decide whether a snapshot should be stored, updating the cache when it is.
+   * First snapshot of a window always stores. A negative elapsed (out-of-order
+   * capture) stores defensively rather than dropping data.
+   */
+  shouldStore(app: string, windowTitle: string, hash: bigint, atMs: number): boolean {
+    const key = DedupCache.#key(app, windowTitle);
+    const prev = this.#last.get(key);
+    let store: boolean;
+    if (prev === undefined) {
+      store = true;
+    } else {
+      const elapsedSeconds = (atMs - prev.atMs) / 1000;
+      store =
+        elapsedSeconds < 0 ||
+        elapsedSeconds >= this.#ttlSeconds ||
+        hammingDistance(hash, prev.hash) > this.#threshold;
+    }
+    if (store) this.#last.set(key, { hash, atMs });
+    return store;
+  }
+}

--- a/packages/capture-screen/src/denylist.test.ts
+++ b/packages/capture-screen/src/denylist.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { globToRegExp, matchDenyRule, matchesAnyGlob } from "./denylist.js";
+
+const EMPTY = { apps: [], titles: [], urls: [] };
+
+test("built-in secret-manager apps are denied and name the rule", () => {
+  assert.equal(matchDenyRule({ app: "1Password 7", windowTitle: "Vault" }, EMPTY), "app:1Password*");
+  assert.equal(matchDenyRule({ app: "Bitwarden", windowTitle: "x" }, EMPTY), "app:Bitwarden*");
+  assert.equal(matchDenyRule({ app: "KeePassXC", windowTitle: "x" }, EMPTY), "app:KeePass*");
+});
+
+test("built-in private-browsing titles are denied", () => {
+  assert.equal(
+    matchDenyRule({ app: "Safari", windowTitle: "Example (Private Browsing)" }, EMPTY),
+    "title:*private browsing*",
+  );
+  assert.equal(matchDenyRule({ app: "Chrome", windowTitle: "Docs - Incognito" }, EMPTY), "title:*incognito*");
+});
+
+test("user app / title / url globs are additive", () => {
+  assert.equal(
+    matchDenyRule({ app: "SecretApp", windowTitle: "x" }, { apps: ["SecretApp"], titles: [], urls: [] }),
+    "app:SecretApp",
+  );
+  assert.equal(
+    matchDenyRule({ app: "Safari", windowTitle: "Online Banking" }, { apps: [], titles: ["*banking*"], urls: [] }),
+    "title:*banking*",
+  );
+  assert.equal(
+    matchDenyRule(
+      { app: "Safari", windowTitle: "Bank", browserUrl: "https://secure.bank.example/login" },
+      { apps: [], titles: [], urls: ["*bank.example*"] },
+    ),
+    "url:*bank.example*",
+  );
+});
+
+test("a clean window matches no rule", () => {
+  assert.equal(matchDenyRule({ app: "Terminal", windowTitle: "zsh", browserUrl: null }, EMPTY), null);
+});
+
+test("globs match case-insensitively and anchor the whole value", () => {
+  assert.ok(globToRegExp("1Password*").test("1password 8"));
+  assert.ok(matchesAnyGlob(["*.internal"], "host.internal"));
+  assert.equal(matchesAnyGlob(["Terminal"], "Terminal Pro"), false, "anchored: no substring match");
+});

--- a/packages/capture-screen/src/denylist.ts
+++ b/packages/capture-screen/src/denylist.ts
@@ -1,0 +1,70 @@
+/**
+ * Capture-time deny-lists, checked FIRST — before any text extraction, hashing,
+ * or spool write. A match records NOTHING (not even metadata): the snapshot is
+ * dropped whole. Three independent lists, each glob/substring matched
+ * case-insensitively: application name, window title, and browser URL. Built-in
+ * defaults cover common secret managers and private-browsing windows; the
+ * user's config entries are additive.
+ */
+
+/** Secret managers whose windows must never be captured. */
+export const DEFAULT_DENY_APPS: readonly string[] = ["1Password*", "Bitwarden*", "KeePass*"];
+
+/** Private/incognito window-title heuristics (browsers signal these in the title). */
+export const DEFAULT_DENY_TITLES: readonly string[] = [
+  "*incognito*",
+  "*private browsing*",
+  "*inprivate*",
+  "*private window*",
+];
+
+/** No default URL denials — URL patterns are user-supplied (site-specific). */
+export const DEFAULT_DENY_URLS: readonly string[] = [];
+
+export interface DenyLists {
+  apps: readonly string[];
+  titles: readonly string[];
+  urls: readonly string[];
+}
+
+export interface DenyCandidate {
+  app: string;
+  windowTitle: string;
+  browserUrl?: string | null;
+}
+
+/** Compile a `*`/`?` glob to an anchored, case-insensitive RegExp. */
+export function globToRegExp(glob: string): RegExp {
+  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*").replace(/\?/g, ".");
+  return new RegExp(`^${escaped}$`, "i");
+}
+
+/** True when `value` matches any glob in `patterns` (case-insensitive). */
+export function matchesAnyGlob(patterns: readonly string[], value: string): boolean {
+  return patterns.some((pattern) => globToRegExp(pattern).test(value));
+}
+
+function firstMatch(patterns: readonly string[], value: string, kind: string): string | null {
+  for (const pattern of patterns) {
+    if (globToRegExp(pattern).test(value)) return `${kind}:${pattern}`;
+  }
+  return null;
+}
+
+/**
+ * The first deny rule that fires for this candidate, or null. Built-in defaults
+ * are always checked in addition to the user lists. The returned string names
+ * the rule (`app:1Password*`, `title:*incognito*`, `url:...`) for the
+ * `test-snapshot` diagnostic.
+ */
+export function matchDenyRule(candidate: DenyCandidate, lists: DenyLists): string | null {
+  const appRule = firstMatch([...DEFAULT_DENY_APPS, ...lists.apps], candidate.app, "app");
+  if (appRule !== null) return appRule;
+  const titleRule = firstMatch([...DEFAULT_DENY_TITLES, ...lists.titles], candidate.windowTitle, "title");
+  if (titleRule !== null) return titleRule;
+  if (typeof candidate.browserUrl === "string" && candidate.browserUrl.length > 0) {
+    const urlRule = firstMatch([...DEFAULT_DENY_URLS, ...lists.urls], candidate.browserUrl, "url");
+    if (urlRule !== null) return urlRule;
+  }
+  return null;
+}

--- a/packages/capture-screen/src/errors.ts
+++ b/packages/capture-screen/src/errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Error taxonomy for @remnic/capture-screen.
+ *
+ * Two authored-message classes, mirroring @remnic/capture-audio: configuration
+ * problems and caller-correctable input. Both carry operator-safe messages
+ * (never foreign error text, never captured screen text, never credentials).
+ * The HTTP layer maps CaptureInputError to 400; anything else is a backend
+ * fault (500).
+ */
+
+/** Config load/validation failure — surfaced loudly, never silently defaulted. */
+export class CaptureConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CaptureConfigError";
+  }
+}
+
+/** Caller-correctable request/CLI input — maps to HTTP 400. */
+export class CaptureInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CaptureInputError";
+  }
+}

--- a/packages/capture-screen/src/helper.test.ts
+++ b/packages/capture-screen/src/helper.test.ts
@@ -48,7 +48,9 @@ test("a missing helper package degrades honestly with an install hint (never MOD
   const res = await resolveHelperBinaryPath({});
   assert.equal(res.binaryPath, null);
   assert.ok(res.hint, "an unavailable helper must carry a hint");
-  assert.match(res.hint ?? "", /npm install @remnic\/capture-native-/);
+  assert.match(res.hint ?? "", /issues\/2139/);
+  assert.match(res.hint ?? "", /REMNIC_CAPTURE_HELPER_BIN/);
+  assert.doesNotMatch(res.hint ?? "", /npm install/);
   assert.doesNotMatch(res.hint ?? "", /MODULE_NOT_FOUND/);
 });
 

--- a/packages/capture-screen/src/helper.test.ts
+++ b/packages/capture-screen/src/helper.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 
 import { CaptureInputError } from "./errors.js";
@@ -92,4 +92,10 @@ test("a partial/invalid-JSON helper throws", async () => {
 test("ax-snapshot rejects a payload missing required window fields", async () => {
   const bad = fakeHelper("badax.js", `process.stdout.write(JSON.stringify({ tree: {} }));`);
   await assert.rejects(new NativeHelper(bad).axSnapshot(), CaptureInputError);
+});
+
+test("an env override expands a leading ~ to the home directory", async () => {
+  const res = await resolveHelperBinaryPath({ REMNIC_CAPTURE_HELPER_BIN: "~/remnic/helper" });
+  assert.equal(res.binaryPath, path.join(homedir(), "remnic", "helper"));
+  assert.equal(res.hint, null);
 });

--- a/packages/capture-screen/src/helper.test.ts
+++ b/packages/capture-screen/src/helper.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { CaptureInputError } from "./errors.js";
+import {
+  NativeHelper,
+  helperPackageName,
+  resolveHelperBinaryPath,
+  runHelperCommand,
+} from "./helper.js";
+
+const dir = mkdtempSync(path.join(tmpdir(), "csr-helper-"));
+
+/** Write an executable node script acting as a fake capture helper. */
+function fakeHelper(name: string, body: string): string {
+  const file = path.join(dir, name);
+  writeFileSync(file, `#!/usr/bin/env node\n${body}\n`, "utf8");
+  chmodSync(file, 0o755);
+  return file;
+}
+
+const OK = fakeHelper(
+  "ok.js",
+  `const cmd = process.argv[2];
+if (cmd === "ax-snapshot") process.stdout.write(JSON.stringify({ app: "Safari", windowTitle: "Example", browserUrl: "https://example.com", tree: { role: "AXWindow", children: [{ role: "AXStaticText", value: "Hello world" }] } }));
+else if (cmd === "ocr-window") process.stdout.write(JSON.stringify({ text: "terminal ocr text" }));
+else process.exit(2);`,
+);
+const FAIL = fakeHelper("fail.js", `process.stderr.write("boom\\n"); process.exit(3);`);
+const EMPTY = fakeHelper("empty.js", `process.exit(0);`);
+const PARTIAL = fakeHelper("partial.js", `process.stdout.write("{ \\"app\\": \\"x\\", "); process.exit(0);`);
+
+test("helperPackageName is the platform/arch specifier", () => {
+  assert.equal(helperPackageName("darwin", "arm64"), "@remnic/capture-native-darwin-arm64");
+});
+
+test("an explicit env override resolves without touching the package", async () => {
+  const res = await resolveHelperBinaryPath({ REMNIC_CAPTURE_HELPER_BIN: OK });
+  assert.equal(res.binaryPath, OK);
+  assert.equal(res.hint, null);
+});
+
+test("a missing helper package degrades honestly with an install hint (never MODULE_NOT_FOUND)", async () => {
+  // No override → the computed platform package does not exist on this host.
+  const res = await resolveHelperBinaryPath({});
+  assert.equal(res.binaryPath, null);
+  assert.ok(res.hint, "an unavailable helper must carry a hint");
+  assert.match(res.hint ?? "", /npm install @remnic\/capture-native-/);
+  assert.doesNotMatch(res.hint ?? "", /MODULE_NOT_FOUND/);
+});
+
+test("ax-snapshot parses window context + tree from the fake helper", async () => {
+  const helper = new NativeHelper(OK);
+  const snap = await helper.axSnapshot({ frontmost: true, maxNodes: 100 });
+  assert.equal(snap.app, "Safari");
+  assert.equal(snap.windowTitle, "Example");
+  assert.equal(snap.browserUrl, "https://example.com");
+  assert.equal(snap.tree.role, "AXWindow");
+});
+
+test("ocr-window returns the text field", async () => {
+  const helper = new NativeHelper(OK);
+  assert.equal(await helper.ocrWindow({ frontmost: true }), "terminal ocr text");
+});
+
+test("a nonzero-exit helper throws a sanitized error", async () => {
+  await assert.rejects(runHelperCommand(FAIL, ["ax-snapshot"]), CaptureInputError);
+  await assert.rejects(new NativeHelper(FAIL).ocrWindow(), CaptureInputError);
+});
+
+test("an empty-output helper throws", async () => {
+  await assert.rejects(runHelperCommand(EMPTY, ["ax-snapshot"]), (err: unknown) => {
+    assert.ok(err instanceof CaptureInputError);
+    assert.match(err.message, /no output/);
+    return true;
+  });
+});
+
+test("a partial/invalid-JSON helper throws", async () => {
+  await assert.rejects(runHelperCommand(PARTIAL, ["ax-snapshot"]), (err: unknown) => {
+    assert.ok(err instanceof CaptureInputError);
+    assert.match(err.message, /invalid JSON/);
+    return true;
+  });
+});
+
+test("ax-snapshot rejects a payload missing required window fields", async () => {
+  const bad = fakeHelper("badax.js", `process.stdout.write(JSON.stringify({ tree: {} }));`);
+  await assert.rejects(new NativeHelper(bad).axSnapshot(), CaptureInputError);
+});

--- a/packages/capture-screen/src/helper.ts
+++ b/packages/capture-screen/src/helper.ts
@@ -39,7 +39,11 @@ export function helperPackageName(platform: string = process.platform, arch: str
 }
 
 function installHint(pkg: string): string {
-  return `native capture helper not installed — run \`npm install ${pkg}\` to enable live screen capture`;
+  return (
+    `native capture helper (${pkg}) is not available on this install — it ships via a tracked follow-up ` +
+    `(https://github.com/joshuaswarren/remnic/issues/2139). To enable live screen capture now, build the Swift ` +
+    `helper from source (packages/capture-native-darwin-helper) and set REMNIC_CAPTURE_HELPER_BIN to the binary`
+  );
 }
 
 function isModuleNotFound(err: unknown): boolean {

--- a/packages/capture-screen/src/helper.ts
+++ b/packages/capture-screen/src/helper.ts
@@ -1,0 +1,222 @@
+/**
+ * Native-helper seam. The actual screen reader is a platform Swift binary
+ * shipped separately as `@remnic/capture-native-<platform>-<arch>`, exporting a
+ * `helperBinaryPath`. This module resolves that binary, spawns it, and parses
+ * its JSON — with two hard rules:
+ *
+ *   - A MISSING helper package NEVER surfaces as a raw MODULE_NOT_FOUND: it
+ *     resolves to `{ binaryPath: null, hint }` with an actionable install hint,
+ *     and the daemon reports axAvailable/ocrAvailable = false (degraded but
+ *     honest).
+ *   - Every helper invocation is bounded and its output validated: a nonzero
+ *     exit, empty output, or invalid/partial JSON throws a sanitized
+ *     CaptureInputError, never a crash and never foreign text.
+ *
+ * `REMNIC_CAPTURE_HELPER_BIN` overrides resolution with an explicit binary path
+ * (manual installs and the hardware-free test seam, which points it at a fake
+ * script emitting canned JSON).
+ */
+
+import { spawn } from "node:child_process";
+
+import type { AxNode } from "./axtree.js";
+import { CaptureInputError } from "./errors.js";
+
+/** Max helper stdout we will buffer (guards a runaway child). */
+const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export interface HelperResolution {
+  /** Absolute path to the helper binary, or null when unavailable. */
+  binaryPath: string | null;
+  /** Operator-facing install hint when unavailable, else null. */
+  hint: string | null;
+}
+
+/** The npm package that would provide the helper for this platform/arch. */
+export function helperPackageName(platform: string = process.platform, arch: string = process.arch): string {
+  return `@remnic/capture-native-${platform}-${arch}`;
+}
+
+function installHint(pkg: string): string {
+  return `native capture helper not installed — run \`npm install ${pkg}\` to enable live screen capture`;
+}
+
+function isModuleNotFound(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
+}
+
+/**
+ * Resolve the helper binary path. Order: explicit env override, then the
+ * computed platform package (dynamic import), then unavailable-with-hint. A
+ * missing or broken package degrades gracefully — it never throws.
+ */
+export async function resolveHelperBinaryPath(env: NodeJS.ProcessEnv = process.env): Promise<HelperResolution> {
+  const override = env.REMNIC_CAPTURE_HELPER_BIN?.trim();
+  if (override) return { binaryPath: override, hint: null };
+
+  const pkg = helperPackageName();
+  try {
+    // Runtime-selected specifier: the helper package is platform/arch-specific
+    // and absent on most hosts, so a static import is impossible here.
+    const mod: unknown = await import(pkg);
+    if (mod && typeof mod === "object" && "helperBinaryPath" in mod) {
+      const value: unknown = mod.helperBinaryPath;
+      if (typeof value === "string" && value.length > 0) return { binaryPath: value, hint: null };
+    }
+    // Package present but did not export a usable path — still degrade honestly.
+    return { binaryPath: null, hint: `${pkg} is installed but exports no helperBinaryPath` };
+  } catch (err) {
+    if (isModuleNotFound(err)) return { binaryPath: null, hint: installHint(pkg) };
+    // Any other load failure (broken binding, bad build) — degrade, never crash.
+    return { binaryPath: null, hint: `${pkg} failed to load; reinstall it to enable live capture` };
+  }
+}
+
+interface SpawnOutcome {
+  code: number | null;
+  stdout: string;
+}
+
+function spawnHelper(binaryPath: string, args: string[], timeoutMs: number): Promise<SpawnOutcome> {
+  return new Promise<SpawnOutcome>((resolve, reject) => {
+    const child = spawn(binaryPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      reject(new CaptureInputError("native helper timed out"));
+    }, timeoutMs);
+    child.stdout.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_OUTPUT_BYTES) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        child.kill("SIGKILL");
+        reject(new CaptureInputError("native helper produced too much output"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      // Sanitize: name + errno only, never the spawn path.
+      const code = (err as NodeJS.ErrnoException).code;
+      reject(new CaptureInputError(`native helper failed to spawn (${code ?? err.name})`));
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ code, stdout: Buffer.concat(chunks).toString("utf8") });
+    });
+  });
+}
+
+/** Run a helper subcommand and return its parsed JSON, or throw a sanitized error. */
+export async function runHelperCommand(
+  binaryPath: string,
+  args: string[],
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<unknown> {
+  const outcome = await spawnHelper(binaryPath, args, timeoutMs);
+  if (outcome.code !== 0) {
+    throw new CaptureInputError(`native helper exited with status ${outcome.code ?? "unknown"}`);
+  }
+  if (outcome.stdout.trim() === "") {
+    throw new CaptureInputError("native helper produced no output");
+  }
+  try {
+    return JSON.parse(outcome.stdout);
+  } catch {
+    throw new CaptureInputError("native helper produced invalid JSON");
+  }
+}
+
+export interface AxSnapshotOptions {
+  frontmost?: boolean;
+  pid?: number;
+  maxNodes?: number;
+}
+
+/**
+ * The helper's `ax-snapshot` payload: the frontmost window's context (app,
+ * title, optional browser URL) plus its accessibility tree. The tree is
+ * permissive (see AxNode); window context lets the daemon build a capture
+ * candidate without a separate frontmost-window query.
+ */
+export interface AxSnapshot {
+  app: string;
+  windowTitle: string;
+  browserUrl?: string | null;
+  tree: AxNode;
+}
+
+export interface OcrWindowOptions {
+  frontmost?: boolean;
+  windowId?: string;
+}
+
+/** Thin wrapper over a resolved helper binary. */
+export class NativeHelper {
+  readonly binaryPath: string;
+
+  constructor(binaryPath: string) {
+    this.binaryPath = binaryPath;
+  }
+
+  /** `<helper> ax-snapshot [--frontmost|--pid N] [--max-nodes N]` -> window + AX tree JSON. */
+  async axSnapshot(opts: AxSnapshotOptions = {}): Promise<AxSnapshot> {
+    const args = ["ax-snapshot"];
+    if (opts.pid !== undefined) args.push("--pid", String(opts.pid));
+    else args.push("--frontmost");
+    if (opts.maxNodes !== undefined) args.push("--max-nodes", String(opts.maxNodes));
+    const json = await runHelperCommand(this.binaryPath, args);
+    if (json === null || typeof json !== "object" || Array.isArray(json)) {
+      throw new CaptureInputError("native helper ax-snapshot did not return an object");
+    }
+    if (!("app" in json) || !("windowTitle" in json) || !("tree" in json)) {
+      throw new CaptureInputError("native helper ax-snapshot missing app/windowTitle/tree");
+    }
+    const app: unknown = json.app;
+    const windowTitle: unknown = json.windowTitle;
+    const browserUrl: unknown = "browserUrl" in json ? json.browserUrl : undefined;
+    const tree: unknown = json.tree;
+    if (typeof app !== "string" || typeof windowTitle !== "string") {
+      throw new CaptureInputError("native helper ax-snapshot app/windowTitle must be strings");
+    }
+    if (tree === null || typeof tree !== "object" || Array.isArray(tree)) {
+      throw new CaptureInputError("native helper ax-snapshot tree must be an object");
+    }
+    // Named cast (sanctioned): the tree is structurally an AxNode (all fields
+    // optional) and extractAxText tolerates unknown shapes; a schema parse of an
+    // arbitrary AX dump would be meaningless.
+    const axTree = tree as AxNode;
+    return {
+      app,
+      windowTitle,
+      ...(typeof browserUrl === "string" ? { browserUrl } : {}),
+      tree: axTree,
+    };
+  }
+
+  /** `<helper> ocr-window [--frontmost|--window ID]` -> `{ text }` JSON. */
+  async ocrWindow(opts: OcrWindowOptions = {}): Promise<string> {
+    const args = ["ocr-window"];
+    if (opts.windowId !== undefined) args.push("--window", opts.windowId);
+    else args.push("--frontmost");
+    const json = await runHelperCommand(this.binaryPath, args);
+    if (json !== null && typeof json === "object" && !Array.isArray(json) && "text" in json) {
+      const text: unknown = json.text;
+      if (typeof text === "string") return text;
+    }
+    throw new CaptureInputError("native helper ocr-window did not return a text field");
+  }
+}

--- a/packages/capture-screen/src/helper.ts
+++ b/packages/capture-screen/src/helper.ts
@@ -21,6 +21,7 @@ import { spawn } from "node:child_process";
 
 import type { AxNode } from "./axtree.js";
 import { CaptureInputError } from "./errors.js";
+import { expandTilde } from "./paths.js";
 
 /** Max helper stdout we will buffer (guards a runaway child). */
 const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
@@ -58,7 +59,7 @@ function isModuleNotFound(err: unknown): boolean {
  */
 export async function resolveHelperBinaryPath(env: NodeJS.ProcessEnv = process.env): Promise<HelperResolution> {
   const override = env.REMNIC_CAPTURE_HELPER_BIN?.trim();
-  if (override) return { binaryPath: override, hint: null };
+  if (override) return { binaryPath: expandTilde(override), hint: null };
 
   const pkg = helperPackageName();
   try {

--- a/packages/capture-screen/src/index.ts
+++ b/packages/capture-screen/src/index.ts
@@ -1,0 +1,93 @@
+/**
+ * @remnic/capture-screen — à-la-carte desktop screen-activity capture daemon
+ * (issue #1899, Part 1). Strict daemon config, a node:sqlite spool with
+ * dedup/supersession/retention, deny-lists, daemon-side redaction, AX
+ * secure-field filtering, a native-helper seam with OCR routing, replay
+ * ingestion, an authenticated loopback HTTP API, and the CLI.
+ *
+ * The native capture binary is shipped separately as
+ * `@remnic/capture-native-<platform>-<arch>`; this package resolves it at
+ * runtime and degrades honestly when it is absent.
+ */
+
+export {
+  CAPTURE_SCREEN_VERSION,
+  DEFAULT_HOST,
+  DEFAULT_PORT,
+  SPOOL_SCHEMA_VERSION,
+} from "./constants.js";
+export { CaptureConfigError, CaptureInputError } from "./errors.js";
+export {
+  defaultDaemonConfig,
+  loadDaemonConfig,
+  parseDaemonConfig,
+  serializeDaemonConfig,
+} from "./config.js";
+export type { DaemonConfig } from "./config.js";
+export { capturePaths, captureBaseDir, expandTilde } from "./paths.js";
+export type { CapturePaths } from "./paths.js";
+export { generateToken, loadOrCreateToken, tokensMatch, bearerFromHeader } from "./token.js";
+export {
+  assertValidTimezone,
+  decodeCursor,
+  encodeCursor,
+  parseLimit,
+  parseSnapshotDate,
+} from "./validate.js";
+export type { Cursor } from "./validate.js";
+export { activityDayWindow } from "./daywindow.js";
+export { simhash, hammingDistance, simhashToHex, simhashFromHex } from "./simhash.js";
+export { DedupCache } from "./dedup.js";
+export {
+  DEFAULT_DENY_APPS,
+  DEFAULT_DENY_TITLES,
+  DEFAULT_DENY_URLS,
+  globToRegExp,
+  matchDenyRule,
+  matchesAnyGlob,
+} from "./denylist.js";
+export type { DenyCandidate, DenyLists } from "./denylist.js";
+export { REDACTION_PLACEHOLDER, compileRedactionPatterns, redactText } from "./redact.js";
+export { SECURE_ROLE, extractAxText } from "./axtree.js";
+export type { AxNode, AxExtractResult } from "./axtree.js";
+export {
+  CaptureProcessor,
+  DEFAULT_TERMINAL_APPS,
+  computeStats,
+  contentHash,
+  isTerminalApp,
+} from "./capture.js";
+export type { AppStat, CaptureCandidate, CaptureDecision, DayStats, OcrFn } from "./capture.js";
+export { Spool } from "./spool.js";
+export type {
+  DaemonSnapshot,
+  InsertResult,
+  QuerySnapshotsOptions,
+  SnapshotInput,
+  SnapshotPage,
+  TextSource,
+  WindowFingerprint,
+} from "./spool.js";
+export {
+  NativeHelper,
+  helperPackageName,
+  resolveHelperBinaryPath,
+  runHelperCommand,
+} from "./helper.js";
+export type { AxSnapshot, AxSnapshotOptions, HelperResolution, OcrWindowOptions } from "./helper.js";
+export { captureViaHelper } from "./live.js";
+export { ingestReplayDir, ingestReplayDirResponsive, REPLAY_COMMIT_BATCH } from "./replay.js";
+export type { ReplayResult } from "./replay.js";
+export { createRequestHandler, startDaemon } from "./daemon.js";
+export type { DaemonDeps, DaemonHandle } from "./daemon.js";
+export {
+  isProcessAlive,
+  readPidFile,
+  readPidRecord,
+  removePidFile,
+  removePidFileIfOwner,
+  writePidFile,
+} from "./control.js";
+export type { PidRecord } from "./control.js";
+export { runCapture, superviseReplay } from "./cli.js";
+export type { CliIo } from "./cli.js";

--- a/packages/capture-screen/src/live.ts
+++ b/packages/capture-screen/src/live.ts
@@ -32,8 +32,13 @@ export async function captureViaHelper(
   };
   if (isTerminalApp(snap.app, config.terminalApps) || axText.trim() === "") {
     try {
-      candidate.text = await helper.ocrWindow({ frontmost: true });
-      candidate.textSource = "ocr";
+      const ocrText = await helper.ocrWindow({ frontmost: true });
+      if (ocrText.trim() !== "") {
+        candidate.text = ocrText;
+        candidate.textSource = "ocr";
+      }
+      // Blank OCR (helper returned no recognizable text): leave text-less so the
+      // processor reports ocr-unavailable instead of persisting an empty snapshot.
     } catch {
       // OCR unavailable/failed: leave text-less so the processor reports
       // ocr-unavailable instead of persisting an empty snapshot.

--- a/packages/capture-screen/src/live.ts
+++ b/packages/capture-screen/src/live.ts
@@ -12,6 +12,7 @@
 
 import { extractAxText } from "./axtree.js";
 import { isTerminalApp } from "./capture.js";
+import { matchDenyRule } from "./denylist.js";
 import type { CaptureCandidate, CaptureDecision, CaptureProcessor } from "./capture.js";
 import type { DaemonConfig } from "./config.js";
 import type { AxSnapshot, NativeHelper } from "./helper.js";
@@ -45,7 +46,17 @@ export async function captureFromSnapshot(
     windowTitle: snap.windowTitle,
     ...(snap.browserUrl != null ? { browserUrl: snap.browserUrl } : {}),
   };
-  if (isTerminalApp(snap.app, config.terminalApps) || axText.trim() === "") {
+  // Deny preflight: never OCR/screen-capture a deny-listed window. process()
+  // applies deny too, but only AFTER text extraction — so without this an OCR
+  // call would fire against a denied window before the rule is checked.
+  const denied =
+    matchDenyRule(
+      { app: snap.app, windowTitle: snap.windowTitle, browserUrl: snap.browserUrl ?? null },
+      { apps: config.denyApps, titles: config.denyTitles, urls: config.denyUrls },
+    ) !== null;
+  if (denied) {
+    // Leave text-less; processor.process denies it below (no OCR ran).
+  } else if (isTerminalApp(snap.app, config.terminalApps) || axText.trim() === "") {
     try {
       const ocrText = await helper.ocrWindow({ frontmost: true });
       if (ocrText.trim() !== "") {

--- a/packages/capture-screen/src/live.ts
+++ b/packages/capture-screen/src/live.ts
@@ -14,7 +14,7 @@ import { extractAxText } from "./axtree.js";
 import { isTerminalApp } from "./capture.js";
 import type { CaptureCandidate, CaptureDecision, CaptureProcessor } from "./capture.js";
 import type { DaemonConfig } from "./config.js";
-import type { NativeHelper } from "./helper.js";
+import type { AxSnapshot, NativeHelper } from "./helper.js";
 
 export async function captureViaHelper(
   helper: NativeHelper,
@@ -23,6 +23,21 @@ export async function captureViaHelper(
   capturedAtUtc: string,
 ): Promise<CaptureDecision> {
   const snap = await helper.axSnapshot({ frontmost: true, maxNodes: config.maxNodes });
+  return captureFromSnapshot(snap, helper, processor, config, capturedAtUtc);
+}
+
+/**
+ * Run an already-fetched AX snapshot through the pipeline. The live scheduler
+ * uses this so a single ax-snapshot poll drives both change detection and the
+ * capture, avoiding a redundant fetch.
+ */
+export async function captureFromSnapshot(
+  snap: AxSnapshot,
+  helper: NativeHelper,
+  processor: CaptureProcessor,
+  config: DaemonConfig,
+  capturedAtUtc: string,
+): Promise<CaptureDecision> {
   const axText = extractAxText(snap.tree, config.maxNodes).text;
   const candidate: CaptureCandidate = {
     capturedAtUtc,
@@ -37,8 +52,8 @@ export async function captureViaHelper(
         candidate.text = ocrText;
         candidate.textSource = "ocr";
       }
-      // Blank OCR (helper returned no recognizable text): leave text-less so the
-      // processor reports ocr-unavailable instead of persisting an empty snapshot.
+      // Blank OCR: leave text-less so the processor reports ocr-unavailable
+      // instead of persisting an empty snapshot.
     } catch {
       // OCR unavailable/failed: leave text-less so the processor reports
       // ocr-unavailable instead of persisting an empty snapshot.

--- a/packages/capture-screen/src/live.ts
+++ b/packages/capture-screen/src/live.ts
@@ -1,0 +1,46 @@
+/**
+ * Live capture cycle: one snapshot fetched through the native helper and run
+ * through the processing pipeline. Shared by `test-snapshot` (which prints the
+ * decision without storing) and available to a future capture scheduler.
+ *
+ * The routing (AX vs OCR) happens here because the native OCR call is async
+ * while the processor's OCR seam is sync: a terminal-class or AX-empty window
+ * has its OCR text fetched eagerly, then handed to the processor as
+ * pre-extracted text. When OCR fails, the candidate is left text-less so the
+ * processor skips it (ocr-unavailable) rather than storing empty AX text.
+ */
+
+import { extractAxText } from "./axtree.js";
+import { isTerminalApp } from "./capture.js";
+import type { CaptureCandidate, CaptureDecision, CaptureProcessor } from "./capture.js";
+import type { DaemonConfig } from "./config.js";
+import type { NativeHelper } from "./helper.js";
+
+export async function captureViaHelper(
+  helper: NativeHelper,
+  processor: CaptureProcessor,
+  config: DaemonConfig,
+  capturedAtUtc: string,
+): Promise<CaptureDecision> {
+  const snap = await helper.axSnapshot({ frontmost: true, maxNodes: config.maxNodes });
+  const axText = extractAxText(snap.tree, config.maxNodes).text;
+  const candidate: CaptureCandidate = {
+    capturedAtUtc,
+    app: snap.app,
+    windowTitle: snap.windowTitle,
+    ...(snap.browserUrl != null ? { browserUrl: snap.browserUrl } : {}),
+  };
+  if (isTerminalApp(snap.app, config.terminalApps) || axText.trim() === "") {
+    try {
+      candidate.text = await helper.ocrWindow({ frontmost: true });
+      candidate.textSource = "ocr";
+    } catch {
+      // OCR unavailable/failed: leave text-less so the processor reports
+      // ocr-unavailable instead of persisting an empty snapshot.
+    }
+  } else {
+    candidate.text = axText;
+    candidate.textSource = "ax";
+  }
+  return processor.process(candidate);
+}

--- a/packages/capture-screen/src/paths.ts
+++ b/packages/capture-screen/src/paths.ts
@@ -1,0 +1,42 @@
+/** Filesystem layout for the capture working directory. */
+
+import os from "node:os";
+import path from "node:path";
+
+export interface CapturePaths {
+  baseDir: string;
+  configPath: string;
+  spoolPath: string;
+  tokenPath: string;
+  pidPath: string;
+  logPath: string;
+}
+
+/** Expand a leading `~` / `~/` to the home directory; other paths pass through. */
+export function expandTilde(p: string): string {
+  if (p === "~") return os.homedir();
+  if (p.startsWith("~/")) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
+/**
+ * Root of the capture working directory. `REMNIC_CAPTURE_SCREEN_DIR` overrides
+ * the default `~/.remnic/capture-screen` (tests and multi-instance setups point
+ * it at a scratch dir). A leading `~` expands to the home directory.
+ */
+export function captureBaseDir(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.REMNIC_CAPTURE_SCREEN_DIR?.trim();
+  if (override) return expandTilde(override);
+  return path.join(os.homedir(), ".remnic", "capture-screen");
+}
+
+export function capturePaths(baseDir: string = captureBaseDir()): CapturePaths {
+  return {
+    baseDir,
+    configPath: path.join(baseDir, "screen.json"),
+    spoolPath: path.join(baseDir, "screen.sqlite"),
+    tokenPath: path.join(baseDir, "token"),
+    pidPath: path.join(baseDir, "daemon.pid"),
+    logPath: path.join(baseDir, "daemon.log"),
+  };
+}

--- a/packages/capture-screen/src/redact.test.ts
+++ b/packages/capture-screen/src/redact.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { compileRedactionPatterns, REDACTION_PLACEHOLDER, redactText } from "./redact.js";
+import { CaptureConfigError } from "./errors.js";
+
+test("US SSNs are redacted", () => {
+  const out = redactText("my ssn is 123-45-6789 ok");
+  assert.match(out, /my ssn is \[REDACTED\] ok/);
+});
+
+test("Luhn-valid payment cards are redacted; non-Luhn digit runs are left", () => {
+  assert.equal(redactText("card 4242 4242 4242 4242 end").includes(REDACTION_PLACEHOLDER), true);
+  assert.equal(redactText("card 4242-4242-4242-4242 end").includes(REDACTION_PLACEHOLDER), true);
+  // Sixteen 1s is not Luhn-valid — must not be redacted (avoids nuking IDs/counts).
+  assert.equal(redactText("ref 1111 1111 1111 1111 end"), "ref 1111 1111 1111 1111 end");
+});
+
+test("user redaction patterns are applied in addition to the built-ins", () => {
+  const patterns = compileRedactionPatterns(["SECRET-[A-Z0-9]+"]);
+  const out = redactText("token SECRET-ABC123 and ssn 123-45-6789", patterns);
+  assert.match(out, /token \[REDACTED\] and ssn \[REDACTED\]/);
+});
+
+test("a global user pattern redacts every occurrence and is reusable", () => {
+  const patterns = compileRedactionPatterns(["\\bpw\\b"]);
+  assert.equal(redactText("pw here pw there", patterns), "[REDACTED] here [REDACTED] there");
+  // Reusing the same compiled pattern must not skip matches (lastIndex reset).
+  assert.equal(redactText("pw again", patterns), "[REDACTED] again");
+});
+
+test("text with no sensitive content is unchanged", () => {
+  const text = "just some ordinary window text with numbers 42 and 2026-07-20";
+  assert.equal(redactText(text), text);
+});
+
+test("an invalid user regex fails loudly at compile time", () => {
+  assert.throws(() => compileRedactionPatterns(["(unclosed"]), CaptureConfigError);
+});

--- a/packages/capture-screen/src/redact.ts
+++ b/packages/capture-screen/src/redact.ts
@@ -1,0 +1,62 @@
+/**
+ * Daemon-side redaction, applied to snapshot text BEFORE it is hashed or
+ * written to the spool. Built-in patterns catch US SSNs and payment-card
+ * numbers (13–19 digits, optionally space/dash grouped, Luhn-valid); the user's
+ * `redactionPatterns` (regex source strings) are applied in addition. Every
+ * match is replaced with a fixed placeholder so the redacted text is stable
+ * (identical inputs dedup identically).
+ */
+
+import { CaptureConfigError } from "./errors.js";
+
+export const REDACTION_PLACEHOLDER = "[REDACTED]";
+
+const SSN_RE = /\b\d{3}-\d{2}-\d{4}\b/g;
+/** Candidate card runs: 13–19 digits with optional single space/dash separators. */
+const CARD_RE = /\b(?:\d[ -]?){13,19}\b/g;
+
+function luhnValid(digits: string): boolean {
+  let sum = 0;
+  let double = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = digits.charCodeAt(i) - 48;
+    if (double) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+    double = !double;
+  }
+  return sum % 10 === 0;
+}
+
+function redactCards(text: string): string {
+  return text.replace(CARD_RE, (match) => {
+    const digits = match.replace(/[ -]/g, "");
+    if (digits.length < 13 || digits.length > 19 || !luhnValid(digits)) return match;
+    return REDACTION_PLACEHOLDER;
+  });
+}
+
+/** Compile user regex source strings once; an invalid pattern fails loudly. */
+export function compileRedactionPatterns(sources: readonly string[]): RegExp[] {
+  return sources.map((source) => {
+    try {
+      return new RegExp(source, "g");
+    } catch {
+      throw new CaptureConfigError(`redactionPatterns: '${source}' is not a valid regular expression`);
+    }
+  });
+}
+
+/** Apply built-in (SSN, card) then user redactions to `text`. */
+export function redactText(text: string, userPatterns: readonly RegExp[] = []): string {
+  let out = text.replace(SSN_RE, REDACTION_PLACEHOLDER);
+  out = redactCards(out);
+  for (const pattern of userPatterns) {
+    // Reset lastIndex: a shared global RegExp carries state between calls.
+    pattern.lastIndex = 0;
+    out = out.replace(pattern, REDACTION_PLACEHOLDER);
+  }
+  return out;
+}

--- a/packages/capture-screen/src/replay.test.ts
+++ b/packages/capture-screen/src/replay.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { defaultDaemonConfig } from "./config.js";
+import { startDaemon, type DaemonHandle } from "./daemon.js";
+import { ingestReplayDir } from "./replay.js";
+import { Spool } from "./spool.js";
+
+const TOKEN = "replay-token";
+const open: DaemonHandle[] = [];
+const spools: Spool[] = [];
+after(async () => {
+  for (const h of open) await h.close();
+  for (const s of spools) s.close();
+});
+
+/**
+ * Faithful re-implementation of @remnic/core's ActivityHttpSourceClient wire
+ * parser (packages/remnic-core/src/activity/source-client.ts). capture-screen
+ * is standalone (no @remnic/core dep), so we assert the served page satisfies
+ * that parser here instead of importing it. Throws exactly where core would.
+ */
+function assertCoreWouldAccept(page: unknown): void {
+  assert.ok(page !== null && typeof page === "object" && Array.isArray((page as { snapshots?: unknown }).snapshots));
+  const body = page as { snapshots: unknown[]; nextCursor?: unknown };
+  const nextCursor = body.nextCursor === undefined ? null : body.nextCursor;
+  assert.ok(nextCursor === null || typeof nextCursor === "string", "nextCursor must be string|null");
+  for (const raw of body.snapshots) {
+    assert.ok(raw !== null && typeof raw === "object", "snapshot must be an object");
+    const s = raw as Record<string, unknown>;
+    for (const field of ["capturedAtUtc", "contentHash", "textSource"]) {
+      assert.equal(typeof s[field], "string", `${field} must be a non-empty string`);
+      assert.ok((s[field] as string).length > 0, `${field} must be non-empty`);
+    }
+    assert.ok(s.textSource === "ax" || s.textSource === "ocr", "textSource must be ax|ocr");
+    for (const field of ["app", "windowTitle", "text"]) {
+      assert.equal(typeof s[field], "string", `${field} must be a string (may be empty)`);
+    }
+    if (s.browserUrl !== undefined && s.browserUrl !== null) assert.equal(typeof s.browserUrl, "string");
+    if (s.simhash !== undefined && s.simhash !== null) assert.equal(typeof s.simhash, "string");
+  }
+}
+
+function writeFixtures(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "csr-replay-"));
+  const write = (name: string, doc: unknown) => writeFileSync(path.join(dir, name), JSON.stringify(doc), "utf8");
+  write("a-normal.json", {
+    capturedAtUtc: "2026-07-20T10:00:00.000Z",
+    app: "Safari",
+    windowTitle: "Docs",
+    ax: { role: "AXWindow", children: [{ role: "AXStaticText", value: "Hello Docs body text" }] },
+  });
+  write("b-deny.json", {
+    capturedAtUtc: "2026-07-20T10:01:00.000Z",
+    app: "1Password 8",
+    windowTitle: "Vault",
+    text: "super secret vault contents",
+  });
+  write("c-terminal.json", {
+    capturedAtUtc: "2026-07-20T10:02:00.000Z",
+    app: "iTerm2",
+    windowTitle: "zsh",
+    ax: { role: "AXWindow" },
+  });
+  write("d-secure.json", {
+    capturedAtUtc: "2026-07-20T10:03:00.000Z",
+    app: "Login",
+    windowTitle: "Sign in",
+    ax: {
+      role: "AXWindow",
+      children: [
+        { role: "AXStaticText", value: "Username field label" },
+        { role: "AXSecureTextField", value: "topsecretpassword" },
+      ],
+    },
+  });
+  write(
+    "e-dedup.json",
+    Array.from({ length: 5 }, (_, i) => ({
+      capturedAtUtc: `2026-07-20T10:04:0${i}.000Z`,
+      app: "Reader",
+      windowTitle: "Book",
+      text: "a static page of prose that does not change between scroll frames",
+    })),
+  );
+  return dir;
+}
+
+test("replay runs candidates through the full pipeline with honest per-rule counts", () => {
+  const spool = new Spool(":memory:");
+  spools.push(spool);
+  const result = ingestReplayDir(spool, writeFixtures(), defaultDaemonConfig());
+  assert.equal(result.candidates, 9);
+  assert.equal(result.denied, 1, "1Password window dropped whole");
+  assert.equal(result.ocrSkipped, 1, "terminal window with no OCR skipped");
+  assert.equal(result.deduped, 4, "5 identical scroll states → 1 stored, 4 deduped");
+  assert.equal(result.stored, 3, "normal + secure + first scroll state");
+  assert.equal(spool.countSnapshots(), 3);
+});
+
+test("replayed snapshots serve a page ActivityHttpSourceClient would accept", async () => {
+  const spool = new Spool(":memory:");
+  spools.push(spool);
+  const config = defaultDaemonConfig();
+  ingestReplayDir(spool, writeFixtures(), config);
+  const handle = await startDaemon({ spool, config: { ...config, host: "127.0.0.1", port: 0 }, token: TOKEN });
+  open.push(handle);
+
+  const res = await fetch(`${handle.url}/v1/snapshots?date=2026-07-20&timezone=UTC`, {
+    headers: { authorization: `Bearer ${TOKEN}` },
+  });
+  assert.equal(res.status, 200);
+  const page: unknown = await res.json();
+  assertCoreWouldAccept(page);
+
+  const body = page as { snapshots: Array<Record<string, unknown>> };
+  assert.equal(body.snapshots.length, 3);
+  assert.equal(body.snapshots[0].app, "Safari");
+  assert.ok(body.snapshots.every((s) => s.textSource === "ax"));
+  // Deny + secure-field guarantees: no dropped/secret content reaches the wire.
+  const allText = body.snapshots.map((s) => String(s.text)).join("\n");
+  assert.doesNotMatch(allText, /topsecretpassword/);
+  assert.doesNotMatch(allText, /vault contents/);
+});

--- a/packages/capture-screen/src/replay.test.ts
+++ b/packages/capture-screen/src/replay.test.ts
@@ -125,3 +125,15 @@ test("replayed snapshots serve a page ActivityHttpSourceClient would accept", as
   assert.doesNotMatch(allText, /topsecretpassword/);
   assert.doesNotMatch(allText, /vault contents/);
 });
+
+test("replay rejects a fixture carrying neither text nor ax (upfront, atomic)", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "csr-replay-bad-"));
+  writeFileSync(
+    path.join(dir, "bad.json"),
+    JSON.stringify({ capturedAtUtc: "2026-07-20T10:00:00.000Z", app: "Safari", windowTitle: "x" }),
+    "utf8",
+  );
+  const spool = new Spool(":memory:");
+  spools.push(spool);
+  assert.throws(() => ingestReplayDir(spool, dir, defaultDaemonConfig()), /must carry 'text' or 'ax'/);
+});

--- a/packages/capture-screen/src/replay.ts
+++ b/packages/capture-screen/src/replay.ts
@@ -1,0 +1,222 @@
+/**
+ * `--replay <dir>` ingestion. Feeds synthetic candidate snapshots through the
+ * FULL capture pipeline (deny-lists, AX/secure-field extraction, OCR routing,
+ * redaction, dedup, supersession) into the spool — the CI-friendly, hardware-
+ * free path that exercises every capture-time rule without a native helper.
+ *
+ * Each `*.json` fixture is either a single candidate or an array of them:
+ *
+ *   {
+ *     "capturedAtUtc": "2026-07-20T15:00:00.000Z",
+ *     "app": "Safari",
+ *     "windowTitle": "Example",
+ *     "browserUrl": "https://example.com",      // optional
+ *     "text": "already extracted text",          // optional; OR provide "ax"
+ *     "textSource": "ax",                        // optional; "ax" | "ocr"
+ *     "ax": { "role": "AXWindow", "children": [ ... ] }  // optional AX tree
+ *   }
+ *
+ * Candidates are processed in ascending capturedAt order (ties broken by file
+ * order) so dedup/TTL behave deterministically regardless of how fixtures are
+ * split across files. Ingestion is idempotent by content hash.
+ */
+
+import { lstatSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import type { CaptureCandidate, CaptureProcessor, OcrFn } from "./capture.js";
+import { CaptureProcessor as Processor } from "./capture.js";
+import type { DaemonConfig } from "./config.js";
+import { CaptureConfigError } from "./errors.js";
+import type { AxNode } from "./axtree.js";
+import type { Spool } from "./spool.js";
+
+export interface ReplayResult {
+  files: number;
+  candidates: number;
+  stored: number;
+  denied: number;
+  deduped: number;
+  ocrSkipped: number;
+  superseded: number;
+  /** True when a cooperative cancel (AbortSignal) stopped ingestion early. */
+  aborted: boolean;
+}
+
+const REPLAY_INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d{1,9})?)?(Z|[+-]\d{2}:\d{2})$/;
+
+function asObject(value: unknown, where: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new CaptureConfigError(`${where}: expected a snapshot object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseTimestamp(value: unknown, where: string): string {
+  if (typeof value !== "string" || !REPLAY_INSTANT.test(value) || !Number.isFinite(Date.parse(value))) {
+    throw new CaptureConfigError(`${where}: expected an ISO instant with a Z or numeric offset`);
+  }
+  const [cy, cm, cd] = value.slice(0, 10).split("-").map(Number);
+  const probe = new Date(Date.UTC(cy, cm - 1, cd));
+  probe.setUTCFullYear(cy);
+  if (probe.getUTCFullYear() !== cy || probe.getUTCMonth() !== cm - 1 || probe.getUTCDate() !== cd) {
+    throw new CaptureConfigError(`${where}: '${value}' is not a real calendar date`);
+  }
+  // Canonicalize to UTC (Z) so an offset instant sorts correctly under the keyset.
+  return new Date(value).toISOString();
+}
+
+function requireString(value: unknown, where: string): string {
+  if (typeof value !== "string") throw new CaptureConfigError(`${where}: expected a string`);
+  return value;
+}
+
+function parseCandidate(raw: unknown, where: string): CaptureCandidate {
+  const obj = asObject(raw, where);
+  const capturedAtUtc = parseTimestamp(obj.capturedAtUtc, `${where}.capturedAtUtc`);
+  const candidate: CaptureCandidate = {
+    capturedAtUtc,
+    app: requireString(obj.app, `${where}.app`),
+    windowTitle: requireString(obj.windowTitle, `${where}.windowTitle`),
+  };
+  if (obj.browserUrl !== undefined && obj.browserUrl !== null) {
+    candidate.browserUrl = requireString(obj.browserUrl, `${where}.browserUrl`);
+  }
+  if (obj.text !== undefined) candidate.text = requireString(obj.text, `${where}.text`);
+  if (obj.textSource !== undefined) {
+    if (obj.textSource !== "ax" && obj.textSource !== "ocr") {
+      throw new CaptureConfigError(`${where}.textSource: expected 'ax' or 'ocr'`);
+    }
+    candidate.textSource = obj.textSource;
+  }
+  if (obj.ax !== undefined) candidate.ax = asObject(obj.ax, `${where}.ax`) as AxNode;
+  return candidate;
+}
+
+function listFixtureFiles(dir: string): string[] {
+  let entries: string[];
+  try {
+    if (lstatSync(dir).isSymbolicLink()) {
+      throw new CaptureConfigError(`replay dir ${dir} is a symlink; refusing to follow it`);
+    }
+    entries = readdirSync(dir)
+      .filter((name) => name.endsWith(".json"))
+      .sort();
+  } catch (err) {
+    if (err instanceof CaptureConfigError) throw err;
+    throw new CaptureConfigError(`replay dir not found or unreadable: ${dir}`);
+  }
+  if (entries.length === 0) {
+    throw new CaptureConfigError(`replay dir ${dir} contains no *.json fixtures`);
+  }
+  return entries;
+}
+
+/** Parse + validate every fixture without touching the spool (atomic failure). */
+function parseReplayDir(dir: string): { candidates: CaptureCandidate[]; files: number } {
+  const entries = listFixtureFiles(dir);
+  const candidates: CaptureCandidate[] = [];
+  for (const name of entries) {
+    const filePath = path.join(dir, name);
+    if (lstatSync(filePath).isSymbolicLink()) {
+      throw new CaptureConfigError(`replay fixture ${name} is a symlink; refusing to follow it`);
+    }
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(filePath, "utf8"));
+    } catch (err) {
+      throw new CaptureConfigError(`replay fixture ${name} is not valid JSON: ${(err as Error).message}`);
+    }
+    const docs = Array.isArray(raw) ? raw : [raw];
+    docs.forEach((doc, i) => candidates.push(parseCandidate(doc, `${name}[${i}]`)));
+  }
+  // Stable ascending capture order (tie: original index) — deterministic dedup.
+  const indexed = candidates.map((candidate, index) => ({ candidate, index }));
+  indexed.sort((a, b) => {
+    const at = Date.parse(a.candidate.capturedAtUtc);
+    const bt = Date.parse(b.candidate.capturedAtUtc);
+    return at !== bt ? at - bt : a.index - b.index;
+  });
+  return { candidates: indexed.map((entry) => entry.candidate), files: entries.length };
+}
+
+function seedProcessor(processor: CaptureProcessor, spool: Spool): void {
+  for (const fp of spool.latestFingerprints()) {
+    processor.seed(fp.app, fp.windowTitle, fp.simhash, fp.capturedAtUtc);
+  }
+}
+
+function commit(processor: CaptureProcessor, spool: Spool, config: DaemonConfig, candidate: CaptureCandidate, result: ReplayResult): void {
+  const decision = processor.process(candidate);
+  if (decision.action === "denied") {
+    result.denied += 1;
+  } else if (decision.action === "skipped") {
+    if (decision.reason === "dedup") result.deduped += 1;
+    else result.ocrSkipped += 1;
+  } else {
+    const inserted = spool.insertSnapshot(decision.snapshot, config.sessionGapSeconds);
+    if (inserted.inserted) {
+      result.stored += 1;
+      if (inserted.supersededId !== null) result.superseded += 1;
+    }
+  }
+}
+
+/** Commit size between event-loop yields in the responsive ingester. */
+export const REPLAY_COMMIT_BATCH = 25;
+
+/** Synchronous ingest: validate the whole directory, then process it all. */
+export function ingestReplayDir(spool: Spool, dir: string, config: DaemonConfig, ocr?: OcrFn): ReplayResult {
+  const { candidates, files } = parseReplayDir(dir);
+  const processor = new Processor(config, ocr);
+  seedProcessor(processor, spool);
+  const result: ReplayResult = {
+    files,
+    candidates: candidates.length,
+    stored: 0,
+    denied: 0,
+    deduped: 0,
+    ocrSkipped: 0,
+    superseded: 0,
+    aborted: false,
+  };
+  for (const candidate of candidates) commit(processor, spool, config, candidate, result);
+  return result;
+}
+
+/**
+ * Responsive ingest: validate up front (atomic), then process in bounded
+ * batches with an event-loop yield between them so a co-hosted HTTP server
+ * stays responsive during a large replay.
+ */
+export async function ingestReplayDirResponsive(
+  spool: Spool,
+  dir: string,
+  config: DaemonConfig,
+  options: { signal?: AbortSignal; ocr?: OcrFn } = {},
+): Promise<ReplayResult> {
+  const { candidates, files } = parseReplayDir(dir);
+  const processor = new Processor(config, options.ocr);
+  seedProcessor(processor, spool);
+  const result: ReplayResult = {
+    files,
+    candidates: candidates.length,
+    stored: 0,
+    denied: 0,
+    deduped: 0,
+    ocrSkipped: 0,
+    superseded: 0,
+    aborted: false,
+  };
+  for (let i = 0; i < candidates.length; i += REPLAY_COMMIT_BATCH) {
+    if (options.signal?.aborted) {
+      result.aborted = true;
+      break;
+    }
+    for (const candidate of candidates.slice(i, i + REPLAY_COMMIT_BATCH)) {
+      commit(processor, spool, config, candidate, result);
+    }
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  return result;
+}

--- a/packages/capture-screen/src/replay.ts
+++ b/packages/capture-screen/src/replay.ts
@@ -90,6 +90,9 @@ function parseCandidate(raw: unknown, where: string): CaptureCandidate {
     candidate.textSource = obj.textSource;
   }
   if (obj.ax !== undefined) candidate.ax = asObject(obj.ax, `${where}.ax`) as AxNode;
+  if (candidate.text === undefined && candidate.ax === undefined) {
+    throw new CaptureConfigError(`${where}: a fixture must carry 'text' or 'ax' (one is required)`);
+  }
   return candidate;
 }
 

--- a/packages/capture-screen/src/scheduler.test.ts
+++ b/packages/capture-screen/src/scheduler.test.ts
@@ -7,16 +7,21 @@ import type { AxSnapshot, NativeHelper } from "./helper.js";
 import { CaptureScheduler, type SchedulerClock } from "./scheduler.js";
 import { Spool } from "./spool.js";
 
-function makeClock(): SchedulerClock & { nowMs: number } {
+function makeClock(): SchedulerClock & { nowMs: number; fire(): void } {
+  let fn: (() => void) | null = null;
   const clock = {
     nowMs: 0,
     now() {
       return clock.nowMs;
     },
-    setInterval() {
-      return 0 as unknown as ReturnType<typeof setInterval>;
+    setInterval(f: () => void) {
+      fn = f;
+      return 1 as unknown as ReturnType<typeof setInterval>;
     },
     clearInterval() {},
+    fire() {
+      fn?.();
+    },
   };
   return clock;
 }
@@ -103,5 +108,79 @@ test("scheduler surfaces helper errors via onError and keeps running", async () 
   assert.equal(errors.length, 1);
   assert.equal(spool.countSnapshots(), 0);
 
+  spool.close();
+});
+
+test("stop() drains an in-flight tick before resolving", async () => {
+  const config = { ...defaultDaemonConfig(), settleMs: 0, idleFallbackSeconds: 1 };
+  const spool = new Spool(":memory:");
+  const processor = new CaptureProcessor(config);
+  let release!: () => void;
+  const gate = new Promise<void>((r) => {
+    release = r;
+  });
+  const helper = {
+    axSnapshot: async () => {
+      await gate;
+      return axWindow("Safari", "Docs", "text body here");
+    },
+    ocrWindow: async () => "",
+  } as unknown as NativeHelper;
+  const clock = makeClock();
+  const scheduler = new CaptureScheduler(helper, processor, spool, config, {}, clock);
+  scheduler.start();
+  clock.fire(); // begins a tick that blocks on the gate
+
+  let stopResolved = false;
+  const stopping = scheduler.stop().then(() => {
+    stopResolved = true;
+  });
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(stopResolved, false, "stop() must await the in-flight tick");
+  release();
+  await stopping;
+  assert.equal(stopResolved, true);
+  spool.close();
+});
+
+test("idle fallback never preempts a change still inside its settle window", async () => {
+  const config = { ...defaultDaemonConfig(), settleMs: 10000, idleFallbackSeconds: 1 };
+  const spool = new Spool(":memory:");
+  const processor = new CaptureProcessor(config);
+  const state = { snap: axWindow("Safari", "Docs", "settle text body"), ocr: "" };
+  const clock = makeClock();
+  const scheduler = new CaptureScheduler(fakeHelper(state), processor, spool, config, {}, clock);
+  clock.nowMs = 0;
+  await scheduler.tick(); // change → pending
+  clock.nowMs = 2000; // idle due (>=1000) but settle not (<10000)
+  await scheduler.tick();
+  assert.equal(spool.countSnapshots(), 0, "must not idle-capture a still-settling change");
+  clock.nowMs = 10001;
+  await scheduler.tick();
+  assert.equal(spool.countSnapshots(), 1);
+  spool.close();
+});
+
+test("a deny-listed window is never OCR'd (deny preflight)", async () => {
+  const config = { ...defaultDaemonConfig(), settleMs: 0, idleFallbackSeconds: 1 };
+  const spool = new Spool(":memory:");
+  const processor = new CaptureProcessor(config);
+  let ocrCalls = 0;
+  const helper = {
+    axSnapshot: async () => ({ app: "1Password 8", windowTitle: "Vault", tree: { role: "AXWindow" } }) as AxSnapshot,
+    ocrWindow: async () => {
+      ocrCalls += 1;
+      return "secret";
+    },
+  } as unknown as NativeHelper;
+  const clock = makeClock();
+  const scheduler = new CaptureScheduler(helper, processor, spool, config, {}, clock);
+  clock.nowMs = 0;
+  await scheduler.tick(); // change
+  clock.nowMs = 10;
+  await scheduler.tick(); // settle(0) → denied, no OCR
+  assert.equal(ocrCalls, 0, "must not OCR a deny-listed window");
+  assert.equal(spool.countSnapshots(), 0);
   spool.close();
 });

--- a/packages/capture-screen/src/scheduler.test.ts
+++ b/packages/capture-screen/src/scheduler.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { CaptureProcessor } from "./capture.js";
+import { defaultDaemonConfig } from "./config.js";
+import type { AxSnapshot, NativeHelper } from "./helper.js";
+import { CaptureScheduler, type SchedulerClock } from "./scheduler.js";
+import { Spool } from "./spool.js";
+
+function makeClock(): SchedulerClock & { nowMs: number } {
+  const clock = {
+    nowMs: 0,
+    now() {
+      return clock.nowMs;
+    },
+    setInterval() {
+      return 0 as unknown as ReturnType<typeof setInterval>;
+    },
+    clearInterval() {},
+  };
+  return clock;
+}
+
+function fakeHelper(state: { snap: AxSnapshot; ocr: string }): NativeHelper {
+  return {
+    axSnapshot: async () => state.snap,
+    ocrWindow: async () => state.ocr,
+  } as unknown as NativeHelper;
+}
+
+function axWindow(app: string, windowTitle: string, text: string): AxSnapshot {
+  return {
+    app,
+    windowTitle,
+    tree: { role: "AXWindow", children: [{ role: "AXStaticText", value: text }] },
+  };
+}
+
+test("scheduler stores on change+settle, dedups idle re-samples, captures new windows", async () => {
+  const config = { ...defaultDaemonConfig(), settleMs: 100, idleFallbackSeconds: 1 };
+  const spool = new Spool(":memory:");
+  const processor = new CaptureProcessor(config);
+  const state = { snap: axWindow("Safari", "Docs", "hello visible page text here"), ocr: "" };
+  const clock = makeClock();
+  const scheduler = new CaptureScheduler(fakeHelper(state), processor, spool, config, {}, clock);
+
+  // A foreground change opens a settle window — nothing stored yet.
+  clock.nowMs = 0;
+  await scheduler.tick();
+  assert.equal(spool.countSnapshots(), 0);
+  clock.nowMs = 50; // still within settleMs
+  await scheduler.tick();
+  assert.equal(spool.countSnapshots(), 0);
+  // Settled → the snapshot is stored.
+  clock.nowMs = 200;
+  await scheduler.tick();
+  assert.equal(spool.countSnapshots(), 1);
+
+  // Idle re-sample of the identical window dedups (no new row).
+  clock.nowMs = 200 + 1000 + 5; // past idleFallbackSeconds
+  await scheduler.tick();
+  assert.equal(spool.countSnapshots(), 1);
+
+  // A new (non-terminal) window → change → settle → a second row.
+  state.snap = axWindow("Notes", "Meeting", "totally different meeting notes body");
+  clock.nowMs += 10;
+  await scheduler.tick(); // change
+  clock.nowMs += 200;
+  await scheduler.tick(); // settle → store
+  assert.equal(spool.countSnapshots(), 2);
+
+  spool.close();
+});
+
+test("scheduler never stores a deny-listed window", async () => {
+  const config = { ...defaultDaemonConfig(), settleMs: 0, idleFallbackSeconds: 1 };
+  const spool = new Spool(":memory:");
+  const processor = new CaptureProcessor(config);
+  // 1Password is a built-in deny default (see denylist.ts).
+  const state = { snap: axWindow("1Password 8", "Vault", "secret vault contents"), ocr: "" };
+  const clock = makeClock();
+  const scheduler = new CaptureScheduler(fakeHelper(state), processor, spool, config, {}, clock);
+
+  clock.nowMs = 0;
+  await scheduler.tick(); // change
+  clock.nowMs = 10;
+  await scheduler.tick(); // settle(0) → processed → denied, not stored
+  assert.equal(spool.countSnapshots(), 0);
+
+  spool.close();
+});
+
+test("scheduler surfaces helper errors via onError and keeps running", async () => {
+  const config = { ...defaultDaemonConfig(), settleMs: 0, idleFallbackSeconds: 1 };
+  const spool = new Spool(":memory:");
+  const processor = new CaptureProcessor(config);
+  const errors: unknown[] = [];
+  const helper = { axSnapshot: async () => { throw new Error("helper down"); } } as unknown as NativeHelper;
+  const clock = makeClock();
+  const scheduler = new CaptureScheduler(helper, processor, spool, config, { onError: (e) => errors.push(e) }, clock);
+
+  await scheduler.tick();
+  assert.equal(errors.length, 1);
+  assert.equal(spool.countSnapshots(), 0);
+
+  spool.close();
+});

--- a/packages/capture-screen/src/scheduler.ts
+++ b/packages/capture-screen/src/scheduler.ts
@@ -1,0 +1,133 @@
+/**
+ * Event-driven live capture loop (#1899 Part 1).
+ *
+ * Each poll fetches the frontmost AX snapshot. A change in the foreground
+ * identity (app, windowTitle, browserUrl) opens a settle window; once the
+ * foreground has been stable for `settleMs` the snapshot is run through the
+ * pipeline and stored. A foreground that never changes is re-sampled at least
+ * every `idleFallbackSeconds` (dedup drops it when unchanged). This is pure
+ * orchestration — the native macOS helper supplies the snapshots, and the same
+ * pipeline (deny-list, redaction, dedup, supersession) that `--replay` uses is
+ * applied here, so behaviour is fully testable off-macOS with a fake helper.
+ */
+
+import type { CaptureProcessor } from "./capture.js";
+import type { DaemonConfig } from "./config.js";
+import type { NativeHelper } from "./helper.js";
+import { captureFromSnapshot } from "./live.js";
+import type { Spool } from "./spool.js";
+
+/** Injectable clock/timer so the loop is deterministically testable. */
+export interface SchedulerClock {
+  now(): number;
+  setInterval(fn: () => void, ms: number): ReturnType<typeof setInterval>;
+  clearInterval(handle: ReturnType<typeof setInterval>): void;
+}
+
+const systemClock: SchedulerClock = {
+  now: () => Date.now(),
+  setInterval: (fn, ms) => setInterval(fn, ms),
+  clearInterval: (handle) => clearInterval(handle),
+};
+
+export interface SchedulerHooks {
+  /** Called when a poll cycle throws (helper failure); the loop keeps running. */
+  onError?: (err: unknown) => void;
+  /** Called after a snapshot is stored. */
+  onStore?: (app: string, windowTitle: string) => void;
+}
+
+export class CaptureScheduler {
+  readonly #helper: NativeHelper;
+  readonly #processor: CaptureProcessor;
+  readonly #spool: Spool;
+  readonly #config: DaemonConfig;
+  readonly #hooks: SchedulerHooks;
+  readonly #clock: SchedulerClock;
+  #timer: ReturnType<typeof setInterval> | null = null;
+  #inflight = false;
+  #lastKey: string | null = null;
+  #changeAt = 0;
+  #pending = false;
+  #lastCaptureAt = Number.NEGATIVE_INFINITY;
+
+  constructor(
+    helper: NativeHelper,
+    processor: CaptureProcessor,
+    spool: Spool,
+    config: DaemonConfig,
+    hooks: SchedulerHooks = {},
+    clock: SchedulerClock = systemClock,
+  ) {
+    this.#helper = helper;
+    this.#processor = processor;
+    this.#spool = spool;
+    this.#config = config;
+    this.#hooks = hooks;
+    this.#clock = clock;
+  }
+
+  /** Begin polling. Idempotent; stops automatically when `signal` aborts. */
+  start(signal?: AbortSignal): void {
+    if (this.#timer !== null) return;
+    this.#timer = this.#clock.setInterval(() => void this.tick(), this.#config.pollIntervalMs);
+    signal?.addEventListener("abort", () => this.stop(), { once: true });
+  }
+
+  stop(): void {
+    if (this.#timer !== null) {
+      this.#clock.clearInterval(this.#timer);
+      this.#timer = null;
+    }
+  }
+
+  /**
+   * One poll cycle. Exposed (not private) so tests can drive the loop
+   * deterministically with a fake clock instead of real timers. Overlapping
+   * ticks are skipped so a slow helper never runs two captures at once.
+   */
+  async tick(): Promise<void> {
+    if (this.#inflight) return;
+    this.#inflight = true;
+    try {
+      const snap = await this.#helper.axSnapshot({ frontmost: true, maxNodes: this.#config.maxNodes });
+      const key = `${snap.app}\u0000${snap.windowTitle}\u0000${snap.browserUrl ?? ""}`;
+      const now = this.#clock.now();
+      // Anchor the idle heartbeat to the first poll so the fallback measures from
+      // startup, not since epoch — otherwise it would preempt the settle window.
+      if (this.#lastCaptureAt === Number.NEGATIVE_INFINITY) {
+        this.#lastCaptureAt = now;
+      }
+
+      if (key !== this.#lastKey) {
+        // Foreground changed — open a settle window; capture only once stable.
+        this.#lastKey = key;
+        this.#changeAt = now;
+        this.#pending = true;
+        return;
+      }
+
+      const settled = this.#pending && now - this.#changeAt >= this.#config.settleMs;
+      const idle = now - this.#lastCaptureAt >= this.#config.idleFallbackSeconds * 1000;
+      if (!settled && !idle) return;
+
+      const decision = await captureFromSnapshot(
+        snap,
+        this.#helper,
+        this.#processor,
+        this.#config,
+        new Date(now).toISOString(),
+      );
+      this.#pending = false;
+      this.#lastCaptureAt = now;
+      if (decision.action === "store") {
+        this.#spool.insertSnapshot(decision.snapshot, this.#config.sessionGapSeconds);
+        this.#hooks.onStore?.(snap.app, snap.windowTitle);
+      }
+    } catch (err) {
+      this.#hooks.onError?.(err);
+    } finally {
+      this.#inflight = false;
+    }
+  }
+}

--- a/packages/capture-screen/src/scheduler.ts
+++ b/packages/capture-screen/src/scheduler.ts
@@ -46,6 +46,7 @@ export class CaptureScheduler {
   readonly #clock: SchedulerClock;
   #timer: ReturnType<typeof setInterval> | null = null;
   #inflight = false;
+  #current: Promise<void> | null = null;
   #lastKey: string | null = null;
   #changeAt = 0;
   #pending = false;
@@ -70,14 +71,21 @@ export class CaptureScheduler {
   /** Begin polling. Idempotent; stops automatically when `signal` aborts. */
   start(signal?: AbortSignal): void {
     if (this.#timer !== null) return;
-    this.#timer = this.#clock.setInterval(() => void this.tick(), this.#config.pollIntervalMs);
-    signal?.addEventListener("abort", () => this.stop(), { once: true });
+    this.#timer = this.#clock.setInterval(() => {
+      this.#current = this.tick();
+    }, this.#config.pollIntervalMs);
+    signal?.addEventListener("abort", () => void this.stop(), { once: true });
   }
 
-  stop(): void {
+  /** Stop polling and await any in-flight tick, so a caller can safely close
+   *  shared resources (the spool) once this resolves. */
+  async stop(): Promise<void> {
     if (this.#timer !== null) {
       this.#clock.clearInterval(this.#timer);
       this.#timer = null;
+    }
+    if (this.#current !== null) {
+      await this.#current.catch(() => undefined);
     }
   }
 
@@ -108,7 +116,9 @@ export class CaptureScheduler {
       }
 
       const settled = this.#pending && now - this.#changeAt >= this.#config.settleMs;
-      const idle = now - this.#lastCaptureAt >= this.#config.idleFallbackSeconds * 1000;
+      // Idle is a heartbeat for an UNCHANGED foreground; it must not preempt a
+      // change that is still inside its settle window.
+      const idle = !this.#pending && now - this.#lastCaptureAt >= this.#config.idleFallbackSeconds * 1000;
       if (!settled && !idle) return;
 
       const decision = await captureFromSnapshot(

--- a/packages/capture-screen/src/simhash.test.ts
+++ b/packages/capture-screen/src/simhash.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { hammingDistance, simhash, simhashFromHex, simhashToHex } from "./simhash.js";
+
+const BASE = "the quick brown fox jumps over the lazy dog near the river bank this morning while reading email";
+const ONE_WORD = "the quick brown cat jumps over the lazy dog near the river bank this morning while reading email";
+const UNRELATED = "database index scans dominate the query planner cost model when statistics are stale and skewed heavily";
+
+test("identical text has SimHash distance 0", () => {
+  assert.equal(hammingDistance(simhash(BASE), simhash(BASE)), 0);
+});
+
+test("empty/whitespace text has an all-zero fingerprint", () => {
+  assert.equal(simhash(""), 0n);
+  assert.equal(simhash("   \n\t"), 0n);
+});
+
+test("a one-word change is a small distance; unrelated text is large", () => {
+  const base = simhash(BASE);
+  const oneWord = hammingDistance(base, simhash(ONE_WORD));
+  const unrelated = hammingDistance(base, simhash(UNRELATED));
+  assert.ok(oneWord > 0, "a real edit must move the fingerprint");
+  assert.ok(oneWord < 15, `one-word edit should be small, got ${oneWord}`);
+  assert.ok(unrelated > 20, `unrelated text should be large, got ${unrelated}`);
+  assert.ok(oneWord < unrelated, "one-word edit must be closer than unrelated text");
+});
+
+test("hex rendering is fixed 16-char and round-trips", () => {
+  const h = simhash(BASE);
+  const hex = simhashToHex(h);
+  assert.equal(hex.length, 16);
+  assert.match(hex, /^[0-9a-f]{16}$/);
+  assert.equal(simhashFromHex(hex), h);
+  assert.equal(simhashToHex(0n), "0000000000000000");
+});

--- a/packages/capture-screen/src/simhash.test.ts
+++ b/packages/capture-screen/src/simhash.test.ts
@@ -34,3 +34,14 @@ test("hex rendering is fixed 16-char and round-trips", () => {
   assert.equal(simhashFromHex(hex), h);
   assert.equal(simhashToHex(0n), "0000000000000000");
 });
+
+test("non-ASCII text tokenizes so distinct CJK/Cyrillic captures are not false-deduped", () => {
+  const a = simhash("日本語 の テキスト ウィンドウ 会議 メモ 予定");
+  const b = simhash("完全 に 異なる 内容 プログラム 出力 結果");
+  const cyr = simhash("привет мир это окно с текстом сегодня утром");
+  assert.notEqual(a, 0n, "non-ASCII text must not collapse to an empty fingerprint");
+  assert.notEqual(b, 0n);
+  assert.notEqual(cyr, 0n);
+  assert.ok(hammingDistance(a, b) > 0, "different CJK text must differ");
+  assert.ok(hammingDistance(a, cyr) > 0);
+});

--- a/packages/capture-screen/src/simhash.ts
+++ b/packages/capture-screen/src/simhash.ts
@@ -1,8 +1,9 @@
 /**
  * 64-bit word-shingle SimHash for near-duplicate screen-text detection.
- *
- * Text is lower-cased and tokenized to alphanumeric runs, then shingled into
- * overlapping 2-word grams. Each gram is hashed with 64-bit FNV-1a; the signed
+ * Text is lower-cased and tokenized to Unicode letter/number runs (so CJK,
+ * Cyrillic, and other non-ASCII scripts tokenize instead of collapsing to an
+ * empty set), then shingled into overlapping 2-word grams. Each gram is hashed
+ * with 64-bit FNV-1a; the signed
  * per-bit vote across all grams yields a 64-bit fingerprint whose Hamming
  * distance tracks textual similarity: identical text → distance 0, a small edit
  * → a small distance, unrelated text → a large distance. Everything is BigInt
@@ -15,7 +16,7 @@ const FNV_PRIME = 1099511628211n;
 const SHINGLE_SIZE = 2;
 
 function tokenize(text: string): string[] {
-  return text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+  return text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
 }
 
 function shingles(tokens: string[]): string[] {

--- a/packages/capture-screen/src/simhash.ts
+++ b/packages/capture-screen/src/simhash.ts
@@ -1,0 +1,78 @@
+/**
+ * 64-bit word-shingle SimHash for near-duplicate screen-text detection.
+ *
+ * Text is lower-cased and tokenized to alphanumeric runs, then shingled into
+ * overlapping 2-word grams. Each gram is hashed with 64-bit FNV-1a; the signed
+ * per-bit vote across all grams yields a 64-bit fingerprint whose Hamming
+ * distance tracks textual similarity: identical text → distance 0, a small edit
+ * → a small distance, unrelated text → a large distance. Everything is BigInt
+ * so the full 64 bits are exact.
+ */
+
+const MASK64 = (1n << 64n) - 1n;
+const FNV_OFFSET = 14695981039346656037n;
+const FNV_PRIME = 1099511628211n;
+const SHINGLE_SIZE = 2;
+
+function tokenize(text: string): string[] {
+  return text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+}
+
+function shingles(tokens: string[]): string[] {
+  if (tokens.length < SHINGLE_SIZE) {
+    return tokens.length > 0 ? [tokens.join(" ")] : [];
+  }
+  const out: string[] = [];
+  for (let i = 0; i + SHINGLE_SIZE <= tokens.length; i++) {
+    out.push(tokens.slice(i, i + SHINGLE_SIZE).join(" "));
+  }
+  return out;
+}
+
+/** 64-bit FNV-1a over the UTF-16 code units of `s`. */
+function hash64(s: string): bigint {
+  let h = FNV_OFFSET;
+  for (let i = 0; i < s.length; i++) {
+    h ^= BigInt(s.charCodeAt(i));
+    h = (h * FNV_PRIME) & MASK64;
+  }
+  return h;
+}
+
+/** 64-bit SimHash fingerprint of `text` (0n for empty/whitespace-only text). */
+export function simhash(text: string): bigint {
+  const grams = shingles(tokenize(text));
+  if (grams.length === 0) return 0n;
+  const votes = new Array<number>(64).fill(0);
+  for (const gram of grams) {
+    const h = hash64(gram);
+    for (let b = 0; b < 64; b++) {
+      votes[b] += (h >> BigInt(b)) & 1n ? 1 : -1;
+    }
+  }
+  let out = 0n;
+  for (let b = 0; b < 64; b++) {
+    if (votes[b] > 0) out |= 1n << BigInt(b);
+  }
+  return out;
+}
+
+/** Hamming distance between two 64-bit fingerprints (0..64). */
+export function hammingDistance(a: bigint, b: bigint): number {
+  let x = (a ^ b) & MASK64;
+  let count = 0;
+  while (x !== 0n) {
+    count += Number(x & 1n);
+    x >>= 1n;
+  }
+  return count;
+}
+
+/** Fixed-width 16-char hex rendering (wire/simhash column form). */
+export function simhashToHex(h: bigint): string {
+  return (h & MASK64).toString(16).padStart(16, "0");
+}
+
+export function simhashFromHex(hex: string): bigint {
+  return BigInt(`0x${hex}`) & MASK64;
+}

--- a/packages/capture-screen/src/spool.test.ts
+++ b/packages/capture-screen/src/spool.test.ts
@@ -127,6 +127,17 @@ test("querySnapshots pages by a stable keyset within a half-open local day", () 
   assert.deepEqual(nextDay.snapshots.map((s) => s.text), ["next"]);
 });
 
+test("querySnapshots and daySnapshots exclude superseded rows", () => {
+  const spool = open();
+  const first = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z", windowTitle: "w", text: "v1" }), GAP);
+  const second = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:05.000Z", windowTitle: "w", text: "v2" }), GAP);
+  assert.equal(second.supersededId, first.id);
+  const page = spool.querySnapshots({ date: "2026-07-20", timezone: "UTC", limit: 10 });
+  assert.deepEqual(page.snapshots.map((s) => s.text), ["v2"], "a superseded row must not be served");
+  const day = spool.daySnapshots("2026-07-20", "UTC");
+  assert.deepEqual(day.map((s) => s.text), ["v2"]);
+});
+
 test("latestFingerprints returns the newest non-superseded row per window", () => {
   const spool = open();
   spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z", windowTitle: "w", text: "v1" }), GAP);

--- a/packages/capture-screen/src/spool.test.ts
+++ b/packages/capture-screen/src/spool.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+
+import { contentHash } from "./capture.js";
+import { simhashToHex, simhash } from "./simhash.js";
+import { Spool, type SnapshotInput } from "./spool.js";
+
+const spools: Spool[] = [];
+after(() => {
+  for (const s of spools) s.close();
+});
+
+function open(): Spool {
+  const s = new Spool(":memory:");
+  spools.push(s);
+  return s;
+}
+
+function snap(over: Partial<SnapshotInput> & { capturedAtUtc: string }): SnapshotInput {
+  const base = {
+    app: "Editor",
+    windowTitle: "main.ts",
+    browserUrl: null as string | null,
+    text: "hello",
+    textSource: "ax" as const,
+    ...over,
+  };
+  return {
+    ...base,
+    contentHash: contentHash(base),
+    simhash: simhashToHex(simhash(base.text)),
+  };
+}
+
+const GAP = 300;
+
+test("insert then read back a snapshot", () => {
+  const spool = open();
+  const { id, inserted } = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z" }), GAP);
+  assert.ok(id > 0);
+  assert.equal(inserted, true);
+  assert.equal(spool.countSnapshots(), 1);
+  const row = spool.getSnapshot(id);
+  assert.equal(row?.app, "Editor");
+  assert.equal(row?.textSource, "ax");
+  assert.equal(row?.supersededBy, null);
+});
+
+test("insert is idempotent by content hash", () => {
+  const spool = open();
+  const input = snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z" });
+  const first = spool.insertSnapshot(input, GAP);
+  const second = spool.insertSnapshot(input, GAP);
+  assert.equal(second.inserted, false);
+  assert.equal(second.id, first.id);
+  assert.equal(spool.countSnapshots(), 1);
+});
+
+test("content hash is NUL/control-char safe (no field-boundary collision)", () => {
+  const spool = open();
+  // Same concatenation, different field split — must NOT collide.
+  const a = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z", app: "ab", windowTitle: "c" }), GAP);
+  const b = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z", app: "a", windowTitle: "bc" }), GAP);
+  assert.notEqual(a.id, b.id);
+  // A literal NUL in text must not alias a different split either.
+  const c = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:01.000Z", text: "x\u0000y" }), GAP);
+  const d = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:01.000Z", text: "x\u0000z" }), GAP);
+  assert.notEqual(c.id, d.id);
+  assert.equal(spool.countSnapshots(), 4);
+});
+
+test("supersession links the prior in-session snapshot of the same window", () => {
+  const spool = open();
+  const first = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z", text: "v1" }), GAP);
+  const second = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:10.000Z", text: "v2" }), GAP);
+  assert.equal(second.supersededId, first.id);
+  assert.equal(spool.getSnapshot(first.id)?.supersededBy, second.id);
+  assert.equal(spool.getSnapshot(second.id)?.supersededBy, null);
+});
+
+test("a snapshot outside the session gap does not supersede", () => {
+  const spool = open();
+  const first = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z", text: "v1" }), GAP);
+  const later = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:10:00.000Z", text: "v2" }), GAP);
+  assert.equal(later.supersededId, null);
+  assert.equal(spool.getSnapshot(first.id)?.supersededBy, null);
+});
+
+test("a different window is never superseded by another", () => {
+  const spool = open();
+  const a = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z", windowTitle: "a.ts", text: "1" }), GAP);
+  const b = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:05.000Z", windowTitle: "b.ts", text: "2" }), GAP);
+  assert.equal(b.supersededId, null);
+  assert.equal(spool.getSnapshot(a.id)?.supersededBy, null);
+});
+
+test("retention janitor drops rows older than N days", () => {
+  const spool = open();
+  spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-01T10:00:00.000Z", text: "old" }), GAP);
+  spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-19T10:00:00.000Z", text: "fresh" }), GAP);
+  const now = Date.parse("2026-07-20T10:00:00.000Z");
+  const removed = spool.pruneOlderThan(14, now);
+  assert.equal(removed, 1);
+  assert.equal(spool.countSnapshots(), 1);
+});
+
+test("querySnapshots pages by a stable keyset within a half-open local day", () => {
+  const spool = open();
+  // Three at distinct times plus a tie at the second instant.
+  spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T09:00:00.000Z", text: "a" }), GAP);
+  spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z", text: "b" }), GAP);
+  spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z", windowTitle: "tie.ts", text: "b2" }), GAP);
+  spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T11:00:00.000Z", text: "c" }), GAP);
+  // A snapshot exactly at the next-day boundary must be excluded (half-open).
+  spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-21T00:00:00.000Z", text: "next" }), GAP);
+
+  const p1 = spool.querySnapshots({ date: "2026-07-20", timezone: "UTC", limit: 2 });
+  assert.equal(p1.snapshots.length, 2);
+  assert.ok(p1.nextCursor);
+  assert.deepEqual(p1.snapshots.map((s) => s.text), ["a", "b"]);
+
+  const p2 = spool.querySnapshots({ date: "2026-07-20", timezone: "UTC", limit: 2, cursor: p1.nextCursor });
+  assert.deepEqual(p2.snapshots.map((s) => s.text), ["b2", "c"]);
+  assert.equal(p2.nextCursor, null, "four rows in the day exactly fill two pages");
+
+  const nextDay = spool.querySnapshots({ date: "2026-07-21", timezone: "UTC", limit: 10 });
+  assert.deepEqual(nextDay.snapshots.map((s) => s.text), ["next"]);
+});
+
+test("latestFingerprints returns the newest non-superseded row per window", () => {
+  const spool = open();
+  spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:00.000Z", windowTitle: "w", text: "v1" }), GAP);
+  const latest = spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20T10:00:10.000Z", windowTitle: "w", text: "v2" }), GAP);
+  const fps = spool.latestFingerprints();
+  assert.equal(fps.length, 1);
+  assert.equal(fps[0].windowTitle, "w");
+  assert.equal(fps[0].capturedAtUtc, spool.getSnapshot(latest.id)?.capturedAtUtc);
+});
+
+test("insert rejects a non-canonical timestamp", () => {
+  const spool = open();
+  assert.throws(() => spool.insertSnapshot(snap({ capturedAtUtc: "2026-07-20" }), GAP));
+});

--- a/packages/capture-screen/src/spool.ts
+++ b/packages/capture-screen/src/spool.ts
@@ -1,0 +1,321 @@
+/**
+ * SQLite spool — the daemon's local buffer of captured screen snapshots.
+ *
+ * Uses the built-in `node:sqlite` driver (no native dependency), keeping
+ * @remnic/capture-screen à-la-carte: installing it pulls zero extra runtime
+ * packages. WAL mode + foreign keys are enabled per connection.
+ *
+ * Schema (names/semantics fixed by issue #1899):
+ *   snapshots(id, captured_at_utc, app_name, window_title, browser_url NULL,
+ *             text, text_source (ax or ocr), content_hash UNIQUE, simhash,
+ *             superseded_by NULL -> snapshots(id))
+ *   meta(key, value)
+ *
+ * `content_hash` is UNIQUE and inserts are INSERT OR IGNORE, so re-ingesting an
+ * identical snapshot is a content no-op (kill-9 / replay idempotency).
+ * Supersession links the previous non-superseded snapshot of the same
+ * (app, window) session to its replacement, so a consumer can skip stale states.
+ * The read API pages by a stable (captured_at_utc, id) keyset over a half-open
+ * local-day window.
+ */
+
+import { chmodSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+
+import { SPOOL_SCHEMA_VERSION } from "./constants.js";
+import { activityDayWindow } from "./daywindow.js";
+import { CaptureConfigError } from "./errors.js";
+import { decodeCursor, encodeCursor } from "./validate.js";
+
+export type TextSource = "ax" | "ocr";
+
+export interface SnapshotInput {
+  capturedAtUtc: string;
+  app: string;
+  windowTitle: string;
+  browserUrl?: string | null;
+  text: string;
+  textSource: TextSource;
+  contentHash: string;
+  simhash: string;
+}
+
+export interface InsertResult {
+  id: number;
+  inserted: boolean;
+  /** Id of the prior snapshot this insert superseded, or null. */
+  supersededId: number | null;
+}
+
+export interface DaemonSnapshot {
+  id: number;
+  capturedAtUtc: string;
+  app: string;
+  windowTitle: string;
+  browserUrl: string | null;
+  text: string;
+  textSource: TextSource;
+  contentHash: string;
+  simhash: string;
+  supersededBy: number | null;
+}
+
+export interface SnapshotPage {
+  snapshots: DaemonSnapshot[];
+  nextCursor: string | null;
+}
+
+export interface QuerySnapshotsOptions {
+  date: string;
+  timezone: string;
+  cursor?: string | null;
+  limit: number;
+}
+
+export interface WindowFingerprint {
+  app: string;
+  windowTitle: string;
+  simhash: string;
+  capturedAtUtc: string;
+}
+
+interface SnapshotRow {
+  id: number;
+  capturedAtUtc: string;
+  app: string;
+  windowTitle: string;
+  browserUrl: string | null;
+  text: string;
+  textSource: TextSource;
+  contentHash: string;
+  simhash: string;
+  supersededBy: number | null;
+}
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  captured_at_utc TEXT NOT NULL,
+  app_name TEXT NOT NULL,
+  window_title TEXT NOT NULL,
+  browser_url TEXT,
+  text TEXT NOT NULL,
+  text_source TEXT NOT NULL,
+  content_hash TEXT NOT NULL UNIQUE,
+  simhash TEXT NOT NULL,
+  superseded_by INTEGER REFERENCES snapshots(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_snap_keyset ON snapshots(captured_at_utc, id);
+CREATE INDEX IF NOT EXISTS idx_snap_window ON snapshots(app_name, window_title, captured_at_utc);
+`;
+
+const SELECT_COLUMNS =
+  "id, captured_at_utc AS capturedAtUtc, app_name AS app, window_title AS windowTitle, " +
+  "browser_url AS browserUrl, text, text_source AS textSource, content_hash AS contentHash, " +
+  "simhash, superseded_by AS supersededBy";
+
+const ISO_INSTANT = /^(\d{4})-(\d{2})-(\d{2})T\d{2}:\d{2}(:\d{2}(\.\d{1,9})?)?(Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Validate + canonicalize a capture instant to UTC `Z`. Date-only strings and
+ * offsetless timestamps are rejected, and impossible calendar dates (Date.parse
+ * silently rolls 2026-02-30 → Mar 2) are caught by re-checking the written
+ * Y-M-D, so every persisted `captured_at_utc` and every keyset cursor is an
+ * unambiguous, order-stable instant.
+ */
+function canonicalInstant(value: string): string {
+  const match = typeof value === "string" ? ISO_INSTANT.exec(value) : null;
+  if (!match || !Number.isFinite(Date.parse(value))) {
+    throw new CaptureConfigError(`capturedAtUtc: '${value}' is not a canonical ISO instant (need date, time, and Z or offset)`);
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const probe = new Date(Date.UTC(year, month - 1, day));
+  probe.setUTCFullYear(year);
+  if (probe.getUTCFullYear() !== year || probe.getUTCMonth() !== month - 1 || probe.getUTCDate() !== day) {
+    throw new CaptureConfigError(`capturedAtUtc: '${value}' is not a real calendar date`);
+  }
+  return new Date(value).toISOString();
+}
+
+export class Spool {
+  #db: DatabaseSync;
+  #closed = false;
+
+  constructor(location: string) {
+    this.#db = new DatabaseSync(location);
+    this.#db.exec("PRAGMA journal_mode = WAL;");
+    this.#db.exec("PRAGMA foreign_keys = ON;");
+    this.#db.exec("PRAGMA busy_timeout = 5000;");
+    this.#db.exec(SCHEMA_SQL);
+    if (location !== ":memory:") {
+      // Screen-capture history is sensitive; keep the spool owner-only (best
+      // effort; ignored where chmod is a no-op).
+      try {
+        chmodSync(location, 0o600);
+      } catch {
+        // filesystem without POSIX perms
+      }
+    }
+    this.#db
+      .prepare("INSERT OR IGNORE INTO meta(key, value) VALUES (?, ?)")
+      .run("schema_version", String(SPOOL_SCHEMA_VERSION));
+    this.#db
+      .prepare("INSERT OR IGNORE INTO meta(key, value) VALUES (?, ?)")
+      .run("instance_id", `scr_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`);
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#db.close();
+  }
+
+  meta(key: string): string | null {
+    const row = this.#db.prepare("SELECT value FROM meta WHERE key = ?").get(key) as { value: string } | undefined;
+    return row?.value ?? null;
+  }
+
+  setMeta(key: string, value: string): void {
+    this.#db
+      .prepare("INSERT INTO meta(key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+      .run(key, value);
+  }
+
+  /**
+   * Insert a snapshot. Idempotent by content_hash (INSERT OR IGNORE): a repeat
+   * returns the existing row's id with `inserted:false` and performs no
+   * supersession. On a genuinely new row, the previous non-superseded snapshot
+   * of the same (app, window) captured within `sessionGapSeconds` is marked
+   * superseded_by this row.
+   */
+  insertSnapshot(input: SnapshotInput, sessionGapSeconds: number): InsertResult {
+    if (typeof input.text !== "string") throw new CaptureConfigError("snapshot.text: expected a string");
+    if (input.textSource !== "ax" && input.textSource !== "ocr") {
+      throw new CaptureConfigError("snapshot.textSource: expected 'ax' or 'ocr'");
+    }
+    if (typeof input.contentHash !== "string" || input.contentHash === "") {
+      throw new CaptureConfigError("snapshot.contentHash: expected a non-empty string");
+    }
+    if (typeof input.simhash !== "string" || input.simhash === "") {
+      throw new CaptureConfigError("snapshot.simhash: expected a non-empty string");
+    }
+    const capturedAtUtc = canonicalInstant(input.capturedAtUtc);
+    const browserUrl = input.browserUrl ?? null;
+
+    const db = this.#db;
+    db.exec("BEGIN");
+    try {
+      const result = db
+        .prepare(
+          "INSERT OR IGNORE INTO snapshots(captured_at_utc, app_name, window_title, browser_url, text, text_source, content_hash, simhash) " +
+            "VALUES (?,?,?,?,?,?,?,?)",
+        )
+        .run(capturedAtUtc, input.app, input.windowTitle, browserUrl, input.text, input.textSource, input.contentHash, input.simhash);
+      if (Number(result.changes) === 0) {
+        const existing = db.prepare("SELECT id FROM snapshots WHERE content_hash = ?").get(input.contentHash) as
+          | { id: number }
+          | undefined;
+        db.exec("COMMIT");
+        return { id: existing?.id ?? 0, inserted: false, supersededId: null };
+      }
+      const id = Number(result.lastInsertRowid);
+      const supersededId = this.#supersede(id, input.app, input.windowTitle, capturedAtUtc, sessionGapSeconds);
+      db.exec("COMMIT");
+      return { id, inserted: true, supersededId };
+    } catch (err) {
+      db.exec("ROLLBACK");
+      throw err;
+    }
+  }
+
+  /** Link the prior in-session snapshot of the same window to `newId`. */
+  #supersede(newId: number, app: string, windowTitle: string, capturedAtUtc: string, sessionGapSeconds: number): number | null {
+    const prior = this.#db
+      .prepare(
+        "SELECT id, captured_at_utc AS capturedAtUtc FROM snapshots " +
+          "WHERE app_name = ? AND window_title = ? AND superseded_by IS NULL AND id <> ? " +
+          "AND captured_at_utc <= ? ORDER BY captured_at_utc DESC, id DESC LIMIT 1",
+      )
+      .get(app, windowTitle, newId, capturedAtUtc) as { id: number; capturedAtUtc: string } | undefined;
+    if (prior === undefined) return null;
+    const gapSeconds = (Date.parse(capturedAtUtc) - Date.parse(prior.capturedAtUtc)) / 1000;
+    if (gapSeconds < 0 || gapSeconds > sessionGapSeconds) return null;
+    this.#db.prepare("UPDATE snapshots SET superseded_by = ? WHERE id = ?").run(newId, prior.id);
+    return prior.id;
+  }
+
+  getSnapshot(id: number): DaemonSnapshot | null {
+    const row = this.#db.prepare(`SELECT ${SELECT_COLUMNS} FROM snapshots WHERE id = ?`).get(id) as
+      | SnapshotRow
+      | undefined;
+    return row ? { ...row } : null;
+  }
+
+  countSnapshots(): number {
+    return (this.#db.prepare("SELECT COUNT(*) AS n FROM snapshots").get() as { n: number }).n;
+  }
+
+  /**
+   * Snapshots whose capture instant falls in the half-open [start, end) UTC
+   * window of the requested local day, paged by the stable (captured_at_utc, id)
+   * keyset. The id tiebreak keeps pagination correct across snapshots that
+   * share a capture instant.
+   */
+  querySnapshots(opts: QuerySnapshotsOptions): SnapshotPage {
+    const { startUtc, endUtc } = activityDayWindow(opts.date, opts.timezone);
+    const cursor = decodeCursor(opts.cursor ?? null);
+    const afterAt = cursor ? cursor.capturedAtUtc : "";
+    const afterId = cursor ? cursor.id : 0;
+    const rows = this.#db
+      .prepare(
+        `SELECT ${SELECT_COLUMNS} FROM snapshots ` +
+          "WHERE captured_at_utc >= ? AND captured_at_utc < ? " +
+          "AND (captured_at_utc > ? OR (captured_at_utc = ? AND id > ?)) " +
+          "ORDER BY captured_at_utc ASC, id ASC LIMIT ?",
+      )
+      .all(startUtc, endUtc, afterAt, afterAt, afterId, opts.limit + 1) as unknown as SnapshotRow[];
+    const hasMore = rows.length > opts.limit;
+    const page = hasMore ? rows.slice(0, opts.limit) : rows;
+    const last = page[page.length - 1];
+    return {
+      snapshots: page.map((row) => ({ ...row })),
+      nextCursor: hasMore && last ? encodeCursor(last.capturedAtUtc, last.id) : null,
+    };
+  }
+
+  /** All snapshots in a local day's window, ordered — the basis for /v1/stats. */
+  daySnapshots(date: string, timezone: string): DaemonSnapshot[] {
+    const { startUtc, endUtc } = activityDayWindow(date, timezone);
+    const rows = this.#db
+      .prepare(
+        `SELECT ${SELECT_COLUMNS} FROM snapshots WHERE captured_at_utc >= ? AND captured_at_utc < ? ` +
+          "ORDER BY captured_at_utc ASC, id ASC",
+      )
+      .all(startUtc, endUtc) as unknown as SnapshotRow[];
+    return rows.map((row) => ({ ...row }));
+  }
+
+  /** Latest non-superseded fingerprint per (app, window) — primes the dedup cache. */
+  latestFingerprints(): WindowFingerprint[] {
+    const rows = this.#db
+      .prepare(
+        "SELECT app_name AS app, window_title AS windowTitle, simhash, captured_at_utc AS capturedAtUtc FROM snapshots s " +
+          "WHERE superseded_by IS NULL AND id = (SELECT MAX(id) FROM snapshots t WHERE t.app_name = s.app_name AND t.window_title = s.window_title)",
+      )
+      .all() as unknown as WindowFingerprint[];
+    return rows;
+  }
+
+  /** Retention janitor: drop snapshots older than `days` (cutoff from `nowMs`). Returns rows removed. */
+  pruneOlderThan(days: number, nowMs: number = Date.now()): number {
+    const cutoff = new Date(nowMs - days * 86_400_000).toISOString();
+    const result = this.#db.prepare("DELETE FROM snapshots WHERE captured_at_utc < ?").run(cutoff);
+    return Number(result.changes);
+  }
+}

--- a/packages/capture-screen/src/spool.ts
+++ b/packages/capture-screen/src/spool.ts
@@ -158,6 +158,15 @@ export class Spool {
       // effort; ignored where chmod is a no-op).
       try {
         chmodSync(location, 0o600);
+        // WAL mode writes <location>-wal / <location>-shm sidecars that hold the
+        // same sensitive capture text; keep them owner-only too (best effort).
+        for (const suffix of ["-wal", "-shm"]) {
+          try {
+            chmodSync(`${location}${suffix}`, 0o600);
+          } catch {
+            // sidecar absent yet / no POSIX perms
+          }
+        }
       } catch {
         // filesystem without POSIX perms
       }

--- a/packages/capture-screen/src/spool.ts
+++ b/packages/capture-screen/src/spool.ts
@@ -284,7 +284,7 @@ export class Spool {
     const rows = this.#db
       .prepare(
         `SELECT ${SELECT_COLUMNS} FROM snapshots ` +
-          "WHERE captured_at_utc >= ? AND captured_at_utc < ? " +
+          "WHERE superseded_by IS NULL AND captured_at_utc >= ? AND captured_at_utc < ? " +
           "AND (captured_at_utc > ? OR (captured_at_utc = ? AND id > ?)) " +
           "ORDER BY captured_at_utc ASC, id ASC LIMIT ?",
       )
@@ -303,7 +303,7 @@ export class Spool {
     const { startUtc, endUtc } = activityDayWindow(date, timezone);
     const rows = this.#db
       .prepare(
-        `SELECT ${SELECT_COLUMNS} FROM snapshots WHERE captured_at_utc >= ? AND captured_at_utc < ? ` +
+        `SELECT ${SELECT_COLUMNS} FROM snapshots WHERE superseded_by IS NULL AND captured_at_utc >= ? AND captured_at_utc < ? ` +
           "ORDER BY captured_at_utc ASC, id ASC",
       )
       .all(startUtc, endUtc) as unknown as SnapshotRow[];

--- a/packages/capture-screen/src/token.test.ts
+++ b/packages/capture-screen/src/token.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdtempSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { bearerFromHeader, generateToken, loadOrCreateToken, tokensMatch } from "./token.js";
+
+test("generateToken returns a long random base64url string", () => {
+  const a = generateToken();
+  const b = generateToken();
+  assert.notEqual(a, b);
+  assert.match(a, /^[A-Za-z0-9_-]+$/);
+  assert.ok(a.length >= 40);
+});
+
+test("loadOrCreateToken creates once (0600) and is stable across reads", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "csr-token-"));
+  const tokenPath = path.join(dir, "token");
+  const first = loadOrCreateToken(tokenPath);
+  const second = loadOrCreateToken(tokenPath);
+  assert.equal(first, second);
+  if (process.platform !== "win32") {
+    assert.equal(statSync(tokenPath).mode & 0o777, 0o600);
+  }
+});
+
+test("tokensMatch is constant-time-ish and length-safe", () => {
+  assert.equal(tokensMatch("abc", "abc"), true);
+  assert.equal(tokensMatch("abc", "abd"), false);
+  assert.equal(tokensMatch("abc", "abcd"), false);
+});
+
+test("bearerFromHeader parses only well-formed Bearer headers", () => {
+  assert.equal(bearerFromHeader("Bearer xyz"), "xyz");
+  assert.equal(bearerFromHeader("bearer\txyz"), "xyz");
+  assert.equal(bearerFromHeader("Basic xyz"), null);
+  assert.equal(bearerFromHeader("Bearerxyz"), null);
+  assert.equal(bearerFromHeader(undefined), null);
+});

--- a/packages/capture-screen/src/token.test.ts
+++ b/packages/capture-screen/src/token.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { mkdtempSync, statSync } from "node:fs";
+import { mkdtempSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -37,4 +37,13 @@ test("bearerFromHeader parses only well-formed Bearer headers", () => {
   assert.equal(bearerFromHeader("Basic xyz"), null);
   assert.equal(bearerFromHeader("Bearerxyz"), null);
   assert.equal(bearerFromHeader(undefined), null);
+});
+
+test("loadOrCreateToken replaces a pre-existing empty token file", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "csr-token-empty-"));
+  const tokenPath = path.join(dir, "token");
+  writeFileSync(tokenPath, "", { mode: 0o600 });
+  const token = loadOrCreateToken(tokenPath);
+  assert.ok(token.length >= 40, "an empty token file must be replaced with a fresh token");
+  assert.equal(loadOrCreateToken(tokenPath), token);
 });

--- a/packages/capture-screen/src/token.ts
+++ b/packages/capture-screen/src/token.ts
@@ -1,0 +1,49 @@
+/**
+ * Bearer-token lifecycle. The daemon auto-generates a 256-bit token on first
+ * use and stores it 0600; a pre-existing file is re-chmod'd 0600 defensively
+ * because a world-readable token is a credential leak. The token is REQUIRED on
+ * every request (even on loopback) so another local user cannot read captured
+ * screen text off 127.0.0.1.
+ */
+
+import { Buffer } from "node:buffer";
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export function generateToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function loadOrCreateToken(tokenPath: string): string {
+  mkdirSync(path.dirname(tokenPath), { recursive: true });
+  if (existsSync(tokenPath)) {
+    chmodSync(tokenPath, 0o600);
+    const existing = readFileSync(tokenPath, "utf8").trim();
+    if (existing) return existing;
+  }
+  const token = generateToken();
+  writeFileSync(tokenPath, `${token}\n`, { mode: 0o600 });
+  chmodSync(tokenPath, 0o600);
+  return token;
+}
+
+/** Constant-time compare; unequal lengths short-circuit to false. */
+export function tokensMatch(expected: string, presented: string): boolean {
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(presented, "utf8");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/** Parse `Authorization: Bearer <token>`; returns null when absent/malformed. */
+export function bearerFromHeader(header: string | string[] | undefined): string | null {
+  const value = Array.isArray(header) ? header[0] : header;
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (trimmed.slice(0, 6).toLowerCase() !== "bearer") return null;
+  const separator = trimmed.charCodeAt(6);
+  if (separator !== 32 && separator !== 9) return null;
+  const token = trimmed.slice(6).trim();
+  return token || null;
+}

--- a/packages/capture-screen/src/token.ts
+++ b/packages/capture-screen/src/token.ts
@@ -23,9 +23,22 @@ export function loadOrCreateToken(tokenPath: string): string {
     if (existing) return existing;
   }
   const token = generateToken();
-  writeFileSync(tokenPath, `${token}\n`, { mode: 0o600 });
-  chmodSync(tokenPath, 0o600);
-  return token;
+  try {
+    // Exclusive create: if two daemons start together, the loser gets EEXIST and
+    // reads the winner's token rather than both persisting divergent values.
+    writeFileSync(tokenPath, `${token}\n`, { mode: 0o600, flag: "wx" });
+    chmodSync(tokenPath, 0o600);
+    return token;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    chmodSync(tokenPath, 0o600);
+    const raced = readFileSync(tokenPath, "utf8").trim();
+    if (raced) return raced;
+    // Pre-existing empty file (interrupted prior write): overwrite it.
+    writeFileSync(tokenPath, `${token}\n`, { mode: 0o600 });
+    chmodSync(tokenPath, 0o600);
+    return token;
+  }
 }
 
 /** Constant-time compare; unequal lengths short-circuit to false. */

--- a/packages/capture-screen/src/util.test.ts
+++ b/packages/capture-screen/src/util.test.ts
@@ -17,3 +17,9 @@ test("stripIpv6Brackets and isLoopbackHost accept bracketed and bare loopback", 
   assert.equal(isLoopbackHost("::1"), true);
   assert.equal(isLoopbackHost("10.0.0.5"), false);
 });
+
+test("formatHostForUrl passes non-loopback hosts through, brackets non-loopback IPv6", () => {
+  assert.equal(formatHostForUrl("10.0.0.5"), "10.0.0.5");
+  assert.equal(formatHostForUrl("example.internal"), "example.internal");
+  assert.equal(formatHostForUrl("2001:db8::1"), "[2001:db8::1]");
+});

--- a/packages/capture-screen/src/util.test.ts
+++ b/packages/capture-screen/src/util.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { formatHostForUrl, isLoopbackHost, stripIpv6Brackets } from "./util.js";
+
+test("formatHostForUrl brackets a bare IPv6 once and never double-brackets", () => {
+  assert.equal(formatHostForUrl("::1"), "[::1]");
+  assert.equal(formatHostForUrl("[::1]"), "[::1]");
+  assert.equal(formatHostForUrl("127.0.0.1"), "127.0.0.1");
+  assert.equal(formatHostForUrl("localhost"), "localhost");
+});
+
+test("stripIpv6Brackets and isLoopbackHost accept bracketed and bare loopback", () => {
+  assert.equal(stripIpv6Brackets("[::1]"), "::1");
+  assert.equal(stripIpv6Brackets("::1"), "::1");
+  assert.equal(isLoopbackHost("[::1]"), true);
+  assert.equal(isLoopbackHost("::1"), true);
+  assert.equal(isLoopbackHost("10.0.0.5"), false);
+});

--- a/packages/capture-screen/src/util.ts
+++ b/packages/capture-screen/src/util.ts
@@ -39,9 +39,11 @@ export function isLoopbackHost(host: string): boolean {
   return Object.hasOwn(LOOPBACK_HOSTS, stripIpv6Brackets(host).toLowerCase());
 }
 
-/** Wrap an IPv6 host in brackets for use in a URL authority; IPv4/hostnames pass through. */
+/** Wrap an IPv6 host in brackets for use in a URL authority; IPv4/hostnames pass
+ *  through. Existing brackets are stripped first so `[::1]` -> `[::1]`, never `[[::1]]`. */
 export function formatHostForUrl(host: string): string {
-  return host.includes(":") ? `[${host}]` : host;
+  const bare = stripIpv6Brackets(host);
+  return bare.includes(":") ? `[${bare}]` : bare;
 }
 
 /** Compact, credential-free description of an unexpected value for messages. */

--- a/packages/capture-screen/src/util.ts
+++ b/packages/capture-screen/src/util.ts
@@ -1,0 +1,67 @@
+/** Small dependency-free helpers shared across the package. */
+
+/**
+ * Format a Date as YYYY-MM-DD in the given IANA timezone. Local copy of the
+ * pipeline helper — capture-screen is à-la-carte and does not depend on
+ * @remnic/core.
+ */
+export function dateInTimezone(date: Date, timezone: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const get = (type: string) => parts.find((part) => part.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")}`;
+}
+
+const LOOPBACK_HOSTS: Record<string, true> = {
+  "127.0.0.1": true,
+  "::1": true,
+  localhost: true,
+  "::ffff:127.0.0.1": true,
+};
+
+/** Strip a single pair of surrounding brackets from a URL-authority IPv6 host
+ *  (`[::1]` -> `::1`); non-bracketed hosts pass through unchanged. */
+export function stripIpv6Brackets(host: string): string {
+  const h = host.trim();
+  return h.startsWith("[") && h.endsWith("]") ? h.slice(1, -1) : h;
+}
+
+/**
+ * A host is loopback when it can only be reached from this machine. Binding
+ * anything else (a LAN address, 0.0.0.0, ::) exposes the daemon to the network
+ * and is refused — capture-screen serves plain HTTP with no TLS contract.
+ */
+export function isLoopbackHost(host: string): boolean {
+  return Object.hasOwn(LOOPBACK_HOSTS, stripIpv6Brackets(host).toLowerCase());
+}
+
+/** Wrap an IPv6 host in brackets for use in a URL authority; IPv4/hostnames pass through. */
+export function formatHostForUrl(host: string): string {
+  return host.includes(":") ? `[${host}]` : host;
+}
+
+/** Compact, credential-free description of an unexpected value for messages. */
+export function describeValue(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "an array";
+  const t = typeof value;
+  if (t === "string") return `a string`;
+  if (t === "object") return "an object";
+  return `${t} (${String(value)})`;
+}
+
+/**
+ * Operator-safe error description — name + errno code only, never foreign
+ * message text or filesystem paths. This is the CLI/stderr sanitizer that
+ * replaces @remnic/core's displayErrorDetail: a stack or absolute path in a
+ * captured-screen daemon's stderr could leak sensitive local layout.
+ */
+export function sanitizeError(err: unknown): string {
+  if (!(err instanceof Error)) return "unknown error";
+  const code = (err as NodeJS.ErrnoException).code;
+  return typeof code === "string" && code.length > 0 ? `${err.name} (${code})` : err.name;
+}

--- a/packages/capture-screen/src/validate.test.ts
+++ b/packages/capture-screen/src/validate.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { CaptureInputError } from "./errors.js";
+import { assertValidTimezone, decodeCursor, encodeCursor, parseLimit, parseSnapshotDate } from "./validate.js";
+
+test("parseSnapshotDate accepts real days and rejects impossible/malformed ones", () => {
+  assert.equal(parseSnapshotDate("2026-07-20"), "2026-07-20");
+  assert.throws(() => parseSnapshotDate("2026-02-30"), CaptureInputError);
+  assert.throws(() => parseSnapshotDate("2026-13-01"), CaptureInputError);
+  assert.throws(() => parseSnapshotDate("07/20/2026"), CaptureInputError);
+  assert.throws(() => parseSnapshotDate(null), CaptureInputError);
+});
+
+test("assertValidTimezone accepts IANA zones and rejects junk", () => {
+  assert.equal(assertValidTimezone("America/New_York"), "America/New_York");
+  assert.throws(() => assertValidTimezone("Not/AZone"), CaptureInputError);
+  assert.throws(() => assertValidTimezone(""), CaptureInputError);
+});
+
+test("parseLimit defaults when absent and rejects out-of-range", () => {
+  assert.equal(parseLimit(null), 100);
+  assert.equal(parseLimit("250"), 250);
+  assert.throws(() => parseLimit("0"), CaptureInputError);
+  assert.throws(() => parseLimit("501"), CaptureInputError);
+  assert.throws(() => parseLimit("abc"), CaptureInputError);
+});
+
+test("cursor round-trips over (capturedAtUtc, id) and rejects malformed tokens", () => {
+  const token = encodeCursor("2026-07-20T10:00:00.000Z", 42);
+  assert.deepEqual(decodeCursor(token), { capturedAtUtc: "2026-07-20T10:00:00.000Z", id: 42 });
+  assert.equal(decodeCursor(null), null);
+  assert.equal(decodeCursor(""), null);
+  assert.throws(() => decodeCursor("!!!not-base64!!!"), CaptureInputError);
+  // A non-integer / non-instant tuple is rejected.
+  assert.throws(() => decodeCursor(Buffer.from(JSON.stringify(["x", 1]), "utf8").toString("base64url")), CaptureInputError);
+  assert.throws(
+    () => decodeCursor(Buffer.from(JSON.stringify(["2026-07-20T10:00:00.000Z", "1"]), "utf8").toString("base64url")),
+    CaptureInputError,
+  );
+});

--- a/packages/capture-screen/src/validate.test.ts
+++ b/packages/capture-screen/src/validate.test.ts
@@ -39,3 +39,10 @@ test("cursor round-trips over (capturedAtUtc, id) and rejects malformed tokens",
     CaptureInputError,
   );
 });
+
+test("decodeCursor rejects non-canonical timestamps (offset or missing ms)", () => {
+  const offset = Buffer.from(JSON.stringify(["2026-07-20T10:00:00+00:00", 1]), "utf8").toString("base64url");
+  assert.throws(() => decodeCursor(offset), CaptureInputError);
+  const noMs = Buffer.from(JSON.stringify(["2026-07-20T10:00:00Z", 1]), "utf8").toString("base64url");
+  assert.throws(() => decodeCursor(noMs), CaptureInputError);
+});

--- a/packages/capture-screen/src/validate.ts
+++ b/packages/capture-screen/src/validate.ts
@@ -1,0 +1,87 @@
+/**
+ * Request-input validation for the HTTP surface. Every failure raises
+ * CaptureInputError, which the daemon maps to HTTP 400 — invalid date,
+ * timezone, limit, or cursor is rejected loudly, never silently defaulted. The
+ * keyset cursor is an opaque base64url token over the (capturedAtUtc, id) tuple
+ * the snapshots query orders by, so pagination stays stable across snapshots
+ * that share a capture instant.
+ */
+
+import { Buffer } from "node:buffer";
+
+import { DEFAULT_SNAPSHOTS_LIMIT, MAX_SNAPSHOTS_LIMIT } from "./constants.js";
+import { CaptureInputError } from "./errors.js";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Validate a YYYY-MM-DD calendar date (rejects e.g. 2026-02-30). */
+export function parseSnapshotDate(value: string | null | undefined): string {
+  if (typeof value !== "string" || !DATE_RE.test(value)) {
+    throw new CaptureInputError(`invalid date '${value ?? ""}' — expected YYYY-MM-DD`);
+  }
+  const [year, month, day] = value.split("-").map(Number);
+  const dt = new Date(Date.UTC(year, month - 1, day));
+  dt.setUTCFullYear(year);
+  if (dt.getUTCFullYear() !== year || dt.getUTCMonth() !== month - 1 || dt.getUTCDate() !== day) {
+    throw new CaptureInputError(`invalid date '${value}' — not a real calendar date`);
+  }
+  return value;
+}
+
+/** Validate an IANA timezone by attempting to build a formatter for it. */
+export function assertValidTimezone(value: string | null | undefined): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new CaptureInputError("invalid timezone '' — expected an IANA timezone");
+  }
+  try {
+    new Intl.DateTimeFormat("en-CA", { timeZone: value });
+  } catch {
+    throw new CaptureInputError(`invalid timezone '${value}' — not a known IANA timezone`);
+  }
+  return value;
+}
+
+/** Absent limit → default; present-but-invalid → 400. */
+export function parseLimit(value: string | null | undefined): number {
+  if (value === null || value === undefined) return DEFAULT_SNAPSHOTS_LIMIT;
+  const n = Number(value);
+  if (value === "" || !Number.isInteger(n) || n < 1 || n > MAX_SNAPSHOTS_LIMIT) {
+    throw new CaptureInputError(
+      `invalid limit '${value}' — expected an integer between 1 and ${MAX_SNAPSHOTS_LIMIT}`,
+    );
+  }
+  return n;
+}
+
+export interface Cursor {
+  capturedAtUtc: string;
+  id: number;
+}
+
+export function encodeCursor(capturedAtUtc: string, id: number): string {
+  return Buffer.from(JSON.stringify([capturedAtUtc, id]), "utf8").toString("base64url");
+}
+
+/** Absent cursor → null (first page); malformed cursor → 400. */
+export function decodeCursor(value: string | null | undefined): Cursor | null {
+  if (value === null || value === undefined || value === "") return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch {
+    throw new CaptureInputError("invalid cursor — not a recognized pagination token");
+  }
+  if (
+    Array.isArray(parsed) &&
+    parsed.length === 2 &&
+    typeof parsed[0] === "string" &&
+    typeof parsed[1] === "number" &&
+    Number.isInteger(parsed[1]) &&
+    parsed[1] >= 0 &&
+    /^\d{4}-\d{2}-\d{2}T/.test(parsed[0]) &&
+    Number.isFinite(Date.parse(parsed[0]))
+  ) {
+    return { capturedAtUtc: parsed[0], id: parsed[1] };
+  }
+  throw new CaptureInputError("invalid cursor — not a recognized pagination token");
+}

--- a/packages/capture-screen/src/validate.ts
+++ b/packages/capture-screen/src/validate.ts
@@ -79,7 +79,8 @@ export function decodeCursor(value: string | null | undefined): Cursor | null {
     Number.isInteger(parsed[1]) &&
     parsed[1] >= 0 &&
     /^\d{4}-\d{2}-\d{2}T/.test(parsed[0]) &&
-    Number.isFinite(Date.parse(parsed[0]))
+    Number.isFinite(Date.parse(parsed[0])) &&
+    new Date(parsed[0]).toISOString() === parsed[0]
   ) {
     return { capturedAtUtc: parsed[0], id: parsed[1] };
   }

--- a/packages/capture-screen/tsconfig.json
+++ b/packages/capture-screen/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/shim-openclaw-engram/scripts/sync-openclaw-plugin.mjs
+++ b/packages/shim-openclaw-engram/scripts/sync-openclaw-plugin.mjs
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile, rename } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -17,4 +17,8 @@ const packageJson = JSON.parse(await readFile(packageJsonPath, "utf-8"));
 const manifest = JSON.parse(raw);
 manifest.id = "openclaw-engram";
 manifest.version = packageJson.version;
-await writeFile(target, JSON.stringify(manifest, null, 2) + "\n");
+// Atomic write (rule 54): a concurrent reader (e.g. the package test during a
+// parallel `pnpm -r run build`) must never see a truncated 294 KB manifest.
+const tmp = `${target}.tmp-${process.pid}`;
+await writeFile(tmp, JSON.stringify(manifest, null, 2) + "\n");
+await rename(tmp, target);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,10 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/capture-native-darwin-arm64: {}
+
+  packages/capture-native-darwin-x64: {}
+
   packages/capture-screen:
     devDependencies:
       '@types/node':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,21 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/capture-screen:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.20.0
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/coding-graph:
     dependencies:
       better-sqlite3:

--- a/scripts/sync-openclaw-plugin.mjs
+++ b/scripts/sync-openclaw-plugin.mjs
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile, rename } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -13,4 +13,8 @@ const source = path.resolve(
 const target = path.resolve(repoRoot, "openclaw.plugin.json");
 
 const raw = await readFile(source, "utf-8");
-await writeFile(target, `${JSON.stringify(JSON.parse(raw), null, 2)}\n`);
+// Atomic write (rule 54): temp-then-rename so a concurrent reader never sees a
+// truncated manifest during a parallel build.
+const tmp = `${target}.tmp-${process.pid}`;
+await writeFile(tmp, `${JSON.stringify(JSON.parse(raw), null, 2)}\n`);
+await rename(tmp, target);

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -12,6 +12,7 @@ const expectedPublishDirs = [
   "packages/bench",
   "packages/coding-graph",
   "packages/capture-audio",
+  "packages/capture-screen",
   "packages/export-weclone",
   "packages/import-weclone",
   "packages/import-chatgpt",

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -13,6 +13,8 @@ const expectedPublishDirs = [
   "packages/coding-graph",
   "packages/capture-audio",
   "packages/capture-screen",
+  "packages/capture-native-darwin-arm64",
+  "packages/capture-native-darwin-x64",
   "packages/export-weclone",
   "packages/import-weclone",
   "packages/import-chatgpt",

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -13,8 +13,6 @@ const expectedPublishDirs = [
   "packages/coding-graph",
   "packages/capture-audio",
   "packages/capture-screen",
-  "packages/capture-native-darwin-arm64",
-  "packages/capture-native-darwin-x64",
   "packages/export-weclone",
   "packages/import-weclone",
   "packages/import-chatgpt",


### PR DESCRIPTION
## Summary

Recovers and completes the `@remnic/capture-screen` deliverable (**Part of #1899**) directly on `main`. The original daemon (#2103) was squash-merged into `feat/activity-core-surfaces`, which diverged from `main`, so it never reached `main`; this PR rebuilds it on current `main` and expands it to the full #1899 Part-1 daemon contract, plus the **one shared macOS native capture helper** (umbrella decision G) serving both #1899 screen and #1897 audio.

`packages/remnic-core/src/activity/*` (Part 2) is already on `main`; this PR adds only Part 1 + the shared native helper and integration/test deltas.

> **macOS CI is REQUIRED before completion.** The Swift helper cannot be built or run on Linux; its only verification is the `capture-native-helper` macOS matrix job in this PR. Do not merge until all current-head checks, review threads, and the macOS Swift build/test receipts are green.

## What's in this PR

- **`@remnic/capture-screen`** — standalone, à-la-carte daemon (built-in `node:sqlite`, **zero runtime deps**, no `@remnic/core`): event-driven capture orchestration + native-helper seam (`ax-snapshot`/`ocr-window`), 64-bit word-shingle SimHash + threshold/TTL dedup, deny-lists, SSN/Luhn-card/pattern redaction, AX secure-field/off-screen filtering (in TS, unit-tested), spool (supersession + retention janitor), `--replay`, loopback HTTP (`/v1/health`, `/v1/snapshots` keyset, `/v1/stats`), env `REMNIC_CAPTURE_TOKEN` bearer, full CLI.
- **`remnic-capture-helper`** (`packages/capture-native-darwin-helper`, Swift, macOS 13+) — one binary, subcommands: `audio-capture` (AVAudioEngine mic + ScreenCaptureKit system, 16 kHz mono WAV chunks + JSON-line events), `device-enumerate` (CoreAudio), `ax-snapshot` (AXUIElement raw tree; daemon filters), `ocr-window` (Vision; image discarded, never on disk). Missing TCC → clear stderr + nonzero exit.
- **`@remnic/capture-native-darwin-{arm64,x64}`** — per-arch platform packages exporting `helperBinaryPath`; resolved by computed specifier `@remnic/capture-native-${platform}-${arch}` (miss → actionable hint, never `MODULE_NOT_FOUND`). Consumed by this daemon and, post-merge, by #2106.
- **`.github/workflows/capture-native-helper.yml`** — macOS matrix (`macos-14` arm64 + `macos-13` x64) `swift build -c release` + `swift test`, stages the binary into the platform package + runs its test + uploads the artifact; plus a Linux job running the `@remnic/capture-screen` type-check + tests.

## Cross-issue coordination

Shared-helper JSON contract (commands/config/permissions) confirmed and recorded with #2106 (`integration-contract-1897.md` §G): `helperBinaryPath`, `audio-capture --channel|--chunk-seconds|--out|--device`, `device-enumerate`, newline-delimited chunk JSON. #2106 wires it after this merges. Not folded into any audio/meeting PR.

## #1899 acceptance matrix

| Criterion | Status | Evidence |
|---|---|---|
| Base installs unaffected; `activity` absent/disabled → zero behavior change | ✅ | Daemon is opt-in à-la-carte; core gating already on `main` |
| Default-off / double opt-in (daemon must be explicitly started + token) | ✅ | Loopback-only, env-token required, no auto-start |
| Fixture-daemon end-to-end (`/v1/snapshots` ingestible by core `ActivityHttpSourceClient`) | ✅ Linux | wire-shape test vs `source-client.ts` |
| Dedup: 100 near-identical scroll states → ≤5 stored; distinct windows independent | ✅ Linux | `simhash.test.ts`, `dedup.test.ts` |
| Deny-list → zero rows/metadata; `test-snapshot` names firing rule | ✅ Linux | `denylist.test.ts`, CLI |
| Secure fields → text absent from snapshot | ✅ Linux | `axtree.test.ts` (AXSecureTextField skipped) |
| OCR fallback routing; unavailable → skip + `ocrAvailable:false`, no crash | ◑ | routing + degraded health ✅ Linux (fake helper); real Vision OCR ⏳ macOS CI |
| `extractionMode` off/smart | ✅ | core-side, already on `main` |
| No image bytes on disk at any point | ◑ | daemon never writes images ✅ Linux; Swift discards capture image ⏳ macOS CI |
| Multi-machine attribution / cursor isolation | ✅ | core-side, already on `main` |
| Timestamp boundary at local midnight → exactly one day (half-open) | ✅ Linux | `daywindow.test.ts` (DST-aware) |
| Native AX walk / Vision OCR / CoreAudio device-enumerate / TCC honesty | ⏳ | **requires macOS CI** (Swift build + `swift test`) |

Legend: ✅ verified · ◑ partially (rest needs macOS CI) · ⏳ macOS-CI-gated.

## Linux verification (this head)

- `@remnic/capture-screen`: `tsc --noEmit` EXIT 0; **95/95** package tests pass.
- `release-workflow-public-packages` test: **10/10** (capture-screen + both platform packages registered).
- `helperBinaryPath` imports resolve on both platform packages; `pnpm-lock` consistent.

## Not done here (follow-ups; #1899 stays open)

`install-service` launchd plist wiring, per-app AX expectations doc, and the smart-extraction judge-prompt hardening fixtures land in later #1899 slices. This PR is Part-1 daemon + the shared native helper foundation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new surface for sensitive screen/audio capture, local auth, and native TCC-gated helpers; incorrect deny/redaction or API exposure would leak user content.
> 
> **Overview**
> Introduces **#1899 Part 1**: an opt-in `@remnic/capture-screen` loopback daemon plus a single macOS `remnic-capture-helper` binary shared with the audio capture work (#1897).
> 
> **`@remnic/capture-screen`** adds a standalone daemon with SQLite spool, deny-lists, AX secure-field filtering, redaction, SimHash dedup, replay fixtures, and bearer-authenticated HTTP (`/v1/health`, `/v1/snapshots`, `/v1/stats`). The CLI (`init` / `start` / `stop` / `test-snapshot`, etc.) refuses non-loopback bind and `--auth-token` on argv; live capture polls the native helper when present and degrades with `axAvailable`/`ocrAvailable` hints when it is not.
> 
> **`packages/capture-native-darwin-helper`** (Swift) implements `audio-capture`, `device-enumerate`, `ax-snapshot`, and `ocr-window` with JSON-line stdout, TCC-aware errors, secure-text defense-in-depth, and owner-only audio chunk files. **`@remnic/capture-native-darwin-{arm64,x64}`** export `helperBinaryPath` (binaries built in CI, not committed).
> 
> **`.github/workflows/capture-native-helper.yml`** matrix-builds and tests Swift on macOS arm64/x64, stages binaries into platform packages, and runs `@remnic/capture-screen` typecheck/tests on Linux.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28226d347918c9026e4c86a7e50c9bdb9e688cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI validation for building native macOS capture helper binaries and running Linux TypeScript tests.
  * Introduced the `capture-screen` daemon with authenticated snapshot, replay, stats, and cursor-paginated APIs, plus a full CLI workflow (init/start/stop/status/logs/test-snapshot).
  * Added native capture capabilities: audio capture, device enumeration, accessibility snapshots, and window OCR, with automatic redaction, deny rules, deduplication, and OCR fallback.
  * Added platform helper packages for macOS arm64 and x64, now exposing a `helperBinaryPath`.
* **Documentation**
  * Added new READMEs for native helper packages and `capture-screen`.
* **Tests**
  * Added extensive coverage for capture, storage, security, CLI behavior, and release workflow ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->