### PR TITLE
test(activity): de-flake scheduler durable-sync test (event-driven wait)

### DIFF
--- a/.changeset/activity-scheduler-durable-sync-flake.md
+++ b/.changeset/activity-scheduler-durable-sync-flake.md
@@ -1,0 +1,12 @@
+---
+"@remnic/core": patch
+---
+
+Make the activity scheduler `parser -> scheduler -> durable sync` test
+deterministic. The test fired a scheduler tick (fire-and-forget
+`runActivitySyncOnce` with real fs + SQLite I/O on the libuv threadpool)
+and then waited a single `setImmediate` before asserting — a race that
+flaked in CI when the durable writes had not settled. It now waits on an
+`onRun` completion signal (the scheduler invokes `onRun(summary)` only
+after the sync promise resolves), so the assertions run exactly once the
+sync is durable. No sleeps, no production changes.

--- a/packages/remnic-core/src/activity/scheduler.test.ts
+++ b/packages/remnic-core/src/activity/scheduler.test.ts
@@ -247,8 +247,13 @@ test("parser -> scheduler -> durable sync: a tick performs a real durable sync",
     // i.e. AFTER invoke() (runActivitySyncOnce) has fully resolved — every fs
     // write and setCursor durable. Awaiting this signal is deterministic; a bare
     // setImmediate flush races the runner's real fs I/O on the libuv threadpool.
-    const { promise: syncCompleted, resolve: signalSyncCompleted } =
-      Promise.withResolvers<ActivitySyncRunSummary>();
+    // onError rejects the same deferred so a runner failure (SQLite/digest write
+    // regression, temp-dir fault) surfaces promptly instead of hanging to timeout.
+    const {
+      promise: syncCompleted,
+      resolve: signalSyncCompleted,
+      reject: failSyncCompleted,
+    } = Promise.withResolvers<ActivitySyncRunSummary>();
     const timer = fakeTimer();
     const scheduler = new ActivitySyncScheduler({
       config: enabledConfig(),
@@ -265,6 +270,7 @@ test("parser -> scheduler -> durable sync: a tick performs a real durable sync",
           createSourceClient: () => client,
         }),
       onRun: signalSyncCompleted,
+      onError: failSyncCompleted,
       setTimer: timer.setTimer,
       clearTimer: timer.clearTimer,
     });

--- a/packages/remnic-core/src/activity/scheduler.test.ts
+++ b/packages/remnic-core/src/activity/scheduler.test.ts
@@ -243,6 +243,12 @@ test("parser -> scheduler -> durable sync: a tick performs a real durable sync",
       },
     };
 
+    // Event-driven completion: the scheduler calls onRun(summary) in its .then,
+    // i.e. AFTER invoke() (runActivitySyncOnce) has fully resolved — every fs
+    // write and setCursor durable. Awaiting this signal is deterministic; a bare
+    // setImmediate flush races the runner's real fs I/O on the libuv threadpool.
+    const { promise: syncCompleted, resolve: signalSyncCompleted } =
+      Promise.withResolvers<ActivitySyncRunSummary>();
     const timer = fakeTimer();
     const scheduler = new ActivitySyncScheduler({
       config: enabledConfig(),
@@ -258,13 +264,14 @@ test("parser -> scheduler -> durable sync: a tick performs a real durable sync",
           signal,
           createSourceClient: () => client,
         }),
+      onRun: signalSyncCompleted,
       setTimer: timer.setTimer,
       clearTimer: timer.clearTimer,
     });
 
     scheduler.start();
     timer.armed[0].fn();
-    await flush();
+    await syncCompleted;
 
     assert.equal(store.getCursor(activityCursorKey("workstation-a", "2026-07-22")), null, "cursor advanced by the durable sync");
     const rows = store.listSnapshotsForDay(null, "2026-07-22T00:00:00.000Z", "2026-07-23T00:00:00.000Z");


### PR DESCRIPTION
## Problem

The activity scheduler test `parser -> scheduler -> durable sync: a tick performs a real durable sync` (`packages/remnic-core/src/activity/scheduler.test.ts`) is timing-dependent and flaked in CI — failed twice (PR #2143 head run and the main run on `9c3d85454`) and passed on rerun.

## Root cause

The test fires a scheduler tick, which runs `runActivitySyncOnce` **fire-and-forget** (`void this.invoke().then(...)`). That runner does real filesystem + SQLite I/O (snapshot inserts, atomic digest write via `writeFile`+`rename`, `setCursor`) which settles on the libuv threadpool. The test then waited a **single `setImmediate` flush** before asserting the cursor advanced and the row persisted. One `setImmediate` (a macrotask) is not guaranteed to be enough for all of the runner's awaited fs promises to resolve, so the assertions sometimes ran before the writes were durable.

## Fix

Wait on an **event-driven completion signal** instead of a timing flush. The scheduler already invokes `onRun(summary)` inside its `.then` — i.e. only after the `invoke()` promise (the full `runActivitySyncOnce`) resolves, at which point every write and `setCursor` is durable. The test now supplies an `onRun` that resolves a `Promise.withResolvers`, and `await`s it before asserting. No sleeps, no production code change (test-only).

## Verification

- Focused loop (`--test-name-pattern='real durable sync'`) **50×: 50 pass, 0 fail**.
- Full `scheduler.test.ts` **10×: 10 pass, 0 fail** (7 tests each).
- `tsc --noEmit` on `@remnic/core`: exit 0.

Small, test-only PR off `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths modified; only reduces flaky CI behavior.
> 
> **Overview**
> Fixes a **CI flake** in the activity scheduler integration test that exercises a real `runActivitySyncOnce` durable sync after a tick.
> 
> The test no longer relies on a single **`setImmediate` flush** before asserting cursor and snapshot persistence. It **awaits completion through existing scheduler hooks**: `onRun` resolves a `Promise.withResolvers` deferred after `invoke()` finishes (when fs/SQLite writes are done), and **`onError` rejects** that same deferred so runner failures fail fast instead of timing out.
> 
> **Test-only** — no scheduler or runner production changes. A changeset patch note documents the test hardening for `@remnic/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e43dffd9d912358ecfc5299b0c4ecb43217b2f0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved scheduler test reliability by deterministically waiting for durable synchronization to finish before validating outcomes.
  * Removed timing/microtask-based waiting to reduce race conditions and flakiness in repeated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->