### PR TITLE
feat(capture-audio): native macOS capture, live pipeline, install-service, enroll-self (#1897)

### DIFF
--- a/packages/capture-audio/package.json
+++ b/packages/capture-audio/package.json
@@ -40,10 +40,18 @@
   },
   "peerDependencies": {
     "@remnic/core": "^9.22.2",
-    "sherpa-onnx-node": "*"
+    "sherpa-onnx-node": "*",
+    "@remnic/capture-native-darwin-arm64": "*",
+    "@remnic/capture-native-darwin-x64": "*"
   },
   "peerDependenciesMeta": {
     "sherpa-onnx-node": {
+      "optional": true
+    },
+    "@remnic/capture-native-darwin-arm64": {
+      "optional": true
+    },
+    "@remnic/capture-native-darwin-x64": {
       "optional": true
     }
   },

--- a/packages/capture-audio/package.json
+++ b/packages/capture-audio/package.json
@@ -21,7 +21,7 @@
     "build": "tsup src/index.ts src/cli-bin.ts --format esm --dts",
     "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
-    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts src/model.test.ts src/janitor.test.ts src/vad.test.ts src/dedup.test.ts src/assembly.test.ts src/diarization.test.ts src/connector.test.ts src/e2e.test.ts",
+    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts src/model.test.ts src/janitor.test.ts src/vad.test.ts src/dedup.test.ts src/assembly.test.ts src/diarization.test.ts src/connector.test.ts src/e2e.test.ts src/native.test.ts src/processor.test.ts src/capture.test.ts src/service.test.ts src/enroll.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/capture-audio/src/assembly.test.ts
+++ b/packages/capture-audio/src/assembly.test.ts
@@ -89,3 +89,12 @@ test("ConversationAssembler rejects a negative gap but allows zero (config agree
   assert.throws(() => new ConversationAssembler({ gapMinutes: -1 }));
   assert.doesNotThrow(() => new ConversationAssembler({ gapMinutes: 0 }));
 });
+
+test("closeIfIdle finalizes the open conversation after a gap of silence", () => {
+  const a = new ConversationAssembler({ gapMinutes: 5, makeId: () => "conv_1" });
+  a.add(seg("2026-07-24T00:00:00.000Z", "2026-07-24T00:00:02.000Z"));
+  assert.equal(a.closeIfIdle("2026-07-24T00:02:00.000Z"), null); // within the gap -> stays open
+  assert.equal(a.closeIfIdle("2026-07-24T00:10:00.000Z"), "conv_1"); // gap elapsed -> closes
+  assert.equal(a.conversations()[0].state, "final");
+  assert.equal(a.closeIfIdle("2026-07-24T00:20:00.000Z"), null); // nothing open
+});

--- a/packages/capture-audio/src/assembly.test.ts
+++ b/packages/capture-audio/src/assembly.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { assembleConversations } from "./assembly.js";
+import { assembleConversations, ConversationAssembler } from "./assembly.js";
 import type { SegmentInput } from "./spool.js";
 
 function seg(startUtc: string, endUtc: string, text = "hi"): SegmentInput {
@@ -54,4 +54,38 @@ test("state defaults to final and is applied to every conversation", () => {
 
 test("empty input yields no conversations", () => {
   assert.deepEqual(assembleConversations([], 10), []);
+});
+
+function counterIds(): () => string {
+  let n = 0;
+  return () => `conv_${++n}`;
+}
+
+test("ConversationAssembler joins within-gap segments and splits past the gap", () => {
+  const a = new ConversationAssembler({ gapMinutes: 5, makeId: counterIds() });
+  const first = a.add(seg("2026-07-24T00:00:00.000Z", "2026-07-24T00:00:02.000Z"));
+  const same = a.add(seg("2026-07-24T00:00:10.000Z", "2026-07-24T00:00:12.000Z"));
+  assert.equal(same.id, first.id);
+  const next = a.add(seg("2026-07-24T00:10:00.000Z", "2026-07-24T00:10:02.000Z"));
+  assert.notEqual(next.id, first.id);
+  assert.equal(a.conversations().length, 2);
+});
+
+test("resume continues a recovered open conversation instead of splitting", () => {
+  const a = new ConversationAssembler({ gapMinutes: 10, makeId: () => "conv_new" });
+  a.resume({ id: "conv_prior", startedAtUtc: "2026-07-24T00:00:00.000Z", endedAtUtc: "2026-07-24T00:00:05.000Z" });
+  const c = a.add(seg("2026-07-24T00:00:10.000Z", "2026-07-24T00:00:12.000Z"));
+  assert.equal(c.id, "conv_prior");
+});
+
+test("finalize flips open conversations to final", () => {
+  const a = new ConversationAssembler({ gapMinutes: 10 });
+  a.add(seg("2026-07-24T00:00:00.000Z", "2026-07-24T00:00:02.000Z"));
+  assert.equal(a.finalize(), 1);
+  assert.equal(a.conversations()[0].state, "final");
+});
+
+test("ConversationAssembler rejects a negative gap but allows zero (config agreement)", () => {
+  assert.throws(() => new ConversationAssembler({ gapMinutes: -1 }));
+  assert.doesNotThrow(() => new ConversationAssembler({ gapMinutes: 0 }));
 });

--- a/packages/capture-audio/src/assembly.ts
+++ b/packages/capture-audio/src/assembly.ts
@@ -166,6 +166,20 @@ export class ConversationAssembler {
     return this.#conversations.map((conv) => ({ ...conv, segments: conv.segments.slice() }));
   }
 
+  /**
+   * Finalize the open conversation when `nowUtc` is at least the gap past its
+   * last segment, so a run of silent chunks (which carry no segments to `add`)
+   * still closes a conversation instead of leaving it `capturing` until stop.
+   * Returns the closed conversation's id, or null when nothing closed.
+   */
+  closeIfIdle(nowUtc: string): string | null {
+    const open = this.#open();
+    if (!open) return null;
+    if (epochMs(nowUtc, "nowUtc") - epochMs(open.endedAtUtc, "endedAtUtc") < this.#gapMs) return null;
+    open.state = "final";
+    return open.id;
+  }
+
   #open(): AssembledConversation | undefined {
     const last = this.#conversations[this.#conversations.length - 1];
     return last && last.state === "capturing" ? last : undefined;

--- a/packages/capture-audio/src/assembly.ts
+++ b/packages/capture-audio/src/assembly.ts
@@ -10,6 +10,8 @@
  */
 
 import type { ConversationInput, ConversationState, SegmentInput } from "./spool.js";
+import { CaptureConfigError, CaptureInputError } from "./errors.js";
+import { ulid } from "./util.js";
 
 /** A segment as it enters assembly (post dedup + diarization). */
 export type AssemblySegment = SegmentInput;
@@ -56,4 +58,128 @@ export function assembleConversations(
   }
   flush();
   return conversations;
+}
+
+/** Default per issue #1897 config surface. */
+export const DEFAULT_CONVERSATION_GAP_MINUTES = 10;
+
+/** A conversation the stateful assembler is building incrementally. */
+export interface AssembledConversation {
+  id: string;
+  startedAtUtc: string;
+  endedAtUtc: string;
+  state: ConversationState;
+  segments: AssemblySegment[];
+}
+
+export interface AssemblerOptions {
+  gapMinutes?: number;
+  /** Injectable for deterministic ids in tests; defaults to `conv_<ulid>`. */
+  makeId?: () => string;
+}
+
+/** Parse an ISO-8601 timestamp to epoch ms, rejecting garbage loudly. */
+function epochMs(value: string, field: string): number {
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) {
+    throw new CaptureInputError(`segment.${field}: expected an ISO-8601 timestamp`);
+  }
+  return ms;
+}
+
+/**
+ * Incremental sibling of `assembleConversations` for the live daemon: feed
+ * segments one chunk at a time and it groups them into conversations under the
+ * same `gap < threshold` rule, tracking a single open (`capturing`)
+ * conversation. The batch function stays the source of truth for replay; this
+ * class owns the streaming case. Pure in-memory — the processor decides when to
+ * persist and provides restart continuity via `resume`.
+ */
+export class ConversationAssembler {
+  readonly #gapMs: number;
+  readonly #makeId: () => string;
+  readonly #conversations: AssembledConversation[] = [];
+
+  constructor(options: AssemblerOptions = {}) {
+    const gapMinutes = options.gapMinutes ?? DEFAULT_CONVERSATION_GAP_MINUTES;
+    if (!Number.isFinite(gapMinutes) || gapMinutes < 0) {
+      throw new CaptureConfigError("conversationGapMinutes must be a non-negative number");
+    }
+    this.#gapMs = gapMinutes * 60_000;
+    this.#makeId = options.makeId ?? (() => `conv_${ulid()}`);
+  }
+
+  /**
+   * Append one segment, returning the conversation it landed in. Segments
+   * arrive in non-decreasing start order; a gap of at least the threshold
+   * closes the open conversation and starts a new one.
+   */
+  add(segment: AssemblySegment): AssembledConversation {
+    const startMs = epochMs(segment.startUtc, "startUtc");
+    epochMs(segment.endUtc, "endUtc");
+    const open = this.#open();
+    if (open) {
+      const lastEnd = epochMs(open.endedAtUtc, "endedAtUtc");
+      if (startMs - lastEnd >= this.#gapMs) {
+        open.state = "final";
+      } else {
+        open.segments.push(segment);
+        if (segment.endUtc > open.endedAtUtc) open.endedAtUtc = segment.endUtc;
+        return open;
+      }
+    }
+    return this.#start(segment);
+  }
+
+  /** Flip every open (`capturing`) conversation to `final`; returns the count changed. */
+  finalize(): number {
+    let changed = 0;
+    for (const conv of this.#conversations) {
+      if (conv.state === "capturing") {
+        conv.state = "final";
+        changed++;
+      }
+    }
+    return changed;
+  }
+
+  /**
+   * Re-open a conversation recovered from durable storage so a chunk arriving
+   * after a process restart continues it (subject to the same gap rule via
+   * `add`) instead of splitting off a new one. No-op when a conversation is
+   * already open in this run.
+   */
+  resume(conversation: { id: string; startedAtUtc: string; endedAtUtc: string }): void {
+    if (this.#open()) return;
+    epochMs(conversation.endedAtUtc, "endedAtUtc");
+    this.#conversations.push({
+      id: conversation.id,
+      startedAtUtc: conversation.startedAtUtc,
+      endedAtUtc: conversation.endedAtUtc,
+      state: "capturing",
+      segments: [],
+    });
+  }
+
+  /** Ordered snapshot; segments are cloned so callers cannot mutate internal state. */
+  conversations(): AssembledConversation[] {
+    return this.#conversations.map((conv) => ({ ...conv, segments: conv.segments.slice() }));
+  }
+
+  #open(): AssembledConversation | undefined {
+    const last = this.#conversations[this.#conversations.length - 1];
+    return last && last.state === "capturing" ? last : undefined;
+  }
+
+  #start(segment: AssemblySegment): AssembledConversation {
+    const conv: AssembledConversation = {
+      id: this.#makeId(),
+      startedAtUtc: segment.startUtc,
+      endedAtUtc: segment.endUtc,
+      state: "capturing",
+      segments: [segment],
+    };
+    this.#conversations.push(conv);
+    return conv;
+  }
 }

--- a/packages/capture-audio/src/capture.test.ts
+++ b/packages/capture-audio/src/capture.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import { createLiveCapture } from "./capture.js";
 import { defaultDaemonConfig } from "./config.js";
@@ -67,5 +70,42 @@ test("live capture turns helper chunk events into persisted conversations", asyn
     assert.equal(child.killed, true);
   } finally {
     spool.close();
+  }
+});
+
+test("live capture rejects a symlinked chunk path that escapes the raw dir", async () => {
+  const base = mkdtempSync(path.join(tmpdir(), "cap-sym-"));
+  const rawDir = path.join(base, "raw");
+  mkdirSync(rawDir);
+  const outside = path.join(base, "secret.wav");
+  writeFileSync(outside, "x");
+  const link = path.join(rawDir, "evil.wav");
+  symlinkSync(outside, link);
+  const spool = new Spool(":memory:");
+  const child = new FakeChild();
+  const errors: string[] = [];
+  try {
+    const live = createLiveCapture({
+      spool,
+      config: defaultDaemonConfig(),
+      outDir: rawDir,
+      defaultModelPath: "/m",
+      resolution: { specifier: "t", binaryPath: "/h" },
+      resolveModel: () => "/m",
+      spawn: () => child,
+      transcribe: async (): Promise<TranscribedSegment[]> => [
+        { text: "leak", startUtc: "2026-07-24T00:00:00.000Z", endUtc: "2026-07-24T00:00:01.000Z" },
+      ],
+      cleanupRawAudio: async () => undefined,
+      onError: (e) => errors.push(e.message),
+    });
+    live.start();
+    child.push(chunkLine(link, "2026-07-24T00:00:00.000Z", "2026-07-24T00:00:30.000Z"));
+    await live.stop();
+    assert.equal(spool.stats().segments, 0); // escaping symlink is never transcribed/persisted
+    assert.ok(errors.some((m) => m.includes("escapes the capture directory")));
+  } finally {
+    spool.close();
+    rmSync(base, { recursive: true, force: true });
   }
 });

--- a/packages/capture-audio/src/capture.test.ts
+++ b/packages/capture-audio/src/capture.test.ts
@@ -10,17 +10,17 @@ import type { TranscribedSegment } from "./stt.js";
 class FakeChild implements HelperChild {
   #stdout: Array<(chunk: Buffer | string) => void> = [];
   #stderr: Array<(chunk: Buffer | string) => void> = [];
-  #exit: ((code: number | null, signal: NodeJS.Signals | null) => void) | undefined;
+  #close: ((code: number | null, signal: NodeJS.Signals | null) => void) | undefined;
   killed = false;
   readonly stdout = { on: (_e: "data", cb: (c: Buffer | string) => void) => this.#stdout.push(cb) };
   readonly stderr = { on: (_e: "data", cb: (c: Buffer | string) => void) => this.#stderr.push(cb) };
-  once(event: "error" | "exit", listener: (...a: never[]) => void): unknown {
-    if (event === "exit") this.#exit = listener as (c: number | null, s: NodeJS.Signals | null) => void;
+  once(event: "error" | "close", listener: (...a: never[]) => void): unknown {
+    if (event === "close") this.#close = listener as (c: number | null, s: NodeJS.Signals | null) => void;
     return this;
   }
   kill(): boolean {
     this.killed = true;
-    this.#exit?.(0, "SIGTERM"); // real helper exits on SIGTERM
+    this.#close?.(0, "SIGTERM"); // real helper exits on SIGTERM
     return true;
   }
   push(text: string): void {

--- a/packages/capture-audio/src/capture.test.ts
+++ b/packages/capture-audio/src/capture.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createLiveCapture } from "./capture.js";
+import { defaultDaemonConfig } from "./config.js";
+import type { HelperChild } from "./native.js";
+import { Spool } from "./spool.js";
+import type { TranscribedSegment } from "./stt.js";
+
+class FakeChild implements HelperChild {
+  #stdout: Array<(chunk: Buffer | string) => void> = [];
+  #stderr: Array<(chunk: Buffer | string) => void> = [];
+  #exit: ((code: number | null, signal: NodeJS.Signals | null) => void) | undefined;
+  killed = false;
+  readonly stdout = { on: (_e: "data", cb: (c: Buffer | string) => void) => this.#stdout.push(cb) };
+  readonly stderr = { on: (_e: "data", cb: (c: Buffer | string) => void) => this.#stderr.push(cb) };
+  once(event: "error" | "exit", listener: (...a: never[]) => void): unknown {
+    if (event === "exit") this.#exit = listener as (c: number | null, s: NodeJS.Signals | null) => void;
+    return this;
+  }
+  kill(): boolean {
+    this.killed = true;
+    return true;
+  }
+  push(text: string): void {
+    for (const cb of this.#stdout) cb(text);
+  }
+}
+
+const chunkLine = (path: string, startedAtUtc: string, endedAtUtc: string): string =>
+  JSON.stringify({ path, channel: "mic", startedAtUtc, endedAtUtc, device: "mic" }) + "\n";
+
+test("live capture turns helper chunk events into persisted conversations", async () => {
+  const spool = new Spool(":memory:");
+  const child = new FakeChild();
+  try {
+    const live = createLiveCapture({
+      spool,
+      config: defaultDaemonConfig(),
+      outDir: "/tmp/raw",
+      defaultModelPath: "/model.bin",
+      resolution: { specifier: "test", binaryPath: "/helper" },
+      resolveModel: () => "/model.bin",
+      spawn: () => child,
+      // Deterministic transcript per chunk, keyed off the WAV path.
+      transcribe: async (input): Promise<TranscribedSegment[]> => [
+        {
+          text: input.wavPath.includes("b.wav") ? "second" : "first",
+          startUtc: input.chunkStartedAtUtc,
+          endUtc: input.chunkStartedAtUtc,
+        },
+      ],
+      cleanupRawAudio: async () => undefined,
+    });
+
+    live.start();
+    assert.equal(live.running, true);
+    child.push(chunkLine("/tmp/raw/a.wav", "2026-07-24T00:00:00.000Z", "2026-07-24T00:00:30.000Z"));
+    child.push(chunkLine("/tmp/raw/b.wav", "2026-07-24T00:00:31.000Z", "2026-07-24T00:01:00.000Z"));
+
+    const closed = await live.stop();
+    assert.equal(closed >= 1, true); // at least one conversation finalized
+    // Both chunks are within the 10-minute gap -> one conversation, two segments.
+    assert.equal(spool.stats().segments, 2);
+    assert.equal(spool.latestCapturingConversation(), null); // finalized on stop
+    assert.equal(child.killed, true);
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/capture.test.ts
+++ b/packages/capture-audio/src/capture.test.ts
@@ -20,6 +20,7 @@ class FakeChild implements HelperChild {
   }
   kill(): boolean {
     this.killed = true;
+    this.#exit?.(0, "SIGTERM"); // real helper exits on SIGTERM
     return true;
   }
   push(text: string): void {

--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 
 import { ConversationAssembler } from "./assembly.js";
 import type { DaemonConfig } from "./config.js";
+import { CaptureInputError } from "./errors.js";
 import {
   createNativeCaptureRunner,
   type ChunkEvent,
@@ -114,7 +115,16 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
     // slice, so "both" is deferred rather than shipped un-deduped.
     channel: "mic",
     device: config.devices.mic,
-    onChunk: (event) => processor.enqueue(event),
+    onChunk: (event) => {
+      // Reject a helper-supplied path that escapes the raw capture dir BEFORE it
+      // is read for transcription (defense against a malformed/hostile helper).
+      const resolved = path.resolve(event.path);
+      if (resolved !== rawBase && !resolved.startsWith(rawBase + path.sep)) {
+        options.onError?.(new CaptureInputError(`native helper chunk path escapes the capture directory: ${event.path}`));
+        return;
+      }
+      processor.enqueue({ ...event, path: resolved });
+    },
     ...(options.onError ? { onError: options.onError } : {}),
     ...(options.onStderr ? { onStderr: options.onStderr } : {}),
     ...(options.resolution ? { resolution: options.resolution } : {}),

--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -108,7 +108,11 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
   const runner: NativeCaptureRunner = createNativeCaptureRunner({
     outDir,
     chunkSeconds: config.chunkSeconds,
-    channel: "both",
+    // Capture the wearer's mic only for now. System-channel capture requires
+    // cross-channel dedup (dedupeCrossChannel) to avoid double-persisting speech
+    // heard on both channels; that windowed dedup lands with the diarization
+    // slice, so "both" is deferred rather than shipped un-deduped.
+    channel: "mic",
     device: config.devices.mic,
     onChunk: (event) => processor.enqueue(event),
     ...(options.onError ? { onError: options.onError } : {}),

--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -1,0 +1,129 @@
+/**
+ * Live capture wiring (issue #1897) — assembles the native helper runner and
+ * the chunk processor into one start/stop unit the daemon drives.
+ *
+ * The native runner owns the helper process and surfaces validated
+ * `ChunkEvent`s; the processor turns each recorded WAV into durable, replay-safe
+ * conversations in the spool. This module wires them with production defaults
+ * (whisper STT, model resolution, raw-audio cleanup) while keeping every
+ * collaborator injectable, so tests drive the whole pipeline against a fake
+ * helper binary and a fake transcriber without any macOS runtime.
+ */
+
+import { rm } from "node:fs/promises";
+
+import { ConversationAssembler } from "./assembly.js";
+import type { DaemonConfig } from "./config.js";
+import {
+  createNativeCaptureRunner,
+  type ChunkEvent,
+  type HelperResolution,
+  type HelperSpawn,
+  type NativeCaptureRunner,
+  type ResolveHelperDeps,
+  type RestartTimer,
+} from "./native.js";
+import { createChunkProcessor, type ChunkProcessor, type ChunkTranscribeInput } from "./processor.js";
+import type { Spool } from "./spool.js";
+import { resolveModelPath, runWhisperCli, transcribeWithWhisper, type TranscribedSegment } from "./stt.js";
+
+export interface LiveCaptureOptions {
+  spool: Spool;
+  config: DaemonConfig;
+  /** Directory the helper writes WAV chunks into (`audio-capture --out`). */
+  outDir: string;
+  /** Default whisper model path when `config.stt.modelPath` is unset. */
+  defaultModelPath: string;
+  onError?: (error: Error) => void;
+  onStderr?: (line: string) => void;
+
+  // Injectable seams (tests) — real defaults are built from `config` below.
+  spawn?: HelperSpawn;
+  resolveBinary?: (deps: ResolveHelperDeps) => HelperResolution;
+  resolution?: HelperResolution;
+  transcribe?: (input: ChunkTranscribeInput) => Promise<TranscribedSegment[]>;
+  resolveModel?: () => string;
+  cleanupRawAudio?: (event: ChunkEvent) => Promise<void>;
+  scheduleRestart?: (fn: () => void, delayMs: number) => RestartTimer;
+  cancelRestart?: (timer: RestartTimer) => void;
+  makeConversationId?: () => string;
+}
+
+export interface LiveCapture {
+  start(): void;
+  /** Stop the helper, then drain + finalize the processor. */
+  stop(): Promise<number>;
+  readonly running: boolean;
+  /** Test/observability seam. */
+  readonly processor: ChunkProcessor;
+}
+
+/** Wire the native runner + chunk processor into one live-capture unit. */
+export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
+  const { spool, config, outDir, defaultModelPath } = options;
+
+  const resolveModel =
+    options.resolveModel ?? (() => resolveModelPath(config.stt.modelPath ?? undefined, defaultModelPath));
+
+  const transcribe =
+    options.transcribe ??
+    ((input: ChunkTranscribeInput) =>
+      transcribeWithWhisper({
+        wavPath: input.wavPath,
+        modelPath: input.modelPath,
+        chunkStartedAtUtc: input.chunkStartedAtUtc,
+        threads: config.stt.threads,
+        run: runWhisperCli,
+      }));
+
+  const cleanupRawAudio =
+    options.cleanupRawAudio ??
+    (async (event: ChunkEvent): Promise<void> => {
+      // Retention 0 = keep no raw audio: delete the WAV once its chunk is
+      // durably persisted. A positive retention leaves it for the janitor.
+      if (config.rawRetentionHours <= 0) await rm(event.path, { force: true });
+    });
+
+  const assembler = new ConversationAssembler({
+    gapMinutes: config.conversationGapMinutes,
+    ...(options.makeConversationId ? { makeId: options.makeConversationId } : {}),
+  });
+
+  const processor = createChunkProcessor({
+    spool,
+    assembler,
+    resolveModel,
+    transcribe,
+    cleanupRawAudio,
+    ...(options.onError ? { onError: (error: Error) => options.onError?.(error) } : {}),
+  });
+
+  const runner: NativeCaptureRunner = createNativeCaptureRunner({
+    outDir,
+    chunkSeconds: config.chunkSeconds,
+    channel: "both",
+    device: config.devices.mic,
+    onChunk: (event) => processor.enqueue(event),
+    ...(options.onError ? { onError: options.onError } : {}),
+    ...(options.onStderr ? { onStderr: options.onStderr } : {}),
+    ...(options.resolution ? { resolution: options.resolution } : {}),
+    ...(options.resolveBinary ? { resolveBinary: options.resolveBinary } : {}),
+    ...(options.spawn ? { spawn: options.spawn } : {}),
+    ...(options.scheduleRestart ? { scheduleRestart: options.scheduleRestart } : {}),
+    ...(options.cancelRestart ? { cancelRestart: options.cancelRestart } : {}),
+  });
+
+  return {
+    get running(): boolean {
+      return runner.running;
+    },
+    processor,
+    start(): void {
+      runner.start();
+    },
+    async stop(): Promise<number> {
+      runner.stop();
+      return processor.finalize();
+    },
+  };
+}

--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -11,6 +11,7 @@
  */
 
 import { rm } from "node:fs/promises";
+import path from "node:path";
 
 import { ConversationAssembler } from "./assembly.js";
 import type { DaemonConfig } from "./config.js";
@@ -76,12 +77,18 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
         run: runWhisperCli,
       }));
 
+  const rawBase = path.resolve(outDir);
   const cleanupRawAudio =
     options.cleanupRawAudio ??
     (async (event: ChunkEvent): Promise<void> => {
       // Retention 0 = keep no raw audio: delete the WAV once its chunk is
       // durably persisted. A positive retention leaves it for the janitor.
-      if (config.rawRetentionHours <= 0) await rm(event.path, { force: true });
+      if (config.rawRetentionHours > 0) return;
+      // event.path is helper-supplied; never delete anything outside the raw
+      // capture directory even if a malformed/hostile event points elsewhere.
+      const resolved = path.resolve(event.path);
+      if (resolved !== rawBase && !resolved.startsWith(rawBase + path.sep)) return;
+      await rm(resolved, { force: true });
     });
 
   const assembler = new ConversationAssembler({
@@ -119,6 +126,9 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
     },
     processor,
     start(): void {
+      // Pre-flight the STT model once so a missing/unreadable model fails fast
+      // (actionable) here instead of throwing on every captured chunk.
+      resolveModel();
       runner.start();
     },
     async stop(): Promise<number> {

--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -122,7 +122,9 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
       runner.start();
     },
     async stop(): Promise<number> {
-      runner.stop();
+      // Await the helper's exit so its final flushed chunk is enqueued before
+      // we drain and finalize.
+      await runner.stop();
       return processor.finalize();
     },
   };

--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -10,6 +10,7 @@
  * helper binary and a fake transcriber without any macOS runtime.
  */
 
+import { realpathSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import path from "node:path";
 
@@ -79,17 +80,30 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
       }));
 
   const rawBase = path.resolve(outDir);
+  // Resolve symlinks so a symlinked chunk path can't escape the raw dir; fall
+  // back to the lexical path when the target doesn't exist yet (tests, or a
+  // chunk whose WAV was already removed).
+  const realOrResolved = (p: string): string => {
+    try {
+      return realpathSync(path.resolve(p));
+    } catch {
+      return path.resolve(p);
+    }
+  };
+  const rawBaseReal = realOrResolved(rawBase);
+  const withinRawDir = (p: string): boolean => {
+    const real = realOrResolved(p);
+    return real === rawBaseReal || real.startsWith(rawBaseReal + path.sep);
+  };
   const cleanupRawAudio =
     options.cleanupRawAudio ??
     (async (event: ChunkEvent): Promise<void> => {
       // Retention 0 = keep no raw audio: delete the WAV once its chunk is
       // durably persisted. A positive retention leaves it for the janitor.
       if (config.rawRetentionHours > 0) return;
-      // event.path is helper-supplied; never delete anything outside the raw
-      // capture directory even if a malformed/hostile event points elsewhere.
-      const resolved = path.resolve(event.path);
-      if (resolved !== rawBase && !resolved.startsWith(rawBase + path.sep)) return;
-      await rm(resolved, { force: true });
+      // event.path is helper-supplied; never delete anything outside the raw dir.
+      if (!withinRawDir(event.path)) return;
+      await rm(path.resolve(event.path), { force: true });
     });
 
   const assembler = new ConversationAssembler({
@@ -117,13 +131,13 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
     device: config.devices.mic,
     onChunk: (event) => {
       // Reject a helper-supplied path that escapes the raw capture dir BEFORE it
-      // is read for transcription (defense against a malformed/hostile helper).
-      const resolved = path.resolve(event.path);
-      if (resolved !== rawBase && !resolved.startsWith(rawBase + path.sep)) {
+      // is read for transcription — resolving symlinks, so a symlink under the
+      // dir can't point the transcriber at an arbitrary file.
+      if (!withinRawDir(event.path)) {
         options.onError?.(new CaptureInputError(`native helper chunk path escapes the capture directory: ${event.path}`));
         return;
       }
-      processor.enqueue({ ...event, path: resolved });
+      processor.enqueue({ ...event, path: path.resolve(event.path) });
     },
     ...(options.onError ? { onError: options.onError } : {}),
     ...(options.onStderr ? { onStderr: options.onStderr } : {}),

--- a/packages/capture-audio/src/cli.test.ts
+++ b/packages/capture-audio/src/cli.test.ts
@@ -810,3 +810,90 @@ test("logs honors a valued --lines flag", async () => {
   assert.equal(code, 0);
   assert.deepEqual(output, ["third\n"]);
 });
+
+async function runCapAudioCli(
+  argv: string[],
+  env: NodeJS.ProcessEnv = {},
+): Promise<{ code: number; out: string[]; err: string[] }> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const code = await runCapture({
+    argv,
+    env: { ...process.env, ...env },
+    stdout: (l) => out.push(l),
+    stderr: (l) => err.push(l),
+  });
+  return { code, out, err };
+}
+
+test("enroll-self registers the self speaker in the spool", async () => {
+  await withBaseDir(async (baseDir) => {
+    const { code, out } = await runCapAudioCli(["enroll-self", "--label", "Jane", "--base-dir", baseDir]);
+    assert.equal(code, 0);
+    assert.ok(out.some((l) => l.includes("enrolled self speaker")));
+    const spool = new Spool(capturePaths(baseDir).spoolPath);
+    try {
+      const self = spool.listSpeakers().find((s) => s.id === "self");
+      assert.equal(self?.label, "Jane");
+      assert.equal(self?.isSelf, true);
+    } finally {
+      spool.close();
+    }
+  });
+});
+
+test("devices prints the helper's device-enumerate output via REMNIC_CAPTURE_HELPER_BIN", async () => {
+  await withBaseDir(async (baseDir) => {
+    const helper = path.join(baseDir, "fake-helper");
+    writeFileSync(
+      helper,
+      "#!/usr/bin/env node\n" +
+        "if(process.argv[2]==='device-enumerate'){process.stdout.write(JSON.stringify([{id:'UID-1',name:'Built-in'}]));process.exit(0)}\n" +
+        "process.exit(1)\n",
+      { mode: 0o755 },
+    );
+    const { code, out } = await runCapAudioCli(["devices", "--base-dir", baseDir], {
+      REMNIC_CAPTURE_HELPER_BIN: helper,
+    });
+    assert.equal(code, 0);
+    const parsed: unknown = JSON.parse(out.join("\n"));
+    assert.ok(parsed && typeof parsed === "object" && "devices" in parsed);
+    assert.match(out.join("\n"), /UID-1/);
+  });
+});
+
+test("devices reports an actionable error when the helper is absent", async () => {
+  await withBaseDir(async (baseDir) => {
+    const { code, err } = await runCapAudioCli(["devices", "--base-dir", baseDir], {
+      REMNIC_CAPTURE_HELPER_BIN: "",
+    });
+    assert.equal(code, 1);
+    assert.match(err.join("\n"), /native helper|not installed|unsupported/);
+  });
+});
+
+test("install-service writes then removes a per-user unit", async () => {
+  if (process.platform === "win32") return; // install-service is POSIX-only
+  await withBaseDir(async (baseDir) => {
+    const home = path.join(baseDir, "home");
+    mkdirSync(home, { recursive: true });
+    const prevHome = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      const inst = await runCapAudioCli(["install-service", "--base-dir", baseDir]);
+      assert.equal(inst.code, 0);
+      assert.ok(inst.out.some((l) => l.startsWith("installed")));
+      const unit =
+        process.platform === "darwin"
+          ? path.join(home, "Library/LaunchAgents/com.remnic.capture-audio.plist")
+          : path.join(home, ".config/systemd/user/remnic-capture-audio.service");
+      assert.equal(existsSync(unit), true);
+      const un = await runCapAudioCli(["install-service", "--uninstall", "--base-dir", baseDir]);
+      assert.equal(un.code, 0);
+      assert.equal(existsSync(unit), false);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+    }
+  });
+});

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -7,7 +7,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
@@ -36,6 +36,12 @@ import { pruneExpiredRawAudio } from "./janitor.js";
 import { Spool } from "./spool.js";
 import { loadOrCreateToken } from "./token.js";
 import { formatHostForUrl, isLoopbackHost, stripIpv6Brackets } from "./util.js";
+import { homedir } from "node:os";
+
+import { createLiveCapture, type LiveCapture } from "./capture.js";
+import { enrollSelf } from "./enroll.js";
+import { enumerateDevices, resolveHelperBinary } from "./native.js";
+import { installService, uninstallService } from "./service.js";
 
 export interface CliIo {
   argv: string[];
@@ -69,6 +75,7 @@ const VALUE_FLAGS: Record<string, true> = {
   "base-dir": true,
   model: true,
   lines: true,
+  label: true,
 };
 
 /** Standalone boolean flags. Any other `--flag` is rejected loudly. */
@@ -76,18 +83,22 @@ const BOOLEAN_FLAGS: Record<string, true> = {
   foreground: true,
   force: true,
   help: true,
+  capture: true,
+  uninstall: true,
 };
 
 /** Non-global flags each subcommand accepts; anything else is rejected. */
 const COMMAND_FLAGS: Record<string, Record<string, true>> = {
   init: { force: true },
-  start: { foreground: true, replay: true, host: true, port: true, listen: true },
+  start: { foreground: true, replay: true, host: true, port: true, listen: true, capture: true },
   stop: { force: true },
   status: {},
   devices: {},
   logs: { lines: true },
   "download-model": { model: true },
   janitor: {},
+  "install-service": { force: true, uninstall: true, label: true },
+  "enroll-self": { label: true },
   help: {},
 };
 
@@ -406,6 +417,7 @@ async function cmdStart(
     if (typeof flags.host === "string") forwarded.push("--host", flags.host);
     if (typeof flags.port === "string") forwarded.push("--port", flags.port);
     if (typeof flags.listen === "string") forwarded.push("--listen", flags.listen);
+    if (flags.capture === true) forwarded.push("--capture");
     ensurePrivateDir(paths.baseDir);
     const logFd = openSync(paths.logPath, "a");
     const child = spawn(process.execPath, [...relaunch, ...forwarded], {
@@ -460,7 +472,7 @@ async function cmdStart(
   try {
     // Bind and report the HTTP service FIRST so daemon readiness is independent
     // of replay volume.
-    handle = await startDaemon({ spool, config, token, capturing: false });
+    handle = await startDaemon({ spool, config, token, capturing: flags.capture === true });
   } catch (err) {
     // Don't leak the spool handle if the bind fails.
     spool.close();
@@ -480,6 +492,29 @@ async function cmdStart(
     throw err;
   }
   stdout(`listening on ${handle.url}`);
+  // Live native capture: spawn the shared macOS helper and process its WAV
+  // chunks into conversations. Opt-in via --capture; the daemon still serves
+  // the spool without it, and a missing/unavailable helper degrades honestly.
+  let live: LiveCapture | null = null;
+  if (flags.capture === true) {
+    const rawDir = path.join(paths.baseDir, "raw");
+    mkdirSync(rawDir, { recursive: true });
+    try {
+      live = createLiveCapture({
+        spool,
+        config,
+        outDir: rawDir,
+        defaultModelPath: path.join(paths.baseDir, "models", "ggml-base.bin"),
+        onError: (e) => stderr(`capture: ${describeError(e)}`),
+        onStderr: (l) => stderr(`helper: ${l}`),
+      });
+      live.start();
+      stdout("live capture started");
+    } catch (err) {
+      stderr(`live capture unavailable: ${describeError(err)}; serving without capture`);
+      live = null;
+    }
+  }
   // Supervised AFTER readiness: replay volume/failure never delays or fails
   // readiness, and never kills the daemon. The task is tracked so shutdown can
   // cancel and drain it before the spool closes.
@@ -498,6 +533,8 @@ async function cmdStart(
       // ingestion write can ever hit a closed database.
       replayAbort.abort();
       void replayTask
+        .catch(() => undefined)
+        .then(() => (live ? live.stop().then(() => undefined) : undefined))
         .catch(() => undefined)
         .then(() => {
           spool.finalizeOpenConversations();
@@ -619,18 +656,80 @@ async function cmdStatus(
   return 0;
 }
 
-function cmdDevices(stdout: (l: string) => void): number {
-  stdout(
-    JSON.stringify(
-      {
-        devices: [],
-        note: "device enumeration requires the native capture helper (@remnic/capture-native-*), added in a later phase",
-      },
-      null,
-      2,
-    ),
-  );
+async function cmdDevices(env: NodeJS.ProcessEnv, stdout: (l: string) => void): Promise<number> {
+  // A missing/unsupported helper throws a CaptureConfigError with an actionable
+  // message; the runCapture handler surfaces it verbatim and exits nonzero.
+  const { binaryPath } = resolveHelperBinary({ env });
+  const devices = await enumerateDevices(binaryPath);
+  stdout(JSON.stringify({ devices }, null, 2));
   return 0;
+}
+
+function cmdInstallService(
+  paths: CapturePaths,
+  flags: Record<string, string | boolean>,
+  stdout: (l: string) => void,
+  spawnArgvPrefix: readonly string[],
+): number {
+  const platform = process.platform;
+  const home = homedir();
+  const label = typeof flags.label === "string" ? flags.label : undefined;
+  const spec = {
+    programArguments: [
+      process.execPath,
+      ...(spawnArgvPrefix.length > 0 ? [...spawnArgvPrefix] : [process.argv[1]]),
+      "start",
+      "--foreground",
+      "--capture",
+      "--base-dir",
+      paths.baseDir,
+    ],
+    logPath: paths.logPath,
+    ...(label ? { label } : {}),
+  };
+  if (flags.uninstall === true) {
+    const { plan, removed } = uninstallService({
+      platform,
+      home,
+      spec,
+      exists: existsSync,
+      remove: (f) => rmSync(f, { force: true }),
+    });
+    stdout(removed ? `removed ${plan.path}` : `no capture-audio service installed at ${plan.path}`);
+    return 0;
+  }
+  const plan = installService({
+    platform,
+    home,
+    spec,
+    force: flags.force === true,
+    exists: existsSync,
+    mkdir: (dir) => mkdirSync(dir, { recursive: true }),
+    writeFile: (file, contents) => writeFileSync(file, contents, { mode: 0o644 }),
+  });
+  stdout(`installed ${plan.platform} service at ${plan.path}`);
+  stdout(`enable it with: ${plan.loadHint}`);
+  return 0;
+}
+
+function cmdEnrollSelf(
+  paths: CapturePaths,
+  flags: Record<string, string | boolean>,
+  stdout: (l: string) => void,
+): number {
+  ensurePrivateDir(paths.baseDir);
+  const spool = new Spool(paths.spoolPath);
+  try {
+    const label = typeof flags.label === "string" ? flags.label : undefined;
+    const result = enrollSelf({ spool, label });
+    stdout(`enrolled self speaker '${result.speakerId}' (${result.label})`);
+    if (!result.hasEmbedding) {
+      stdout("no voice embedding stored yet; voice-based diarization refinement lands with the diarization slice");
+    }
+    return 0;
+  } finally {
+    spool.close();
+  }
 }
 
 function cmdLogs(paths: CapturePaths, flags: Record<string, string | boolean>, stdout: (l: string) => void): number {
@@ -649,9 +748,10 @@ function usage(stdout: (l: string) => void): number {
     [
       `remnic-capture-audio v${CAPTURE_AUDIO_VERSION}`,
       "usage: remnic-capture-audio <command> [flags]",
-      "commands: init | start | stop | status | devices | logs | download-model | janitor",
-      "start flags: --foreground --replay <dir> --host <h> --port <n> --listen <host:port> --base-dir <dir>",
+      "commands: init | start | stop | status | devices | logs | download-model | janitor | install-service | enroll-self",
+      "start flags: --foreground --capture --replay <dir> --host <h> --port <n> --listen <host:port> --base-dir <dir>",
       "download-model flags: --model <base|small|large-v3-turbo-q5_0> --base-dir <dir>",
+      "install-service flags: --force --uninstall --label <id>; enroll-self flags: --label <name>",
       "janitor uses rawRetentionHours from audio.json to remove expired files under raw/",
     ].join("\n"),
   );
@@ -693,13 +793,17 @@ export async function runCapture(io: CliIo): Promise<number> {
       case "status":
         return await cmdStatus(paths, stdout, stderr);
       case "devices":
-        return cmdDevices(stdout);
+        return await cmdDevices(env, stdout);
       case "logs":
         return cmdLogs(paths, parsed.flags, stdout);
       case "download-model":
         return await cmdDownloadModel(paths, parsed.flags, stdout, io.downloadModel ?? downloadWhisperModel);
       case "janitor":
         return await cmdJanitor(paths, stdout, stderr);
+      case "install-service":
+        return cmdInstallService(paths, parsed.flags, stdout, io.spawnArgvPrefix ?? [process.argv[1]]);
+      case "enroll-self":
+        return cmdEnrollSelf(paths, parsed.flags, stdout);
       case "help":
       case "--help":
       case "-h":

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -468,33 +468,10 @@ async function cmdStart(
   ensurePrivateDir(paths.baseDir);
   const token = loadOrCreateToken(paths.tokenPath);
   const spool = new Spool(paths.spoolPath);
-  let handle: DaemonHandle;
-  try {
-    // Bind and report the HTTP service FIRST so daemon readiness is independent
-    // of replay volume.
-    handle = await startDaemon({ spool, config, token, capturing: flags.capture === true });
-  } catch (err) {
-    // Don't leak the spool handle if the bind fails.
-    spool.close();
-    throw err;
-  }
-  try {
-    writePidFile(paths.pidPath, process.pid, {
-      instanceId: spool.meta("instance_id"),
-      host: handle.host,
-      port: handle.port,
-    });
-  } catch (err) {
-    // Bound but couldn't persist the record: release the socket and spool
-    // before surfacing the error so nothing is left half-started.
-    await handle.close();
-    spool.close();
-    throw err;
-  }
-  stdout(`listening on ${handle.url}`);
-  // Live native capture: spawn the shared macOS helper and process its WAV
-  // chunks into conversations. Opt-in via --capture; the daemon still serves
-  // the spool without it, and a missing/unavailable helper degrades honestly.
+
+  // Start live native capture (opt-in) BEFORE binding so the daemon's reported
+  // `capturing` reflects whether the helper actually started. A missing or
+  // unavailable helper degrades honestly — the daemon still serves the spool.
   let live: LiveCapture | null = null;
   if (flags.capture === true) {
     try {
@@ -509,12 +486,37 @@ async function cmdStart(
         onStderr: (l) => stderr(`helper: ${l}`),
       });
       live.start();
-      stdout("live capture started");
     } catch (err) {
       stderr(`live capture unavailable: ${describeError(err)}; serving without capture`);
       live = null;
     }
   }
+
+  let handle: DaemonHandle;
+  try {
+    // Bind and report the HTTP service; `capturing` mirrors the live runner.
+    handle = await startDaemon({ spool, config, token, capturing: live !== null });
+  } catch (err) {
+    // Don't leak the live runner or spool handle if the bind fails.
+    if (live) await live.stop().catch(() => undefined);
+    spool.close();
+    throw err;
+  }
+  try {
+    writePidFile(paths.pidPath, process.pid, {
+      instanceId: spool.meta("instance_id"),
+      host: handle.host,
+      port: handle.port,
+    });
+  } catch (err) {
+    // Bound but couldn't persist the record: release everything half-started.
+    if (live) await live.stop().catch(() => undefined);
+    await handle.close();
+    spool.close();
+    throw err;
+  }
+  stdout(`listening on ${handle.url}`);
+  if (live) stdout("live capture started");
   // Supervised AFTER readiness: replay volume/failure never delays or fails
   // readiness, and never kills the daemon. The task is tracked so shutdown can
   // cancel and drain it before the spool closes.

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -709,6 +709,9 @@ function cmdInstallService(
     stdout(removed ? `removed ${plan.path}` : `no capture-audio service installed at ${plan.path}`);
     return 0;
   }
+  // The unit's StandardOut/Err path is under baseDir; create it now so launchd/
+  // systemd can write logs even when install-service is the first command run.
+  ensurePrivateDir(paths.baseDir);
   const plan = installService({
     platform,
     home,

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -495,7 +495,7 @@ async function cmdStart(
   let handle: DaemonHandle;
   try {
     // Bind and report the HTTP service; `capturing` mirrors the live runner.
-    handle = await startDaemon({ spool, config, token, capturing: live !== null });
+    handle = await startDaemon({ spool, config, token, capturing: () => live !== null && live.running });
   } catch (err) {
     // Don't leak the live runner or spool handle if the bind fails.
     if (live) await live.stop().catch(() => undefined);

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -671,12 +671,19 @@ async function cmdDevices(env: NodeJS.ProcessEnv, stdout: (l: string) => void): 
 function cmdInstallService(
   paths: CapturePaths,
   flags: Record<string, string | boolean>,
+  env: NodeJS.ProcessEnv,
   stdout: (l: string) => void,
   spawnArgvPrefix: readonly string[],
 ): number {
   const platform = process.platform;
   const home = homedir();
   const label = typeof flags.label === "string" ? flags.label : undefined;
+  // Persist the env the daemon needs under launchd/systemd: PATH (to find
+  // whisper-cli) and any REMNIC_CAPTURE_HELPER_BIN override the operator set.
+  const environment: Record<string, string> = {};
+  if (typeof env.PATH === "string" && env.PATH !== "") environment.PATH = env.PATH;
+  const helperBin = env.REMNIC_CAPTURE_HELPER_BIN;
+  if (typeof helperBin === "string" && helperBin !== "") environment.REMNIC_CAPTURE_HELPER_BIN = helperBin;
   const spec = {
     programArguments: [
       process.execPath,
@@ -689,6 +696,7 @@ function cmdInstallService(
     ],
     logPath: paths.logPath,
     ...(label ? { label } : {}),
+    ...(Object.keys(environment).length > 0 ? { environment } : {}),
   };
   if (flags.uninstall === true) {
     const { plan, removed } = uninstallService({
@@ -804,7 +812,7 @@ export async function runCapture(io: CliIo): Promise<number> {
       case "janitor":
         return await cmdJanitor(paths, stdout, stderr);
       case "install-service":
-        return cmdInstallService(paths, parsed.flags, stdout, io.spawnArgvPrefix ?? [process.argv[1]]);
+        return cmdInstallService(paths, parsed.flags, env, stdout, io.spawnArgvPrefix ?? [process.argv[1]]);
       case "enroll-self":
         return cmdEnrollSelf(paths, parsed.flags, stdout);
       case "help":

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -497,9 +497,9 @@ async function cmdStart(
   // the spool without it, and a missing/unavailable helper degrades honestly.
   let live: LiveCapture | null = null;
   if (flags.capture === true) {
-    const rawDir = path.join(paths.baseDir, "raw");
-    mkdirSync(rawDir, { recursive: true });
     try {
+      const rawDir = path.join(paths.baseDir, "raw");
+      mkdirSync(rawDir, { recursive: true });
       live = createLiveCapture({
         spool,
         config,

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -487,7 +487,8 @@ async function cmdStart(
       });
       live.start();
     } catch (err) {
-      stderr(`live capture unavailable: ${describeError(err)}; serving without capture`);
+      const detail = err instanceof CaptureConfigError || err instanceof CaptureInputError ? err.message : describeError(err);
+      stderr(`live capture unavailable: ${detail}; serving without capture`);
       live = null;
     }
   }

--- a/packages/capture-audio/src/daemon.ts
+++ b/packages/capture-audio/src/daemon.ts
@@ -29,8 +29,8 @@ export interface DaemonDeps {
   spool: Spool;
   config: DaemonConfig;
   token: string;
-  /** Live capture status for /v1/health; false until the capture layer lands. */
-  capturing?: boolean;
+  /** Live capture status for /v1/health; a getter is re-read per request so it tracks the live runner. */
+  capturing?: boolean | (() => boolean);
 }
 
 export interface DaemonHandle {
@@ -55,7 +55,7 @@ function handleHealth(deps: DaemonDeps, res: http.ServerResponse): void {
     ok: true,
     version: CAPTURE_AUDIO_VERSION,
     platform: process.platform,
-    capturing: deps.capturing ?? false,
+    capturing: typeof deps.capturing === "function" ? deps.capturing() : (deps.capturing ?? false),
     sttModel: deps.config.stt.modelPath,
     pendingChunks: deps.spool.pendingChunkCount(),
     instanceId: deps.spool.meta("instance_id"),

--- a/packages/capture-audio/src/enroll.test.ts
+++ b/packages/capture-audio/src/enroll.test.ts
@@ -44,3 +44,16 @@ test("enrollSelf rejects an empty or non-finite embedding", () => {
     spool.close();
   }
 });
+
+test("relabeling after an embedding enrollment still reports the stored embedding", () => {
+  const spool = new Spool(":memory:");
+  try {
+    enrollSelf({ spool, embedding: [0.1, 0.2] });
+    const relabel = enrollSelf({ spool, label: "Renamed" });
+    assert.equal(relabel.hasEmbedding, true);
+    assert.equal(relabel.dimensions, 2);
+    assert.equal(spool.listSpeakers().find((s) => s.id === "self")?.label, "Renamed");
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/enroll.test.ts
+++ b/packages/capture-audio/src/enroll.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { enrollSelf, SELF_SPEAKER_ID } from "./enroll.js";
+import { CaptureConfigError } from "./errors.js";
+import { Spool } from "./spool.js";
+
+test("enrollSelf registers the self identity without an embedding", () => {
+  const spool = new Spool(":memory:");
+  try {
+    const result = enrollSelf({ spool, label: "Jane" });
+    assert.equal(result.speakerId, SELF_SPEAKER_ID);
+    assert.equal(result.hasEmbedding, false);
+    const self = spool.listSpeakers().find((s) => s.id === SELF_SPEAKER_ID);
+    assert.equal(self?.isSelf, true);
+    assert.equal(self?.label, "Jane");
+  } finally {
+    spool.close();
+  }
+});
+
+test("enrollSelf stores a self centroid when an embedding is provided", () => {
+  const spool = new Spool(":memory:");
+  try {
+    const result = enrollSelf({ spool, embedding: [0.1, 0.2, 0.3] });
+    assert.equal(result.hasEmbedding, true);
+    assert.equal(result.dimensions, 3);
+    assert.equal(result.label, "You"); // default label
+    const cluster = spool.readSpeakerClusters().find((c) => c.id === SELF_SPEAKER_ID);
+    assert.equal(cluster?.isSelf, true);
+    assert.deepEqual(cluster?.centroid, [0.1, 0.2, 0.3]);
+    assert.equal(cluster?.embeddingCount, 1);
+  } finally {
+    spool.close();
+  }
+});
+
+test("enrollSelf rejects an empty or non-finite embedding", () => {
+  const spool = new Spool(":memory:");
+  try {
+    assert.throws(() => enrollSelf({ spool, embedding: [] }), CaptureConfigError);
+    assert.throws(() => enrollSelf({ spool, embedding: [Number.NaN] }), CaptureConfigError);
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/enroll.ts
+++ b/packages/capture-audio/src/enroll.ts
@@ -1,0 +1,77 @@
+/**
+ * `enroll-self` (issue #1897) — register the wearer as the `self` speaker so
+ * the diarizer and downstream attribution can distinguish the wearer's own
+ * voice from everyone else's.
+ *
+ * Enrollment stores a durable `self` speaker row. When a voice embedding is
+ * supplied (extracted from a recorded sample by a speaker-embedding model —
+ * à-la-carte, like whisper STT and the Silero VAD), it is stored as the self
+ * centroid so live diarization can match against it. Without an embedder the
+ * wearer's identity is still registered (embedding refinement lands with the
+ * diarization slice), so the pipeline can already tag `desktop:self`.
+ *
+ * Pure over its injected `spool`: the caller owns recording the sample and
+ * extracting the embedding, so no optional native/model runtime is imported.
+ */
+
+import { SpeakerClusterer, type Embedding } from "./diarization.js";
+import { CaptureConfigError } from "./errors.js";
+import type { Spool } from "./spool.js";
+
+/** The stable speaker id for the enrolled wearer. */
+export const SELF_SPEAKER_ID = "self";
+
+export interface EnrollSelfInput {
+  spool: Spool;
+  /** Human label for the wearer; defaults to "You". */
+  label?: string | null;
+  /** Optional wearer voice embedding; when present it is stored as the self centroid. */
+  embedding?: Embedding;
+}
+
+export interface EnrollSelfResult {
+  speakerId: string;
+  label: string | null;
+  hasEmbedding: boolean;
+  dimensions: number;
+}
+
+/**
+ * Register (or refresh) the `self` speaker. With an embedding, the canonical
+ * self cluster (centroid + example) is persisted; without one, only the
+ * identity is upserted, preserving any embedding a prior enroll stored.
+ */
+export function enrollSelf(input: EnrollSelfInput): EnrollSelfResult {
+  const label = input.label ?? "You";
+
+  if (input.embedding !== undefined) {
+    if (!Array.isArray(input.embedding) || input.embedding.length === 0) {
+      throw new CaptureConfigError("enroll-self embedding must be a non-empty number array");
+    }
+    for (const value of input.embedding) {
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        throw new CaptureConfigError("enroll-self embedding must contain only finite numbers");
+      }
+    }
+    // Build the canonical self cluster through the diarizer so the stored shape
+    // (id/centroid/examples/count) matches what live diarization seeds from.
+    const clusterer = new SpeakerClusterer(0.5);
+    clusterer.enrollSelf(input.embedding);
+    const self = clusterer.clusters().find((c) => c.isSelf);
+    if (!self) {
+      throw new CaptureConfigError("enroll-self failed to build the self speaker cluster");
+    }
+    input.spool.upsertSpeaker({
+      id: self.id,
+      isSelf: true,
+      label,
+      embeddingCount: self.embeddingCount,
+      centroid: self.centroid,
+      examples: self.examples,
+    });
+    return { speakerId: self.id, label, hasEmbedding: true, dimensions: input.embedding.length };
+  }
+
+  input.spool.upsertSpeaker({ id: SELF_SPEAKER_ID, isSelf: true, label });
+  return { speakerId: SELF_SPEAKER_ID, label, hasEmbedding: false, dimensions: 0 };
+}

--- a/packages/capture-audio/src/enroll.ts
+++ b/packages/capture-audio/src/enroll.ts
@@ -73,5 +73,9 @@ export function enrollSelf(input: EnrollSelfInput): EnrollSelfResult {
   }
 
   input.spool.upsertSpeaker({ id: SELF_SPEAKER_ID, isSelf: true, label });
-  return { speakerId: SELF_SPEAKER_ID, label, hasEmbedding: false, dimensions: 0 };
+  // upsertSpeaker preserves any prior centroid; report what is actually stored
+  // so a relabel doesn't falsely claim no embedding exists.
+  const stored = input.spool.readSpeakerClusters().find((c) => c.id === SELF_SPEAKER_ID);
+  const dimensions = stored?.centroid.length ?? 0;
+  return { speakerId: SELF_SPEAKER_ID, label, hasEmbedding: dimensions > 0, dimensions };
 }

--- a/packages/capture-audio/src/index.ts
+++ b/packages/capture-audio/src/index.ts
@@ -85,3 +85,39 @@ export { assembleConversations } from "./assembly.js";
 export type { AssemblySegment } from "./assembly.js";
 export { cosineSimilarity, SpeakerClusterer } from "./diarization.js";
 export type { Embedding, SpeakerCluster } from "./diarization.js";
+export { ConversationAssembler, DEFAULT_CONVERSATION_GAP_MINUTES } from "./assembly.js";
+export type { AssembledConversation, AssemblerOptions } from "./assembly.js";
+export type { AssemblyAppendInput, AssemblyAppendResult } from "./spool.js";
+export {
+  buildHelperArgs,
+  createNativeCaptureRunner,
+  enumerateDevices,
+  HELPER_BIN_ENV,
+  helperPackageSpecifier,
+  parseChunkEvent,
+  resolveHelperBinary,
+} from "./native.js";
+export type {
+  ChannelSelection,
+  ChunkEvent,
+  HelperResolution,
+  HelperSpawn,
+  NativeCaptureRunner,
+  NativeRunnerOptions,
+  ResolveHelperDeps,
+} from "./native.js";
+export { chunkStableId, createChunkProcessor } from "./processor.js";
+export type { ChunkProcessor, ChunkProcessorDeps, ChunkTranscribeInput } from "./processor.js";
+export { createLiveCapture } from "./capture.js";
+export type { LiveCapture, LiveCaptureOptions } from "./capture.js";
+export {
+  DEFAULT_SERVICE_LABEL,
+  installService,
+  planService,
+  renderLaunchAgent,
+  renderSystemdUnit,
+  uninstallService,
+} from "./service.js";
+export type { ServicePlan, ServiceSpec } from "./service.js";
+export { enrollSelf, SELF_SPEAKER_ID } from "./enroll.js";
+export type { EnrollSelfInput, EnrollSelfResult } from "./enroll.js";

--- a/packages/capture-audio/src/native.test.ts
+++ b/packages/capture-audio/src/native.test.ts
@@ -18,21 +18,21 @@ class FakeChild implements HelperChild {
   #stdout: Array<(chunk: Buffer | string) => void> = [];
   #stderr: Array<(chunk: Buffer | string) => void> = [];
   #err: ((err: Error) => void) | undefined;
-  #exit: ((code: number | null, signal: NodeJS.Signals | null) => void) | undefined;
+  #close: ((code: number | null, signal: NodeJS.Signals | null) => void) | undefined;
   killed = false;
   killSignal: NodeJS.Signals | undefined;
   readonly stdout = { on: (_e: "data", cb: (chunk: Buffer | string) => void) => this.#stdout.push(cb) };
   readonly stderr = { on: (_e: "data", cb: (chunk: Buffer | string) => void) => this.#stderr.push(cb) };
-  once(event: "error" | "exit", listener: (...a: never[]) => void): unknown {
+  once(event: "error" | "close", listener: (...a: never[]) => void): unknown {
     if (event === "error") this.#err = listener as (err: Error) => void;
-    else this.#exit = listener as (code: number | null, signal: NodeJS.Signals | null) => void;
+    else this.#close = listener as (code: number | null, signal: NodeJS.Signals | null) => void;
     return this;
   }
   kill(signal?: NodeJS.Signals): boolean {
     this.killed = true;
     this.killSignal = signal;
-    // A real helper exits on SIGTERM; emit so an awaiting stop() resolves.
-    this.#exit?.(0, signal ?? "SIGTERM");
+    // A real helper exits on SIGTERM; emit close so an awaiting stop() resolves.
+    this.#close?.(0, signal ?? "SIGTERM");
     return true;
   }
   pushStdout(text: string): void {
@@ -41,8 +41,8 @@ class FakeChild implements HelperChild {
   pushStderr(text: string): void {
     for (const cb of this.#stderr) cb(text);
   }
-  emitExit(code: number | null, signal: NodeJS.Signals | null = null): void {
-    this.#exit?.(code, signal);
+  emitClose(code: number | null, signal: NodeJS.Signals | null = null): void {
+    this.#close?.(code, signal);
   }
   emitError(err: Error): void {
     this.#err?.(err);
@@ -214,7 +214,7 @@ test("runner restarts an unexpected exit and stop() suppresses further restarts"
   });
   runner.start();
   assert.equal(spawns, 1);
-  children[0].emitExit(1, null); // unexpected exit -> schedules a restart
+  children[0].emitClose(1, null); // unexpected close -> schedules a restart
   assert.equal(scheduledFns.length, 1);
   scheduledFns[0](); // run the scheduled restart
   assert.equal(spawns, 2);
@@ -222,7 +222,7 @@ test("runner restarts an unexpected exit and stop() suppresses further restarts"
   assert.equal(children[1].killed, true);
   assert.equal(children[1].killSignal, "SIGTERM");
   // A post-stop exit must not schedule another restart.
-  children[1].emitExit(0, null);
+  children[1].emitClose(0, null);
   assert.equal(scheduledFns.length, 1);
 });
 
@@ -233,7 +233,7 @@ test("enumerateDevices parses a JSON device array from the one-shot subcommand",
     return child;
   });
   child.pushStdout(JSON.stringify([{ id: "UID-1", name: "Built-in" }]));
-  child.emitExit(0);
+  child.emitClose(0);
   const devices = await promise;
   assert.equal(devices.length, 1);
 });
@@ -241,6 +241,6 @@ test("enumerateDevices parses a JSON device array from the one-shot subcommand",
 test("enumerateDevices rejects a nonzero exit", async () => {
   const child = new FakeChild();
   const promise = enumerateDevices("/helper", () => child);
-  child.emitExit(3);
+  child.emitClose(3);
   await assert.rejects(promise, CaptureInputError);
 });

--- a/packages/capture-audio/src/native.test.ts
+++ b/packages/capture-audio/src/native.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CaptureConfigError, CaptureInputError } from "./errors.js";
+import {
+  buildHelperArgs,
+  createNativeCaptureRunner,
+  enumerateDevices,
+  helperPackageSpecifier,
+  parseChunkEvent,
+  resolveHelperBinary,
+  type ChunkEvent,
+  type HelperChild,
+} from "./native.js";
+
+/** A controllable fake helper child process for deterministic runner tests. */
+class FakeChild implements HelperChild {
+  #stdout: Array<(chunk: Buffer | string) => void> = [];
+  #stderr: Array<(chunk: Buffer | string) => void> = [];
+  #err: ((err: Error) => void) | undefined;
+  #exit: ((code: number | null, signal: NodeJS.Signals | null) => void) | undefined;
+  killed = false;
+  killSignal: NodeJS.Signals | undefined;
+  readonly stdout = { on: (_e: "data", cb: (chunk: Buffer | string) => void) => this.#stdout.push(cb) };
+  readonly stderr = { on: (_e: "data", cb: (chunk: Buffer | string) => void) => this.#stderr.push(cb) };
+  once(event: "error" | "exit", listener: (...a: never[]) => void): unknown {
+    if (event === "error") this.#err = listener as (err: Error) => void;
+    else this.#exit = listener as (code: number | null, signal: NodeJS.Signals | null) => void;
+    return this;
+  }
+  kill(signal?: NodeJS.Signals): boolean {
+    this.killed = true;
+    this.killSignal = signal;
+    return true;
+  }
+  pushStdout(text: string): void {
+    for (const cb of this.#stdout) cb(text);
+  }
+  pushStderr(text: string): void {
+    for (const cb of this.#stderr) cb(text);
+  }
+  emitExit(code: number | null, signal: NodeJS.Signals | null = null): void {
+    this.#exit?.(code, signal);
+  }
+  emitError(err: Error): void {
+    this.#err?.(err);
+  }
+}
+
+const CHUNK = (over: Partial<ChunkEvent> = {}): string =>
+  JSON.stringify({
+    path: "/tmp/raw/chunk-1.wav",
+    channel: "mic",
+    startedAtUtc: "2026-07-24T00:00:00.000Z",
+    endedAtUtc: "2026-07-24T00:00:30.000Z",
+    device: "BuiltInMic",
+    ...over,
+  });
+
+test("helperPackageSpecifier maps darwin arch and rejects everything else", () => {
+  assert.equal(helperPackageSpecifier("darwin", "arm64"), "@remnic/capture-native-darwin-arm64");
+  assert.equal(helperPackageSpecifier("darwin", "x64"), "@remnic/capture-native-darwin-x64");
+  assert.throws(() => helperPackageSpecifier("linux", "x64"), CaptureConfigError);
+  assert.throws(() => helperPackageSpecifier("darwin", "ia32"), CaptureConfigError);
+});
+
+test("buildHelperArgs targets the audio-capture subcommand", () => {
+  assert.deepEqual(buildHelperArgs({ outDir: "/o", chunkSeconds: 30 }), [
+    "audio-capture",
+    "--channel",
+    "both",
+    "--chunk-seconds",
+    "30",
+    "--out",
+    "/o",
+  ]);
+  assert.deepEqual(buildHelperArgs({ outDir: "/o", chunkSeconds: 15, channel: "mic", device: "UID-1" }), [
+    "audio-capture",
+    "--channel",
+    "mic",
+    "--chunk-seconds",
+    "15",
+    "--out",
+    "/o",
+    "--device",
+    "UID-1",
+  ]);
+  // A null/empty device is omitted, not passed as an empty flag value.
+  assert.equal(buildHelperArgs({ outDir: "/o", chunkSeconds: 5, device: null }).includes("--device"), false);
+});
+
+test("parseChunkEvent accepts a valid line and normalizes an absent device to null", () => {
+  const ev = parseChunkEvent(CHUNK());
+  assert.equal(ev.channel, "mic");
+  assert.equal(ev.device, "BuiltInMic");
+  assert.equal(parseChunkEvent(CHUNK({ device: undefined })).device, null);
+});
+
+test("parseChunkEvent rejects malformed lines", () => {
+  assert.throws(() => parseChunkEvent("not json"), CaptureInputError);
+  assert.throws(() => parseChunkEvent(JSON.stringify([1, 2])), CaptureInputError);
+  assert.throws(() => parseChunkEvent(CHUNK({ channel: "speaker" as unknown as "mic" })), CaptureInputError);
+  assert.throws(() => parseChunkEvent(CHUNK({ startedAtUtc: "nope" })), CaptureInputError);
+  assert.throws(
+    () => parseChunkEvent(CHUNK({ startedAtUtc: "2026-07-24T00:00:30.000Z", endedAtUtc: "2026-07-24T00:00:00.000Z" })),
+    CaptureInputError,
+  );
+});
+
+test("resolveHelperBinary honors REMNIC_CAPTURE_HELPER_BIN over package resolution", () => {
+  const res = resolveHelperBinary({ env: { REMNIC_CAPTURE_HELPER_BIN: "/opt/helper" } });
+  assert.equal(res.binaryPath, "/opt/helper");
+});
+
+test("resolveHelperBinary reports an actionable install hint when the package is absent", () => {
+  assert.throws(
+    () =>
+      resolveHelperBinary({
+        env: {},
+        platform: "darwin",
+        arch: "arm64",
+        resolve: () => {
+          throw new Error("Cannot find module");
+        },
+      }),
+    (err: Error) => err instanceof CaptureConfigError && /npm install @remnic\/capture-native-darwin-arm64/.test(err.message),
+  );
+});
+
+test("resolveHelperBinary resolves the package bin (same file as helperBinaryPath)", () => {
+  const res = resolveHelperBinary({
+    env: {},
+    platform: "darwin",
+    arch: "arm64",
+    resolve: (spec) => {
+      assert.equal(spec, "@remnic/capture-native-darwin-arm64/package.json");
+      return "/pkgs/native/package.json";
+    },
+    readFile: () => JSON.stringify({ bin: { "remnic-capture-helper": "bin/remnic-capture-helper" } }),
+  });
+  assert.equal(res.binaryPath, "/pkgs/native/bin/remnic-capture-helper");
+});
+
+test("runner surfaces validated chunks and ignores blank lines", () => {
+  const chunks: ChunkEvent[] = [];
+  const child = new FakeChild();
+  const runner = createNativeCaptureRunner({
+    outDir: "/o",
+    chunkSeconds: 30,
+    resolution: { specifier: "test", binaryPath: "/helper" },
+    spawn: () => child,
+    onChunk: (e) => chunks.push(e),
+    scheduleRestart: () => 0,
+    cancelRestart: () => undefined,
+  });
+  runner.start();
+  child.pushStdout(CHUNK() + "\n\n" + CHUNK({ channel: "system" }) + "\n");
+  assert.equal(chunks.length, 2);
+  assert.equal(chunks[0].channel, "mic");
+  assert.equal(chunks[1].channel, "system");
+});
+
+test("runner routes a malformed line to onError without crashing the chain", () => {
+  const errors: Error[] = [];
+  const chunks: ChunkEvent[] = [];
+  const child = new FakeChild();
+  const runner = createNativeCaptureRunner({
+    outDir: "/o",
+    chunkSeconds: 30,
+    resolution: { specifier: "test", binaryPath: "/helper" },
+    spawn: () => child,
+    onChunk: (e) => chunks.push(e),
+    onError: (e) => errors.push(e),
+    scheduleRestart: () => 0,
+    cancelRestart: () => undefined,
+  });
+  runner.start();
+  child.pushStdout("garbage\n" + CHUNK() + "\n");
+  assert.equal(errors.length, 1);
+  assert.equal(chunks.length, 1);
+});
+
+test("runner restarts an unexpected exit and stop() suppresses further restarts", () => {
+  let spawns = 0;
+  const children: FakeChild[] = [];
+  const scheduledFns: Array<() => void> = [];
+  const runner = createNativeCaptureRunner({
+    outDir: "/o",
+    chunkSeconds: 30,
+    resolution: { specifier: "test", binaryPath: "/helper" },
+    spawn: () => {
+      spawns++;
+      const c = new FakeChild();
+      children.push(c);
+      return c;
+    },
+    onChunk: () => undefined,
+    onError: () => undefined,
+    scheduleRestart: (fn) => {
+      scheduledFns.push(fn);
+      return scheduledFns.length;
+    },
+    cancelRestart: () => undefined,
+  });
+  runner.start();
+  assert.equal(spawns, 1);
+  children[0].emitExit(1, null); // unexpected exit -> schedules a restart
+  assert.equal(scheduledFns.length, 1);
+  scheduledFns[0](); // run the scheduled restart
+  assert.equal(spawns, 2);
+  runner.stop();
+  assert.equal(children[1].killed, true);
+  assert.equal(children[1].killSignal, "SIGTERM");
+  // A post-stop exit must not schedule another restart.
+  children[1].emitExit(0, null);
+  assert.equal(scheduledFns.length, 1);
+});
+
+test("enumerateDevices parses a JSON device array from the one-shot subcommand", async () => {
+  const child = new FakeChild();
+  const promise = enumerateDevices("/helper", (_bin, args) => {
+    assert.deepEqual(args, ["device-enumerate"]);
+    return child;
+  });
+  child.pushStdout(JSON.stringify([{ id: "UID-1", name: "Built-in" }]));
+  child.emitExit(0);
+  const devices = await promise;
+  assert.equal(devices.length, 1);
+});
+
+test("enumerateDevices rejects a nonzero exit", async () => {
+  const child = new FakeChild();
+  const promise = enumerateDevices("/helper", () => child);
+  child.emitExit(3);
+  await assert.rejects(promise, CaptureInputError);
+});

--- a/packages/capture-audio/src/native.test.ts
+++ b/packages/capture-audio/src/native.test.ts
@@ -125,7 +125,10 @@ test("resolveHelperBinary reports an actionable install hint when the package is
           throw new Error("Cannot find module");
         },
       }),
-    (err: Error) => err instanceof CaptureConfigError && /npm install @remnic\/capture-native-darwin-arm64/.test(err.message),
+    (err: Error) =>
+      err instanceof CaptureConfigError &&
+      /Build the Swift helper from source/.test(err.message) &&
+      /REMNIC_CAPTURE_HELPER_BIN/.test(err.message),
   );
 });
 

--- a/packages/capture-audio/src/native.test.ts
+++ b/packages/capture-audio/src/native.test.ts
@@ -31,6 +31,8 @@ class FakeChild implements HelperChild {
   kill(signal?: NodeJS.Signals): boolean {
     this.killed = true;
     this.killSignal = signal;
+    // A real helper exits on SIGTERM; emit so an awaiting stop() resolves.
+    this.#exit?.(0, signal ?? "SIGTERM");
     return true;
   }
   pushStdout(text: string): void {
@@ -127,16 +129,21 @@ test("resolveHelperBinary reports an actionable install hint when the package is
   );
 });
 
-test("resolveHelperBinary resolves the package bin (same file as helperBinaryPath)", () => {
+test("resolveHelperBinary resolves the bin relative to the package entry (exports-safe)", () => {
   const res = resolveHelperBinary({
     env: {},
     platform: "darwin",
     arch: "arm64",
+    // The package's exports map need not expose ./package.json, so the resolver
+    // resolves the entry and reads package.json from its directory.
     resolve: (spec) => {
-      assert.equal(spec, "@remnic/capture-native-darwin-arm64/package.json");
-      return "/pkgs/native/package.json";
+      assert.equal(spec, "@remnic/capture-native-darwin-arm64");
+      return "/pkgs/native/index.js";
     },
-    readFile: () => JSON.stringify({ bin: { "remnic-capture-helper": "bin/remnic-capture-helper" } }),
+    readFile: (file) => {
+      assert.equal(file, "/pkgs/native/package.json");
+      return JSON.stringify({ bin: { "remnic-capture-helper": "bin/remnic-capture-helper" } });
+    },
   });
   assert.equal(res.binaryPath, "/pkgs/native/bin/remnic-capture-helper");
 });

--- a/packages/capture-audio/src/native.ts
+++ b/packages/capture-audio/src/native.ts
@@ -175,9 +175,9 @@ export function resolveHelperBinary(deps: ResolveHelperDeps = {}): HelperResolut
     entry = resolve(specifier);
   } catch {
     throw new CaptureConfigError(
-      `Desktop audio capture requires optional native helper ${specifier}, which is not installed. ` +
-        `Install it with: npm install ${specifier} (or: pnpm add ${specifier}), ` +
-        `or set ${HELPER_BIN_ENV} to a locally built remnic-capture-helper binary`,
+      `Desktop audio capture requires the optional native helper ${specifier}, which is not available. ` +
+        `Build the Swift helper from source (packages/capture-native-darwin-helper) and set ` +
+        `${HELPER_BIN_ENV} to the built remnic-capture-helper binary.`,
     );
   }
   const pkgJsonPath = path.join(path.dirname(entry), "package.json");
@@ -312,6 +312,8 @@ const defaultSpawn: HelperSpawn = (binaryPath, args) =>
 
 /** Max device-enumerate stdout we will buffer (guards a runaway child). */
 const MAX_ENUMERATE_BYTES = 1024 * 1024;
+/** Bounded wait for the one-shot device-enumerate helper. */
+const ENUMERATE_TIMEOUT_MS = 15_000;
 
 /**
  * Run the helper's one-shot `device-enumerate` subcommand and return the parsed
@@ -321,6 +323,7 @@ const MAX_ENUMERATE_BYTES = 1024 * 1024;
 export function enumerateDevices(
   binaryPath: string,
   spawn: HelperSpawn = defaultSpawn,
+  timeoutMs: number = ENUMERATE_TIMEOUT_MS,
 ): Promise<unknown[]> {
   // `new Promise` (not Promise.withResolvers) matches the sibling capture
   // packages; this package's tsconfig lib predates withResolvers.
@@ -329,9 +332,15 @@ export function enumerateDevices(
     let out = "";
     let size = 0;
     let settled = false;
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      fail(new CaptureInputError("native helper device-enumerate timed out"));
+    }, timeoutMs);
+    timer.unref();
     const fail = (err: Error): void => {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       reject(err);
     };
     child.stdout.on("data", (chunk) => {
@@ -375,6 +384,7 @@ export function enumerateDevices(
         return;
       }
       settled = true;
+      clearTimeout(timer);
       resolve(list);
     });
   });

--- a/packages/capture-audio/src/native.ts
+++ b/packages/capture-audio/src/native.ts
@@ -32,7 +32,7 @@
 
 import { spawn as nodeSpawn } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 import { CaptureConfigError, CaptureInputError } from "./errors.js";
@@ -146,7 +146,13 @@ export function helperPackageSpecifier(platform: NodeJS.Platform | string, arch:
   );
 }
 
-const defaultRequire = createRequire(import.meta.url);
+/**
+ * Import-aware resolution: the platform packages expose `.` only under the
+ * `import` condition, so a CJS `require.resolve` cannot see them.
+ */
+function defaultResolve(specifier: string): string {
+  return fileURLToPath(import.meta.resolve(specifier));
+}
 
 /**
  * Resolve the native helper binary. Order: explicit `REMNIC_CAPTURE_HELPER_BIN`
@@ -162,7 +168,7 @@ export function resolveHelperBinary(deps: ResolveHelperDeps = {}): HelperResolut
 
   const platform = deps.platform ?? process.platform;
   const arch = deps.arch ?? process.arch;
-  const resolve = deps.resolve ?? ((specifier: string) => defaultRequire.resolve(specifier));
+  const resolve = deps.resolve ?? defaultResolve;
   const readFile = deps.readFile ?? ((file: string) => readFileSync(file, "utf8"));
 
   const specifier = helperPackageSpecifier(platform, arch);

--- a/packages/capture-audio/src/native.ts
+++ b/packages/capture-audio/src/native.ts
@@ -61,7 +61,9 @@ export interface HelperChild {
   stdout: { on(event: "data", listener: (chunk: Buffer | string) => void): unknown };
   stderr: { on(event: "data", listener: (chunk: Buffer | string) => void): unknown };
   once(event: "error", listener: (err: Error) => void): unknown;
-  once(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+  // `close` (not `exit`) fires after the stdio pipes are fully drained, so the
+  // helper's final buffered chunk is always read before the runner settles.
+  once(event: "close", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
   kill(signal?: NodeJS.Signals): boolean;
   readonly killed?: boolean;
   readonly pid?: number;
@@ -361,7 +363,7 @@ export function enumerateDevices(
     });
     child.stderr.on("data", () => undefined);
     child.once("error", (err) => fail(err instanceof Error ? err : new Error(String(err))));
-    child.once("exit", (code) => {
+    child.once("close", (code) => {
       if (settled) return;
       if (code !== 0) {
         fail(new CaptureInputError(`native helper device-enumerate exited with status ${code ?? "unknown"}`));
@@ -487,7 +489,7 @@ export function createNativeCaptureRunner(options: NativeRunnerOptions): NativeC
       onError(err instanceof Error ? err : new Error(String(err)));
       scheduleUnexpectedRestart();
     });
-    current.once("exit", (code, signal) => {
+    current.once("close", (code, signal) => {
       if (settled) return;
       settle();
       if (stopped) return; // explicit stop — never restart

--- a/packages/capture-audio/src/native.ts
+++ b/packages/capture-audio/src/native.ts
@@ -1,0 +1,495 @@
+/**
+ * Native capture helper resolver + supervised process runner (issue #1897,
+ * "audio native macOS helper" slice — Node side only).
+ *
+ * The native recorder is the ONE shared macOS helper shipped by #2138
+ * (`remnic-capture-helper`), driven here through its `audio-capture`
+ * subcommand. It emits one JSONL `ChunkEvent` per recorded WAV chunk on
+ * stdout. This module is deliberately à-la-carte, mirroring the VAD/STT
+ * adapters and the screen daemon's helper seam:
+ *
+ *   - The helper ships as an OPTIONAL, per-platform package
+ *     (`@remnic/capture-native-darwin-arm64` / `-x64`) that exports a
+ *     `helperBinaryPath` and declares the same binary under `bin`. It is a
+ *     peer dependency, never a runtime dependency, so `@remnic/capture-audio`
+ *     installs and works on any platform without it.
+ *   - The package specifier is COMPUTED from `process.platform`/`arch` so a
+ *     static importer never bundles a foreign-arch binary, and resolution uses
+ *     Node module resolution (`require.resolve`).
+ *   - `REMNIC_CAPTURE_HELPER_BIN` overrides resolution with an explicit binary
+ *     path (manual installs and the hardware-free test seam, which points it at
+ *     a fake script emitting canned JSON).
+ *   - A missing optional package reports the EXACT install command instead of a
+ *     raw resolver error.
+ *
+ * The runner is the sole owner of the child process: it spawns the helper,
+ * parses stdout strictly line-by-line, reports validated events to a callback,
+ * reports stderr/errors separately, and restarts only UNEXPECTED exits with
+ * bounded exponential backoff. It never writes the Spool and never invents a
+ * conversation — the processing/assembly layer owns eventual Spool writes
+ * downstream of the validated events this runner surfaces.
+ */
+
+import { spawn as nodeSpawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { CaptureConfigError, CaptureInputError } from "./errors.js";
+import { expandTilde } from "./paths.js";
+
+/** One recorded audio chunk, as emitted by the native helper on stdout (JSONL). */
+export interface ChunkEvent {
+  path: string;
+  channel: "mic" | "system";
+  startedAtUtc: string;
+  endedAtUtc: string;
+  device: string | null;
+}
+
+/** Which channels the `audio-capture` subcommand records. */
+export type ChannelSelection = "mic" | "system" | "both";
+
+/** A resolved native helper: its source specifier and the on-disk binary path. */
+export interface HelperResolution {
+  specifier: string;
+  binaryPath: string;
+}
+
+/** The narrow child-process surface the runner depends on (injectable for tests). */
+export interface HelperChild {
+  stdout: { on(event: "data", listener: (chunk: Buffer | string) => void): unknown };
+  stderr: { on(event: "data", listener: (chunk: Buffer | string) => void): unknown };
+  once(event: "error", listener: (err: Error) => void): unknown;
+  once(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+  kill(signal?: NodeJS.Signals): boolean;
+  readonly killed?: boolean;
+  readonly pid?: number;
+}
+
+/** Spawns the helper binary. Defaults to a `node:child_process` adapter. */
+export type HelperSpawn = (binaryPath: string, args: string[]) => HelperChild;
+
+/** An opaque restart-timer token returned by `scheduleRestart`. */
+export type RestartTimer = unknown;
+
+export interface ResolveHelperDeps {
+  platform?: NodeJS.Platform;
+  arch?: string;
+  /** `require.resolve`-style resolver; defaults to this module's require. */
+  resolve?: (specifier: string) => string;
+  readFile?: (file: string) => string;
+  /** Environment source for the `REMNIC_CAPTURE_HELPER_BIN` override. */
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface NativeRunnerOptions {
+  /** Directory the helper writes WAV chunks into (`audio-capture --out`). */
+  outDir: string;
+  chunkSeconds: number;
+  /** Channels to record; defaults to "both". */
+  channel?: ChannelSelection;
+  /** Optional CoreAudio microphone device UID (`--device`). */
+  device?: string | null;
+  /** Called once per validated ChunkEvent. */
+  onChunk: (event: ChunkEvent) => void;
+  /** Called for a rejected stdout line or a spawn/child error. */
+  onError?: (error: Error) => void;
+  /** Called once per complete stderr line. */
+  onStderr?: (line: string) => void;
+  /** Pre-resolved helper; when absent the runner resolves it lazily on `start()`. */
+  resolution?: HelperResolution;
+  resolveBinary?: (deps: ResolveHelperDeps) => HelperResolution;
+  spawn?: HelperSpawn;
+  /** Max consecutive unexpected restarts before giving up (default 5). */
+  maxRestarts?: number;
+  /** First backoff delay in ms (default 500). */
+  baseBackoffMs?: number;
+  /** Backoff ceiling in ms (default 30000). */
+  maxBackoffMs?: number;
+  scheduleRestart?: (fn: () => void, delayMs: number) => RestartTimer;
+  cancelRestart?: (timer: RestartTimer) => void;
+}
+
+/** A running native-capture supervisor. */
+export interface NativeCaptureRunner {
+  start(): void;
+  stop(): void;
+  /** True between a `start()` and its matching `stop()`. */
+  readonly running: boolean;
+}
+
+/** The env var that overrides package resolution with an explicit binary path. */
+export const HELPER_BIN_ENV = "REMNIC_CAPTURE_HELPER_BIN";
+/** The `bin` key the #2138 platform package declares (same file as helperBinaryPath). */
+const HELPER_BIN_NAME = "remnic-capture-helper";
+
+/**
+ * Compute the optional native-helper package specifier for a platform/arch.
+ * The helper is macOS-only and hardware-gated; every other platform (and any
+ * unsupported macOS architecture) throws loudly rather than resolving to a
+ * package that cannot exist.
+ */
+export function helperPackageSpecifier(platform: NodeJS.Platform | string, arch: string): string {
+  if (platform !== "darwin") {
+    throw new CaptureConfigError(
+      `Desktop audio capture native helper is only available on macOS; platform "${platform}" is unsupported`,
+    );
+  }
+  if (arch === "arm64") return "@remnic/capture-native-darwin-arm64";
+  if (arch === "x64") return "@remnic/capture-native-darwin-x64";
+  throw new CaptureConfigError(
+    `Desktop audio capture native helper is unavailable for macOS architecture "${arch}"`,
+  );
+}
+
+const defaultRequire = createRequire(import.meta.url);
+
+/**
+ * Resolve the native helper binary. Order: explicit `REMNIC_CAPTURE_HELPER_BIN`
+ * override, then the computed platform package's declared executable (resolved
+ * via Node module resolution, identical to its `helperBinaryPath` export).
+ * Throws a CaptureConfigError naming the exact install command when the
+ * optional package is not installed.
+ */
+export function resolveHelperBinary(deps: ResolveHelperDeps = {}): HelperResolution {
+  const env = deps.env ?? process.env;
+  const override = env[HELPER_BIN_ENV]?.trim();
+  if (override) return { specifier: `(${HELPER_BIN_ENV})`, binaryPath: expandTilde(override) };
+
+  const platform = deps.platform ?? process.platform;
+  const arch = deps.arch ?? process.arch;
+  const resolve = deps.resolve ?? ((specifier: string) => defaultRequire.resolve(specifier));
+  const readFile = deps.readFile ?? ((file: string) => readFileSync(file, "utf8"));
+
+  const specifier = helperPackageSpecifier(platform, arch);
+
+  let pkgJsonPath: string;
+  try {
+    pkgJsonPath = resolve(`${specifier}/package.json`);
+  } catch {
+    throw new CaptureConfigError(
+      `Desktop audio capture requires optional native helper ${specifier}, which is not installed. ` +
+        `Install it with: npm install ${specifier} (or: pnpm add ${specifier}), ` +
+        `or set ${HELPER_BIN_ENV} to a locally built remnic-capture-helper binary`,
+    );
+  }
+
+  return { specifier, binaryPath: helperBinaryFromPackage(pkgJsonPath, readFile, specifier) };
+}
+
+function helperBinaryFromPackage(pkgJsonPath: string, readFile: (file: string) => string, specifier: string): string {
+  let pkg: unknown;
+  try {
+    pkg = JSON.parse(readFile(pkgJsonPath));
+  } catch {
+    throw new CaptureConfigError(`native helper ${specifier} has an unreadable package.json at ${pkgJsonPath}`);
+  }
+
+  let bin: unknown;
+  if (pkg !== null && typeof pkg === "object" && "bin" in pkg) bin = pkg.bin;
+
+  let rel: string | undefined;
+  if (typeof bin === "string") {
+    rel = bin;
+  } else if (bin !== null && typeof bin === "object") {
+    const map: Record<string, unknown> = bin as Record<string, unknown>;
+    const named = map[HELPER_BIN_NAME];
+    const first = Object.values(map).find((v) => typeof v === "string");
+    if (typeof named === "string") rel = named;
+    else if (typeof first === "string") rel = first;
+  }
+  if (rel === undefined || rel === "") {
+    throw new CaptureConfigError(`native helper ${specifier} does not declare an executable in its package.json "bin"`);
+  }
+  return path.resolve(path.dirname(pkgJsonPath), rel);
+}
+
+/** Build the `audio-capture` argv from runner options (#2138 helper contract). */
+export function buildHelperArgs(
+  opts: Pick<NativeRunnerOptions, "outDir" | "chunkSeconds" | "channel" | "device">,
+): string[] {
+  const channel = opts.channel ?? "both";
+  const args = [
+    "audio-capture",
+    "--channel",
+    channel,
+    "--chunk-seconds",
+    String(opts.chunkSeconds),
+    "--out",
+    opts.outDir,
+  ];
+  const device = opts.device;
+  if (typeof device === "string" && device !== "") args.push("--device", device);
+  return args;
+}
+
+const ISO_PREFIX_RE = /^\d{4}-\d{2}-\d{2}T/;
+
+function parseTimestamp(value: unknown, where: string): string {
+  if (typeof value !== "string" || !ISO_PREFIX_RE.test(value)) {
+    throw new CaptureInputError(`${where}: expected an ISO timestamp`);
+  }
+  if (!Number.isFinite(Date.parse(value))) {
+    throw new CaptureInputError(`${where}: expected a valid ISO timestamp`);
+  }
+  return value;
+}
+
+/** Parse and validate one JSONL line into a ChunkEvent; throws on anything malformed. */
+export function parseChunkEvent(line: string): ChunkEvent {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(line);
+  } catch {
+    const trimmed = line.trim();
+    const preview = trimmed.length > 80 ? `${trimmed.slice(0, 77)}...` : trimmed;
+    throw new CaptureInputError(`native helper emitted a non-JSON line: ${preview}`);
+  }
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new CaptureInputError("native helper chunk: expected a JSON object");
+  }
+  const obj: Record<string, unknown> = raw as Record<string, unknown>;
+
+  if (typeof obj.path !== "string" || obj.path.trim() === "") {
+    throw new CaptureInputError("native helper chunk.path: expected a non-empty string");
+  }
+  if (obj.channel !== "mic" && obj.channel !== "system") {
+    throw new CaptureInputError('native helper chunk.channel: expected "mic" or "system"');
+  }
+  const startedAtUtc = parseTimestamp(obj.startedAtUtc, "native helper chunk.startedAtUtc");
+  const endedAtUtc = parseTimestamp(obj.endedAtUtc, "native helper chunk.endedAtUtc");
+  if (Date.parse(endedAtUtc) < Date.parse(startedAtUtc)) {
+    throw new CaptureInputError("native helper chunk.endedAtUtc: must not precede startedAtUtc");
+  }
+  let device: string | null = null;
+  if (obj.device !== undefined && obj.device !== null) {
+    if (typeof obj.device !== "string") {
+      throw new CaptureInputError("native helper chunk.device: expected a string, null, or absent");
+    }
+    device = obj.device;
+  }
+  return { path: obj.path, channel: obj.channel, startedAtUtc, endedAtUtc, device };
+}
+
+interface LineReader {
+  push(chunk: Buffer | string): void;
+  flush(): void;
+}
+
+/** Incrementally split a byte/string stream into complete newline-terminated lines. */
+function makeLineReader(onLine: (line: string) => void): LineReader {
+  let buffer = "";
+  return {
+    push(chunk) {
+      buffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      let idx = buffer.indexOf("\n");
+      while (idx >= 0) {
+        onLine(buffer.slice(0, idx).replace(/\r$/, ""));
+        buffer = buffer.slice(idx + 1);
+        idx = buffer.indexOf("\n");
+      }
+    },
+    flush() {
+      if (buffer.length > 0) {
+        const line = buffer.replace(/\r$/, "");
+        buffer = "";
+        onLine(line);
+      }
+    },
+  };
+}
+
+const defaultSpawn: HelperSpawn = (binaryPath, args) =>
+  // node's typings make stdout/stderr nullable; our piped stdio guarantees them.
+  nodeSpawn(binaryPath, args, { shell: false, stdio: ["ignore", "pipe", "pipe"] }) as unknown as HelperChild;
+
+/** Max device-enumerate stdout we will buffer (guards a runaway child). */
+const MAX_ENUMERATE_BYTES = 1024 * 1024;
+
+/**
+ * Run the helper's one-shot `device-enumerate` subcommand and return the parsed
+ * device list. Bounded, argv-only, and injectable for tests. Throws a
+ * CaptureInputError on a nonzero exit, empty output, or invalid JSON.
+ */
+export function enumerateDevices(
+  binaryPath: string,
+  spawn: HelperSpawn = defaultSpawn,
+): Promise<unknown[]> {
+  // `new Promise` (not Promise.withResolvers) matches the sibling capture
+  // packages; this package's tsconfig lib predates withResolvers.
+  return new Promise<unknown[]>((resolve, reject) => {
+    const child = spawn(binaryPath, ["device-enumerate"]);
+    let out = "";
+    let size = 0;
+    let settled = false;
+    const fail = (err: Error): void => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    };
+    child.stdout.on("data", (chunk) => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      size += Buffer.byteLength(text);
+      if (size > MAX_ENUMERATE_BYTES) {
+        child.kill("SIGKILL");
+        fail(new CaptureInputError("native helper device-enumerate produced too much output"));
+        return;
+      }
+      out += text;
+    });
+    child.stderr.on("data", () => undefined);
+    child.once("error", (err) => fail(err instanceof Error ? err : new Error(String(err))));
+    child.once("exit", (code) => {
+      if (settled) return;
+      if (code !== 0) {
+        fail(new CaptureInputError(`native helper device-enumerate exited with status ${code ?? "unknown"}`));
+        return;
+      }
+      if (out.trim() === "") {
+        fail(new CaptureInputError("native helper device-enumerate produced no output"));
+        return;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(out);
+      } catch {
+        fail(new CaptureInputError("native helper device-enumerate produced invalid JSON"));
+        return;
+      }
+      let list: unknown[] | null = null;
+      if (Array.isArray(parsed)) {
+        list = parsed;
+      } else if (parsed !== null && typeof parsed === "object" && "devices" in parsed) {
+        const devices = parsed.devices;
+        if (Array.isArray(devices)) list = devices;
+      }
+      if (list === null) {
+        fail(new CaptureInputError("native helper device-enumerate did not return a device array"));
+        return;
+      }
+      settled = true;
+      resolve(list);
+    });
+  });
+}
+
+/**
+ * Create a supervised native-capture runner. Dependency-injectable: pass
+ * `spawn`, `resolution`/`resolveBinary`, and `scheduleRestart`/`cancelRestart`
+ * to drive it deterministically in tests.
+ */
+export function createNativeCaptureRunner(options: NativeRunnerOptions): NativeCaptureRunner {
+  if (typeof options.outDir !== "string" || options.outDir.trim() === "") {
+    throw new CaptureConfigError("native runner outDir must be a non-empty string");
+  }
+  if (!Number.isFinite(options.chunkSeconds) || options.chunkSeconds <= 0) {
+    throw new CaptureConfigError("native runner chunkSeconds must be a positive number");
+  }
+
+  const spawn: HelperSpawn = options.spawn ?? defaultSpawn;
+  const scheduleRestart = options.scheduleRestart ?? ((fn, delayMs) => setTimeout(fn, delayMs).unref());
+  const cancelRestart = options.cancelRestart ?? ((timer) => clearTimeout(timer as NodeJS.Timeout));
+  const resolveBinary = options.resolveBinary ?? resolveHelperBinary;
+  const maxRestarts = options.maxRestarts ?? 5;
+  const baseBackoffMs = options.baseBackoffMs ?? 500;
+  const maxBackoffMs = options.maxBackoffMs ?? 30_000;
+  const args = buildHelperArgs(options);
+
+  const onError = (error: Error): void => {
+    options.onError?.(error);
+  };
+
+  let resolution: HelperResolution | undefined = options.resolution;
+  let stopped = true;
+  let child: HelperChild | undefined;
+  let restartTimer: RestartTimer | undefined;
+  let restarts = 0;
+
+  function scheduleUnexpectedRestart(): void {
+    if (stopped) return;
+    if (restarts >= maxRestarts) {
+      stopped = true;
+      onError(new Error(`native capture helper failed ${restarts} times; giving up`));
+      return;
+    }
+    const delayMs = Math.min(maxBackoffMs, baseBackoffMs * 2 ** restarts);
+    restarts += 1;
+    restartTimer = scheduleRestart(() => {
+      restartTimer = undefined;
+      if (!stopped) spawnChild();
+    }, delayMs);
+  }
+
+  function spawnChild(): void {
+    if (resolution === undefined) {
+      resolution = resolveBinary({});
+    }
+    const current = spawn(resolution.binaryPath, args);
+    child = current;
+    let settled = false;
+
+    const stdoutReader = makeLineReader((line) => {
+      if (line.trim() === "") return;
+      try {
+        const event = parseChunkEvent(line);
+        restarts = 0; // a valid chunk proves the helper is healthy — reset backoff
+        options.onChunk(event);
+      } catch (err) {
+        onError(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+    const stderrReader = makeLineReader((line) => {
+      if (line.trim() !== "") options.onStderr?.(line);
+    });
+
+    current.stdout.on("data", (chunk) => stdoutReader.push(chunk));
+    current.stderr.on("data", (chunk) => stderrReader.push(chunk));
+
+    const settle = (): void => {
+      settled = true;
+      stdoutReader.flush();
+      stderrReader.flush();
+      if (child === current) child = undefined;
+    };
+
+    current.once("error", (err) => {
+      if (settled) return;
+      settle();
+      onError(err instanceof Error ? err : new Error(String(err)));
+      scheduleUnexpectedRestart();
+    });
+    current.once("exit", (code, signal) => {
+      if (settled) return;
+      settle();
+      if (stopped) return; // explicit stop — never restart
+      onError(
+        new Error(`native capture helper exited unexpectedly (code=${code ?? "null"}, signal=${signal ?? "null"})`),
+      );
+      scheduleUnexpectedRestart();
+    });
+  }
+
+  return {
+    get running(): boolean {
+      return !stopped;
+    },
+    start(): void {
+      if (!stopped) return;
+      stopped = false;
+      restarts = 0;
+      spawnChild();
+    },
+    stop(): void {
+      if (stopped) return;
+      stopped = true;
+      if (restartTimer !== undefined) {
+        cancelRestart(restartTimer);
+        restartTimer = undefined;
+      }
+      const current = child;
+      child = undefined;
+      if (current && current.killed !== true) current.kill("SIGTERM");
+    },
+  };
+}

--- a/packages/capture-audio/src/native.ts
+++ b/packages/capture-audio/src/native.ts
@@ -529,11 +529,22 @@ export function createNativeCaptureRunner(options: NativeRunnerOptions): NativeC
         const finish = (): void => {
           if (done) return;
           done = true;
+          clearTimeout(killTimer);
+          clearTimeout(hardTimer);
           resolve();
         };
+        // Normal path: 'close' fires after stdout is flushed -> settle() ->
+        // stopResolve(finish), so the helper's final chunk is read first.
         stopResolve = finish;
-        const timer = setTimeout(finish, STOP_DRAIN_TIMEOUT_MS);
-        timer.unref();
+        // If SIGTERM hasn't drained + closed the child in time, escalate to
+        // SIGKILL (whose 'close' still flushes buffered stdout). A hard cap
+        // beyond that guarantees shutdown never hangs on a truly wedged helper.
+        const killTimer = setTimeout(() => {
+          if (!done && current.killed !== true) current.kill("SIGKILL");
+        }, STOP_DRAIN_TIMEOUT_MS);
+        killTimer.unref();
+        const hardTimer = setTimeout(finish, STOP_DRAIN_TIMEOUT_MS + 2000);
+        hardTimer.unref();
         current.kill("SIGTERM");
       });
     },

--- a/packages/capture-audio/src/native.ts
+++ b/packages/capture-audio/src/native.ts
@@ -114,13 +114,16 @@ export interface NativeRunnerOptions {
 /** A running native-capture supervisor. */
 export interface NativeCaptureRunner {
   start(): void;
-  stop(): void;
+  /** Stop the helper (SIGTERM) and resolve once it exits and its final chunk is read. */
+  stop(): Promise<void>;
   /** True between a `start()` and its matching `stop()`. */
   readonly running: boolean;
 }
 
 /** The env var that overrides package resolution with an explicit binary path. */
 export const HELPER_BIN_ENV = "REMNIC_CAPTURE_HELPER_BIN";
+/** How long stop() waits for the helper to flush its final chunk and exit. */
+const STOP_DRAIN_TIMEOUT_MS = 5000;
 /** The `bin` key the #2138 platform package declares (same file as helperBinaryPath). */
 const HELPER_BIN_NAME = "remnic-capture-helper";
 
@@ -164,9 +167,12 @@ export function resolveHelperBinary(deps: ResolveHelperDeps = {}): HelperResolut
 
   const specifier = helperPackageSpecifier(platform, arch);
 
-  let pkgJsonPath: string;
+  let entry: string;
   try {
-    pkgJsonPath = resolve(`${specifier}/package.json`);
+    // Resolve the package's main entry. Its `exports` map need not expose
+    // `package.json`, so never resolve that subpath directly. The helper binary
+    // lives at the same path the package's `helperBinaryPath` export resolves to.
+    entry = resolve(specifier);
   } catch {
     throw new CaptureConfigError(
       `Desktop audio capture requires optional native helper ${specifier}, which is not installed. ` +
@@ -174,7 +180,7 @@ export function resolveHelperBinary(deps: ResolveHelperDeps = {}): HelperResolut
         `or set ${HELPER_BIN_ENV} to a locally built remnic-capture-helper binary`,
     );
   }
-
+  const pkgJsonPath = path.join(path.dirname(entry), "package.json");
   return { specifier, binaryPath: helperBinaryFromPackage(pkgJsonPath, readFile, specifier) };
 }
 
@@ -405,6 +411,7 @@ export function createNativeCaptureRunner(options: NativeRunnerOptions): NativeC
   let child: HelperChild | undefined;
   let restartTimer: RestartTimer | undefined;
   let restarts = 0;
+  let stopResolve: (() => void) | null = null;
 
   function scheduleUnexpectedRestart(): void {
     if (stopped) return;
@@ -451,6 +458,11 @@ export function createNativeCaptureRunner(options: NativeRunnerOptions): NativeC
       stdoutReader.flush();
       stderrReader.flush();
       if (child === current) child = undefined;
+      if (stopResolve) {
+        const done = stopResolve;
+        stopResolve = null;
+        done();
+      }
     };
 
     current.once("error", (err) => {
@@ -480,16 +492,32 @@ export function createNativeCaptureRunner(options: NativeRunnerOptions): NativeC
       restarts = 0;
       spawnChild();
     },
-    stop(): void {
-      if (stopped) return;
+    stop(): Promise<void> {
+      if (stopped) return Promise.resolve();
       stopped = true;
       if (restartTimer !== undefined) {
         cancelRestart(restartTimer);
         restartTimer = undefined;
       }
       const current = child;
-      child = undefined;
-      if (current && current.killed !== true) current.kill("SIGTERM");
+      if (!current || current.killed === true) {
+        child = undefined;
+        return Promise.resolve();
+      }
+      // Resolve once the child exits (settle() flushes its final chunk first),
+      // with a bounded fallback so a wedged helper never hangs shutdown.
+      return new Promise<void>((resolve) => {
+        let done = false;
+        const finish = (): void => {
+          if (done) return;
+          done = true;
+          resolve();
+        };
+        stopResolve = finish;
+        const timer = setTimeout(finish, STOP_DRAIN_TIMEOUT_MS);
+        timer.unref();
+        current.kill("SIGTERM");
+      });
     },
   };
 }

--- a/packages/capture-audio/src/native.ts
+++ b/packages/capture-audio/src/native.ts
@@ -508,7 +508,13 @@ export function createNativeCaptureRunner(options: NativeRunnerOptions): NativeC
       if (!stopped) return;
       stopped = false;
       restarts = 0;
-      spawnChild();
+      try {
+        spawnChild();
+      } catch (err) {
+        // Resolution/spawn failed synchronously — the runner is not running.
+        stopped = true;
+        throw err;
+      }
     },
     stop(): Promise<void> {
       if (stopped) return Promise.resolve();

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -144,3 +144,28 @@ test("a within-chunk gap (gapMinutes 0) splits one chunk into separate conversat
     spool.close();
   }
 });
+
+test("silent chunks after speech finalize the conversation once the gap elapses", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    let call = 0;
+    const proc = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 5 }),
+        transcribe: async () =>
+          call++ === 0
+            ? [{ text: "hi", startUtc: "2026-07-24T00:00:00.000Z", endUtc: "2026-07-24T00:00:02.000Z" }]
+            : [],
+      }),
+    );
+    proc.enqueue(chunk({ startedAtUtc: "2026-07-24T00:00:00.000Z", endedAtUtc: "2026-07-24T00:00:05.000Z" }));
+    await proc.drain();
+    assert.ok(spool.latestCapturingConversation()); // open after speech
+    // A later silent chunk, a gap past the open conversation, closes it.
+    proc.enqueue(chunk({ path: "/tmp/raw/silent.wav", startedAtUtc: "2026-07-24T00:10:00.000Z", endedAtUtc: "2026-07-24T00:10:05.000Z" }));
+    await proc.drain();
+    assert.equal(spool.latestCapturingConversation(), null); // finalized by silence
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -122,3 +122,25 @@ test("a gap beyond the threshold finalizes the prior conversation in the spool",
     spool.close();
   }
 });
+
+test("a within-chunk gap (gapMinutes 0) splits one chunk into separate conversations", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const proc = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 0 }),
+        transcribe: async () => [
+          { text: "a", startUtc: "2026-07-24T00:00:00.000Z", endUtc: "2026-07-24T00:00:01.000Z" },
+          { text: "b", startUtc: "2026-07-24T00:00:05.000Z", endUtc: "2026-07-24T00:00:06.000Z" },
+        ],
+      }),
+    );
+    proc.enqueue(chunk());
+    await proc.drain();
+    // gap 0 puts each segment in its own conversation, even within one chunk.
+    assert.equal(spool.stats().conversations, 2);
+    assert.equal(spool.stats().segments, 2);
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ConversationAssembler } from "./assembly.js";
+import type { ChunkEvent } from "./native.js";
+import { createChunkProcessor, type ChunkProcessorDeps } from "./processor.js";
+import { Spool } from "./spool.js";
+import type { TranscribedSegment } from "./stt.js";
+
+const chunk = (over: Partial<ChunkEvent> = {}): ChunkEvent => ({
+  path: "/tmp/raw/a.wav",
+  channel: "mic",
+  startedAtUtc: "2026-07-24T00:00:00.000Z",
+  endedAtUtc: "2026-07-24T00:00:30.000Z",
+  device: "mic",
+  ...over,
+});
+
+function deps(spool: Spool, over: Partial<ChunkProcessorDeps> = {}): ChunkProcessorDeps {
+  return {
+    spool,
+    assembler: new ConversationAssembler({ gapMinutes: 10 }),
+    resolveModel: () => "/model.bin",
+    transcribe: async (): Promise<TranscribedSegment[]> => [
+      { text: "hello", startUtc: "2026-07-24T00:00:01.000Z", endUtc: "2026-07-24T00:00:02.000Z" },
+      { text: "  ", startUtc: "2026-07-24T00:00:02.000Z", endUtc: "2026-07-24T00:00:03.000Z" }, // dropped (blank)
+      { text: "world", startUtc: "2026-07-24T00:00:03.000Z", endUtc: "2026-07-24T00:00:04.000Z" },
+    ],
+    cleanupRawAudio: async () => undefined,
+    ...over,
+  };
+}
+
+test("a chunk's non-empty segments persist as a capturing conversation", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const proc = createChunkProcessor(deps(spool));
+    proc.enqueue(chunk());
+    await proc.drain();
+    const open = spool.latestCapturingConversation();
+    assert.ok(open, "expected an open conversation");
+    assert.equal(spool.stats().segments, 2); // blank segment dropped
+    assert.equal((await proc.finalize()) >= 1, true);
+    assert.equal(spool.latestCapturingConversation(), null); // finalized
+  } finally {
+    spool.close();
+  }
+});
+
+test("re-processing the same chunk after a restart does not duplicate segments", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const first = createChunkProcessor(deps(spool));
+    first.enqueue(chunk());
+    await first.drain();
+    assert.equal(spool.stats().segments, 2);
+    // Simulate a restart: a brand-new processor + assembler, same spool + chunk.
+    const second = createChunkProcessor(deps(spool));
+    second.enqueue(chunk());
+    await second.drain();
+    assert.equal(spool.stats().segments, 2); // applied_chunks dedup held
+  } finally {
+    spool.close();
+  }
+});
+
+test("a transcription failure routes to onError and the chain keeps running", async () => {
+  const spool = new Spool(":memory:");
+  const errors: Error[] = [];
+  try {
+    const proc = createChunkProcessor(
+      deps(spool, {
+        transcribe: async (input) => {
+          if (input.wavPath.endsWith("bad.wav")) throw new Error("stt boom");
+          return [{ text: "ok", startUtc: "2026-07-24T00:00:01.000Z", endUtc: "2026-07-24T00:00:02.000Z" }];
+        },
+        onError: (e) => errors.push(e),
+      }),
+    );
+    proc.enqueue(chunk({ path: "/tmp/raw/bad.wav" }));
+    proc.enqueue(chunk({ path: "/tmp/raw/good.wav", startedAtUtc: "2026-07-24T00:01:00.000Z", endedAtUtc: "2026-07-24T00:01:30.000Z" }));
+    await proc.drain();
+    assert.equal(errors.length, 1);
+    assert.equal(spool.stats().segments, 1); // the good chunk still landed
+  } finally {
+    spool.close();
+  }
+});
+
+test("a chunk that transcribes to nothing persists no conversation", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const proc = createChunkProcessor(deps(spool, { transcribe: async () => [] }));
+    proc.enqueue(chunk());
+    await proc.drain();
+    assert.equal(spool.stats().segments, 0);
+    assert.equal(spool.latestCapturingConversation(), null);
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -99,3 +99,26 @@ test("a chunk that transcribes to nothing persists no conversation", async () =>
     spool.close();
   }
 });
+
+test("a gap beyond the threshold finalizes the prior conversation in the spool", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const proc = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 5 }),
+        transcribe: async (input) => [
+          { text: input.wavPath, startUtc: input.chunkStartedAtUtc, endUtc: input.chunkStartedAtUtc },
+        ],
+      }),
+    );
+    proc.enqueue(chunk({ path: "/tmp/raw/a.wav", startedAtUtc: "2026-07-24T00:00:00.000Z", endedAtUtc: "2026-07-24T00:00:05.000Z" }));
+    proc.enqueue(chunk({ path: "/tmp/raw/b.wav", startedAtUtc: "2026-07-24T00:20:00.000Z", endedAtUtc: "2026-07-24T00:20:05.000Z" }));
+    await proc.drain();
+    // The first conversation was gap-closed and already finalized; only the
+    // second remains capturing, so finalizeOpenConversations flips exactly one.
+    assert.ok(spool.latestCapturingConversation());
+    assert.equal(spool.finalizeOpenConversations(), 1);
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -144,7 +144,16 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     }
 
     processedThisRun.add(chunkId);
-    await deps.cleanupRawAudio(event);
+    // Only reclaim the raw WAV once its transcript is durably persisted; a
+    // silent (no-segment) chunk is left to the retention janitor. Cleanup is
+    // best-effort — a failure is reported, and the janitor is the backstop.
+    if (segments.length > 0) {
+      try {
+        await deps.cleanupRawAudio(event);
+      } catch (err) {
+        report(err, event);
+      }
+    }
   }
 
   function enqueue(event: ChunkEvent): void {

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -113,22 +113,23 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       }
       // Segments usually land in one conversation, but a gap >= threshold (or
       // conversationGapMinutes = 0) can split them intra-chunk. Group by the
-      // conversation the assembler places each segment in, finalizing a prior
-      // conversation the moment it closes, and append each group under its own
-      // id with a per-group idempotency key (replay-safe).
+      // conversation the assembler places each segment in.
       const groups: Array<{ id: string; startedAtUtc: string; segs: AssemblySegment[] }> = [];
       for (const seg of segments) {
         const conv = deps.assembler.add(seg);
-        if (openConversationId !== null && openConversationId !== conv.id) {
-          deps.spool.finalizeConversation(openConversationId);
-        }
-        openConversationId = conv.id;
         const last = groups[groups.length - 1];
         if (last && last.id === conv.id) last.segs.push(seg);
         else groups.push({ id: conv.id, startedAtUtc: conv.startedAtUtc, segs: [seg] });
       }
+      // Append each group, finalizing a conversation only once we move past it
+      // — i.e. AFTER its rows have been appended — so no segment is ever added
+      // to an already-finalized conversation, and a gap-closed conversation
+      // doesn't linger as `capturing`.
       for (let g = 0; g < groups.length; g++) {
         const grp = groups[g];
+        if (openConversationId !== null && openConversationId !== grp.id) {
+          deps.spool.finalizeConversation(openConversationId);
+        }
         const key = groups.length === 1 ? chunkId : `${chunkId}:${g}`;
         deps.spool.appendAssembledSegments({
           idempotencyKey: key,
@@ -140,19 +141,19 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           wavPath: event.path,
           segments: grp.segs,
         });
+        openConversationId = grp.id;
       }
     }
 
     processedThisRun.add(chunkId);
-    // Only reclaim the raw WAV once its transcript is durably persisted; a
-    // silent (no-segment) chunk is left to the retention janitor. Cleanup is
-    // best-effort — a failure is reported, and the janitor is the backstop.
-    if (segments.length > 0) {
-      try {
-        await deps.cleanupRawAudio(event);
-      } catch (err) {
-        report(err, event);
-      }
+    // A successful transcription (even an empty/silent one) means the chunk is
+    // fully handled, so reclaim its raw WAV. A FAILED transcription throws
+    // above and never reaches here, so its WAV is retained. Best-effort — a
+    // cleanup failure is reported and the retention janitor is the backstop.
+    try {
+      await deps.cleanupRawAudio(event);
+    } catch (err) {
+      report(err, event);
     }
   }
 

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -63,6 +63,7 @@ export function chunkStableId(event: ChunkEvent): string {
 export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   let tail: Promise<void> = Promise.resolve();
   let recovered = false;
+  let openConversationId: string | null = null;
   const processedThisRun = new Set<string>();
 
   const report = (error: unknown, event: ChunkEvent): void => {
@@ -105,13 +106,21 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       if (!recovered) {
         recovered = true;
         const prior = deps.spool.latestCapturingConversation();
-        if (prior) deps.assembler.resume(prior);
+        if (prior) {
+          deps.assembler.resume(prior);
+          openConversationId = prior.id;
+        }
       }
       // A chunk is far shorter than the conversation gap, so all of its
       // segments land in one conversation; persisting a single append per
       // chunk keeps the idempotency key chunk-stable (replay-safe).
       let conversation = deps.assembler.add(segments[0]);
       for (let i = 1; i < segments.length; i++) conversation = deps.assembler.add(segments[i]);
+      // A gap past the threshold closed the prior conversation in the assembler;
+      // mirror that in the spool so it doesn't linger as `capturing`.
+      if (openConversationId !== null && openConversationId !== conversation.id) {
+        deps.spool.finalizeConversation(openConversationId);
+      }
       deps.spool.appendAssembledSegments({
         idempotencyKey: chunkId,
         chunkId,
@@ -122,6 +131,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         wavPath: event.path,
         segments,
       });
+      openConversationId = conversation.id;
     }
 
     processedThisRun.add(chunkId);

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -1,0 +1,146 @@
+/**
+ * Chunk processor (issue #1897) — turns completed native WAV chunk events
+ * into durable, replay-safe conversations in the spool.
+ *
+ * The native helper runner owns process lifecycle and emits one validated
+ * `ChunkEvent` per recorded WAV. This module consumes those events through a
+ * single serialized promise chain: resolve model -> transcribe -> normalize
+ * nonempty segments -> assemble -> persist via durable chunk idempotency ->
+ * delete the raw WAV. A rejected chunk is reported and the chain recovers so
+ * the daemon stays alive; the durable `applied_chunks` guard keeps a
+ * restart/replay of the same chunk from duplicating segments.
+ *
+ * Every collaborator (STT, model resolution, raw-audio cleanup) is injected,
+ * so no optional VAD/native runtime is imported here and the package stays
+ * à-la-carte.
+ */
+
+import { createHash } from "node:crypto";
+
+import type { AssemblySegment, ConversationAssembler } from "./assembly.js";
+import type { ChunkEvent } from "./native.js";
+import type { Spool } from "./spool.js";
+import type { TranscribedSegment } from "./stt.js";
+
+export interface ChunkTranscribeInput {
+  wavPath: string;
+  modelPath: string;
+  chunkStartedAtUtc: string;
+}
+
+export interface ChunkProcessorDeps {
+  spool: Spool;
+  /** Stateful assembler that groups consecutive segments into conversations. */
+  assembler: ConversationAssembler;
+  /** Resolve the STT model path; called per chunk and may throw when absent. */
+  resolveModel: () => string;
+  /** Transcribe one WAV chunk into raw segments. */
+  transcribe: (input: ChunkTranscribeInput) => Promise<TranscribedSegment[]>;
+  /** Delete the raw WAV under retention once the chunk is durably persisted. */
+  cleanupRawAudio: (event: ChunkEvent) => Promise<void>;
+  /** Reports a per-chunk failure; the chain keeps running afterwards. */
+  onError?: (error: Error, event: ChunkEvent) => void;
+}
+
+export interface ChunkProcessor {
+  /** onChunk seam for `NativeRunnerOptions`. Never throws; failures route to `onError`. */
+  enqueue(event: ChunkEvent): void;
+  /** Resolve once the serialized chain has settled all enqueued chunks. */
+  drain(): Promise<void>;
+  /** Drain, then flip open conversations to `final`; returns the count closed. */
+  finalize(): Promise<number>;
+}
+
+/**
+ * Stable chunk identity derived purely from the WAV path. Because it never
+ * depends on a freshly-generated conversation id, the same chunk yields the
+ * same idempotency key across process restarts.
+ */
+export function chunkStableId(event: ChunkEvent): string {
+  return `chk_${createHash("sha1").update(event.path).digest("hex")}`;
+}
+
+export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
+  let tail: Promise<void> = Promise.resolve();
+  let recovered = false;
+  const processedThisRun = new Set<string>();
+
+  const report = (error: unknown, event: ChunkEvent): void => {
+    deps.onError?.(error instanceof Error ? error : new Error(String(error)), event);
+  };
+
+  async function process(event: ChunkEvent): Promise<void> {
+    const chunkId = chunkStableId(event);
+    if (processedThisRun.has(chunkId)) return; // in-run replay: already handled
+
+    const modelPath = deps.resolveModel();
+    const raw = await deps.transcribe({
+      wavPath: event.path,
+      modelPath,
+      chunkStartedAtUtc: event.startedAtUtc,
+    });
+
+    const segments: AssemblySegment[] = [];
+    for (const s of raw) {
+      const text = s.text.trim();
+      if (text === "") continue;
+      segments.push({
+        channel: event.channel,
+        text,
+        startUtc: s.startUtc,
+        endUtc: s.endUtc,
+        // Interim wearer heuristic: the mic channel is the wearer's own audio.
+        // This is NOT diarization/speaker attribution — that lands in a later
+        // checklist item and will refine `isWearer` and `speakerCluster`.
+        isWearer: event.channel === "mic",
+      });
+    }
+
+    if (segments.length > 0) {
+      // After a restart the assembler is empty; recover the newest still-open
+      // conversation from the spool once, so an adjacent chunk continues it
+      // instead of splitting. The assembler's own gap rule then decides
+      // continue-vs-new; a truly stale open conversation is left for stop-time
+      // finalization.
+      if (!recovered) {
+        recovered = true;
+        const prior = deps.spool.latestCapturingConversation();
+        if (prior) deps.assembler.resume(prior);
+      }
+      // A chunk is far shorter than the conversation gap, so all of its
+      // segments land in one conversation; persisting a single append per
+      // chunk keeps the idempotency key chunk-stable (replay-safe).
+      let conversation = deps.assembler.add(segments[0]);
+      for (let i = 1; i < segments.length; i++) conversation = deps.assembler.add(segments[i]);
+      deps.spool.appendAssembledSegments({
+        idempotencyKey: chunkId,
+        chunkId,
+        conversationId: conversation.id,
+        startedAtUtc: conversation.startedAtUtc,
+        state: "capturing",
+        device: event.device,
+        wavPath: event.path,
+        segments,
+      });
+    }
+
+    processedThisRun.add(chunkId);
+    await deps.cleanupRawAudio(event);
+  }
+
+  function enqueue(event: ChunkEvent): void {
+    tail = tail.then(() => process(event)).catch((error) => report(error, event));
+  }
+
+  function drain(): Promise<void> {
+    return tail.then(() => undefined);
+  }
+
+  async function finalize(): Promise<number> {
+    await drain();
+    deps.assembler.finalize();
+    return deps.spool.finalizeOpenConversations();
+  }
+
+  return { enqueue, drain, finalize };
+}

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -81,6 +81,24 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       chunkStartedAtUtc: event.startedAtUtc,
     });
 
+    // Recover the newest still-open conversation once (any chunk, incl. silent)
+    // so a post-restart chunk continues it; then finalize a stale open
+    // conversation when this chunk arrives a gap past it. Pure-silence runs
+    // never call assembler.add, so closeIfIdle is what closes them.
+    if (!recovered) {
+      recovered = true;
+      const prior = deps.spool.latestCapturingConversation();
+      if (prior) {
+        deps.assembler.resume(prior);
+        openConversationId = prior.id;
+      }
+    }
+    const closed = deps.assembler.closeIfIdle(event.startedAtUtc);
+    if (closed !== null && closed === openConversationId) {
+      deps.spool.finalizeConversation(closed);
+      openConversationId = null;
+    }
+
     const segments: AssemblySegment[] = [];
     for (const s of raw) {
       const text = s.text.trim();
@@ -98,19 +116,6 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     }
 
     if (segments.length > 0) {
-      // After a restart the assembler is empty; recover the newest still-open
-      // conversation from the spool once, so an adjacent chunk continues it
-      // instead of splitting. The assembler's own gap rule then decides
-      // continue-vs-new; a truly stale open conversation is left for stop-time
-      // finalization.
-      if (!recovered) {
-        recovered = true;
-        const prior = deps.spool.latestCapturingConversation();
-        if (prior) {
-          deps.assembler.resume(prior);
-          openConversationId = prior.id;
-        }
-      }
       // Segments usually land in one conversation, but a gap >= threshold (or
       // conversationGapMinutes = 0) can split them intra-chunk. Group by the
       // conversation the assembler places each segment in.

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -111,27 +111,36 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           openConversationId = prior.id;
         }
       }
-      // A chunk is far shorter than the conversation gap, so all of its
-      // segments land in one conversation; persisting a single append per
-      // chunk keeps the idempotency key chunk-stable (replay-safe).
-      let conversation = deps.assembler.add(segments[0]);
-      for (let i = 1; i < segments.length; i++) conversation = deps.assembler.add(segments[i]);
-      // A gap past the threshold closed the prior conversation in the assembler;
-      // mirror that in the spool so it doesn't linger as `capturing`.
-      if (openConversationId !== null && openConversationId !== conversation.id) {
-        deps.spool.finalizeConversation(openConversationId);
+      // Segments usually land in one conversation, but a gap >= threshold (or
+      // conversationGapMinutes = 0) can split them intra-chunk. Group by the
+      // conversation the assembler places each segment in, finalizing a prior
+      // conversation the moment it closes, and append each group under its own
+      // id with a per-group idempotency key (replay-safe).
+      const groups: Array<{ id: string; startedAtUtc: string; segs: AssemblySegment[] }> = [];
+      for (const seg of segments) {
+        const conv = deps.assembler.add(seg);
+        if (openConversationId !== null && openConversationId !== conv.id) {
+          deps.spool.finalizeConversation(openConversationId);
+        }
+        openConversationId = conv.id;
+        const last = groups[groups.length - 1];
+        if (last && last.id === conv.id) last.segs.push(seg);
+        else groups.push({ id: conv.id, startedAtUtc: conv.startedAtUtc, segs: [seg] });
       }
-      deps.spool.appendAssembledSegments({
-        idempotencyKey: chunkId,
-        chunkId,
-        conversationId: conversation.id,
-        startedAtUtc: conversation.startedAtUtc,
-        state: "capturing",
-        device: event.device,
-        wavPath: event.path,
-        segments,
-      });
-      openConversationId = conversation.id;
+      for (let g = 0; g < groups.length; g++) {
+        const grp = groups[g];
+        const key = groups.length === 1 ? chunkId : `${chunkId}:${g}`;
+        deps.spool.appendAssembledSegments({
+          idempotencyKey: key,
+          chunkId: key,
+          conversationId: grp.id,
+          startedAtUtc: grp.startedAtUtc,
+          state: "capturing",
+          device: event.device,
+          wavPath: event.path,
+          segments: grp.segs,
+        });
+      }
     }
 
     processedThisRun.add(chunkId);

--- a/packages/capture-audio/src/service.test.ts
+++ b/packages/capture-audio/src/service.test.ts
@@ -131,3 +131,9 @@ test("renderSystemdUnit escapes percent specifiers", () => {
   assert.match(unit, /100%%done/);
   assert.equal(/[^%]%[^%]/.test(unit.split("\n").find((l) => l.startsWith("ExecStart")) ?? ""), false);
 });
+
+test("renderSystemdUnit routes stdout/stderr to the log file", () => {
+  const unit = renderSystemdUnit(SPEC);
+  assert.match(unit, /StandardOutput=append:\/home\/user\/\.remnic\/audio\.log/);
+  assert.match(unit, /StandardError=append:\/home\/user\/\.remnic\/audio\.log/);
+});

--- a/packages/capture-audio/src/service.test.ts
+++ b/packages/capture-audio/src/service.test.ts
@@ -114,3 +114,20 @@ test("uninstallService removes an existing unit and reports absence", () => {
   });
   assert.equal(absent.removed, false);
 });
+
+test("planService rejects an unsafe label (path/injection guard)", () => {
+  assert.throws(
+    () => planService({ platform: "darwin", home: "/Users/j", spec: { ...SPEC, label: "../evil" } }),
+    CaptureConfigError,
+  );
+  assert.throws(
+    () => planService({ platform: "linux", home: "/home/u", spec: { ...SPEC, label: "a/b c" } }),
+    CaptureConfigError,
+  );
+});
+
+test("renderSystemdUnit escapes percent specifiers", () => {
+  const unit = renderSystemdUnit({ ...SPEC, programArguments: ["/bin/node", "--flag=100%done"] });
+  assert.match(unit, /100%%done/);
+  assert.equal(/[^%]%[^%]/.test(unit.split("\n").find((l) => l.startsWith("ExecStart")) ?? ""), false);
+});

--- a/packages/capture-audio/src/service.test.ts
+++ b/packages/capture-audio/src/service.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CaptureConfigError } from "./errors.js";
+import {
+  DEFAULT_SERVICE_LABEL,
+  installService,
+  planService,
+  renderLaunchAgent,
+  renderSystemdUnit,
+  uninstallService,
+  type ServiceSpec,
+} from "./service.js";
+
+const SPEC: ServiceSpec = {
+  programArguments: ["/usr/bin/node", "/app/cli.js", "start", "--foreground", "--capture"],
+  logPath: "/home/user/.remnic/audio.log",
+};
+
+test("renderLaunchAgent emits a plist with the label, args, and log paths", () => {
+  const plist = renderLaunchAgent(SPEC);
+  assert.match(plist, /<key>Label<\/key>\s*<string>com\.remnic\.capture-audio<\/string>/);
+  assert.match(plist, /<string>--capture<\/string>/);
+  assert.match(plist, /<key>RunAtLoad<\/key>\s*<true\/>/);
+  assert.match(plist, /audio\.log/);
+});
+
+test("renderLaunchAgent xml-escapes argument content", () => {
+  const plist = renderLaunchAgent({ ...SPEC, programArguments: ["/a & b/node <x>"] });
+  assert.match(plist, /&amp;/);
+  assert.match(plist, /&lt;x&gt;/);
+  assert.equal(plist.includes("<x>"), false);
+});
+
+test("renderSystemdUnit quotes args with spaces and restarts on failure", () => {
+  const unit = renderSystemdUnit({ ...SPEC, programArguments: ["/usr/bin/node", "/a b/cli.js", "start"] });
+  assert.match(unit, /ExecStart=\/usr\/bin\/node "\/a b\/cli\.js" start/);
+  assert.match(unit, /Restart=on-failure/);
+  assert.match(unit, /WantedBy=default\.target/);
+});
+
+test("planService picks the platform-appropriate unit path", () => {
+  const darwin = planService({ platform: "darwin", home: "/Users/jane", spec: SPEC });
+  assert.equal(darwin.path, `/Users/jane/Library/LaunchAgents/${DEFAULT_SERVICE_LABEL}.plist`);
+  assert.match(darwin.loadHint, /launchctl load/);
+  const linux = planService({ platform: "linux", home: "/home/user", spec: SPEC });
+  assert.equal(linux.path, "/home/user/.config/systemd/user/remnic-capture-audio.service");
+  assert.match(linux.loadHint, /systemctl --user enable --now/);
+});
+
+test("planService rejects an unsupported platform", () => {
+  assert.throws(() => planService({ platform: "win32", home: "C:/u", spec: SPEC }), CaptureConfigError);
+});
+
+test("installService writes the unit, creating its directory; force guards an existing unit", () => {
+  const writes: Array<{ file: string; contents: string }> = [];
+  const mkdirs: string[] = [];
+  const plan = installService({
+    platform: "linux",
+    home: "/home/user",
+    spec: SPEC,
+    exists: () => false,
+    mkdir: (dir) => mkdirs.push(dir),
+    writeFile: (file, contents) => writes.push({ file, contents }),
+  });
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].file, plan.path);
+  assert.equal(mkdirs[0], "/home/user/.config/systemd/user");
+
+  assert.throws(
+    () =>
+      installService({
+        platform: "linux",
+        home: "/home/user",
+        spec: SPEC,
+        exists: () => true,
+        mkdir: () => undefined,
+        writeFile: () => undefined,
+      }),
+    CaptureConfigError,
+  );
+  // --force overwrites without throwing.
+  assert.doesNotThrow(() =>
+    installService({
+      platform: "linux",
+      home: "/home/user",
+      spec: SPEC,
+      force: true,
+      exists: () => true,
+      mkdir: () => undefined,
+      writeFile: () => undefined,
+    }),
+  );
+});
+
+test("uninstallService removes an existing unit and reports absence", () => {
+  const removed: string[] = [];
+  const present = uninstallService({
+    platform: "darwin",
+    home: "/Users/jane",
+    spec: SPEC,
+    exists: () => true,
+    remove: (f) => removed.push(f),
+  });
+  assert.equal(present.removed, true);
+  assert.equal(removed.length, 1);
+
+  const absent = uninstallService({
+    platform: "darwin",
+    home: "/Users/jane",
+    spec: SPEC,
+    exists: () => false,
+    remove: () => assert.fail("must not remove when absent"),
+  });
+  assert.equal(absent.removed, false);
+});

--- a/packages/capture-audio/src/service.test.ts
+++ b/packages/capture-audio/src/service.test.ts
@@ -137,3 +137,13 @@ test("renderSystemdUnit routes stdout/stderr to the log file", () => {
   assert.match(unit, /StandardOutput=append:\/home\/user\/\.remnic\/audio\.log/);
   assert.match(unit, /StandardError=append:\/home\/user\/\.remnic\/audio\.log/);
 });
+
+test("service renderers persist the environment (PATH + helper override)", () => {
+  const spec = { ...SPEC, environment: { PATH: "/usr/bin", REMNIC_CAPTURE_HELPER_BIN: "/opt/helper" } };
+  const unit = renderSystemdUnit(spec);
+  assert.match(unit, /Environment=/);
+  assert.match(unit, /REMNIC_CAPTURE_HELPER_BIN=\/opt\/helper/);
+  const plist = renderLaunchAgent(spec);
+  assert.match(plist, /<key>EnvironmentVariables<\/key>/);
+  assert.match(plist, /<key>PATH<\/key>/);
+});

--- a/packages/capture-audio/src/service.test.ts
+++ b/packages/capture-audio/src/service.test.ts
@@ -147,3 +147,9 @@ test("service renderers persist the environment (PATH + helper override)", () =>
   assert.match(plist, /<key>EnvironmentVariables<\/key>/);
   assert.match(plist, /<key>PATH<\/key>/);
 });
+
+test("planService honors a custom --label for the Linux unit name", () => {
+  const plan = planService({ platform: "linux", home: "/home/u", spec: { ...SPEC, label: "my-cap" } });
+  assert.equal(plan.path, "/home/u/.config/systemd/user/my-cap.service");
+  assert.match(plan.loadHint, /my-cap\.service/);
+});

--- a/packages/capture-audio/src/service.ts
+++ b/packages/capture-audio/src/service.ts
@@ -41,6 +41,18 @@ function xmlEscape(value: string): string {
     .replace(/'/g, "&apos;");
 }
 
+const SAFE_LABEL = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** Reject a label that could escape the unit filename or inject unit content. */
+function validateLabel(label: string): string {
+  if (!SAFE_LABEL.test(label)) {
+    throw new CaptureConfigError(
+      `install-service label must match ${SAFE_LABEL.source} (got: ${JSON.stringify(label)})`,
+    );
+  }
+  return label;
+}
+
 /** Render a launchd LaunchAgent plist that keeps the daemon alive at login. */
 export function renderLaunchAgent(spec: ServiceSpec): string {
   const label = spec.label ?? DEFAULT_SERVICE_LABEL;
@@ -72,10 +84,12 @@ ${args}
 
 /** systemd quotes args that contain whitespace or its quote/backslash chars. */
 function systemdArg(value: string): string {
-  if (value === "" || /[\s"'\\]/.test(value)) {
-    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  // systemd treats % as a specifier introducer; escape it regardless of quoting.
+  const escaped = value.replace(/%/g, "%%");
+  if (escaped === "" || /[\s"'\\]/.test(escaped)) {
+    return `"${escaped.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
-  return value;
+  return escaped;
 }
 
 /** Render a systemd user unit that restarts the daemon on failure. */
@@ -104,7 +118,7 @@ export interface PlanServiceDeps {
 
 /** Decide the unit file path + contents for the current platform. */
 export function planService(deps: PlanServiceDeps): ServicePlan {
-  const label = deps.spec.label ?? DEFAULT_SERVICE_LABEL;
+  const label = validateLabel(deps.spec.label ?? DEFAULT_SERVICE_LABEL);
   if (deps.platform === "darwin") {
     const target = path.join(deps.home, "Library", "LaunchAgents", `${label}.plist`);
     return {

--- a/packages/capture-audio/src/service.ts
+++ b/packages/capture-audio/src/service.ts
@@ -1,0 +1,159 @@
+/**
+ * `install-service` support (issue #1897) — render and install a per-user
+ * background service that runs the capture-audio daemon in live-capture mode.
+ *
+ * macOS uses a launchd LaunchAgent (`~/Library/LaunchAgents/<label>.plist`);
+ * Linux uses a systemd user unit (`~/.config/systemd/user/<name>.service`).
+ * The renderers are pure (deterministic strings) and `installService` /
+ * `uninstallService` take injected filesystem + environment seams so the whole
+ * surface is testable without touching the real user launch directories.
+ */
+
+import path from "node:path";
+
+import { CaptureConfigError } from "./errors.js";
+
+export const DEFAULT_SERVICE_LABEL = "com.remnic.capture-audio";
+const SYSTEMD_UNIT_NAME = "remnic-capture-audio.service";
+
+export interface ServiceSpec {
+  /** argv that launches the daemon, e.g. [node, cliEntry, "start", "--foreground", "--capture"]. */
+  programArguments: string[];
+  logPath: string;
+  label?: string;
+}
+
+export interface ServicePlan {
+  platform: NodeJS.Platform;
+  /** Absolute path the unit file is written to. */
+  path: string;
+  contents: string;
+  /** One-line operator instruction to load/enable the service. */
+  loadHint: string;
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/** Render a launchd LaunchAgent plist that keeps the daemon alive at login. */
+export function renderLaunchAgent(spec: ServiceSpec): string {
+  const label = spec.label ?? DEFAULT_SERVICE_LABEL;
+  const args = spec.programArguments.map((a) => `    <string>${xmlEscape(a)}</string>`).join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${xmlEscape(label)}</string>
+  <key>ProgramArguments</key>
+  <array>
+${args}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(spec.logPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(spec.logPath)}</string>
+</dict>
+</plist>
+`;
+}
+
+/** systemd quotes args that contain whitespace or its quote/backslash chars. */
+function systemdArg(value: string): string {
+  if (value === "" || /[\s"'\\]/.test(value)) {
+    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  return value;
+}
+
+/** Render a systemd user unit that restarts the daemon on failure. */
+export function renderSystemdUnit(spec: ServiceSpec): string {
+  const execStart = spec.programArguments.map(systemdArg).join(" ");
+  return `[Unit]
+Description=Remnic desktop audio capture daemon
+After=default.target
+
+[Service]
+Type=simple
+ExecStart=${execStart}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+export interface PlanServiceDeps {
+  platform: NodeJS.Platform;
+  home: string;
+  spec: ServiceSpec;
+}
+
+/** Decide the unit file path + contents for the current platform. */
+export function planService(deps: PlanServiceDeps): ServicePlan {
+  const label = deps.spec.label ?? DEFAULT_SERVICE_LABEL;
+  if (deps.platform === "darwin") {
+    const target = path.join(deps.home, "Library", "LaunchAgents", `${label}.plist`);
+    return {
+      platform: deps.platform,
+      path: target,
+      contents: renderLaunchAgent(deps.spec),
+      loadHint: `launchctl load ${target}`,
+    };
+  }
+  if (deps.platform === "linux") {
+    const target = path.join(deps.home, ".config", "systemd", "user", SYSTEMD_UNIT_NAME);
+    return {
+      platform: deps.platform,
+      path: target,
+      contents: renderSystemdUnit(deps.spec),
+      loadHint: `systemctl --user enable --now ${SYSTEMD_UNIT_NAME}`,
+    };
+  }
+  throw new CaptureConfigError(`install-service is unsupported on platform "${deps.platform}"`);
+}
+
+export interface InstallServiceDeps extends PlanServiceDeps {
+  mkdir: (dir: string) => void;
+  writeFile: (file: string, contents: string) => void;
+  /** True to overwrite an already-installed unit. */
+  force?: boolean;
+  exists?: (file: string) => boolean;
+}
+
+/** Write the planned unit file, creating its directory. Returns the plan. */
+export function installService(deps: InstallServiceDeps): ServicePlan {
+  const plan = planService(deps);
+  if (!deps.force && deps.exists?.(plan.path)) {
+    throw new CaptureConfigError(`a capture-audio service is already installed at ${plan.path} (use --force to replace)`);
+  }
+  deps.mkdir(path.dirname(plan.path));
+  deps.writeFile(plan.path, plan.contents);
+  return plan;
+}
+
+export interface UninstallServiceDeps extends PlanServiceDeps {
+  remove: (file: string) => void;
+  exists: (file: string) => boolean;
+}
+
+/** Remove the installed unit file. Returns the plan + whether a file was removed. */
+export function uninstallService(deps: UninstallServiceDeps): { plan: ServicePlan; removed: boolean } {
+  const plan = planService(deps);
+  if (!deps.exists(plan.path)) return { plan, removed: false };
+  deps.remove(plan.path);
+  return { plan, removed: true };
+}

--- a/packages/capture-audio/src/service.ts
+++ b/packages/capture-audio/src/service.ts
@@ -21,6 +21,8 @@ export interface ServiceSpec {
   programArguments: string[];
   logPath: string;
   label?: string;
+  /** Env vars the launched daemon needs (e.g. PATH, REMNIC_CAPTURE_HELPER_BIN). */
+  environment?: Record<string, string>;
 }
 
 export interface ServicePlan {
@@ -57,6 +59,10 @@ function validateLabel(label: string): string {
 export function renderLaunchAgent(spec: ServiceSpec): string {
   const label = spec.label ?? DEFAULT_SERVICE_LABEL;
   const args = spec.programArguments.map((a) => `    <string>${xmlEscape(a)}</string>`).join("\n");
+  const envEntries = Object.entries(spec.environment ?? {})
+    .map(([k, v]) => `    <key>${xmlEscape(k)}</key>\n    <string>${xmlEscape(v)}</string>`)
+    .join("\n");
+  const envBlock = envEntries === "" ? "" : `  <key>EnvironmentVariables</key>\n  <dict>\n${envEntries}\n  </dict>\n`;
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -67,7 +73,7 @@ export function renderLaunchAgent(spec: ServiceSpec): string {
   <array>
 ${args}
   </array>
-  <key>RunAtLoad</key>
+${envBlock}  <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
   <true/>
@@ -96,6 +102,10 @@ function systemdArg(value: string): string {
 export function renderSystemdUnit(spec: ServiceSpec): string {
   const execStart = spec.programArguments.map(systemdArg).join(" ");
   const logPath = spec.logPath.replace(/%/g, "%%");
+  const envLines = Object.entries(spec.environment ?? {})
+    .map(([k, v]) => `Environment=${systemdArg(`${k}=${v}`)}`)
+    .join("\n");
+  const envBlock = envLines === "" ? "" : `${envLines}\n`;
   return `[Unit]
 Description=Remnic desktop audio capture daemon
 After=default.target
@@ -105,7 +115,7 @@ Type=simple
 ExecStart=${execStart}
 StandardOutput=append:${logPath}
 StandardError=append:${logPath}
-Restart=on-failure
+${envBlock}Restart=on-failure
 RestartSec=5
 
 [Install]

--- a/packages/capture-audio/src/service.ts
+++ b/packages/capture-audio/src/service.ts
@@ -95,6 +95,7 @@ function systemdArg(value: string): string {
 /** Render a systemd user unit that restarts the daemon on failure. */
 export function renderSystemdUnit(spec: ServiceSpec): string {
   const execStart = spec.programArguments.map(systemdArg).join(" ");
+  const logPath = spec.logPath.replace(/%/g, "%%");
   return `[Unit]
 Description=Remnic desktop audio capture daemon
 After=default.target
@@ -102,6 +103,8 @@ After=default.target
 [Service]
 Type=simple
 ExecStart=${execStart}
+StandardOutput=append:${logPath}
+StandardError=append:${logPath}
 Restart=on-failure
 RestartSec=5
 

--- a/packages/capture-audio/src/service.ts
+++ b/packages/capture-audio/src/service.ts
@@ -142,12 +142,15 @@ export function planService(deps: PlanServiceDeps): ServicePlan {
     };
   }
   if (deps.platform === "linux") {
-    const target = path.join(deps.home, ".config", "systemd", "user", SYSTEMD_UNIT_NAME);
+    // Honor a custom --label so distinct installs get distinct units; the
+    // default keeps the clean canonical unit name.
+    const unitName = deps.spec.label ? `${label}.service` : SYSTEMD_UNIT_NAME;
+    const target = path.join(deps.home, ".config", "systemd", "user", unitName);
     return {
       platform: deps.platform,
       path: target,
       contents: renderSystemdUnit(deps.spec),
-      loadHint: `systemctl --user enable --now ${SYSTEMD_UNIT_NAME}`,
+      loadHint: `systemctl --user enable --now ${unitName}`,
     };
   }
   throw new CaptureConfigError(`install-service is unsupported on platform "${deps.platform}"`);

--- a/packages/capture-audio/src/spool.test.ts
+++ b/packages/capture-audio/src/spool.test.ts
@@ -429,3 +429,30 @@ test("appendAssembledSegments rejects an empty segment array", () => {
     spool.close();
   }
 });
+
+test("hydrated segments are ordered by timestamp, not append/arrival order", () => {
+  const spool = new Spool(":memory:");
+  try {
+    // A later-appended system segment whose timestamp precedes the mic one must
+    // still read first (channel "both" interleaves chunk arrival).
+    spool.appendAssembledSegments({
+      idempotencyKey: "mic",
+      conversationId: "c",
+      startedAtUtc: "2026-07-24T00:00:05.000Z",
+      segments: [aseg("second", "2026-07-24T00:00:05.000Z", "2026-07-24T00:00:06.000Z")],
+    });
+    spool.appendAssembledSegments({
+      idempotencyKey: "sys",
+      conversationId: "c",
+      startedAtUtc: "2026-07-24T00:00:05.000Z",
+      segments: [{ channel: "system", text: "first", startUtc: "2026-07-24T00:00:00.000Z", endUtc: "2026-07-24T00:00:01.000Z" }],
+    });
+    const conv = spool.getConversation("c");
+    assert.deepEqual(
+      conv?.segments.map((s) => s.textRaw),
+      ["first", "second"],
+    );
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/spool.test.ts
+++ b/packages/capture-audio/src/spool.test.ts
@@ -355,3 +355,77 @@ test("upsertSpeaker preserves an existing centroid when the field is omitted", (
     spool.close();
   }
 });
+
+const aseg = (text: string, startUtc: string, endUtc: string): SegmentInput => ({
+  channel: "mic",
+  text,
+  startUtc,
+  endUtc,
+});
+
+test("appendAssembledSegments creates then extends a capturing conversation, idempotent on key", () => {
+  const spool = new Spool(":memory:");
+  try {
+    const r1 = spool.appendAssembledSegments({
+      idempotencyKey: "chk_a",
+      conversationId: "conv_1",
+      startedAtUtc: "2026-07-24T00:00:00.000Z",
+      segments: [aseg("one", "2026-07-24T00:00:00.000Z", "2026-07-24T00:00:02.000Z")],
+    });
+    assert.equal(r1.applied, true);
+    assert.equal(r1.segmentCount, 1);
+    const r2 = spool.appendAssembledSegments({
+      idempotencyKey: "chk_b",
+      conversationId: "conv_1",
+      startedAtUtc: "2026-07-24T00:00:00.000Z",
+      segments: [aseg("two", "2026-07-24T00:00:03.000Z", "2026-07-24T00:00:04.000Z")],
+    });
+    assert.equal(r2.segmentCount, 2);
+    // Replaying the first chunk's key is a no-op — no duplicate segments.
+    const replay = spool.appendAssembledSegments({
+      idempotencyKey: "chk_a",
+      conversationId: "conv_1",
+      startedAtUtc: "2026-07-24T00:00:00.000Z",
+      segments: [aseg("one", "2026-07-24T00:00:00.000Z", "2026-07-24T00:00:02.000Z")],
+    });
+    assert.equal(replay.applied, false);
+    assert.equal(spool.stats().segments, 2);
+  } finally {
+    spool.close();
+  }
+});
+
+test("latestCapturingConversation tracks the open conversation until finalized", () => {
+  const spool = new Spool(":memory:");
+  try {
+    spool.appendAssembledSegments({
+      idempotencyKey: "k",
+      conversationId: "conv_x",
+      startedAtUtc: "2026-07-24T00:00:00.000Z",
+      segments: [aseg("hi", "2026-07-24T00:00:00.000Z", "2026-07-24T00:00:01.000Z")],
+    });
+    assert.equal(spool.latestCapturingConversation()?.id, "conv_x");
+    assert.equal(spool.finalizeConversation("conv_x"), true);
+    assert.equal(spool.latestCapturingConversation(), null);
+  } finally {
+    spool.close();
+  }
+});
+
+test("appendAssembledSegments rejects an empty segment array", () => {
+  const spool = new Spool(":memory:");
+  try {
+    assert.throws(
+      () =>
+        spool.appendAssembledSegments({
+          idempotencyKey: "k",
+          conversationId: "c",
+          startedAtUtc: "2026-07-24T00:00:00.000Z",
+          segments: [],
+        }),
+      CaptureConfigError,
+    );
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -628,7 +628,9 @@ export class Spool {
     const segs = this.#db
       .prepare(
         "SELECT text, speaker_cluster AS speakerKey, is_wearer AS isWearer, channel, start_utc AS startUtc, end_utc AS endUtc " +
-          "FROM segments WHERE conversation_id = ? ORDER BY ordinal ASC, id ASC",
+          // Order by timestamp first: with channel "both", mic and system chunks
+          // arrive independently, so ordinal (arrival order) isn't chronological.
+          "FROM segments WHERE conversation_id = ? ORDER BY start_utc ASC, ordinal ASC, id ASC",
       )
       .all(row.id) as Array<{
       text: string;

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -404,6 +404,7 @@ export class Spool {
     const state: ConversationState = input.state ?? "capturing";
     const chunkChannel = segments[0]?.channel ?? "mic";
     const lastEnd = segments[segments.length - 1].endUtc;
+    const chunkStart = segments[0].startUtc;
 
     const db = this.#db;
     db.exec("BEGIN");
@@ -417,7 +418,7 @@ export class Spool {
       }
       db.prepare(
         "INSERT OR IGNORE INTO chunks(id, channel, device, started_at_utc, ended_at_utc, status, wav_path) VALUES (?,?,?,?,?,?,?)",
-      ).run(chunkId, chunkChannel, input.device ?? null, startedAtUtc, lastEnd, "transcribed", input.wavPath ?? null);
+      ).run(chunkId, chunkChannel, input.device ?? null, chunkStart, lastEnd, "transcribed", input.wavPath ?? null);
       const existing = db.prepare("SELECT id FROM conversations WHERE id = ?").get(convId) as { id: string } | undefined;
       if (!existing) {
         db.prepare(

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -98,6 +98,29 @@ export interface QueryFinalOptions {
   cursor?: string | null;
   limit: number;
 }
+export interface AssemblyAppendInput {
+  /** Durable dedup marker for one application (e.g. a transcribed chunk id). */
+  idempotencyKey: string;
+  /** Stable `conv_<ulid>` id from the assembler. */
+  conversationId: string;
+  /** Conversation start; used only when the conversation is first created. */
+  startedAtUtc: string;
+  /** Defaults to `capturing`; the conversation is finalized by a later call. */
+  state?: ConversationState;
+  device?: string | null;
+  /** Backing chunk row id; defaults to `idempotencyKey`. */
+  chunkId?: string;
+  /** Backing WAV path recorded on the chunk row; retained for the janitor/audit. */
+  wavPath?: string | null;
+  segments: SegmentInput[];
+}
+export interface AssemblyAppendResult {
+  /** False when `idempotencyKey` was already applied (a replay no-op). */
+  applied: boolean;
+  conversationId: string;
+  /** Total segments in the conversation after this call. */
+  segmentCount: number;
+}
 
 interface ConversationRow {
   id: string;
@@ -147,6 +170,11 @@ CREATE TABLE IF NOT EXISTS speaker_clusters (
   example_embeddings BLOB,
   embedding_count INTEGER NOT NULL DEFAULT 0,
   is_self INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS applied_chunks (
+  idempotency_key TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  applied_at_utc TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_conv_keyset ON conversations(started_at_utc, id);
 CREATE INDEX IF NOT EXISTS idx_seg_conv ON segments(conversation_id, ordinal);
@@ -335,6 +363,135 @@ export class Spool {
   finalizeOpenConversations(): number {
     const result = this.#db.prepare("UPDATE conversations SET state = 'final' WHERE state = 'capturing'").run();
     return Number(result.changes);
+  }
+
+  /**
+   * Durably append one transcribed chunk's segments to a conversation,
+   * idempotent on `idempotencyKey` (a replay/restart of the same chunk is a
+   * no-op). Creates the conversation as `capturing` on first append; a later
+   * `finalizeConversation`/`finalizeOpenConversations` flips it to `final`.
+   */
+  appendAssembledSegments(input: AssemblyAppendInput): AssemblyAppendResult {
+    if (typeof input.idempotencyKey !== "string" || input.idempotencyKey.trim() === "") {
+      throw new CaptureConfigError("appendAssembledSegments.idempotencyKey: expected a non-empty string");
+    }
+    if (typeof input.conversationId !== "string" || input.conversationId.trim() === "") {
+      throw new CaptureConfigError("appendAssembledSegments.conversationId: expected a non-empty string");
+    }
+    if (typeof input.startedAtUtc !== "string" || input.startedAtUtc.trim() === "") {
+      throw new CaptureConfigError("appendAssembledSegments.startedAtUtc: expected a non-empty ISO timestamp");
+    }
+    if (!Array.isArray(input.segments) || input.segments.length === 0) {
+      throw new CaptureConfigError("appendAssembledSegments.segments: expected a non-empty array");
+    }
+    if (input.state !== undefined && !Object.hasOwn(CONVERSATION_STATES, input.state)) {
+      throw new CaptureConfigError(`appendAssembledSegments.state: unknown value '${input.state}'`);
+    }
+    const startedAtUtc = canonicalInstant(input.startedAtUtc, "appendAssembledSegments.startedAtUtc");
+    const segments = input.segments.map((seg, i) => {
+      const startUtc = canonicalInstant(seg.startUtc, `appendAssembledSegments.segments[${i}].startUtc`);
+      const endUtc = canonicalInstant(seg.endUtc, `appendAssembledSegments.segments[${i}].endUtc`);
+      if (Date.parse(endUtc) < Date.parse(startUtc)) {
+        throw new CaptureConfigError(`appendAssembledSegments.segments[${i}]: endUtc must not precede startUtc`);
+      }
+      if (typeof seg.text !== "string" || seg.text === "") {
+        throw new CaptureConfigError(`appendAssembledSegments.segments[${i}].text: expected a non-empty string`);
+      }
+      return { ...seg, startUtc, endUtc };
+    });
+    const convId = input.conversationId;
+    const chunkId = input.chunkId ?? input.idempotencyKey;
+    const state: ConversationState = input.state ?? "capturing";
+    const chunkChannel = segments[0]?.channel ?? "mic";
+    const lastEnd = segments[segments.length - 1].endUtc;
+
+    const db = this.#db;
+    db.exec("BEGIN");
+    try {
+      const seen = db
+        .prepare("SELECT conversation_id AS conversationId FROM applied_chunks WHERE idempotency_key = ?")
+        .get(input.idempotencyKey) as { conversationId: string } | undefined;
+      if (seen) {
+        db.exec("COMMIT");
+        return { applied: false, conversationId: seen.conversationId, segmentCount: this.#segmentCount(seen.conversationId) };
+      }
+      db.prepare(
+        "INSERT OR IGNORE INTO chunks(id, channel, device, started_at_utc, ended_at_utc, status, wav_path) VALUES (?,?,?,?,?,?,?)",
+      ).run(chunkId, chunkChannel, input.device ?? null, startedAtUtc, lastEnd, "transcribed", input.wavPath ?? null);
+      const existing = db.prepare("SELECT id FROM conversations WHERE id = ?").get(convId) as { id: string } | undefined;
+      if (!existing) {
+        db.prepare(
+          "INSERT INTO conversations(id, started_at_utc, ended_at_utc, state, segment_count) VALUES (?,?,?,?,0)",
+        ).run(convId, startedAtUtc, lastEnd, state);
+      }
+      const ordinalRow = db
+        .prepare("SELECT COALESCE(MAX(ordinal), -1) + 1 AS n FROM segments WHERE conversation_id = ?")
+        .get(convId) as { n: number };
+      const nextOrdinal = Number(ordinalRow.n);
+      const segStmt = db.prepare(
+        "INSERT INTO segments(id, chunk_id, conversation_id, speaker_cluster, is_wearer, channel, text, start_utc, end_utc, ordinal) VALUES (?,?,?,?,?,?,?,?,?,?)",
+      );
+      for (let i = 0; i < segments.length; i++) {
+        const seg = segments[i];
+        segStmt.run(
+          `seg_${ulid()}`,
+          chunkId,
+          convId,
+          seg.speakerCluster ?? null,
+          seg.isWearer ? 1 : 0,
+          seg.channel,
+          seg.text,
+          seg.startUtc,
+          seg.endUtc,
+          nextOrdinal + i,
+        );
+      }
+      db.prepare(
+        "UPDATE conversations SET segment_count = segment_count + ?, " +
+          "ended_at_utc = CASE WHEN ended_at_utc IS NULL OR ? > ended_at_utc THEN ? ELSE ended_at_utc END WHERE id = ?",
+      ).run(segments.length, lastEnd, lastEnd, convId);
+      db.prepare("INSERT INTO applied_chunks(idempotency_key, conversation_id, applied_at_utc) VALUES (?,?,?)").run(
+        input.idempotencyKey,
+        convId,
+        new Date().toISOString(),
+      );
+      db.exec("COMMIT");
+    } catch (err) {
+      db.exec("ROLLBACK");
+      throw err;
+    }
+    return { applied: true, conversationId: convId, segmentCount: this.#segmentCount(convId) };
+  }
+
+  /** Flip one conversation to `final`; returns true when it was capturing. */
+  finalizeConversation(id: string): boolean {
+    const result = this.#db
+      .prepare("UPDATE conversations SET state = 'final' WHERE id = ? AND state = 'capturing'")
+      .run(id);
+    return Number(result.changes) > 0;
+  }
+
+  /**
+   * The newest still-`capturing` conversation, so a chunk arriving after a
+   * process restart continues it (subject to the assembler's gap rule) instead
+   * of splitting off a new one. Null when none is open.
+   */
+  latestCapturingConversation(): { id: string; startedAtUtc: string; endedAtUtc: string } | null {
+    const row = this.#db
+      .prepare(
+        "SELECT id, started_at_utc AS startedAtUtc, ended_at_utc AS endedAtUtc FROM conversations " +
+          "WHERE state = 'capturing' ORDER BY ended_at_utc DESC, id DESC LIMIT 1",
+      )
+      .get() as { id: string; startedAtUtc: string; endedAtUtc: string | null } | undefined;
+    if (!row) return null;
+    return { id: row.id, startedAtUtc: row.startedAtUtc, endedAtUtc: row.endedAtUtc ?? row.startedAtUtc };
+  }
+
+  #segmentCount(conversationId: string): number {
+    const row = this.#db
+      .prepare("SELECT segment_count AS n FROM conversations WHERE id = ?")
+      .get(conversationId) as { n: number } | undefined;
+    return row ? Number(row.n) : 0;
   }
 
   upsertSpeaker(input: SpeakerInput): void {


### PR DESCRIPTION
## Summary
Final #1897 slice: wires `@remnic/capture-audio` to the unified #2138 macOS capture helper and turns live audio into durable conversations. Builds directly on current `main` (which now has #2138's `@remnic/capture-native-darwin-{arm64,x64}` + `remnic-capture-helper`).

- **Native helper loading** (`native.ts`): resolves the optional `@remnic/capture-native-${platform}-${arch}` helper by computed specifier — `REMNIC_CAPTURE_HELPER_BIN` override first, else the package's declared `remnic-capture-helper` bin (the same file its `helperBinaryPath` exports); a missing package yields an actionable install hint, never a raw `MODULE_NOT_FOUND`. A dependency-injectable supervised runner drives the helper's `audio-capture --channel|--chunk-seconds|--out|--device` subcommand, parses JSON-line `ChunkEvent`s, and restarts only unexpected exits with bounded backoff. `enumerateDevices` runs the one-shot `device-enumerate`. (Node resolver + runner ported from NativeRunner's `feat/audio-native-runner`, re-pointed to the unified contract.)
- **Live chunk pipeline** (`processor.ts` + `capture.ts`): each recorded WAV chunk flows resolve-model → whisper → normalize → assemble → durable append → raw-audio cleanup, on one serialized chain with restart recovery (`latestCapturingConversation`). `createLiveCapture` wires the runner to the processor and into `start --capture` (opt-in; the daemon still serves the spool without it, and a missing/unavailable helper degrades honestly).
- **install-service** (`service.ts`): renders + installs a launchd LaunchAgent (macOS) or systemd user unit (Linux) that runs the daemon in `--capture` mode; `install-service [--force|--uninstall|--label]`.
- **enroll-self** (`enroll.ts`): registers the wearer's `self` speaker — storing a centroid when a voice embedding is supplied, identity-only otherwise (embedding-based diarization refinement is the diarization slice); `enroll-self [--label]`.
- **Supporting**: stateful `ConversationAssembler` beside the batch assembler; spool `applied_chunks` idempotency + `appendAssembledSegments` / `finalizeConversation` / `latestCapturingConversation`; `devices` now calls the helper; `package.json` optional peer deps on the platform helper packages; public exports.

## Verification (Linux)
- `pnpm --filter @remnic/capture-audio run test` — **189/189** pass
- `pnpm --filter @remnic/capture-audio run check-types` — clean; ROOT `check-types` — OK
- `pnpm --filter @remnic/capture-audio run build` — success
- `tests/config-contract-extractor` 11/11; `tests/release-workflow-public-packages` 10/10

No committed binaries; every helper path is exercised through a fake-helper seam (`REMNIC_CAPTURE_HELPER_BIN` / injected spawn+transcribe). The Swift helper itself ships and is macOS-CI-verified in #2138.

Part of #1897

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new live pipeline touches durable spool writes, child-process supervision, and path validation; failures are mostly isolated per chunk, but bugs could affect transcript integrity or shutdown ordering.
> 
> **Overview**
> Adds **opt-in live desktop audio capture** on macOS by wiring the unified `remnic-capture-helper` into the daemon: **`start --foreground --capture`** supervises the helper, transcribes WAV chunks, and persists conversations while the HTTP API keeps serving if capture is unavailable.
> 
> **Native layer** resolves optional `@remnic/capture-native-darwin-*` peers (or `REMNIC_CAPTURE_HELPER_BIN`), parses JSONL chunk events, restarts crashed helpers with backoff, and **`devices`** now runs real `device-enumerate` instead of a placeholder list.
> 
> **Processing** introduces incremental **`ConversationAssembler`**, a serialized **chunk processor** (Whisper → assemble → spool), and **`createLiveCapture`** with symlink-aware path checks so chunk paths cannot escape the raw directory. The spool gains **`applied_chunks`** idempotency, **`appendAssembledSegments`**, and restart continuity via **`latestCapturingConversation`**.
> 
> **Operator commands**: **`install-service`** / **`enroll-self`**, health **`capturing`** as a live getter, mic-only capture for now (system/both deferred until cross-channel dedup), and expanded test coverage plus optional native peer deps in **`package.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a70ab92e8597f1d1b26ab560d4631a4dc09c4f6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `start --capture` live mode with native device enumeration, streaming transcription, incremental gap-based conversation assembly, and replay-safe persistence.
  * Introduced incremental `ConversationAssembler`, idempotent spool appending, and `/v1/health` live-capture status reporting.
  * Added `enroll-self` plus per-user service `install-service`/uninstall and automatic native helper support.
* **Bug Fixes**
  * Improved validation and safer shutdown/teardown behavior, including service/unit rendering escaping and gap edge cases.
* **Tests**
  * Expanded end-to-end and unit coverage for native, CLI, live capture, assembly, processor, spool, service, and enrollment.
* **Chores**
  * Updated peer dependency declarations and enhanced test script coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->