### PR TITLE
fix(openclaw): preflight delegate authorization

### DIFF
--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -21,6 +21,21 @@ export interface BridgeConfig {
   daemonPort: number;
 }
 
+export type DaemonAuthTokenSource =
+  | "OPENCLAW_REMNIC_ACCESS_TOKEN"
+  | "OPENCLAW_ENGRAM_ACCESS_TOKEN"
+  | "REMNIC_AUTH_TOKEN"
+  | "ENGRAM_AUTH_TOKEN"
+  | "remnic token store"
+  | "engram token store"
+  | "daemon configuration"
+  | "no configured token";
+
+export interface DaemonAuthToken {
+  readonly token: string;
+  readonly source: DaemonAuthTokenSource;
+}
+
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 4318;
 const LEGACY_HEALTH_PATH = "/engram/v1/health";
@@ -168,7 +183,7 @@ export function checkDaemonHealthSync(host: string, port: number, timeoutMs = SY
         host,
         port,
         path: LEGACY_HEALTH_PATH,
-        token: loadDaemonAuthToken(),
+        token: loadDaemonAuth().token,
         timeoutMs,
         state,
       },
@@ -327,57 +342,73 @@ export function resolveBridgeMode(configBridgeMode: string): BridgeConfig {
   };
 }
 
+function isOpenClawTokenEntry(value: unknown): value is { token: string } {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "connector" in value &&
+    value.connector === "openclaw" &&
+    "token" in value &&
+    typeof value.token === "string"
+  );
+}
+
 /**
- * Load the first valid daemon auth token from the standard token stores,
- * daemon config, or environment. Shared by the health preflight and the
- * delegate runtime (issue #2120).
+ * Load daemon credentials from the environment, standard token stores, or
+ * daemon configuration. Shared by health and delegate requests.
  */
-export function loadDaemonAuthToken(): string {
-  // Environment-provided tokens first: for delegate-mode daemon operations the
-  // operator must be able to pin a token authorized for recall/observe/lcm
-  // rather than inheriting whatever happens to be first in tokens.json
-  // (least-privilege stores can hold narrowly scoped tokens up front).
-  const envToken =
-    readEnv("OPENCLAW_REMNIC_ACCESS_TOKEN") ??
-    readEnv("OPENCLAW_ENGRAM_ACCESS_TOKEN") ??
-    readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN");
-  if (envToken) return envToken;
-  const tokenPaths = [
-    path.join(resolveHomeDir(), ".remnic", "tokens.json"),
-    path.join(resolveHomeDir(), ".engram", "tokens.json"),
-  ];
-  for (const tokensPath of tokenPaths) {
-    if (!fs.existsSync(tokensPath)) continue;
+export function loadDaemonAuth(): DaemonAuthToken {
+  const environmentTokens = [
+    ["OPENCLAW_REMNIC_ACCESS_TOKEN", readEnv("OPENCLAW_REMNIC_ACCESS_TOKEN")],
+    ["OPENCLAW_ENGRAM_ACCESS_TOKEN", readEnv("OPENCLAW_ENGRAM_ACCESS_TOKEN")],
+    ["REMNIC_AUTH_TOKEN", readEnv("REMNIC_AUTH_TOKEN")],
+    ["ENGRAM_AUTH_TOKEN", readEnv("ENGRAM_AUTH_TOKEN")],
+  ] as const;
+  for (const [source, token] of environmentTokens) {
+    if (token) return { token, source };
+  }
+
+  const tokenStores = [
+    { path: path.join(resolveHomeDir(), ".remnic", "tokens.json"), source: "remnic token store" },
+    { path: path.join(resolveHomeDir(), ".engram", "tokens.json"), source: "engram token store" },
+  ] as const;
+  for (const tokenStore of tokenStores) {
+    if (!fs.existsSync(tokenStore.path)) continue;
     try {
-      const store = JSON.parse(fs.readFileSync(tokensPath, "utf8"));
+      const store = JSON.parse(fs.readFileSync(tokenStore.path, "utf8"));
       const tokens = Array.isArray(store.tokens) ? store.tokens : [];
-      if (tokens.length > 0 && tokens[0].token) return tokens[0].token;
-      if (typeof store === "object" && store !== null) {
-        for (const val of Object.values(store)) {
-          if (
-            typeof val === "string" &&
-            val.length > 0 &&
-            (val.startsWith("remnic_") || val.startsWith("engram_"))
-          ) {
-            return val;
-          }
-        }
+      const openClawToken = tokens.find(isOpenClawTokenEntry)?.token;
+      if (typeof openClawToken === "string" && openClawToken.length > 0) {
+        return { token: openClawToken, source: tokenStore.source };
+      }
+      if (
+        typeof store === "object" &&
+        store !== null &&
+        "openclaw" in store &&
+        typeof store.openclaw === "string" &&
+        store.openclaw.length > 0 &&
+        (store.openclaw.startsWith("remnic_") || store.openclaw.startsWith("engram_"))
+      ) {
+        return { token: store.openclaw, source: tokenStore.source };
       }
     } catch {
-      // Ignore malformed token files and continue to the next candidate.
+      continue;
     }
   }
+
   try {
-    for (const p of configPathCandidates()) {
-      if (fs.existsSync(p)) {
-        const raw = JSON.parse(fs.readFileSync(p, "utf8"));
-        if (raw.server?.authToken) return raw.server.authToken;
+    for (const configPath of configPathCandidates()) {
+      if (!fs.existsSync(configPath)) continue;
+      const raw = JSON.parse(fs.readFileSync(configPath, "utf8"));
+      const token = raw.server?.authToken;
+      if (typeof token === "string" && token.length > 0) {
+        return { token, source: "daemon configuration" };
       }
     }
   } catch {
-    // ignore
+    return { token: "", source: "no configured token" };
   }
-  return "";
+  return { token: "", source: "no configured token" };
 }
 
 /**
@@ -387,7 +418,7 @@ export function loadDaemonAuthToken(): string {
 export async function checkDaemonHealth(host: string, port: number): Promise<boolean> {
   try {
     const { request } = await import("node:http");
-    const token = loadDaemonAuthToken();
+    const token = loadDaemonAuth().token;
     const headers: Record<string, string> = {};
     if (token) headers["Authorization"] = `Bearer ${token}`;
 

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -1,13 +1,19 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import http from "node:http";
+import test from "node:test";
+import { initLogger, resetLogger } from "@remnic/core/logger";
 
 import {
   maybeRegisterDelegateRuntime,
+  probeDelegateAuthorization,
   registerDelegateRuntime,
   type DelegateRuntimeOptions,
+  type MaybeRegisterDelegateDeps,
 } from "./delegate-runtime.js";
-import { resolveBridgeMode } from "./bridge.js";
+import { loadDaemonAuth, resolveBridgeMode } from "./bridge.js";
 
 type HookHandler = (
   event: Record<string, unknown>,
@@ -96,7 +102,14 @@ async function startDaemonStub(
 function optionsFor(port: number, overrides: Partial<DelegateRuntimeOptions> = {}): DelegateRuntimeOptions {
   return {
     serviceId: "openclaw-remnic",
-    target: { host: "127.0.0.1", port, authToken: "test-token" },
+    target: {
+      host: "127.0.0.1",
+      port,
+      resolveAuthToken: () => ({
+        token: "test-token",
+        source: "OPENCLAW_REMNIC_ACCESS_TOKEN",
+      }),
+    },
     namespace: "",
     allowPromptInjection: true,
     passive: false,
@@ -249,6 +262,58 @@ test("delegate honors allowPromptInjection=false but keeps observe/flush", async
   assert.ok(api.handlers.has("before_reset"), "flush hooks still registered");
 });
 
+
+test("loadDaemonAuth selects only the OpenClaw token from multi-connector stores", () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-openclaw-token-"));
+  const priorHome = process.env.HOME;
+  const authVariables = [
+    "OPENCLAW_REMNIC_ACCESS_TOKEN",
+    "OPENCLAW_ENGRAM_ACCESS_TOKEN",
+    "REMNIC_AUTH_TOKEN",
+    "ENGRAM_AUTH_TOKEN",
+  ] as const;
+  const priorAuth = new Map(authVariables.map((name) => [name, process.env[name]]));
+  try {
+    for (const name of authVariables) Reflect.deleteProperty(process.env, name);
+    process.env.HOME = tempHome;
+    fs.mkdirSync(path.join(tempHome, ".remnic"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempHome, ".remnic", "tokens.json"),
+      JSON.stringify({
+        tokens: [
+          { token: "remnic_other_token", connector: "other", createdAt: "2026-01-01T00:00:00.000Z" },
+          { token: "remnic_openclaw_token", connector: "openclaw", createdAt: "2026-01-01T00:00:00.000Z" },
+        ],
+      }),
+    );
+
+    assert.deepEqual(loadDaemonAuth(), {
+      token: "remnic_openclaw_token",
+      source: "remnic token store",
+    });
+
+    fs.writeFileSync(
+      path.join(tempHome, ".remnic", "tokens.json"),
+      JSON.stringify({
+        tokens: [
+          { token: "remnic_other_token", connector: "other", createdAt: "2026-01-01T00:00:00.000Z" },
+        ],
+      }),
+    );
+    assert.deepEqual(loadDaemonAuth(), {
+      token: "",
+      source: "no configured token",
+    });
+  } finally {
+    if (priorHome === undefined) Reflect.deleteProperty(process.env, "HOME");
+    else process.env.HOME = priorHome;
+    for (const [name, value] of priorAuth) {
+      if (value === undefined) Reflect.deleteProperty(process.env, name);
+      else process.env[name] = value;
+    }
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
 test("resolveBridgeMode is explicit-only: config delegate activates, absence stays embedded", () => {
   const priorEnv = process.env.REMNIC_BRIDGE_MODE;
   Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
@@ -749,5 +814,250 @@ test("maybeRegister: an embedded-mode registration blocks a later delegate flip 
   } finally {
     if (priorEnv === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
     else process.env.REMNIC_BRIDGE_MODE = priorEnv;
+  }
+});
+
+test("delegate runtime reloads a rotated daemon token without re-registering hooks", async () => {
+  let currentToken = "expired-token";
+  const receivedAuthorization: Array<string | undefined> = [];
+  const server = http.createServer((req, res) => {
+    receivedAuthorization.push(req.headers.authorization);
+    res.setHeader("content-type", "application/json");
+    if (req.headers.authorization !== "Bearer accepted-token") {
+      res.writeHead(401);
+      res.end(JSON.stringify({ error: "unauthorized" }));
+      return;
+    }
+    res.end(JSON.stringify({ context: "recovered context" }));
+  });
+  const listening = Promise.withResolvers<void>();
+  server.once("error", listening.reject);
+  server.listen(0, "127.0.0.1", listening.resolve);
+  await listening.promise;
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const target: DelegateRuntimeOptions["target"] = {
+    host: "127.0.0.1",
+    port: address.port,
+    resolveAuthToken: () => ({
+      token: currentToken,
+      source: "OPENCLAW_REMNIC_ACCESS_TOKEN",
+    }),
+  };
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(address.port, { target }));
+
+    const first = await invoke(
+      api,
+      "before_prompt_build",
+      { prompt: "what did we decide about the durable release?" },
+      { sessionKey: "rotation" },
+    );
+    assert.equal(first, undefined, "the expired token receives no injected context");
+
+    currentToken = "accepted-token";
+    const second = await invoke(
+      api,
+      "before_prompt_build",
+      { prompt: "what did we decide about the durable release?" },
+      { sessionKey: "rotation" },
+    );
+    assert.match(String((second as Record<string, unknown>)?.prependSystemContext), /recovered context/);
+    assert.deepEqual(receivedAuthorization, ["Bearer expired-token", "Bearer accepted-token"]);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => error ? reject(error) : resolve()),
+    );
+  }
+});
+
+test("delegate authorization probe reports grant, rejection, and network failure without exposing credentials", async () => {
+  let responseStatus = 200;
+  const receivedAuthorization: Array<string | undefined> = [];
+  const server = http.createServer((req, res) => {
+    assert.equal(req.method, "GET");
+    assert.match(
+      String(req.url),
+      /\/engram\/v1\/authorization\?op=recall&op=observe&op=lcm_compaction_flush&namespace=/,
+    );
+    receivedAuthorization.push(req.headers.authorization);
+    res.writeHead(responseStatus, { "content-type": "application/json" });
+    res.end(JSON.stringify({ authorized: responseStatus === 200 }));
+  });
+  const listening = Promise.withResolvers<void>();
+  server.listen(0, "127.0.0.1", listening.resolve);
+  await listening.promise;
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const target: DelegateRuntimeOptions["target"] = {
+    host: "127.0.0.1",
+    port: address.port,
+    resolveAuthToken: () => ({
+      token: "test-preflight-token",
+      source: "OPENCLAW_REMNIC_ACCESS_TOKEN",
+    }),
+  };
+  try {
+    assert.deepEqual(await probeDelegateAuthorization(target), {
+      state: "authorized",
+      tokenSource: "OPENCLAW_REMNIC_ACCESS_TOKEN",
+    });
+
+    responseStatus = 403;
+    assert.deepEqual(await probeDelegateAuthorization(target), {
+      state: "unauthorized",
+      status: 403,
+      tokenSource: "OPENCLAW_REMNIC_ACCESS_TOKEN",
+    });
+    assert.deepEqual(receivedAuthorization, ["Bearer test-preflight-token", "Bearer test-preflight-token"]);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => error ? reject(error) : resolve()),
+    );
+  }
+
+  const unavailable: DelegateRuntimeOptions["target"] = {
+    host: "127.0.0.1",
+    port: 1,
+    resolveAuthToken: () => ({
+      token: "test-preflight-token",
+      source: "OPENCLAW_REMNIC_ACCESS_TOKEN",
+    }),
+  };
+  assert.deepEqual(await probeDelegateAuthorization(unavailable), {
+    state: "unavailable",
+    tokenSource: "OPENCLAW_REMNIC_ACCESS_TOKEN",
+  });
+});
+
+test("delegate activation warns each service once and keeps its memory hooks", async (t) => {
+  const priorMode = process.env.REMNIC_BRIDGE_MODE;
+  const priorToken = process.env.OPENCLAW_REMNIC_ACCESS_TOKEN;
+  const warnings: string[] = [];
+  initLogger(
+    {
+      info() {},
+      warn(message) {
+        warnings.push(message);
+      },
+      error() {},
+    },
+    false,
+    { timestamps: false },
+  );
+  t.after(() => {
+    resetLogger();
+    if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
+    else process.env.REMNIC_BRIDGE_MODE = priorMode;
+    if (priorToken === undefined) Reflect.deleteProperty(process.env, "OPENCLAW_REMNIC_ACCESS_TOKEN");
+    else process.env.OPENCLAW_REMNIC_ACCESS_TOKEN = priorToken;
+  });
+  process.env.REMNIC_BRIDGE_MODE = "delegate";
+  process.env.OPENCLAW_REMNIC_ACCESS_TOKEN = "test-preflight-token";
+  const api = recordingApi();
+  const options = {
+    serviceId: "openclaw-remnic",
+    configBridgeMode: "delegate",
+    passive: false,
+    allowPromptInjection: true,
+    gateHeartbeatTurns: false,
+    recallBudgetChars: 8_000,
+    memoryDir: "/tmp/remnic-delegate-test-memory",
+    sessionTogglesEnabled: false,
+    respectBundledActiveMemoryToggle: false,
+    cleanUserMessage: (text: string) => text,
+    hookTimeoutMs: 5_000,
+    shouldSkipRecall: () => false,
+    flushOnResetEnabled: true,
+  };
+  let probeCalls = 0;
+  const probedOperations: Array<readonly string[]> = [];
+  const deps: MaybeRegisterDelegateDeps = {
+    checkHealth: () => true,
+    probeAuthorization: async (_target, _namespace, operations) => {
+      probeCalls += 1;
+      probedOperations.push(operations);
+      return {
+        state: "unauthorized" as const,
+        status: 403 as const,
+        tokenSource: "OPENCLAW_REMNIC_ACCESS_TOKEN" as const,
+      };
+    },
+  };
+  assert.equal(maybeRegisterDelegateRuntime(api, options, deps), true);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.ok(api.handlers.has("agent_end"), "authorization preflight must not fall back to embedded");
+  assert.equal(probeCalls, 1);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0]!, /authorization preflight rejected/);
+  assert.match(warnings[0]!, /OPENCLAW_REMNIC_ACCESS_TOKEN/);
+  assert.doesNotMatch(warnings[0]!, /test-preflight-token/);
+
+  assert.equal(
+    maybeRegisterDelegateRuntime(
+      api,
+      { ...options, serviceId: "openclaw-engram", allowPromptInjection: false },
+      deps,
+    ),
+    true,
+  );
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(probeCalls, 2, "each service receives a preflight");
+  assert.equal(warnings.length, 2);
+  assert.deepEqual(probedOperations, [
+    ["recall", "observe", "lcm_compaction_flush"],
+    ["observe", "lcm_compaction_flush"],
+  ]);
+});
+
+test("delegate authorization preflight probes only the operations enabled by configuration", async () => {
+  const priorMode = process.env.REMNIC_BRIDGE_MODE;
+  process.env.REMNIC_BRIDGE_MODE = "delegate";
+  const options = {
+    serviceId: "openclaw-remnic",
+    configBridgeMode: "delegate",
+    passive: false,
+    allowPromptInjection: true,
+    gateHeartbeatTurns: false,
+    recallBudgetChars: 8_000,
+    memoryDir: "/tmp/remnic-delegate-test-memory",
+    sessionTogglesEnabled: false,
+    respectBundledActiveMemoryToggle: false,
+    cleanUserMessage: (text: string) => text,
+    hookTimeoutMs: 5_000,
+    shouldSkipRecall: () => false,
+    flushOnResetEnabled: true,
+  };
+  try {
+    for (const disabledRecall of [
+      { allowPromptInjection: false },
+      { recallBudgetChars: 0 },
+    ]) {
+      let operations: readonly string[] | undefined;
+      const api = recordingApi();
+      assert.equal(
+        maybeRegisterDelegateRuntime(
+          api,
+          { ...options, ...disabledRecall },
+          {
+            checkHealth: () => true,
+            probeAuthorization: async (_target, _namespace, requestedOperations) => {
+              operations = requestedOperations;
+              return {
+                state: "authorized",
+                tokenSource: "no configured token",
+              };
+            },
+          },
+        ),
+        true,
+      );
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.deepEqual(operations, ["observe", "lcm_compaction_flush"]);
+    }
+  } finally {
+    if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");
+    else process.env.REMNIC_BRIDGE_MODE = priorMode;
   }
 });

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -25,8 +25,9 @@ import path from "node:path";
 import { createFileToggleStore } from "@remnic/core/session-toggles";
 import {
   checkDaemonHealthSync,
-  loadDaemonAuthToken,
+  loadDaemonAuth,
   resolveBridgeMode,
+  type DaemonAuthToken,
 } from "./bridge.js";
 import {
   extractLastTurn,
@@ -36,7 +37,7 @@ import {
 export interface DelegateDaemonTarget {
   host: string;
   port: number;
-  authToken: string;
+  resolveAuthToken: () => DaemonAuthToken;
 }
 
 export interface DelegateRuntimeOptions {
@@ -90,6 +91,55 @@ export interface DelegateHookApi {
 
 const MEMORY_CONTEXT_HEADER = "## Memory Context (Remnic)";
 
+const DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS = [
+  "recall",
+  "observe",
+  "lcm_compaction_flush",
+] as const;
+
+type DelegateAuthorizationOperation = (typeof DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS)[number];
+
+export interface DelegateAuthorizationPreflight {
+  readonly state: "authorized" | "unauthorized" | "unavailable";
+  readonly tokenSource: DaemonAuthToken["source"];
+  readonly status?: 401 | 403;
+}
+
+function daemonUrl(target: DelegateDaemonTarget, pathname: string): string {
+  const host = target.host.includes(":") && !target.host.startsWith("[")
+    ? `[${target.host}]`
+    : target.host;
+  return `http://${host}:${target.port}${pathname}`;
+}
+
+export async function probeDelegateAuthorization(
+  target: DelegateDaemonTarget,
+  namespace = "",
+  operations: readonly DelegateAuthorizationOperation[] = DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS,
+): Promise<DelegateAuthorizationPreflight> {
+  const auth = target.resolveAuthToken();
+  const headers = auth.token ? { Authorization: `Bearer ${auth.token}` } : undefined;
+  const query = new URLSearchParams();
+  for (const operation of operations) query.append("op", operation);
+  query.set("namespace", namespace);
+  try {
+    const response = await fetch(daemonUrl(target, `/engram/v1/authorization?${query}`), {
+      headers,
+      signal: AbortSignal.timeout(2_000),
+    });
+    await response.body?.cancel();
+    if (response.status === 200) {
+      return { state: "authorized", tokenSource: auth.source };
+    }
+    if (response.status === 401 || response.status === 403) {
+      return { state: "unauthorized", status: response.status, tokenSource: auth.source };
+    }
+  } catch {
+    return { state: "unavailable", tokenSource: auth.source };
+  }
+  return { state: "unavailable", tokenSource: auth.source };
+}
+
 async function postJson(
   target: DelegateDaemonTarget,
   pathname: string,
@@ -97,13 +147,9 @@ async function postJson(
   timeoutMs: number,
 ): Promise<Record<string, unknown> | null> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
-  if (target.authToken) headers.Authorization = `Bearer ${target.authToken}`;
-  // Bracket bare IPv6 hosts (e.g. ::1, fd00::1) — a raw colon-containing
-  // host in a URL literal is ambiguous with the port separator.
-  const host = target.host.includes(":") && !target.host.startsWith("[")
-    ? `[${target.host}]`
-    : target.host;
-  const res = await fetch(`http://${host}:${target.port}${pathname}`, {
+  const auth = target.resolveAuthToken();
+  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
+  const res = await fetch(daemonUrl(target, pathname), {
     method: "POST",
     headers,
     body: JSON.stringify(body),
@@ -409,6 +455,14 @@ export interface MaybeRegisterDelegateOptions {
   flushOnResetEnabled: boolean;
 }
 
+function activeDelegateAuthorizationOperations(
+  options: MaybeRegisterDelegateOptions,
+): readonly DelegateAuthorizationOperation[] {
+  return options.allowPromptInjection && options.recallBudgetChars !== 0
+    ? DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS
+    : DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS.slice(1);
+}
+
 // Mirrors the embedded runtime's per-api hook dedup (globalThis HOOK_APIS
 // WeakSet), scoped per serviceId: a migration install can register BOTH the
 // canonical and legacy plugin ids against the same api object, and each
@@ -420,6 +474,7 @@ const delegateHookApiServices = new WeakMap<object, Set<string>>();
 // hooks from the fallback are still bound (OpenClaw exposes no unregister), so
 // switching would stack both memory paths (double recall/observe/flush).
 const delegateEmbeddedFallbackApis = new WeakSet<object>();
+const delegateAuthorizationPreflightServices = new WeakMap<object, Set<string>>();
 
 /**
  * Resolve bridge mode, preflight the daemon, and register the delegate
@@ -429,8 +484,14 @@ const delegateEmbeddedFallbackApis = new WeakSet<object>();
  * requested daemon failed its preflight (logged loudly).
  */
 export interface MaybeRegisterDelegateDeps {
-  /** Injectable preflight — defaults to the bridge's worker-backed sync probe. */
+  /** Injectable liveness preflight — defaults to the bridge's worker-backed sync probe. */
   checkHealth: (host: string, port: number) => boolean;
+  /** Injectable authorization preflight for standalone daemon compatibility. */
+  probeAuthorization?: (
+    target: DelegateDaemonTarget,
+    namespace: string,
+    operations: readonly DelegateAuthorizationOperation[],
+  ) => Promise<DelegateAuthorizationPreflight>;
 }
 
 export function maybeRegisterDelegateRuntime(
@@ -502,13 +563,14 @@ export function maybeRegisterDelegateRuntime(
         },
       )
     : null;
+  const target: DelegateDaemonTarget = {
+    host: bridge.daemonHost,
+    port: bridge.daemonPort,
+    resolveAuthToken: loadDaemonAuth,
+  };
   registerDelegateRuntime(api, {
     serviceId: options.serviceId,
-    target: {
-      host: bridge.daemonHost,
-      port: bridge.daemonPort,
-      authToken: loadDaemonAuthToken(),
-    },
+    target,
     namespace: "",
     allowPromptInjection: options.allowPromptInjection,
     passive: options.passive,
@@ -526,5 +588,32 @@ export function maybeRegisterDelegateRuntime(
     observeTimeoutMs: 120_000,
     flushTimeoutMs: 55_000,
   });
+  let preflightServices = delegateAuthorizationPreflightServices.get(api);
+  if (!options.passive && !preflightServices?.has(options.serviceId)) {
+    if (!preflightServices) {
+      preflightServices = new Set<string>();
+      delegateAuthorizationPreflightServices.set(api, preflightServices);
+    }
+    preflightServices.add(options.serviceId);
+    const operations = activeDelegateAuthorizationOperations(options);
+    const probe = deps.probeAuthorization ?? probeDelegateAuthorization;
+    const operationLabel = operations.join("/");
+    void probe(target, "", operations)
+      .then((result) => {
+        if (result.state === "authorized") return;
+        if (result.state === "unauthorized") {
+          log.warn(
+            `delegate authorization preflight rejected ${operationLabel} (${result.status}; token source: ${result.tokenSource}) — runtime remains active`,
+          );
+          return;
+        }
+        log.warn(
+          `delegate authorization preflight could not verify ${operationLabel} (token source: ${result.tokenSource}) — runtime remains active`,
+        );
+      })
+      .catch(() => {
+        log.warn("delegate authorization preflight could not complete — runtime remains active");
+      });
+  }
   return true;
 }

--- a/packages/remnic-core/src/access-authorization-probe.ts
+++ b/packages/remnic-core/src/access-authorization-probe.ts
@@ -2,7 +2,6 @@ import {
   getOperation,
   operationRequiresAuthorizedNamespace,
   OPERATION_NAMES,
-  RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS,
   type OperationName,
 } from "./access-boundary.js";
 import { EngramAccessInputError } from "./access-errors.js";
@@ -10,6 +9,13 @@ import {
   assertOperationAuthorizationAllowed,
   type TokenCapabilities,
 } from "./access-token-capabilities.js";
+
+const UNRESOLVABLE_RESOURCE_OPERATIONS = new Set<OperationName>([
+  "review_resolve",
+  "contradiction_detail",
+  "chat_message",
+  "chat_events",
+]);
 
 export interface AuthorizationProbeResponse {
   readonly authorized: true;
@@ -49,24 +55,18 @@ export function probeOperationAuthorization(
 }
 
 /**
- * Resolve every namespace an authorization probe must check. Resource-scoped
- * routes ignore the query namespace and use their stored target or daemon
- * default, so mixed probes check both the requested and default namespaces.
+ * Resolve every namespace an authorization probe can verify from the request.
+ * Resource-scoped routes resolve their stored target only after a resource id
+ * is supplied, so probes validate only request-resolvable namespaces.
  */
 export function authorizationProbeNamespaces(
   operations: readonly OperationName[],
   requestedNamespace: string | undefined,
 ): readonly (string | undefined)[] {
-  const namespaceOperations = operations.filter(operationRequiresAuthorizedNamespace);
-  const usesRequestNamespace = namespaceOperations.some(
-    (operation) => RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS[operation] !== true,
+  const namespaceOperations = operations.filter(
+    (operation) =>
+      operationRequiresAuthorizedNamespace(operation) &&
+      !UNRESOLVABLE_RESOURCE_OPERATIONS.has(operation),
   );
-  const usesResourceNamespace = namespaceOperations.some(
-    (operation) => RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS[operation] === true,
-  );
-  const namespaces: Array<string | undefined> = usesRequestNamespace ? [requestedNamespace] : [];
-  if (usesResourceNamespace && (requestedNamespace !== undefined || !usesRequestNamespace)) {
-    namespaces.push(undefined);
-  }
-  return namespaces;
+  return namespaceOperations.length > 0 ? [requestedNamespace] : [];
 }

--- a/packages/remnic-core/src/access-authorization-probe.ts
+++ b/packages/remnic-core/src/access-authorization-probe.ts
@@ -1,4 +1,10 @@
-import { getOperation, type OperationName, OPERATION_NAMES } from "./access-boundary.js";
+import {
+  getOperation,
+  operationRequiresAuthorizedNamespace,
+  OPERATION_NAMES,
+  RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS,
+  type OperationName,
+} from "./access-boundary.js";
 import { EngramAccessInputError } from "./access-errors.js";
 import {
   assertOperationAuthorizationAllowed,
@@ -40,4 +46,27 @@ export function probeOperationAuthorization(
   }
 
   return { authorized: true, operations };
+}
+
+/**
+ * Resolve every namespace an authorization probe must check. Resource-scoped
+ * routes ignore the query namespace and use their stored target or daemon
+ * default, so mixed probes check both the requested and default namespaces.
+ */
+export function authorizationProbeNamespaces(
+  operations: readonly OperationName[],
+  requestedNamespace: string | undefined,
+): readonly (string | undefined)[] {
+  const namespaceOperations = operations.filter(operationRequiresAuthorizedNamespace);
+  const usesRequestNamespace = namespaceOperations.some(
+    (operation) => RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS[operation] !== true,
+  );
+  const usesResourceNamespace = namespaceOperations.some(
+    (operation) => RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS[operation] === true,
+  );
+  const namespaces: Array<string | undefined> = usesRequestNamespace ? [requestedNamespace] : [];
+  if (usesResourceNamespace && (requestedNamespace !== undefined || !usesRequestNamespace)) {
+    namespaces.push(undefined);
+  }
+  return namespaces;
 }

--- a/packages/remnic-core/src/access-boundary.ts
+++ b/packages/remnic-core/src/access-boundary.ts
@@ -196,16 +196,7 @@ const IMPLICIT_HTTP_NAMESPACE_OPERATIONS = new Set<OperationName>([
   "trust_zones_status",
   "graph_events",
   "citations_observed",
-  "review_resolve",
-  "chat_message",
-  "chat_events",
 ]);
-export const RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS: Partial<Record<OperationName, true>> = {
-  review_resolve: true,
-  contradiction_detail: true,
-  chat_message: true,
-  chat_events: true,
-};
 
 // ---------------------------------------------------------------------------
 // Operation context — what every handler receives

--- a/packages/remnic-core/src/access-boundary.ts
+++ b/packages/remnic-core/src/access-boundary.ts
@@ -186,6 +186,21 @@ export const OPERATION_NAMES = [
  */
 export type OperationName = (typeof OPERATION_NAMES)[number];
 
+const IMPLICIT_HTTP_NAMESPACE_OPERATIONS = new Set<OperationName>([
+  "offline_sync_snapshot",
+  "offline_sync_snapshot_stream",
+  "memory_list",
+  "entity_list",
+  "maintenance_status",
+  "quality_status",
+  "trust_zones_status",
+  "graph_events",
+  "citations_observed",
+  "review_resolve",
+  "chat_message",
+  "chat_events",
+]);
+
 // ---------------------------------------------------------------------------
 // Operation context — what every handler receives
 // ---------------------------------------------------------------------------
@@ -433,6 +448,15 @@ export function defineOperation<In, Out>(spec: OperationSpec<In, Out>): BoundOpe
 /** Look up a registered operation by canonical name. */
 export function getOperation(name: OperationName): BoundOperation | undefined {
   return registry.get(name);
+}
+
+/** Whether a probe must authorize an operation's effective namespace. */
+export function operationRequiresAuthorizedNamespace(name: OperationName): boolean {
+  if (name === "namespace_writable") return false;
+  if (IMPLICIT_HTTP_NAMESPACE_OPERATIONS.has(name)) return true;
+  const schema = registry.get(name)?.spec.schema;
+  const objectSchema = schema instanceof z.ZodEffects ? schema.innerType() : schema;
+  return objectSchema instanceof z.ZodObject && Object.hasOwn(objectSchema.shape, "namespace");
 }
 
 /** All registered operation names. */

--- a/packages/remnic-core/src/access-boundary.ts
+++ b/packages/remnic-core/src/access-boundary.ts
@@ -200,6 +200,11 @@ const IMPLICIT_HTTP_NAMESPACE_OPERATIONS = new Set<OperationName>([
   "chat_message",
   "chat_events",
 ]);
+export const RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS: Partial<Record<OperationName, true>> = {
+  review_resolve: true,
+  chat_message: true,
+  chat_events: true,
+};
 
 // ---------------------------------------------------------------------------
 // Operation context — what every handler receives

--- a/packages/remnic-core/src/access-boundary.ts
+++ b/packages/remnic-core/src/access-boundary.ts
@@ -202,6 +202,7 @@ const IMPLICIT_HTTP_NAMESPACE_OPERATIONS = new Set<OperationName>([
 ]);
 export const RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS: Partial<Record<OperationName, true>> = {
   review_resolve: true,
+  contradiction_detail: true,
   chat_message: true,
   chat_events: true,
 };

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -3019,7 +3019,7 @@ test("HTTP authorization probe verifies requested operation grants without invok
         token: "resource-scoped-chat-token",
         capabilities: {
           version: 1,
-          ops: ["chat_message"],
+          ops: ["chat_message", "contradiction_detail"],
           namespaces: ["other"],
         },
       },
@@ -3027,7 +3027,7 @@ test("HTTP authorization probe verifies requested operation grants without invok
         token: "resource-scoped-chat-default-token",
         capabilities: {
           version: 1,
-          ops: ["chat_message"],
+          ops: ["chat_message", "contradiction_detail"],
           namespaces: ["default"],
         },
       },
@@ -3118,6 +3118,18 @@ test("HTTP authorization probe verifies requested operation grants without invok
     );
     await resourceNamespaceDenied.text();
 
+    const contradictionNamespaceDenied = await probe(
+      "resource-scoped-chat-token",
+      ["contradiction_detail"],
+      "other",
+    );
+    assert.equal(
+      contradictionNamespaceDenied.status,
+      403,
+      "contradiction detail probes must check the stored resource namespace contract",
+    );
+    await contradictionNamespaceDenied.text();
+
     const resourceNamespaceAllowed = await probe(
       "resource-scoped-chat-default-token",
       ["chat_message"],
@@ -3129,6 +3141,18 @@ test("HTTP authorization probe verifies requested operation grants without invok
       "resource-scoped chat probes accept a query override when the daemon default is allowed",
     );
     await resourceNamespaceAllowed.text();
+
+    const contradictionNamespaceAllowed = await probe(
+      "resource-scoped-chat-default-token",
+      ["contradiction_detail"],
+      "other",
+    );
+    assert.equal(
+      contradictionNamespaceAllowed.status,
+      200,
+      "contradiction detail probes accept a query override when the daemon default is allowed",
+    );
+    await contradictionNamespaceAllowed.text();
 
     const fleetWide = await probe("fleet-scoped-token", ["continuity_audit_generate"]);
     assert.equal(fleetWide.status, 403);

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -2983,6 +2983,20 @@ test("HTTP authorization probe verifies requested operation grants without invok
   const service = {
     configRef: parseConfig({ memoryDir: "/tmp/remnic-http-authorization-probe", defaultNamespace: "default" }),
   } as unknown as EngramAccessService;
+  const implicitNamespaceOperations = [
+    "offline_sync_snapshot",
+    "offline_sync_snapshot_stream",
+    "memory_list",
+    "entity_list",
+    "maintenance_status",
+    "quality_status",
+    "trust_zones_status",
+    "graph_events",
+    "citations_observed",
+    "review_resolve",
+    "chat_message",
+    "chat_events",
+  ];
   const server = new EngramAccessHttpServer({
     service,
     port: 0,
@@ -2993,6 +3007,30 @@ test("HTTP authorization probe verifies requested operation grants without invok
       },
       { token: "recall-only-token", capabilities: { version: 1, ops: ["recall"] } },
       { token: "observe-only-token", capabilities: { version: 1, ops: ["observe"] } },
+      {
+        token: "namespace-scoped-delegate-token",
+        capabilities: {
+          version: 1,
+          ops: ["recall", "observe", "lcm_compaction_flush"],
+          namespaces: ["other"],
+        },
+      },
+      {
+        token: "namespace-scoped-adapters-token",
+        capabilities: {
+          version: 1,
+          ops: ["adapters_status"],
+          namespaces: ["other"],
+        },
+      },
+      {
+        token: "implicit-namespace-token",
+        capabilities: {
+          version: 1,
+          ops: implicitNamespaceOperations,
+          namespaces: ["other"],
+        },
+      },
       {
         token: "fleet-scoped-token",
         capabilities: {
@@ -3005,9 +3043,10 @@ test("HTTP authorization probe verifies requested operation grants without invok
     adminConsoleEnabled: false,
   });
   const status = await server.start();
-  const probe = (token: string, operations: string[]) => {
+  const probe = (token: string, operations: string[], namespace?: string) => {
     const query = new URLSearchParams();
     for (const operation of operations) query.append("op", operation);
+    if (namespace !== undefined) query.set("namespace", namespace);
     return fetch(`http://127.0.0.1:${status.port}/engram/v1/authorization?${query}`, {
       headers: { authorization: `Bearer ${token}` },
     });
@@ -3022,6 +3061,35 @@ test("HTTP authorization probe verifies requested operation grants without invok
     const alternateGrant = await probe("observe-only-token", ["namespace_writable"]);
     assert.equal(alternateGrant.status, 200);
     await alternateGrant.text();
+
+    const namespaceDiagnostic = await probe(
+      "namespace-scoped-delegate-token",
+      ["namespace_writable"],
+    );
+    assert.equal(namespaceDiagnostic.status, 200, "writability diagnostics report scope in their response");
+    await namespaceDiagnostic.text();
+
+    const namespaceAgnostic = await probe("namespace-scoped-adapters-token", ["adapters_status"]);
+    assert.equal(namespaceAgnostic.status, 200, "namespace-free operations must not use the daemon default");
+    await namespaceAgnostic.text();
+
+    const namespaceDenied = await probe("namespace-scoped-delegate-token", delegateOperations);
+    assert.equal(namespaceDenied.status, 403, "a scoped token must cover the daemon default namespace");
+
+    for (const operation of implicitNamespaceOperations) {
+      const implicitNamespace = await probe("implicit-namespace-token", [operation]);
+      assert.equal(implicitNamespace.status, 403, `${operation} must authorize the effective namespace`);
+      await implicitNamespace.text();
+    }
+    await namespaceDenied.text();
+
+    const namespaceAllowed = await probe(
+      "namespace-scoped-delegate-token",
+      delegateOperations,
+      "other",
+    );
+    assert.equal(namespaceAllowed.status, 200);
+    await namespaceAllowed.text();
 
     const fleetWide = await probe("fleet-scoped-token", ["continuity_audit_generate"]);
     assert.equal(fleetWide.status, 403);

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -3016,6 +3016,22 @@ test("HTTP authorization probe verifies requested operation grants without invok
         },
       },
       {
+        token: "resource-scoped-chat-token",
+        capabilities: {
+          version: 1,
+          ops: ["chat_message"],
+          namespaces: ["other"],
+        },
+      },
+      {
+        token: "resource-scoped-chat-default-token",
+        capabilities: {
+          version: 1,
+          ops: ["chat_message"],
+          namespaces: ["default"],
+        },
+      },
+      {
         token: "namespace-scoped-adapters-token",
         capabilities: {
           version: 1,
@@ -3090,6 +3106,29 @@ test("HTTP authorization probe verifies requested operation grants without invok
     );
     assert.equal(namespaceAllowed.status, 200);
     await namespaceAllowed.text();
+    const resourceNamespaceDenied = await probe(
+      "resource-scoped-chat-token",
+      ["chat_message"],
+      "other",
+    );
+    assert.equal(
+      resourceNamespaceDenied.status,
+      403,
+      "resource-scoped chat probes must check the daemon default, not trust the query namespace",
+    );
+    await resourceNamespaceDenied.text();
+
+    const resourceNamespaceAllowed = await probe(
+      "resource-scoped-chat-default-token",
+      ["chat_message"],
+      "other",
+    );
+    assert.equal(
+      resourceNamespaceAllowed.status,
+      200,
+      "resource-scoped chat probes accept a query override when the daemon default is allowed",
+    );
+    await resourceNamespaceAllowed.text();
 
     const fleetWide = await probe("fleet-scoped-token", ["continuity_audit_generate"]);
     assert.equal(fleetWide.status, 403);

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -2993,9 +2993,6 @@ test("HTTP authorization probe verifies requested operation grants without invok
     "trust_zones_status",
     "graph_events",
     "citations_observed",
-    "review_resolve",
-    "chat_message",
-    "chat_events",
   ];
   const server = new EngramAccessHttpServer({
     service,
@@ -3021,14 +3018,6 @@ test("HTTP authorization probe verifies requested operation grants without invok
           version: 1,
           ops: ["chat_message", "contradiction_detail"],
           namespaces: ["other"],
-        },
-      },
-      {
-        token: "resource-scoped-chat-default-token",
-        capabilities: {
-          version: 1,
-          ops: ["chat_message", "contradiction_detail"],
-          namespaces: ["default"],
         },
       },
       {
@@ -3106,53 +3095,18 @@ test("HTTP authorization probe verifies requested operation grants without invok
     );
     assert.equal(namespaceAllowed.status, 200);
     await namespaceAllowed.text();
-    const resourceNamespaceDenied = await probe(
+
+    const resourceNamespaceProbe = await probe(
       "resource-scoped-chat-token",
-      ["chat_message"],
+      ["chat_message", "contradiction_detail"],
       "other",
     );
     assert.equal(
-      resourceNamespaceDenied.status,
-      403,
-      "resource-scoped chat probes must check the daemon default, not trust the query namespace",
-    );
-    await resourceNamespaceDenied.text();
-
-    const contradictionNamespaceDenied = await probe(
-      "resource-scoped-chat-token",
-      ["contradiction_detail"],
-      "other",
-    );
-    assert.equal(
-      contradictionNamespaceDenied.status,
-      403,
-      "contradiction detail probes must check the stored resource namespace contract",
-    );
-    await contradictionNamespaceDenied.text();
-
-    const resourceNamespaceAllowed = await probe(
-      "resource-scoped-chat-default-token",
-      ["chat_message"],
-      "other",
-    );
-    assert.equal(
-      resourceNamespaceAllowed.status,
+      resourceNamespaceProbe.status,
       200,
-      "resource-scoped chat probes accept a query override when the daemon default is allowed",
+      "resource-scoped probes must not claim a namespace they cannot resolve without a resource id",
     );
-    await resourceNamespaceAllowed.text();
-
-    const contradictionNamespaceAllowed = await probe(
-      "resource-scoped-chat-default-token",
-      ["contradiction_detail"],
-      "other",
-    );
-    assert.equal(
-      contradictionNamespaceAllowed.status,
-      200,
-      "contradiction detail probes accept a query override when the daemon default is allowed",
-    );
-    await contradictionNamespaceAllowed.text();
+    await resourceNamespaceProbe.text();
 
     const fleetWide = await probe("fleet-scoped-token", ["continuity_audit_generate"]);
     assert.equal(fleetWide.status, 403);

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -37,7 +37,12 @@ import {
 } from "./graph-events.js";
 import { expandTildePath } from "./utils/path.js";
 import { projectTagProjectId } from "./coding/coding-namespace.js";
-import { getOperation, operationRequiresAuthorizedNamespace, type OperationName } from "./access-boundary.js";
+import {
+  getOperation,
+  operationRequiresAuthorizedNamespace,
+  RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS,
+  type OperationName,
+} from "./access-boundary.js";
 import { probeOperationAuthorization } from "./access-authorization-probe.js";
 import { resolveQueryNamespaceWritablePreflight } from "./access-namespace-preflight.js";
 import {
@@ -893,8 +898,14 @@ export class EngramAccessHttpServer {
     if (req.method === "GET" && pathname === "/engram/v1/authorization") {
       res.setHeader("cache-control", "no-store");
       const probe = probeOperationAuthorization(tokenCapabilityStore.getStore(), parsed.searchParams.getAll("op"));
-      if (probe.operations.some(operationRequiresAuthorizedNamespace)) {
+      const namespaceOperations = probe.operations.filter(operationRequiresAuthorizedNamespace);
+      if (namespaceOperations.some((operation) => RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS[operation] !== true)) {
         this.resolveNamespace(req, parsed.searchParams.get("namespace") ?? undefined);
+      }
+      if (namespaceOperations.some((operation) => RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS[operation] === true)) {
+        // Resource-scoped routes derive the namespace from their stored target
+        // or the daemon default, not from the probe's query-string override.
+        this.resolveNamespace(req, undefined);
       }
       this.respondJson(res, 200, probe);
       return;

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -37,13 +37,8 @@ import {
 } from "./graph-events.js";
 import { expandTildePath } from "./utils/path.js";
 import { projectTagProjectId } from "./coding/coding-namespace.js";
-import {
-  getOperation,
-  operationRequiresAuthorizedNamespace,
-  RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS,
-  type OperationName,
-} from "./access-boundary.js";
-import { probeOperationAuthorization } from "./access-authorization-probe.js";
+import { getOperation, type OperationName } from "./access-boundary.js";
+import { authorizationProbeNamespaces, probeOperationAuthorization } from "./access-authorization-probe.js";
 import { resolveQueryNamespaceWritablePreflight } from "./access-namespace-preflight.js";
 import {
   assertOperationAllowed,
@@ -898,15 +893,9 @@ export class EngramAccessHttpServer {
     if (req.method === "GET" && pathname === "/engram/v1/authorization") {
       res.setHeader("cache-control", "no-store");
       const probe = probeOperationAuthorization(tokenCapabilityStore.getStore(), parsed.searchParams.getAll("op"));
-      const namespaceOperations = probe.operations.filter(operationRequiresAuthorizedNamespace);
-      if (namespaceOperations.some((operation) => RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS[operation] !== true)) {
-        this.resolveNamespace(req, parsed.searchParams.get("namespace") ?? undefined);
-      }
-      if (namespaceOperations.some((operation) => RESOURCE_SCOPED_HTTP_NAMESPACE_OPERATIONS[operation] === true)) {
-        // Resource-scoped routes derive the namespace from their stored target
-        // or the daemon default, not from the probe's query-string override.
-        this.resolveNamespace(req, undefined);
-      }
+      const namespaceParam = parsed.searchParams.get("namespace") ?? undefined;
+      for (const namespace of authorizationProbeNamespaces(probe.operations, namespaceParam))
+        this.resolveNamespace(req, namespace);
       this.respondJson(res, 200, probe);
       return;
     }

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -37,7 +37,7 @@ import {
 } from "./graph-events.js";
 import { expandTildePath } from "./utils/path.js";
 import { projectTagProjectId } from "./coding/coding-namespace.js";
-import { getOperation, type OperationName } from "./access-boundary.js";
+import { getOperation, operationRequiresAuthorizedNamespace, type OperationName } from "./access-boundary.js";
 import { probeOperationAuthorization } from "./access-authorization-probe.js";
 import { resolveQueryNamespaceWritablePreflight } from "./access-namespace-preflight.js";
 import {
@@ -892,11 +892,11 @@ export class EngramAccessHttpServer {
 
     if (req.method === "GET" && pathname === "/engram/v1/authorization") {
       res.setHeader("cache-control", "no-store");
-      this.respondJson(
-        res,
-        200,
-        probeOperationAuthorization(tokenCapabilityStore.getStore(), parsed.searchParams.getAll("op")),
-      );
+      const probe = probeOperationAuthorization(tokenCapabilityStore.getStore(), parsed.searchParams.getAll("op"));
+      if (probe.operations.some(operationRequiresAuthorizedNamespace)) {
+        this.resolveNamespace(req, parsed.searchParams.get("namespace") ?? undefined);
+      }
+      this.respondJson(res, 200, probe);
       return;
     }
 


### PR DESCRIPTION
Part of #2129.

Adds fail-open authorization preflight for delegate activation, sanitized credential-source warnings, and per-request daemon credential resolution for token rotation recovery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch authentication token selection, delegate daemon calls, and HTTP authorization probing with namespace enforcement—important for security but covered by extensive new tests and fail-open delegate behavior.
> 
> **Overview**
> **Delegate mode** now resolves daemon credentials on every HTTP call via `loadDaemonAuth()` (token + labeled source), picks only **OpenClaw** entries from multi-connector `tokens.json`, and runs a **fail-open** async authorization preflight against `GET /engram/v1/authorization` after hooks register—warnings cite the token **source**, not the secret, and recall is omitted from the probe when injection is disabled.
> 
> **HTTP authorization probe** (`/engram/v1/authorization`) now runs **namespace resolution** for operations that actually need an effective namespace (including implicit HTTP routes like `memory_list`), while skipping resource-only ops that cannot be validated without a resource id—so delegate preflight and scoped tokens behave like real traffic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cf761e631cf0effa0bce2601177c563f5613d79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->