### PR TITLE
fix(openclaw): forward session namespace in delegate hooks

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -248,12 +248,13 @@ Drain pending LCM observation work for a session before a host compacts its loca
 Request fields:
 - `sessionKey` (string, required) — conversation session identifier
 - `namespace` (string, optional) — target namespace for a single flush
-- `namespaces` (array of strings, optional) — target namespaces for one quota-counted batch flush; each namespace is resolved and authorized independently
+- `namespaces` (array of strings, optional, 1–64 entries, no duplicates) — target namespaces for one quota-counted batch flush; each namespace is resolved and authorized independently. Mutually exclusive with `namespace`; supplying both, or duplicate entries, returns HTTP 400.
 
 Response (HTTP 200):
 
 - Single flush: `enabled`, `flushed`, `sessionKey`, `namespace`, and optional `reason`
 - Batch flush: `enabled`, `flushed`, `sessionKey`, `namespaces`, and `results` entries with `status`, `namespace`, and (for fulfilled entries) `result`
+- A batch flush still returns HTTP 200 when an individual namespace fails or is denied; that namespace appears in `results` with `status: "rejected"`, and `enabled`/`flushed` are `false` for the batch.
 
 #### `POST /engram/v1/lcm/compaction/record`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -246,17 +246,14 @@ Response (HTTP 200):
 Drain pending LCM observation work for a session before a host compacts its local context. Pi uses this from `session_before_compact` so Remnic has the latest turns before the compacted checkpoint is generated.
 
 Request fields:
-
 - `sessionKey` (string, required) — conversation session identifier
-- `namespace` (string, optional) — target namespace
+- `namespace` (string, optional) — target namespace for a single flush
+- `namespaces` (array of strings, optional) — target namespaces for one quota-counted batch flush; each namespace is resolved and authorized independently
 
 Response (HTTP 200):
 
-- `enabled` — whether LCM is enabled
-- `flushed` — whether a flush was performed
-- `sessionKey` — echo of the session key
-- `namespace` — resolved namespace
-- `reason` (optional) — present when LCM is disabled
+- Single flush: `enabled`, `flushed`, `sessionKey`, `namespace`, and optional `reason`
+- Batch flush: `enabled`, `flushed`, `sessionKey`, `namespaces`, and `results` entries with `status`, `namespace`, and (for fulfilled entries) `result`
 
 #### `POST /engram/v1/lcm/compaction/record`
 

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -58,7 +58,10 @@ function recordingApi(): RecordingApi {
 }
 
 async function startDaemonStub(
-  respond: (pathname: string) => Record<string, unknown>,
+  respond: (
+    pathname: string,
+    body: Record<string, unknown>,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>,
 ): Promise<DaemonStub> {
   const calls: RecordedCall[] = [];
   const server = http.createServer((req, res) => {
@@ -75,8 +78,17 @@ async function startDaemonStub(
         // empty/non-JSON bodies stay {}
       }
       calls.push({ pathname, body });
-      res.setHeader("content-type", "application/json");
-      res.end(JSON.stringify(respond(pathname)));
+      void Promise.resolve(respond(pathname, body))
+        .then((response) => {
+          if (res.destroyed) return;
+          res.setHeader("content-type", "application/json");
+          res.end(JSON.stringify(response));
+        })
+        .catch(() => {
+          if (res.destroyed) return;
+          res.statusCode = 500;
+          res.end();
+        });
     });
   });
   const listening = Promise.withResolvers<void>();
@@ -355,6 +367,72 @@ test("delegate flush uses the ended session namespace after a session rebinding"
   }
 });
 
+test("delegate records a matching default scope as a session rebind", async () => {
+  const stub = await startDaemonStub((pathname) =>
+    pathname === "/engram/v1/recall" ? { context: "default daemon context" } : { accepted: true },
+  );
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+    const sessionKey = "default-rebound-session";
+
+    await invoke(
+      api,
+      "agent_end",
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture the named session namespace" },
+          { role: "assistant", content: "the namespace is bound" },
+        ],
+      },
+      { sessionKey, runtime: { agent: { session: { namespace: "team-named" } } } },
+    );
+    const defaultScopeContext = { sessionKey, runtime: { agent: { session: {} } } };
+    await invoke(
+      api,
+      "before_prompt_build",
+      { prompt: "recall from the new default scope" },
+      defaultScopeContext,
+    );
+    await invoke(
+      api,
+      "agent_end",
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture the new default scope" },
+          { role: "assistant", content: "the default binding is explicit" },
+        ],
+      },
+      defaultScopeContext,
+    );
+    await invoke(
+      api,
+      "agent_end",
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture sparse default scope metadata" },
+          { role: "assistant", content: "the default binding remains current" },
+        ],
+      },
+      { sessionKey },
+    );
+
+    const calls = stub.calls.filter((call) =>
+      ["/engram/v1/recall", "/engram/v1/observe"].includes(call.pathname),
+    );
+    assert.equal(calls.length, 4);
+    assert.equal(calls[0].body.namespace, "team-named");
+    for (const call of calls.slice(1)) {
+      assert.equal("namespace" in call.body, false);
+    }
+  } finally {
+    await stub.close();
+  }
+});
+
 test("delegate ignores unkeyed runtime metadata when resolving an ended session namespace", async () => {
   const stub = await startDaemonStub(() => ({ flushed: true }));
   try {
@@ -553,6 +631,48 @@ test("delegate flushes every namespace observed before a session rebind", async 
     }
     await invoke(api, "session_end", { sessionKey });
 
+    const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.deepEqual(
+      flushes.map((call) => call.body.namespace).sort(),
+      ["team-first", "team-second"],
+    );
+  } finally {
+    await stub.close();
+  }
+});
+
+test("delegate flushes rebound namespaces concurrently within one hook deadline", async () => {
+  const pendingFlushes: Array<() => void> = [];
+  const stub = await startDaemonStub((pathname) => {
+    if (pathname !== "/engram/v1/lcm/compaction/flush") return { accepted: true };
+    return new Promise<Record<string, unknown>>((resolve) => {
+      pendingFlushes.push(() => resolve({ flushed: true }));
+      if (pendingFlushes.length === 2) {
+        for (const flush of pendingFlushes) flush();
+      }
+    });
+  });
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port, { flushTimeoutMs: 50 }));
+    const sessionKey = "concurrent-rebound-session";
+
+    for (const namespace of ["team-first", "team-second"]) {
+      await invoke(
+        api,
+        "agent_end",
+        {
+          success: true,
+          messages: [
+            { role: "user", content: `capture the ${namespace} session namespace` },
+            { role: "assistant", content: "the namespace is bound" },
+          ],
+        },
+        { sessionKey, runtime: { agent: { session: { namespace } } } },
+      );
+    }
+
+    assert.equal(await invoke(api, "before_compaction", { sessionKey }), true);
     const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
     assert.deepEqual(
       flushes.map((call) => call.body.namespace).sort(),

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./delegate-runtime.js";
 import { loadDaemonAuth, resolveBridgeMode } from "./bridge.js";
 import {
+  SESSION_NAMESPACE_BINDING_MAX_ENTRIES,
   createFileSessionNamespaceBindingStore,
   createInMemorySessionNamespaceBindingStore,
 } from "@remnic/core/session-namespace-bindings";
@@ -951,6 +952,54 @@ test("delegate revalidates cached negative batch support after expiry", async ()
     await stub.close();
   }
 });
+
+test("delegate revalidates cached positive batch support after expiry", async () => {
+  let now = 0;
+  const stub = await startDaemonStub(
+    () => ({ flushed: true }),
+    {
+      capabilityResponses: [
+        { status: 200, body: { lcmCompactionFlushBatch: true } },
+        { status: 200, body: { lcmCompactionFlushBatch: false } },
+      ],
+    },
+  );
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port, { now: () => now }));
+    const sessionKey = "positive-capability-expiry-session";
+
+    for (const namespace of ["team-first", "team-second"]) {
+      await invoke(
+        api,
+        "agent_end",
+        {
+          success: true,
+          messages: [
+            { role: "user", content: `capture the ${namespace} session namespace` },
+            { role: "assistant", content: "the namespace is bound" },
+          ],
+        },
+        { sessionKey, runtime: { agent: { session: { namespace } } } },
+      );
+    }
+
+    await invoke(api, "before_compaction", { sessionKey });
+    now = Number.POSITIVE_INFINITY;
+    await invoke(api, "before_reset", { sessionKey });
+
+    const capabilityCalls = stub.calls.filter((call) => call.pathname === "/engram/v1/capabilities");
+    assert.equal(capabilityCalls.length, 2);
+    const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.deepEqual(flushes[0]?.body.namespaces, ["team-first", "team-second"]);
+    assert.deepEqual(
+      flushes.slice(1).map((call) => call.body.namespace).sort(),
+      ["team-first", "team-second"],
+    );
+  } finally {
+    await stub.close();
+  }
+});
 test("delegate reprobes batch support after daemon replacement", async () => {
   let replaced = false;
   const stub = await startDaemonStub(
@@ -1363,6 +1412,102 @@ test("delegate restores full canonical history during concurrent explicit legacy
       entries: Record<string, unknown>;
     };
     assert.deepEqual(migratedLegacy.entries, {});
+  } finally {
+    if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
+    else process.env.REMNIC_BRIDGE_MODE = priorMode;
+    if (priorHost === undefined) Reflect.deleteProperty(process.env, "REMNIC_HOST");
+    else process.env.REMNIC_HOST = priorHost;
+    if (priorPort === undefined) Reflect.deleteProperty(process.env, "REMNIC_PORT");
+    else process.env.REMNIC_PORT = priorPort;
+    await rm(memoryDir, { recursive: true, force: true });
+    await stub.close();
+  }
+});
+
+test("delegate bounds completed legacy migration sessions and rechecks evicted keys", async () => {
+  const stub = await startDaemonStub(() => ({ accepted: true }));
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-bindings-"));
+  const priorMode = process.env.REMNIC_BRIDGE_MODE;
+  const priorHost = process.env.REMNIC_HOST;
+  const priorPort = process.env.REMNIC_PORT;
+  const sessionKey = "evicted-legacy-session";
+  const primaryPath = path.join(
+    memoryDir,
+    "state",
+    "plugins",
+    "openclaw-remnic",
+    "session-namespace-bindings.json",
+  );
+  const legacyPath = path.join(
+    memoryDir,
+    "state",
+    "plugins",
+    "openclaw-engram",
+    "session-namespace-bindings.json",
+  );
+  try {
+    process.env.REMNIC_BRIDGE_MODE = "delegate";
+    process.env.REMNIC_HOST = "127.0.0.1";
+    process.env.REMNIC_PORT = String(stub.port);
+    const common = {
+      serviceId: "openclaw-remnic",
+      configBridgeMode: "delegate",
+      passive: false,
+      allowPromptInjection: true,
+      gateHeartbeatTurns: false,
+      recallBudgetChars: 8_000,
+      memoryDir,
+      sessionTogglesEnabled: false,
+      respectBundledActiveMemoryToggle: false,
+      cleanUserMessage: (text: string) => text,
+      hookTimeoutMs: 5_000,
+      shouldSkipRecall: () => false,
+      flushOnResetEnabled: true,
+    };
+    const api = recordingApi();
+    assert.equal(maybeRegisterDelegateRuntime(api, common, { checkHealth: () => true }), true);
+    const observe = async (key: string, namespace: string): Promise<void> => {
+      await invoke(
+        api,
+        "agent_end",
+        {
+          success: true,
+          messages: [
+            { role: "user", content: `capture the ${namespace} session namespace` },
+            { role: "assistant", content: "the namespace is bound" },
+          ],
+        },
+        { sessionKey: key, runtime: { agent: { session: { namespace } } } },
+      );
+    };
+
+    await observe(sessionKey, "team-initial");
+    for (let index = 0; index < SESSION_NAMESPACE_BINDING_MAX_ENTRIES; index += 1) {
+      await observe(`legacy-cache-${index}`, `team-${index}`);
+    }
+
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          [encodeURIComponent(sessionKey)]: {
+            namespaces: ["team-recovered"],
+            updatedAt: new Date().toISOString(),
+          },
+        },
+      }),
+    );
+    await observe(sessionKey, "team-after");
+
+    const persisted = JSON.parse(fs.readFileSync(primaryPath, "utf8")) as {
+      entries: Record<string, { namespaces: string[] }>;
+    };
+    assert.deepEqual(
+      persisted.entries[encodeURIComponent(sessionKey)]?.namespaces,
+      ["team-recovered", "team-after"],
+    );
   } finally {
     if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
     else process.env.REMNIC_BRIDGE_MODE = priorMode;

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -371,6 +371,47 @@ test("delegate ignores unkeyed runtime metadata when resolving an ended session 
   }
 });
 
+test("delegate retains a proven namespace binding for a sparse ended-session flush", async () => {
+  const stub = await startDaemonStub(() => ({ accepted: true }));
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+    const endedContext = {
+      sessionKey: "ended-session",
+      runtime: { agent: { session: { namespace: "team-ended" } } },
+    };
+
+    await invoke(
+      api,
+      "agent_end",
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture the ended session namespace" },
+          { role: "assistant", content: "the namespace is bound" },
+        ],
+      },
+      endedContext,
+    );
+    await invoke(
+      api,
+      "before_reset",
+      { sessionKey: "ended-session" },
+      {
+        sessionKey: "successor-session",
+        runtime: { agent: { session: { namespace: "team-successor" } } },
+      },
+    );
+
+    const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.ok(flush);
+    assert.equal(flush.body.sessionKey, "ended-session");
+    assert.equal(flush.body.namespace, "team-ended");
+  } finally {
+    await stub.close();
+  }
+});
+
 test("delegate passive mode registers no hooks", async () => {
   const api = recordingApi();
   registerDelegateRuntime(api, optionsFor(1, { passive: true }));

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -1557,10 +1557,11 @@ test("delegate preserves legacy bindings while the legacy adapter is active", as
       shouldSkipRecall: () => false,
       flushOnResetEnabled: true,
     };
-    const api = recordingApi();
+    const legacyApi = recordingApi();
+    const canonicalApi = recordingApi();
     assert.equal(
       maybeRegisterDelegateRuntime(
-        api,
+        legacyApi,
         { ...common, serviceId: "openclaw-engram" },
         { checkHealth: () => true },
       ),
@@ -1568,12 +1569,14 @@ test("delegate preserves legacy bindings while the legacy adapter is active", as
     );
     assert.equal(
       maybeRegisterDelegateRuntime(
-        api,
+        canonicalApi,
         { ...common, serviceId: "openclaw-remnic" },
         { checkHealth: () => true },
       ),
       true,
     );
+    assert.equal(legacyApi.handlers.get("agent_end")?.length, 1);
+    assert.equal(canonicalApi.handlers.get("agent_end")?.length, 1);
 
     fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
     fs.writeFileSync(
@@ -1589,9 +1592,7 @@ test("delegate preserves legacy bindings while the legacy adapter is active", as
       }),
     );
 
-    const agentEndHandlers = api.handlers.get("agent_end");
-    assert.equal(agentEndHandlers?.length, 2);
-    const canonicalAgentEnd = agentEndHandlers?.at(-1);
+    const canonicalAgentEnd = canonicalApi.handlers.get("agent_end")?.[0];
     assert.ok(canonicalAgentEnd);
     await canonicalAgentEnd(
       {

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -367,6 +367,35 @@ test("delegate flush uses the ended session namespace after a session rebinding"
   }
 });
 
+test("delegate flush retains an explicit namespace when binding persistence fails", async () => {
+  const stub = await startDaemonStub(() => ({ flushed: true }));
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(
+      api,
+      optionsFor(stub.port, {
+        namespaceBindings: {
+          namespacesFor: async () => [],
+          remember: async () => {
+            throw new Error("binding storage unavailable");
+          },
+        },
+      }),
+    );
+
+    await invoke(api, "session_end", {
+      sessionKey: "persist-failure-session",
+      runtime: { agent: { session: { namespace: "team-explicit" } } },
+    });
+
+    const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.ok(flush);
+    assert.equal(flush.body.namespace, "team-explicit");
+  } finally {
+    await stub.close();
+  }
+});
+
 test("delegate records a matching default scope as a session rebind", async () => {
   const stub = await startDaemonStub((pathname) =>
     pathname === "/engram/v1/recall" ? { context: "default daemon context" } : { accepted: true },

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -164,6 +164,7 @@ test("delegate recall injects daemon context under the memory header", async () 
     assert.ok(recall, "daemon recall route was called");
     assert.equal(recall.body.sessionKey, "session-a");
     assert.equal(recall.body.query, "what did we decide about the rollout?");
+    assert.equal("namespace" in recall.body, false, "default sessions preserve daemon default scope");
   } finally {
     await stub.close();
   }
@@ -271,6 +272,78 @@ test("delegate flush fires on compaction, reset, and session end", async () => {
       ["s1", "s2", "s3"],
       "each lifecycle boundary flushes its own session",
     );
+  } finally {
+    await stub.close();
+  }
+});
+
+test("delegate forwards the hook session namespace to recall, observe, and flush", async () => {
+  const stub = await startDaemonStub((pathname) =>
+    pathname === "/engram/v1/recall" ? { context: "scoped daemon context" } : { accepted: true },
+  );
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+    const ctx = {
+      sessionKey: "scoped-session",
+      runtime: { agent: { session: { namespace: "team-alpha" } } },
+    };
+
+    await invoke(api, "before_prompt_build", { prompt: "recall scoped memory" }, ctx);
+    await invoke(
+      api,
+      "agent_end",
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture scoped memory" },
+          { role: "assistant", content: "scoped answer" },
+        ],
+      },
+      ctx,
+    );
+    await invoke(api, "before_compaction", {}, ctx);
+
+    const calls = stub.calls.filter((call) =>
+      [
+        "/engram/v1/recall",
+        "/engram/v1/observe",
+        "/engram/v1/lcm/compaction/flush",
+      ].includes(call.pathname),
+    );
+    assert.equal(calls.length, 3);
+    assert.deepEqual(
+      calls.map((call) => call.body.namespace),
+      ["team-alpha", "team-alpha", "team-alpha"],
+    );
+  } finally {
+    await stub.close();
+  }
+});
+
+test("delegate flush uses the ended session namespace after a session rebinding", async () => {
+  const stub = await startDaemonStub(() => ({ flushed: true }));
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+
+    await invoke(
+      api,
+      "before_reset",
+      {
+        sessionKey: "ended-session",
+        runtime: { agent: { session: { namespace: "team-ended" } } },
+      },
+      {
+        sessionKey: "successor-session",
+        runtime: { agent: { session: { namespace: "team-successor" } } },
+      },
+    );
+
+    const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.ok(flush);
+    assert.equal(flush.body.sessionKey, "ended-session");
+    assert.equal(flush.body.namespace, "team-ended");
   } finally {
     await stub.close();
   }

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -412,6 +412,82 @@ test("delegate retains a proven namespace binding for a sparse ended-session flu
   }
 });
 
+test("delegate retains a namespace binding after a failed ended-session flush", async () => {
+  const stub = await startDaemonStub(() => ({ accepted: true }));
+  const unavailable = await startDaemonStub(() => ({ accepted: true }));
+  const unavailablePort = unavailable.port;
+  await unavailable.close();
+  try {
+    const api = recordingApi();
+    const options = optionsFor(stub.port);
+    registerDelegateRuntime(api, options);
+    const endedContext = {
+      sessionKey: "retry-session",
+      runtime: { agent: { session: { namespace: "team-retry" } } },
+    };
+
+    await invoke(
+      api,
+      "agent_end",
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture the retry session namespace" },
+          { role: "assistant", content: "the namespace is bound" },
+        ],
+      },
+      endedContext,
+    );
+    options.target.port = unavailablePort;
+    await invoke(api, "before_reset", { sessionKey: "retry-session" });
+    options.target.port = stub.port;
+    await invoke(api, "session_end", { sessionKey: "retry-session" });
+
+    const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.ok(flush);
+    assert.equal(flush.body.sessionKey, "retry-session");
+    assert.equal(flush.body.namespace, "team-retry");
+  } finally {
+    await stub.close();
+  }
+});
+
+test("delegate retains a namespace binding across runtime re-registration", async () => {
+  const stub = await startDaemonStub(() => ({ accepted: true }));
+  try {
+    const originalApi = recordingApi();
+    registerDelegateRuntime(originalApi, optionsFor(stub.port));
+    const endedContext = {
+      sessionKey: "reload-session",
+      runtime: { agent: { session: { namespace: "team-reload" } } },
+    };
+
+    await invoke(
+      originalApi,
+      "agent_end",
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture the reload session namespace" },
+          { role: "assistant", content: "the namespace is bound" },
+        ],
+      },
+      endedContext,
+    );
+
+    const reloadedApi = recordingApi();
+    registerDelegateRuntime(reloadedApi, optionsFor(stub.port));
+    await invoke(reloadedApi, "session_end", { sessionKey: "reload-session" });
+
+    const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.ok(flush);
+    assert.equal(flush.body.sessionKey, "reload-session");
+    assert.equal(flush.body.namespace, "team-reload");
+  } finally {
+    await stub.close();
+  }
+});
+
 test("delegate passive mode registers no hooks", async () => {
   const api = recordingApi();
   registerDelegateRuntime(api, optionsFor(1, { passive: true }));

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -1073,7 +1073,7 @@ test("delegate ignores a corrupt legacy binding file when canonical scope is ava
   }
 });
 
-test("delegate restores full canonical history during legacy migration", async () => {
+test("delegate restores full canonical history during explicit legacy migration", async () => {
   const stub = await startDaemonStub(() => ({ flushed: true }));
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-bindings-"));
   const priorMode = process.env.REMNIC_BRIDGE_MODE;
@@ -1082,7 +1082,7 @@ test("delegate restores full canonical history during legacy migration", async (
   const sessionKey = "legacy-recency-session";
   const current = Array.from({ length: 40 }, (_unused, index) => `team-current-${index}`);
   const legacy = Array.from({ length: 40 }, (_unused, index) => `team-legacy-${index}`);
-  const expected = [...legacy.slice(-24), ...current];
+  const expected = [...legacy.slice(-23), ...current, "team-explicit"];
   try {
     const primaryPath = path.join(
       memoryDir,
@@ -1147,6 +1147,18 @@ test("delegate restores full canonical history during legacy migration", async (
       true,
     );
 
+    await invoke(
+      api,
+      "agent_end",
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture the explicit migration namespace" },
+          { role: "assistant", content: "the explicit namespace is bound" },
+        ],
+      },
+      { sessionKey, runtime: { agent: { session: { namespace: "team-explicit" } } } },
+    );
     await invoke(api, "session_end", { sessionKey });
     const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
     assert.ok(flush);

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -64,6 +64,7 @@ async function startDaemonStub(
   ) => Record<string, unknown> | Promise<Record<string, unknown>>,
   options: {
     batchFlush?: boolean;
+    batchResponse?: boolean;
     capabilityResponses?: Array<{ status: number; body: Record<string, unknown> }>;
   } = {},
 ): Promise<DaemonStub> {
@@ -94,10 +95,29 @@ async function startDaemonStub(
             ? Promise.resolve({ status: 200, body: { lcmCompactionFlushBatch: true } })
             : Promise.resolve()
                 .then(() => respond(pathname, body))
-                .then((response) => ({
-                  status: 200,
-                  body: response,
-                }));
+                .then((response) => {
+                  const requestedNamespaces = Array.isArray(body.namespaces)
+                    ? body.namespaces
+                    : undefined;
+                  if (requestedNamespaces === undefined || options.batchResponse === false) {
+                    return { status: 200, body: response };
+                  }
+                  return {
+                    status: 200,
+                    body: {
+                      ...response,
+                      enabled: response.enabled ?? true,
+                      flushed: response.flushed ?? true,
+                      sessionKey: body.sessionKey,
+                      namespaces: requestedNamespaces,
+                      results: requestedNamespaces.map((namespace) => ({
+                        status: "fulfilled",
+                        namespace,
+                        result: response,
+                      })),
+                    },
+                  };
+                });
       void responsePromise
         .then(({ status, body: response }) => {
           if (res.destroyed) return;
@@ -820,12 +840,12 @@ test("delegate falls back to singular flushes when batch capability is unavailab
   }
 });
 
-test("delegate retries a transient batch capability probe", async () => {
+test("delegate retries a transient or malformed batch capability probe", async () => {
   const stub = await startDaemonStub(
     () => ({ flushed: true }),
     {
       capabilityResponses: [
-        { status: 503, body: {} },
+        { status: 200, body: {} },
         { status: 200, body: { lcmCompactionFlushBatch: true } },
       ],
     },
@@ -861,6 +881,75 @@ test("delegate retries a transient batch capability probe", async () => {
       ["team-first", "team-second"],
     );
     assert.deepEqual(flushes.at(-1)?.body.namespaces, ["team-first", "team-second"]);
+  } finally {
+    await stub.close();
+  }
+});
+test("delegate reprobes batch support after daemon replacement", async () => {
+  let replaced = false;
+  const stub = await startDaemonStub(
+    (_pathname, body) => {
+      const requestedNamespaces = Array.isArray(body.namespaces) ? body.namespaces : undefined;
+      if (requestedNamespaces !== undefined && !replaced) {
+        replaced = true;
+        return {
+          enabled: true,
+          flushed: true,
+          sessionKey: body.sessionKey,
+          namespaces: requestedNamespaces,
+          results: requestedNamespaces.map((namespace) => ({
+            status: "fulfilled",
+            namespace,
+            result: { enabled: true, flushed: true },
+          })),
+        };
+      }
+      return { flushed: true };
+    },
+    {
+      batchResponse: false,
+      capabilityResponses: [
+        { status: 200, body: { lcmCompactionFlushBatch: true } },
+        { status: 200, body: { lcmCompactionFlushBatch: false } },
+      ],
+    },
+  );
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+    const sessionKey = "replaced-daemon-session";
+
+    for (const namespace of ["team-first", "team-second"]) {
+      await invoke(
+        api,
+        "agent_end",
+        {
+          success: true,
+          messages: [
+            { role: "user", content: `capture the ${namespace} session namespace` },
+            { role: "assistant", content: "the namespace is bound" },
+          ],
+        },
+        { sessionKey, runtime: { agent: { session: { namespace } } } },
+      );
+    }
+
+    await invoke(api, "before_compaction", { sessionKey });
+    await invoke(api, "before_reset", { sessionKey });
+    await invoke(api, "session_end", { sessionKey });
+
+    const capabilityCalls = stub.calls.filter((call) => call.pathname === "/engram/v1/capabilities");
+    assert.equal(capabilityCalls.length, 2);
+    const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.deepEqual(flushes[0]?.body.namespaces, ["team-first", "team-second"]);
+    assert.deepEqual(
+      flushes
+        .filter((call) => !("namespaces" in call.body))
+        .slice(-2)
+        .map((call) => call.body.namespace)
+        .sort(),
+      ["team-first", "team-second"],
+    );
   } finally {
     await stub.close();
   }
@@ -1167,6 +1256,10 @@ test("delegate restores full canonical history during explicit legacy migration"
       entries: Record<string, { namespaces: string[] }>;
     };
     assert.deepEqual(persisted.entries[encodeURIComponent(sessionKey)].namespaces, expected);
+    const migratedLegacy = JSON.parse(fs.readFileSync(legacyPath, "utf8")) as {
+      entries: Record<string, unknown>;
+    };
+    assert.deepEqual(migratedLegacy.entries, {});
   } finally {
     if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
     else process.env.REMNIC_BRIDGE_MODE = priorMode;

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -762,6 +762,7 @@ test("delegate flushes rebound namespaces concurrently within one hook deadline"
       ["team-first", "team-second"],
     );
   } finally {
+    for (const flush of pendingFlushes.splice(0)) flush();
     await stub.close();
   }
 });

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -1070,7 +1070,7 @@ test("delegate reprobes batch support after daemon replacement", async () => {
   }
 });
 
-test("delegate invalidates cached batch support after a failed batch flush", async () => {
+test("delegate falls back to singular flushes after a failed batch request", async () => {
   let batchAttempts = 0;
   const stub = await startDaemonStub((pathname) => {
     if (pathname === "/engram/v1/lcm/compaction/flush" && batchAttempts++ === 0) {
@@ -1098,16 +1098,20 @@ test("delegate invalidates cached batch support after a failed batch flush", asy
       );
     }
 
-    assert.equal(await invoke(api, "before_compaction", { sessionKey }), false);
-    await invoke(api, "before_reset", { sessionKey });
+    assert.equal(await invoke(api, "before_compaction", { sessionKey }), true);
+    assert.equal(await invoke(api, "before_reset", { sessionKey }), true);
     assert.equal(
       stub.calls.filter((call) => call.pathname === "/engram/v1/capabilities").length,
       2,
     );
     const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
-    assert.equal(flushes.length, 2);
+    assert.equal(flushes.length, 4);
     assert.deepEqual(flushes[0]?.body.namespaces, ["team-first", "team-second"]);
-    assert.deepEqual(flushes[1]?.body.namespaces, ["team-first", "team-second"]);
+    assert.deepEqual(
+      flushes.slice(1, 3).map((call) => call.body.namespace).sort(),
+      ["team-first", "team-second"],
+    );
+    assert.deepEqual(flushes[3]?.body.namespaces, ["team-first", "team-second"]);
   } finally {
     await stub.close();
   }
@@ -1601,11 +1605,52 @@ test("delegate preserves legacy bindings while the legacy adapter is active", as
     );
 
     const persistedLegacy = JSON.parse(fs.readFileSync(legacyPath, "utf8")) as {
-      entries: Record<string, { namespaces: string[] }>;
+      entries: Record<string, { namespaces: string[]; updatedAt: string }>;
     };
     assert.deepEqual(
       persistedLegacy.entries[encodeURIComponent(sessionKey)]?.namespaces,
       ["team-legacy"],
+    );
+
+    const lateSessionKey = "late-legacy-adapter-session";
+    await canonicalAgentEnd(
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture the first late canonical namespace" },
+          { role: "assistant", content: "the first late namespace is bound" },
+        ],
+      },
+      { sessionKey: lateSessionKey, runtime: { agent: { session: { namespace: "team-canonical-first" } } } },
+    );
+    persistedLegacy.entries[encodeURIComponent(lateSessionKey)] = {
+      namespaces: ["team-legacy-late"],
+      updatedAt: new Date().toISOString(),
+    };
+    fs.writeFileSync(legacyPath, JSON.stringify(persistedLegacy));
+    await canonicalAgentEnd(
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture the second late canonical namespace" },
+          { role: "assistant", content: "the second late namespace is bound" },
+        ],
+      },
+      { sessionKey: lateSessionKey, runtime: { agent: { session: { namespace: "team-canonical-second" } } } },
+    );
+    const canonicalPath = path.join(
+      memoryDir,
+      "state",
+      "plugins",
+      "openclaw-remnic",
+      "session-namespace-bindings.json",
+    );
+    const persistedCanonical = JSON.parse(fs.readFileSync(canonicalPath, "utf8")) as {
+      entries: Record<string, { namespaces: string[] }>;
+    };
+    assert.deepEqual(
+      persistedCanonical.entries[encodeURIComponent(lateSessionKey)]?.namespaces,
+      ["team-legacy-late", "team-canonical-first", "team-canonical-second"],
     );
   } finally {
     if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -1073,15 +1073,16 @@ test("delegate ignores a corrupt legacy binding file when canonical scope is ava
   }
 });
 
-test("delegate keeps the canonical current namespace last during legacy history merge", async () => {
+test("delegate restores full canonical history during legacy migration", async () => {
   const stub = await startDaemonStub(() => ({ flushed: true }));
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-bindings-"));
   const priorMode = process.env.REMNIC_BRIDGE_MODE;
   const priorHost = process.env.REMNIC_HOST;
   const priorPort = process.env.REMNIC_PORT;
   const sessionKey = "legacy-recency-session";
-  const current = Array.from({ length: 64 }, (_unused, index) => `team-current-${index}`);
-  const legacy = Array.from({ length: 64 }, (_unused, index) => `team-legacy-${index}`);
+  const current = Array.from({ length: 40 }, (_unused, index) => `team-current-${index}`);
+  const legacy = Array.from({ length: 40 }, (_unused, index) => `team-legacy-${index}`);
+  const expected = [...legacy.slice(-24), ...current];
   try {
     const primaryPath = path.join(
       memoryDir,
@@ -1149,11 +1150,11 @@ test("delegate keeps the canonical current namespace last during legacy history 
     await invoke(api, "session_end", { sessionKey });
     const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
     assert.ok(flush);
-    assert.deepEqual(flush.body.namespaces, current);
+    assert.deepEqual(flush.body.namespaces, expected);
     const persisted = JSON.parse(fs.readFileSync(primaryPath, "utf8")) as {
       entries: Record<string, { namespaces: string[] }>;
     };
-    assert.equal(persisted.entries[encodeURIComponent(sessionKey)].namespaces.at(-1), "team-current-63");
+    assert.deepEqual(persisted.entries[encodeURIComponent(sessionKey)].namespaces, expected);
   } finally {
     if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
     else process.env.REMNIC_BRIDGE_MODE = priorMode;

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -1520,6 +1520,104 @@ test("delegate bounds completed legacy migration sessions and rechecks evicted k
   }
 });
 
+
+test("delegate preserves legacy bindings while the legacy adapter is active", async () => {
+  const stub = await startDaemonStub(() => ({ accepted: true }));
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-bindings-"));
+  const priorMode = process.env.REMNIC_BRIDGE_MODE;
+  const priorHost = process.env.REMNIC_HOST;
+  const priorPort = process.env.REMNIC_PORT;
+  const sessionKey = "active-legacy-adapter-session";
+  const legacyPath = path.join(
+    memoryDir,
+    "state",
+    "plugins",
+    "openclaw-engram",
+    "session-namespace-bindings.json",
+  );
+  try {
+    process.env.REMNIC_BRIDGE_MODE = "delegate";
+    process.env.REMNIC_HOST = "127.0.0.1";
+    process.env.REMNIC_PORT = String(stub.port);
+    const common = {
+      configBridgeMode: "delegate",
+      passive: false,
+      allowPromptInjection: true,
+      gateHeartbeatTurns: false,
+      recallBudgetChars: 8_000,
+      memoryDir,
+      sessionTogglesEnabled: false,
+      respectBundledActiveMemoryToggle: false,
+      cleanUserMessage: (text: string) => text,
+      hookTimeoutMs: 5_000,
+      shouldSkipRecall: () => false,
+      flushOnResetEnabled: true,
+    };
+    const api = recordingApi();
+    assert.equal(
+      maybeRegisterDelegateRuntime(
+        api,
+        { ...common, serviceId: "openclaw-engram" },
+        { checkHealth: () => true },
+      ),
+      true,
+    );
+    assert.equal(
+      maybeRegisterDelegateRuntime(
+        api,
+        { ...common, serviceId: "openclaw-remnic" },
+        { checkHealth: () => true },
+      ),
+      true,
+    );
+
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          [encodeURIComponent(sessionKey)]: {
+            namespaces: ["team-legacy"],
+            updatedAt: new Date().toISOString(),
+          },
+        },
+      }),
+    );
+
+    const agentEndHandlers = api.handlers.get("agent_end");
+    assert.equal(agentEndHandlers?.length, 2);
+    const canonicalAgentEnd = agentEndHandlers?.at(-1);
+    assert.ok(canonicalAgentEnd);
+    await canonicalAgentEnd(
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture the canonical session namespace" },
+          { role: "assistant", content: "the namespace is bound" },
+        ],
+      },
+      { sessionKey, runtime: { agent: { session: { namespace: "team-canonical" } } } },
+    );
+
+    const persistedLegacy = JSON.parse(fs.readFileSync(legacyPath, "utf8")) as {
+      entries: Record<string, { namespaces: string[] }>;
+    };
+    assert.deepEqual(
+      persistedLegacy.entries[encodeURIComponent(sessionKey)]?.namespaces,
+      ["team-legacy"],
+    );
+  } finally {
+    if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
+    else process.env.REMNIC_BRIDGE_MODE = priorMode;
+    if (priorHost === undefined) Reflect.deleteProperty(process.env, "REMNIC_HOST");
+    else process.env.REMNIC_HOST = priorHost;
+    if (priorPort === undefined) Reflect.deleteProperty(process.env, "REMNIC_PORT");
+    else process.env.REMNIC_PORT = priorPort;
+    await rm(memoryDir, { recursive: true, force: true });
+    await stub.close();
+  }
+});
 test("delegate passive mode registers no hooks", async () => {
   const api = recordingApi();
   registerDelegateRuntime(api, optionsFor(1, { passive: true }));

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -1210,7 +1210,7 @@ test("delegate ignores a corrupt legacy binding file when canonical scope is ava
   }
 });
 
-test("delegate restores full canonical history during explicit legacy migration", async () => {
+test("delegate restores full canonical history during concurrent explicit legacy migration", async () => {
   const stub = await startDaemonStub(() => ({ flushed: true }));
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-bindings-"));
   const priorMode = process.env.REMNIC_BRIDGE_MODE;
@@ -1261,9 +1261,32 @@ test("delegate restores full canonical history during explicit legacy migration"
     process.env.REMNIC_HOST = "127.0.0.1";
     process.env.REMNIC_PORT = String(stub.port);
     const api = recordingApi();
+    const secondApi = recordingApi();
     assert.equal(
       maybeRegisterDelegateRuntime(
         api,
+        {
+          serviceId: "openclaw-remnic",
+          configBridgeMode: "delegate",
+          passive: false,
+          allowPromptInjection: true,
+          gateHeartbeatTurns: false,
+          recallBudgetChars: 8_000,
+          memoryDir,
+          sessionTogglesEnabled: false,
+          respectBundledActiveMemoryToggle: false,
+          cleanUserMessage: (text: string) => text,
+          hookTimeoutMs: 5_000,
+          shouldSkipRecall: () => false,
+          flushOnResetEnabled: true,
+        },
+        { checkHealth: () => true },
+      ),
+      true,
+    );
+    assert.equal(
+      maybeRegisterDelegateRuntime(
+        secondApi,
         {
           serviceId: "openclaw-remnic",
           configBridgeMode: "delegate",
@@ -1298,7 +1321,7 @@ test("delegate restores full canonical history during explicit legacy migration"
         { sessionKey, runtime: { agent: { session: { namespace: "team-explicit" } } } },
       ),
       invoke(
-        api,
+        secondApi,
         "agent_end",
         {
           success: true,

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -62,6 +62,7 @@ async function startDaemonStub(
     pathname: string,
     body: Record<string, unknown>,
   ) => Record<string, unknown> | Promise<Record<string, unknown>>,
+  options: { batchFlush?: boolean } = {},
 ): Promise<DaemonStub> {
   const calls: RecordedCall[] = [];
   const server = http.createServer((req, res) => {
@@ -78,7 +79,11 @@ async function startDaemonStub(
         // empty/non-JSON bodies stay {}
       }
       calls.push({ pathname, body });
-      void Promise.resolve(respond(pathname, body))
+      const responsePromise =
+        pathname === "/engram/v1/capabilities" && options.batchFlush !== false
+          ? Promise.resolve({ lcmCompactionFlushBatch: true })
+          : Promise.resolve(respond(pathname, body));
+      void responsePromise
         .then((response) => {
           if (res.destroyed) return;
           res.setHeader("content-type", "application/json");
@@ -761,6 +766,40 @@ test("delegate batches rebound namespace flushes within one hook deadline", asyn
     assert.deepEqual(flushes[0]?.body.namespaces, ["team-first", "team-second"]);
   } finally {
     for (const flush of pendingFlushes.splice(0)) flush();
+    await stub.close();
+  }
+});
+
+test("delegate falls back to singular flushes when batch capability is unavailable", async () => {
+  const stub = await startDaemonStub(() => ({ flushed: true }), { batchFlush: false });
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+    const sessionKey = "legacy-rebound-session";
+
+    for (const namespace of ["team-first", "team-second"]) {
+      await invoke(
+        api,
+        "agent_end",
+        {
+          success: true,
+          messages: [
+            { role: "user", content: `capture the ${namespace} session namespace` },
+            { role: "assistant", content: "the namespace is bound" },
+          ],
+        },
+        { sessionKey, runtime: { agent: { session: { namespace } } } },
+      );
+    }
+    await invoke(api, "session_end", { sessionKey });
+
+    const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.deepEqual(
+      flushes.map((call) => call.body.namespace),
+      ["team-first", "team-second"],
+    );
+    assert.equal(flushes.every((call) => !("namespaces" in call.body)), true);
+  } finally {
     await stub.close();
   }
 });

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -885,6 +885,54 @@ test("delegate retries a transient or malformed batch capability probe", async (
     await stub.close();
   }
 });
+
+test("delegate revalidates cached negative batch support after expiry", async () => {
+  let now = 0;
+  const stub = await startDaemonStub(
+    () => ({ flushed: true }),
+    {
+      capabilityResponses: [
+        { status: 200, body: { lcmCompactionFlushBatch: false } },
+        { status: 200, body: { lcmCompactionFlushBatch: true } },
+      ],
+    },
+  );
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port, { now: () => now }));
+    const sessionKey = "negative-capability-expiry-session";
+
+    for (const namespace of ["team-first", "team-second"]) {
+      await invoke(
+        api,
+        "agent_end",
+        {
+          success: true,
+          messages: [
+            { role: "user", content: `capture the ${namespace} session namespace` },
+            { role: "assistant", content: "the namespace is bound" },
+          ],
+        },
+        { sessionKey, runtime: { agent: { session: { namespace } } } },
+      );
+    }
+
+    await invoke(api, "before_compaction", { sessionKey });
+    now = Number.POSITIVE_INFINITY;
+    await invoke(api, "before_reset", { sessionKey });
+
+    const capabilityCalls = stub.calls.filter((call) => call.pathname === "/engram/v1/capabilities");
+    assert.equal(capabilityCalls.length, 2);
+    const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.deepEqual(
+      flushes.slice(0, 2).map((call) => call.body.namespace).sort(),
+      ["team-first", "team-second"],
+    );
+    assert.deepEqual(flushes.at(-1)?.body.namespaces, ["team-first", "team-second"]);
+  } finally {
+    await stub.close();
+  }
+});
 test("delegate reprobes batch support after daemon replacement", async () => {
   let replaced = false;
   const stub = await startDaemonStub(

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -62,9 +62,13 @@ async function startDaemonStub(
     pathname: string,
     body: Record<string, unknown>,
   ) => Record<string, unknown> | Promise<Record<string, unknown>>,
-  options: { batchFlush?: boolean } = {},
+  options: {
+    batchFlush?: boolean;
+    capabilityResponses?: Array<{ status: number; body: Record<string, unknown> }>;
+  } = {},
 ): Promise<DaemonStub> {
   const calls: RecordedCall[] = [];
+  let capabilityResponseIndex = 0;
   const server = http.createServer((req, res) => {
     let raw = "";
     req.on("data", (chunk: Buffer) => {
@@ -79,13 +83,23 @@ async function startDaemonStub(
         // empty/non-JSON bodies stay {}
       }
       calls.push({ pathname, body });
+      const capabilityResponse =
+        pathname === "/engram/v1/capabilities"
+          ? options.capabilityResponses?.[capabilityResponseIndex++]
+          : undefined;
       const responsePromise =
-        pathname === "/engram/v1/capabilities" && options.batchFlush !== false
-          ? Promise.resolve({ lcmCompactionFlushBatch: true })
-          : Promise.resolve(respond(pathname, body));
+        pathname === "/engram/v1/capabilities" && capabilityResponse !== undefined
+          ? Promise.resolve(capabilityResponse)
+          : pathname === "/engram/v1/capabilities" && options.batchFlush !== false
+            ? Promise.resolve({ status: 200, body: { lcmCompactionFlushBatch: true } })
+            : Promise.resolve(respond(pathname, body)).then((response) => ({
+                status: 200,
+                body: response,
+              }));
       void responsePromise
-        .then((response) => {
+        .then(({ status, body: response }) => {
           if (res.destroyed) return;
+          res.statusCode = status;
           res.setHeader("content-type", "application/json");
           res.end(JSON.stringify(response));
         })
@@ -804,6 +818,52 @@ test("delegate falls back to singular flushes when batch capability is unavailab
   }
 });
 
+test("delegate retries a transient batch capability probe", async () => {
+  const stub = await startDaemonStub(
+    () => ({ flushed: true }),
+    {
+      capabilityResponses: [
+        { status: 503, body: {} },
+        { status: 200, body: { lcmCompactionFlushBatch: true } },
+      ],
+    },
+  );
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+    const sessionKey = "transient-capability-session";
+
+    for (const namespace of ["team-first", "team-second"]) {
+      await invoke(
+        api,
+        "agent_end",
+        {
+          success: true,
+          messages: [
+            { role: "user", content: `capture the ${namespace} session namespace` },
+            { role: "assistant", content: "the namespace is bound" },
+          ],
+        },
+        { sessionKey, runtime: { agent: { session: { namespace } } } },
+      );
+    }
+
+    await invoke(api, "before_compaction", { sessionKey });
+    await invoke(api, "before_reset", { sessionKey });
+
+    const capabilityCalls = stub.calls.filter((call) => call.pathname === "/engram/v1/capabilities");
+    assert.equal(capabilityCalls.length, 2);
+    const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.deepEqual(
+      flushes.slice(0, 2).map((call) => call.body.namespace).sort(),
+      ["team-first", "team-second"],
+    );
+    assert.deepEqual(flushes.at(-1)?.body.namespaces, ["team-first", "team-second"]);
+  } finally {
+    await stub.close();
+  }
+});
+
 
 test("delegate reloads a persisted namespace binding after its daemon host configuration changes", async () => {
   const stub = await startDaemonStub(() => ({ accepted: true }));
@@ -947,6 +1007,15 @@ test("delegate ignores a corrupt legacy binding file when canonical scope is ava
     const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
     assert.ok(flush);
     assert.equal(flush.body.namespace, "team-canonical");
+    const flushCount = stub.calls.filter(
+      (call) => call.pathname === "/engram/v1/lcm/compaction/flush",
+    ).length;
+    fs.rmSync(primaryPath);
+    await invoke(api, "before_reset", { sessionKey: "missing-canonical-session" });
+    assert.equal(
+      stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush").length,
+      flushCount,
+    );
   } finally {
     if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
     else process.env.REMNIC_BRIDGE_MODE = priorMode;

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import http from "node:http";
@@ -14,6 +15,10 @@ import {
   type MaybeRegisterDelegateDeps,
 } from "./delegate-runtime.js";
 import { loadDaemonAuth, resolveBridgeMode } from "./bridge.js";
+import {
+  createFileSessionNamespaceBindingStore,
+  createInMemorySessionNamespaceBindingStore,
+} from "@remnic/core/session-namespace-bindings";
 
 type HookHandler = (
   event: Record<string, unknown>,
@@ -111,6 +116,7 @@ function optionsFor(port: number, overrides: Partial<DelegateRuntimeOptions> = {
       }),
     },
     namespace: "",
+    namespaceBindings: createInMemorySessionNamespaceBindingStore(),
     allowPromptInjection: true,
     passive: false,
     gateHeartbeatTurns: false,
@@ -455,8 +461,9 @@ test("delegate retains a namespace binding after a failed ended-session flush", 
 test("delegate retains a namespace binding across runtime re-registration", async () => {
   const stub = await startDaemonStub(() => ({ accepted: true }));
   try {
+    const namespaceBindings = createInMemorySessionNamespaceBindingStore();
     const originalApi = recordingApi();
-    registerDelegateRuntime(originalApi, optionsFor(stub.port));
+    registerDelegateRuntime(originalApi, optionsFor(stub.port, { namespaceBindings }));
     const endedContext = {
       sessionKey: "reload-session",
       runtime: { agent: { session: { namespace: "team-reload" } } },
@@ -476,7 +483,7 @@ test("delegate retains a namespace binding across runtime re-registration", asyn
     );
 
     const reloadedApi = recordingApi();
-    registerDelegateRuntime(reloadedApi, optionsFor(stub.port));
+    registerDelegateRuntime(reloadedApi, optionsFor(stub.port, { namespaceBindings }));
     await invoke(reloadedApi, "session_end", { sessionKey: "reload-session" });
 
     const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
@@ -484,6 +491,147 @@ test("delegate retains a namespace binding across runtime re-registration", asyn
     assert.equal(flush.body.sessionKey, "reload-session");
     assert.equal(flush.body.namespace, "team-reload");
   } finally {
+    await stub.close();
+  }
+});
+
+test("delegate replays ended-session flushes in the remembered namespace", async () => {
+  const stub = await startDaemonStub(() => ({ accepted: true }));
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+    const endedContext = {
+      sessionKey: "replayed-session",
+      runtime: { agent: { session: { namespace: "team-replayed" } } },
+    };
+
+    await invoke(
+      api,
+      "agent_end",
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture the replayed session namespace" },
+          { role: "assistant", content: "the namespace is bound" },
+        ],
+      },
+      endedContext,
+    );
+    await invoke(api, "before_reset", { sessionKey: "replayed-session" });
+    await invoke(api, "session_end", { sessionKey: "replayed-session" });
+
+    const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.deepEqual(
+      flushes.map((call) => call.body.namespace),
+      ["team-replayed", "team-replayed"],
+    );
+  } finally {
+    await stub.close();
+  }
+});
+
+test("delegate flushes every namespace observed before a session rebind", async () => {
+  const stub = await startDaemonStub(() => ({ accepted: true }));
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+    const sessionKey = "rebound-session";
+
+    for (const namespace of ["team-first", "team-second"]) {
+      await invoke(
+        api,
+        "agent_end",
+        {
+          success: true,
+          messages: [
+            { role: "user", content: `capture the ${namespace} session namespace` },
+            { role: "assistant", content: "the namespace is bound" },
+          ],
+        },
+        { sessionKey, runtime: { agent: { session: { namespace } } } },
+      );
+    }
+    await invoke(api, "session_end", { sessionKey });
+
+    const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.deepEqual(
+      flushes.map((call) => call.body.namespace).sort(),
+      ["team-first", "team-second"],
+    );
+  } finally {
+    await stub.close();
+  }
+});
+
+test("delegate reloads a persisted namespace binding after its daemon host configuration changes", async () => {
+  const stub = await startDaemonStub(() => ({ accepted: true }));
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-bindings-"));
+  const priorMode = process.env.REMNIC_BRIDGE_MODE;
+  const priorHost = process.env.REMNIC_HOST;
+  const priorPort = process.env.REMNIC_PORT;
+  try {
+    process.env.REMNIC_BRIDGE_MODE = "delegate";
+    process.env.REMNIC_HOST = "127.0.0.1";
+    process.env.REMNIC_PORT = String(stub.port);
+    const common = {
+      serviceId: "persistent-delegate",
+      configBridgeMode: "delegate",
+      passive: false,
+      allowPromptInjection: true,
+      gateHeartbeatTurns: false,
+      recallBudgetChars: 8_000,
+      memoryDir,
+      sessionTogglesEnabled: false,
+      respectBundledActiveMemoryToggle: false,
+      cleanUserMessage: (text: string) => text,
+      hookTimeoutMs: 5_000,
+      shouldSkipRecall: () => false,
+      flushOnResetEnabled: true,
+    };
+    const firstApi = recordingApi();
+    assert.equal(maybeRegisterDelegateRuntime(firstApi, common, { checkHealth: () => true }), true);
+    await invoke(
+      firstApi,
+      "agent_end",
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "capture the persisted namespace binding" },
+          { role: "assistant", content: "the namespace is bound" },
+        ],
+      },
+      {
+        sessionKey: "persisted-session",
+        runtime: { agent: { session: { namespace: "team-persisted" } } },
+      },
+    );
+    const persistedBindings = createFileSessionNamespaceBindingStore(
+      path.join(
+        memoryDir,
+        "state",
+        "plugins",
+        "persistent-delegate",
+        "session-namespace-bindings.json",
+      ),
+    );
+    assert.deepEqual(await persistedBindings.namespacesFor("persisted-session"), ["team-persisted"]);
+
+    process.env.REMNIC_HOST = "localhost";
+    const reloadedApi = recordingApi();
+    assert.equal(maybeRegisterDelegateRuntime(reloadedApi, common, { checkHealth: () => true }), true);
+    await invoke(reloadedApi, "session_end", { sessionKey: "persisted-session" });
+
+    const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.ok(flush);
+    assert.equal(flush.body.namespace, "team-persisted");
+  } finally {
+    if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
+    else process.env.REMNIC_BRIDGE_MODE = priorMode;
+    if (priorHost === undefined) Reflect.deleteProperty(process.env, "REMNIC_HOST");
+    else process.env.REMNIC_HOST = priorHost;
+    if (priorPort === undefined) Reflect.deleteProperty(process.env, "REMNIC_PORT");
+    else process.env.REMNIC_PORT = priorPort;
+    await rm(memoryDir, { recursive: true, force: true });
     await stub.close();
   }
 });

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -484,6 +484,27 @@ test("delegate ignores unkeyed runtime metadata when resolving an ended session 
   }
 });
 
+test("delegate rejects malformed lifecycle session keys without ambient fallback", async () => {
+  const stub = await startDaemonStub(() => ({ flushed: true }));
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+    const ctx = {
+      sessionKey: "successor-session",
+      runtime: { agent: { session: { namespace: "team-successor" } } },
+    };
+
+    for (const hook of ["before_reset", "session_end"]) {
+      for (const sessionKey of [42, null, {}, ""]) {
+        await invoke(api, hook, { sessionKey }, ctx);
+      }
+    }
+    assert.equal(stub.calls.length, 0);
+  } finally {
+    await stub.close();
+  }
+});
+
 test("delegate rejects malformed namespace metadata without defaulting", async () => {
   const stub = await startDaemonStub(() => ({ accepted: true }));
   try {

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -61,7 +61,7 @@ async function startDaemonStub(
   respond: (
     pathname: string,
     body: Record<string, unknown>,
-  ) => Record<string, unknown> | Promise<Record<string, unknown>>,
+  ) => Record<string, unknown> | Promise<Record<string, unknown> | null> | null,
   options: {
     batchFlush?: boolean;
     batchResponse?: boolean;
@@ -102,6 +102,7 @@ async function startDaemonStub(
                   if (requestedNamespaces === undefined || options.batchResponse === false) {
                     return { status: 200, body: response };
                   }
+                  if (response === null) return { status: 200, body: null };
                   return {
                     status: 200,
                     body: {
@@ -330,6 +331,23 @@ test("delegate flush fires on compaction, reset, and session end", async () => {
       flushes.map((call) => call.body.sessionKey),
       ["s1", "s2", "s3"],
       "each lifecycle boundary flushes its own session",
+    );
+  } finally {
+    await stub.close();
+  }
+});
+
+test("delegate fails closed when a singular flush response is null", async () => {
+  const stub = await startDaemonStub((pathname) =>
+    pathname === "/engram/v1/lcm/compaction/flush" ? null : { accepted: true },
+  );
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+
+    assert.equal(
+      await invoke(api, "before_compaction", {}, { sessionKey: "null-flush-session" }),
+      false,
     );
   } finally {
     await stub.close();

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -349,6 +349,28 @@ test("delegate flush uses the ended session namespace after a session rebinding"
   }
 });
 
+test("delegate ignores unkeyed runtime metadata when resolving an ended session namespace", async () => {
+  const stub = await startDaemonStub(() => ({ flushed: true }));
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+
+    await invoke(
+      api,
+      "before_reset",
+      { sessionKey: "ended-session" },
+      { runtime: { agent: { session: { namespace: "team-successor" } } } },
+    );
+
+    const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.ok(flush);
+    assert.equal(flush.body.sessionKey, "ended-session");
+    assert.equal("namespace" in flush.body, false);
+  } finally {
+    await stub.close();
+  }
+});
+
 test("delegate passive mode registers no hooks", async () => {
   const api = recordingApi();
   registerDelegateRuntime(api, optionsFor(1, { passive: true }));

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -367,7 +367,7 @@ test("delegate flush uses the ended session namespace after a session rebinding"
   }
 });
 
-test("delegate flush retains an explicit namespace when binding persistence fails", async () => {
+test("delegate fails closed when binding persistence fails", async () => {
   const stub = await startDaemonStub(() => ({ flushed: true }));
   try {
     const api = recordingApi();
@@ -388,9 +388,11 @@ test("delegate flush retains an explicit namespace when binding persistence fail
       runtime: { agent: { session: { namespace: "team-explicit" } } },
     });
 
-    const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
-    assert.ok(flush);
-    assert.equal(flush.body.namespace, "team-explicit");
+    assert.equal(
+      stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush").length,
+      0,
+      "an explicit namespace must not be sent when its binding cannot be retained",
+    );
   } finally {
     await stub.close();
   }

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -795,7 +795,7 @@ test("delegate falls back to singular flushes when batch capability is unavailab
 
     const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
     assert.deepEqual(
-      flushes.map((call) => call.body.namespace),
+      flushes.map((call) => call.body.namespace).sort(),
       ["team-first", "team-second"],
     );
     assert.equal(flushes.every((call) => !("namespaces" in call.body)), true);
@@ -865,6 +865,87 @@ test("delegate reloads a persisted namespace binding after its daemon host confi
     const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
     assert.ok(flush);
     assert.equal(flush.body.namespace, "team-persisted");
+  } finally {
+    if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
+    else process.env.REMNIC_BRIDGE_MODE = priorMode;
+    if (priorHost === undefined) Reflect.deleteProperty(process.env, "REMNIC_HOST");
+    else process.env.REMNIC_HOST = priorHost;
+    if (priorPort === undefined) Reflect.deleteProperty(process.env, "REMNIC_PORT");
+    else process.env.REMNIC_PORT = priorPort;
+    await rm(memoryDir, { recursive: true, force: true });
+    await stub.close();
+  }
+});
+
+test("delegate ignores a corrupt legacy binding file when canonical scope is available", async () => {
+  const stub = await startDaemonStub(() => ({ flushed: true }));
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-bindings-"));
+  const priorMode = process.env.REMNIC_BRIDGE_MODE;
+  const priorHost = process.env.REMNIC_HOST;
+  const priorPort = process.env.REMNIC_PORT;
+  const sessionKey = "corrupt-legacy-session";
+  try {
+    const primaryPath = path.join(
+      memoryDir,
+      "state",
+      "plugins",
+      "openclaw-remnic",
+      "session-namespace-bindings.json",
+    );
+    const legacyPath = path.join(
+      memoryDir,
+      "state",
+      "plugins",
+      "openclaw-engram",
+      "session-namespace-bindings.json",
+    );
+    fs.mkdirSync(path.dirname(primaryPath), { recursive: true });
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(
+      primaryPath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          [encodeURIComponent(sessionKey)]: {
+            namespaces: ["team-canonical"],
+            updatedAt: new Date().toISOString(),
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(legacyPath, "{ malformed legacy binding");
+
+    process.env.REMNIC_BRIDGE_MODE = "delegate";
+    process.env.REMNIC_HOST = "127.0.0.1";
+    process.env.REMNIC_PORT = String(stub.port);
+    const api = recordingApi();
+    assert.equal(
+      maybeRegisterDelegateRuntime(
+        api,
+        {
+          serviceId: "openclaw-remnic",
+          configBridgeMode: "delegate",
+          passive: false,
+          allowPromptInjection: true,
+          gateHeartbeatTurns: false,
+          recallBudgetChars: 8_000,
+          memoryDir,
+          sessionTogglesEnabled: false,
+          respectBundledActiveMemoryToggle: false,
+          cleanUserMessage: (text: string) => text,
+          hookTimeoutMs: 5_000,
+          shouldSkipRecall: () => false,
+          flushOnResetEnabled: true,
+        },
+        { checkHealth: () => true },
+      ),
+      true,
+    );
+
+    await invoke(api, "session_end", { sessionKey });
+    const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.ok(flush);
+    assert.equal(flush.body.namespace, "team-canonical");
   } finally {
     if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
     else process.env.REMNIC_BRIDGE_MODE = priorMode;

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -804,6 +804,7 @@ test("delegate falls back to singular flushes when batch capability is unavailab
   }
 });
 
+
 test("delegate reloads a persisted namespace binding after its daemon host configuration changes", async () => {
   const stub = await startDaemonStub(() => ({ accepted: true }));
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-bindings-"));
@@ -946,6 +947,99 @@ test("delegate ignores a corrupt legacy binding file when canonical scope is ava
     const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
     assert.ok(flush);
     assert.equal(flush.body.namespace, "team-canonical");
+  } finally {
+    if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
+    else process.env.REMNIC_BRIDGE_MODE = priorMode;
+    if (priorHost === undefined) Reflect.deleteProperty(process.env, "REMNIC_HOST");
+    else process.env.REMNIC_HOST = priorHost;
+    if (priorPort === undefined) Reflect.deleteProperty(process.env, "REMNIC_PORT");
+    else process.env.REMNIC_PORT = priorPort;
+    await rm(memoryDir, { recursive: true, force: true });
+    await stub.close();
+  }
+});
+
+test("delegate keeps the canonical current namespace last during legacy history merge", async () => {
+  const stub = await startDaemonStub(() => ({ flushed: true }));
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-bindings-"));
+  const priorMode = process.env.REMNIC_BRIDGE_MODE;
+  const priorHost = process.env.REMNIC_HOST;
+  const priorPort = process.env.REMNIC_PORT;
+  const sessionKey = "legacy-recency-session";
+  const current = Array.from({ length: 64 }, (_unused, index) => `team-current-${index}`);
+  const legacy = Array.from({ length: 64 }, (_unused, index) => `team-legacy-${index}`);
+  try {
+    const primaryPath = path.join(
+      memoryDir,
+      "state",
+      "plugins",
+      "openclaw-remnic",
+      "session-namespace-bindings.json",
+    );
+    const legacyPath = path.join(
+      memoryDir,
+      "state",
+      "plugins",
+      "openclaw-engram",
+      "session-namespace-bindings.json",
+    );
+    fs.mkdirSync(path.dirname(primaryPath), { recursive: true });
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    const updatedAt = new Date().toISOString();
+    fs.writeFileSync(
+      primaryPath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          [encodeURIComponent(sessionKey)]: { namespaces: current, updatedAt },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          [encodeURIComponent(sessionKey)]: { namespaces: legacy, updatedAt },
+        },
+      }),
+    );
+
+    process.env.REMNIC_BRIDGE_MODE = "delegate";
+    process.env.REMNIC_HOST = "127.0.0.1";
+    process.env.REMNIC_PORT = String(stub.port);
+    const api = recordingApi();
+    assert.equal(
+      maybeRegisterDelegateRuntime(
+        api,
+        {
+          serviceId: "openclaw-remnic",
+          configBridgeMode: "delegate",
+          passive: false,
+          allowPromptInjection: true,
+          gateHeartbeatTurns: false,
+          recallBudgetChars: 8_000,
+          memoryDir,
+          sessionTogglesEnabled: false,
+          respectBundledActiveMemoryToggle: false,
+          cleanUserMessage: (text: string) => text,
+          hookTimeoutMs: 5_000,
+          shouldSkipRecall: () => false,
+          flushOnResetEnabled: true,
+        },
+        { checkHealth: () => true },
+      ),
+      true,
+    );
+
+    await invoke(api, "session_end", { sessionKey });
+    const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.ok(flush);
+    assert.deepEqual(flush.body.namespaces, current);
+    const persisted = JSON.parse(fs.readFileSync(primaryPath, "utf8")) as {
+      entries: Record<string, { namespaces: string[] }>;
+    };
+    assert.equal(persisted.entries[encodeURIComponent(sessionKey)].namespaces.at(-1), "team-current-63");
   } finally {
     if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
     else process.env.REMNIC_BRIDGE_MODE = priorMode;

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -1171,7 +1171,7 @@ test("delegate restores full canonical history during explicit legacy migration"
   const sessionKey = "legacy-recency-session";
   const current = Array.from({ length: 40 }, (_unused, index) => `team-current-${index}`);
   const legacy = Array.from({ length: 40 }, (_unused, index) => `team-legacy-${index}`);
-  const expected = [...legacy.slice(-23), ...current, "team-explicit"];
+  const expected = [...legacy.slice(-22), ...current, "team-explicit", "team-explicit-second"];
   try {
     const primaryPath = path.join(
       memoryDir,
@@ -1236,18 +1236,32 @@ test("delegate restores full canonical history during explicit legacy migration"
       true,
     );
 
-    await invoke(
-      api,
-      "agent_end",
-      {
-        success: true,
-        messages: [
-          { role: "user", content: "capture the explicit migration namespace" },
-          { role: "assistant", content: "the explicit namespace is bound" },
-        ],
-      },
-      { sessionKey, runtime: { agent: { session: { namespace: "team-explicit" } } } },
-    );
+    await Promise.all([
+      invoke(
+        api,
+        "agent_end",
+        {
+          success: true,
+          messages: [
+            { role: "user", content: "capture the explicit migration namespace" },
+            { role: "assistant", content: "the explicit namespace is bound" },
+          ],
+        },
+        { sessionKey, runtime: { agent: { session: { namespace: "team-explicit" } } } },
+      ),
+      invoke(
+        api,
+        "agent_end",
+        {
+          success: true,
+          messages: [
+            { role: "user", content: "capture the second migration namespace" },
+            { role: "assistant", content: "the second namespace is bound" },
+          ],
+        },
+        { sessionKey, runtime: { agent: { session: { namespace: "team-explicit-second" } } } },
+      ),
+    ]);
     await invoke(api, "session_end", { sessionKey });
     const flush = stub.calls.find((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
     assert.ok(flush);

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -715,22 +715,20 @@ test("delegate flushes every namespace observed before a session rebind", async 
     await invoke(api, "session_end", { sessionKey });
 
     const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
-    assert.deepEqual(
-      flushes.map((call) => call.body.namespace).sort(),
-      ["team-first", "team-second"],
-    );
+    assert.equal(flushes.length, 1);
+    assert.deepEqual(flushes[0]?.body.namespaces, ["team-first", "team-second"]);
   } finally {
     await stub.close();
   }
 });
 
-test("delegate flushes rebound namespaces concurrently within one hook deadline", async () => {
+test("delegate batches rebound namespace flushes within one hook deadline", async () => {
   const pendingFlushes: Array<() => void> = [];
   const stub = await startDaemonStub((pathname) => {
     if (pathname !== "/engram/v1/lcm/compaction/flush") return { accepted: true };
     return new Promise<Record<string, unknown>>((resolve) => {
       pendingFlushes.push(() => resolve({ flushed: true }));
-      if (pendingFlushes.length === 2) {
+      if (pendingFlushes.length === 1) {
         for (const flush of pendingFlushes) flush();
       }
     });
@@ -757,10 +755,8 @@ test("delegate flushes rebound namespaces concurrently within one hook deadline"
 
     assert.equal(await invoke(api, "before_compaction", { sessionKey }), true);
     const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
-    assert.deepEqual(
-      flushes.map((call) => call.body.namespace).sort(),
-      ["team-first", "team-second"],
-    );
+    assert.equal(flushes.length, 1);
+    assert.deepEqual(flushes[0]?.body.namespaces, ["team-first", "team-second"]);
   } finally {
     for (const flush of pendingFlushes.splice(0)) flush();
     await stub.close();

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -92,10 +92,12 @@ async function startDaemonStub(
           ? Promise.resolve(capabilityResponse)
           : pathname === "/engram/v1/capabilities" && options.batchFlush !== false
             ? Promise.resolve({ status: 200, body: { lcmCompactionFlushBatch: true } })
-            : Promise.resolve(respond(pathname, body)).then((response) => ({
-                status: 200,
-                body: response,
-              }));
+            : Promise.resolve()
+                .then(() => respond(pathname, body))
+                .then((response) => ({
+                  status: 200,
+                  body: response,
+                }));
       void responsePromise
         .then(({ status, body: response }) => {
           if (res.destroyed) return;
@@ -859,6 +861,49 @@ test("delegate retries a transient batch capability probe", async () => {
       ["team-first", "team-second"],
     );
     assert.deepEqual(flushes.at(-1)?.body.namespaces, ["team-first", "team-second"]);
+  } finally {
+    await stub.close();
+  }
+});
+
+test("delegate invalidates cached batch support after a failed batch flush", async () => {
+  let batchAttempts = 0;
+  const stub = await startDaemonStub((pathname) => {
+    if (pathname === "/engram/v1/lcm/compaction/flush" && batchAttempts++ === 0) {
+      throw new Error("transient batch failure");
+    }
+    return { flushed: true };
+  });
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+    const sessionKey = "failed-batch-session";
+
+    for (const namespace of ["team-first", "team-second"]) {
+      await invoke(
+        api,
+        "agent_end",
+        {
+          success: true,
+          messages: [
+            { role: "user", content: `capture the ${namespace} session namespace` },
+            { role: "assistant", content: "the namespace is bound" },
+          ],
+        },
+        { sessionKey, runtime: { agent: { session: { namespace } } } },
+      );
+    }
+
+    assert.equal(await invoke(api, "before_compaction", { sessionKey }), false);
+    await invoke(api, "before_reset", { sessionKey });
+    assert.equal(
+      stub.calls.filter((call) => call.pathname === "/engram/v1/capabilities").length,
+      2,
+    );
+    const flushes = stub.calls.filter((call) => call.pathname === "/engram/v1/lcm/compaction/flush");
+    assert.equal(flushes.length, 2);
+    assert.deepEqual(flushes[0]?.body.namespaces, ["team-first", "team-second"]);
+    assert.deepEqual(flushes[1]?.body.namespaces, ["team-first", "team-second"]);
   } finally {
     await stub.close();
   }

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -484,6 +484,39 @@ test("delegate ignores unkeyed runtime metadata when resolving an ended session 
   }
 });
 
+test("delegate rejects malformed namespace metadata without defaulting", async () => {
+  const stub = await startDaemonStub(() => ({ accepted: true }));
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port));
+    const ctx = {
+      sessionKey: "malformed-session",
+      runtime: { agent: { session: { namespace: 42 } } },
+    };
+
+    assert.equal(await invoke(api, "before_prompt_build", { prompt: "recall malformed scope" }, ctx), undefined);
+    assert.equal(
+      await invoke(
+        api,
+        "agent_end",
+        {
+          success: true,
+          messages: [
+            { role: "user", content: "capture malformed scope metadata" },
+            { role: "assistant", content: "do not route this turn" },
+          ],
+        },
+        ctx,
+      ),
+      undefined,
+    );
+    assert.equal(await invoke(api, "before_compaction", {}, ctx), false);
+    assert.equal(stub.calls.length, 0);
+  } finally {
+    await stub.close();
+  }
+});
+
 test("delegate retains a proven namespace binding for a sparse ended-session flush", async () => {
   const stub = await startDaemonStub(() => ({ accepted: true }));
   try {

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -27,16 +27,18 @@ import {
 } from "@remnic/core";
 import { log } from "@remnic/core/logger";
 import {
-  type SessionNamespaceBindingStore,
+  SESSION_NAMESPACE_BINDING_MAX_ENTRIES,
   SESSION_NAMESPACE_BINDING_MAX_NAMESPACES,
+  SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH,
+  type SessionNamespaceBindingStore,
   createFileSessionNamespaceBindingStore,
 } from "@remnic/core/session-namespace-bindings";
 import { createFileToggleStore } from "@remnic/core/session-toggles";
 import {
+  type DaemonAuthToken,
   checkDaemonHealthSync,
   loadDaemonAuth,
   resolveBridgeMode,
-  type DaemonAuthToken,
 } from "./bridge.js";
 import {
   REMNIC_OPENCLAW_LEGACY_PLUGIN_ID,
@@ -105,10 +107,8 @@ export interface DelegateHookApi {
   // builder parameter is a wider SDK union — remains assignable.
   registerMemoryPromptSection?(builder: (params: { sessionKey?: string }) => string[] | null): void;
 }
-
 const MEMORY_CONTEXT_HEADER = "## Memory Context (Remnic)";
-const DELEGATE_NAMESPACE_MAX_LENGTH = 256;
-const DELEGATE_BATCH_FLUSH_NEGATIVE_CACHE_TTL_MS = 30_000;
+const DELEGATE_BATCH_FLUSH_CACHE_TTL_MS = 30_000;
 
 const DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS = [
   "recall",
@@ -352,9 +352,9 @@ async function rememberNamespace(
   namespace: string,
   namespaceBindings: SessionNamespaceBindingStore,
 ): Promise<void> {
-  if (namespace.length > DELEGATE_NAMESPACE_MAX_LENGTH) {
+  if (namespace.length > SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH) {
     throw new Error(
-      `delegate session namespace exceeds the daemon limit of ${DELEGATE_NAMESPACE_MAX_LENGTH} characters`,
+      `delegate session namespace exceeds the daemon limit of ${SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH} characters`,
     );
   }
   try {
@@ -621,13 +621,11 @@ export function registerDelegateRuntime(
   };
   const cacheBatchFlushSupport = (supported: boolean): void => {
     cachedBatchFlushSupport = supported;
-    cachedBatchFlushSupportExpiresAt = supported
-      ? Number.POSITIVE_INFINITY
-      : now() + DELEGATE_BATCH_FLUSH_NEGATIVE_CACHE_TTL_MS;
+    cachedBatchFlushSupportExpiresAt = now() + DELEGATE_BATCH_FLUSH_CACHE_TTL_MS;
   };
   const supportsBatchFlush = (timeoutMs: number): Promise<boolean> => {
     if (cachedBatchFlushSupport !== undefined) {
-      if (cachedBatchFlushSupport || now() < cachedBatchFlushSupportExpiresAt) {
+      if (now() < cachedBatchFlushSupportExpiresAt) {
         return Promise.resolve(cachedBatchFlushSupport);
       }
       invalidateCachedBatchFlushSupport();
@@ -850,6 +848,15 @@ function createDelegateNamespaceBindingStore(
     bindingPath(REMNIC_OPENCLAW_LEGACY_PLUGIN_ID),
   );
   const migratedLegacySessions = new Set<string>();
+  const rememberMigratedLegacySession = (sessionKey: string): void => {
+    if (migratedLegacySessions.has(sessionKey)) return;
+    migratedLegacySessions.add(sessionKey);
+    while (migratedLegacySessions.size > SESSION_NAMESPACE_BINDING_MAX_ENTRIES) {
+      const oldest = migratedLegacySessions.values().next().value;
+      if (oldest === undefined) return;
+      migratedLegacySessions.delete(oldest);
+    }
+  };
   const queueSessionMigration = <T>(
     sessionKey: string,
     operation: () => Promise<T>,
@@ -861,7 +868,7 @@ function createDelegateNamespaceBindingStore(
     if (migratedLegacySessions.has(sessionKey)) return [];
     try {
       const previous = await legacy.namespacesFor(sessionKey);
-      if (previous.length === 0) migratedLegacySessions.add(sessionKey);
+      if (previous.length === 0) rememberMigratedLegacySession(sessionKey);
       return previous;
     } catch (err) {
       if (current.length > 0) {
@@ -901,7 +908,7 @@ function createDelegateNamespaceBindingStore(
     } catch (err) {
       log.warn(`[${serviceId}] delegate legacy namespace cleanup failed: ${String(err)}`);
     }
-    migratedLegacySessions.add(sessionKey);
+    rememberMigratedLegacySession(sessionKey);
   };
   return {
     async namespacesFor(sessionKey: string): Promise<string[]> {

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -201,6 +201,16 @@ function sessionKeyFrom(
   return "default";
 }
 
+function lifecycleSessionKeyFrom(
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>,
+): string {
+  const fromEvent = event?.sessionKey;
+  return typeof fromEvent === "string" && fromEvent.length > 0
+    ? fromEvent
+    : sessionKeyFrom(event, ctx);
+}
+
 function recallQueryFrom(event: Record<string, unknown>): string {
   // Mirrors the embedded recall hook: prefer event.prompt, but when it is
   // missing or shorter than 5 chars, scan event.messages backward for the most
@@ -248,6 +258,7 @@ function sessionNamespaceFrom(
   event: Record<string, unknown>,
   ctx: Record<string, unknown>,
   fallback: string,
+  boundNamespaces: Map<string, string>,
 ): string | undefined {
   const eventSessionKey = typeof event.sessionKey === "string" ? event.sessionKey : undefined;
   const ctxSessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : undefined;
@@ -267,11 +278,16 @@ function sessionNamespaceFrom(
     const session = (agent as Record<string, unknown>).session;
     if (typeof session !== "object" || session === null) continue;
     const namespace = (session as Record<string, unknown>).namespace;
-    if (typeof namespace === "string" && namespace.trim().length > 0) {
-      return namespace.trim();
+    if (typeof namespace !== "string") continue;
+    const resolved = namespace.trim();
+    if (resolved) {
+      boundNamespaces.set(sessionKey, resolved);
+      return resolved;
     }
+    boundNamespaces.delete(sessionKey);
+    return fallback.trim() || undefined;
   }
-  return fallback.trim() || undefined;
+  return boundNamespaces.get(sessionKey) ?? (fallback.trim() || undefined);
 }
 
 function readContextComposition(
@@ -312,6 +328,7 @@ export function registerDelegateRuntime(
     );
     return;
   }
+  const boundNamespaces = new Map<string, string>();
 
   // Embedded zero-limit contract: recallBudgetChars === 0 disables injection.
   if (options.allowPromptInjection && options.recallBudgetChars !== 0) {
@@ -350,7 +367,7 @@ export function registerDelegateRuntime(
           target,
           options.serviceId,
           "/engram/v1/recall",
-          withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace), {
+          withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace, boundNamespaces), {
             query,
             sessionKey,
             mode: "auto",
@@ -454,7 +471,7 @@ export function registerDelegateRuntime(
         target,
         options.serviceId,
         "/engram/v1/observe",
-        withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace), {
+        withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace, boundNamespaces), {
           sessionKey,
           messages: turn,
           ...(cwd ? { cwd } : {}),
@@ -471,19 +488,13 @@ export function registerDelegateRuntime(
     event: Record<string, unknown>,
     ctx: Record<string, unknown>,
   ): Promise<void> => {
-    // Embedded parity: lifecycle events name the ENDED/RESET session on the
-    // event; the ambient ctx may already point at the successor session.
-    const fromEvent = event?.sessionKey;
-    const sessionKey =
-      typeof fromEvent === "string" && fromEvent.length > 0
-        ? fromEvent
-        : sessionKeyFrom(event, ctx);
+    const sessionKey = lifecycleSessionKeyFrom(event, ctx);
     try {
       await postJson(
         target,
         options.serviceId,
         "/engram/v1/lcm/compaction/flush",
-        withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace), { sessionKey }),
+        withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace, boundNamespaces), { sessionKey }),
         options.flushTimeoutMs,
       );
     } catch (err) {
@@ -492,8 +503,16 @@ export function registerDelegateRuntime(
   };
   api.on("before_compaction", flushHandler);
   if (options.flushOnResetEnabled) {
-    api.on("before_reset", flushHandler);
-    api.on("session_end", flushHandler);
+    const flushEndedSession = async (
+      event: Record<string, unknown>,
+      ctx: Record<string, unknown>,
+    ): Promise<void> => {
+      const sessionKey = lifecycleSessionKeyFrom(event, ctx);
+      await flushHandler(event, ctx);
+      boundNamespaces.delete(sessionKey);
+    };
+    api.on("before_reset", flushEndedSession);
+    api.on("session_end", flushEndedSession);
   }
 
   log.info(

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -26,6 +26,10 @@ import {
   renderMemoryContextPrompt,
 } from "@remnic/core";
 import { log } from "@remnic/core/logger";
+import {
+  type SessionNamespaceBindingStore,
+  createFileSessionNamespaceBindingStore,
+} from "@remnic/core/session-namespace-bindings";
 import { createFileToggleStore } from "@remnic/core/session-toggles";
 import {
   checkDaemonHealthSync,
@@ -49,6 +53,8 @@ export interface DelegateRuntimeOptions {
   target: DelegateDaemonTarget;
   /** Session namespace forwarded on every daemon call ("" = daemon default). */
   namespace: string;
+  /** Durable, per-session routing history for sparse lifecycle hooks. */
+  namespaceBindings: SessionNamespaceBindingStore;
   /** Mirrors the embedded `hooks.allowPromptInjection` policy. */
   allowPromptInjection: boolean;
   /** Passive slot mode: register nothing, exactly like embedded passive mode
@@ -253,29 +259,10 @@ function withNamespace(
   return namespace ? { ...body, namespace } : body;
 }
 
-const namespaceBindingsByDaemonScope = new Map<string, Map<string, string>>();
-
-function namespaceBindingsFor(
-  serviceId: string,
-  target: DelegateDaemonTarget,
-  fallbackNamespace: string,
-): Map<string, string> {
-  const scope = JSON.stringify([serviceId, target.host, target.port, fallbackNamespace.trim()]);
-  let bindings = namespaceBindingsByDaemonScope.get(scope);
-  if (!bindings) {
-    bindings = new Map<string, string>();
-    namespaceBindingsByDaemonScope.set(scope, bindings);
-  }
-  return bindings;
-}
-
-
-function sessionNamespaceFrom(
+function explicitSessionNamespaceFrom(
   sessionKey: string,
   event: Record<string, unknown>,
   ctx: Record<string, unknown>,
-  fallback: string,
-  boundNamespaces: Map<string, string>,
 ): string | undefined {
   const eventSessionKey = typeof event.sessionKey === "string" ? event.sessionKey : undefined;
   const ctxSessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : undefined;
@@ -295,16 +282,63 @@ function sessionNamespaceFrom(
     const session = (agent as Record<string, unknown>).session;
     if (typeof session !== "object" || session === null) continue;
     const namespace = (session as Record<string, unknown>).namespace;
-    if (typeof namespace !== "string") continue;
-    const resolved = namespace.trim();
-    if (resolved) {
-      boundNamespaces.set(sessionKey, resolved);
-      return resolved;
-    }
-    boundNamespaces.delete(sessionKey);
-    return fallback.trim() || undefined;
+    if (typeof namespace === "string") return namespace.trim();
   }
-  return boundNamespaces.get(sessionKey) ?? (fallback.trim() || undefined);
+  return undefined;
+}
+
+async function rememberedNamespacesFor(
+  sessionKey: string,
+  namespaceBindings: SessionNamespaceBindingStore,
+): Promise<string[]> {
+  try {
+    return await namespaceBindings.namespacesFor(sessionKey);
+  } catch (err) {
+    log.warn(`delegate namespace binding lookup failed: ${String(err)}`);
+    return [];
+  }
+}
+
+async function rememberNamespace(
+  sessionKey: string,
+  namespace: string,
+  namespaceBindings: SessionNamespaceBindingStore,
+): Promise<void> {
+  try {
+    await namespaceBindings.remember(sessionKey, namespace);
+  } catch (err) {
+    log.warn(`delegate namespace binding persistence failed: ${String(err)}`);
+  }
+}
+
+async function sessionNamespaceFrom(
+  sessionKey: string,
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>,
+  fallback: string,
+  namespaceBindings: SessionNamespaceBindingStore,
+): Promise<string | undefined> {
+  const explicit = explicitSessionNamespaceFrom(sessionKey, event, ctx);
+  if (explicit !== undefined) {
+    await rememberNamespace(sessionKey, explicit, namespaceBindings);
+    return explicit || undefined;
+  }
+  const remembered = await rememberedNamespacesFor(sessionKey, namespaceBindings);
+  return remembered.at(-1) || fallback.trim() || undefined;
+}
+
+async function lifecycleSessionNamespacesFrom(
+  sessionKey: string,
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>,
+  fallback: string,
+  namespaceBindings: SessionNamespaceBindingStore,
+): Promise<Array<string | undefined>> {
+  const explicit = explicitSessionNamespaceFrom(sessionKey, event, ctx);
+  if (explicit !== undefined) await rememberNamespace(sessionKey, explicit, namespaceBindings);
+  const remembered = await rememberedNamespacesFor(sessionKey, namespaceBindings);
+  if (remembered.length > 0) return remembered.map((namespace) => namespace || undefined);
+  return [fallback.trim() || undefined];
 }
 
 function readContextComposition(
@@ -338,14 +372,13 @@ export function registerDelegateRuntime(
   api: DelegateHookApi,
   options: DelegateRuntimeOptions,
 ): void {
-  const { target, namespace } = options;
+  const { target, namespace, namespaceBindings } = options;
   if (options.passive) {
     log.info(
       `[${options.serviceId}] bridge mode delegate: memory slot not owned — passive, no hooks registered`,
     );
     return;
   }
-  const boundNamespaces = namespaceBindingsFor(options.serviceId, target, namespace);
 
   // Embedded zero-limit contract: recallBudgetChars === 0 disables injection.
   if (options.allowPromptInjection && options.recallBudgetChars !== 0) {
@@ -380,11 +413,18 @@ export function registerDelegateRuntime(
           return undefined;
         }
         const cwd = cwdFrom(event, ctx, options.cwd);
+        const scopedNamespace = await sessionNamespaceFrom(
+          sessionKey,
+          event,
+          ctx,
+          namespace,
+          namespaceBindings,
+        );
         const response = await postJson(
           target,
           options.serviceId,
           "/engram/v1/recall",
-          withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace, boundNamespaces), {
+          withNamespace(scopedNamespace, {
             query,
             sessionKey,
             mode: "auto",
@@ -484,11 +524,18 @@ export function registerDelegateRuntime(
     if (turn.length === 0) return;
     try {
       const cwd = cwdFrom(event, ctx, options.cwd);
+      const scopedNamespace = await sessionNamespaceFrom(
+        sessionKey,
+        event,
+        ctx,
+        namespace,
+        namespaceBindings,
+      );
       await postJson(
         target,
         options.serviceId,
         "/engram/v1/observe",
-        withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace, boundNamespaces), {
+        withNamespace(scopedNamespace, {
           sessionKey,
           messages: turn,
           ...(cwd ? { cwd } : {}),
@@ -507,18 +554,34 @@ export function registerDelegateRuntime(
   ): Promise<boolean> => {
     const sessionKey = lifecycleSessionKeyFrom(event, ctx);
     try {
-      await postJson(
-        target,
-        options.serviceId,
-        "/engram/v1/lcm/compaction/flush",
-        withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace, boundNamespaces), { sessionKey }),
-        options.flushTimeoutMs,
+      const namespaces = await lifecycleSessionNamespacesFrom(
+        sessionKey,
+        event,
+        ctx,
+        namespace,
+        namespaceBindings,
       );
-      return true;
+      let flushed = true;
+      for (const sessionNamespace of namespaces) {
+        try {
+          await postJson(
+            target,
+            options.serviceId,
+            "/engram/v1/lcm/compaction/flush",
+            withNamespace(sessionNamespace, { sessionKey }),
+            options.flushTimeoutMs,
+          );
+        } catch (err) {
+          log.warn(`delegate flush failed: ${String(err)}`);
+          flushed = false;
+        }
+      }
+      return flushed;
     } catch (err) {
       log.warn(`delegate flush failed: ${String(err)}`);
       return false;
     }
+    return flushed;
   };
   api.on("before_compaction", flushHandler);
   if (options.flushOnResetEnabled) {
@@ -526,8 +589,7 @@ export function registerDelegateRuntime(
       event: Record<string, unknown>,
       ctx: Record<string, unknown>,
     ): Promise<void> => {
-      const sessionKey = lifecycleSessionKeyFrom(event, ctx);
-      if (await flushHandler(event, ctx)) boundNamespaces.delete(sessionKey);
+      await flushHandler(event, ctx);
     };
     api.on("before_reset", flushEndedSession);
     api.on("session_end", flushEndedSession);
@@ -686,6 +748,15 @@ export function maybeRegisterDelegateRuntime(
     serviceId: options.serviceId,
     target,
     namespace: "",
+    namespaceBindings: createFileSessionNamespaceBindingStore(
+      path.join(
+        options.memoryDir,
+        "state",
+        "plugins",
+        options.serviceId,
+        "session-namespace-bindings.json",
+      ),
+    ),
     allowPromptInjection: options.allowPromptInjection,
     passive: options.passive,
     gateHeartbeatTurns: options.gateHeartbeatTurns,

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -38,6 +38,10 @@ import {
   type DaemonAuthToken,
 } from "./bridge.js";
 import {
+  REMNIC_OPENCLAW_LEGACY_PLUGIN_ID,
+  REMNIC_OPENCLAW_PLUGIN_ID,
+} from "./plugin-id.js";
+import {
   extractLastTurn,
   extractTextContent,
 } from "./transcript-turns.js";
@@ -100,6 +104,7 @@ export interface DelegateHookApi {
 }
 
 const MEMORY_CONTEXT_HEADER = "## Memory Context (Remnic)";
+const DELEGATE_NAMESPACE_MAX_LENGTH = 256;
 
 const DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS = [
   "recall",
@@ -299,12 +304,7 @@ async function rememberedNamespacesFor(
   sessionKey: string,
   namespaceBindings: SessionNamespaceBindingStore,
 ): Promise<string[]> {
-  try {
-    return await namespaceBindings.namespacesFor(sessionKey);
-  } catch (err) {
-    log.warn(`delegate namespace binding lookup failed: ${String(err)}`);
-    return [];
-  }
+  return namespaceBindings.namespacesFor(sessionKey);
 }
 
 async function rememberNamespace(
@@ -312,6 +312,11 @@ async function rememberNamespace(
   namespace: string,
   namespaceBindings: SessionNamespaceBindingStore,
 ): Promise<void> {
+  if (namespace.length > DELEGATE_NAMESPACE_MAX_LENGTH) {
+    throw new Error(
+      `delegate session namespace exceeds the daemon limit of ${DELEGATE_NAMESPACE_MAX_LENGTH} characters`,
+    );
+  }
   try {
     await namespaceBindings.remember(sessionKey, namespace);
   } catch (err) {
@@ -582,22 +587,19 @@ export function registerDelegateRuntime(
         namespace,
         namespaceBindings,
       );
-      let flushed = true;
-      for (const sessionNamespace of namespaces) {
-        try {
-          await postJson(
-            target,
-            options.serviceId,
-            "/engram/v1/lcm/compaction/flush",
-            withNamespace(sessionNamespace, { sessionKey }),
-            options.flushTimeoutMs,
-          );
-        } catch (err) {
-          log.warn(`delegate flush failed: ${String(err)}`);
-          flushed = false;
-        }
-      }
-      return flushed;
+      const response = await postJson(
+        target,
+        options.serviceId,
+        "/engram/v1/lcm/compaction/flush",
+        namespaces.length > 1
+          ? {
+              sessionKey,
+              namespaces: namespaces.map((sessionNamespace) => sessionNamespace ?? ""),
+            }
+          : withNamespace(namespaces[0], { sessionKey }),
+        options.flushTimeoutMs,
+      );
+      return response?.flushed !== false;
     } catch (err) {
       log.warn(`delegate flush failed: ${String(err)}`);
       return false;
@@ -658,6 +660,35 @@ function activeDelegateAuthorizationOperations(
   return options.allowPromptInjection && options.recallBudgetChars !== 0
     ? DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS
     : DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS.slice(1);
+}
+function createDelegateNamespaceBindingStore(
+  memoryDir: string,
+  serviceId: string,
+): SessionNamespaceBindingStore {
+  const bindingPath = (pluginId: string): string =>
+    path.join(memoryDir, "state", "plugins", pluginId, "session-namespace-bindings.json");
+  const primary = createFileSessionNamespaceBindingStore(bindingPath(serviceId));
+  if (serviceId !== REMNIC_OPENCLAW_PLUGIN_ID) return primary;
+
+  const legacy = createFileSessionNamespaceBindingStore(
+    bindingPath(REMNIC_OPENCLAW_LEGACY_PLUGIN_ID),
+  );
+  return {
+    async namespacesFor(sessionKey: string): Promise<string[]> {
+      const current = await primary.namespacesFor(sessionKey);
+      return current.length > 0 ? current : legacy.namespacesFor(sessionKey);
+    },
+    async remember(sessionKey: string, namespace: string): Promise<void> {
+      const current = await primary.namespacesFor(sessionKey);
+      if (current.length === 0) {
+        const previous = await legacy.namespacesFor(sessionKey);
+        for (const remembered of previous) {
+          await primary.remember(sessionKey, remembered);
+        }
+      }
+      await primary.remember(sessionKey, namespace);
+    },
+  };
 }
 
 // Mirrors the embedded runtime's per-api hook dedup (globalThis HOOK_APIS
@@ -769,15 +800,7 @@ export function maybeRegisterDelegateRuntime(
     serviceId: options.serviceId,
     target,
     namespace: "",
-    namespaceBindings: createFileSessionNamespaceBindingStore(
-      path.join(
-        options.memoryDir,
-        "state",
-        "plugins",
-        options.serviceId,
-        "session-namespace-bindings.json",
-      ),
-    ),
+    namespaceBindings: createDelegateNamespaceBindingStore(options.memoryDir, options.serviceId),
     allowPromptInjection: options.allowPromptInjection,
     passive: options.passive,
     gateHeartbeatTurns: options.gateHeartbeatTurns,

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -671,20 +671,30 @@ export function registerDelegateRuntime(
           remainingTimeout(),
         );
       if (namespaces.length <= 1 || (await supportsBatchFlush(remainingTimeout()))) {
-        const response =
-          namespaces.length > 1
-            ? await postJson(
-                target,
-                options.serviceId,
-                "/engram/v1/lcm/compaction/flush",
-                {
-                  sessionKey,
-                  namespaces: namespaces.map((sessionNamespace) => sessionNamespace ?? ""),
-                },
-                remainingTimeout(),
-              )
-            : await flushNamespace(namespaces[0]);
-        return response?.flushed !== false;
+        if (namespaces.length <= 1) {
+          const response = await flushNamespace(namespaces[0]);
+          return response?.flushed !== false;
+        }
+        try {
+          const response = await postJson(
+            target,
+            options.serviceId,
+            "/engram/v1/lcm/compaction/flush",
+            {
+              sessionKey,
+              namespaces: namespaces.map((sessionNamespace) => sessionNamespace ?? ""),
+            },
+            remainingTimeout(),
+          );
+          if (response === null || response.flushed === false) {
+            cachedBatchFlushSupport = undefined;
+            return false;
+          }
+          return true;
+        } catch (err) {
+          cachedBatchFlushSupport = undefined;
+          throw err;
+        }
       }
       const outcomes = await Promise.allSettled(namespaces.map(flushNamespace));
       return outcomes.every(

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -343,6 +343,13 @@ async function lifecycleSessionNamespacesFrom(
     await rememberNamespace(sessionKey, explicit.namespace ?? "", namespaceBindings);
   }
   const remembered = await rememberedNamespacesFor(sessionKey, namespaceBindings);
+  if (explicit !== undefined) {
+    const explicitNamespace = explicit.namespace ?? "";
+    const namespaces = remembered.includes(explicitNamespace)
+      ? remembered
+      : [...remembered, explicitNamespace];
+    return namespaces.map((namespace) => namespace || undefined);
+  }
   if (remembered.length > 0) return remembered.map((namespace) => namespace || undefined);
   return [fallback.trim() || undefined];
 }

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -805,38 +805,52 @@ function activeDelegateAuthorizationOperations(
     ? DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS
     : DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS.slice(1);
 }
+const delegateNamespaceMigrationChains = new Map<string, Map<string, Promise<void>>>();
+const queueDelegateNamespaceMigration = <T>(
+  bindingPath: string,
+  sessionKey: string,
+  operation: () => Promise<T>,
+): Promise<T> => {
+  let sessionChains = delegateNamespaceMigrationChains.get(bindingPath);
+  if (sessionChains === undefined) {
+    sessionChains = new Map();
+    delegateNamespaceMigrationChains.set(bindingPath, sessionChains);
+  }
+  const prior = sessionChains.get(sessionKey) ?? Promise.resolve();
+  const run = prior.catch(() => undefined).then(operation);
+  const settled = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  sessionChains.set(sessionKey, settled);
+  void settled.then(() => {
+    if (sessionChains?.get(sessionKey) !== settled) return;
+    sessionChains.delete(sessionKey);
+    if (sessionChains.size === 0 && delegateNamespaceMigrationChains.get(bindingPath) === sessionChains) {
+      delegateNamespaceMigrationChains.delete(bindingPath);
+    }
+  });
+  return run;
+};
+
 function createDelegateNamespaceBindingStore(
   memoryDir: string,
   serviceId: string,
 ): SessionNamespaceBindingStore {
   const bindingPath = (pluginId: string): string =>
     path.join(memoryDir, "state", "plugins", pluginId, "session-namespace-bindings.json");
-  const primary = createFileSessionNamespaceBindingStore(bindingPath(serviceId));
+  const primaryPath = bindingPath(serviceId);
+  const primary = createFileSessionNamespaceBindingStore(primaryPath);
   if (serviceId !== REMNIC_OPENCLAW_PLUGIN_ID) return primary;
 
   const legacy = createFileSessionNamespaceBindingStore(
     bindingPath(REMNIC_OPENCLAW_LEGACY_PLUGIN_ID),
   );
   const migratedLegacySessions = new Set<string>();
-  const sessionMigrationChains = new Map<string, Promise<void>>();
   const queueSessionMigration = <T>(
     sessionKey: string,
     operation: () => Promise<T>,
-  ): Promise<T> => {
-    const prior = sessionMigrationChains.get(sessionKey) ?? Promise.resolve();
-    const run = prior.catch(() => undefined).then(operation);
-    const settled = run.then(
-      () => undefined,
-      () => undefined,
-    );
-    sessionMigrationChains.set(sessionKey, settled);
-    void settled.then(() => {
-      if (sessionMigrationChains.get(sessionKey) === settled) {
-        sessionMigrationChains.delete(sessionKey);
-      }
-    });
-    return run;
-  };
+  ): Promise<T> => queueDelegateNamespaceMigration(primaryPath, sessionKey, operation);
   const readLegacyNamespaces = async (
     sessionKey: string,
     current: string[],

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -695,13 +695,16 @@ export function registerDelegateRuntime(
       const flushIndividually = async (): Promise<boolean> => {
         const outcomes = await Promise.allSettled(namespaces.map(flushNamespace));
         return outcomes.every(
-          (outcome) => outcome.status === "fulfilled" && outcome.value?.flushed !== false,
+          (outcome) =>
+            outcome.status === "fulfilled" &&
+            outcome.value !== null &&
+            outcome.value.flushed === true,
         );
       };
       if (namespaces.length <= 1 || (await supportsBatchFlush(remainingTimeout()))) {
         if (namespaces.length <= 1) {
           const response = await flushNamespace(namespaces[0]);
-          return response?.flushed !== false;
+          return response !== null && response.flushed === true;
         }
         try {
           const response = await postJson(
@@ -733,7 +736,7 @@ export function registerDelegateRuntime(
             invalidateCachedBatchFlushSupport();
             return flushIndividually();
           }
-          if (response.flushed === false) {
+          if (response.flushed !== true) {
             invalidateCachedBatchFlushSupport();
             return false;
           }

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -739,9 +739,9 @@ export function registerDelegateRuntime(
             return false;
           }
           return true;
-        } catch (err) {
+        } catch {
           invalidateCachedBatchFlushSupport();
-          throw err;
+          return flushIndividually();
         }
       }
       return flushIndividually();
@@ -756,9 +756,7 @@ export function registerDelegateRuntime(
     const flushEndedSession = async (
       event: Record<string, unknown>,
       ctx: Record<string, unknown>,
-    ): Promise<void> => {
-      await flushHandler(event, ctx);
-    };
+    ): Promise<boolean> => flushHandler(event, ctx);
     api.on("before_reset", flushEndedSession);
     api.on("session_end", flushEndedSession);
   }
@@ -866,7 +864,7 @@ function createDelegateNamespaceBindingStore(
     sessionKey: string,
     current: string[],
   ): Promise<string[]> => {
-    if (migratedLegacySessions.has(sessionKey)) return [];
+    if (!isLegacyAdapterActive() && migratedLegacySessions.has(sessionKey)) return [];
     try {
       const previous = await legacy.namespacesFor(sessionKey);
       if (previous.length === 0) rememberMigratedLegacySession(sessionKey);

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -28,6 +28,7 @@ import {
 import { log } from "@remnic/core/logger";
 import {
   type SessionNamespaceBindingStore,
+  SESSION_NAMESPACE_BINDING_MAX_NAMESPACES,
   createFileSessionNamespaceBindingStore,
 } from "@remnic/core/session-namespace-bindings";
 import { createFileToggleStore } from "@remnic/core/session-toggles";
@@ -600,12 +601,12 @@ export function registerDelegateRuntime(
   });
 
   let supportsBatchFlushPromise: Promise<boolean> | undefined;
-  const supportsBatchFlush = (): Promise<boolean> => {
+  const supportsBatchFlush = (timeoutMs: number): Promise<boolean> => {
     supportsBatchFlushPromise ??= getJson(
       target,
       options.serviceId,
       "/engram/v1/capabilities",
-      options.flushTimeoutMs,
+      timeoutMs,
     )
       .then((response) => response?.lcmCompactionFlushBatch === true)
       .catch(() => false);
@@ -616,6 +617,8 @@ export function registerDelegateRuntime(
     ctx: Record<string, unknown>,
   ): Promise<boolean> => {
     try {
+      const deadline = Date.now() + options.flushTimeoutMs;
+      const remainingTimeout = (): number => Math.max(1, deadline - Date.now());
       const sessionKey = lifecycleSessionKeyFrom(event, ctx);
       if (sessionKey === undefined) {
         log.warn("delegate flush skipped: lifecycle event has malformed session key");
@@ -634,9 +637,9 @@ export function registerDelegateRuntime(
           options.serviceId,
           "/engram/v1/lcm/compaction/flush",
           withNamespace(sessionNamespace, { sessionKey }),
-          options.flushTimeoutMs,
+          remainingTimeout(),
         );
-      if (namespaces.length <= 1 || (await supportsBatchFlush())) {
+      if (namespaces.length <= 1 || (await supportsBatchFlush(remainingTimeout()))) {
         const response =
           namespaces.length > 1
             ? await postJson(
@@ -647,7 +650,7 @@ export function registerDelegateRuntime(
                   sessionKey,
                   namespaces: namespaces.map((sessionNamespace) => sessionNamespace ?? ""),
                 },
-                options.flushTimeoutMs,
+                remainingTimeout(),
               )
             : await flushNamespace(namespaces[0]);
         return response?.flushed !== false;
@@ -736,19 +739,35 @@ function createDelegateNamespaceBindingStore(
       return [];
     }
   };
+  const mergeNamespaceHistory = (current: string[], previous: string[]): string[] => {
+    const merged: string[] = [];
+    for (const remembered of [...previous, ...current]) {
+      const existing = merged.indexOf(remembered);
+      if (existing >= 0) merged.splice(existing, 1);
+      merged.push(remembered);
+    }
+    return merged.slice(-SESSION_NAMESPACE_BINDING_MAX_NAMESPACES);
+  };
   return {
     async namespacesFor(sessionKey: string): Promise<string[]> {
       const current = await primary.namespacesFor(sessionKey);
       const previous = await readLegacyNamespaces(sessionKey);
       if (previous.length === 0) return current;
-      const merged = [...current];
+      const merged = mergeNamespaceHistory(current, previous);
+      const hasMissingLegacy = previous.some((remembered) => !current.includes(remembered));
       for (const remembered of previous) {
-        if (!merged.includes(remembered)) merged.push(remembered);
         if (current.includes(remembered)) continue;
         try {
           await primary.remember(sessionKey, remembered);
         } catch {
           break;
+        }
+      }
+      const currentNamespace = current[current.length - 1];
+      if (hasMissingLegacy && currentNamespace !== undefined) {
+        try {
+          await primary.remember(sessionKey, currentNamespace);
+        } catch {
         }
       }
       return merged;

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -201,12 +201,16 @@ async function postJson(
     ? (parsed as Record<string, unknown>)
     : null;
 }
+interface DelegateJsonResponse {
+  status: number;
+  body: Record<string, unknown> | null;
+}
 async function getJson(
   target: DelegateDaemonTarget,
   serviceId: string,
   pathname: string,
   timeoutMs: number,
-): Promise<Record<string, unknown> | null> {
+): Promise<DelegateJsonResponse> {
   const headers: Record<string, string> = {};
   const auth = target.resolveAuthToken();
   if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
@@ -219,15 +223,19 @@ async function getJson(
       const status = res.status === 401 ? 401 : 403;
       await res.body?.cancel();
       reportDaemonAuthorizationFailure(serviceId, pathname, status, auth.source);
-      return null;
+      return { status: res.status, body: null };
     }
     await res.body?.cancel();
-    return null;
+    return { status: res.status, body: null };
   }
   const parsed: unknown = await res.json().catch(() => null);
-  return typeof parsed === "object" && parsed !== null
-    ? (parsed as Record<string, unknown>)
-    : null;
+  return {
+    status: res.status,
+    body:
+      typeof parsed === "object" && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : null,
+  };
 }
 
 function sessionKeyFrom(
@@ -600,16 +608,39 @@ export function registerDelegateRuntime(
     }
   });
 
+  let cachedBatchFlushSupport: boolean | undefined;
   let supportsBatchFlushPromise: Promise<boolean> | undefined;
   const supportsBatchFlush = (timeoutMs: number): Promise<boolean> => {
-    supportsBatchFlushPromise ??= getJson(
+    if (cachedBatchFlushSupport !== undefined) {
+      return Promise.resolve(cachedBatchFlushSupport);
+    }
+    if (supportsBatchFlushPromise !== undefined) return supportsBatchFlushPromise;
+    const probe = getJson(
       target,
       options.serviceId,
       "/engram/v1/capabilities",
       timeoutMs,
     )
-      .then((response) => response?.lcmCompactionFlushBatch === true)
+      .then((response) => {
+        const isSuccessfulResponse = response.status >= 200 && response.status < 300;
+        if (isSuccessfulResponse && response.body !== null) {
+          cachedBatchFlushSupport = response.body.lcmCompactionFlushBatch === true;
+          return cachedBatchFlushSupport;
+        }
+        if (
+          response.status === 204 ||
+          response.status === 404 ||
+          response.status === 405 ||
+          response.status === 501
+        ) {
+          cachedBatchFlushSupport = false;
+        }
+        return false;
+      })
       .catch(() => false);
+    supportsBatchFlushPromise = probe.finally(() => {
+      supportsBatchFlushPromise = undefined;
+    });
     return supportsBatchFlushPromise;
   };
   const flushHandler = async (
@@ -732,11 +763,15 @@ function createDelegateNamespaceBindingStore(
   const legacy = createFileSessionNamespaceBindingStore(
     bindingPath(REMNIC_OPENCLAW_LEGACY_PLUGIN_ID),
   );
-  const readLegacyNamespaces = async (sessionKey: string): Promise<string[]> => {
+  const readLegacyNamespaces = async (
+    sessionKey: string,
+    current: string[],
+  ): Promise<string[]> => {
     try {
       return await legacy.namespacesFor(sessionKey);
-    } catch {
-      return [];
+    } catch (err) {
+      if (current.length > 0) return [];
+      throw err;
     }
   };
   const mergeNamespaceHistory = (current: string[], previous: string[]): string[] => {
@@ -751,7 +786,7 @@ function createDelegateNamespaceBindingStore(
   return {
     async namespacesFor(sessionKey: string): Promise<string[]> {
       const current = await primary.namespacesFor(sessionKey);
-      const previous = await readLegacyNamespaces(sessionKey);
+      const previous = await readLegacyNamespaces(sessionKey, current);
       if (previous.length === 0) return current;
       const merged = mergeNamespaceHistory(current, previous);
       const hasMissingLegacy = previous.some((remembered) => !current.includes(remembered));
@@ -774,7 +809,7 @@ function createDelegateNamespaceBindingStore(
     },
     async remember(sessionKey: string, namespace: string): Promise<void> {
       const current = await primary.namespacesFor(sessionKey);
-      const previous = await readLegacyNamespaces(sessionKey);
+      const previous = await readLegacyNamespaces(sessionKey, current);
       for (const remembered of previous) {
         if (!current.includes(remembered)) await primary.remember(sessionKey, remembered);
       }

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -729,10 +729,17 @@ function createDelegateNamespaceBindingStore(
   const legacy = createFileSessionNamespaceBindingStore(
     bindingPath(REMNIC_OPENCLAW_LEGACY_PLUGIN_ID),
   );
+  const readLegacyNamespaces = async (sessionKey: string): Promise<string[]> => {
+    try {
+      return await legacy.namespacesFor(sessionKey);
+    } catch {
+      return [];
+    }
+  };
   return {
     async namespacesFor(sessionKey: string): Promise<string[]> {
       const current = await primary.namespacesFor(sessionKey);
-      const previous = await legacy.namespacesFor(sessionKey);
+      const previous = await readLegacyNamespaces(sessionKey);
       if (previous.length === 0) return current;
       const merged = [...current];
       for (const remembered of previous) {
@@ -748,7 +755,7 @@ function createDelegateNamespaceBindingStore(
     },
     async remember(sessionKey: string, namespace: string): Promise<void> {
       const current = await primary.namespacesFor(sessionKey);
-      const previous = await legacy.namespacesFor(sessionKey);
+      const previous = await readLegacyNamespaces(sessionKey);
       for (const remembered of previous) {
         if (!current.includes(remembered)) await primary.remember(sessionKey, remembered);
       }

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -837,6 +837,7 @@ const queueDelegateNamespaceMigration = <T>(
 function createDelegateNamespaceBindingStore(
   memoryDir: string,
   serviceId: string,
+  isLegacyAdapterActive: () => boolean,
 ): SessionNamespaceBindingStore {
   const bindingPath = (pluginId: string): string =>
     path.join(memoryDir, "state", "plugins", pluginId, "session-namespace-bindings.json");
@@ -903,10 +904,12 @@ function createDelegateNamespaceBindingStore(
     }
   };
   const completeLegacyMigration = async (sessionKey: string): Promise<void> => {
-    try {
-      await legacy.replace?.(sessionKey, []);
-    } catch (err) {
-      log.warn(`[${serviceId}] delegate legacy namespace cleanup failed: ${String(err)}`);
+    if (!isLegacyAdapterActive()) {
+      try {
+        await legacy.replace?.(sessionKey, []);
+      } catch (err) {
+        log.warn(`[${serviceId}] delegate legacy namespace cleanup failed: ${String(err)}`);
+      }
     }
     rememberMigratedLegacySession(sessionKey);
   };
@@ -1056,7 +1059,11 @@ export function maybeRegisterDelegateRuntime(
     serviceId: options.serviceId,
     target,
     namespace: "",
-    namespaceBindings: createDelegateNamespaceBindingStore(options.memoryDir, options.serviceId),
+    namespaceBindings: createDelegateNamespaceBindingStore(
+      options.memoryDir,
+      options.serviceId,
+      () => delegateHookApiServices.get(api)?.has(REMNIC_OPENCLAW_LEGACY_PLUGIN_ID) === true,
+    ),
     allowPromptInjection: options.allowPromptInjection,
     passive: options.passive,
     gateHeartbeatTurns: options.gateHeartbeatTurns,

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -286,6 +286,9 @@ function explicitSessionNamespaceFrom(
     const session = (agent as Record<string, unknown>).session;
     if (typeof session !== "object" || session === null) continue;
     const namespace = (session as Record<string, unknown>).namespace;
+    if (namespace !== undefined && typeof namespace !== "string") {
+      throw new Error("delegate session namespace metadata must be a string");
+    }
     return { namespace: typeof namespace === "string" ? namespace.trim() || undefined : undefined };
   }
   return undefined;
@@ -565,8 +568,8 @@ export function registerDelegateRuntime(
     event: Record<string, unknown>,
     ctx: Record<string, unknown>,
   ): Promise<boolean> => {
-    const sessionKey = lifecycleSessionKeyFrom(event, ctx);
     try {
+      const sessionKey = lifecycleSessionKeyFrom(event, ctx);
       const namespaces = await lifecycleSessionNamespacesFrom(
         sessionKey,
         event,
@@ -594,7 +597,7 @@ export function registerDelegateRuntime(
       log.warn(`delegate flush failed: ${String(err)}`);
       return false;
     }
-    return flushed;
+
   };
   api.on("before_compaction", flushHandler);
   if (options.flushOnResetEnabled) {

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -800,20 +800,12 @@ function createDelegateNamespaceBindingStore(
       if (previous.length === 0) return current;
       const merged = mergeNamespaceHistory(current, previous);
       const hasMissingLegacy = previous.some((remembered) => !current.includes(remembered));
-      for (const remembered of previous) {
-        if (current.includes(remembered)) continue;
-        try {
+      if (!hasMissingLegacy) return current;
+      try {
+        for (const remembered of merged) {
           await primary.remember(sessionKey, remembered);
-        } catch {
-          break;
         }
-      }
-      const currentNamespace = current[current.length - 1];
-      if (hasMissingLegacy && currentNamespace !== undefined) {
-        try {
-          await primary.remember(sessionKey, currentNamespace);
-        } catch {
-        }
+      } catch {
       }
       return merged;
     },

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -259,7 +259,7 @@ function sessionNamespaceFrom(
         : [ctx, event];
   for (const source of sources) {
     const sourceSessionKey = typeof source.sessionKey === "string" ? source.sessionKey : undefined;
-    if (sourceSessionKey && sourceSessionKey !== sessionKey) continue;
+    if (sourceSessionKey !== sessionKey) continue;
     const runtime = source.runtime;
     if (typeof runtime !== "object" || runtime === null) continue;
     const agent = (runtime as Record<string, unknown>).agent;

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -210,11 +210,12 @@ function sessionKeyFrom(
 function lifecycleSessionKeyFrom(
   event: Record<string, unknown>,
   ctx: Record<string, unknown>,
-): string {
+): string | undefined {
   const fromEvent = event?.sessionKey;
-  return typeof fromEvent === "string" && fromEvent.length > 0
-    ? fromEvent
-    : sessionKeyFrom(event, ctx);
+  if (fromEvent !== undefined) {
+    return typeof fromEvent === "string" && fromEvent.length > 0 ? fromEvent : undefined;
+  }
+  return sessionKeyFrom(event, ctx);
 }
 
 function recallQueryFrom(event: Record<string, unknown>): string {
@@ -570,6 +571,10 @@ export function registerDelegateRuntime(
   ): Promise<boolean> => {
     try {
       const sessionKey = lifecycleSessionKeyFrom(event, ctx);
+      if (sessionKey === undefined) {
+        log.warn("delegate flush skipped: lifecycle event has malformed session key");
+        return false;
+      }
       const namespaces = await lifecycleSessionNamespacesFrom(
         sessionKey,
         event,

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -237,10 +237,41 @@ function cwdFrom(
 }
 
 function withNamespace(
-  namespace: string,
+  namespace: string | undefined,
   body: Record<string, unknown>,
 ): Record<string, unknown> {
-  return namespace.length > 0 ? { ...body, namespace } : body;
+  return namespace ? { ...body, namespace } : body;
+}
+
+function sessionNamespaceFrom(
+  sessionKey: string,
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>,
+  fallback: string,
+): string | undefined {
+  const eventSessionKey = typeof event.sessionKey === "string" ? event.sessionKey : undefined;
+  const ctxSessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : undefined;
+  const sources =
+    eventSessionKey === sessionKey
+      ? [event, ctx]
+      : ctxSessionKey === sessionKey
+        ? [ctx, event]
+        : [ctx, event];
+  for (const source of sources) {
+    const sourceSessionKey = typeof source.sessionKey === "string" ? source.sessionKey : undefined;
+    if (sourceSessionKey && sourceSessionKey !== sessionKey) continue;
+    const runtime = source.runtime;
+    if (typeof runtime !== "object" || runtime === null) continue;
+    const agent = (runtime as Record<string, unknown>).agent;
+    if (typeof agent !== "object" || agent === null) continue;
+    const session = (agent as Record<string, unknown>).session;
+    if (typeof session !== "object" || session === null) continue;
+    const namespace = (session as Record<string, unknown>).namespace;
+    if (typeof namespace === "string" && namespace.trim().length > 0) {
+      return namespace.trim();
+    }
+  }
+  return fallback.trim() || undefined;
 }
 
 function readContextComposition(
@@ -319,7 +350,7 @@ export function registerDelegateRuntime(
           target,
           options.serviceId,
           "/engram/v1/recall",
-          withNamespace(namespace, {
+          withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace), {
             query,
             sessionKey,
             mode: "auto",
@@ -423,7 +454,7 @@ export function registerDelegateRuntime(
         target,
         options.serviceId,
         "/engram/v1/observe",
-        withNamespace(namespace, {
+        withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace), {
           sessionKey,
           messages: turn,
           ...(cwd ? { cwd } : {}),
@@ -452,7 +483,7 @@ export function registerDelegateRuntime(
         target,
         options.serviceId,
         "/engram/v1/lcm/compaction/flush",
-        withNamespace(namespace, { sessionKey }),
+        withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace), { sessionKey }),
         options.flushTimeoutMs,
       );
     } catch (err) {

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -253,6 +253,23 @@ function withNamespace(
   return namespace ? { ...body, namespace } : body;
 }
 
+const namespaceBindingsByDaemonScope = new Map<string, Map<string, string>>();
+
+function namespaceBindingsFor(
+  serviceId: string,
+  target: DelegateDaemonTarget,
+  fallbackNamespace: string,
+): Map<string, string> {
+  const scope = JSON.stringify([serviceId, target.host, target.port, fallbackNamespace.trim()]);
+  let bindings = namespaceBindingsByDaemonScope.get(scope);
+  if (!bindings) {
+    bindings = new Map<string, string>();
+    namespaceBindingsByDaemonScope.set(scope, bindings);
+  }
+  return bindings;
+}
+
+
 function sessionNamespaceFrom(
   sessionKey: string,
   event: Record<string, unknown>,
@@ -328,7 +345,7 @@ export function registerDelegateRuntime(
     );
     return;
   }
-  const boundNamespaces = new Map<string, string>();
+  const boundNamespaces = namespaceBindingsFor(options.serviceId, target, namespace);
 
   // Embedded zero-limit contract: recallBudgetChars === 0 disables injection.
   if (options.allowPromptInjection && options.recallBudgetChars !== 0) {
@@ -487,7 +504,7 @@ export function registerDelegateRuntime(
   const flushHandler = async (
     event: Record<string, unknown>,
     ctx: Record<string, unknown>,
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     const sessionKey = lifecycleSessionKeyFrom(event, ctx);
     try {
       await postJson(
@@ -497,8 +514,10 @@ export function registerDelegateRuntime(
         withNamespace(sessionNamespaceFrom(sessionKey, event, ctx, namespace, boundNamespaces), { sessionKey }),
         options.flushTimeoutMs,
       );
+      return true;
     } catch (err) {
       log.warn(`delegate flush failed: ${String(err)}`);
+      return false;
     }
   };
   api.on("before_compaction", flushHandler);
@@ -508,8 +527,7 @@ export function registerDelegateRuntime(
       ctx: Record<string, unknown>,
     ): Promise<void> => {
       const sessionKey = lifecycleSessionKeyFrom(event, ctx);
-      await flushHandler(event, ctx);
-      boundNamespaces.delete(sessionKey);
+      if (await flushHandler(event, ctx)) boundNamespaces.delete(sessionKey);
     };
     api.on("before_reset", flushEndedSession);
     api.on("session_end", flushEndedSession);

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -954,6 +954,9 @@ function createDelegateNamespaceBindingStore(
 // service must get its own binding exactly once (double-register of one
 // service would double-fire every handler).
 const delegateHookApiServices = new WeakMap<object, Set<string>>();
+// Service registration can span distinct OpenClaw api objects. Keep the active
+// service IDs process-scoped so migration callbacks see sibling registrations.
+const delegateActiveServiceIds = new Set<string>();
 // Apis that previously fell back to embedded because the daemon was down. A
 // later register() on the SAME api must NOT switch to delegate — the embedded
 // hooks from the fallback are still bound (OpenClaw exposes no unregister), so
@@ -1035,6 +1038,7 @@ export function maybeRegisterDelegateRuntime(
     (boundServices ?? delegateHookApiServices.set(api, new Set()).get(api))?.add(
       options.serviceId,
     );
+    delegateActiveServiceIds.add(options.serviceId);
   }
   // Embedded toggle-store parity: same primary path (per-service plugin state)
   // and optional bundled active-memory secondary read.
@@ -1060,7 +1064,7 @@ export function maybeRegisterDelegateRuntime(
     namespaceBindings: createDelegateNamespaceBindingStore(
       options.memoryDir,
       options.serviceId,
-      () => delegateHookApiServices.get(api)?.has(REMNIC_OPENCLAW_LEGACY_PLUGIN_ID) === true,
+      () => delegateActiveServiceIds.has(REMNIC_OPENCLAW_LEGACY_PLUGIN_ID),
     ),
     allowPromptInjection: options.allowPromptInjection,
     passive: options.passive,

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -321,6 +321,7 @@ async function rememberNamespace(
     await namespaceBindings.remember(sessionKey, namespace);
   } catch (err) {
     log.warn(`delegate namespace binding persistence failed: ${String(err)}`);
+    throw err;
   }
 }
 

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -812,10 +812,14 @@ function createDelegateNamespaceBindingStore(
     async remember(sessionKey: string, namespace: string): Promise<void> {
       const current = await primary.namespacesFor(sessionKey);
       const previous = await readLegacyNamespaces(sessionKey, current);
-      for (const remembered of previous) {
-        if (!current.includes(remembered)) await primary.remember(sessionKey, remembered);
+      if (previous.length === 0) {
+        await primary.remember(sessionKey, namespace);
+        return;
       }
-      await primary.remember(sessionKey, namespace);
+      const merged = mergeNamespaceHistory([...current, namespace], previous);
+      for (const remembered of merged) {
+        await primary.remember(sessionKey, remembered);
+      }
     },
   };
 }

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -624,8 +624,12 @@ export function registerDelegateRuntime(
       .then((response) => {
         const isSuccessfulResponse = response.status >= 200 && response.status < 300;
         if (isSuccessfulResponse && response.body !== null) {
-          cachedBatchFlushSupport = response.body.lcmCompactionFlushBatch === true;
-          return cachedBatchFlushSupport;
+          const batchFlushSupport = response.body.lcmCompactionFlushBatch;
+          if (typeof batchFlushSupport === "boolean") {
+            cachedBatchFlushSupport = batchFlushSupport;
+            return batchFlushSupport;
+          }
+          return false;
         }
         if (
           response.status === 204 ||
@@ -670,6 +674,12 @@ export function registerDelegateRuntime(
           withNamespace(sessionNamespace, { sessionKey }),
           remainingTimeout(),
         );
+      const flushIndividually = async (): Promise<boolean> => {
+        const outcomes = await Promise.allSettled(namespaces.map(flushNamespace));
+        return outcomes.every(
+          (outcome) => outcome.status === "fulfilled" && outcome.value?.flushed !== false,
+        );
+      };
       if (namespaces.length <= 1 || (await supportsBatchFlush(remainingTimeout()))) {
         if (namespaces.length <= 1) {
           const response = await flushNamespace(namespaces[0]);
@@ -686,7 +696,26 @@ export function registerDelegateRuntime(
             },
             remainingTimeout(),
           );
-          if (response === null || response.flushed === false) {
+          if (response === null) {
+            cachedBatchFlushSupport = undefined;
+            return flushIndividually();
+          }
+          const responseNamespaces = response.namespaces;
+          const responseResults = response.results;
+          const isBatchResponse =
+            Array.isArray(responseNamespaces) &&
+            Array.isArray(responseResults) &&
+            responseNamespaces.length === namespaces.length &&
+            responseNamespaces.every(
+              (responseNamespace, index) =>
+                responseNamespace === (namespaces[index] ?? ""),
+            ) &&
+            responseResults.length === namespaces.length;
+          if (!isBatchResponse) {
+            cachedBatchFlushSupport = undefined;
+            return flushIndividually();
+          }
+          if (response.flushed === false) {
             cachedBatchFlushSupport = undefined;
             return false;
           }
@@ -696,10 +725,7 @@ export function registerDelegateRuntime(
           throw err;
         }
       }
-      const outcomes = await Promise.allSettled(namespaces.map(flushNamespace));
-      return outcomes.every(
-        (outcome) => outcome.status === "fulfilled" && outcome.value?.flushed !== false,
-      );
+      return flushIndividually();
     } catch (err) {
       log.warn(`delegate flush failed: ${String(err)}`);
       return false;
@@ -773,14 +799,23 @@ function createDelegateNamespaceBindingStore(
   const legacy = createFileSessionNamespaceBindingStore(
     bindingPath(REMNIC_OPENCLAW_LEGACY_PLUGIN_ID),
   );
+  const migratedLegacySessions = new Set<string>();
   const readLegacyNamespaces = async (
     sessionKey: string,
     current: string[],
   ): Promise<string[]> => {
+    if (migratedLegacySessions.has(sessionKey)) return [];
     try {
-      return await legacy.namespacesFor(sessionKey);
+      const previous = await legacy.namespacesFor(sessionKey);
+      if (previous.length === 0) migratedLegacySessions.add(sessionKey);
+      return previous;
     } catch (err) {
-      if (current.length > 0) return [];
+      if (current.length > 0) {
+        log.warn(
+          `[${serviceId}] delegate legacy namespace read failed; using canonical bindings: ${String(err)}`,
+        );
+        return [];
+      }
       throw err;
     }
   };
@@ -793,6 +828,27 @@ function createDelegateNamespaceBindingStore(
     }
     return merged.slice(-SESSION_NAMESPACE_BINDING_MAX_NAMESPACES);
   };
+  const persistNamespaceHistory = async (
+    store: SessionNamespaceBindingStore,
+    sessionKey: string,
+    namespaces: string[],
+  ): Promise<void> => {
+    if (store.replace !== undefined) {
+      await store.replace(sessionKey, namespaces);
+      return;
+    }
+    for (const namespace of namespaces) {
+      await store.remember(sessionKey, namespace);
+    }
+  };
+  const completeLegacyMigration = async (sessionKey: string): Promise<void> => {
+    try {
+      await legacy.replace?.(sessionKey, []);
+    } catch (err) {
+      log.warn(`[${serviceId}] delegate legacy namespace cleanup failed: ${String(err)}`);
+    }
+    migratedLegacySessions.add(sessionKey);
+  };
   return {
     async namespacesFor(sessionKey: string): Promise<string[]> {
       const current = await primary.namespacesFor(sessionKey);
@@ -800,12 +856,15 @@ function createDelegateNamespaceBindingStore(
       if (previous.length === 0) return current;
       const merged = mergeNamespaceHistory(current, previous);
       const hasMissingLegacy = previous.some((remembered) => !current.includes(remembered));
-      if (!hasMissingLegacy) return current;
+      if (!hasMissingLegacy) {
+        await completeLegacyMigration(sessionKey);
+        return current;
+      }
       try {
-        for (const remembered of merged) {
-          await primary.remember(sessionKey, remembered);
-        }
-      } catch {
+        await persistNamespaceHistory(primary, sessionKey, merged);
+        await completeLegacyMigration(sessionKey);
+      } catch (err) {
+        log.warn(`[${serviceId}] delegate namespace migration failed: ${String(err)}`);
       }
       return merged;
     },
@@ -817,9 +876,8 @@ function createDelegateNamespaceBindingStore(
         return;
       }
       const merged = mergeNamespaceHistory([...current, namespace], previous);
-      for (const remembered of merged) {
-        await primary.remember(sessionKey, remembered);
-      }
+      await persistNamespaceHistory(primary, sessionKey, merged);
+      await completeLegacyMigration(sessionKey);
     },
   };
 }

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -200,6 +200,34 @@ async function postJson(
     ? (parsed as Record<string, unknown>)
     : null;
 }
+async function getJson(
+  target: DelegateDaemonTarget,
+  serviceId: string,
+  pathname: string,
+  timeoutMs: number,
+): Promise<Record<string, unknown> | null> {
+  const headers: Record<string, string> = {};
+  const auth = target.resolveAuthToken();
+  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
+  const res = await fetch(daemonUrl(target, pathname), {
+    headers,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) {
+    if (res.status === 401 || res.status === 403) {
+      const status = res.status === 401 ? 401 : 403;
+      await res.body?.cancel();
+      reportDaemonAuthorizationFailure(serviceId, pathname, status, auth.source);
+      return null;
+    }
+    await res.body?.cancel();
+    return null;
+  }
+  const parsed: unknown = await res.json().catch(() => null);
+  return typeof parsed === "object" && parsed !== null
+    ? (parsed as Record<string, unknown>)
+    : null;
+}
 
 function sessionKeyFrom(
   event: Record<string, unknown>,
@@ -571,6 +599,18 @@ export function registerDelegateRuntime(
     }
   });
 
+  let supportsBatchFlushPromise: Promise<boolean> | undefined;
+  const supportsBatchFlush = (): Promise<boolean> => {
+    supportsBatchFlushPromise ??= getJson(
+      target,
+      options.serviceId,
+      "/engram/v1/capabilities",
+      options.flushTimeoutMs,
+    )
+      .then((response) => response?.lcmCompactionFlushBatch === true)
+      .catch(() => false);
+    return supportsBatchFlushPromise;
+  };
   const flushHandler = async (
     event: Record<string, unknown>,
     ctx: Record<string, unknown>,
@@ -588,19 +628,34 @@ export function registerDelegateRuntime(
         namespace,
         namespaceBindings,
       );
-      const response = await postJson(
-        target,
-        options.serviceId,
-        "/engram/v1/lcm/compaction/flush",
-        namespaces.length > 1
-          ? {
-              sessionKey,
-              namespaces: namespaces.map((sessionNamespace) => sessionNamespace ?? ""),
-            }
-          : withNamespace(namespaces[0], { sessionKey }),
-        options.flushTimeoutMs,
+      const flushNamespace = (sessionNamespace: string | undefined) =>
+        postJson(
+          target,
+          options.serviceId,
+          "/engram/v1/lcm/compaction/flush",
+          withNamespace(sessionNamespace, { sessionKey }),
+          options.flushTimeoutMs,
+        );
+      if (namespaces.length <= 1 || (await supportsBatchFlush())) {
+        const response =
+          namespaces.length > 1
+            ? await postJson(
+                target,
+                options.serviceId,
+                "/engram/v1/lcm/compaction/flush",
+                {
+                  sessionKey,
+                  namespaces: namespaces.map((sessionNamespace) => sessionNamespace ?? ""),
+                },
+                options.flushTimeoutMs,
+              )
+            : await flushNamespace(namespaces[0]);
+        return response?.flushed !== false;
+      }
+      const outcomes = await Promise.allSettled(namespaces.map(flushNamespace));
+      return outcomes.every(
+        (outcome) => outcome.status === "fulfilled" && outcome.value?.flushed !== false,
       );
-      return response?.flushed !== false;
     } catch (err) {
       log.warn(`delegate flush failed: ${String(err)}`);
       return false;
@@ -677,15 +732,25 @@ function createDelegateNamespaceBindingStore(
   return {
     async namespacesFor(sessionKey: string): Promise<string[]> {
       const current = await primary.namespacesFor(sessionKey);
-      return current.length > 0 ? current : legacy.namespacesFor(sessionKey);
+      const previous = await legacy.namespacesFor(sessionKey);
+      if (previous.length === 0) return current;
+      const merged = [...current];
+      for (const remembered of previous) {
+        if (!merged.includes(remembered)) merged.push(remembered);
+        if (current.includes(remembered)) continue;
+        try {
+          await primary.remember(sessionKey, remembered);
+        } catch {
+          break;
+        }
+      }
+      return merged;
     },
     async remember(sessionKey: string, namespace: string): Promise<void> {
       const current = await primary.namespacesFor(sessionKey);
-      if (current.length === 0) {
-        const previous = await legacy.namespacesFor(sessionKey);
-        for (const remembered of previous) {
-          await primary.remember(sessionKey, remembered);
-        }
+      const previous = await legacy.namespacesFor(sessionKey);
+      for (const remembered of previous) {
+        if (!current.includes(remembered)) await primary.remember(sessionKey, remembered);
       }
       await primary.remember(sessionKey, namespace);
     },

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -259,11 +259,15 @@ function withNamespace(
   return namespace ? { ...body, namespace } : body;
 }
 
+interface ExplicitSessionNamespace {
+  namespace: string | undefined;
+}
+
 function explicitSessionNamespaceFrom(
   sessionKey: string,
   event: Record<string, unknown>,
   ctx: Record<string, unknown>,
-): string | undefined {
+): ExplicitSessionNamespace | undefined {
   const eventSessionKey = typeof event.sessionKey === "string" ? event.sessionKey : undefined;
   const ctxSessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : undefined;
   const sources =
@@ -282,7 +286,7 @@ function explicitSessionNamespaceFrom(
     const session = (agent as Record<string, unknown>).session;
     if (typeof session !== "object" || session === null) continue;
     const namespace = (session as Record<string, unknown>).namespace;
-    if (typeof namespace === "string") return namespace.trim();
+    return { namespace: typeof namespace === "string" ? namespace.trim() || undefined : undefined };
   }
   return undefined;
 }
@@ -320,11 +324,11 @@ async function sessionNamespaceFrom(
 ): Promise<string | undefined> {
   const explicit = explicitSessionNamespaceFrom(sessionKey, event, ctx);
   if (explicit !== undefined) {
-    await rememberNamespace(sessionKey, explicit, namespaceBindings);
-    return explicit || undefined;
+    await rememberNamespace(sessionKey, explicit.namespace ?? "", namespaceBindings);
+    return explicit.namespace;
   }
   const remembered = await rememberedNamespacesFor(sessionKey, namespaceBindings);
-  return remembered.at(-1) || fallback.trim() || undefined;
+  return remembered.length > 0 ? remembered.at(-1) || undefined : fallback.trim() || undefined;
 }
 
 async function lifecycleSessionNamespacesFrom(
@@ -335,7 +339,9 @@ async function lifecycleSessionNamespacesFrom(
   namespaceBindings: SessionNamespaceBindingStore,
 ): Promise<Array<string | undefined>> {
   const explicit = explicitSessionNamespaceFrom(sessionKey, event, ctx);
-  if (explicit !== undefined) await rememberNamespace(sessionKey, explicit, namespaceBindings);
+  if (explicit !== undefined) {
+    await rememberNamespace(sessionKey, explicit.namespace ?? "", namespaceBindings);
+  }
   const remembered = await rememberedNamespacesFor(sessionKey, namespaceBindings);
   if (remembered.length > 0) return remembered.map((namespace) => namespace || undefined);
   return [fallback.trim() || undefined];

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -91,6 +91,8 @@ export interface DelegateRuntimeOptions {
   recallTimeoutMs: number;
   observeTimeoutMs: number;
   flushTimeoutMs: number;
+  /** Injectable clock for capability-cache expiry tests and deterministic hosts. */
+  now?: () => number;
 }
 
 export interface DelegateHookApi {
@@ -106,6 +108,7 @@ export interface DelegateHookApi {
 
 const MEMORY_CONTEXT_HEADER = "## Memory Context (Remnic)";
 const DELEGATE_NAMESPACE_MAX_LENGTH = 256;
+const DELEGATE_BATCH_FLUSH_NEGATIVE_CACHE_TTL_MS = 30_000;
 
 const DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS = [
   "recall",
@@ -433,6 +436,7 @@ export function registerDelegateRuntime(
   options: DelegateRuntimeOptions,
 ): void {
   const { target, namespace, namespaceBindings } = options;
+  const now = options.now ?? Date.now;
   if (options.passive) {
     log.info(
       `[${options.serviceId}] bridge mode delegate: memory slot not owned — passive, no hooks registered`,
@@ -609,10 +613,24 @@ export function registerDelegateRuntime(
   });
 
   let cachedBatchFlushSupport: boolean | undefined;
+  let cachedBatchFlushSupportExpiresAt = 0;
   let supportsBatchFlushPromise: Promise<boolean> | undefined;
+  const invalidateCachedBatchFlushSupport = (): void => {
+    cachedBatchFlushSupport = undefined;
+    cachedBatchFlushSupportExpiresAt = 0;
+  };
+  const cacheBatchFlushSupport = (supported: boolean): void => {
+    cachedBatchFlushSupport = supported;
+    cachedBatchFlushSupportExpiresAt = supported
+      ? Number.POSITIVE_INFINITY
+      : now() + DELEGATE_BATCH_FLUSH_NEGATIVE_CACHE_TTL_MS;
+  };
   const supportsBatchFlush = (timeoutMs: number): Promise<boolean> => {
     if (cachedBatchFlushSupport !== undefined) {
-      return Promise.resolve(cachedBatchFlushSupport);
+      if (cachedBatchFlushSupport || now() < cachedBatchFlushSupportExpiresAt) {
+        return Promise.resolve(cachedBatchFlushSupport);
+      }
+      invalidateCachedBatchFlushSupport();
     }
     if (supportsBatchFlushPromise !== undefined) return supportsBatchFlushPromise;
     const probe = getJson(
@@ -626,7 +644,7 @@ export function registerDelegateRuntime(
         if (isSuccessfulResponse && response.body !== null) {
           const batchFlushSupport = response.body.lcmCompactionFlushBatch;
           if (typeof batchFlushSupport === "boolean") {
-            cachedBatchFlushSupport = batchFlushSupport;
+            cacheBatchFlushSupport(batchFlushSupport);
             return batchFlushSupport;
           }
           return false;
@@ -637,7 +655,7 @@ export function registerDelegateRuntime(
           response.status === 405 ||
           response.status === 501
         ) {
-          cachedBatchFlushSupport = false;
+          cacheBatchFlushSupport(false);
         }
         return false;
       })
@@ -697,7 +715,7 @@ export function registerDelegateRuntime(
             remainingTimeout(),
           );
           if (response === null) {
-            cachedBatchFlushSupport = undefined;
+            invalidateCachedBatchFlushSupport();
             return flushIndividually();
           }
           const responseNamespaces = response.namespaces;
@@ -712,16 +730,16 @@ export function registerDelegateRuntime(
             ) &&
             responseResults.length === namespaces.length;
           if (!isBatchResponse) {
-            cachedBatchFlushSupport = undefined;
+            invalidateCachedBatchFlushSupport();
             return flushIndividually();
           }
           if (response.flushed === false) {
-            cachedBatchFlushSupport = undefined;
+            invalidateCachedBatchFlushSupport();
             return false;
           }
           return true;
         } catch (err) {
-          cachedBatchFlushSupport = undefined;
+          invalidateCachedBatchFlushSupport();
           throw err;
         }
       }

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -800,6 +800,25 @@ function createDelegateNamespaceBindingStore(
     bindingPath(REMNIC_OPENCLAW_LEGACY_PLUGIN_ID),
   );
   const migratedLegacySessions = new Set<string>();
+  const sessionMigrationChains = new Map<string, Promise<void>>();
+  const queueSessionMigration = <T>(
+    sessionKey: string,
+    operation: () => Promise<T>,
+  ): Promise<T> => {
+    const prior = sessionMigrationChains.get(sessionKey) ?? Promise.resolve();
+    const run = prior.catch(() => undefined).then(operation);
+    const settled = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    sessionMigrationChains.set(sessionKey, settled);
+    void settled.then(() => {
+      if (sessionMigrationChains.get(sessionKey) === settled) {
+        sessionMigrationChains.delete(sessionKey);
+      }
+    });
+    return run;
+  };
   const readLegacyNamespaces = async (
     sessionKey: string,
     current: string[],
@@ -851,33 +870,37 @@ function createDelegateNamespaceBindingStore(
   };
   return {
     async namespacesFor(sessionKey: string): Promise<string[]> {
-      const current = await primary.namespacesFor(sessionKey);
-      const previous = await readLegacyNamespaces(sessionKey, current);
-      if (previous.length === 0) return current;
-      const merged = mergeNamespaceHistory(current, previous);
-      const hasMissingLegacy = previous.some((remembered) => !current.includes(remembered));
-      if (!hasMissingLegacy) {
-        await completeLegacyMigration(sessionKey);
-        return current;
-      }
-      try {
-        await persistNamespaceHistory(primary, sessionKey, merged);
-        await completeLegacyMigration(sessionKey);
-      } catch (err) {
-        log.warn(`[${serviceId}] delegate namespace migration failed: ${String(err)}`);
-      }
-      return merged;
+      return queueSessionMigration(sessionKey, async () => {
+        const current = await primary.namespacesFor(sessionKey);
+        const previous = await readLegacyNamespaces(sessionKey, current);
+        if (previous.length === 0) return current;
+        const merged = mergeNamespaceHistory(current, previous);
+        const hasMissingLegacy = previous.some((remembered) => !current.includes(remembered));
+        if (!hasMissingLegacy) {
+          await completeLegacyMigration(sessionKey);
+          return current;
+        }
+        try {
+          await persistNamespaceHistory(primary, sessionKey, merged);
+          await completeLegacyMigration(sessionKey);
+        } catch (err) {
+          log.warn(`[${serviceId}] delegate namespace migration failed: ${String(err)}`);
+        }
+        return merged;
+      });
     },
     async remember(sessionKey: string, namespace: string): Promise<void> {
-      const current = await primary.namespacesFor(sessionKey);
-      const previous = await readLegacyNamespaces(sessionKey, current);
-      if (previous.length === 0) {
-        await primary.remember(sessionKey, namespace);
-        return;
-      }
-      const merged = mergeNamespaceHistory([...current, namespace], previous);
-      await persistNamespaceHistory(primary, sessionKey, merged);
-      await completeLegacyMigration(sessionKey);
+      return queueSessionMigration(sessionKey, async () => {
+        const current = await primary.namespacesFor(sessionKey);
+        const previous = await readLegacyNamespaces(sessionKey, current);
+        if (previous.length === 0) {
+          await primary.remember(sessionKey, namespace);
+          return;
+        }
+        const merged = mergeNamespaceHistory([...current, namespace], previous);
+        await persistNamespaceHistory(primary, sessionKey, merged);
+        await completeLegacyMigration(sessionKey);
+      });
     },
   };
 }

--- a/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
@@ -64,12 +64,25 @@ async function startDaemonStub(): Promise<DaemonStub> {
       }
       calls.push({ pathname: req.url ?? "", body });
       res.setHeader("content-type", "application/json");
+      const requestedNamespaces = Array.isArray(body.namespaces) ? body.namespaces : undefined;
       const response =
         req.url === "/engram/v1/recall"
           ? { context: "remembered" }
           : req.url === "/engram/v1/capabilities"
             ? { lcmCompactionFlushBatch: true }
-            : {};
+            : requestedNamespaces !== undefined
+              ? {
+                  enabled: true,
+                  flushed: true,
+                  sessionKey: body.sessionKey,
+                  namespaces: requestedNamespaces,
+                  results: requestedNamespaces.map((namespace) => ({
+                    status: "fulfilled",
+                    namespace,
+                    result: { enabled: true, flushed: true },
+                  })),
+                }
+              : {};
       res.end(JSON.stringify(response));
     });
   });
@@ -276,6 +289,7 @@ const subject: LifecycleSubject<DelegateLifecycleState> = {
         assert.equal(recallCalls[0]?.body.namespace, "team-remembered");
         return;
       case "sparse-metadata-without-binding":
+        assert.equal(recallCalls.length, 1, "expected exactly one recall call");
         assert.equal("namespace" in (recallCalls[0]?.body ?? {}), false);
         return;
       case "provider-rebinding":

--- a/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
@@ -90,7 +90,14 @@ async function startDaemonStub(): Promise<DaemonStub> {
 function optionsFor(port: number, namespaceBindings: SessionNamespaceBindingStore): DelegateRuntimeOptions {
   return {
     serviceId: "delegate-lifecycle-matrix",
-    target: { host: "127.0.0.1", port, authToken: "" },
+    target: {
+      host: "127.0.0.1",
+      port,
+      resolveAuthToken: () => ({
+        token: "",
+        source: "no configured token",
+      }),
+    },
     namespace: "",
     namespaceBindings,
     allowPromptInjection: true,

--- a/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
@@ -56,7 +56,12 @@ async function startDaemonStub(): Promise<DaemonStub> {
       raw += String(chunk);
     });
     req.on("end", () => {
-      const body = JSON.parse(raw) as Record<string, unknown>;
+      let body: Record<string, unknown> = {};
+      try {
+        body = JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        body = {};
+      }
       calls.push({ pathname: req.url ?? "", body });
       res.setHeader("content-type", "application/json");
       res.end(JSON.stringify(req.url === "/engram/v1/recall" ? { context: "remembered" } : {}));

--- a/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
@@ -273,7 +273,7 @@ const subject: LifecycleSubject<DelegateLifecycleState> = {
         assert.equal("namespace" in (recallCalls[0]?.body ?? {}), false);
         return;
       case "provider-rebinding":
-        assert.deepEqual(flushCalls.map((call) => call.body.namespace).sort(), ["team-first", "team-second"]);
+        assert.deepEqual(flushCalls.map((call) => call.body.namespaces), [["team-first", "team-second"]]);
         return;
       case "restart-reload-recovery":
         assert.equal(recallCalls.at(-1)?.body.namespace, "team-persisted");

--- a/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
@@ -64,7 +64,13 @@ async function startDaemonStub(): Promise<DaemonStub> {
       }
       calls.push({ pathname: req.url ?? "", body });
       res.setHeader("content-type", "application/json");
-      res.end(JSON.stringify(req.url === "/engram/v1/recall" ? { context: "remembered" } : {}));
+      const response =
+        req.url === "/engram/v1/recall"
+          ? { context: "remembered" }
+          : req.url === "/engram/v1/capabilities"
+            ? { lcmCompactionFlushBatch: true }
+            : {};
+      res.end(JSON.stringify(response));
     });
   });
   const listening = Promise.withResolvers<void>();
@@ -273,7 +279,10 @@ const subject: LifecycleSubject<DelegateLifecycleState> = {
         assert.equal("namespace" in (recallCalls[0]?.body ?? {}), false);
         return;
       case "provider-rebinding":
-        assert.deepEqual(flushCalls.map((call) => call.body.namespaces), [["team-first", "team-second"]]);
+        assert.deepEqual(
+          flushCalls.map((call) => call.body.namespaces),
+          [["team-first", "team-second"]],
+        );
         return;
       case "restart-reload-recovery":
         assert.equal(recallCalls.at(-1)?.body.namespace, "team-persisted");

--- a/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
@@ -82,7 +82,12 @@ async function startDaemonStub(): Promise<DaemonStub> {
                     result: { enabled: true, flushed: true },
                   })),
                 }
-              : {};
+              : {
+                  enabled: true,
+                  flushed: true,
+                  sessionKey: body.sessionKey,
+                  namespace: typeof body.namespace === "string" ? body.namespace : "",
+                };
       res.end(JSON.stringify(response));
     });
   });
@@ -245,13 +250,37 @@ const subject: LifecycleSubject<DelegateLifecycleState> = {
         );
         return;
       case "compaction-flush":
-        await invoke(state, "before_compaction", { sessionKey }, namespaceContext(sessionKey, "team-compaction"));
+        assert.equal(
+          await invoke(
+            state,
+            "before_compaction",
+            { sessionKey },
+            namespaceContext(sessionKey, "team-compaction"),
+          ),
+          true,
+        );
         return;
       case "before-reset":
-        await invoke(state, "before_reset", { sessionKey }, namespaceContext(sessionKey, "team-reset"));
+        assert.equal(
+          await invoke(
+            state,
+            "before_reset",
+            { sessionKey },
+            namespaceContext(sessionKey, "team-reset"),
+          ),
+          true,
+        );
         return;
       case "session-end":
-        await invoke(state, "session_end", { sessionKey }, namespaceContext(sessionKey, "team-end"));
+        assert.equal(
+          await invoke(
+            state,
+            "session_end",
+            { sessionKey },
+            namespaceContext(sessionKey, "team-end"),
+          ),
+          true,
+        );
         return;
       case "dedupe-replay":
         await invoke(

--- a/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  type SessionNamespaceBindingStore,
+  createFileSessionNamespaceBindingStore,
+} from "@remnic/core/session-namespace-bindings";
+import { type LifecycleSubject, type MatrixRow, runLifecycleMatrix } from "@remnic/core/testing/lifecycle-matrix";
+import { type DelegateRuntimeOptions, registerDelegateRuntime } from "../../delegate-runtime.js";
+
+type HookHandler = (event: Record<string, unknown>, ctx: Record<string, unknown>) => unknown;
+
+interface RecordedCall {
+  pathname: string;
+  body: Record<string, unknown>;
+}
+
+interface DelegateLifecycleState {
+  directory: string;
+  filePath: string;
+  namespaceBindings: SessionNamespaceBindingStore;
+  api: RecordingApi;
+  daemon: DaemonStub;
+  sessionKey: string;
+}
+
+interface DaemonStub {
+  port: number;
+  calls: RecordedCall[];
+  close: () => Promise<void>;
+}
+
+interface RecordingApi {
+  handlers: Map<string, HookHandler[]>;
+  on: (hook: string, handler: HookHandler) => void;
+}
+
+function recordingApi(): RecordingApi {
+  const handlers = new Map<string, HookHandler[]>();
+  return {
+    handlers,
+    on(hook: string, handler: HookHandler): void {
+      handlers.set(hook, [...(handlers.get(hook) ?? []), handler]);
+    },
+  };
+}
+
+async function startDaemonStub(): Promise<DaemonStub> {
+  const calls: RecordedCall[] = [];
+  const server = http.createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk: Buffer) => {
+      raw += String(chunk);
+    });
+    req.on("end", () => {
+      const body = JSON.parse(raw) as Record<string, unknown>;
+      calls.push({ pathname: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify(req.url === "/engram/v1/recall" ? { context: "remembered" } : {}));
+    });
+  });
+  const listening = Promise.withResolvers<void>();
+  server.once("error", listening.reject);
+  server.listen(0, "127.0.0.1", listening.resolve);
+  await listening.promise;
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("delegate matrix daemon did not bind");
+  }
+  return {
+    port: address.port,
+    calls,
+    close: () => {
+      const closed = Promise.withResolvers<void>();
+      server.close(() => closed.resolve());
+      return closed.promise;
+    },
+  };
+}
+
+function optionsFor(port: number, namespaceBindings: SessionNamespaceBindingStore): DelegateRuntimeOptions {
+  return {
+    serviceId: "delegate-lifecycle-matrix",
+    target: { host: "127.0.0.1", port, authToken: "" },
+    namespace: "",
+    namespaceBindings,
+    allowPromptInjection: true,
+    passive: false,
+    gateHeartbeatTurns: false,
+    recallBudgetChars: 8_000,
+    resolveSessionDisabled: async () => false,
+    cleanUserMessage: (text) => text,
+    hookTimeoutMs: 5_000,
+    shouldSkipRecall: () => false,
+    flushOnResetEnabled: true,
+    recallTimeoutMs: 5_000,
+    observeTimeoutMs: 5_000,
+    flushTimeoutMs: 5_000,
+  };
+}
+
+function registerRuntime(state: DelegateLifecycleState): void {
+  state.api = recordingApi();
+  registerDelegateRuntime(state.api, optionsFor(state.daemon.port, state.namespaceBindings));
+}
+
+async function invoke(
+  state: DelegateLifecycleState,
+  hook: string,
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown> = {}
+): Promise<unknown> {
+  const handlers = state.api.handlers.get(hook);
+  assert.ok(handlers && handlers.length === 1, `${hook} must have exactly one handler`);
+  return await handlers[0](event, ctx);
+}
+
+function namespaceContext(sessionKey: string, namespace: string): Record<string, unknown> {
+  return {
+    sessionKey,
+    runtime: { agent: { session: { namespace } } },
+  };
+}
+
+function callsFor(state: DelegateLifecycleState, pathname: string): RecordedCall[] {
+  return state.daemon.calls.filter((call) => call.pathname === pathname);
+}
+
+const subject: LifecycleSubject<DelegateLifecycleState> = {
+  async setup(row: MatrixRow): Promise<DelegateLifecycleState> {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-lifecycle-"));
+    try {
+      const filePath = path.join(directory, "session-namespace-bindings.json");
+      const state: DelegateLifecycleState = {
+        directory,
+        filePath,
+        namespaceBindings: createFileSessionNamespaceBindingStore(filePath),
+        api: recordingApi(),
+        daemon: await startDaemonStub(),
+        sessionKey: `matrix-${row.id}`,
+      };
+      registerRuntime(state);
+      return state;
+    } catch (error) {
+      await rm(directory, { recursive: true, force: true });
+      throw error;
+    }
+  },
+
+  async exercise(state: DelegateLifecycleState, row: MatrixRow): Promise<void> {
+    const { sessionKey } = state;
+    switch (row.id) {
+      case "explicit-provider-identity":
+        await invoke(
+          state,
+          "before_prompt_build",
+          { prompt: "recall this retained memory" },
+          namespaceContext(sessionKey, "team-explicit")
+        );
+        await invoke(
+          state,
+          "agent_end",
+          {
+            success: true,
+            sessionKey,
+            messages: [
+              { role: "user", content: "Please retain this meaningful user turn." },
+              { role: "assistant", content: "I will retain this useful assistant response." },
+            ],
+          },
+          namespaceContext(sessionKey, "team-explicit")
+        );
+        return;
+      case "sparse-metadata-with-binding":
+        await state.namespaceBindings.remember(sessionKey, "team-remembered");
+        await invoke(state, "before_prompt_build", { prompt: "recall this retained memory" }, { sessionKey });
+        return;
+      case "sparse-metadata-without-binding":
+        await invoke(state, "before_prompt_build", { prompt: "recall this retained memory" }, { sessionKey });
+        return;
+      case "provider-rebinding":
+        await invoke(
+          state,
+          "before_prompt_build",
+          { prompt: "recall the first provider binding" },
+          namespaceContext(sessionKey, "team-first")
+        );
+        await invoke(
+          state,
+          "before_prompt_build",
+          { prompt: "recall the rebound provider binding" },
+          namespaceContext(sessionKey, "team-second")
+        );
+        await invoke(state, "before_compaction", { sessionKey });
+        return;
+      case "restart-reload-recovery":
+        await invoke(
+          state,
+          "before_prompt_build",
+          { prompt: "record the persisted provider binding" },
+          namespaceContext(sessionKey, "team-persisted")
+        );
+        state.namespaceBindings = createFileSessionNamespaceBindingStore(state.filePath);
+        registerRuntime(state);
+        await invoke(
+          state,
+          "before_prompt_build",
+          { prompt: "recover the persisted provider binding" },
+          { sessionKey }
+        );
+        return;
+      case "compaction-flush":
+        await invoke(state, "before_compaction", { sessionKey }, namespaceContext(sessionKey, "team-compaction"));
+        return;
+      case "before-reset":
+        await invoke(state, "before_reset", { sessionKey }, namespaceContext(sessionKey, "team-reset"));
+        return;
+      case "session-end":
+        await invoke(state, "session_end", { sessionKey }, namespaceContext(sessionKey, "team-end"));
+        return;
+      case "dedupe-replay":
+        await invoke(
+          state,
+          "before_prompt_build",
+          { prompt: "record one replayable provider binding" },
+          namespaceContext(sessionKey, "team-replay")
+        );
+        await invoke(
+          state,
+          "before_prompt_build",
+          { prompt: "replay the same provider binding again" },
+          namespaceContext(sessionKey, "team-replay")
+        );
+        await invoke(state, "before_compaction", { sessionKey });
+        await invoke(state, "before_compaction", { sessionKey });
+        return;
+      default: {
+        const exhaustive: never = row.id;
+        throw new Error(`unhandled lifecycle row ${String(exhaustive)}`);
+      }
+    }
+  },
+
+  async invariants(state: DelegateLifecycleState, row: MatrixRow): Promise<void> {
+    const recallCalls = callsFor(state, "/engram/v1/recall");
+    const flushCalls = callsFor(state, "/engram/v1/lcm/compaction/flush");
+    switch (row.id) {
+      case "explicit-provider-identity": {
+        assert.equal(recallCalls[0]?.body.namespace, "team-explicit");
+        assert.equal(callsFor(state, "/engram/v1/observe")[0]?.body.namespace, "team-explicit");
+        return;
+      }
+      case "sparse-metadata-with-binding":
+        assert.equal(recallCalls[0]?.body.namespace, "team-remembered");
+        return;
+      case "sparse-metadata-without-binding":
+        assert.equal("namespace" in (recallCalls[0]?.body ?? {}), false);
+        return;
+      case "provider-rebinding":
+        assert.deepEqual(flushCalls.map((call) => call.body.namespace).sort(), ["team-first", "team-second"]);
+        return;
+      case "restart-reload-recovery":
+        assert.equal(recallCalls.at(-1)?.body.namespace, "team-persisted");
+        return;
+      case "compaction-flush":
+        assert.equal(flushCalls[0]?.body.namespace, "team-compaction");
+        return;
+      case "before-reset":
+        assert.equal(flushCalls[0]?.body.namespace, "team-reset");
+        return;
+      case "session-end":
+        assert.equal(flushCalls[0]?.body.namespace, "team-end");
+        return;
+      case "dedupe-replay":
+        assert.deepEqual(await state.namespaceBindings.namespacesFor(state.sessionKey), ["team-replay"]);
+        assert.deepEqual(
+          flushCalls.map((call) => call.body.namespace),
+          ["team-replay", "team-replay"]
+        );
+        return;
+      default: {
+        const exhaustive: never = row.id;
+        throw new Error(`unhandled lifecycle row ${String(exhaustive)}`);
+      }
+    }
+  },
+
+  async teardown(state: DelegateLifecycleState): Promise<void> {
+    await state.daemon.close();
+    await rm(state.directory, { recursive: true, force: true });
+  },
+};
+
+runLifecycleMatrix("openclaw-delegate-runtime", subject);

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -2430,6 +2430,16 @@
       "remnic-source": "./src/session-namespace-bindings.ts",
       "import": "./dist/session-namespace-bindings.js"
     },
+    "./testing/lifecycle-matrix": {
+      "types": "./dist/testing/lifecycle-matrix.d.ts",
+      "remnic-source": "./src/testing/lifecycle-matrix.ts",
+      "import": "./dist/testing/lifecycle-matrix.js"
+    },
+    "./testing/lifecycle-matrix.js": {
+      "types": "./dist/testing/lifecycle-matrix.d.ts",
+      "remnic-source": "./src/testing/lifecycle-matrix.ts",
+      "import": "./dist/testing/lifecycle-matrix.js"
+    },
     "./session-observer-bands": {
       "types": "./dist/session-observer-bands.d.ts",
       "remnic-source": "./src/session-observer-bands.ts",

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -2420,6 +2420,16 @@
       "remnic-source": "./src/session-integrity.ts",
       "import": "./dist/session-integrity.js"
     },
+    "./session-namespace-bindings": {
+      "types": "./dist/session-namespace-bindings.d.ts",
+      "remnic-source": "./src/session-namespace-bindings.ts",
+      "import": "./dist/session-namespace-bindings.js"
+    },
+    "./session-namespace-bindings.js": {
+      "types": "./dist/session-namespace-bindings.d.ts",
+      "remnic-source": "./src/session-namespace-bindings.ts",
+      "import": "./dist/session-namespace-bindings.js"
+    },
     "./session-observer-bands": {
       "types": "./dist/session-observer-bands.d.ts",
       "remnic-source": "./src/session-observer-bands.ts",

--- a/packages/remnic-core/src/access-http-lcm-compaction.ts
+++ b/packages/remnic-core/src/access-http-lcm-compaction.ts
@@ -17,6 +17,12 @@ export interface LcmCompactionFlushHttpOptions {
   respondJson: JsonResponder;
 }
 
+export function respondLcmCompactionCapabilitiesHttp(response: ServerResponse): void {
+  response.statusCode = 200;
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.end(JSON.stringify({ lcmCompactionFlushBatch: true }, null, 2));
+}
+
 export async function handleLcmCompactionFlushHttp({
   body,
   service,

--- a/packages/remnic-core/src/access-http-lcm-compaction.ts
+++ b/packages/remnic-core/src/access-http-lcm-compaction.ts
@@ -1,7 +1,7 @@
 import type { ServerResponse } from "node:http";
 
-import type { EngramAccessService } from "./access-service.js";
 import type { LcmCompactionFlushRequest } from "./access-schema.js";
+import type { EngramAccessLcmCompactionFlushResponse, EngramAccessService } from "./access-service.js";
 
 type LcmCompactionService = Pick<EngramAccessService, "lcmCompactionFlush">;
 type JsonResponder = (res: ServerResponse, status: number, payload: unknown) => void;
@@ -13,6 +13,7 @@ export interface LcmCompactionFlushHttpOptions {
   ensureWriteRateLimitAvailable: () => void;
   recordWriteRateLimitHit: () => void;
   resolveNamespace: (namespace?: string) => string | undefined;
+  defaultNamespace?: string;
   resolveRequestPrincipal: () => string | undefined;
   respondJson: JsonResponder;
 }
@@ -30,6 +31,7 @@ export async function handleLcmCompactionFlushHttp({
   ensureWriteRateLimitAvailable,
   recordWriteRateLimitHit,
   resolveNamespace,
+  defaultNamespace,
   resolveRequestPrincipal,
   respondJson,
 }: LcmCompactionFlushHttpOptions): Promise<void> {
@@ -45,30 +47,68 @@ export async function handleLcmCompactionFlushHttp({
     respondJson(response, 200, result);
     return;
   }
-
-  const outcomes = await Promise.allSettled(
-    requestedNamespaces.map(async (requestedNamespace) =>
+  const resolutionOutcomes = await Promise.allSettled(
+    requestedNamespaces.map(async (requestedNamespace) => {
+      const namespace = resolveNamespace(requestedNamespace);
+      return {
+        requestedNamespace,
+        namespace,
+        effectiveNamespace: namespace ?? defaultNamespace ?? "",
+      };
+    })
+  );
+  const uniqueResolvedNamespaces: Array<{
+    requestedNamespace: string;
+    namespace: string | undefined;
+    effectiveNamespace: string;
+  }> = [];
+  const queuedEffectiveNamespaces = new Set<string>();
+  for (const outcome of resolutionOutcomes) {
+    if (outcome.status === "fulfilled" && !queuedEffectiveNamespaces.has(outcome.value.effectiveNamespace)) {
+      queuedEffectiveNamespaces.add(outcome.value.effectiveNamespace);
+      uniqueResolvedNamespaces.push(outcome.value);
+    }
+  }
+  const serviceOutcomes = await Promise.allSettled(
+    uniqueResolvedNamespaces.map(({ namespace }) =>
       service.lcmCompactionFlush({
         sessionKey: body.sessionKey,
-        namespace: resolveNamespace(requestedNamespace),
+        namespace,
         authenticatedPrincipal: resolveRequestPrincipal(),
-      }),
-    ),
+      })
+    )
   );
+  type BatchResult =
+    | {
+        requestedNamespace: string;
+        status: "fulfilled";
+        result: EngramAccessLcmCompactionFlushResponse;
+      }
+    | { requestedNamespace: string; status: "rejected" };
+  const results: BatchResult[] = [];
+  const emittedEffectiveNamespaces = new Set<string>();
+  let serviceOutcomeIndex = 0;
+  for (const [index, outcome] of resolutionOutcomes.entries()) {
+    const requestedNamespace = requestedNamespaces[index] ?? "";
+    if (outcome.status === "rejected") {
+      results.push({ status: "rejected", requestedNamespace });
+      continue;
+    }
+    if (emittedEffectiveNamespaces.has(outcome.value.effectiveNamespace)) continue;
+    emittedEffectiveNamespaces.add(outcome.value.effectiveNamespace);
+    const serviceOutcome = serviceOutcomes[serviceOutcomeIndex++];
+    if (serviceOutcome?.status === "fulfilled") {
+      results.push({ status: "fulfilled", requestedNamespace, result: serviceOutcome.value });
+    } else {
+      results.push({ status: "rejected", requestedNamespace });
+    }
+  }
   recordWriteRateLimitHit();
   respondJson(response, 200, {
-    enabled: outcomes.every(
-      (outcome) => outcome.status === "fulfilled" && outcome.value.enabled !== false,
-    ),
-    flushed: outcomes.every(
-      (outcome) => outcome.status === "fulfilled" && outcome.value.flushed !== false,
-    ),
+    enabled: results.every((result) => result.status === "fulfilled" && result.result.enabled !== false),
+    flushed: results.every((result) => result.status === "fulfilled" && result.result.flushed !== false),
     sessionKey: body.sessionKey,
-    namespaces: requestedNamespaces,
-    results: outcomes.map((outcome, index) =>
-      outcome.status === "fulfilled"
-        ? { status: "fulfilled", namespace: requestedNamespaces[index], result: outcome.value }
-        : { status: "rejected", namespace: requestedNamespaces[index] },
-    ),
+    namespaces: results.map(({ requestedNamespace }) => requestedNamespace),
+    results: results.map(({ requestedNamespace, ...result }) => ({ ...result, namespace: requestedNamespace })),
   });
 }

--- a/packages/remnic-core/src/access-http-lcm-compaction.ts
+++ b/packages/remnic-core/src/access-http-lcm-compaction.ts
@@ -1,0 +1,68 @@
+import type { ServerResponse } from "node:http";
+
+import type { EngramAccessService } from "./access-service.js";
+import type { LcmCompactionFlushRequest } from "./access-schema.js";
+
+type LcmCompactionService = Pick<EngramAccessService, "lcmCompactionFlush">;
+type JsonResponder = (res: ServerResponse, status: number, payload: unknown) => void;
+
+export interface LcmCompactionFlushHttpOptions {
+  body: LcmCompactionFlushRequest;
+  service: LcmCompactionService;
+  response: ServerResponse;
+  ensureWriteRateLimitAvailable: () => void;
+  recordWriteRateLimitHit: () => void;
+  resolveNamespace: (namespace?: string) => string | undefined;
+  resolveRequestPrincipal: () => string | undefined;
+  respondJson: JsonResponder;
+}
+
+export async function handleLcmCompactionFlushHttp({
+  body,
+  service,
+  response,
+  ensureWriteRateLimitAvailable,
+  recordWriteRateLimitHit,
+  resolveNamespace,
+  resolveRequestPrincipal,
+  respondJson,
+}: LcmCompactionFlushHttpOptions): Promise<void> {
+  ensureWriteRateLimitAvailable();
+  const requestedNamespaces = body.namespaces;
+  if (requestedNamespaces === undefined) {
+    const result = await service.lcmCompactionFlush({
+      sessionKey: body.sessionKey,
+      namespace: resolveNamespace(body.namespace),
+      authenticatedPrincipal: resolveRequestPrincipal(),
+    });
+    recordWriteRateLimitHit();
+    respondJson(response, 200, result);
+    return;
+  }
+
+  const outcomes = await Promise.allSettled(
+    requestedNamespaces.map(async (requestedNamespace) =>
+      service.lcmCompactionFlush({
+        sessionKey: body.sessionKey,
+        namespace: resolveNamespace(requestedNamespace),
+        authenticatedPrincipal: resolveRequestPrincipal(),
+      }),
+    ),
+  );
+  recordWriteRateLimitHit();
+  respondJson(response, 200, {
+    enabled: outcomes.every(
+      (outcome) => outcome.status === "fulfilled" && outcome.value.enabled !== false,
+    ),
+    flushed: outcomes.every(
+      (outcome) => outcome.status === "fulfilled" && outcome.value.flushed !== false,
+    ),
+    sessionKey: body.sessionKey,
+    namespaces: requestedNamespaces,
+    results: outcomes.map((outcome, index) =>
+      outcome.status === "fulfilled"
+        ? { status: "fulfilled", namespace: requestedNamespaces[index], result: outcome.value }
+        : { status: "rejected", namespace: requestedNamespaces[index] },
+    ),
+  });
+}

--- a/packages/remnic-core/src/access-http-lcm-compaction.ts
+++ b/packages/remnic-core/src/access-http-lcm-compaction.ts
@@ -78,6 +78,16 @@ export async function handleLcmCompactionFlushHttp({
       })
     )
   );
+  const serviceOutcomesByEffectiveNamespace = new Map<
+    string,
+    PromiseSettledResult<EngramAccessLcmCompactionFlushResponse>
+  >();
+  for (const [index, resolved] of uniqueResolvedNamespaces.entries()) {
+    const serviceOutcome = serviceOutcomes[index];
+    if (serviceOutcome !== undefined) {
+      serviceOutcomesByEffectiveNamespace.set(resolved.effectiveNamespace, serviceOutcome);
+    }
+  }
   type BatchResult =
     | {
         requestedNamespace: string;
@@ -85,30 +95,22 @@ export async function handleLcmCompactionFlushHttp({
         result: EngramAccessLcmCompactionFlushResponse;
       }
     | { requestedNamespace: string; status: "rejected" };
-  const results: BatchResult[] = [];
-  const emittedEffectiveNamespaces = new Set<string>();
-  let serviceOutcomeIndex = 0;
-  for (const [index, outcome] of resolutionOutcomes.entries()) {
+  const results: BatchResult[] = resolutionOutcomes.map((outcome, index) => {
     const requestedNamespace = requestedNamespaces[index] ?? "";
     if (outcome.status === "rejected") {
-      results.push({ status: "rejected", requestedNamespace });
-      continue;
+      return { status: "rejected", requestedNamespace };
     }
-    if (emittedEffectiveNamespaces.has(outcome.value.effectiveNamespace)) continue;
-    emittedEffectiveNamespaces.add(outcome.value.effectiveNamespace);
-    const serviceOutcome = serviceOutcomes[serviceOutcomeIndex++];
-    if (serviceOutcome?.status === "fulfilled") {
-      results.push({ status: "fulfilled", requestedNamespace, result: serviceOutcome.value });
-    } else {
-      results.push({ status: "rejected", requestedNamespace });
-    }
-  }
+    const serviceOutcome = serviceOutcomesByEffectiveNamespace.get(outcome.value.effectiveNamespace);
+    return serviceOutcome?.status === "fulfilled"
+      ? { status: "fulfilled", requestedNamespace, result: serviceOutcome.value }
+      : { status: "rejected", requestedNamespace };
+  });
   recordWriteRateLimitHit();
   respondJson(response, 200, {
     enabled: results.every((result) => result.status === "fulfilled" && result.result.enabled !== false),
     flushed: results.every((result) => result.status === "fulfilled" && result.result.flushed !== false),
     sessionKey: body.sessionKey,
-    namespaces: results.map(({ requestedNamespace }) => requestedNamespace),
+    namespaces: requestedNamespaces,
     results: results.map(({ requestedNamespace, ...result }) => ({ ...result, namespace: requestedNamespace })),
   });
 }

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -203,6 +203,65 @@ test("HTTP batch LCM flush isolates namespace failures and charges one write quo
   }
 });
 
+test("HTTP batch LCM flush deduplicates aliases after effective namespace resolution", async () => {
+  const calls: Array<{ namespace?: string; sessionKey: string; authenticatedPrincipal?: string }> = [];
+  const service = {
+    configRef: parseConfig({ namespacesEnabled: true, defaultNamespace: "default" }),
+    lcmCompactionFlush: async (request: {
+      namespace?: string;
+      sessionKey: string;
+      authenticatedPrincipal?: string;
+    }) => {
+      calls.push(request);
+      return { enabled: true, flushed: true };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/engram/v1/lcm/compaction/flush`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        sessionKey: "effective-namespace-session",
+        namespaces: ["", "default"],
+      }),
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      enabled: true,
+      flushed: true,
+      sessionKey: "effective-namespace-session",
+      namespaces: [""],
+      results: [
+        {
+          status: "fulfilled",
+          namespace: "",
+          result: { enabled: true, flushed: true },
+        },
+      ],
+    });
+    assert.deepEqual(calls, [
+      {
+        sessionKey: "effective-namespace-session",
+        namespace: undefined,
+        authenticatedPrincipal: undefined,
+      },
+    ]);
+  } finally {
+    await server.stop();
+  }
+});
+
 
 test("HTTP batch LCM flush isolates per-namespace authorization failures", async () => {
   const calls: string[] = [];

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -170,6 +170,21 @@ test("HTTP batch LCM flush isolates namespace failures and charges one write quo
       },
     ]);
 
+    const conflicting = await fetch(`http://127.0.0.1:${status.port}/engram/v1/lcm/compaction/flush`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        sessionKey: "batch-session",
+        namespace: "team-a",
+        namespaces: ["team-b"],
+      }),
+    });
+    assert.equal(conflicting.status, 400);
+    assert.equal(calls.length, 2, "conflicting namespace forms must fail before dispatch");
+
     const rateLimited = await fetch(`http://127.0.0.1:${status.port}/engram/v1/lcm/compaction/flush`, {
       method: "POST",
       headers: {

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -241,11 +241,16 @@ test("HTTP batch LCM flush deduplicates aliases after effective namespace resolu
       enabled: true,
       flushed: true,
       sessionKey: "effective-namespace-session",
-      namespaces: [""],
+      namespaces: ["", "default"],
       results: [
         {
           status: "fulfilled",
           namespace: "",
+          result: { enabled: true, flushed: true },
+        },
+        {
+          status: "fulfilled",
+          namespace: "default",
           result: { enabled: true, flushed: true },
         },
       ],

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -108,6 +108,145 @@ test("HTTP memory browse rejects malformed pagination and sort query values", as
   }
 });
 
+test("HTTP batch LCM flush isolates namespace failures and charges one write quota", async () => {
+  const calls: Array<{ namespace?: string; sessionKey: string; authenticatedPrincipal?: string }> = [];
+  const service = {
+    lcmCompactionFlush: async (request: {
+      namespace?: string;
+      sessionKey: string;
+      authenticatedPrincipal?: string;
+    }) => {
+      calls.push(request);
+      if (request.namespace === "team-b") throw new Error("team-b flush failed");
+      return { enabled: true, flushed: true };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+    writeRateLimitMaxRequests: 1,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/engram/v1/lcm/compaction/flush`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        sessionKey: "batch-session",
+        namespaces: ["team-a", "team-b"],
+      }),
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      enabled: false,
+      flushed: false,
+      sessionKey: "batch-session",
+      namespaces: ["team-a", "team-b"],
+      results: [
+        {
+          status: "fulfilled",
+          namespace: "team-a",
+          result: { enabled: true, flushed: true },
+        },
+        { status: "rejected", namespace: "team-b" },
+      ],
+    });
+    assert.deepEqual(calls, [
+      {
+        sessionKey: "batch-session",
+        namespace: "team-a",
+        authenticatedPrincipal: undefined,
+      },
+      {
+        sessionKey: "batch-session",
+        namespace: "team-b",
+        authenticatedPrincipal: undefined,
+      },
+    ]);
+
+    const rateLimited = await fetch(`http://127.0.0.1:${status.port}/engram/v1/lcm/compaction/flush`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        sessionKey: "batch-session",
+        namespaces: ["team-a"],
+      }),
+    });
+    assert.equal(rateLimited.status, 429);
+    assert.equal(calls.length, 2, "a batch consumes one write quota unit");
+  } finally {
+    await server.stop();
+  }
+});
+
+
+test("HTTP batch LCM flush isolates per-namespace authorization failures", async () => {
+  const calls: string[] = [];
+  const service = {
+    lcmCompactionFlush: async (request: { namespace?: string }) => {
+      calls.push(request.namespace ?? "");
+      return { enabled: true, flushed: true };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "unused-token",
+    authTokenEntriesGetter: () => [
+      {
+        token: "scoped-token",
+        capabilities: {
+          version: 1,
+          ops: ["lcm_compaction_flush"],
+          namespaces: ["team-a"],
+        },
+      },
+    ],
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/engram/v1/lcm/compaction/flush`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer scoped-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        sessionKey: "authorized-batch-session",
+        namespaces: ["team-a", "team-b"],
+      }),
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      enabled: false,
+      flushed: false,
+      sessionKey: "authorized-batch-session",
+      namespaces: ["team-a", "team-b"],
+      results: [
+        {
+          status: "fulfilled",
+          namespace: "team-a",
+          result: { enabled: true, flushed: true },
+        },
+        { status: "rejected", namespace: "team-b" },
+      ],
+    });
+    assert.deepEqual(calls, ["team-a"]);
+  } finally {
+    await server.stop();
+  }
+});
 test("HTTP admin console assets are public but API routes require bearer authentication", async () => {
   const service = {} as EngramAccessService;
   const server = new EngramAccessHttpServer({

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -40,7 +40,7 @@ import { projectTagProjectId } from "./coding/coding-namespace.js";
 import { getOperation, type OperationName } from "./access-boundary.js";
 import { authorizationProbeNamespaces, probeOperationAuthorization } from "./access-authorization-probe.js";
 import { resolveQueryNamespaceWritablePreflight } from "./access-namespace-preflight.js";
-import { handleLcmCompactionFlushHttp } from "./access-http-lcm-compaction.js";
+import * as lcm from "./access-http-lcm-compaction.js";
 import {
   assertOperationAllowed,
   capabilityAllowsOp,
@@ -890,11 +890,7 @@ export class EngramAccessHttpServer {
       this.respondJson(res, 200, await this.service.health());
       return;
     }
-    if (req.method === "GET" && pathname === "/engram/v1/capabilities") {
-      this.respondJson(res, 200, { lcmCompactionFlushBatch: true });
-      return;
-    }
-
+    if (req.method === "GET" && pathname === "/engram/v1/capabilities") return lcm.respondLcmCompactionCapabilitiesHttp(res);
     if (req.method === "GET" && pathname === "/engram/v1/authorization") {
       res.setHeader("cache-control", "no-store");
       const probe = probeOperationAuthorization(tokenCapabilityStore.getStore(), parsed.searchParams.getAll("op"));
@@ -1679,7 +1675,7 @@ export class EngramAccessHttpServer {
     ) {
       this.enforceTokenOp("lcm_compaction_flush"); // boundary dispatch (issue #1525)
       const body = await this.readValidatedBody(req, "lcmCompactionFlush");
-      await handleLcmCompactionFlushHttp({
+      await lcm.handleLcmCompactionFlushHttp({
         body, service: this.service,
         response: res, ensureWriteRateLimitAvailable: () => this.ensureWriteRateLimitAvailable(req),
         recordWriteRateLimitHit: () => this.recordWriteRateLimitHit(req),

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -40,6 +40,7 @@ import { projectTagProjectId } from "./coding/coding-namespace.js";
 import { getOperation, type OperationName } from "./access-boundary.js";
 import { authorizationProbeNamespaces, probeOperationAuthorization } from "./access-authorization-probe.js";
 import { resolveQueryNamespaceWritablePreflight } from "./access-namespace-preflight.js";
+import { handleLcmCompactionFlushHttp } from "./access-http-lcm-compaction.js";
 import {
   assertOperationAllowed,
   capabilityAllowsOp,
@@ -1674,43 +1675,12 @@ export class EngramAccessHttpServer {
     ) {
       this.enforceTokenOp("lcm_compaction_flush"); // boundary dispatch (issue #1525)
       const body = await this.readValidatedBody(req, "lcmCompactionFlush");
-      this.ensureWriteRateLimitAvailable(req);
-      const requestedNamespaces = body.namespaces;
-      if (requestedNamespaces === undefined) {
-        const response = await this.service.lcmCompactionFlush({
-          sessionKey: body.sessionKey,
-          namespace: this.resolveNamespace(req, body.namespace),
-          authenticatedPrincipal: this.resolveRequestPrincipal(req),
-        });
-        this.recordWriteRateLimitHit(req);
-        this.respondJson(res, 200, response);
-        return;
-      }
-
-      const outcomes = await Promise.allSettled(
-        requestedNamespaces.map(async (requestedNamespace) =>
-          this.service.lcmCompactionFlush({
-            sessionKey: body.sessionKey,
-            namespace: this.resolveNamespace(req, requestedNamespace),
-            authenticatedPrincipal: this.resolveRequestPrincipal(req),
-          }),
-        ),
-      );
-      this.recordWriteRateLimitHit(req);
-      this.respondJson(res, 200, {
-        enabled: outcomes.every(
-          (outcome) => outcome.status === "fulfilled" && outcome.value.enabled !== false,
-        ),
-        flushed: outcomes.every(
-          (outcome) => outcome.status === "fulfilled" && outcome.value.flushed !== false,
-        ),
-        sessionKey: body.sessionKey,
-        namespaces: requestedNamespaces,
-        results: outcomes.map((outcome, index) =>
-          outcome.status === "fulfilled"
-            ? { status: "fulfilled", namespace: requestedNamespaces[index], result: outcome.value }
-            : { status: "rejected", namespace: requestedNamespaces[index] },
-        ),
+      await handleLcmCompactionFlushHttp({
+        body, service: this.service,
+        response: res, ensureWriteRateLimitAvailable: () => this.ensureWriteRateLimitAvailable(req),
+        recordWriteRateLimitHit: () => this.recordWriteRateLimitHit(req),
+        resolveNamespace: (namespace) => this.resolveNamespace(req, namespace),
+        resolveRequestPrincipal: () => this.resolveRequestPrincipal(req), respondJson: this.respondJson.bind(this),
       });
       return;
     }

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1675,13 +1675,43 @@ export class EngramAccessHttpServer {
       this.enforceTokenOp("lcm_compaction_flush"); // boundary dispatch (issue #1525)
       const body = await this.readValidatedBody(req, "lcmCompactionFlush");
       this.ensureWriteRateLimitAvailable(req);
-      const response = await this.service.lcmCompactionFlush({
-        sessionKey: body.sessionKey,
-        namespace: this.resolveNamespace(req, body.namespace),
-        authenticatedPrincipal: this.resolveRequestPrincipal(req),
-      });
+      const requestedNamespaces = body.namespaces;
+      if (requestedNamespaces === undefined) {
+        const response = await this.service.lcmCompactionFlush({
+          sessionKey: body.sessionKey,
+          namespace: this.resolveNamespace(req, body.namespace),
+          authenticatedPrincipal: this.resolveRequestPrincipal(req),
+        });
+        this.recordWriteRateLimitHit(req);
+        this.respondJson(res, 200, response);
+        return;
+      }
+
+      const outcomes = await Promise.allSettled(
+        requestedNamespaces.map(async (requestedNamespace) =>
+          this.service.lcmCompactionFlush({
+            sessionKey: body.sessionKey,
+            namespace: this.resolveNamespace(req, requestedNamespace),
+            authenticatedPrincipal: this.resolveRequestPrincipal(req),
+          }),
+        ),
+      );
       this.recordWriteRateLimitHit(req);
-      this.respondJson(res, 200, response);
+      this.respondJson(res, 200, {
+        enabled: outcomes.every(
+          (outcome) => outcome.status === "fulfilled" && outcome.value.enabled !== false,
+        ),
+        flushed: outcomes.every(
+          (outcome) => outcome.status === "fulfilled" && outcome.value.flushed !== false,
+        ),
+        sessionKey: body.sessionKey,
+        namespaces: requestedNamespaces,
+        results: outcomes.map((outcome, index) =>
+          outcome.status === "fulfilled"
+            ? { status: "fulfilled", namespace: requestedNamespaces[index], result: outcome.value }
+            : { status: "rejected", namespace: requestedNamespaces[index] },
+        ),
+      });
       return;
     }
 

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -890,6 +890,10 @@ export class EngramAccessHttpServer {
       this.respondJson(res, 200, await this.service.health());
       return;
     }
+    if (req.method === "GET" && pathname === "/engram/v1/capabilities") {
+      this.respondJson(res, 200, { lcmCompactionFlushBatch: true });
+      return;
+    }
 
     if (req.method === "GET" && pathname === "/engram/v1/authorization") {
       res.setHeader("cache-control", "no-store");

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1680,6 +1680,7 @@ export class EngramAccessHttpServer {
         response: res, ensureWriteRateLimitAvailable: () => this.ensureWriteRateLimitAvailable(req),
         recordWriteRateLimitHit: () => this.recordWriteRateLimitHit(req),
         resolveNamespace: (namespace) => this.resolveNamespace(req, namespace),
+        defaultNamespace: this.service.configRef?.defaultNamespace,
         resolveRequestPrincipal: () => this.resolveRequestPrincipal(req), respondJson: this.respondJson.bind(this),
       });
       return;

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1679,8 +1679,7 @@ export class EngramAccessHttpServer {
         body, service: this.service,
         response: res, ensureWriteRateLimitAvailable: () => this.ensureWriteRateLimitAvailable(req),
         recordWriteRateLimitHit: () => this.recordWriteRateLimitHit(req),
-        resolveNamespace: (namespace) => this.resolveNamespace(req, namespace),
-        defaultNamespace: this.service.configRef?.defaultNamespace,
+        resolveNamespace: (namespace) => this.resolveNamespace(req, namespace), defaultNamespace: this.service.configRef?.defaultNamespace,
         resolveRequestPrincipal: () => this.resolveRequestPrincipal(req), respondJson: this.respondJson.bind(this),
       });
       return;

--- a/packages/remnic-core/src/access-schema-pi.test.ts
+++ b/packages/remnic-core/src/access-schema-pi.test.ts
@@ -49,6 +49,15 @@ test("LCM compaction schemas validate Pi extension requests", () => {
   assert.equal(record.success, true);
 });
 
+test("LCM compaction flush rejects duplicate namespace batches", () => {
+  const result = validateRequest("lcmCompactionFlush", {
+    sessionKey: "pi:session",
+    namespaces: ["work", "work"],
+  });
+
+  assert.equal(result.success, false);
+});
+
 test("LCM compaction record rejects invalid token counts", () => {
   const result = validateRequest("lcmCompactionRecord", {
     sessionKey: "pi:session",

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -331,15 +331,25 @@ export const lcmSearchRequestSchema = z.object({
   limit: z.number().int().min(1).max(100).optional(),
 });
 
-export const lcmCompactionFlushRequestSchema = z.object({
-  sessionKey: z.string().trim().min(1, "sessionKey is required").max(512),
-  namespace: namespaceSchema,
-  /**
-   * Optional multi-namespace flush used by delegate lifecycle replay. The
-   * server handles the whole list as one quota-counted write.
-   */
-  namespaces: z.array(z.string().trim().max(256)).min(1).max(64).optional(),
-});
+export const lcmCompactionFlushRequestSchema = z
+  .object({
+    sessionKey: z.string().trim().min(1, "sessionKey is required").max(512),
+    namespace: namespaceSchema,
+    /**
+     * Optional multi-namespace flush used by delegate lifecycle replay. The
+     * server handles the whole list as one quota-counted write.
+     */
+    namespaces: z.array(z.string().trim().max(256)).min(1).max(64).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.namespace !== undefined && value.namespaces !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "namespace and namespaces are mutually exclusive",
+        path: ["namespaces"],
+      });
+    }
+  });
 
 export const lcmCompactionRecordRequestSchema = z.object({
   sessionKey: z.string().trim().min(1, "sessionKey is required").max(512),

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -349,6 +349,16 @@ export const lcmCompactionFlushRequestSchema = z
         path: ["namespaces"],
       });
     }
+    if (
+      value.namespaces !== undefined &&
+      new Set(value.namespaces).size !== value.namespaces.length
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "namespaces must not contain duplicates",
+        path: ["namespaces"],
+      });
+    }
   });
 
 export const lcmCompactionRecordRequestSchema = z.object({

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -334,6 +334,11 @@ export const lcmSearchRequestSchema = z.object({
 export const lcmCompactionFlushRequestSchema = z.object({
   sessionKey: z.string().trim().min(1, "sessionKey is required").max(512),
   namespace: namespaceSchema,
+  /**
+   * Optional multi-namespace flush used by delegate lifecycle replay. The
+   * server handles the whole list as one quota-counted write.
+   */
+  namespaces: z.array(z.string().trim().max(256)).min(1).max(64).optional(),
 });
 
 export const lcmCompactionRecordRequestSchema = z.object({

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -534,6 +534,7 @@ test("HTTP handler source routes match the catalog (static completeness)", () =>
 
   const INFRA = [
     /^\/engram\/v1\/health$/,
+    /^\/engram\/v1\/capabilities$/,
     /^\/engram\/v1\/authorization$/,
     /^\/engram\/v1\/admin\//,
     /^\/engram\/ui/,

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createFileSessionNamespaceBindingStore } from "./session-namespace-bindings.js";
+
+test("session namespace bindings persist prototype-named session keys", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  try {
+    const store = createFileSessionNamespaceBindingStore(filePath);
+    await store.remember("__proto__", "team-prototype");
+
+    const reloaded = createFileSessionNamespaceBindingStore(filePath);
+    assert.deepEqual(await reloaded.namespacesFor("__proto__"), ["team-prototype"]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("session namespace bindings retain concurrent scope observations", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  try {
+    await Promise.all([
+      createFileSessionNamespaceBindingStore(filePath).remember("session-1", "team-first"),
+      createFileSessionNamespaceBindingStore(filePath).remember("session-1", "team-second"),
+    ]);
+
+    const reloaded = createFileSessionNamespaceBindingStore(filePath);
+    assert.deepEqual((await reloaded.namespacesFor("session-1")).sort(), ["team-first", "team-second"]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -7,6 +7,8 @@ import test from "node:test";
 import {
   createFileSessionNamespaceBindingStore,
   createInMemorySessionNamespaceBindingStore,
+  SESSION_NAMESPACE_BINDING_MAX_ENTRIES,
+  SESSION_NAMESPACE_BINDING_MAX_NAMESPACES,
 } from "./session-namespace-bindings.js";
 
 test("session namespace bindings persist prototype-named session keys", async () => {
@@ -97,4 +99,68 @@ test("in-memory session namespace bindings cap inactive routing history", async 
 
   assert.deepEqual(await store.namespacesFor("session-0"), []);
   assert.deepEqual(await store.namespacesFor("session-1000"), ["team-1000"]);
+});
+
+test("in-memory session namespace bindings retain sparse active sessions", async () => {
+  const store = createInMemorySessionNamespaceBindingStore();
+  for (let index = 0; index < SESSION_NAMESPACE_BINDING_MAX_ENTRIES; index += 1) {
+    await store.remember(`session-${index}`, `team-${index}`);
+  }
+
+  assert.deepEqual(await store.namespacesFor("session-0"), ["team-0"]);
+  await store.remember("overflow-session", "team-overflow");
+
+  assert.deepEqual(await store.namespacesFor("session-0"), ["team-0"]);
+  assert.deepEqual(await store.namespacesFor("session-1"), []);
+});
+
+test("session namespace bindings refresh a sparse active binding", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  const updatedAt = new Date(Date.now() - 60 * 60 * 1_000).toISOString();
+  try {
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "active-session": { namespaces: ["team-active"], updatedAt },
+        },
+      }),
+      "utf8",
+    );
+    const store = createFileSessionNamespaceBindingStore(filePath);
+
+    assert.deepEqual(await store.namespacesFor("active-session"), ["team-active"]);
+
+    const persisted = JSON.parse(await readFile(filePath, "utf8")) as {
+      entries: Record<string, { updatedAt: string }>;
+    };
+    assert.ok(Date.parse(persisted.entries["active-session"].updatedAt) > Date.parse(updatedAt));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("session namespace bindings cap each session's namespace history", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  try {
+    const fileStore = createFileSessionNamespaceBindingStore(filePath);
+    const memoryStore = createInMemorySessionNamespaceBindingStore();
+    for (let index = 0; index <= SESSION_NAMESPACE_BINDING_MAX_NAMESPACES; index += 1) {
+      const namespace = `team-${index}`;
+      await fileStore.remember("rebound-session", namespace);
+      await memoryStore.remember("rebound-session", namespace);
+    }
+
+    const expected = Array.from(
+      { length: SESSION_NAMESPACE_BINDING_MAX_NAMESPACES },
+      (_unused, index) => `team-${index + 1}`,
+    );
+    assert.deepEqual(await fileStore.namespacesFor("rebound-session"), expected);
+    assert.deepEqual(await memoryStore.namespacesFor("rebound-session"), expected);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -206,6 +206,47 @@ test("session namespace bindings return known scope when timestamp refresh fails
   }
 });
 
+test("session namespace bindings retain failed refreshes in volatile state", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  const updatedAt = new Date(Date.now() - 60 * 60 * 1_000).toISOString();
+  try {
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "volatile-refresh-session": { namespaces: ["team-known"], updatedAt },
+        },
+      }),
+      "utf8",
+    );
+    const store = createFileSessionNamespaceBindingStore(filePath, {
+      writeBindingFile: async () => {
+        throw new Error("forced refresh write failure");
+      },
+    });
+
+    assert.deepEqual(await store.namespacesFor("volatile-refresh-session"), ["team-known"]);
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "volatile-refresh-session": {
+            namespaces: ["team-known"],
+            updatedAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1_000).toISOString(),
+          },
+        },
+      }),
+      "utf8",
+    );
+    assert.deepEqual(await store.namespacesFor("volatile-refresh-session"), ["team-known"]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("session namespace bindings cap each session's namespace history", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
   const filePath = path.join(directory, "session-namespace-bindings.json");

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -9,6 +9,7 @@ import {
   createInMemorySessionNamespaceBindingStore,
   SESSION_NAMESPACE_BINDING_MAX_ENTRIES,
   SESSION_NAMESPACE_BINDING_MAX_NAMESPACES,
+  SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH,
 } from "./session-namespace-bindings.js";
 
 test("session namespace bindings persist prototype-named session keys", async () => {
@@ -93,6 +94,12 @@ test("session namespace bindings reject malformed persisted entries", async () =
     { "missing-namespaces": { updatedAt } },
     { "missing-updated-at": { namespaces: ["team-known"] } },
     { "invalid-namespaces": { namespaces: ["team-known", null], updatedAt } },
+    {
+      "oversized-namespace": {
+        namespaces: ["x".repeat(SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH + 1)],
+        updatedAt,
+      },
+    },
   ];
   try {
     for (const entries of invalidEntries) {

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -35,3 +35,18 @@ test("session namespace bindings retain concurrent scope observations", async ()
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+test("session namespace bindings persist an explicit default scope", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  try {
+    const store = createFileSessionNamespaceBindingStore(filePath);
+    await store.remember("session-1", "team-named");
+    await store.remember("session-1", "");
+
+    const reloaded = createFileSessionNamespaceBindingStore(filePath);
+    assert.deepEqual(await reloaded.namespacesFor("session-1"), ["team-named", ""]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -54,6 +54,36 @@ test("session namespace bindings reject structurally invalid files without overw
   }
 });
 
+test("session namespace bindings reject unsupported file versions without overwriting them", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  const updatedAt = new Date().toISOString();
+  const validEntry = { namespaces: ["team-known"], updatedAt };
+  const invalidFiles = [
+    { entries: { "versionless-session": validEntry } },
+    { version: 2, entries: { "newer-version-session": validEntry } },
+  ];
+  try {
+    for (const file of invalidFiles) {
+      const raw = JSON.stringify(file);
+      await writeFile(filePath, raw, "utf8");
+      const store = createFileSessionNamespaceBindingStore(filePath);
+
+      await assert.rejects(
+        () => store.namespacesFor("unsupported-version-session"),
+        /invalid structure/,
+      );
+      await assert.rejects(
+        () => store.remember("unsupported-version-session", "team-known"),
+        /invalid structure/,
+      );
+      assert.equal(await readFile(filePath, "utf8"), raw);
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("session namespace bindings reject malformed persisted entries", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
   const filePath = path.join(directory, "session-namespace-bindings.json");

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -39,6 +39,21 @@ test("session namespace bindings propagate malformed-file reads without overwrit
   }
 });
 
+test("session namespace bindings reject structurally invalid files without overwriting them", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  try {
+    await writeFile(filePath, JSON.stringify({ entries: null }), "utf8");
+    const store = createFileSessionNamespaceBindingStore(filePath);
+
+    await assert.rejects(() => store.namespacesFor("invalid-structure-session"), /invalid structure/);
+    await assert.rejects(() => store.remember("invalid-structure-session", "team-known"), /invalid structure/);
+    assert.equal(await readFile(filePath, "utf8"), JSON.stringify({ entries: null }));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("session namespace bindings retain concurrent scope observations", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
   const filePath = path.join(directory, "session-namespace-bindings.json");

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -138,6 +138,21 @@ test("session namespace bindings refresh a sparse active binding", async () => {
     };
     assert.ok(Date.parse(persisted.entries["active-session"].updatedAt) > Date.parse(updatedAt));
   } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("session namespace bindings return known scope when timestamp refresh fails", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  try {
+    const store = createFileSessionNamespaceBindingStore(filePath);
+    await store.remember("refresh-failure-session", "team-known");
+    await chmod(directory, 0o555);
+
+    assert.deepEqual(await store.namespacesFor("refresh-failure-session"), ["team-known"]);
+  } finally {
+    await chmod(directory, 0o700);
     await rm(directory, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -54,6 +54,37 @@ test("session namespace bindings reject structurally invalid files without overw
   }
 });
 
+test("session namespace bindings reject malformed persisted entries", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  const updatedAt = new Date().toISOString();
+  const invalidEntries = [
+    { "null-entry": null },
+    { "missing-namespaces": { updatedAt } },
+    { "missing-updated-at": { namespaces: ["team-known"] } },
+    { "invalid-namespaces": { namespaces: ["team-known", null], updatedAt } },
+  ];
+  try {
+    for (const entries of invalidEntries) {
+      const raw = JSON.stringify({ version: 1, entries });
+      await writeFile(filePath, raw, "utf8");
+      const store = createFileSessionNamespaceBindingStore(filePath);
+
+      await assert.rejects(
+        () => store.namespacesFor("invalid-entry-session"),
+        /entry has invalid structure/,
+      );
+      await assert.rejects(
+        () => store.remember("invalid-entry-session", "team-known"),
+        /entry has invalid structure/,
+      );
+      assert.equal(await readFile(filePath, "utf8"), raw);
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("session namespace bindings retain concurrent scope observations", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
   const filePath = path.join(directory, "session-namespace-bindings.json");

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -145,14 +145,34 @@ test("session namespace bindings refresh a sparse active binding", async () => {
 test("session namespace bindings return known scope when timestamp refresh fails", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
   const filePath = path.join(directory, "session-namespace-bindings.json");
+  const updatedAt = new Date(Date.now() - 60 * 60 * 1_000).toISOString();
   try {
-    const store = createFileSessionNamespaceBindingStore(filePath);
-    await store.remember("refresh-failure-session", "team-known");
-    await chmod(directory, 0o555);
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "refresh-failure-session": { namespaces: ["team-known"], updatedAt },
+        },
+      }),
+      "utf8",
+    );
+    let writeAttempts = 0;
+    const store = createFileSessionNamespaceBindingStore(filePath, {
+      writeBindingFile: async () => {
+        writeAttempts += 1;
+        throw new Error("forced refresh write failure");
+      },
+    });
 
     assert.deepEqual(await store.namespacesFor("refresh-failure-session"), ["team-known"]);
+    assert.equal(writeAttempts, 1);
+
+    const persisted = JSON.parse(await readFile(filePath, "utf8")) as {
+      entries: Record<string, { updatedAt: string }>;
+    };
+    assert.equal(persisted.entries["refresh-failure-session"].updatedAt, updatedAt);
   } finally {
-    await chmod(directory, 0o700);
     await rm(directory, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -296,6 +296,25 @@ test("session namespace bindings cap each session's namespace history", async ()
     );
     assert.deepEqual(await fileStore.namespacesFor("rebound-session"), expected);
     assert.deepEqual(await memoryStore.namespacesFor("rebound-session"), expected);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("session namespace bindings clean temporary files after atomic write failure", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  const store = createFileSessionNamespaceBindingStore(filePath, {
+    renameBindingFile: async () => {
+      throw new Error("forced atomic rename failure");
+    },
+  });
+  try {
+    await assert.rejects(
+      () => store.remember("atomic-failure-session", "team-known"),
+      /forced atomic rename failure/,
+    );
+    assert.deepEqual(await readdir(directory), []);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { createFileSessionNamespaceBindingStore } from "./session-namespace-bindings.js";
+import {
+  createFileSessionNamespaceBindingStore,
+  createInMemorySessionNamespaceBindingStore,
+} from "./session-namespace-bindings.js";
 
 test("session namespace bindings persist prototype-named session keys", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
@@ -49,4 +52,49 @@ test("session namespace bindings persist an explicit default scope", async () =>
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
+});
+
+test("session namespace bindings prune expired and overflowed persisted history", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  const now = Date.now();
+  const entries = Object.fromEntries(
+    Array.from({ length: 1_000 }, (_unused, index) => [
+      `session-${index}`,
+      {
+        namespaces: [`team-${index}`],
+        updatedAt: new Date(now - index).toISOString(),
+      },
+    ])
+  ) as Record<string, { namespaces: string[]; updatedAt: string }>;
+  entries["stale-session"] = {
+    namespaces: ["team-stale"],
+    updatedAt: new Date(now - 8 * 24 * 60 * 60 * 1_000).toISOString(),
+  };
+  try {
+    await writeFile(filePath, JSON.stringify({ version: 1, entries }), "utf8");
+    const store = createFileSessionNamespaceBindingStore(filePath);
+
+    assert.deepEqual(await store.namespacesFor("stale-session"), []);
+    await store.remember("current-session", "team-current");
+
+    const persisted = JSON.parse(await readFile(filePath, "utf8")) as {
+      entries: Record<string, { namespaces: string[] }>;
+    };
+    assert.equal(Object.keys(persisted.entries).length, 1_000);
+    assert.equal("stale-session" in persisted.entries, false);
+    assert.deepEqual(await store.namespacesFor("current-session"), ["team-current"]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("in-memory session namespace bindings cap inactive routing history", async () => {
+  const store = createInMemorySessionNamespaceBindingStore();
+  for (let index = 0; index <= 1_000; index += 1) {
+    await store.remember(`session-${index}`, `team-${index}`);
+  }
+
+  assert.deepEqual(await store.namespacesFor("session-0"), []);
+  assert.deepEqual(await store.namespacesFor("session-1000"), ["team-1000"]);
 });

--- a/packages/remnic-core/src/session-namespace-bindings.test.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.test.ts
@@ -24,6 +24,20 @@ test("session namespace bindings persist prototype-named session keys", async ()
     await rm(directory, { recursive: true, force: true });
   }
 });
+test("session namespace bindings propagate malformed-file reads without overwriting them", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));
+  const filePath = path.join(directory, "session-namespace-bindings.json");
+  try {
+    await writeFile(filePath, "{", "utf8");
+    const store = createFileSessionNamespaceBindingStore(filePath);
+
+    await assert.rejects(() => store.namespacesFor("malformed-session"), SyntaxError);
+    await assert.rejects(() => store.remember("malformed-session", "team-known"), SyntaxError);
+    assert.equal(await readFile(filePath, "utf8"), "{");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
 
 test("session namespace bindings retain concurrent scope observations", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "remnic-namespace-bindings-"));

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -20,6 +20,7 @@ interface NamespaceBindingFile {
   version: 1;
   entries: Record<string, NamespaceBindingEntry>;
 }
+type BindingFileWriter = (filePath: string, bindings: NamespaceBindingFile) => Promise<void>;
 
 const fileWriteChains = new Map<string, Promise<void>>();
 
@@ -147,7 +148,11 @@ export function createInMemorySessionNamespaceBindingStore(): SessionNamespaceBi
   };
 }
 
-export function createFileSessionNamespaceBindingStore(filePath: string): SessionNamespaceBindingStore {
+export function createFileSessionNamespaceBindingStore(
+  filePath: string,
+  options: { writeBindingFile?: BindingFileWriter } = {},
+): SessionNamespaceBindingStore {
+  const write = options.writeBindingFile ?? writeBindingFile;
   return {
     async namespacesFor(sessionKey: string): Promise<string[]> {
       const key = encodeSessionKey(sessionKey);
@@ -159,7 +164,7 @@ export function createFileSessionNamespaceBindingStore(filePath: string): Sessio
         entry.updatedAt = new Date().toISOString();
         bindings.entries = pruneBindingEntries(bindings.entries, key);
         try {
-          await writeBindingFile(filePath, bindings);
+          await write(filePath, bindings);
         } catch {
           return namespaces;
         }
@@ -176,7 +181,7 @@ export function createFileSessionNamespaceBindingStore(filePath: string): Sessio
           updatedAt: new Date().toISOString(),
         };
         bindings.entries = pruneBindingEntries(bindings.entries, key);
-        await writeBindingFile(filePath, bindings);
+        await write(filePath, bindings);
       });
     },
   };

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -7,6 +7,9 @@ export interface SessionNamespaceBindingStore {
   remember(sessionKey: string, namespace: string): Promise<void>;
 }
 
+export const SESSION_NAMESPACE_BINDING_MAX_ENTRIES = 1_000;
+export const SESSION_NAMESPACE_BINDING_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1_000;
+
 interface NamespaceBindingEntry {
   namespaces: string[];
   updatedAt: string;
@@ -41,6 +44,27 @@ function addNamespace(namespaces: string[], namespace: string): string[] {
   return [...namespaces.filter((candidate) => candidate !== normalized), normalized];
 }
 
+function pruneBindingEntries(
+  entries: Record<string, NamespaceBindingEntry>,
+  protectedKey?: string
+): Record<string, NamespaceBindingEntry> {
+  const cutoff = Date.now() - SESSION_NAMESPACE_BINDING_MAX_AGE_MS;
+  const retained = Object.entries(entries)
+    .filter(([_key, entry]) => {
+      const updatedAt = Date.parse(entry.updatedAt);
+      return Number.isFinite(updatedAt) && updatedAt >= cutoff;
+    })
+    .sort(([leftKey, left], [rightKey, right]) => {
+      if (leftKey === protectedKey) return -1;
+      if (rightKey === protectedKey) return 1;
+      return Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
+    })
+    .slice(0, SESSION_NAMESPACE_BINDING_MAX_ENTRIES);
+  const pruned = Object.create(null) as Record<string, NamespaceBindingEntry>;
+  for (const [key, entry] of retained) pruned[key] = entry;
+  return pruned;
+}
+
 function encodeSessionKey(sessionKey: string): string {
   return encodeURIComponent(sessionKey);
 }
@@ -61,7 +85,7 @@ async function readBindingFile(filePath: string): Promise<NamespaceBindingFile> 
       if (namespaces.length === 0) continue;
       entries[key] = { namespaces, updatedAt: entry.updatedAt };
     }
-    return { version: 1, entries };
+    return { version: 1, entries: pruneBindingEntries(entries) };
   } catch {
     return emptyBindingFile();
   }
@@ -91,7 +115,14 @@ export function createInMemorySessionNamespaceBindingStore(): SessionNamespaceBi
       return [...(entries.get(sessionKey) ?? [])];
     },
     async remember(sessionKey: string, namespace: string): Promise<void> {
-      entries.set(sessionKey, addNamespace(entries.get(sessionKey) ?? [], namespace));
+      const existing = entries.get(sessionKey) ?? [];
+      entries.delete(sessionKey);
+      entries.set(sessionKey, addNamespace(existing, namespace));
+      while (entries.size > SESSION_NAMESPACE_BINDING_MAX_ENTRIES) {
+        const oldest = entries.keys().next().value;
+        if (typeof oldest !== "string") break;
+        entries.delete(oldest);
+      }
     },
   };
 }
@@ -112,6 +143,7 @@ export function createFileSessionNamespaceBindingStore(filePath: string): Sessio
           namespaces: addNamespace(existing, namespace),
           updatedAt: new Date().toISOString(),
         };
+        bindings.entries = pruneBindingEntries(bindings.entries, key);
         await writeBindingFile(filePath, bindings);
       });
     },

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -93,8 +93,15 @@ async function readBindingFile(filePath: string): Promise<NamespaceBindingFile> 
     throw err;
   }
   const parsed = JSON.parse(raw) as Partial<NamespaceBindingFile>;
-  if (!parsed || typeof parsed !== "object" || !parsed.entries || typeof parsed.entries !== "object") {
-    return emptyBindingFile();
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    !parsed.entries ||
+    typeof parsed.entries !== "object" ||
+    Array.isArray(parsed.entries)
+  ) {
+    throw new Error("session namespace binding file has invalid structure");
   }
   const entries = Object.create(null) as Record<string, NamespaceBindingEntry>;
   for (const [key, value] of Object.entries(parsed.entries)) {

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -10,6 +10,7 @@ export interface SessionNamespaceBindingStore {
 
 export const SESSION_NAMESPACE_BINDING_MAX_ENTRIES = 1_000;
 export const SESSION_NAMESPACE_BINDING_MAX_NAMESPACES = 64;
+export const SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH = 256;
 export const SESSION_NAMESPACE_BINDING_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1_000;
 
 interface NamespaceBindingEntry {
@@ -154,7 +155,9 @@ async function readBindingFile(filePath: string): Promise<NamespaceBindingFile> 
       !Array.isArray(entry.namespaces) ||
       entry.namespaces.length === 0 ||
       entry.namespaces.some(
-        (namespace) => typeof namespace !== "string",
+        (namespace) =>
+          typeof namespace !== "string" ||
+          namespace.trim().length > SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH,
       )
     ) {
       throw new Error("session namespace binding entry has invalid structure");

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -1,0 +1,119 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface SessionNamespaceBindingStore {
+  namespacesFor(sessionKey: string): Promise<string[]>;
+  remember(sessionKey: string, namespace: string): Promise<void>;
+}
+
+interface NamespaceBindingEntry {
+  namespaces: string[];
+  updatedAt: string;
+}
+
+interface NamespaceBindingFile {
+  version: 1;
+  entries: Record<string, NamespaceBindingEntry>;
+}
+
+const fileWriteChains = new Map<string, Promise<void>>();
+
+function emptyBindingFile(): NamespaceBindingFile {
+  return { version: 1, entries: Object.create(null) as Record<string, NamespaceBindingEntry> };
+}
+
+function normalizeNamespaces(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const namespaces: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") continue;
+    const namespace = entry.trim();
+    const existing = namespaces.indexOf(namespace);
+    if (existing >= 0) namespaces.splice(existing, 1);
+    namespaces.push(namespace);
+  }
+  return namespaces;
+}
+
+function addNamespace(namespaces: string[], namespace: string): string[] {
+  const normalized = namespace.trim();
+  return [...namespaces.filter((candidate) => candidate !== normalized), normalized];
+}
+
+function encodeSessionKey(sessionKey: string): string {
+  return encodeURIComponent(sessionKey);
+}
+
+async function readBindingFile(filePath: string): Promise<NamespaceBindingFile> {
+  try {
+    const raw = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw) as Partial<NamespaceBindingFile>;
+    if (!parsed || typeof parsed !== "object" || !parsed.entries || typeof parsed.entries !== "object") {
+      return emptyBindingFile();
+    }
+    const entries = Object.create(null) as Record<string, NamespaceBindingEntry>;
+    for (const [key, value] of Object.entries(parsed.entries)) {
+      if (!value || typeof value !== "object") continue;
+      const entry = value as Partial<NamespaceBindingEntry>;
+      if (typeof entry.updatedAt !== "string") continue;
+      const namespaces = normalizeNamespaces(entry.namespaces);
+      if (namespaces.length === 0) continue;
+      entries[key] = { namespaces, updatedAt: entry.updatedAt };
+    }
+    return { version: 1, entries };
+  } catch {
+    return emptyBindingFile();
+  }
+}
+
+async function writeBindingFile(filePath: string, bindings: NamespaceBindingFile): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
+  await writeFile(temporaryPath, JSON.stringify(bindings, null, 2), "utf8");
+  await rename(temporaryPath, filePath);
+}
+
+async function queueFileWrite(filePath: string, operation: () => Promise<void>): Promise<void> {
+  const prior = fileWriteChains.get(filePath) ?? Promise.resolve();
+  const run = prior.catch(() => undefined).then(operation);
+  fileWriteChains.set(
+    filePath,
+    run.catch(() => undefined)
+  );
+  await run;
+}
+
+export function createInMemorySessionNamespaceBindingStore(): SessionNamespaceBindingStore {
+  const entries = new Map<string, string[]>();
+  return {
+    async namespacesFor(sessionKey: string): Promise<string[]> {
+      return [...(entries.get(sessionKey) ?? [])];
+    },
+    async remember(sessionKey: string, namespace: string): Promise<void> {
+      entries.set(sessionKey, addNamespace(entries.get(sessionKey) ?? [], namespace));
+    },
+  };
+}
+
+export function createFileSessionNamespaceBindingStore(filePath: string): SessionNamespaceBindingStore {
+  return {
+    async namespacesFor(sessionKey: string): Promise<string[]> {
+      await (fileWriteChains.get(filePath) ?? Promise.resolve()).catch(() => undefined);
+      const bindings = await readBindingFile(filePath);
+      return [...(bindings.entries[encodeSessionKey(sessionKey)]?.namespaces ?? [])];
+    },
+    async remember(sessionKey: string, namespace: string): Promise<void> {
+      const key = encodeSessionKey(sessionKey);
+      await queueFileWrite(filePath, async () => {
+        const bindings = await readBindingFile(filePath);
+        const existing = bindings.entries[key]?.namespaces ?? [];
+        bindings.entries[key] = {
+          namespaces: addNamespace(existing, namespace),
+          updatedAt: new Date().toISOString(),
+        };
+        await writeBindingFile(filePath, bindings);
+      });
+    },
+  };
+}

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -8,6 +8,7 @@ export interface SessionNamespaceBindingStore {
 }
 
 export const SESSION_NAMESPACE_BINDING_MAX_ENTRIES = 1_000;
+export const SESSION_NAMESPACE_BINDING_MAX_NAMESPACES = 64;
 export const SESSION_NAMESPACE_BINDING_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1_000;
 
 interface NamespaceBindingEntry {
@@ -26,6 +27,12 @@ function emptyBindingFile(): NamespaceBindingFile {
   return { version: 1, entries: Object.create(null) as Record<string, NamespaceBindingEntry> };
 }
 
+function capNamespaceHistory(namespaces: string[]): string[] {
+  return namespaces.length > SESSION_NAMESPACE_BINDING_MAX_NAMESPACES
+    ? namespaces.slice(-SESSION_NAMESPACE_BINDING_MAX_NAMESPACES)
+    : namespaces;
+}
+
 function normalizeNamespaces(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   const namespaces: string[] = [];
@@ -36,12 +43,15 @@ function normalizeNamespaces(value: unknown): string[] {
     if (existing >= 0) namespaces.splice(existing, 1);
     namespaces.push(namespace);
   }
-  return namespaces;
+  return capNamespaceHistory(namespaces);
 }
 
 function addNamespace(namespaces: string[], namespace: string): string[] {
   const normalized = namespace.trim();
-  return [...namespaces.filter((candidate) => candidate !== normalized), normalized];
+  return capNamespaceHistory([
+    ...namespaces.filter((candidate) => candidate !== normalized),
+    normalized,
+  ]);
 }
 
 function pruneBindingEntries(
@@ -98,21 +108,31 @@ async function writeBindingFile(filePath: string, bindings: NamespaceBindingFile
   await rename(temporaryPath, filePath);
 }
 
-async function queueFileWrite(filePath: string, operation: () => Promise<void>): Promise<void> {
+async function queueFileWrite<TResult>(
+  filePath: string,
+  operation: () => Promise<TResult>,
+): Promise<TResult> {
   const prior = fileWriteChains.get(filePath) ?? Promise.resolve();
   const run = prior.catch(() => undefined).then(operation);
   fileWriteChains.set(
     filePath,
-    run.catch(() => undefined)
+    run.then(
+      () => undefined,
+      () => undefined,
+    ),
   );
-  await run;
+  return run;
 }
 
 export function createInMemorySessionNamespaceBindingStore(): SessionNamespaceBindingStore {
   const entries = new Map<string, string[]>();
   return {
     async namespacesFor(sessionKey: string): Promise<string[]> {
-      return [...(entries.get(sessionKey) ?? [])];
+      const namespaces = entries.get(sessionKey);
+      if (namespaces === undefined) return [];
+      entries.delete(sessionKey);
+      entries.set(sessionKey, namespaces);
+      return [...namespaces];
     },
     async remember(sessionKey: string, namespace: string): Promise<void> {
       const existing = entries.get(sessionKey) ?? [];
@@ -130,9 +150,16 @@ export function createInMemorySessionNamespaceBindingStore(): SessionNamespaceBi
 export function createFileSessionNamespaceBindingStore(filePath: string): SessionNamespaceBindingStore {
   return {
     async namespacesFor(sessionKey: string): Promise<string[]> {
-      await (fileWriteChains.get(filePath) ?? Promise.resolve()).catch(() => undefined);
-      const bindings = await readBindingFile(filePath);
-      return [...(bindings.entries[encodeSessionKey(sessionKey)]?.namespaces ?? [])];
+      const key = encodeSessionKey(sessionKey);
+      return queueFileWrite(filePath, async () => {
+        const bindings = await readBindingFile(filePath);
+        const entry = bindings.entries[key];
+        if (entry === undefined) return [];
+        entry.updatedAt = new Date().toISOString();
+        bindings.entries = pruneBindingEntries(bindings.entries, key);
+        await writeBindingFile(filePath, bindings);
+        return [...(bindings.entries[key]?.namespaces ?? [])];
+      });
     },
     async remember(sessionKey: string, namespace: string): Promise<void> {
       const key = encodeSessionKey(sessionKey);

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -23,6 +23,40 @@ interface NamespaceBindingFile {
 type BindingFileWriter = (filePath: string, bindings: NamespaceBindingFile) => Promise<void>;
 
 const fileWriteChains = new Map<string, Promise<void>>();
+const volatileRefreshes = new Map<string, Map<string, string>>();
+
+function retainVolatileRefresh(filePath: string, sessionKey: string, updatedAt: string): void {
+  const refreshes = volatileRefreshes.get(filePath) ?? new Map<string, string>();
+  refreshes.set(sessionKey, updatedAt);
+  volatileRefreshes.set(filePath, refreshes);
+}
+
+function clearVolatileRefresh(filePath: string, sessionKey: string): void {
+  const refreshes = volatileRefreshes.get(filePath);
+  if (refreshes === undefined) return;
+  refreshes.delete(sessionKey);
+  if (refreshes.size === 0) volatileRefreshes.delete(filePath);
+}
+
+function applyVolatileRefreshes(filePath: string, entries: Record<string, NamespaceBindingEntry>): void {
+  const refreshes = volatileRefreshes.get(filePath);
+  if (refreshes === undefined) return;
+  for (const [key, updatedAt] of refreshes) {
+    const entry = entries[key];
+    if (entry === undefined) {
+      refreshes.delete(key);
+      continue;
+    }
+    const persistedAt = Date.parse(entry.updatedAt);
+    const refreshedAt = Date.parse(updatedAt);
+    if (Number.isFinite(refreshedAt) && (!Number.isFinite(persistedAt) || refreshedAt > persistedAt)) {
+      entry.updatedAt = updatedAt;
+    } else {
+      refreshes.delete(key);
+    }
+  }
+  if (refreshes.size === 0) volatileRefreshes.delete(filePath);
+}
 
 function emptyBindingFile(): NamespaceBindingFile {
   return { version: 1, entries: Object.create(null) as Record<string, NamespaceBindingEntry> };
@@ -89,7 +123,10 @@ async function readBindingFile(filePath: string): Promise<NamespaceBindingFile> 
   try {
     raw = await readFile(filePath, "utf8");
   } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return emptyBindingFile();
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      volatileRefreshes.delete(filePath);
+      return emptyBindingFile();
+    }
     throw err;
   }
   const parsed = JSON.parse(raw) as Partial<NamespaceBindingFile>;
@@ -112,6 +149,7 @@ async function readBindingFile(filePath: string): Promise<NamespaceBindingFile> 
     if (namespaces.length === 0) continue;
     entries[key] = { namespaces, updatedAt: entry.updatedAt };
   }
+  applyVolatileRefreshes(filePath, entries);
   return { version: 1, entries: pruneBindingEntries(entries) };
 }
 
@@ -174,11 +212,14 @@ export function createFileSessionNamespaceBindingStore(
         const entry = bindings.entries[key];
         if (entry === undefined) return [];
         const namespaces = [...entry.namespaces];
-        entry.updatedAt = new Date().toISOString();
+        const updatedAt = new Date().toISOString();
+        entry.updatedAt = updatedAt;
         bindings.entries = pruneBindingEntries(bindings.entries, key);
         try {
           await write(filePath, bindings);
+          clearVolatileRefresh(filePath, key);
         } catch {
+          retainVolatileRefresh(filePath, key, updatedAt);
           return namespaces;
         }
         return namespaces;

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -68,7 +68,11 @@ function pruneBindingEntries(
     .sort(([leftKey, left], [rightKey, right]) => {
       if (leftKey === protectedKey) return -1;
       if (rightKey === protectedKey) return 1;
-      return Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
+      const leftAt = Date.parse(left.updatedAt);
+      const rightAt = Date.parse(right.updatedAt);
+      if (leftAt !== rightAt) return rightAt > leftAt ? 1 : -1;
+      if (leftKey === rightKey) return 0;
+      return leftKey < rightKey ? -1 : 1;
     })
     .slice(0, SESSION_NAMESPACE_BINDING_MAX_ENTRIES);
   const pruned = Object.create(null) as Record<string, NamespaceBindingEntry>;
@@ -81,8 +85,14 @@ function encodeSessionKey(sessionKey: string): string {
 }
 
 async function readBindingFile(filePath: string): Promise<NamespaceBindingFile> {
+  let raw: string;
   try {
-    const raw = await readFile(filePath, "utf8");
+    raw = await readFile(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return emptyBindingFile();
+    throw err;
+  }
+  try {
     const parsed = JSON.parse(raw) as Partial<NamespaceBindingFile>;
     if (!parsed || typeof parsed !== "object" || !parsed.entries || typeof parsed.entries !== "object") {
       return emptyBindingFile();

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -142,11 +142,25 @@ async function readBindingFile(filePath: string): Promise<NamespaceBindingFile> 
   }
   const entries = Object.create(null) as Record<string, NamespaceBindingEntry>;
   for (const [key, value] of Object.entries(parsed.entries)) {
-    if (!value || typeof value !== "object") continue;
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("session namespace binding entry has invalid structure");
+    }
     const entry = value as Partial<NamespaceBindingEntry>;
-    if (typeof entry.updatedAt !== "string") continue;
+    if (
+      typeof entry.updatedAt !== "string" ||
+      !Number.isFinite(Date.parse(entry.updatedAt)) ||
+      !Array.isArray(entry.namespaces) ||
+      entry.namespaces.length === 0 ||
+      entry.namespaces.some(
+        (namespace) => typeof namespace !== "string",
+      )
+    ) {
+      throw new Error("session namespace binding entry has invalid structure");
+    }
     const namespaces = normalizeNamespaces(entry.namespaces);
-    if (namespaces.length === 0) continue;
+    if (namespaces.length === 0) {
+      throw new Error("session namespace binding entry has invalid structure");
+    }
     entries[key] = { namespaces, updatedAt: entry.updatedAt };
   }
   applyVolatileRefreshes(filePath, entries);

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -92,24 +92,20 @@ async function readBindingFile(filePath: string): Promise<NamespaceBindingFile> 
     if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return emptyBindingFile();
     throw err;
   }
-  try {
-    const parsed = JSON.parse(raw) as Partial<NamespaceBindingFile>;
-    if (!parsed || typeof parsed !== "object" || !parsed.entries || typeof parsed.entries !== "object") {
-      return emptyBindingFile();
-    }
-    const entries = Object.create(null) as Record<string, NamespaceBindingEntry>;
-    for (const [key, value] of Object.entries(parsed.entries)) {
-      if (!value || typeof value !== "object") continue;
-      const entry = value as Partial<NamespaceBindingEntry>;
-      if (typeof entry.updatedAt !== "string") continue;
-      const namespaces = normalizeNamespaces(entry.namespaces);
-      if (namespaces.length === 0) continue;
-      entries[key] = { namespaces, updatedAt: entry.updatedAt };
-    }
-    return { version: 1, entries: pruneBindingEntries(entries) };
-  } catch {
+  const parsed = JSON.parse(raw) as Partial<NamespaceBindingFile>;
+  if (!parsed || typeof parsed !== "object" || !parsed.entries || typeof parsed.entries !== "object") {
     return emptyBindingFile();
   }
+  const entries = Object.create(null) as Record<string, NamespaceBindingEntry>;
+  for (const [key, value] of Object.entries(parsed.entries)) {
+    if (!value || typeof value !== "object") continue;
+    const entry = value as Partial<NamespaceBindingEntry>;
+    if (typeof entry.updatedAt !== "string") continue;
+    const namespaces = normalizeNamespaces(entry.namespaces);
+    if (namespaces.length === 0) continue;
+    entries[key] = { namespaces, updatedAt: entry.updatedAt };
+  }
+  return { version: 1, entries: pruneBindingEntries(entries) };
 }
 
 async function writeBindingFile(filePath: string, bindings: NamespaceBindingFile): Promise<void> {

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -66,12 +66,12 @@ function pruneBindingEntries(
       return Number.isFinite(updatedAt) && updatedAt >= cutoff;
     })
     .sort(([leftKey, left], [rightKey, right]) => {
+      if (leftKey === rightKey) return 0;
       if (leftKey === protectedKey) return -1;
       if (rightKey === protectedKey) return 1;
       const leftAt = Date.parse(left.updatedAt);
       const rightAt = Date.parse(right.updatedAt);
       if (leftAt !== rightAt) return rightAt > leftAt ? 1 : -1;
-      if (leftKey === rightKey) return 0;
       return leftKey < rightKey ? -1 : 1;
     })
     .slice(0, SESSION_NAMESPACE_BINDING_MAX_ENTRIES);

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 export interface SessionNamespaceBindingStore {
@@ -167,11 +167,20 @@ async function readBindingFile(filePath: string): Promise<NamespaceBindingFile> 
   return { version: 1, entries: pruneBindingEntries(entries) };
 }
 
-async function writeBindingFile(filePath: string, bindings: NamespaceBindingFile): Promise<void> {
+async function writeBindingFile(
+  filePath: string,
+  bindings: NamespaceBindingFile,
+  renameFile: typeof rename = rename,
+): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
   const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
-  await writeFile(temporaryPath, JSON.stringify(bindings, null, 2), "utf8");
-  await rename(temporaryPath, filePath);
+  try {
+    await writeFile(temporaryPath, JSON.stringify(bindings, null, 2), "utf8");
+    await renameFile(temporaryPath, filePath);
+  } catch (err) {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+    throw err;
+  }
 }
 
 async function queueFileWrite<TResult>(
@@ -215,9 +224,12 @@ export function createInMemorySessionNamespaceBindingStore(): SessionNamespaceBi
 
 export function createFileSessionNamespaceBindingStore(
   filePath: string,
-  options: { writeBindingFile?: BindingFileWriter } = {},
+  options: { writeBindingFile?: BindingFileWriter; renameBindingFile?: typeof rename } = {},
 ): SessionNamespaceBindingStore {
-  const write = options.writeBindingFile ?? writeBindingFile;
+  const write =
+    options.writeBindingFile ??
+    ((targetPath: string, bindings: NamespaceBindingFile) =>
+      writeBindingFile(targetPath, bindings, options.renameBindingFile));
   return {
     async namespacesFor(sessionKey: string): Promise<string[]> {
       const key = encodeSessionKey(sessionKey);

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -135,6 +135,7 @@ async function readBindingFile(filePath: string): Promise<NamespaceBindingFile> 
     !parsed ||
     typeof parsed !== "object" ||
     Array.isArray(parsed) ||
+    parsed.version !== 1 ||
     !parsed.entries ||
     typeof parsed.entries !== "object" ||
     Array.isArray(parsed.entries)

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 export interface SessionNamespaceBindingStore {
   namespacesFor(sessionKey: string): Promise<string[]>;
   remember(sessionKey: string, namespace: string): Promise<void>;
+  replace?(sessionKey: string, namespaces: string[]): Promise<void>;
 }
 
 export const SESSION_NAMESPACE_BINDING_MAX_ENTRIES = 1_000;
@@ -219,6 +220,17 @@ export function createInMemorySessionNamespaceBindingStore(): SessionNamespaceBi
         entries.delete(oldest);
       }
     },
+    async replace(sessionKey: string, namespaces: string[]): Promise<void> {
+      entries.delete(sessionKey);
+      if (namespaces.length > 0) {
+        entries.set(sessionKey, capNamespaceHistory([...namespaces]));
+      }
+      while (entries.size > SESSION_NAMESPACE_BINDING_MAX_ENTRIES) {
+        const oldest = entries.keys().next().value;
+        if (typeof oldest !== "string") break;
+        entries.delete(oldest);
+      }
+    },
   };
 }
 
@@ -262,6 +274,23 @@ export function createFileSessionNamespaceBindingStore(
         };
         bindings.entries = pruneBindingEntries(bindings.entries, key);
         await write(filePath, bindings);
+      });
+    },
+    async replace(sessionKey: string, namespaces: string[]): Promise<void> {
+      const key = encodeSessionKey(sessionKey);
+      await queueFileWrite(filePath, async () => {
+        const bindings = await readBindingFile(filePath);
+        if (namespaces.length === 0) {
+          delete bindings.entries[key];
+        } else {
+          bindings.entries[key] = {
+            namespaces: capNamespaceHistory([...namespaces]),
+            updatedAt: new Date().toISOString(),
+          };
+        }
+        bindings.entries = pruneBindingEntries(bindings.entries, key);
+        await write(filePath, bindings);
+        clearVolatileRefresh(filePath, key);
       });
     },
   };

--- a/packages/remnic-core/src/session-namespace-bindings.ts
+++ b/packages/remnic-core/src/session-namespace-bindings.ts
@@ -155,10 +155,15 @@ export function createFileSessionNamespaceBindingStore(filePath: string): Sessio
         const bindings = await readBindingFile(filePath);
         const entry = bindings.entries[key];
         if (entry === undefined) return [];
+        const namespaces = [...entry.namespaces];
         entry.updatedAt = new Date().toISOString();
         bindings.entries = pruneBindingEntries(bindings.entries, key);
-        await writeBindingFile(filePath, bindings);
-        return [...(bindings.entries[key]?.namespaces ?? [])];
+        try {
+          await writeBindingFile(filePath, bindings);
+        } catch {
+          return namespaces;
+        }
+        return namespaces;
       });
     },
     async remember(sessionKey: string, namespace: string): Promise<void> {

--- a/packages/remnic-core/src/testing/lifecycle-matrix.ts
+++ b/packages/remnic-core/src/testing/lifecycle-matrix.ts
@@ -220,7 +220,11 @@ type NodeTestRegistrar = {
   (name: string, options: { skip: string }, fn: () => void): void;
 };
 
-const nodeTest = createRequire(import.meta.url)("node:test") as NodeTestRegistrar;
+const requiredNodeTest = createRequire(import.meta.url)("node:test") as
+  | NodeTestRegistrar
+  | { test: NodeTestRegistrar };
+const nodeTest: NodeTestRegistrar =
+  typeof requiredNodeTest === "function" ? requiredNodeTest : requiredNodeTest.test;
 
 const defaultRegister: MatrixTestRegistrar = (name, fn) => {
   nodeTest(name, fn);

--- a/packages/remnic-core/src/testing/lifecycle-matrix.ts
+++ b/packages/remnic-core/src/testing/lifecycle-matrix.ts
@@ -15,13 +15,13 @@
  * `MATRIX_ROWS` entry. Adding a row here is a one-file change that
  * automatically extends every adopter — the whole point of the harness.
  *
- * Test-support only: this file lives under `src/testing/` (a subdirectory, so
- * tsup — which entry-points only top-level `src/*.ts` and the public exports —
- * never bundles it) and is intentionally absent from package.json `exports`.
- * It imports `node:test` and must NEVER be imported by runtime code.
+ * Test-support only: this file lives under `src/testing/` and is exported solely
+ * so adapter test subjects can share the canonical matrix across packages.
+ * The registrar loads `node:test` through `createRequire` so the built artifact
+ * keeps the builtin specifier, and runtime code must never import this module.
  */
 
-import test from "node:test";
+import { createRequire } from "node:module";
 
 /** The nine canonical AGENTS.md session/retrieval/cache matrix rows. */
 export type MatrixRowId =
@@ -215,13 +215,19 @@ export interface RunLifecycleMatrixOptions {
 export function lifecycleTestName(subjectName: string, row: MatrixRow): string {
   return `lifecycle-matrix[${subjectName}] :: ${row.id} — ${row.title}`;
 }
+type NodeTestRegistrar = {
+  (name: string, fn: () => void | Promise<void>): void;
+  (name: string, options: { skip: string }, fn: () => void): void;
+};
+
+const nodeTest = createRequire(import.meta.url)("node:test") as NodeTestRegistrar;
 
 const defaultRegister: MatrixTestRegistrar = (name, fn) => {
-  test(name, fn);
+  nodeTest(name, fn);
 };
 
 const defaultRegisterSkipped: MatrixSkipRegistrar = (name, reason) => {
-  test(name, { skip: reason }, () => {});
+  nodeTest(name, { skip: reason }, () => {});
 };
 
 /**

--- a/scripts/lifecycle-matrix/check-coverage.mjs
+++ b/scripts/lifecycle-matrix/check-coverage.mjs
@@ -6,7 +6,7 @@
  * paths — reusing scripts/effective-diff.mjs) touches a lifecycle-critical path
  * in scripts/lifecycle-matrix/coverage.json's `lifecycleManifest`, this gate
  * requires that path to be covered by a registered `LifecycleSubject`
- * (packages/remnic-core/src/testing/subjects). Grandfathered paths (decision C)
+ * (package `src/testing/subjects` directories). Grandfathered paths (decision C)
  * warn instead of fail; the grandfather list is a ratchet — it may shrink,
  * never grow. A manifest glob with no coverage mapping and no grandfather entry
  * fails the gate, naming the path and the manifest.
@@ -554,14 +554,17 @@ export function unexplainedRemovals(removed, explained) {
   return removed.filter((glob) => glob.includes("*") || !explained.has(glob));
 }
 
-/** Scan the subjects directory for `runLifecycleMatrix("<name>", ...)` registrations. */
-export function registeredSubjectNames(subjectsDir) {
-  if (!existsSync(subjectsDir)) return [];
+/** Scan subject directories for `runLifecycleMatrix("<name>", ...)` registrations. */
+export function registeredSubjectNames(subjectsDirs) {
+  const directories = Array.isArray(subjectsDirs) ? subjectsDirs : [subjectsDirs];
   const names = new Set();
-  for (const entry of readdirSync(subjectsDir)) {
-    if (!entry.endsWith(".test.ts")) continue;
-    const source = readFileSync(join(subjectsDir, entry), "utf8");
-    for (const name of discoverSubjectRegistrations(source)) names.add(name);
+  for (const subjectsDir of directories) {
+    if (!existsSync(subjectsDir)) continue;
+    for (const entry of readdirSync(subjectsDir)) {
+      if (!entry.endsWith(".test.ts")) continue;
+      const source = readFileSync(join(subjectsDir, entry), "utf8");
+      for (const name of discoverSubjectRegistrations(source)) names.add(name);
+    }
   }
   return [...names];
 }
@@ -695,9 +698,10 @@ function main() {
     : join(scriptDir, "coverage.json");
   const manifest = loadCoverageManifest(JSON.parse(readFileSync(manifestPath, "utf8")));
 
-  const registered = registeredSubjectNames(
+  const registered = registeredSubjectNames([
     join(repoRoot, "packages", "remnic-core", "src", "testing", "subjects"),
-  );
+    join(repoRoot, "packages", "plugin-openclaw", "src", "testing", "subjects"),
+  ]);
   const missingSubjects = unregisteredSubjects(manifest, registered);
   if (missingSubjects.length > 0) {
     console.error(

--- a/scripts/lifecycle-matrix/coverage.json
+++ b/scripts/lifecycle-matrix/coverage.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Lifecycle scenario-matrix coverage manifest (issue #1993, umbrella #1988 phase 5, decisions A + C). `lifecycleManifest` is the set of lifecycle-critical path globs that trigger the `lifecycle-matrix` CI gate (gitignore-subset syntax, repo-root-relative, forward slashes). Each glob is one of three states: `coverage` (mapped to a registered LifecycleSubject in packages/remnic-core/src/testing/subjects \u2014 a touched covered path PASSES); `grandfathered` (warn-only, shrink-only ratchet: entries may be removed but the CI gate FAILS if the list grows); or unmapped (permitted in the manifest at load time, but a touched unmapped path FAILS the gate \u2014 this is the mechanism that forces a newly-added lifecycle path to gain a subject rather than silently escaping coverage). loadCoverageManifest() validates structure (coverage/grandfathered keys must exist in lifecycleManifest, no glob is both) but does not reject unmapped globs; the gate enforces coverage only for paths a PR actually touches. See packages/remnic-core/src/testing/lifecycle-matrix.ts.",
+  "$comment": "Lifecycle scenario-matrix coverage manifest. Lifecycle-critical paths trigger the lifecycle-matrix gate. Covered paths map to registered LifecycleSubject implementations in package testing subject directories; grandfathered paths warn only and form a shrink-only ratchet; unmapped touched paths fail.",
   "lifecycleManifest": [
     "src/orchestration/**",
     "src/orchestrator.ts",
@@ -12,6 +12,7 @@
     "packages/remnic-core/src/storage.ts",
     "packages/remnic-core/src/storage/**",
     "packages/remnic-core/src/session-toggles.ts",
+    "packages/remnic-core/src/session-namespace-bindings.ts",
     "packages/remnic-core/src/memory-cache.ts",
     "packages/remnic-core/src/lifecycle.ts",
     "packages/remnic-core/src/qmd-recall-cache.ts",
@@ -121,13 +122,15 @@
     "packages/remnic-core/src/maintenance/dreams-ledger.ts",
     "packages/remnic-core/src/maintenance/projection-support.ts",
     "packages/remnic-core/src/maintenance/rebuild-memory-projection.ts",
-    "packages/remnic-core/src/orchestration/projection-rebuild-schedule.ts"
+    "packages/remnic-core/src/orchestration/projection-rebuild-schedule.ts",
+    "packages/plugin-openclaw/src/delegate-runtime.ts"
   ],
   "coverage": {
     "packages/remnic-core/src/orchestrator.ts": "extraction-lifecycle",
     "packages/remnic-core/src/buffer.ts": "extraction-lifecycle",
     "packages/remnic-core/src/storage.ts": "extraction-lifecycle",
     "packages/remnic-core/src/session-toggles.ts": "serialized-write-chain",
+    "packages/remnic-core/src/session-namespace-bindings.ts": "openclaw-delegate-runtime",
     "packages/remnic-core/src/orchestration/extraction-run.ts": "extraction-lifecycle",
     "packages/remnic-core/src/orchestration/extraction-persist.ts": "extraction-lifecycle",
     "packages/remnic-core/src/orchestration/extraction-persist-promotion.ts": "extraction-lifecycle",
@@ -147,7 +150,8 @@
     "packages/remnic-core/src/recall-qos.ts": "recall-budget",
     "packages/remnic-core/src/maintenance/projection-support.ts": "memory-projection",
     "packages/remnic-core/src/maintenance/rebuild-memory-projection.ts": "memory-projection",
-    "packages/remnic-core/src/orchestration/projection-rebuild-schedule.ts": "memory-projection"
+    "packages/remnic-core/src/orchestration/projection-rebuild-schedule.ts": "memory-projection",
+    "packages/plugin-openclaw/src/delegate-runtime.ts": "openclaw-delegate-runtime"
   },
   "grandfathered": [
     "packages/remnic-core/src/lifecycle.ts",

--- a/tests/lifecycle-matrix-coverage.test.mjs
+++ b/tests/lifecycle-matrix-coverage.test.mjs
@@ -39,6 +39,7 @@ import {
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const realManifestPath = join(repoRoot, "scripts", "lifecycle-matrix", "coverage.json");
 const subjectsDir = join(repoRoot, "packages", "remnic-core", "src", "testing", "subjects");
+const pluginSubjectsDir = join(repoRoot, "packages", "plugin-openclaw", "src", "testing", "subjects");
 
 function loadReal() {
   return loadCoverageManifest(JSON.parse(readFileSync(realManifestPath, "utf8")));
@@ -52,10 +53,20 @@ test("the committed coverage.json is structurally valid", () => {
 
 test("every coverage subject name is a registered LifecycleSubject", () => {
   const manifest = loadReal();
-  const registered = registeredSubjectNames(subjectsDir);
+  const registered = registeredSubjectNames([subjectsDir, pluginSubjectsDir]);
   assert.ok(registered.includes("extraction-lifecycle"), "extraction-lifecycle must be registered");
   assert.ok(registered.includes("serialized-write-chain"), "serialized-write-chain must be registered");
   assert.deepEqual(unregisteredSubjects(manifest, registered), []);
+});
+
+test("registered lifecycle subjects include OpenClaw adapter scenarios", () => {
+  const registered = registeredSubjectNames([subjectsDir, pluginSubjectsDir]);
+  assert.ok(registered.includes("openclaw-delegate-runtime"));
+});
+
+test("session namespace bindings map to the delegate lifecycle subject", () => {
+  const manifest = loadReal();
+  assert.equal(manifest.coverage["packages/remnic-core/src/session-namespace-bindings.ts"], "openclaw-delegate-runtime");
 });
 
 test("a PR touching a mapped lifecycle path passes (orchestration/turn-ingestion.ts)", () => {


### PR DESCRIPTION
Part of #2130\n\nForwards the OpenClaw session namespace to delegate recall, observe, and flush requests. Hooks read the namespace only from metadata tied to the active hook session, preserving omission for default sessions and preventing stale metadata from a rebound session from selecting a namespace.\n\nVerification:\n- pnpm exec tsx --test packages/plugin-openclaw/src/delegate-runtime.test.ts\n- pnpm --filter @remnic/plugin-openclaw run check-types\n- npm run preflight:quick\n- npm run test:entity-hardening

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session-scoped routing for recall/observe/flush and adds durable binding migration logic; mistakes could mis-route memory or drop flushes, but fail-closed validation and broad test coverage reduce exposure.
> 
> **Overview**
> The OpenClaw **delegate runtime** now routes recall, observe, and compaction flush to the correct memory namespace per session. It reads namespace only from hook metadata tied to the active session key, omits `namespace` for default-scope sessions, and **fails closed** on malformed session keys or namespace metadata and when binding persistence fails.
> 
> A new **session-namespace binding store** (in-memory and file-backed, with legacy `openclaw-engram` migration) records namespace history across rebinds and sparse lifecycle hooks so ended-session flushes still target the right scope.
> 
> **LCM compaction flush** gains `GET /engram/v1/capabilities` (`lcmCompactionFlushBatch`) and an optional **`namespaces` batch** on flush (one write quota, per-namespace results with isolated auth failures). The delegate probes capabilities, batches multi-namespace flushes when supported, and falls back to singular flushes for older daemons or failed batch calls.
> 
> Docs, schema validation (no duplicate `namespaces`), lifecycle-matrix coverage for `openclaw-delegate-runtime`, and extensive tests accompany the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f92266beae8a35bc68c906653709033abcf36b3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-session session-namespace binding with in-memory and file-backed persistence, plus new public exports for bindings and lifecycle-matrix testing.
  * Added `GET /engram/v1/capabilities` and batch support for `POST /engram/v1/lcm/compaction/flush` via optional `namespaces`.
* **Bug Fixes**
  * Delegate recall/observe/flush now use computed per-session namespaces (including rebind, session-ending, and fail-closed behavior).
  * HTTP flush now supports batch capability/probing and isolates per-namespace authorization/outcome results; request validation rejects duplicate namespaces.
* **Tests**
  * Expanded lifecycle-matrix and binding store coverage (persistence reload/recovery, dedupe/replay, corruption handling, batching edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->