### PR TITLE
fix(release): key unprovisioned-package skip on E404, not package existence

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -543,10 +543,15 @@ jobs:
           # plugins) must ship so end users can install only what they need
           # — see the à-la-carte invariant in CLAUDE.md / AGENTS.md.
           mapfile -t PUBLISH_ORDER < "${RUNNER_TEMP}/remnic-publish-order.txt"
-          # New packages that npm rejects with E404 on their FIRST publish
-          # (trusted publishing not yet provisioned for the name) must not
+          # Packages that npm rejects with E404 on publish (PUT) must not
           # strand every package after them in topological order — that
           # left @remnic/cli and friends lagging whole release trains.
+          # E404 means this automation identity may not publish the name,
+          # whether the name is brand new (cannot create it) or already
+          # exists (no write permission — npm returns 404, not 403, so
+          # package existence is not leaked). Both are the same operator-
+          # actionable provisioning gap, so the branch is keyed on the
+          # error class, NOT on whether the name happens to exist yet.
           # They are collected, surfaced loudly, and skipped; everything
           # else still publishes. Any other publish failure remains fatal.
           UNPROVISIONED=()
@@ -563,10 +568,6 @@ jobs:
             fi
             pkg_name="$(node -p "require('./$pkg_json').name")"
             pkg_version="$(node -p "require('./$pkg_json').version")"
-            pkg_exists="false"
-            if npm view "${pkg_name}" version >/dev/null 2>&1; then
-              pkg_exists="true"
-            fi
             if npm view "${pkg_name}@${pkg_version}" version >/dev/null 2>&1; then
               echo "::notice::${pkg_name}@${pkg_version} already published; skipping."
               continue
@@ -580,8 +581,8 @@ jobs:
             else
               publish_status=$?
               cat "$publish_log"
-              if [ "$pkg_exists" != "true" ] && grep -q "npm error code E404" "$publish_log"; then
-                echo "::warning::${pkg_name}@${pkg_version} is not provisioned for first-time npm publish from this automation. Set up trusted publishing for this package name, then rerun the release workflow (already-published packages are skipped automatically). Continuing with the remaining packages."
+              if grep -q "npm error code E404" "$publish_log"; then
+                echo "::warning::This automation identity is not provisioned to publish ${pkg_name}@${pkg_version} to npm (E404 on publish — the name is either not yet created or grants this identity no write access). Set up trusted publishing for this package name, then rerun the release workflow (already-published packages are skipped automatically). Continuing with the remaining packages."
                 UNPROVISIONED+=("${pkg_name}@${pkg_version}")
                 rm -f "$publish_log"
                 continue
@@ -592,7 +593,7 @@ jobs:
           done
           if [ "${#UNPROVISIONED[@]}" -gt 0 ]; then
             {
-              echo "## Unprovisioned first-time packages (not published)"
+              echo "## Unprovisioned packages (not published)"
               echo ""
               echo "Provision npm trusted publishing for each name, then rerun this workflow:"
               echo ""

--- a/tests/release-publish-workflow.test.mjs
+++ b/tests/release-publish-workflow.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 // Contract tests for the workspace-publish step of the release workflow.
 //
@@ -16,7 +18,13 @@ import test from "node:test";
 // alone, non-E404 failures stay fatal, and unprovisioned names still fail the
 // run loudly (pattern 38).
 
-const workflow = readFileSync(".github/workflows/release-and-publish.yml", "utf8");
+// Resolve from this module, not the caller's CWD, so the test still runs when
+// invoked by absolute path from another directory (IDEs, targeted runners).
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workflow = readFileSync(
+  path.join(repoRoot, ".github/workflows/release-and-publish.yml"),
+  "utf8",
+);
 
 // Scope assertions to the publish loop rather than the whole file.
 function step(name) {

--- a/tests/release-publish-workflow.test.mjs
+++ b/tests/release-publish-workflow.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// Contract tests for the workspace-publish step of the release workflow.
+//
+// Live incident (v9.24.1): the unprovisioned-package guard was keyed on
+// whether the package name already existed on the registry, not on the error
+// class. An operator manually first-published two new names to unblock a
+// stalled release; that flipped pkg_exists to "true", so the SAME E404
+// (npm returns 404 rather than 403 to avoid leaking package existence, so an
+// existing-name permission failure looks identical to a missing-name one)
+// stopped matching the guard and became fatal. The release then aborted at the
+// first capture package and shipped NOTHING -- not even packages earlier in
+// topological order. These tests pin the fix: the branch is keyed on the error
+// alone, non-E404 failures stay fatal, and unprovisioned names still fail the
+// run loudly (pattern 38).
+
+const workflow = readFileSync(".github/workflows/release-and-publish.yml", "utf8");
+
+// Scope assertions to the publish loop rather than the whole file.
+function step(name) {
+  const marker = `- name: ${name}`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `step "${name}" not found in release workflow`);
+  const rest = workflow.slice(start + marker.length);
+  const nextIdx = rest.indexOf("\n      - name: ");
+  return nextIdx === -1 ? workflow.slice(start) : workflow.slice(start, start + marker.length + nextIdx);
+}
+
+const publishStep = step("Publish workspace packages to npm");
+
+const e404GuardLine = publishStep
+  .split("\n")
+  .find((line) => /grep -q "npm error code E404"/.test(line));
+
+const warningLine = publishStep
+  .split("\n")
+  .find((line) => line.includes("::warning::") && /provision/i.test(line));
+
+test("E404 unprovisioned branch is keyed on the error, not package existence", () => {
+  assert.ok(e404GuardLine, "E404 publish-failure guard not found");
+  assert.doesNotMatch(
+    e404GuardLine,
+    /pkg_exists/,
+    "the E404 branch must not gate on whether the package name already exists",
+  );
+  assert.doesNotMatch(
+    publishStep,
+    /pkg_exists/,
+    "the pkg_exists precondition must be removed entirely, not left dead in the loop",
+  );
+});
+
+test("non-E404 publish failures stay fatal, and the fatal path is reachable", () => {
+  assert.match(
+    publishStep,
+    /exit \$publish_status/,
+    "a failed publish must still exit non-zero for any non-E404 error class",
+  );
+  // The E404 branch must `continue`, so control falls through to the fatal
+  // `exit $publish_status` for every other failure class (EPUBLISHCONFLICT,
+  // auth, network, build). Match the branch through its continue and out to
+  // the exit to prove the fatal path is not shadowed.
+  const e404BranchFallsThroughToExit =
+    /grep -q "npm error code E404"[\s\S]*?continue[\s\S]*?fi\s*\n\s*rm -f "\$publish_log"\s*\n\s*exit \$publish_status/.test(
+      publishStep,
+    );
+  assert.ok(
+    e404BranchFallsThroughToExit,
+    "the E404 branch must skip via continue, leaving the fatal exit reachable for other failures",
+  );
+});
+
+test("collected unprovisioned packages still make the run exit non-zero (visible red run)", () => {
+  assert.match(
+    publishStep,
+    /if \[ "\$\{#UNPROVISIONED\[@\]\}" -gt 0 \]; then/,
+    "the workflow must still check whether any packages were collected as unprovisioned",
+  );
+  assert.match(
+    publishStep,
+    /UNPROVISIONED\[@\][\s\S]*?exit 1/,
+    "unprovisioned packages must fail the run (pattern 38: never silently green)",
+  );
+});
+
+test("the unprovisioned warning covers existing names, not just first-time publishes", () => {
+  assert.ok(warningLine, "unprovisioned warning line not found");
+  assert.doesNotMatch(
+    warningLine,
+    /first-time/i,
+    "the warning must not claim a first-time-only publish (misleading for an existing name)",
+  );
+  assert.match(
+    warningLine,
+    /not provisioned to publish/i,
+    "the warning must state the identity is not provisioned to publish the package",
+  );
+});


### PR DESCRIPTION
## What broke, live

The workspace-publish loop in `.github/workflows/release-and-publish.yml`
already tolerated a package it cannot publish: it collected the name, warned
loudly, skipped it, and kept going so the rest of the release train still
shipped. But the guard was keyed on the wrong thing -- whether the package
name already existed on the registry -- instead of on the error itself:

```sh
if [ "$pkg_exists" != "true" ] && grep -q "npm error code E404" "$publish_log"; then
```

An `E404` on `PUT` during publish is a pure permissions signal. CI publishes
via OIDC trusted publishing only (`id-token: write`, no `NODE_AUTH_TOKEN`), and
npm deliberately returns `404` rather than `403` so it never leaks whether a
name exists. The same `E404` fires in both cases:

- the name does not exist yet -> this identity cannot create it
- the name exists -> the trusted publisher is not configured for it, so this
  identity has no write access

Both are the identical operator-actionable provisioning gap.

## The sequence that took down three release trains

`@remnic/capture-screen` and `@remnic/capture-audio` could not be published by
CI because trusted publishing was never set up for those two names. An operator
manually first-published them to unblock a stalled release. That flipped
`pkg_exists` to `true`, so the very same `E404` stopped matching the guard and
became **fatal** -- aborting the whole topological publish loop at the first
capture package and stranding every package behind it.

Concrete impact: three consecutive release trains went down this way -- v9.24.0
partially, v9.24.1 and v9.24.2 completely -- leaving `@remnic/core` stuck at
9.24.0 while `main` sits at v9.24.2. (The two capture names now exist on npm and
CI *still* gets `E404` on `PUT`, which is the live proof that existence is
irrelevant and the error class is the right key.)

## The fix

Drop the `pkg_exists` precondition so the branch keys on the error class alone,
remove the now-dead `pkg_exists` probe, and reword the warning to cover both
cases (the old text claimed a "first-time npm publish", which is misleading for
a name that already exists).

## This does NOT make releases green while packages are missing

The run still fails loudly. When any package lands in `UNPROVISIONED`, the step
writes the affected names to the job summary and exits non-zero (pattern 38 --
never silently green; the trusted-publishing provisioning is a real operator
action). The change only stops one unpublishable package from stranding every
other package behind it in topological order. Every other publish failure --
`EPUBLISHCONFLICT`, auth, network, build -- stays fatal, unchanged.

## Tests

`tests/release-publish-workflow.test.mjs` (contract tests over the workflow
YAML, matching the established `tests/*-workflow.test.mjs` style) asserts:

- the `E404` unprovisioned branch does not depend on `pkg_exists`
- non-`E404` publish failures stay fatal and the fatal path stays reachable
- a non-empty `UNPROVISIONED` set still exits the run non-zero
- the warning no longer claims a first-time-only publish

Reverting the workflow fix turns the suite red (the `pkg_exists` and
"first-time" assertions fail); restoring it makes all four pass. Existing
release-workflow contract tests (24) and `npm run preflight:quick` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only CI release automation (npm publish error handling), but incorrect logic could still block or partially ship releases; contract tests reduce regression risk.
> 
> **Overview**
> Fixes a release workflow bug where **npm publish `E404`** was only treated as “unprovisioned” when the package name **did not** already exist on the registry. After manual first publishes, the same permission `E404` became **fatal** and aborted the whole topological publish loop, stranding later packages.
> 
> The **Publish workspace packages to npm** step now skips and collects packages on **`E404` alone** (drops `pkg_exists` / `npm view` existence checks), updates warnings and job summary copy for both missing names and existing names without trusted publishing, and still **exits non-zero** when anything lands in `UNPROVISIONED`. Other publish errors remain fatal.
> 
> Adds **`tests/release-publish-workflow.test.mjs`** contract tests on the workflow YAML to lock in that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 123fa829935983b04ae506c183f0100a32410dc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->