### PR TITLE
feat(capture-audio): wire live VAD gate, diarization, and cross-channel dedup

### DIFF
--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -138,11 +138,12 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
   const runner: NativeCaptureRunner = createNativeCaptureRunner({
     outDir,
     chunkSeconds: config.chunkSeconds,
-    // Capture both the wearer mic and the system (loopback) channel; the
-    // processor's windowed cross-channel dedup (dedupeCrossChannel) drops mic
-    // segments that duplicate system speech, so speech heard on both channels
-    // is persisted once (keeping the cleaner system copy).
-    channel: "both",
+    // Channels to record (config.captureChannel, default "both"). With "both",
+    // the processor's finalize-time cross-channel dedup drops mic segments that
+    // duplicate system (loopback) speech, so it is stored once (the cleaner
+    // system copy). Operators without system-audio permission can set "mic" so
+    // microphone capture never depends on the system-audio path being available.
+    channel: config.captureChannel,
     device: config.devices.mic,
     onChunk: (event) => {
       // Reject a helper-supplied path that escapes the raw capture dir BEFORE it

--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -15,6 +15,7 @@ import { rm } from "node:fs/promises";
 import path from "node:path";
 
 import { ConversationAssembler } from "./assembly.js";
+import { SpeakerClusterer, type Embedding } from "./diarization.js";
 import type { DaemonConfig } from "./config.js";
 import { CaptureInputError } from "./errors.js";
 import {
@@ -50,6 +51,10 @@ export interface LiveCaptureOptions {
   scheduleRestart?: (fn: () => void, delayMs: number) => RestartTimer;
   cancelRestart?: (timer: RestartTimer) => void;
   makeConversationId?: () => string;
+  /** VAD speech gate seam; production supplies a sherpa-onnx detector. */
+  detectSpeech?: (event: ChunkEvent) => boolean | Promise<boolean>;
+  /** Speaker-embedding seam for diarization; production supplies sherpa speaker-id. */
+  embed?: (event: ChunkEvent, segment: TranscribedSegment) => Embedding | Promise<Embedding>;
 }
 
 export interface LiveCapture {
@@ -111,23 +116,33 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
     ...(options.makeConversationId ? { makeId: options.makeConversationId } : {}),
   });
 
+  // Diarization is active only when an embedder is wired (production: the
+  // sherpa speaker-id model from the native layer; tests inject a fake). Seed
+  // the clusterer from persisted clusters so speaker ids survive restarts.
+  const diarizer = options.embed
+    ? new SpeakerClusterer(config.diarization.similarityThreshold, spool.readSpeakerClusters())
+    : undefined;
+
   const processor = createChunkProcessor({
     spool,
     assembler,
     resolveModel,
     transcribe,
     cleanupRawAudio,
+    ...(options.detectSpeech ? { detectSpeech: options.detectSpeech } : {}),
+    ...(options.embed ? { embed: options.embed } : {}),
+    ...(diarizer ? { diarizer } : {}),
     ...(options.onError ? { onError: (error: Error) => options.onError?.(error) } : {}),
   });
 
   const runner: NativeCaptureRunner = createNativeCaptureRunner({
     outDir,
     chunkSeconds: config.chunkSeconds,
-    // Capture the wearer's mic only for now. System-channel capture requires
-    // cross-channel dedup (dedupeCrossChannel) to avoid double-persisting speech
-    // heard on both channels; that windowed dedup lands with the diarization
-    // slice, so "both" is deferred rather than shipped un-deduped.
-    channel: "mic",
+    // Capture both the wearer mic and the system (loopback) channel; the
+    // processor's windowed cross-channel dedup (dedupeCrossChannel) drops mic
+    // segments that duplicate system speech, so speech heard on both channels
+    // is persisted once (keeping the cleaner system copy).
+    channel: "both",
     device: config.devices.mic,
     onChunk: (event) => {
       // Reject a helper-supplied path that escapes the raw capture dir BEFORE it

--- a/packages/capture-audio/src/config.test.ts
+++ b/packages/capture-audio/src/config.test.ts
@@ -117,3 +117,11 @@ test("null is accepted as absent for optional nullable fields", () => {
   assert.equal(cfg.devices.mic, null);
   assert.equal(cfg.devices.system, null);
 });
+
+test("captureChannel defaults to both and rejects anything but mic|system|both", () => {
+  assert.equal(parseDaemonConfig({}).captureChannel, "both");
+  assert.equal(parseDaemonConfig({ captureChannel: "mic" }).captureChannel, "mic");
+  assert.equal(parseDaemonConfig({ captureChannel: "system" }).captureChannel, "system");
+  assert.throws(() => parseDaemonConfig({ captureChannel: "speaker" }), CaptureConfigError);
+  assert.throws(() => parseDaemonConfig({ captureChannel: 1 }), CaptureConfigError);
+});

--- a/packages/capture-audio/src/config.ts
+++ b/packages/capture-audio/src/config.ts
@@ -40,6 +40,7 @@ export interface DaemonConfig {
   host: string;
   port: number;
   chunkSeconds: number;
+  captureChannel: "mic" | "system" | "both";
   conversationGapMinutes: number;
   rawRetentionHours: number;
   spoolRetentionDays: number;
@@ -55,6 +56,7 @@ export function defaultDaemonConfig(): DaemonConfig {
     host: DEFAULT_HOST,
     port: DEFAULT_PORT,
     chunkSeconds: 30,
+    captureChannel: "both",
     conversationGapMinutes: 10,
     rawRetentionHours: 0,
     spoolRetentionDays: 30,
@@ -77,6 +79,7 @@ const KNOWN_TOP_KEYS: Record<string, true> = {
   host: true,
   port: true,
   chunkSeconds: true,
+  captureChannel: true,
   conversationGapMinutes: true,
   rawRetentionHours: true,
   spoolRetentionDays: true,
@@ -120,6 +123,14 @@ export function parseDaemonConfig(raw: unknown): DaemonConfig {
   }
   if (obj.chunkSeconds !== undefined) {
     cfg.chunkSeconds = coerceNumber(obj.chunkSeconds, "chunkSeconds", { integer: true, min: 1, max: 3600 });
+  }
+  if (obj.captureChannel !== undefined) {
+    if (obj.captureChannel !== "mic" && obj.captureChannel !== "system" && obj.captureChannel !== "both") {
+      throw new CaptureConfigError(
+        `captureChannel: expected 'mic' | 'system' | 'both', got ${describeValue(obj.captureChannel)}`,
+      );
+    }
+    cfg.captureChannel = obj.captureChannel;
   }
   if (obj.conversationGapMinutes !== undefined) {
     cfg.conversationGapMinutes = coerceNumber(obj.conversationGapMinutes, "conversationGapMinutes", { min: 0 });

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { ConversationAssembler } from "./assembly.js";
 import type { ChunkEvent } from "./native.js";
-import { createChunkProcessor, type ChunkProcessorDeps } from "./processor.js";
+import { chunkStableId, createChunkProcessor, type ChunkProcessorDeps } from "./processor.js";
 import { Spool } from "./spool.js";
 import type { TranscribedSegment } from "./stt.js";
 import { SpeakerClusterer, type Embedding } from "./diarization.js";
@@ -495,19 +495,67 @@ test("a durable replay does not re-consume the embedding or corrupt the cluster"
     const before = spool.readSpeakerClusters();
     assert.equal(before.length, 1);
     const count0 = before[0].embeddingCount;
-    // Restart replays the SAME chunk (same WAV path -> same stable id).
+    // Restart replays the SAME chunk (same WAV path -> same stable id). The
+    // ':done' marker from run 1 must make run 2 skip transcription AND embedding
+    // entirely, not merely avoid mutating the cluster.
+    let transcribeCalls = 0;
+    let embedCalls = 0;
     const run2 = createChunkProcessor(
       deps(spool, {
         diarizer: new SpeakerClusterer(0.7, spool.readSpeakerClusters()),
-        embed: () => guest,
-        transcribe: async () => [{ text: "guest", startUtc: t(1), endUtc: t(2) }],
+        embed: () => {
+          embedCalls++;
+          return guest;
+        },
+        transcribe: async () => {
+          transcribeCalls++;
+          return [{ text: "guest", startUtc: t(1), endUtc: t(2) }];
+        },
       }),
     );
     run2.enqueue(chunk());
     await run2.finalize();
+    assert.equal(transcribeCalls, 0, "a full replay skips transcription");
+    assert.equal(embedCalls, 0, "a full replay skips embedding");
     const after = spool.readSpeakerClusters();
     assert.equal(after.length, 1, "a replay creates no new cluster");
     assert.equal(after[0].embeddingCount, count0, "a replay did not inflate the embedding count");
+  } finally {
+    spool.close();
+  }
+});
+
+test("partial-chunk replay appends the missing tail group instead of skipping the whole chunk", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const ev = chunk({ path: "/tmp/raw/multi.wav" });
+    const cid = chunkStableId(ev);
+    // Simulate a kill-9 AFTER group 0 appended but BEFORE group 1 / the :done
+    // marker: persist only group 0 under its per-group key.
+    spool.appendAssembledSegments({
+      idempotencyKey: `${cid}:0`,
+      chunkId: `${cid}:0`,
+      conversationId: "conv_grp0",
+      startedAtUtc: t(1),
+      state: "capturing",
+      segments: [{ channel: "mic", text: "first group", startUtc: t(1), endUtc: t(2), isWearer: true }],
+    });
+    assert.equal(spool.stats().segments, 1);
+    assert.equal(spool.isChunkApplied(`${cid}:done`), false);
+    // Replay the whole chunk; gapMinutes 0 splits its two segments into two groups.
+    const proc = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 0 }),
+        transcribe: async () => [
+          { text: "first group", startUtc: t(1), endUtc: t(2) },
+          { text: "second group", startUtc: t(30), endUtc: t(31) },
+        ],
+      }),
+    );
+    proc.enqueue(ev);
+    await proc.finalize();
+    assert.equal(spool.stats().segments, 2, "the previously-lost tail group was appended; group 0 not duplicated");
+    assert.equal(spool.isChunkApplied(`${cid}:done`), true, "the chunk is now marked complete");
   } finally {
     spool.close();
   }

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -429,3 +429,86 @@ test("kill-9 durability: a diarized append persists its speaker cluster before f
     spool.close();
   }
 });
+
+test("finalize dedups a crash-left capturing conversation even when this run processes no chunk", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    // Run 1 leaves a capturing conversation holding a system segment + its mic
+    // loopback duplicate, then is killed (-9) before finalize.
+    const run1 = createChunkProcessor(
+      deps(spool, {
+        transcribe: async () => [{ text: "hello there world", startUtc: t(1), endUtc: t(3) }],
+      }),
+    );
+    run1.enqueue(chunk({ path: "/tmp/raw/sys.wav", channel: "system", startedAtUtc: t(0), endedAtUtc: t(4) }));
+    run1.enqueue(chunk({ path: "/tmp/raw/mic.wav", channel: "mic", startedAtUtc: t(0), endedAtUtc: t(4) }));
+    await run1.drain(); // no finalize -> capturing, dup still present
+    assert.equal(spool.stats().segments, 2);
+    // Run 2 processes NO chunk (so it has no in-memory open id); finalize must
+    // still prune the crash-left duplicate.
+    const run2 = createChunkProcessor(deps(spool));
+    assert.ok((await run2.finalize()) >= 1);
+    const segs = finalSegments(spool);
+    assert.equal(segs.length, 1, "the loopback dup was pruned at finalize despite no chunk this run");
+    assert.equal(segs[0].channel, "system");
+  } finally {
+    spool.close();
+  }
+});
+
+test("diarization: a label-only self keeps the mic=wearer heuristic (no voice embedding to match)", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    // Label-only enrollment: a self cluster with no embedding to match against.
+    spool.upsertSpeaker({ id: "self", isSelf: true, label: "me", embeddingCount: 0, centroid: [], examples: [] });
+    const diarizer = new SpeakerClusterer(0.7, spool.readSpeakerClusters());
+    const guest: Embedding = [0, 1, 0, 0];
+    const proc = createChunkProcessor(
+      deps(spool, {
+        diarizer,
+        embed: () => guest,
+        transcribe: async () => [{ text: "wearer on mic", startUtc: t(1), endUtc: t(2) }],
+      }),
+    );
+    proc.enqueue(chunk()); // mic channel
+    await proc.finalize();
+    const segs = finalSegments(spool);
+    assert.equal(segs[0].isWearer, true, "mic wearer heuristic retained until self is voice-enrolled");
+  } finally {
+    spool.close();
+  }
+});
+
+test("a durable replay does not re-consume the embedding or corrupt the cluster", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const guest: Embedding = [0, 1, 0, 0];
+    const run1 = createChunkProcessor(
+      deps(spool, {
+        diarizer: new SpeakerClusterer(0.7, spool.readSpeakerClusters()),
+        embed: () => guest,
+        transcribe: async () => [{ text: "guest", startUtc: t(1), endUtc: t(2) }],
+      }),
+    );
+    run1.enqueue(chunk());
+    await run1.finalize();
+    const before = spool.readSpeakerClusters();
+    assert.equal(before.length, 1);
+    const count0 = before[0].embeddingCount;
+    // Restart replays the SAME chunk (same WAV path -> same stable id).
+    const run2 = createChunkProcessor(
+      deps(spool, {
+        diarizer: new SpeakerClusterer(0.7, spool.readSpeakerClusters()),
+        embed: () => guest,
+        transcribe: async () => [{ text: "guest", startUtc: t(1), endUtc: t(2) }],
+      }),
+    );
+    run2.enqueue(chunk());
+    await run2.finalize();
+    const after = spool.readSpeakerClusters();
+    assert.equal(after.length, 1, "a replay creates no new cluster");
+    assert.equal(after[0].embeddingCount, count0, "a replay did not inflate the embedding count");
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -6,6 +6,7 @@ import type { ChunkEvent } from "./native.js";
 import { createChunkProcessor, type ChunkProcessorDeps } from "./processor.js";
 import { Spool } from "./spool.js";
 import type { TranscribedSegment } from "./stt.js";
+import { SpeakerClusterer, type Embedding } from "./diarization.js";
 
 const chunk = (over: Partial<ChunkEvent> = {}): ChunkEvent => ({
   path: "/tmp/raw/a.wav",
@@ -165,6 +166,211 @@ test("silent chunks after speech finalize the conversation once the gap elapses"
     proc.enqueue(chunk({ path: "/tmp/raw/silent.wav", startedAtUtc: "2026-07-24T00:10:00.000Z", endedAtUtc: "2026-07-24T00:10:05.000Z" }));
     await proc.drain();
     assert.equal(spool.latestCapturingConversation(), null); // finalized by silence
+  } finally {
+    spool.close();
+  }
+});
+
+// Seconds-granularity UTC timestamp on the fixtures' capture day.
+const t = (s: number): string => `2026-07-24T00:00:${String(s).padStart(2, "0")}.000Z`;
+
+const finalSegments = (spool: Spool) =>
+  spool
+    .queryFinalConversations({ date: "2026-07-24", timezone: "UTC", limit: 100 })
+    .conversations.flatMap((c) => c.segments);
+
+test("VAD gate: a non-speech chunk skips STT (and model resolution) yet still reclaims its WAV", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    let transcribeCalls = 0;
+    let modelResolves = 0;
+    let cleaned = 0;
+    const proc = createChunkProcessor(
+      deps(spool, {
+        detectSpeech: () => false,
+        resolveModel: () => {
+          modelResolves++;
+          return "/model.bin";
+        },
+        transcribe: async () => {
+          transcribeCalls++;
+          return [{ text: "unheard", startUtc: t(1), endUtc: t(2) }];
+        },
+        cleanupRawAudio: async () => {
+          cleaned++;
+        },
+      }),
+    );
+    proc.enqueue(chunk());
+    await proc.drain();
+    assert.equal(transcribeCalls, 0, "STT skipped for a non-speech chunk");
+    assert.equal(modelResolves, 0, "model resolution skipped for a non-speech chunk");
+    assert.equal(spool.stats().segments, 0, "no segments persist for silence");
+    assert.equal(cleaned, 1, "raw WAV is still reclaimed");
+  } finally {
+    spool.close();
+  }
+});
+
+test("VAD gate: a speech chunk transcribes and persists as normal", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const proc = createChunkProcessor(deps(spool, { detectSpeech: () => true }));
+    proc.enqueue(chunk());
+    await proc.drain();
+    assert.equal(spool.stats().segments, 2, "speech still flows through STT + assembly");
+  } finally {
+    spool.close();
+  }
+});
+
+test("diarization: same-voice segments share one non-self cluster and are not the wearer", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const guest: Embedding = [0, 1, 0, 0];
+    const diarizer = new SpeakerClusterer(0.7);
+    diarizer.enrollSelf([1, 0, 0, 0]);
+    const proc = createChunkProcessor(
+      deps(spool, {
+        diarizer,
+        embed: () => guest,
+        transcribe: async () => [
+          { text: "guest one", startUtc: t(1), endUtc: t(2) },
+          { text: "guest two", startUtc: t(3), endUtc: t(4) },
+        ],
+      }),
+    );
+    proc.enqueue(chunk());
+    await proc.finalize();
+    const segs = finalSegments(spool);
+    assert.equal(segs.length, 2);
+    assert.equal(segs[0].speakerKey, segs[1].speakerKey, "one synthetic voice -> one cluster (no fragmentation)");
+    assert.notEqual(segs[0].speakerKey, "self");
+    assert.equal(segs[0].isWearer, false, "a guest voice on the mic is NOT the wearer");
+    const clusters = spool.readSpeakerClusters();
+    assert.ok(
+      clusters.some((c) => c.isSelf) && clusters.some((c) => !c.isSelf),
+      "self + guest clusters both persisted on finalize",
+    );
+  } finally {
+    spool.close();
+  }
+});
+
+test("diarization: the enrolled self voice on the mic is attributed to the wearer", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const self: Embedding = [1, 0, 0, 0];
+    const diarizer = new SpeakerClusterer(0.7);
+    diarizer.enrollSelf(self);
+    const proc = createChunkProcessor(
+      deps(spool, {
+        diarizer,
+        embed: () => self,
+        transcribe: async () => [{ text: "my own words", startUtc: t(1), endUtc: t(2) }],
+      }),
+    );
+    proc.enqueue(chunk());
+    await proc.finalize();
+    const segs = finalSegments(spool);
+    assert.equal(segs[0].speakerKey, "self");
+    assert.equal(segs[0].isWearer, true);
+  } finally {
+    spool.close();
+  }
+});
+
+test("diarization: persisted clusters seed a restart so speaker ids stay stable", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const guest: Embedding = [0, 1, 0, 0];
+    const run1 = createChunkProcessor(
+      deps(spool, {
+        diarizer: new SpeakerClusterer(0.7, spool.readSpeakerClusters()),
+        embed: () => guest,
+        transcribe: async () => [{ text: "first", startUtc: t(1), endUtc: t(2) }],
+      }),
+    );
+    run1.enqueue(chunk({ path: "/tmp/raw/a.wav", startedAtUtc: t(1), endedAtUtc: t(3) }));
+    await run1.finalize();
+    const firstId = spool.readSpeakerClusters()[0]?.id;
+    assert.ok(firstId, "a cluster was persisted");
+    // Restart: a fresh clusterer seeded from the spool must reuse the same id
+    // for the same voice rather than mint a new one.
+    const run2 = createChunkProcessor(
+      deps(spool, {
+        diarizer: new SpeakerClusterer(0.7, spool.readSpeakerClusters()),
+        embed: () => guest,
+        transcribe: async () => [{ text: "second", startUtc: t(5), endUtc: t(6) }],
+      }),
+    );
+    run2.enqueue(chunk({ path: "/tmp/raw/b.wav", startedAtUtc: t(5), endedAtUtc: t(7) }));
+    await run2.finalize();
+    const segs = finalSegments(spool);
+    assert.equal(segs.length, 2);
+    assert.ok(
+      segs.every((s) => s.speakerKey === firstId),
+      "the same voice keeps its cluster id across a restart",
+    );
+    assert.equal(spool.readSpeakerClusters().length, 1, "no duplicate cluster was created");
+  } finally {
+    spool.close();
+  }
+});
+
+test("cross-channel dedup: a mic segment duplicating a recent system segment is dropped", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const proc = createChunkProcessor(
+      deps(spool, {
+        transcribe: async (input) =>
+          input.wavPath.includes("sys")
+            ? [{ text: "hello there world", startUtc: t(1), endUtc: t(3) }]
+            : [
+                { text: "hello there world", startUtc: t(1), endUtc: t(3) }, // loopback dup -> dropped
+                { text: "unique mic line", startUtc: t(10), endUtc: t(11) }, // kept
+              ],
+      }),
+    );
+    // System (loopback) chunk arrives first, then the mic chunk that re-hears it.
+    proc.enqueue(chunk({ path: "/tmp/raw/sys.wav", channel: "system", startedAtUtc: t(0), endedAtUtc: t(4) }));
+    proc.enqueue(chunk({ path: "/tmp/raw/mic.wav", channel: "mic", startedAtUtc: t(0), endedAtUtc: t(12) }));
+    await proc.finalize();
+    const segs = finalSegments(spool);
+    assert.deepEqual(
+      segs.map((s) => s.textRaw).sort(),
+      ["hello there world", "unique mic line"],
+      "the duplicate mic copy is dropped; the unique mic line survives",
+    );
+    const kept = segs.find((s) => s.textRaw === "hello there world");
+    assert.equal(kept?.channel, "system", "the retained copy is the cleaner system channel");
+  } finally {
+    spool.close();
+  }
+});
+
+test("kill-9 recovery: a restart resumes the open conversation and stays idempotent on replay", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    // Run 1 processes chunk A, then the process is killed (-9) BEFORE finalize,
+    // so the conversation is left `capturing` in the durable spool.
+    const run1 = createChunkProcessor(deps(spool));
+    run1.enqueue(chunk({ path: "/tmp/raw/a.wav", startedAtUtc: t(1), endedAtUtc: t(5) }));
+    await run1.drain();
+    const open = spool.latestCapturingConversation();
+    assert.ok(open, "conversation left capturing after a kill-9 (no finalize)");
+    const openId = open.id;
+    assert.equal(spool.stats().segments, 2);
+    // Run 2 (restart) with a brand-new processor + assembler over the SAME spool:
+    // a replay of A must not duplicate, and a follow-on chunk B within the gap
+    // must resume the SAME conversation rather than start a new one.
+    const run2 = createChunkProcessor(deps(spool));
+    run2.enqueue(chunk({ path: "/tmp/raw/a.wav", startedAtUtc: t(1), endedAtUtc: t(5) })); // replay
+    run2.enqueue(chunk({ path: "/tmp/raw/b.wav", startedAtUtc: t(6), endedAtUtc: t(9) }));
+    await run2.drain();
+    assert.equal(spool.stats().segments, 4, "replay added nothing; chunk B appended its 2 segments");
+    assert.equal(spool.stats().conversations, 1, "the open conversation was resumed, not split");
+    assert.equal(spool.latestCapturingConversation()?.id, openId, "same conversation id resumed across restart");
   } finally {
     spool.close();
   }

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -618,3 +618,28 @@ test("a done-marked replay retries raw-WAV cleanup", async () => {
     spool.close();
   }
 });
+
+test("pruning the earliest duplicate recomputes the conversation's time bounds", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const proc = createChunkProcessor(
+      deps(spool, {
+        transcribe: async (input) =>
+          input.wavPath.includes("sys")
+            ? [{ text: "shared line", startUtc: t(5), endUtc: t(6) }]
+            : [{ text: "shared line", startUtc: t(1), endUtc: t(2) }], // earlier mic dup -> pruned
+      }),
+    );
+    proc.enqueue(chunk({ path: "/tmp/raw/mic.wav", channel: "mic", startedAtUtc: t(0), endedAtUtc: t(3) }));
+    proc.enqueue(chunk({ path: "/tmp/raw/sys.wav", channel: "system", startedAtUtc: t(4), endedAtUtc: t(7) }));
+    await proc.finalize();
+    const page = spool.queryFinalConversations({ date: "2026-07-24", timezone: "UTC", limit: 100 });
+    assert.equal(page.conversations.length, 1);
+    const conv = page.conversations[0];
+    assert.equal(conv.segments.length, 1, "only the system copy survives");
+    assert.equal(conv.startedAtUtc, t(5), "started_at_utc recomputed to the surviving earliest segment");
+    assert.equal(conv.endedAtUtc, t(6), "ended_at_utc recomputed to the surviving latest segment");
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -560,3 +560,61 @@ test("partial-chunk replay appends the missing tail group instead of skipping th
     spool.close();
   }
 });
+
+test("a zero-segment replay of a partially-applied chunk does NOT mark it done (tail stays recoverable)", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const ev = chunk({ path: "/tmp/raw/multi.wav" });
+    const cid = chunkStableId(ev);
+    spool.appendAssembledSegments({
+      idempotencyKey: `${cid}:0`,
+      chunkId: `${cid}:0`,
+      conversationId: "conv_grp0",
+      startedAtUtc: t(1),
+      state: "capturing",
+      segments: [{ channel: "mic", text: "first group", startUtc: t(1), endUtc: t(2), isWearer: true }],
+    });
+    // A replay that yields ZERO segments (VAD off / empty STT / WAV already gone).
+    const empty = createChunkProcessor(
+      deps(spool, { assembler: new ConversationAssembler({ gapMinutes: 0 }), transcribe: async () => [] }),
+    );
+    empty.enqueue(ev);
+    await empty.finalize();
+    assert.equal(spool.isChunkApplied(`${cid}:done`), false, "not marked done while the tail is still missing");
+    // A later correct replay still recovers the missing tail group.
+    const fixed = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 0 }),
+        transcribe: async () => [
+          { text: "first group", startUtc: t(1), endUtc: t(2) },
+          { text: "second group", startUtc: t(30), endUtc: t(31) },
+        ],
+      }),
+    );
+    fixed.enqueue(ev);
+    await fixed.finalize();
+    assert.equal(spool.stats().segments, 2, "the tail group was recovered on a correct replay");
+    assert.equal(spool.isChunkApplied(`${cid}:done`), true);
+  } finally {
+    spool.close();
+  }
+});
+
+test("a done-marked replay retries raw-WAV cleanup", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    let cleanupCalls = 0;
+    const mk = () => createChunkProcessor(deps(spool, { cleanupRawAudio: async () => { cleanupCalls++; } }));
+    const run1 = mk();
+    run1.enqueue(chunk());
+    await run1.finalize();
+    assert.equal(cleanupCalls, 1);
+    // Replay: the :done marker short-circuits transcription, but WAV cleanup is retried.
+    const run2 = mk();
+    run2.enqueue(chunk());
+    await run2.drain();
+    assert.equal(cleanupCalls, 2, "the done-replay retried WAV cleanup");
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -247,10 +247,12 @@ test("diarization: same-voice segments share one non-self cluster and are not th
     assert.equal(segs[0].speakerKey, segs[1].speakerKey, "one synthetic voice -> one cluster (no fragmentation)");
     assert.notEqual(segs[0].speakerKey, "self");
     assert.equal(segs[0].isWearer, false, "a guest voice on the mic is NOT the wearer");
+    // Only the guest cluster is captured here, so per-append persistence stores
+    // it; `self` durability is enrollment's job (it seeds the clusterer + spool).
     const clusters = spool.readSpeakerClusters();
     assert.ok(
-      clusters.some((c) => c.isSelf) && clusters.some((c) => !c.isSelf),
-      "self + guest clusters both persisted on finalize",
+      clusters.some((c) => !c.isSelf),
+      "the assigned guest cluster is persisted",
     );
   } finally {
     spool.close();
@@ -371,6 +373,58 @@ test("kill-9 recovery: a restart resumes the open conversation and stays idempot
     assert.equal(spool.stats().segments, 4, "replay added nothing; chunk B appended its 2 segments");
     assert.equal(spool.stats().conversations, 1, "the open conversation was resumed, not split");
     assert.equal(spool.latestCapturingConversation()?.id, openId, "same conversation id resumed across restart");
+  } finally {
+    spool.close();
+  }
+});
+
+test("cross-channel dedup is order-independent: a mic chunk processed BEFORE its system copy still dedups", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const proc = createChunkProcessor(
+      deps(spool, {
+        transcribe: async (input) =>
+          input.wavPath.includes("sys")
+            ? [{ text: "hello there world", startUtc: t(1), endUtc: t(3) }]
+            : [
+                { text: "hello there world", startUtc: t(1), endUtc: t(3) }, // loopback dup
+                { text: "unique mic line", startUtc: t(10), endUtc: t(11) },
+              ],
+      }),
+    );
+    // Mic chunk arrives FIRST (native helper stops mic before system on shutdown);
+    // the streaming approach would leak the dup here, finalize-time dedup does not.
+    proc.enqueue(chunk({ path: "/tmp/raw/mic.wav", channel: "mic", startedAtUtc: t(0), endedAtUtc: t(12) }));
+    proc.enqueue(chunk({ path: "/tmp/raw/sys.wav", channel: "system", startedAtUtc: t(0), endedAtUtc: t(4) }));
+    await proc.finalize();
+    const segs = finalSegments(spool);
+    assert.deepEqual(
+      segs.map((s) => s.textRaw).sort(),
+      ["hello there world", "unique mic line"],
+      "the duplicate mic copy is dropped regardless of arrival order",
+    );
+    assert.equal(segs.find((s) => s.textRaw === "hello there world")?.channel, "system");
+  } finally {
+    spool.close();
+  }
+});
+
+test("kill-9 durability: a diarized append persists its speaker cluster before finalize", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const guest: Embedding = [0, 1, 0, 0];
+    const proc = createChunkProcessor(
+      deps(spool, {
+        diarizer: new SpeakerClusterer(0.7),
+        embed: () => guest,
+        transcribe: async () => [{ text: "guest speaking", startUtc: t(1), endUtc: t(2) }],
+      }),
+    );
+    proc.enqueue(chunk());
+    await proc.drain(); // process is killed (-9) here: no finalize() runs
+    const clusters = spool.readSpeakerClusters();
+    assert.equal(clusters.length, 1, "the new cluster is durable as soon as its segment is appended");
+    assert.equal(clusters[0].isSelf, false);
   } finally {
     spool.close();
   }

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -83,9 +83,23 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   let recovered = false;
   let openConversationId: string | null = null;
   const processedThisRun = new Set<string>();
-  // Rolling window of recent SYSTEM-channel segments for cross-channel dedup:
-  // a mic segment duplicating a recent system (loopback) segment is dropped.
-  let recentSystem: AssemblySegment[] = [];
+  // Order-independent cross-channel dedup, applied at finalization: a mic
+  // segment duplicating a system (loopback) segment in the same conversation is
+  // pruned, keeping the cleaner system copy. Running at finalize — when every
+  // segment is present — means arrival order (mic-before-system or the reverse)
+  // never matters, so the native helper's shutdown ordering can't leak a dup.
+  const dedupeConversation = (id: string): void => {
+    const segs = deps.spool.conversationSegmentsForDedup(id);
+    if (segs.length === 0) return;
+    const options = deps.dedupWindowMs !== undefined ? { toleranceMs: deps.dedupWindowMs } : {};
+    const keep = new Set(dedupeCrossChannel(segs, options).map((s) => s.id));
+    const drop = segs.filter((s) => !keep.has(s.id)).map((s) => s.id);
+    if (drop.length > 0) deps.spool.deleteSegments(drop);
+  };
+  const finalizeConv = (id: string): void => {
+    dedupeConversation(id);
+    deps.spool.finalizeConversation(id);
+  };
 
   const report = (error: unknown, event: ChunkEvent): void => {
     deps.onError?.(error instanceof Error ? error : new Error(String(error)), event);
@@ -121,11 +135,11 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     }
     const closed = deps.assembler.closeIfIdle(event.startedAtUtc);
     if (closed !== null && closed === openConversationId) {
-      deps.spool.finalizeConversation(closed);
+      finalizeConv(closed);
       openConversationId = null;
     }
 
-    const built: AssemblySegment[] = [];
+    const segments: AssemblySegment[] = [];
     for (const s of raw) {
       const text = s.text.trim();
       if (text === "") continue;
@@ -139,7 +153,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         speakerCluster = deps.diarizer.assign(embedding);
         isWearer = deps.diarizer.clusters().find((c) => c.id === speakerCluster)?.isSelf ?? false;
       }
-      built.push({
+      segments.push({
         channel: event.channel,
         text,
         startUtc: s.startUtc,
@@ -147,28 +161,6 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         isWearer,
         ...(speakerCluster !== null ? { speakerCluster } : {}),
       });
-    }
-
-    // Cross-channel dedup (keep system, drop mic). A mic chunk's segments are
-    // filtered against the recent system window; a system chunk's segments are
-    // always kept and buffered so a later mic loopback is deduped. Forward-only:
-    // an already-appended mic segment is not retro-removed by a later system
-    // dup, which suits the streaming loopback case (system leads or is concurrent).
-    let segments = built;
-    if (event.channel === "mic" && recentSystem.length > 0) {
-      const options = deps.dedupWindowMs !== undefined ? { toleranceMs: deps.dedupWindowMs } : {};
-      const survivors = new Set(dedupeCrossChannel([...recentSystem, ...built], options));
-      segments = built.filter((seg) => survivors.has(seg));
-    } else if (event.channel === "system" && built.length > 0) {
-      recentSystem.push(...built);
-      const windowMs = deps.dedupWindowMs ?? 5_000;
-      const cutoff = Date.parse(event.endedAtUtc) - windowMs;
-      if (Number.isFinite(cutoff)) {
-        recentSystem = recentSystem.filter((seg) => {
-          const end = Date.parse(seg.endUtc);
-          return Number.isFinite(end) ? end >= cutoff : true;
-        });
-      }
     }
 
     if (segments.length > 0) {
@@ -189,7 +181,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       for (let g = 0; g < groups.length; g++) {
         const grp = groups[g];
         if (openConversationId !== null && openConversationId !== grp.id) {
-          deps.spool.finalizeConversation(openConversationId);
+          finalizeConv(openConversationId);
         }
         const key = groups.length === 1 ? chunkId : `${chunkId}:${g}`;
         deps.spool.appendAssembledSegments({
@@ -202,6 +194,30 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           wavPath: event.path,
           segments: grp.segs,
         });
+        // Persist any speaker clusters referenced by the just-appended segments
+        // immediately, so a kill-9 after this durable append cannot lose the
+        // cluster map and let the next voice reuse an id (mis-attribution).
+        if (deps.diarizer) {
+          const touched = new Set(
+            grp.segs.map((s) => s.speakerCluster).filter((id): id is string => typeof id === "string"),
+          );
+          if (touched.size > 0) {
+            const byId = new Map(deps.diarizer.clusters().map((c) => [c.id, c]));
+            for (const cid of touched) {
+              const c = byId.get(cid);
+              if (c) {
+                deps.spool.upsertSpeaker({
+                  id: c.id,
+                  label: c.label,
+                  isSelf: c.isSelf,
+                  embeddingCount: c.embeddingCount,
+                  centroid: c.centroid,
+                  examples: c.examples,
+                });
+              }
+            }
+          }
+        }
         openConversationId = grp.id;
       }
     }
@@ -229,20 +245,9 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   async function finalize(): Promise<number> {
     await drain();
     deps.assembler.finalize();
-    // Persist diarization clusters so their ids survive a daemon restart
-    // (the next run seeds SpeakerClusterer from readSpeakerClusters()).
-    if (deps.diarizer) {
-      for (const cluster of deps.diarizer.clusters()) {
-        deps.spool.upsertSpeaker({
-          id: cluster.id,
-          label: cluster.label,
-          isSelf: cluster.isSelf,
-          embeddingCount: cluster.embeddingCount,
-          centroid: cluster.centroid,
-          examples: cluster.examples,
-        });
-      }
-    }
+    // Dedup the still-open conversation before it flips to final so the served
+    // (final-only) output never contains a loopback duplicate.
+    if (openConversationId !== null) dedupeConversation(openConversationId);
     return deps.spool.finalizeOpenConversations();
   }
 

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -217,19 +217,11 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
             item.seg.speakerCluster = clusterId;
           }
         }
-        deps.spool.appendAssembledSegments({
-          idempotencyKey: key,
-          chunkId: key,
-          conversationId: grp.id,
-          startedAtUtc: grp.startedAtUtc,
-          state: "capturing",
-          device: event.device,
-          wavPath: event.path,
-          segments: grp.items.map((it) => it.seg),
-        });
-        // Persist any speaker clusters referenced by the just-appended segments
-        // immediately, so a kill-9 after this durable append cannot lose the
-        // cluster map and let the next voice reuse an id (mis-attribution).
+        // Persist any speaker clusters this group references BEFORE appending its
+        // segments, so a durable append always implies its clusters are already
+        // persisted: a transient upsert failure aborts before the append commits
+        // (nothing applied, replay retries), leaving no window where applied
+        // segments reference an unpersisted cluster.
         if (deps.diarizer) {
           const touched = new Set(
             grp.items.map((it) => it.seg.speakerCluster).filter((id): id is string => typeof id === "string"),
@@ -251,6 +243,16 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
             }
           }
         }
+        deps.spool.appendAssembledSegments({
+          idempotencyKey: key,
+          chunkId: key,
+          conversationId: grp.id,
+          startedAtUtc: grp.startedAtUtc,
+          state: "capturing",
+          device: event.device,
+          wavPath: event.path,
+          segments: grp.items.map((it) => it.seg),
+        });
         openConversationId = grp.id;
       }
     }
@@ -262,18 +264,18 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // (a partial crash) must NOT be marked done, or the missing tail groups
     // would be stranded forever.
     const chunkFullyProcessed = built.length > 0 || !deps.spool.isChunkApplied(`${chunkId}:0`);
-    if (chunkFullyProcessed) {
-      deps.spool.markChunkComplete(chunkId, openConversationId ?? "-");
-    }
     processedThisRun.add(chunkId);
-    // A successful transcription (even an empty/silent one) means the chunk is
-    // fully handled, so reclaim its raw WAV. A FAILED transcription throws
-    // above and never reaches here, so its WAV is retained. Best-effort — a
-    // cleanup failure is reported and the retention janitor is the backstop.
-    try {
-      await deps.cleanupRawAudio(event);
-    } catch (err) {
-      report(err, event);
+    if (chunkFullyProcessed) {
+      // The chunk is fully durably transcribed: record completion and reclaim
+      // the raw WAV. A partial chunk (earlier groups applied, this run added
+      // nothing) must RETAIN its WAV so a later full replay can still transcribe
+      // the missing tail groups. Cleanup is best-effort; the janitor is the backstop.
+      deps.spool.markChunkComplete(chunkId, openConversationId ?? "-");
+      try {
+        await deps.cleanupRawAudio(event);
+      } catch (err) {
+        report(err, event);
+      }
     }
   }
 

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -115,6 +115,14 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // idempotency re-appends only the missing groups below.
     if (deps.spool.isChunkApplied(`${chunkId}:done`)) {
       processedThisRun.add(chunkId);
+      // Retry raw-WAV reclaim: the marker is written before cleanup, so if the
+      // first run's cleanup failed (or it died between marking and deleting), a
+      // replay is our chance to remove the file instead of waiting for the janitor.
+      try {
+        await deps.cleanupRawAudio(event);
+      } catch (err) {
+        report(err, event);
+      }
       return;
     }
 
@@ -247,10 +255,16 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       }
     }
 
-    // Mark the whole chunk complete only after every group appended, so a later
-    // full replay skips transcription + diarization; a crash before here leaves
-    // no marker and the missing groups re-append on replay.
-    deps.spool.markChunkComplete(chunkId, openConversationId ?? "-");
+    // Mark the whole chunk complete only when it is safe: either we processed
+    // real segments this run (so every group of this chunk is now applied), or
+    // it is a genuinely fresh silent chunk with no prior partial application. A
+    // zero-segment run over a chunk whose earlier groups were already applied
+    // (a partial crash) must NOT be marked done, or the missing tail groups
+    // would be stranded forever.
+    const chunkFullyProcessed = built.length > 0 || !deps.spool.isChunkApplied(`${chunkId}:0`);
+    if (chunkFullyProcessed) {
+      deps.spool.markChunkComplete(chunkId, openConversationId ?? "-");
+    }
     processedThisRun.add(chunkId);
     // A successful transcription (even an empty/silent one) means the chunk is
     // fully handled, so reclaim its raw WAV. A FAILED transcription throws

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -108,11 +108,12 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   async function process(event: ChunkEvent): Promise<void> {
     const chunkId = chunkStableId(event);
     if (processedThisRun.has(chunkId)) return; // in-run replay: already handled
-    // Durable (cross-restart) replay: this chunk was already applied in a prior
-    // run, so its segments AND speaker-cluster updates are persisted. Skip it
-    // entirely — re-running transcription/diarization would re-consume the
-    // embedding and corrupt the cluster centroid/count.
-    if (deps.spool.isChunkApplied(chunkId) || deps.spool.isChunkApplied(`${chunkId}:0`)) {
+    // Durable (cross-restart) FULL replay: a completed chunk wrote a per-chunk
+    // ':done' marker, so its segments AND cluster updates are persisted. Skip
+    // transcription + diarization entirely. A PARTIAL replay (crash between
+    // group appends) has no marker, so it falls through and per-group
+    // idempotency re-appends only the missing groups below.
+    if (deps.spool.isChunkApplied(`${chunkId}:done`)) {
       processedThisRun.add(chunkId);
       return;
     }
@@ -152,54 +153,62 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // must remain the wearer signal until voice enrollment lands.
     const selfVoiceEnrolled =
       deps.diarizer !== undefined && deps.diarizer.clusters().some((c) => c.isSelf && c.embeddingCount > 0);
-    const segments: AssemblySegment[] = [];
+    // Build base segments WITHOUT diarization; diarization is applied lazily per
+    // group below, only for groups that will actually be appended, so a partial
+    // replay never re-embeds an already-applied group (which would corrupt its
+    // speaker centroid/count). Each base segment carries its raw segment for the
+    // lazy embedding.
+    const built: Array<{ seg: AssemblySegment; raw: TranscribedSegment }> = [];
     for (const s of raw) {
       const text = s.text.trim();
       if (text === "") continue;
-      // Diarization: embed the segment and assign it to a stable speaker cluster;
-      // isWearer comes from the assigned cluster's self flag. When self is only
-      // label-enrolled (no embedding), keep the mic=wearer heuristic rather than
-      // mis-attribute the wearer's own mic speech to a fresh guest cluster.
-      let speakerCluster: string | null = null;
-      let isWearer = event.channel === "mic";
-      if (deps.embed && deps.diarizer) {
-        const embedding = await deps.embed(event, s);
-        speakerCluster = deps.diarizer.assign(embedding);
-        const assigned = deps.diarizer.clusters().find((c) => c.id === speakerCluster);
-        isWearer = assigned?.isSelf ?? false;
-        if (!isWearer && event.channel === "mic" && !selfVoiceEnrolled) isWearer = true;
-      }
-      segments.push({
-        channel: event.channel,
-        text,
-        startUtc: s.startUtc,
-        endUtc: s.endUtc,
-        isWearer,
-        ...(speakerCluster !== null ? { speakerCluster } : {}),
+      built.push({
+        seg: { channel: event.channel, text, startUtc: s.startUtc, endUtc: s.endUtc, isWearer: event.channel === "mic" },
+        raw: s,
       });
     }
 
-    if (segments.length > 0) {
+    if (built.length > 0) {
       // Segments usually land in one conversation, but a gap >= threshold (or
       // conversationGapMinutes = 0) can split them intra-chunk. Group by the
       // conversation the assembler places each segment in.
-      const groups: Array<{ id: string; startedAtUtc: string; segs: AssemblySegment[] }> = [];
-      for (const seg of segments) {
-        const conv = deps.assembler.add(seg);
+      const groups: Array<{
+        id: string;
+        startedAtUtc: string;
+        items: Array<{ seg: AssemblySegment; raw: TranscribedSegment }>;
+      }> = [];
+      for (const item of built) {
+        const conv = deps.assembler.add(item.seg);
         const last = groups[groups.length - 1];
-        if (last && last.id === conv.id) last.segs.push(seg);
-        else groups.push({ id: conv.id, startedAtUtc: conv.startedAtUtc, segs: [seg] });
+        if (last && last.id === conv.id) last.items.push(item);
+        else groups.push({ id: conv.id, startedAtUtc: conv.startedAtUtc, items: [item] });
       }
       // Append each group, finalizing a conversation only once we move past it
-      // — i.e. AFTER its rows have been appended — so no segment is ever added
-      // to an already-finalized conversation, and a gap-closed conversation
-      // doesn't linger as `capturing`.
+      // (AFTER its rows are appended). A group already applied in a prior run is
+      // skipped so the SAME chunk's later, unpersisted groups still append.
       for (let g = 0; g < groups.length; g++) {
         const grp = groups[g];
+        const key = groups.length === 1 ? chunkId : `${chunkId}:${g}`;
+        if (deps.spool.isChunkApplied(key)) {
+          openConversationId = grp.id;
+          continue;
+        }
         if (openConversationId !== null && openConversationId !== grp.id) {
           finalizeConv(openConversationId);
         }
-        const key = groups.length === 1 ? chunkId : `${chunkId}:${g}`;
+        // Diarize this group now (lazily), only because it will be appended.
+        if (deps.embed && deps.diarizer) {
+          for (const item of grp.items) {
+            const embedding = await deps.embed(event, item.raw);
+            const clusterId = deps.diarizer.assign(embedding);
+            const assigned = deps.diarizer.clusters().find((c) => c.id === clusterId);
+            let isWearer = assigned?.isSelf ?? false;
+            // Label-only self can't match live audio: keep the mic=wearer heuristic.
+            if (!isWearer && event.channel === "mic" && !selfVoiceEnrolled) isWearer = true;
+            item.seg.isWearer = isWearer;
+            item.seg.speakerCluster = clusterId;
+          }
+        }
         deps.spool.appendAssembledSegments({
           idempotencyKey: key,
           chunkId: key,
@@ -208,14 +217,14 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           state: "capturing",
           device: event.device,
           wavPath: event.path,
-          segments: grp.segs,
+          segments: grp.items.map((it) => it.seg),
         });
         // Persist any speaker clusters referenced by the just-appended segments
         // immediately, so a kill-9 after this durable append cannot lose the
         // cluster map and let the next voice reuse an id (mis-attribution).
         if (deps.diarizer) {
           const touched = new Set(
-            grp.segs.map((s) => s.speakerCluster).filter((id): id is string => typeof id === "string"),
+            grp.items.map((it) => it.seg.speakerCluster).filter((id): id is string => typeof id === "string"),
           );
           if (touched.size > 0) {
             const byId = new Map(deps.diarizer.clusters().map((c) => [c.id, c]));
@@ -238,6 +247,10 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       }
     }
 
+    // Mark the whole chunk complete only after every group appended, so a later
+    // full replay skips transcription + diarization; a crash before here leaves
+    // no marker and the missing groups re-append on replay.
+    deps.spool.markChunkComplete(chunkId, openConversationId ?? "-");
     processedThisRun.add(chunkId);
     // A successful transcription (even an empty/silent one) means the chunk is
     // fully handled, so reclaim its raw WAV. A FAILED transcription throws

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -18,6 +18,8 @@
 import { createHash } from "node:crypto";
 
 import type { AssemblySegment, ConversationAssembler } from "./assembly.js";
+import { dedupeCrossChannel } from "./dedup.js";
+import type { Embedding, SpeakerClusterer } from "./diarization.js";
 import type { ChunkEvent } from "./native.js";
 import type { Spool } from "./spool.js";
 import type { TranscribedSegment } from "./stt.js";
@@ -32,12 +34,28 @@ export interface ChunkProcessorDeps {
   spool: Spool;
   /** Stateful assembler that groups consecutive segments into conversations. */
   assembler: ConversationAssembler;
-  /** Resolve the STT model path; called per chunk and may throw when absent. */
+  /** Resolve the STT model path; called per speech chunk and may throw when absent. */
   resolveModel: () => string;
   /** Transcribe one WAV chunk into raw segments. */
   transcribe: (input: ChunkTranscribeInput) => Promise<TranscribedSegment[]>;
   /** Delete the raw WAV under retention once the chunk is durably persisted. */
   cleanupRawAudio: (event: ChunkEvent) => Promise<void>;
+  /**
+   * VAD speech gate. When provided and it resolves false, the chunk is treated
+   * as non-speech: STT is skipped (the CPU-budget guard) and no segments
+   * persist. Absent -> every chunk is transcribed.
+   */
+  detectSpeech?: (event: ChunkEvent) => boolean | Promise<boolean>;
+  /**
+   * Speaker-embedding extractor for diarization. With `diarizer`, each segment
+   * is embedded and assigned to a speaker cluster; absent -> the interim
+   * mic=wearer heuristic and no speaker cluster.
+   */
+  embed?: (event: ChunkEvent, segment: TranscribedSegment) => Embedding | Promise<Embedding>;
+  /** Speaker clusterer (seeded from the spool); its clusters are persisted on finalize. */
+  diarizer?: SpeakerClusterer;
+  /** Cross-channel dedup window in ms; defaults to the dedup module's tolerance. */
+  dedupWindowMs?: number;
   /** Reports a per-chunk failure; the chain keeps running afterwards. */
   onError?: (error: Error, event: ChunkEvent) => void;
 }
@@ -65,6 +83,9 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   let recovered = false;
   let openConversationId: string | null = null;
   const processedThisRun = new Set<string>();
+  // Rolling window of recent SYSTEM-channel segments for cross-channel dedup:
+  // a mic segment duplicating a recent system (loopback) segment is dropped.
+  let recentSystem: AssemblySegment[] = [];
 
   const report = (error: unknown, event: ChunkEvent): void => {
     deps.onError?.(error instanceof Error ? error : new Error(String(error)), event);
@@ -74,12 +95,17 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     const chunkId = chunkStableId(event);
     if (processedThisRun.has(chunkId)) return; // in-run replay: already handled
 
-    const modelPath = deps.resolveModel();
-    const raw = await deps.transcribe({
-      wavPath: event.path,
-      modelPath,
-      chunkStartedAtUtc: event.startedAtUtc,
-    });
+    // VAD gate: a non-speech chunk skips STT (and model resolution) entirely,
+    // flowing through as a zero-segment chunk so idle-close + WAV reclaim still
+    // run. Absent detectSpeech -> transcribe every chunk.
+    const isSpeech = deps.detectSpeech ? await deps.detectSpeech(event) : true;
+    const raw = isSpeech
+      ? await deps.transcribe({
+          wavPath: event.path,
+          modelPath: deps.resolveModel(),
+          chunkStartedAtUtc: event.startedAtUtc,
+        })
+      : [];
 
     // Recover the newest still-open conversation once (any chunk, incl. silent)
     // so a post-restart chunk continues it; then finalize a stale open
@@ -99,20 +125,50 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       openConversationId = null;
     }
 
-    const segments: AssemblySegment[] = [];
+    const built: AssemblySegment[] = [];
     for (const s of raw) {
       const text = s.text.trim();
       if (text === "") continue;
-      segments.push({
+      // Diarization: with an embedder + clusterer, embed the segment and assign
+      // it to a stable speaker cluster (self -> the enrolled wearer). Without
+      // them, fall back to the interim mic=wearer heuristic and no cluster.
+      let speakerCluster: string | null = null;
+      let isWearer = event.channel === "mic";
+      if (deps.embed && deps.diarizer) {
+        const embedding = await deps.embed(event, s);
+        speakerCluster = deps.diarizer.assign(embedding);
+        isWearer = deps.diarizer.clusters().find((c) => c.id === speakerCluster)?.isSelf ?? false;
+      }
+      built.push({
         channel: event.channel,
         text,
         startUtc: s.startUtc,
         endUtc: s.endUtc,
-        // Interim wearer heuristic: the mic channel is the wearer's own audio.
-        // This is NOT diarization/speaker attribution — that lands in a later
-        // checklist item and will refine `isWearer` and `speakerCluster`.
-        isWearer: event.channel === "mic",
+        isWearer,
+        ...(speakerCluster !== null ? { speakerCluster } : {}),
       });
+    }
+
+    // Cross-channel dedup (keep system, drop mic). A mic chunk's segments are
+    // filtered against the recent system window; a system chunk's segments are
+    // always kept and buffered so a later mic loopback is deduped. Forward-only:
+    // an already-appended mic segment is not retro-removed by a later system
+    // dup, which suits the streaming loopback case (system leads or is concurrent).
+    let segments = built;
+    if (event.channel === "mic" && recentSystem.length > 0) {
+      const options = deps.dedupWindowMs !== undefined ? { toleranceMs: deps.dedupWindowMs } : {};
+      const survivors = new Set(dedupeCrossChannel([...recentSystem, ...built], options));
+      segments = built.filter((seg) => survivors.has(seg));
+    } else if (event.channel === "system" && built.length > 0) {
+      recentSystem.push(...built);
+      const windowMs = deps.dedupWindowMs ?? 5_000;
+      const cutoff = Date.parse(event.endedAtUtc) - windowMs;
+      if (Number.isFinite(cutoff)) {
+        recentSystem = recentSystem.filter((seg) => {
+          const end = Date.parse(seg.endUtc);
+          return Number.isFinite(end) ? end >= cutoff : true;
+        });
+      }
     }
 
     if (segments.length > 0) {
@@ -173,6 +229,20 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   async function finalize(): Promise<number> {
     await drain();
     deps.assembler.finalize();
+    // Persist diarization clusters so their ids survive a daemon restart
+    // (the next run seeds SpeakerClusterer from readSpeakerClusters()).
+    if (deps.diarizer) {
+      for (const cluster of deps.diarizer.clusters()) {
+        deps.spool.upsertSpeaker({
+          id: cluster.id,
+          label: cluster.label,
+          isSelf: cluster.isSelf,
+          embeddingCount: cluster.embeddingCount,
+          centroid: cluster.centroid,
+          examples: cluster.examples,
+        });
+      }
+    }
     return deps.spool.finalizeOpenConversations();
   }
 

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -108,6 +108,14 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   async function process(event: ChunkEvent): Promise<void> {
     const chunkId = chunkStableId(event);
     if (processedThisRun.has(chunkId)) return; // in-run replay: already handled
+    // Durable (cross-restart) replay: this chunk was already applied in a prior
+    // run, so its segments AND speaker-cluster updates are persisted. Skip it
+    // entirely — re-running transcription/diarization would re-consume the
+    // embedding and corrupt the cluster centroid/count.
+    if (deps.spool.isChunkApplied(chunkId) || deps.spool.isChunkApplied(`${chunkId}:0`)) {
+      processedThisRun.add(chunkId);
+      return;
+    }
 
     // VAD gate: a non-speech chunk skips STT (and model resolution) entirely,
     // flowing through as a zero-segment chunk so idle-close + WAV reclaim still
@@ -139,19 +147,27 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       openConversationId = null;
     }
 
+    // Whether self is VOICE-enrolled (has an embedding to match), computed once:
+    // a label-only enroll-self can never match live audio, so the mic heuristic
+    // must remain the wearer signal until voice enrollment lands.
+    const selfVoiceEnrolled =
+      deps.diarizer !== undefined && deps.diarizer.clusters().some((c) => c.isSelf && c.embeddingCount > 0);
     const segments: AssemblySegment[] = [];
     for (const s of raw) {
       const text = s.text.trim();
       if (text === "") continue;
-      // Diarization: with an embedder + clusterer, embed the segment and assign
-      // it to a stable speaker cluster (self -> the enrolled wearer). Without
-      // them, fall back to the interim mic=wearer heuristic and no cluster.
+      // Diarization: embed the segment and assign it to a stable speaker cluster;
+      // isWearer comes from the assigned cluster's self flag. When self is only
+      // label-enrolled (no embedding), keep the mic=wearer heuristic rather than
+      // mis-attribute the wearer's own mic speech to a fresh guest cluster.
       let speakerCluster: string | null = null;
       let isWearer = event.channel === "mic";
       if (deps.embed && deps.diarizer) {
         const embedding = await deps.embed(event, s);
         speakerCluster = deps.diarizer.assign(embedding);
-        isWearer = deps.diarizer.clusters().find((c) => c.id === speakerCluster)?.isSelf ?? false;
+        const assigned = deps.diarizer.clusters().find((c) => c.id === speakerCluster);
+        isWearer = assigned?.isSelf ?? false;
+        if (!isWearer && event.channel === "mic" && !selfVoiceEnrolled) isWearer = true;
       }
       segments.push({
         channel: event.channel,
@@ -245,9 +261,11 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   async function finalize(): Promise<number> {
     await drain();
     deps.assembler.finalize();
-    // Dedup the still-open conversation before it flips to final so the served
-    // (final-only) output never contains a loopback duplicate.
-    if (openConversationId !== null) dedupeConversation(openConversationId);
+    // Dedup EVERY still-capturing conversation before the bulk flip to final —
+    // including one left by a crashed prior run that this process never touched
+    // (so it has no in-memory openConversationId) — so the served (final-only)
+    // output never contains a loopback duplicate.
+    for (const id of deps.spool.capturingConversationIds()) dedupeConversation(id);
     return deps.spool.finalizeOpenConversations();
   }
 

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -473,6 +473,51 @@ export class Spool {
   }
 
   /**
+   * A conversation's segments in the shape cross-channel dedup needs (segment
+   * id + DedupSegment fields), chronological. Used to prune loopback duplicates
+   * at finalization, which is order-independent (all segments are present).
+   */
+  conversationSegmentsForDedup(
+    conversationId: string,
+  ): Array<{ id: string; channel: string; text: string; startUtc: string; endUtc: string }> {
+    return this.#db
+      .prepare(
+        "SELECT id, channel, text, start_utc AS startUtc, end_utc AS endUtc FROM segments " +
+          "WHERE conversation_id = ? ORDER BY start_utc ASC, ordinal ASC, id ASC",
+      )
+      .all(conversationId) as Array<{ id: string; channel: string; text: string; startUtc: string; endUtc: string }>;
+  }
+
+  /**
+   * Delete specific segments (dedup prune), keeping each owning conversation's
+   * segment_count in sync. Returns the number actually removed.
+   */
+  deleteSegments(ids: readonly string[]): number {
+    if (ids.length === 0) return 0;
+    const db = this.#db;
+    let removed = 0;
+    db.exec("BEGIN");
+    try {
+      const findConv = db.prepare("SELECT conversation_id AS conversationId FROM segments WHERE id = ?");
+      const del = db.prepare("DELETE FROM segments WHERE id = ?");
+      const dec = db.prepare("UPDATE conversations SET segment_count = MAX(segment_count - 1, 0) WHERE id = ?");
+      for (const id of ids) {
+        const row = findConv.get(id) as { conversationId: string } | undefined;
+        if (!row) continue;
+        if (Number(del.run(id).changes) > 0) {
+          dec.run(row.conversationId);
+          removed++;
+        }
+      }
+      db.exec("COMMIT");
+    } catch (err) {
+      db.exec("ROLLBACK");
+      throw err;
+    }
+    return removed;
+  }
+
+  /**
    * The newest still-`capturing` conversation, so a chunk arriving after a
    * process restart continues it (subject to the assembler's gap rule) instead
    * of splitting off a new one. Null when none is open.

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -534,6 +534,17 @@ export class Spool {
   }
 
   /**
+   * Record that a whole chunk finished (every group appended) via a `<id>:done`
+   * marker, so a later full replay can skip transcription + diarization. A crash
+   * before this leaves no marker, so the missing groups re-append on replay.
+   */
+  markChunkComplete(chunkId: string, conversationId: string): void {
+    this.#db
+      .prepare("INSERT OR IGNORE INTO applied_chunks(idempotency_key, conversation_id, applied_at_utc) VALUES (?,?,?)")
+      .run(`${chunkId}:done`, conversationId, new Date().toISOString());
+  }
+
+  /**
    * The newest still-`capturing` conversation, so a chunk arriving after a
    * process restart continues it (subject to the assembler's gap rule) instead
    * of splitting off a new one. Null when none is open.

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -517,6 +517,22 @@ export class Spool {
     return removed;
   }
 
+  /** Ids of every still-`capturing` conversation (dedup-before-finalize sweep). */
+  capturingConversationIds(): string[] {
+    const rows = this.#db
+      .prepare("SELECT id FROM conversations WHERE state = 'capturing' ORDER BY id ASC")
+      .all() as Array<{ id: string }>;
+    return rows.map((r) => r.id);
+  }
+
+  /** Whether a chunk with this idempotency key was already durably applied. */
+  isChunkApplied(idempotencyKey: string): boolean {
+    return (
+      this.#db.prepare("SELECT 1 FROM applied_chunks WHERE idempotency_key = ? LIMIT 1").get(idempotencyKey) !==
+      undefined
+    );
+  }
+
   /**
    * The newest still-`capturing` conversation, so a chunk arriving after a
    * process restart continues it (subject to the assembler's gap rule) instead

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -501,13 +501,26 @@ export class Spool {
       const findConv = db.prepare("SELECT conversation_id AS conversationId FROM segments WHERE id = ?");
       const del = db.prepare("DELETE FROM segments WHERE id = ?");
       const dec = db.prepare("UPDATE conversations SET segment_count = MAX(segment_count - 1, 0) WHERE id = ?");
+      const affected = new Set<string>();
       for (const id of ids) {
         const row = findConv.get(id) as { conversationId: string } | undefined;
         if (!row) continue;
         if (Number(del.run(id).changes) > 0) {
           dec.run(row.conversationId);
+          affected.add(row.conversationId);
           removed++;
         }
+      }
+      // Recompute time bounds from the surviving segments: pruning the earliest
+      // or latest segment must not leave the conversation under a deleted row's
+      // start/end (which would mis-bucket/mis-order it in queryFinalConversations).
+      const bounds = db.prepare(
+        "SELECT MIN(start_utc) AS minStart, MAX(end_utc) AS maxEnd FROM segments WHERE conversation_id = ?",
+      );
+      const setBounds = db.prepare("UPDATE conversations SET started_at_utc = ?, ended_at_utc = ? WHERE id = ?");
+      for (const convId of affected) {
+        const b = bounds.get(convId) as { minStart: string | null; maxEnd: string | null };
+        if (b.minStart !== null && b.maxEnd !== null) setBounds.run(b.minStart, b.maxEnd, convId);
       }
       db.exec("COMMIT");
     } catch (err) {


### PR DESCRIPTION
## Summary
- Wires the previously-unwired VAD, speaker-diarization, and cross-channel-dedup modules into the `@remnic/capture-audio` live pipeline (they shipped as pure helpers with #1897 but were never invoked by the chunk processor).
- All three are injected behind optional seams so the package stays à-la-carte and Linux-verifiable with synthetic fixtures (no native runtime).

## What changed
- **VAD gate** (`processor.ts`, `capture.ts`): an optional `detectSpeech` seam runs before STT. A non-speech chunk skips transcription **and** model resolution, then flows through as a zero-segment chunk so idle-close and raw-WAV reclaim still run.
- **Diarization**: with an `embed` seam + `SpeakerClusterer`, each segment is embedded and assigned to a stable speaker cluster (`self` -> the enrolled wearer), replacing the interim `mic=wearer` heuristic. `capture.ts` seeds the clusterer from persisted clusters; the processor writes clusters back on `finalize`, so speaker ids survive daemon restarts.
- **Cross-channel dedup**: a rolling window of recent system-channel segments lets a mic segment duplicating system (loopback) speech be dropped, keeping the cleaner system copy. With dedup wired, capture re-enables `channel: "both"` (was mic-only).

## Verification
- `pnpm --filter @remnic/capture-audio run test` — 235 passing (7 new behavioral regressions: VAD skips STT/model-resolve for silence; one synthetic voice -> one cluster; enrolled self voice is the wearer; clusters seed a restart with stable ids; duplicated mic loopback line dropped; kill-9 restart resumes the open conversation and stays idempotent on replay)
- `pnpm --filter @remnic/capture-audio run check-types`
- `pnpm --filter @remnic/capture-audio run build`

Part of #1897

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core transcript persistence, speaker attribution, and crash/replay semantics; behavior is heavily regression-tested but mistakes could drop or duplicate conversation text.
> 
> **Overview**
> Connects previously unused **VAD**, **speaker diarization**, and **cross-channel dedup** into the live chunk pipeline via injectable `detectSpeech`, `embed`, and `SpeakerClusterer` seams. Non-speech chunks skip STT and model resolution but still drive idle-close and raw WAV cleanup.
> 
> **Diarization** embeds segments lazily per append group, assigns stable speaker clusters (with `self` / wearer logic and label-only self fallback to mic=wearer), and **persists clusters before segment append** so kill-9 recovery stays consistent. `createLiveCapture` seeds the clusterer from the spool.
> 
> **Cross-channel dedup** runs at conversation finalize (and when gap-closing), pruning mic duplicates of system loopback speech regardless of chunk arrival order; the spool gains segment delete + conversation time-bound recomputation.
> 
> **Durability**: per-group idempotency, a chunk `:done` marker to skip full replays (while retrying WAV cleanup), rules so partial crashes can recover tail groups without marking the chunk done, and finalize sweeps all capturing conversations—including crash leftovers.
> 
> Adds **`captureChannel`** (`mic` | `system` | `both`, default `both`) so capture can record both channels now that dedup is wired (replacing the temporary mic-only default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4353b7f4556b95d0e4953160f5e721f0544d86a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional speech-activity gating to skip transcription for non-speech chunks.
  - Added embedding-based diarization with speaker clustering and wearer identification support.
  - Added configurable `captureChannel` mode selection (mic/system/both; default: both).

- **Bug Fixes**
  - Reduced loopback and multi-channel duplicates using time-tolerant cross-channel deduplication.
  - Improved crash-resilience by deduplicating and persisting diarization-related metadata more reliably.

- **Tests**
  - Expanded VAD, diarization/clustering, cross-channel dedup ordering, and kill-9 style idempotency/recovery coverage.
  - Added config parsing/validation tests for `captureChannel`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->