### PR TITLE
fix(extraction): reject structural placeholder output

### DIFF
--- a/packages/remnic-core/src/extraction-prompt-safety.test.ts
+++ b/packages/remnic-core/src/extraction-prompt-safety.test.ts
@@ -43,6 +43,29 @@ const STRUCTURAL_PLACEHOLDER_EXTRACTION = {
     content: SOURCE_TURN.content,
     confidence: 0.95,
     tags: ["theme"],
+  },
+  {
+    category: "procedure",
+    content: SOURCE_TURN.content,
+    confidence: 0.95,
+    tags: ["theme"],
+    procedureSteps: [
+      { order: 1, intent: "<step>" },
+      { order: 2, intent: "<step>" },
+    ],
+  },
+  {
+    category: "reasoning_trace",
+    content: SOURCE_TURN.content,
+    confidence: 0.95,
+    tags: ["theme"],
+    reasoningTrace: {
+      steps: [
+        { order: 1, description: "<step>" },
+        { order: 2, description: "<step>" },
+      ],
+      finalAnswer: "<answer>",
+    },
   }],
   profileUpdates: ["<source-grounded profile update>"],
   entities: [{
@@ -50,6 +73,11 @@ const STRUCTURAL_PLACEHOLDER_EXTRACTION = {
     type: "<entity-type>",
     facts: ["<source-grounded statement>"],
     promptedByQuestion: "<optional source-grounded question>",
+  },
+  {
+    name: "Moonlight",
+    type: "<entity-type>",
+    facts: [SOURCE_TURN.content],
   }],
   questions: [{
     question: "<source-grounded unresolved question>",

--- a/packages/remnic-core/src/extraction-prompt-safety.test.ts
+++ b/packages/remnic-core/src/extraction-prompt-safety.test.ts
@@ -53,6 +53,18 @@ const STRUCTURAL_PLACEHOLDER_EXTRACTION = {
   }],
 };
 
+const GATEWAY_PLACEHOLDER_EXTRACTION = {
+  ...STRUCTURAL_PLACEHOLDER_EXTRACTION,
+  facts: [{
+    ...STRUCTURAL_PLACEHOLDER_EXTRACTION.facts[0],
+    category: "fact",
+  }],
+  entities: [{
+    ...STRUCTURAL_PLACEHOLDER_EXTRACTION.entities[0],
+    type: "other",
+  }],
+};
+
 type ChatMessage = { role: string; content: string };
 
 type LocalLlmFixture = {
@@ -145,6 +157,25 @@ test("local extraction discards literal structural placeholders", async () => {
   };
   assert.equal(Reflect.set(engine, "localLlm", localLlm), true);
   assert.equal(Reflect.set(engine, "modelRegistry", modelRegistry), true);
+
+  const result = await engine.extract([SOURCE_TURN]);
+
+  assert.deepEqual(result.facts, []);
+  assert.deepEqual(result.profileUpdates, []);
+  assert.deepEqual(result.entities, []);
+  assert.deepEqual(result.questions, []);
+  assert.deepEqual(result.relationships, []);
+  assert.equal(result.identityReflection, undefined);
+});
+
+test("gateway extraction discards literal structural placeholders", async () => {
+  const engine = new ExtractionEngine(parseConfig({ modelSource: "gateway" }));
+  const fallbackLlm: GatewayFixture = {
+    async parseWithSchemaDetailed() {
+      return { modelUsed: "fixture-gateway", result: GATEWAY_PLACEHOLDER_EXTRACTION };
+    },
+  };
+  assert.equal(Reflect.set(engine, "fallbackLlm", fallbackLlm), true);
 
   const result = await engine.extract([SOURCE_TURN]);
 

--- a/packages/remnic-core/src/extraction-prompt-safety.test.ts
+++ b/packages/remnic-core/src/extraction-prompt-safety.test.ts
@@ -23,6 +23,35 @@ const SOURCE_GROUNDED_EXTRACTION = {
   entities: [],
   questions: [],
 };
+const STRUCTURAL_PLACEHOLDER_EXTRACTION = {
+  facts: [{
+    category: "<category>",
+    content: "<source-grounded statement>",
+    confidence: 0,
+    tags: ["<tag>"],
+    entityRef: "<optional normalized-name>",
+    promptedByQuestion: "<optional source-grounded question>",
+    quote: "<optional exact contiguous source span>",
+  }],
+  profileUpdates: ["<source-grounded profile update>"],
+  entities: [{
+    name: "<normalized-name>",
+    type: "<entity-type>",
+    facts: ["<source-grounded statement>"],
+    promptedByQuestion: "<optional source-grounded question>",
+  }],
+  questions: [{
+    question: "<source-grounded unresolved question>",
+    context: "<source-grounded context>",
+    priority: 0,
+  }],
+  identityReflection: "<conversation-grounded agent reflection>",
+  relationships: [{
+    source: "<normalized-name>",
+    target: "<normalized-name>",
+    label: "<source-grounded relationship>",
+  }],
+};
 
 type ChatMessage = { role: string; content: string };
 
@@ -98,6 +127,33 @@ test("local extraction prompt uses placeholders and accepts an empty question li
   assertSafeExtractionPrompt(prompt);
   assertStructuralResponseShape(prompt);
   assert.doesNotMatch(prompt, /^- rule:/m);
+});
+
+test("local extraction discards literal structural placeholders", async () => {
+  const engine = new ExtractionEngine(parseConfig({
+    localLlmEnabled: true,
+    localLlmModel: "fixture-local",
+    localLlmFallback: false,
+  }));
+  const localLlm: LocalLlmFixture = {
+    async chatCompletion() {
+      return { content: JSON.stringify(STRUCTURAL_PLACEHOLDER_EXTRACTION) };
+    },
+  };
+  const modelRegistry = {
+    calculateContextSizes: () => ({ maxInputChars: 8_000, maxOutputTokens: 1_000, description: "fixture" }),
+  };
+  assert.equal(Reflect.set(engine, "localLlm", localLlm), true);
+  assert.equal(Reflect.set(engine, "modelRegistry", modelRegistry), true);
+
+  const result = await engine.extract([SOURCE_TURN]);
+
+  assert.deepEqual(result.facts, []);
+  assert.deepEqual(result.profileUpdates, []);
+  assert.deepEqual(result.entities, []);
+  assert.deepEqual(result.questions, []);
+  assert.deepEqual(result.relationships, []);
+  assert.equal(result.identityReflection, undefined);
 });
 
 test("gateway extraction prompt uses placeholders and accepts an empty question list", async () => {

--- a/packages/remnic-core/src/extraction-prompt-safety.test.ts
+++ b/packages/remnic-core/src/extraction-prompt-safety.test.ts
@@ -32,6 +32,12 @@ const STRUCTURAL_PLACEHOLDER_EXTRACTION = {
     entityRef: "<optional normalized-name>",
     promptedByQuestion: "<optional source-grounded question>",
     quote: "<optional exact contiguous source span>",
+  },
+  {
+    category: "<category>",
+    content: SOURCE_TURN.content,
+    confidence: 0.95,
+    tags: ["theme"],
   }],
   profileUpdates: ["<source-grounded profile update>"],
   entities: [{

--- a/packages/remnic-core/src/extraction-prompt-safety.test.ts
+++ b/packages/remnic-core/src/extraction-prompt-safety.test.ts
@@ -12,6 +12,11 @@ const SOURCE_TURN: BufferTurn = {
   timestamp: "2026-07-25T12:00:00.000Z",
 };
 
+const TAG_SOURCE_TURN: BufferTurn = {
+  ...SOURCE_TURN,
+  content: "The page uses <main> as the primary landmark.",
+};
+
 const SOURCE_GROUNDED_EXTRACTION = {
   facts: [{
     category: "fact",
@@ -172,6 +177,59 @@ test("local extraction discards literal structural placeholders", async () => {
   assert.deepEqual(result.questions, []);
   assert.deepEqual(result.relationships, []);
   assert.equal(result.identityReflection, undefined);
+});
+
+test("local extraction preserves source text that looks like a tag", async () => {
+  const engine = new ExtractionEngine(parseConfig({
+    localLlmEnabled: true,
+    localLlmModel: "fixture-local",
+    localLlmFallback: false,
+  }));
+  const localLlm: LocalLlmFixture = {
+    async chatCompletion() {
+      return {
+        content: JSON.stringify({
+          facts: [{ category: "fact", content: "<main>", confidence: 0.95, tags: [] }],
+          profileUpdates: [],
+          entities: [],
+          questions: [],
+        }),
+      };
+    },
+  };
+  const modelRegistry = {
+    calculateContextSizes: () => ({ maxInputChars: 8_000, maxOutputTokens: 1_000, description: "fixture" }),
+  };
+  assert.equal(Reflect.set(engine, "localLlm", localLlm), true);
+  assert.equal(Reflect.set(engine, "modelRegistry", modelRegistry), true);
+
+  const result = await engine.extract([TAG_SOURCE_TURN]);
+
+  assert.equal(result.facts[0]?.content, "<main>");
+});
+
+test("local truncated recovery discards literal structural placeholders", async () => {
+  const engine = new ExtractionEngine(parseConfig({
+    localLlmEnabled: true,
+    localLlmModel: "fixture-local",
+    localLlmFallback: false,
+  }));
+  const localLlm: LocalLlmFixture = {
+    async chatCompletion() {
+      return {
+        content: "{\"facts\":[{\"category\":\"<category>\",\"content\":\"<source-grounded statement>\",\"confidence\":0.7}",
+      };
+    },
+  };
+  const modelRegistry = {
+    calculateContextSizes: () => ({ maxInputChars: 8_000, maxOutputTokens: 1_000, description: "fixture" }),
+  };
+  assert.equal(Reflect.set(engine, "localLlm", localLlm), true);
+  assert.equal(Reflect.set(engine, "modelRegistry", modelRegistry), true);
+
+  const result = await engine.extract([SOURCE_TURN]);
+
+  assert.deepEqual(result.facts, []);
 });
 
 test("gateway extraction discards literal structural placeholders", async () => {

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -332,16 +332,16 @@ export class ExtractionEngine {
     const facts = Array.isArray(parsed?.facts)
       ? parsed.facts
           .map((candidate: unknown) => {
-            const fact = isPlainRecord(candidate) ? candidate : {};
-            const category = typeof fact.category === "string" ? fact.category.trim() : "fact";
-            const reasoningTraceInput = isPlainRecord(fact.reasoningTrace)
-              ? fact.reasoningTrace
-              : isPlainRecord(fact.reasoning_trace)
-                ? fact.reasoning_trace
+            const f = isPlainRecord(candidate) ? candidate : {};
+            const category = typeof f.category === "string" ? f.category.trim() : "fact";
+            const reasoningTraceInput = isPlainRecord(f.reasoningTrace)
+              ? f.reasoningTrace
+              : isPlainRecord(f?.reasoning_trace)
+                ? f.reasoning_trace
                 : undefined;
             if (!isMemoryCategory(category)) return undefined;
-            const procedureSteps = Array.isArray(fact.procedureSteps)
-              ? normalizeProcedureSteps(fact.procedureSteps)
+            const procedureSteps = Array.isArray(f.procedureSteps)
+              ? normalizeProcedureSteps(f.procedureSteps)
               : undefined;
             const reasoningTrace = reasoningTraceInput
               ? normalizeReasoningTrace(reasoningTraceInput) ?? undefined
@@ -354,23 +354,23 @@ export class ExtractionEngine {
             }
             return {
               category,
-              content: extractionText(fact.content) ?? extractionText(fact.text) ?? "",
-              confidence: typeof fact.confidence === "number" ? fact.confidence : 0.7,
-              tags: Array.isArray(fact.tags)
-                ? fact.tags.flatMap((tag: unknown) => {
+              content: extractionText(f.content) ?? extractionText(f.text) ?? "",
+              confidence: typeof f.confidence === "number" ? f.confidence : 0.7,
+              tags: Array.isArray(f.tags)
+                ? f.tags.flatMap((tag: unknown) => {
                     const text = extractionText(tag);
                     return text === undefined ? [] : [text];
                   })
                 : [],
-              entityRef: extractionText(fact.entityRef),
-              promptedByQuestion: extractionText(fact.promptedByQuestion),
+              entityRef: extractionText(f.entityRef),
+              promptedByQuestion: extractionText(f.promptedByQuestion),
               scope:
-                fact.scope === "global" || fact.scope === "project" ? fact.scope : undefined,
-              structuredAttributes: extractionAttributes(fact.structuredAttributes),
+                f.scope === "global" || f.scope === "project" ? f.scope : undefined,
+              structuredAttributes: extractionAttributes(f.structuredAttributes),
               procedureSteps,
               reasoningTrace,
-              quote: extractionText(fact.quote),
-              eventTime: extractionText(fact.eventTime) ?? extractionText(fact.event_time),
+              quote: extractionText(f.quote),
+              eventTime: extractionText(f.eventTime) ?? extractionText(f.event_time),
             };
           })
           .filter((fact: ExtractedFactResult | undefined): fact is ExtractedFactResult => (

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -321,7 +321,7 @@ export class ExtractionEngine {
       ? parsed.facts
           .map((candidate: unknown) => {
             const fact = isPlainRecord(candidate) ? candidate : {};
-            const category = extractionText(fact.category) ?? "fact";
+            const category = typeof fact.category === "string" ? fact.category.trim() : "fact";
             const reasoningTrace = isPlainRecord(fact.reasoningTrace)
               ? fact.reasoningTrace
               : isPlainRecord(fact.reasoning_trace)

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -84,6 +84,10 @@ const EXTRACTION_RESPONSE_SHAPE = `{
   "identityReflection": "<conversation-grounded agent reflection>",
   "relationships": [{"source": "<normalized-name>", "target": "<normalized-name>", "label": "<source-grounded relationship>"}]
 }`;
+const EXTRACTION_RESPONSE_PLACEHOLDERS: Record<string, true> = {};
+for (const placeholder of EXTRACTION_RESPONSE_SHAPE.match(/<[^<>\r\n]+>/g) ?? []) {
+  EXTRACTION_RESPONSE_PLACEHOLDERS[placeholder] = true;
+}
 const CONSOLIDATION_RESPONSE_SCHEMA = `{
   "items": [
     {
@@ -105,7 +109,7 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 function extractionText(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const text = value.trim();
-  return text.length > 0 && !/^<[^<>\r\n]+>$/.test(text) ? text : undefined;
+  return text.length > 0 && EXTRACTION_RESPONSE_PLACEHOLDERS[text] !== true ? text : undefined;
 }
 
 function extractionAttributes(value: unknown): Record<string, string> | undefined {
@@ -1546,29 +1550,6 @@ ${truncatedConversation}`;
    * Local LLMs sometimes hit token limits mid-JSON. This tries to salvage valid facts.
    */
   private extractPartialFacts(jsonStr: string): ExtractionResult {
-    const allowedCategories = new Set([
-      "fact",
-      "preference",
-      "correction",
-      "entity",
-      "decision",
-      "relationship",
-      "principle",
-      "commitment",
-      "moment",
-      "skill",
-      "rule",
-      "procedure",
-      "reasoning_trace",
-    ]);
-    const allowedEntityTypes = new Set([
-      "person",
-      "project",
-      "tool",
-      "company",
-      "place",
-      "other",
-    ]);
 
     const facts: ExtractionResult["facts"] = [];
     const entities: ExtractionResult["entities"] = [];
@@ -1578,8 +1559,8 @@ ${truncatedConversation}`;
       const factRegex = /\{\s*"category"\s*:\s*"([^"]+)"\s*,\s*"content"\s*:\s*"([^"]+)"\s*,\s*"confidence"\s*:\s*([0-9.]+)/g;
       let match;
       while ((match = factRegex.exec(jsonStr)) !== null) {
-        const rawCat = match[1];
-        const category = allowedCategories.has(rawCat) ? (rawCat as ExtractionResult["facts"][number]["category"]) : "fact";
+        const category = match[1]?.trim() ?? "";
+        if (!isMemoryCategory(category)) continue;
         facts.push({
           category,
           content: match[2].replace(/\\n/g, '\n').replace(/\\"/g, '"'),
@@ -1591,8 +1572,8 @@ ${truncatedConversation}`;
       // Find all complete entity objects
       const entityRegex = /\{\s*"name"\s*:\s*"([^"]+)"\s*,\s*"type"\s*:\s*"([^"]+)"/g;
       while ((match = entityRegex.exec(jsonStr)) !== null) {
-        const rawType = match[2];
-        const type = allowedEntityTypes.has(rawType) ? (rawType as ExtractionResult["entities"][number]["type"]) : "other";
+        const type = extractionEntityType(match[2]);
+        if (type === undefined) continue;
         entities.push({
           name: match[1],
           type,
@@ -1603,7 +1584,7 @@ ${truncatedConversation}`;
       // Ignore regex errors
     }
 
-    return { facts, entities, profileUpdates: [], questions: [] };
+    return this.normalizeExtractionResultPayload({ facts, entities, profileUpdates: [], questions: [] });
   }
 
   /**

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -1318,37 +1318,8 @@ export class ExtractionEngine {
         log.debug(
           `extracted ${result.facts.length} facts, ${result.entities.length} entities, ${(result.questions ?? []).length} questions via fallback (${detailed.modelUsed})`,
         );
-        // Zod schema accepts snake_case aliases (final_answer / observed_outcome)
-        // alongside camelCase for gateway-tolerance, but the downstream
-        // ExtractedFact contract only exposes camelCase. Collapse each fact's
-        // reasoningTrace through normalizeReasoningTrace before passing it on so
-        // gateway output matches the shape local/direct-client paths produce.
-        const normalizedFacts = result.facts.map((f: any) => {
-          if (!f) return f;
-          // Gateway tolerance: collapse snake_case event_time → camelCase
-          // eventTime so the gateway path matches the local/direct/proactive
-          // normalization (#1578 r3 — cursor bugbot).
-          const eventTime =
-            typeof f.eventTime === "string" && f.eventTime.trim().length > 0
-              ? f.eventTime.trim()
-              : typeof f.event_time === "string" && f.event_time.trim().length > 0
-                ? f.event_time.trim()
-                : undefined;
-          if (!f.reasoningTrace && eventTime === undefined) return f;
-          return {
-            ...f,
-            ...(f.reasoningTrace
-              ? { reasoningTrace: normalizeReasoningTrace(f.reasoningTrace) ?? undefined }
-              : {}),
-            ...(eventTime !== undefined ? { eventTime } : {}),
-          };
-        });
-        const sanitized = this.sanitizeExtractionResult({
-          ...result,
-          facts: normalizedFacts,
-          questions: result.questions ?? [],
-          identityReflection: result.identityReflection ?? undefined,
-        } as ExtractionResult, messageTimestamp);
+        const normalized = this.normalizeExtractionResultPayload(result);
+        const sanitized = this.sanitizeExtractionResult(normalized, messageTimestamp);
         const finalResult = await this.applyProactiveQuestionPass(conversation, sanitized);
         return this.attachProvenanceToResult(finalResult, boundedTurns);
       }

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -40,6 +40,7 @@ import { normalizeProcedureSteps } from "./procedural/procedure-types.js";
 import { normalizeReasoningTrace } from "./reasoning-trace-types.js";
 import { looksLikeMechanicalTelemetryTranscript } from "./telemetry-transcript.js";
 import { buildFactProvenance, type ProvenanceTurnInput } from "./provenance.js";
+import { isMemoryCategory } from "./write-envelope.js";
 import { classifyExtractionThrownError, classifyFallbackParseFailure } from "./extraction-error-classification.js";
 export { classifyExtractionThrownError, classifyFallbackParseFailure } from "./extraction-error-classification.js";
 import { resolvePipelineProcessingCapabilities } from "./capabilities.js";
@@ -99,6 +100,40 @@ const CONSOLIDATION_RESPONSE_SCHEMA = `{
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function extractionText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  return text.length > 0 && !/^<[^<>\r\n]+>$/.test(text) ? text : undefined;
+}
+
+function extractionAttributes(value: unknown): Record<string, string> | undefined {
+  if (!isPlainRecord(value)) return undefined;
+  const attributes: Record<string, string> = {};
+  for (const [key, candidate] of Object.entries(value)) {
+    const normalizedKey = extractionText(key);
+    const normalizedValue = extractionText(candidate);
+    if (normalizedKey !== undefined && normalizedValue !== undefined) {
+      attributes[normalizedKey] = normalizedValue;
+    }
+  }
+  return Object.keys(attributes).length > 0 ? attributes : undefined;
+}
+
+function extractionEntityType(value: unknown): ExtractedEntityResult["type"] | undefined {
+  const type = extractionText(value);
+  if (
+    type === "person" ||
+    type === "project" ||
+    type === "tool" ||
+    type === "company" ||
+    type === "place" ||
+    type === "other"
+  ) {
+    return type;
+  }
+  return undefined;
 }
 
 function normalizeQuestion(question: ExtractionQuestion): ExtractionQuestion {
@@ -276,182 +311,155 @@ export class ExtractionEngine {
   }
 
   private normalizeExtractionResultPayload(parsed: any): ExtractionResult {
-    const entities = Array.isArray(parsed?.entities)
+    const entities: ExtractedEntityResult[] = Array.isArray(parsed?.entities)
       ? parsed.entities
-          .map((e: any) => this.normalizeEntityUpdate(e))
-          .filter((e: any) => e.name.length > 0)
+          .map((candidate: unknown) => this.normalizeEntityUpdate(candidate))
+          .filter((entity: ExtractedEntityResult) => entity.name.length > 0)
       : [];
 
     const facts = Array.isArray(parsed?.facts)
       ? parsed.facts
-          .map((f: any) => ({
-            category: typeof f?.category === "string" ? f.category : "fact",
-            content: typeof f?.content === "string" ? f.content : typeof f?.text === "string" ? f.text : "",
-            confidence: typeof f?.confidence === "number" ? f.confidence : 0.7,
-            tags: Array.isArray(f?.tags) ? f.tags.filter((t: any) => typeof t === "string") : [],
-            entityRef: typeof f?.entityRef === "string" ? f.entityRef : undefined,
-            promptedByQuestion:
-              typeof f?.promptedByQuestion === "string" ? f.promptedByQuestion : undefined,
-            scope:
-              f?.scope === "global" || f?.scope === "project" ? f.scope : undefined,
-            structuredAttributes:
-              f?.structuredAttributes && typeof f.structuredAttributes === "object" && !Array.isArray(f.structuredAttributes)
-                ? Object.fromEntries(
-                    Object.entries(f.structuredAttributes)
-                      .filter(([k, v]) => typeof k === "string" && typeof v === "string")
-                  ) as Record<string, string>
-                : undefined,
-            procedureSteps: Array.isArray(f?.procedureSteps)
-              ? normalizeProcedureSteps(f.procedureSteps)
-              : undefined,
-            reasoningTrace: (() => {
-              // Accept both camelCase and snake_case payload keys. The
-              // category itself is snake_case and we already tolerate
-              // snake_case nested fields in normalizeReasoningTrace, so a
-              // loose local/direct LLM that outputs `reasoning_trace` on the
-              // fact should not silently drop the structured chain.
-              const candidate =
-                f?.reasoningTrace && typeof f.reasoningTrace === "object" && !Array.isArray(f.reasoningTrace)
-                  ? f.reasoningTrace
-                  : f?.reasoning_trace && typeof f.reasoning_trace === "object" && !Array.isArray(f.reasoning_trace)
-                    ? f.reasoning_trace
-                    : null;
-              return candidate ? normalizeReasoningTrace(candidate) ?? undefined : undefined;
-            })(),
-            // Issue #1575 PR 2: the LLM provides a verbatim supporting quote
-            // per fact. Optional/nullable per repo gotcha 6 (OpenAI Responses
-            // API emits null for absent optional fields). The post-parse
-            // validator (buildFactProvenance) locates this quote in the
-            // buffered turns and builds verified ProvenanceSource[] entries.
-            quote:
-              typeof f?.quote === "string" && f.quote.trim().length > 0
-                ? f.quote
-                : undefined,
-            eventTime:
-              typeof f?.eventTime === "string" && f.eventTime.trim().length > 0
-                ? f.eventTime.trim()
-                : typeof f?.event_time === "string" && f.event_time.trim().length > 0
-                  ? f.event_time.trim()
-                  : undefined,
-          }))
-          .filter((f: any) => f.content.length > 0)
-      : [];
-
-    const questions = Array.isArray(parsed?.questions)
-      ? parsed.questions
-          .map((q: any) => {
-            if (typeof q === "string") return { question: q, context: "", priority: 0.5 };
+          .map((candidate: unknown) => {
+            const fact = isPlainRecord(candidate) ? candidate : {};
+            const category = extractionText(fact.category) ?? "fact";
+            const reasoningTrace = isPlainRecord(fact.reasoningTrace)
+              ? fact.reasoningTrace
+              : isPlainRecord(fact.reasoning_trace)
+                ? fact.reasoning_trace
+                : undefined;
+            if (!isMemoryCategory(category)) return undefined;
             return {
-              question: typeof q?.question === "string" ? q.question : typeof q?.text === "string" ? q.text : "",
-              context: typeof q?.context === "string" ? q.context : "",
-              priority: typeof q?.priority === "number" ? q.priority : 0.5,
+              category,
+              content: extractionText(fact.content) ?? extractionText(fact.text) ?? "",
+              confidence: typeof fact.confidence === "number" ? fact.confidence : 0.7,
+              tags: Array.isArray(fact.tags)
+                ? fact.tags.flatMap((tag: unknown) => {
+                    const text = extractionText(tag);
+                    return text === undefined ? [] : [text];
+                  })
+                : [],
+              entityRef: extractionText(fact.entityRef),
+              promptedByQuestion: extractionText(fact.promptedByQuestion),
+              scope:
+                fact.scope === "global" || fact.scope === "project" ? fact.scope : undefined,
+              structuredAttributes: extractionAttributes(fact.structuredAttributes),
+              procedureSteps: Array.isArray(fact.procedureSteps)
+                ? normalizeProcedureSteps(fact.procedureSteps)
+                : undefined,
+              reasoningTrace: reasoningTrace
+                ? normalizeReasoningTrace(reasoningTrace) ?? undefined
+                : undefined,
+              quote: extractionText(fact.quote),
+              eventTime: extractionText(fact.eventTime) ?? extractionText(fact.event_time),
             };
           })
-          .filter((q: any) => q.question.length > 0)
+          .filter((fact: ExtractedFactResult | undefined): fact is ExtractedFactResult => (
+            fact !== undefined && fact.content.length > 0
+          ))
       : [];
+
+    const questions: ExtractionQuestion[] = Array.isArray(parsed?.questions)
+      ? parsed.questions.flatMap((candidate: unknown) => {
+          const record = isPlainRecord(candidate) ? candidate : undefined;
+          const question =
+            extractionText(record?.question) ??
+            extractionText(record?.text) ??
+            extractionText(candidate);
+          if (question === undefined) return [];
+          return [{
+            question,
+            context: extractionText(record?.context) ?? "",
+            priority: typeof record?.priority === "number" ? record.priority : 0.5,
+          }];
+        })
+      : [];
+
+    const profileUpdates = Array.isArray(parsed?.profileUpdates)
+      ? parsed.profileUpdates.flatMap((candidate: unknown) => {
+          const update = extractionText(candidate);
+          return update === undefined ? [] : [update];
+        })
+      : [];
+
+    const relationships: ExtractedRelationshipResult[] | undefined = Array.isArray(parsed?.relationships)
+      ? parsed.relationships.flatMap((candidate: unknown) => {
+          const relationship = isPlainRecord(candidate) ? candidate : undefined;
+          const source = extractionText(relationship?.source);
+          const target = extractionText(relationship?.target);
+          const label = extractionText(relationship?.label);
+          if (source === undefined || target === undefined || label === undefined) return [];
+          return [{
+            source,
+            target,
+            label,
+            promptedByQuestion: extractionText(relationship?.promptedByQuestion),
+          }];
+        })
+      : undefined;
 
     return {
       facts,
       entities,
-      profileUpdates: Array.isArray(parsed?.profileUpdates)
-        ? parsed.profileUpdates.filter((u: any) => typeof u === "string" && u.trim().length > 0)
-        : [],
+      profileUpdates,
       questions,
-      identityReflection: parsed?.identityReflection ?? undefined,
-      relationships: Array.isArray(parsed?.relationships)
-        ? parsed.relationships.filter(
-            (r: any) =>
-              typeof r?.source === "string" &&
-              typeof r?.target === "string" &&
-              typeof r?.label === "string",
-          )
-            .map((r: any) => ({
-              source: r.source,
-              target: r.target,
-              label: r.label,
-              promptedByQuestion:
-                typeof r?.promptedByQuestion === "string" ? r.promptedByQuestion : undefined,
-            }))
-        : undefined,
+      identityReflection: extractionText(parsed?.identityReflection),
+      relationships,
     };
   }
 
-  private normalizeEntityUpdate(entity: any): ExtractedEntityResult {
-    const rawUpdates = isPlainRecord(entity?.updates) ? entity.updates : null;
-    const directFacts = Array.isArray(entity?.facts)
-      ? entity.facts
-          .filter((fact: any) => typeof fact === "string")
-          .map((fact: string) => fact.trim())
-          .filter((fact: string) => fact.length > 0)
-      : [];
-    const updateFacts = rawUpdates && Array.isArray(rawUpdates.facts)
-      ? rawUpdates.facts
-          .filter((fact: unknown) => typeof fact === "string")
-          .map((fact: string) => fact.trim())
-          .filter((fact: string) => fact.length > 0)
-      : [];
+  private normalizeEntityUpdate(entity: unknown): ExtractedEntityResult {
+    const record = isPlainRecord(entity) ? entity : {};
+    const rawUpdates = isPlainRecord(record.updates) ? record.updates : undefined;
+    const normalizedTexts = (value: unknown): string[] =>
+      Array.isArray(value)
+        ? value.flatMap((candidate: unknown) => {
+            const text = extractionText(candidate);
+            return text === undefined ? [] : [text];
+          })
+        : [];
+    const directFacts = normalizedTexts(record.facts);
+    const updateFacts = normalizedTexts(rawUpdates?.facts);
     const scalarUpdateFacts = rawUpdates
-      ? Object.keys(rawUpdates)
-          .sort((a, b) => a.localeCompare(b))
-          .filter((key) => !["facts", "name", "promptedByQuestion", "structuredSections", "type"].includes(key))
-          .flatMap((key) => {
-            const value = rawUpdates[key];
-            if (typeof value === "string" && value.trim().length > 0) {
-              return [`${key}: ${value.trim()}`];
+      ? Object.entries(rawUpdates)
+          .sort(([left], [right]) => left.localeCompare(right))
+          .flatMap(([key, value]) => {
+            if (["facts", "name", "promptedByQuestion", "structuredSections", "type"].includes(key)) {
+              return [];
             }
+            const normalizedKey = extractionText(key);
+            if (normalizedKey === undefined) return [];
+            const normalizedValue = extractionText(value);
+            if (normalizedValue !== undefined) return [`${normalizedKey}: ${normalizedValue}`];
             if (typeof value === "number" || typeof value === "boolean") {
-              return [`${key}: ${String(value)}`];
+              return [`${normalizedKey}: ${String(value)}`];
             }
             return [];
           })
       : [];
-    const structuredSectionsSource = Array.isArray(entity?.structuredSections)
-      ? entity.structuredSections
+    const structuredSectionsSource = Array.isArray(record.structuredSections)
+      ? record.structuredSections
       : Array.isArray(rawUpdates?.structuredSections)
         ? rawUpdates.structuredSections
         : [];
-    const name =
-      typeof entity?.name === "string"
-        ? entity.name.trim()
-        : typeof entity?.entityId === "string"
-          ? entity.entityId.trim()
-          : typeof rawUpdates?.name === "string"
-            ? rawUpdates.name.trim()
-            : "";
-    const type =
-      typeof entity?.type === "string" && entity.type.trim().length > 0
-        ? entity.type.trim()
-        : typeof rawUpdates?.type === "string" && rawUpdates.type.trim().length > 0
-          ? rawUpdates.type.trim()
-          : "other";
+    const structuredSections = structuredSectionsSource.flatMap((candidate: unknown) => {
+      const section = isPlainRecord(candidate) ? candidate : {};
+      const key = extractionText(section.key);
+      const title = extractionText(section.title);
+      const facts = normalizedTexts(section.facts);
+      if (key === undefined || title === undefined || facts.length === 0) return [];
+      return [{ key, title, facts }];
+    });
 
     return {
-      name,
-      type,
+      name:
+        extractionText(record.name) ??
+        extractionText(record.entityId) ??
+        extractionText(rawUpdates?.name) ??
+        "",
+      type: extractionEntityType(record.type) ?? extractionEntityType(rawUpdates?.type) ?? "other",
       facts: [...directFacts, ...updateFacts, ...scalarUpdateFacts],
-      structuredSections: structuredSectionsSource.length > 0
-        ? structuredSectionsSource
-            .map((section: any) => ({
-              key: typeof section?.key === "string" ? section.key.trim() : "",
-              title: typeof section?.title === "string" ? section.title.trim() : "",
-              facts: Array.isArray(section?.facts)
-                ? section.facts.filter((fact: any) => typeof fact === "string")
-                    .map((fact: string) => fact.trim())
-                    .filter((fact: string) => fact.length > 0)
-                : [],
-            }))
-            .filter((section: any) => (
-              section.key.length > 0 &&
-              section.title.length > 0 &&
-              section.facts.length > 0
-            ))
-        : undefined,
-      promptedByQuestion:
-        typeof entity?.promptedByQuestion === "string"
-          ? entity.promptedByQuestion
-          : typeof rawUpdates?.promptedByQuestion === "string"
-            ? rawUpdates.promptedByQuestion
-            : undefined,
+      structuredSections: structuredSections.length > 0 ? structuredSections : undefined,
+      promptedByQuestion: extractionText(record.promptedByQuestion) ?? extractionText(rawUpdates?.promptedByQuestion),
     };
   }
 

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -106,10 +106,16 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function containsExtractionPlaceholder(value: unknown): boolean {
+  if (typeof value === "string") return EXTRACTION_RESPONSE_PLACEHOLDERS[value.trim()] === true;
+  if (Array.isArray(value)) return value.some(containsExtractionPlaceholder);
+  return isPlainRecord(value) && Object.values(value).some(containsExtractionPlaceholder);
+}
+
 function extractionText(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const text = value.trim();
-  return text.length > 0 && EXTRACTION_RESPONSE_PLACEHOLDERS[text] !== true ? text : undefined;
+  return text.length > 0 && !containsExtractionPlaceholder(text) ? text : undefined;
 }
 
 function extractionAttributes(value: unknown): Record<string, string> | undefined {
@@ -317,8 +323,10 @@ export class ExtractionEngine {
   private normalizeExtractionResultPayload(parsed: any): ExtractionResult {
     const entities: ExtractedEntityResult[] = Array.isArray(parsed?.entities)
       ? parsed.entities
-          .map((candidate: unknown) => this.normalizeEntityUpdate(candidate))
-          .filter((entity: ExtractedEntityResult) => entity.name.length > 0)
+          .map((candidate: unknown): ExtractedEntityResult | undefined => this.normalizeEntityUpdate(candidate))
+          .filter((entity: ExtractedEntityResult | undefined): entity is ExtractedEntityResult => (
+            entity !== undefined && entity.name.length > 0
+          ))
       : [];
 
     const facts = Array.isArray(parsed?.facts)
@@ -326,12 +334,24 @@ export class ExtractionEngine {
           .map((candidate: unknown) => {
             const fact = isPlainRecord(candidate) ? candidate : {};
             const category = typeof fact.category === "string" ? fact.category.trim() : "fact";
-            const reasoningTrace = isPlainRecord(fact.reasoningTrace)
+            const reasoningTraceInput = isPlainRecord(fact.reasoningTrace)
               ? fact.reasoningTrace
               : isPlainRecord(fact.reasoning_trace)
                 ? fact.reasoning_trace
                 : undefined;
             if (!isMemoryCategory(category)) return undefined;
+            const procedureSteps = Array.isArray(fact.procedureSteps)
+              ? normalizeProcedureSteps(fact.procedureSteps)
+              : undefined;
+            const reasoningTrace = reasoningTraceInput
+              ? normalizeReasoningTrace(reasoningTraceInput) ?? undefined
+              : undefined;
+            if (
+              containsExtractionPlaceholder(procedureSteps) ||
+              containsExtractionPlaceholder(reasoningTrace)
+            ) {
+              return undefined;
+            }
             return {
               category,
               content: extractionText(fact.content) ?? extractionText(fact.text) ?? "",
@@ -347,12 +367,8 @@ export class ExtractionEngine {
               scope:
                 fact.scope === "global" || fact.scope === "project" ? fact.scope : undefined,
               structuredAttributes: extractionAttributes(fact.structuredAttributes),
-              procedureSteps: Array.isArray(fact.procedureSteps)
-                ? normalizeProcedureSteps(fact.procedureSteps)
-                : undefined,
-              reasoningTrace: reasoningTrace
-                ? normalizeReasoningTrace(reasoningTrace) ?? undefined
-                : undefined,
+              procedureSteps,
+              reasoningTrace,
               quote: extractionText(fact.quote),
               eventTime: extractionText(fact.eventTime) ?? extractionText(fact.event_time),
             };
@@ -411,7 +427,7 @@ export class ExtractionEngine {
     };
   }
 
-  private normalizeEntityUpdate(entity: unknown): ExtractedEntityResult {
+  private normalizeEntityUpdate(entity: unknown): ExtractedEntityResult | undefined {
     const record = isPlainRecord(entity) ? entity : {};
     const rawUpdates = isPlainRecord(record.updates) ? record.updates : undefined;
     const normalizedTexts = (value: unknown): string[] =>
@@ -454,13 +470,16 @@ export class ExtractionEngine {
       return [{ key, title, facts }];
     });
 
+    const rawType = record.type ?? rawUpdates?.type;
+    const type = rawType === undefined ? "other" : extractionEntityType(rawType);
+    if (type === undefined) return undefined;
     return {
       name:
         extractionText(record.name) ??
         extractionText(record.entityId) ??
         extractionText(rawUpdates?.name) ??
         "",
-      type: extractionEntityType(record.type) ?? extractionEntityType(rawUpdates?.type) ?? "other",
+      type,
       facts: [...directFacts, ...updateFacts, ...scalarUpdateFacts],
       structuredSections: structuredSections.length > 0 ? structuredSections : undefined,
       promptedByQuestion: extractionText(record.promptedByQuestion) ?? extractionText(rawUpdates?.promptedByQuestion),
@@ -627,8 +646,10 @@ export class ExtractionEngine {
       )
       .filter((update) => update.length > 0);
     const entityUpdates = (Array.isArray(result.entityUpdates) ? result.entityUpdates : [])
-      .map((entity: any) => this.normalizeEntityUpdate(entity))
-      .filter((entity: ExtractedEntityResult) => entity.name.length > 0);
+      .map((entity: unknown): ExtractedEntityResult | undefined => this.normalizeEntityUpdate(entity))
+      .filter((entity: ExtractedEntityResult | undefined): entity is ExtractedEntityResult => (
+        entity !== undefined && entity.name.length > 0
+      ));
     return { items, profileUpdates, entityUpdates };
   }
 


### PR DESCRIPTION
## Summary
- Reject literal structural response placeholders at the shared extraction normalization boundary.
- Cover a copied response shape through the local extractor.

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm exec tsx --test src/extraction-prompt-safety.test.ts`

Part of #2152

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core memory extraction normalization path for all LLM backends; incorrect placeholder matching could drop valid memories, though tests cover false-positive cases like `<main>`.
> 
> **Overview**
> **Prevents models from persisting prompt template text** by treating angle-bracket strings from `EXTRACTION_RESPONSE_SHAPE` (e.g. `<source-grounded statement>`, `<category>`) as non-evidence and dropping them during shared `normalizeExtractionResultPayload` handling.
> 
> **Centralizes cleanup** across facts, entities, profile updates, questions, relationships, and nested fields (`procedureSteps`, `reasoningTrace`, tags, entity types). Invalid categories use `isMemoryCategory`; gateway results no longer use a separate fact-normalization path. Truncated JSON recovery runs through the same filter.
> 
> **Regression tests** assert empty extraction when placeholders are echoed (local full JSON, truncated recovery, gateway), and that conversation-grounded strings such as `<main>` are still kept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0327a21a8b91aadbaca7c677ee339670c95424b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->