### PR TITLE
feat(core): probe delegate token operation grants

### DIFF
--- a/packages/remnic-core/src/access-authorization-probe.ts
+++ b/packages/remnic-core/src/access-authorization-probe.ts
@@ -1,6 +1,9 @@
-import { type OperationName, OPERATION_NAMES } from "./access-boundary.js";
-import { EngramAccessForbiddenError, EngramAccessInputError } from "./access-errors.js";
-import { capabilityAllowsOp, type TokenCapabilities } from "./access-token-capabilities.js";
+import { getOperation, type OperationName, OPERATION_NAMES } from "./access-boundary.js";
+import { EngramAccessInputError } from "./access-errors.js";
+import {
+  assertOperationAuthorizationAllowed,
+  type TokenCapabilities,
+} from "./access-token-capabilities.js";
 
 export interface AuthorizationProbeResponse {
   readonly authorized: true;
@@ -29,9 +32,11 @@ export function probeOperationAuthorization(
   }
 
   for (const operation of operations) {
-    if (!capabilityAllowsOp(capabilities, operation)) {
-      throw new EngramAccessForbiddenError(`token is not permitted to call operation: ${operation}`);
+    const boundOperation = getOperation(operation);
+    if (!boundOperation) {
+      throw new Error(`authorization probe operation is not registered: ${operation}`);
     }
+    assertOperationAuthorizationAllowed(capabilities, boundOperation.spec);
   }
 
   return { authorized: true, operations };

--- a/packages/remnic-core/src/access-authorization-probe.ts
+++ b/packages/remnic-core/src/access-authorization-probe.ts
@@ -1,0 +1,38 @@
+import { type OperationName, OPERATION_NAMES } from "./access-boundary.js";
+import { EngramAccessForbiddenError, EngramAccessInputError } from "./access-errors.js";
+import { capabilityAllowsOp, type TokenCapabilities } from "./access-token-capabilities.js";
+
+export interface AuthorizationProbeResponse {
+  readonly authorized: true;
+  readonly operations: readonly OperationName[];
+}
+
+/**
+ * Verify that the presenting token may call every requested operation without
+ * invoking any operation handler.
+ */
+export function probeOperationAuthorization(
+  capabilities: TokenCapabilities | undefined | null,
+  requestedOperations: readonly string[],
+): AuthorizationProbeResponse {
+  const operations: OperationName[] = [];
+  for (const candidate of requestedOperations) {
+    if (!OPERATION_NAMES.includes(candidate as OperationName)) {
+      throw new EngramAccessInputError(`unsupported operation: ${candidate}`);
+    }
+    const operation = candidate as OperationName;
+    if (!operations.includes(operation)) operations.push(operation);
+  }
+
+  if (operations.length === 0) {
+    throw new EngramAccessInputError("at least one operation is required");
+  }
+
+  for (const operation of operations) {
+    if (!capabilityAllowsOp(capabilities, operation)) {
+      throw new EngramAccessForbiddenError(`token is not permitted to call operation: ${operation}`);
+    }
+  }
+
+  return { authorized: true, operations };
+}

--- a/packages/remnic-core/src/access-boundary.ts
+++ b/packages/remnic-core/src/access-boundary.ts
@@ -16,12 +16,9 @@
  */
 
 import { z } from "zod";
-import { EngramAccessForbiddenError } from "./access-errors.js";
 import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
 import {
-  assertFleetWideOperationAllowed,
-  assertOperationAllowed,
-  capabilityAllowsOp,
+  assertOperationAuthorizationAllowed,
   tokenCapabilityStore,
 } from "./access-token-capabilities.js";
 import { expandTildePath } from "./utils/path.js";
@@ -423,33 +420,7 @@ export function defineOperation<In, Out>(spec: OperationSpec<In, Out>): BoundOpe
       if (!parseResult.success) {
         throw new EngramAccessInputError(formatZodIssues(parseResult.error));
       }
-      // Per-token capability enforcement (issue #1837): when the presenting
-      // token carries an ops allow-list, reject operations not in it. The
-      // capability record is carried via AsyncLocalStorage, set once per
-      // authorized HTTP/MCP request; absent (CLI/tests/direct callers) ⇒
-      // unrestricted. Default-deny ONLY when an ops axis is present — legacy
-      // tokens (absent record) and explicit-unrestricted new tokens are
-      // unaffected.
-      // When the op declares alternate grant ops, permit any of them (so the
-      // batch/MCP path matches an HTTP transport that relaxes the same op);
-      // otherwise the token must carry the op's own name. Unrestricted/legacy
-      // tokens pass either way (capabilityAllowsOp is true when no ops axis).
-      if (spec.allowedByOps && spec.allowedByOps.length > 0) {
-        const store = tokenCapabilityStore.getStore();
-        if (!spec.allowedByOps.some((op) => capabilityAllowsOp(store, op))) {
-          throw new EngramAccessForbiddenError(`token is not permitted to call operation: ${spec.name}`);
-        }
-      } else {
-        assertOperationAllowed(tokenCapabilityStore.getStore(), spec.name);
-      }
-      // Fleet-wide / global maintenance ops (issue #1850 round 10): these run
-      // across all namespaces with no `namespace` arg, so the tools/call
-      // effective-namespace gate never fires. A namespace-SCOPED token must not
-      // trigger cross-namespace maintenance — fail closed BEFORE the handler so
-      // a denial never leaks a partial mutation. No-op for unrestricted/legacy.
-      if (spec.fleetWide) {
-        assertFleetWideOperationAllowed(tokenCapabilityStore.getStore());
-      }
+      assertOperationAuthorizationAllowed(tokenCapabilityStore.getStore(), spec);
       return spec.handler(parseResult.data, ctx);
     },
   };

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -2978,3 +2978,46 @@ test("HTTP meetings get returns 400 (not 500) for a malformed percent-encoded id
     await server.stop();
   }
 });
+
+test("HTTP authorization probe verifies requested operation grants without invoking operations (issue #2129)", async () => {
+  const service = {
+    configRef: parseConfig({ memoryDir: "/tmp/remnic-http-authorization-probe", defaultNamespace: "default" }),
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authTokenEntriesGetter: () => [
+      {
+        token: "delegate-token",
+        capabilities: { version: 1, ops: ["recall", "observe", "lcm_compaction_flush"] },
+      },
+      { token: "recall-only-token", capabilities: { version: 1, ops: ["recall"] } },
+    ],
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+  const probe = (token: string, operations: string[]) => {
+    const query = new URLSearchParams();
+    for (const operation of operations) query.append("op", operation);
+    return fetch(`http://127.0.0.1:${status.port}/engram/v1/authorization?${query}`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+  };
+  const delegateOperations = ["recall", "observe", "lcm_compaction_flush"];
+  try {
+    const authorized = await probe("delegate-token", delegateOperations);
+    assert.equal(authorized.status, 200);
+    assert.deepEqual(await authorized.json(), { authorized: true, operations: delegateOperations });
+
+    assert.equal(
+      (await probe("recall-only-token", delegateOperations)).status,
+      403,
+      "a token missing any requested operation is rejected without running it",
+    );
+    assert.equal((await probe("wrong-token", delegateOperations)).status, 401);
+    assert.equal((await probe("delegate-token", [])).status, 400);
+    assert.equal((await probe("delegate-token", ["not_an_operation"])).status, 400);
+  } finally {
+    await server.stop();
+  }
+});

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -2992,6 +2992,15 @@ test("HTTP authorization probe verifies requested operation grants without invok
         capabilities: { version: 1, ops: ["recall", "observe", "lcm_compaction_flush"] },
       },
       { token: "recall-only-token", capabilities: { version: 1, ops: ["recall"] } },
+      { token: "observe-only-token", capabilities: { version: 1, ops: ["observe"] } },
+      {
+        token: "fleet-scoped-token",
+        capabilities: {
+          version: 1,
+          ops: ["continuity_audit_generate"],
+          namespaces: ["default"],
+        },
+      },
     ],
     adminConsoleEnabled: false,
   });
@@ -3005,18 +3014,42 @@ test("HTTP authorization probe verifies requested operation grants without invok
   };
   const delegateOperations = ["recall", "observe", "lcm_compaction_flush"];
   try {
-    const authorized = await probe("delegate-token", delegateOperations);
+    const authorized = await probe("delegate-token", [...delegateOperations, "recall"]);
     assert.equal(authorized.status, 200);
+    assert.equal(authorized.headers.get("cache-control"), "no-store");
     assert.deepEqual(await authorized.json(), { authorized: true, operations: delegateOperations });
 
+    const alternateGrant = await probe("observe-only-token", ["namespace_writable"]);
+    assert.equal(alternateGrant.status, 200);
+    await alternateGrant.text();
+
+    const fleetWide = await probe("fleet-scoped-token", ["continuity_audit_generate"]);
+    assert.equal(fleetWide.status, 403);
+    assert.equal(fleetWide.headers.get("cache-control"), "no-store");
+    await fleetWide.text();
+
+    const denied = await probe("recall-only-token", delegateOperations);
     assert.equal(
-      (await probe("recall-only-token", delegateOperations)).status,
+      denied.status,
       403,
       "a token missing any requested operation is rejected without running it",
     );
-    assert.equal((await probe("wrong-token", delegateOperations)).status, 401);
-    assert.equal((await probe("delegate-token", [])).status, 400);
-    assert.equal((await probe("delegate-token", ["not_an_operation"])).status, 400);
+    assert.equal(denied.headers.get("cache-control"), "no-store");
+    await denied.text();
+
+    const wrongToken = await probe("wrong-token", delegateOperations);
+    assert.equal(wrongToken.status, 401);
+    await wrongToken.text();
+
+    const empty = await probe("delegate-token", []);
+    assert.equal(empty.status, 400);
+    assert.equal(empty.headers.get("cache-control"), "no-store");
+    await empty.text();
+
+    const unknown = await probe("delegate-token", ["not_an_operation"]);
+    assert.equal(unknown.status, 400);
+    assert.equal(unknown.headers.get("cache-control"), "no-store");
+    await unknown.text();
   } finally {
     await server.stop();
   }

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -38,6 +38,7 @@ import {
 import { expandTildePath } from "./utils/path.js";
 import { projectTagProjectId } from "./coding/coding-namespace.js";
 import { getOperation, type OperationName } from "./access-boundary.js";
+import { probeOperationAuthorization } from "./access-authorization-probe.js";
 import { resolveQueryNamespaceWritablePreflight } from "./access-namespace-preflight.js";
 import {
   assertOperationAllowed,
@@ -886,6 +887,15 @@ export class EngramAccessHttpServer {
 
     if (req.method === "GET" && pathname === "/engram/v1/health") {
       this.respondJson(res, 200, await this.service.health());
+      return;
+    }
+
+    if (req.method === "GET" && pathname === "/engram/v1/authorization") {
+      this.respondJson(
+        res,
+        200,
+        probeOperationAuthorization(tokenCapabilityStore.getStore(), parsed.searchParams.getAll("op")),
+      );
       return;
     }
 

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -891,6 +891,7 @@ export class EngramAccessHttpServer {
     }
 
     if (req.method === "GET" && pathname === "/engram/v1/authorization") {
+      res.setHeader("cache-control", "no-store");
       this.respondJson(
         res,
         200,

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -493,9 +493,9 @@ test("MCP tools/list matches the catalog exactly (no untracked handlers)", async
  * patterns from the source and compares against HTTP_ROUTES so a new
  * service-invoking route cannot land without a catalog entry.
  *
- * Infrastructure routes (health, admin console, UI assets, MCP delegate) are
- * excluded — they carry no user-validated request envelope. (Adapters was
- * migrated into the catalog in issue #1850 round 5.)
+ * Infrastructure routes (health, auth capability probes, admin console, UI
+ * assets, MCP delegate) are excluded — they do not invoke an access-service
+ * method. (Adapters was migrated into the catalog in issue #1850 round 5.)
  */
 test("HTTP handler source routes match the catalog (static completeness)", () => {
   const httpSource = readFileSync(
@@ -534,6 +534,7 @@ test("HTTP handler source routes match the catalog (static completeness)", () =>
 
   const INFRA = [
     /^\/engram\/v1\/health$/,
+    /^\/engram\/v1\/authorization$/,
     /^\/engram\/v1\/admin\//,
     /^\/engram\/ui/,
     /^\/mcp$/,

--- a/packages/remnic-core/src/access-token-capabilities.ts
+++ b/packages/remnic-core/src/access-token-capabilities.ts
@@ -250,6 +250,37 @@ export function capabilityAllowsOp(caps: TokenCapabilities | undefined | null, o
 }
 
 /**
+ * The operation policy that all access surfaces use to decide whether a token
+ * can invoke an operation.
+ */
+export interface OperationAuthorizationPolicy {
+  readonly name: string;
+  readonly allowedByOps?: readonly string[];
+  readonly fleetWide?: boolean;
+}
+
+/**
+ * Apply an operation's alternate grant and fleet-wide restrictions without
+ * invoking its handler.
+ */
+export function assertOperationAuthorizationAllowed(
+  caps: TokenCapabilities | undefined | null,
+  operation: OperationAuthorizationPolicy,
+): void {
+  if (operation.allowedByOps && operation.allowedByOps.length > 0) {
+    if (!operation.allowedByOps.some((allowedOperation) => capabilityAllowsOp(caps, allowedOperation))) {
+      throw new EngramAccessForbiddenError(`token is not permitted to call operation: ${operation.name}`);
+    }
+  } else {
+    assertOperationAllowed(caps, operation.name);
+  }
+
+  if (operation.fleetWide) {
+    assertFleetWideOperationAllowed(caps);
+  }
+}
+
+/**
  * True when `caps` permits `namespace`.
  *   - record ABSENT / namespaces axis ABSENT ⇒ unrestricted (true).
  *   - namespaces axis PRESENT ⇒ `namespace` must be listed; undefined


### PR DESCRIPTION
Part of #2129.

## Summary
- add an authenticated, side-effect-free capability probe for a requested operation set
- keep health as a liveness-only endpoint
- validate unknown and empty operation requests without invoking the access service

## Verification
- `NODE_OPTIONS="--conditions=remnic-source" pnpm exec tsx --test packages/remnic-core/src/access-http.test.ts packages/remnic-core/src/access-surface-catalog.test.ts`
- `pnpm --filter @remnic/core check-types`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared authorization path used on every operation run and exposes a new authenticated endpoint; behavior is intended to match prior checks, but auth regressions would affect all surfaces.
> 
> **Overview**
> Adds **`GET /engram/v1/authorization`** with repeated `op` query parameters so clients can check whether the bearer token may run a set of operations **without** calling handlers or the access service. Successful responses return `{ authorized: true, operations }` (deduplicated); responses use **`Cache-Control: no-store`**.
> 
> Authorization rules are centralized in **`assertOperationAuthorizationAllowed`**, which applies per-op grants (`allowedByOps`) and **fleet-wide** restrictions. **`defineOperation`** in the access boundary now calls that helper instead of inlined capability checks, so the probe and real invocations share one policy.
> 
> Invalid requests (empty op list, unknown operation names) yield client errors; missing or insufficient grants yield **403** without side effects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23ae37ef65f480dbdaf103999d8b2fd2a613f891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authorization probe endpoint at `GET /engram/v1/authorization`.
  * Clients can validate whether a token permits requested operations without executing them.
  * Responses identify authorized operations and handle duplicate requests.

* **Bug Fixes**
  * Invalid, empty, unsupported, unauthorized, and incorrectly authenticated requests now return appropriate errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->