### PR TITLE
feat(recall): compose curiosity footer in core recall

### DIFF
--- a/packages/remnic-core/src/access-mcp-output-schemas.ts
+++ b/packages/remnic-core/src/access-mcp-output-schemas.ts
@@ -31,6 +31,7 @@ const TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
     query: T_STRING,
     namespace: T_STRING,
     context: T_STRING,
+    contextComposition: objectSchema({ context: T_STRING, footer: T_STRING }),
     count: T_NUMBER,
     memoryIds: T_ARRAY,
     results: T_ARRAY,

--- a/packages/remnic-core/src/access-recall-response.ts
+++ b/packages/remnic-core/src/access-recall-response.ts
@@ -16,6 +16,11 @@ import { decideDisclosureEscalation } from "./recall-disclosure-escalation.js";
 import { type TagMatchMode, applyTagFilter, normalizeTags, parseTagMatch } from "./recall-tag-filter.js";
 import type { RecallDisclosure, RecallPlanMode } from "./types.js";
 import { displaySafeBudgetsApplied, displaySafeRecallSnapshot } from "./orchestration/recall-result-formatter.js";
+import {
+  boundRecallContextComposition,
+  composeRecallContext,
+  type RecallContextComposition,
+} from "./recall-context-composition.js";
 
 /**
  * Build the recall response from the completed pipeline (issue #1906 review
@@ -29,6 +34,7 @@ export async function assembleRecallResponse(
   params: {
   request: EngramAccessRecallRequest;
   context: string;
+  contextComposition?: RecallContextComposition;
   query: string;
   mode: RecallPlanMode | undefined;
   namespace: string;
@@ -47,6 +53,7 @@ export async function assembleRecallResponse(
   const {
     request,
     context,
+    contextComposition,
     query,
     mode,
     namespace,
@@ -191,7 +198,8 @@ export async function assembleRecallResponse(
       err instanceof Error ? err.message : String(err),
     );
   }
-  let effectiveContext = context;
+  let effectiveComposition: RecallContextComposition = contextComposition ?? { context };
+  let effectiveContext = composeRecallContext(effectiveComposition);
   if (filterTags && filterTags.length > 0) {
     const beforeIds = results.map((r) => r.id);
     const { results: admitted } = applyTagFilter(results, {
@@ -213,20 +221,16 @@ export async function assembleRecallResponse(
     const admittedIds = new Set(results.map((r) => r.id));
     const droppedAny = beforeIds.some((id) => !admittedIds.has(id));
     if (droppedAny) {
-      effectiveContext = results
-        .map((r) => {
-          const content =
-            typeof (r as { content?: unknown }).content === "string"
-              ? ((r as { content?: string }).content ?? "")
-              : "";
-          const preview =
-            typeof (r as { preview?: unknown }).preview === "string"
-              ? ((r as { preview?: string }).preview ?? "")
-              : "";
-          return content || preview;
-        })
+      const filteredContext = results
+        .map((result) => result.content || result.preview)
         .filter((s) => s.length > 0)
         .join("\n\n");
+      effectiveComposition = boundRecallContextComposition({
+        context: filteredContext,
+        footer: effectiveComposition.footer,
+        maxChars: deps.orchestrator.config.recallBudgetChars,
+      });
+      effectiveContext = composeRecallContext(effectiveComposition);
     }
   }
   const filteredMemoryIds = filterTags && filterTags.length > 0
@@ -289,6 +293,7 @@ export async function assembleRecallResponse(
       sessionKey: request.sessionKey,
       namespace: effectiveNamespace,
       context: effectiveContext,
+      contextComposition: effectiveComposition,
       count: filterTags && filterTags.length > 0
         ? results.length
         : (snapshot?.memoryIds.length ?? results.length),

--- a/packages/remnic-core/src/access-recall-surface.ts
+++ b/packages/remnic-core/src/access-recall-surface.ts
@@ -27,6 +27,7 @@ import type { Orchestrator, RecallInvocationOptions } from "./orchestrator.js";
 import { decideDisclosureEscalation } from "./recall-disclosure-escalation.js";
 import { assembleRecallResponse } from "./access-recall-response.js";
 import type { LastRecallSnapshot } from "./recall-state.js";
+import type { RecallContextComposition } from "./recall-context-composition.js";
 import { type TagMatchMode, applyTagFilter, normalizeTags, parseTagMatch } from "./recall-tag-filter.js";
 import { type RecallXraySnapshot, estimateRecallTokens } from "./recall-xray.js";
 import { SecureStoreLockedError } from "./secure-store/index.js";
@@ -852,10 +853,14 @@ export class AccessRecallSurface {
       }
       asOf = request.asOf;
     }
+    let contextComposition: RecallContextComposition | undefined;
     const recallOptions: RecallInvocationOptions = {
       namespace: namespaceOverride,
       topK,
       mode,
+      onContextComposition: (composition) => {
+        contextComposition = composition;
+      },
       ...(authenticatedPrincipal ? { principalOverride: authenticatedPrincipal } : {}),
       ...(asOf !== undefined ? { asOf } : {}),
       ...(request.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
@@ -892,10 +897,15 @@ export class AccessRecallSurface {
     // construction — so ANY failure after the reserve releases the exact
     // budget entry (by token, review #4) instead of leaking it.
     try {
-      const context = await this.deps.orchestrator.recall(query, request.sessionKey, recallOptions);
+      const context = await this.deps.orchestrator.recall(
+        query,
+        request.sessionKey,
+        recallOptions,
+      );
       const assembled = await assembleRecallResponse(this.deps, {
         request,
         context,
+        contextComposition,
         query,
         mode,
         namespace,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -170,6 +170,7 @@ import {
   type ScopeInspection,
 } from "./admin/admin-surfaces.js";
 import type { LastRecallSnapshot } from "./recall-state.js";
+import type { RecallContextComposition } from "./recall-context-composition.js";
 import type {
   GraphRecallSnapshot,
   IntentDebugSnapshot,
@@ -453,6 +454,8 @@ export interface EngramAccessRecallResponse {
   sessionKey?: string;
   namespace: string;
   context: string;
+  /** Request-local split used by adapters that must re-render a tighter prompt budget. */
+  contextComposition?: RecallContextComposition;
   count: number;
   memoryIds: string[];
   results: EngramAccessMemorySummary[];

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -471,18 +471,7 @@ export {
 } from "./resolve-auth-token.js";
 export type { ResolveSecretRefFn } from "./resolve-auth-token.js";
 export type { SecretRef, AgentAccessAuthToken } from "./types.js";
-
-export {
-  composeRecallContext,
-  contextBudgetForFooter,
-  formatCuriosityFooter,
-  renderMemoryContextPrompt,
-  selectCuriosityQuestion,
-  type CuriosityQuestion,
-  type RecallContextComposition,
-  type RenderedMemoryContextPrompt,
-} from "./recall-context-composition.js";
-
+export * from "./recall-context-composition.js";
 // Recall X-ray CLI helpers (issue #570).  Exported so the standalone
 // `@remnic/cli` binary can wire the `remnic xray` command without
 // reimporting core-internal modules by relative path (CLAUDE.md rule 26).

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -472,6 +472,17 @@ export {
 export type { ResolveSecretRefFn } from "./resolve-auth-token.js";
 export type { SecretRef, AgentAccessAuthToken } from "./types.js";
 
+export {
+  composeRecallContext,
+  contextBudgetForFooter,
+  formatCuriosityFooter,
+  renderMemoryContextPrompt,
+  selectCuriosityQuestion,
+  type CuriosityQuestion,
+  type RecallContextComposition,
+  type RenderedMemoryContextPrompt,
+} from "./recall-context-composition.js";
+
 // Recall X-ray CLI helpers (issue #570).  Exported so the standalone
 // `@remnic/cli` binary can wire the `remnic xray` command without
 // reimporting core-internal modules by relative path (CLAUDE.md rule 26).

--- a/packages/remnic-core/src/orchestration/orchestrator-helpers.ts
+++ b/packages/remnic-core/src/orchestration/orchestrator-helpers.ts
@@ -27,6 +27,7 @@ import type { GraphRecallRankedResult, GraphRecallShadowComparison } from "./gra
 import { parseQmdExplain } from "../qmd.js";
 import type { GraphRecallExpandedEntry } from "../recall-state.js";
 import type { RecallXrayServedBy } from "../recall-xray.js";
+import type { RecallContextComposition } from "../recall-context-composition.js";
 import { type BufferTurn, type MemoryActionEvent, type MemoryFile, type MemoryFrontmatter, type MemoryIntent, type PluginConfig, type QmdSearchResult, type RecallPlanMode, confidenceTier } from "../types.js";
 import { categoryDirName } from "../utils/category-dir.js";
 import { parseFlexibleIsoTimestamp } from "../utils/iso-timestamp.js";
@@ -256,6 +257,12 @@ export interface RecallInvocationOptions {
    * absent, so existing timing consumers are unaffected.
    */
   queueWaitMs?: number;
+  /**
+   * Receives the bounded, request-local split between recall body and an
+   * optional enrichment footer. Transport surfaces use it to serialize the
+   * footer without reading storage or relying on a session-global snapshot.
+   */
+  onContextComposition?: (composition: RecallContextComposition) => void;
 }
 
 export type QueryAwarePrefilter = {

--- a/packages/remnic-core/src/orchestration/orchestrator-helpers.ts
+++ b/packages/remnic-core/src/orchestration/orchestrator-helpers.ts
@@ -261,8 +261,11 @@ export interface RecallInvocationOptions {
    * Receives the bounded, request-local split between recall body and an
    * optional enrichment footer. Transport surfaces use it to serialize the
    * footer without reading storage or relying on a session-global snapshot.
+   * A returned thenable is observed without delaying the recall result.
    */
-  onContextComposition?: (composition: RecallContextComposition) => void;
+  onContextComposition?: (
+    composition: RecallContextComposition,
+  ) => void | PromiseLike<void>;
 }
 
 export type QueryAwarePrefilter = {

--- a/packages/remnic-core/src/orchestration/orchestrator-helpers.ts
+++ b/packages/remnic-core/src/orchestration/orchestrator-helpers.ts
@@ -257,15 +257,7 @@ export interface RecallInvocationOptions {
    * absent, so existing timing consumers are unaffected.
    */
   queueWaitMs?: number;
-  /**
-   * Receives the bounded, request-local split between recall body and an
-   * optional enrichment footer. Transport surfaces use it to serialize the
-   * footer without reading storage or relying on a session-global snapshot.
-   * A returned thenable is observed without delaying the recall result.
-   */
-  onContextComposition?: (
-    composition: RecallContextComposition,
-  ) => void | PromiseLike<void>;
+  onContextComposition?: (composition: RecallContextComposition) => void | PromiseLike<void>;
 }
 
 export type QueryAwarePrefilter = {

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -48,6 +48,14 @@ import { buildProcedureRecallSection } from "../procedural/procedure-recall.js";
 import { ProfilingCollector } from "../profiling.js";
 import { buildQmdRecallCacheKey, getCachedQmdRecall, setCachedQmdRecall } from "../qmd-recall-cache.js";
 import { MEMORY_ID_PATTERN } from "../recall-handles.js";
+import {
+  boundRecallContextComposition,
+  composeRecallContext,
+  contextBudgetForFooter,
+  formatCuriosityFooter,
+  selectCuriosityQuestion,
+  type RecallContextComposition,
+} from "../recall-context-composition.js";
 import { createRecallSectionMetricRecorder } from "../recall-qos.js";
 import { buildRecallQueryPolicy } from "../recall-query-policy.js";
 import { type GraphRecallExpandedEntry, type LastRecallBudgetSummary, type LastRecallSnapshot, LastRecallStore, RecallHandleHistoryStore } from "../recall-state.js";
@@ -5265,7 +5273,7 @@ export class RecallInternalCoordinator {
       );
     }
 
-    // 5. Inject most relevant question (if enabled) (existing)
+    let curiosityFooter: string | undefined;
     if (
       this.deps.config.injectQuestions &&
       this.deps.isRecallSectionEnabled("questions", true)
@@ -5273,16 +5281,9 @@ export class RecallInternalCoordinator {
       const questions = await profileStorage.readQuestions({
         unresolvedOnly: true,
       });
-      if (questions.length > 0) {
-        // Find the most relevant question to the current prompt
-        // Simple approach: use the highest-priority unresolved question
-        // TODO: Could use QMD search to find the most contextually relevant one
-        const topQuestion = questions[0]; // Already sorted by priority desc
-        this.deps.appendRecallSection(
-          sectionBuckets,
-          "questions",
-          `## Open Question\n\nSomething I've been curious about: ${topQuestion.question}\n\n_Context: ${topQuestion.context}_`,
-        );
+      const topQuestion = selectCuriosityQuestion(questions);
+      if (topQuestion) {
+        curiosityFooter = formatCuriosityFooter(topQuestion);
       }
     }
 
@@ -5319,9 +5320,12 @@ export class RecallInternalCoordinator {
       queryPolicy: timings.queryPolicy,
     });
 
+    const recallBudgetChars = this.deps.getRecallBudgetChars(
+      options.budgetCharsOverride,
+    );
     const assembledRecall = this.deps.assembleRecallSections(
       sectionBuckets,
-      options.budgetCharsOverride,
+      contextBudgetForFooter(recallBudgetChars, curiosityFooter),
     );
     recalledMemoryIds = assembledRecall.includedMemoryIds;
     recalledMemoryPaths = assembledRecall.includedMemoryPaths;
@@ -5332,10 +5336,20 @@ export class RecallInternalCoordinator {
       assembledRecall.includedMemoryPaths,
       assembledRecall.includedMemoryNamespaces,
     );
-    const context =
+    const recalledContext =
       assembledRecall.sections.length === 0
         ? ""
         : assembledRecall.sections.join("\n\n---\n\n");
+    const composition: RecallContextComposition = boundRecallContextComposition({
+      context: recalledContext,
+      footer: curiosityFooter,
+      maxChars: recallBudgetChars,
+    });
+    const context = composeRecallContext(composition);
+    options.onContextComposition?.(composition);
+    const compositionTruncated =
+      context.length <
+      composeRecallContext({ context: recalledContext, footer: curiosityFooter }).length;
     const sourcesUsed = this.deps.collectLastRecallSources(
       sectionBuckets,
       recallSource,
@@ -5345,8 +5359,8 @@ export class RecallInternalCoordinator {
       recallResultLimit,
       qmdFetchLimit,
       qmdHybridFetchLimit,
-      finalContextChars: assembledRecall.finalChars,
-      truncated: assembledRecall.truncated,
+      finalContextChars: context.length,
+      truncated: assembledRecall.truncated || compositionTruncated,
       includedSections: assembledRecall.includedIds,
       omittedSections: assembledRecall.omittedIds,
       includedMemoryIds: assembledRecall.includedMemoryIds,
@@ -5535,7 +5549,7 @@ export class RecallInternalCoordinator {
           filters,
           budget: {
             chars: this.deps.getRecallBudgetChars(options.budgetCharsOverride),
-            used: assembledRecall.finalChars,
+            used: context.length,
           },
           sessionKey,
           namespace: selfNamespace,

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -49,12 +49,8 @@ import { ProfilingCollector } from "../profiling.js";
 import { buildQmdRecallCacheKey, getCachedQmdRecall, setCachedQmdRecall } from "../qmd-recall-cache.js";
 import { MEMORY_ID_PATTERN } from "../recall-handles.js";
 import {
-  boundRecallContextComposition,
-  composeRecallContext,
-  contextBudgetForFooter,
-  formatCuriosityFooter,
-  selectCuriosityQuestion,
-  type RecallContextComposition,
+  boundRecallContextComposition, composeRecallContext, contextBudgetForFooter,
+  formatCuriosityFooter, selectCuriosityQuestion,
 } from "../recall-context-composition.js";
 import { createRecallSectionMetricRecorder } from "../recall-qos.js";
 import { buildRecallQueryPolicy } from "../recall-query-policy.js";
@@ -4413,7 +4409,6 @@ export class RecallInternalCoordinator {
           success: !trustFellBack,
         });
       }
-
       // Synapse-inspired confidence gate: check scores BEFORE slicing so
       // reranking doesn't affect which score the gate evaluates.
       //
@@ -4453,7 +4448,6 @@ export class RecallInternalCoordinator {
           confidenceGateRejected = true;
         }
       }
-
       // Diversify via MMR over the full candidate pool *before* truncating to
       // the final recall limit. Running MMR after the slice would be unable
       // to promote diverse candidates sitting just below the cutoff.
@@ -4464,7 +4458,6 @@ export class RecallInternalCoordinator {
         retrievalQuery,
         caps,
       );
-
       // E-Mem-inspired memory reconstruction: fill gaps for referenced entities
       if (resolveRecallEnhancementCapabilities(this.deps.config).memoryReconstruction && memoryResults.length > 0) {
         try {
@@ -4507,7 +4500,6 @@ export class RecallInternalCoordinator {
           log.warn("recall: memory reconstruction failed (non-fatal)", err);
         }
       }
-
       if (memoryResults.length > 0) {
         if (shouldPersistGraphSnapshot) {
           graphSnapshotFinalResults = this.deps.buildGraphRecallRankedResults(
@@ -4697,7 +4689,6 @@ export class RecallInternalCoordinator {
         }
         }
       }
-
       if (globalResults.length > 0) {
         this.deps.appendRecallSection(
           sectionBuckets,
@@ -4705,7 +4696,6 @@ export class RecallInternalCoordinator {
           this.deps.formatQmdResults("Workspace Context", globalResults, sessionKey, recallTrustByPath),
         );
       }
-
       recordRecallSectionMetric({
         section: "qmdPost",
         priority: "enrichment",
@@ -4714,7 +4704,6 @@ export class RecallInternalCoordinator {
         source: "fresh",
         success: true,
       });
-
       // If the user is pushing back ("that's not right", "why did you say that"),
       // gently suggest an explicit workflow to inspect what was recalled and record feedback.
       // IMPORTANT: this is suggestion-only; never auto-mark negatives.
@@ -5034,7 +5023,6 @@ export class RecallInternalCoordinator {
                 success: !trustFellBack,
               });
             }
-
             if (recent.length > 0) {
               if (shouldPersistGraphSnapshot) {
                 graphSnapshotFinalResults = this.deps.buildGraphRecallRankedResults(
@@ -5163,7 +5151,6 @@ export class RecallInternalCoordinator {
         }
       }
       }
-
       if (isDisagreementPrompt(prompt)) {
         this.deps.appendRecallSection(
           sectionBuckets,
@@ -5182,7 +5169,6 @@ export class RecallInternalCoordinator {
         );
       }
     }
-
     const phase2AfterQmdMs = Date.now() - recallStart;
     if (shouldPersistGraphSnapshot) {
       if (!graphSnapshotStatus) {
@@ -5219,7 +5205,6 @@ export class RecallInternalCoordinator {
       storage: profileStorage,
       snapshot: buildIntentDebugSnapshot(),
     });
-
     // 2.5. Compression guideline recall section (v8.11 Task 5)
     if (
       this.deps.isRecallSectionEnabled(
@@ -5237,7 +5222,6 @@ export class RecallInternalCoordinator {
         );
       }
     }
-
     // 3. Transcript/summaries/conversation/compounding are fetched in parallel above,
     // then assembled here according to recallPipeline order.
     if (transcriptSection) {
@@ -5272,32 +5256,22 @@ export class RecallInternalCoordinator {
         compoundingSection,
       );
     }
-
-    let curiosityFooter: string | undefined;
-    let curiosityQuestionSelected = false;
-    let curiosityFooterTruncated = false;
-    if (
-      this.deps.config.injectQuestions &&
+    let curiosityFooter: string | undefined, curiosityQuestionSelected = false, curiosityFooterTruncated = false;
+    const topQuestion = this.deps.config.injectQuestions &&
       this.deps.isRecallSectionEnabled("questions", true)
-    ) {
-      const questions = await profileStorage.readQuestions({
-        unresolvedOnly: true,
-      });
-      const topQuestion = selectCuriosityQuestion(questions);
-      if (topQuestion) {
-        curiosityQuestionSelected = true;
-        const formattedFooter = formatCuriosityFooter(topQuestion);
-        const questionMaxChars = this.deps.getRecallSectionMaxChars("questions");
-        if (questionMaxChars !== 0) {
-          curiosityFooter =
-            typeof questionMaxChars === "number"
-              ? this.deps.truncateRecallSectionToBudget(formattedFooter, questionMaxChars)
-              : formattedFooter;
-          curiosityFooterTruncated = curiosityFooter.length < formattedFooter.length;
-        }
+      ? selectCuriosityQuestion(await profileStorage.readQuestions({ unresolvedOnly: true }))
+      : undefined;
+    if (topQuestion) {
+      curiosityQuestionSelected = true;
+      const formattedFooter = formatCuriosityFooter(topQuestion);
+      const questionMaxChars = this.deps.getRecallSectionMaxChars("questions");
+      if (questionMaxChars !== 0) {
+        curiosityFooter = typeof questionMaxChars === "number"
+          ? this.deps.truncateRecallSectionToBudget(formattedFooter, questionMaxChars)
+          : formattedFooter;
+        curiosityFooterTruncated = curiosityFooter.length < formattedFooter.length;
       }
     }
-
     const phase2QuestionsDoneMs = Date.now() - recallStart;
     const finalizedQueryAwarePrefilter = await queryAwarePrefilterPromise;
     const phase2QapDoneMs = Date.now() - recallStart;
@@ -5311,7 +5285,6 @@ export class RecallInternalCoordinator {
       ).length;
       timings.queryAware = `${timings.queryAware};helped=${helpedCount}`;
     }
-
     // --- Timing summary ---
     timings.total = `${Date.now() - recallStart}ms`;
     this.deps.profiler.endSpan("assembly", profileTraceId);
@@ -5330,13 +5303,9 @@ export class RecallInternalCoordinator {
       recallPlan: timings.recallPlan,
       queryPolicy: timings.queryPolicy,
     });
-
-    const recallBudgetChars = this.deps.getRecallBudgetChars(
-      options.budgetCharsOverride,
-    );
+    const recallBudgetChars = this.deps.getRecallBudgetChars(options.budgetCharsOverride);
     const assembledRecall = this.deps.assembleRecallSections(
-      sectionBuckets,
-      contextBudgetForFooter(recallBudgetChars, curiosityFooter),
+      sectionBuckets, contextBudgetForFooter(recallBudgetChars, curiosityFooter),
     );
     recalledMemoryIds = assembledRecall.includedMemoryIds;
     recalledMemoryPaths = assembledRecall.includedMemoryPaths;
@@ -5347,43 +5316,31 @@ export class RecallInternalCoordinator {
       assembledRecall.includedMemoryPaths,
       assembledRecall.includedMemoryNamespaces,
     );
-    const recalledContext =
-      assembledRecall.sections.length === 0
-        ? ""
-        : assembledRecall.sections.join("\n\n---\n\n");
-    const composition: RecallContextComposition = boundRecallContextComposition({
-      context: recalledContext,
-      footer: curiosityFooter,
-      maxChars: recallBudgetChars,
+    const recalledContext = assembledRecall.sections.join("\n\n---\n\n");
+    const composition = boundRecallContextComposition({
+      context: recalledContext, footer: curiosityFooter, maxChars: recallBudgetChars,
     });
     const context = composeRecallContext(composition);
     try {
       const observerResult = options.onContextComposition?.(composition);
       if (observerResult && typeof observerResult.then === "function") {
-        void Promise.resolve(observerResult).catch((err) => {
-          log.warn("recall: context composition observer rejected", err);
-        });
+        void Promise.resolve(observerResult).catch((err) => log.warn(
+          "recall: context composition observer rejected", err,
+        ));
       }
     } catch (err) {
       log.warn("recall: context composition observer failed open", err);
     }
-    const compositionTruncated =
-      context.length <
-      composeRecallContext({ context: recalledContext, footer: curiosityFooter }).length;
+    const compositionTruncated = context.length < composeRecallContext({
+      context: recalledContext, footer: curiosityFooter,
+    }).length;
     const includedSections = [...assembledRecall.includedIds];
     const omittedSections = [...assembledRecall.omittedIds];
-    if (composition.footer) {
-      if (!includedSections.includes("questions")) includedSections.push("questions");
-    } else if (curiosityQuestionSelected) {
-      if (!omittedSections.includes("questions")) omittedSections.push("questions");
-    }
-    const sourcesUsed = this.deps.collectLastRecallSources(
-      sectionBuckets,
-      recallSource,
-    );
-    if (composition.footer && !sourcesUsed.includes("questions")) {
-      sourcesUsed.push("questions");
-    }
+    if (composition.footer && !includedSections.includes("questions")) includedSections.push("questions");
+    else if (!composition.footer && curiosityQuestionSelected && !omittedSections.includes("questions"))
+      omittedSections.push("questions");
+    const sourcesUsed = this.deps.collectLastRecallSources(sectionBuckets, recallSource);
+    if (composition.footer && !sourcesUsed.includes("questions")) sourcesUsed.push("questions");
     const budgetsApplied = this.deps.buildLastRecallBudgetSummary({
       requestedTopK,
       recallResultLimit,
@@ -5398,7 +5355,6 @@ export class RecallInternalCoordinator {
       includedMemoryNamespaces: assembledRecall.includedMemoryNamespaces,
       omittedMemoryIds: assembledRecall.omittedMemoryIds,
     });
-
     // X-ray capture (issue #570 PR 1).  Only fires when the caller
     // explicitly opts in via `xrayCapture: true`.  No behavior change
     // when the flag is absent — this branch and the setter both

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -5358,7 +5358,12 @@ export class RecallInternalCoordinator {
     });
     const context = composeRecallContext(composition);
     try {
-      options.onContextComposition?.(composition);
+      const observerResult = options.onContextComposition?.(composition);
+      if (observerResult && typeof observerResult.then === "function") {
+        void Promise.resolve(observerResult).catch((err) => {
+          log.warn("recall: context composition observer rejected", err);
+        });
+      }
     } catch (err) {
       log.warn("recall: context composition observer failed open", err);
     }

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -5274,6 +5274,8 @@ export class RecallInternalCoordinator {
     }
 
     let curiosityFooter: string | undefined;
+    let curiosityQuestionSelected = false;
+    let curiosityFooterTruncated = false;
     if (
       this.deps.config.injectQuestions &&
       this.deps.isRecallSectionEnabled("questions", true)
@@ -5283,7 +5285,16 @@ export class RecallInternalCoordinator {
       });
       const topQuestion = selectCuriosityQuestion(questions);
       if (topQuestion) {
-        curiosityFooter = formatCuriosityFooter(topQuestion);
+        curiosityQuestionSelected = true;
+        const formattedFooter = formatCuriosityFooter(topQuestion);
+        const questionMaxChars = this.deps.getRecallSectionMaxChars("questions");
+        if (questionMaxChars !== 0) {
+          curiosityFooter =
+            typeof questionMaxChars === "number"
+              ? this.deps.truncateRecallSectionToBudget(formattedFooter, questionMaxChars)
+              : formattedFooter;
+          curiosityFooterTruncated = curiosityFooter.length < formattedFooter.length;
+        }
       }
     }
 
@@ -5346,23 +5357,37 @@ export class RecallInternalCoordinator {
       maxChars: recallBudgetChars,
     });
     const context = composeRecallContext(composition);
-    options.onContextComposition?.(composition);
+    try {
+      options.onContextComposition?.(composition);
+    } catch (err) {
+      log.warn("recall: context composition observer failed open", err);
+    }
     const compositionTruncated =
       context.length <
       composeRecallContext({ context: recalledContext, footer: curiosityFooter }).length;
+    const includedSections = [...assembledRecall.includedIds];
+    const omittedSections = [...assembledRecall.omittedIds];
+    if (composition.footer) {
+      if (!includedSections.includes("questions")) includedSections.push("questions");
+    } else if (curiosityQuestionSelected) {
+      if (!omittedSections.includes("questions")) omittedSections.push("questions");
+    }
     const sourcesUsed = this.deps.collectLastRecallSources(
       sectionBuckets,
       recallSource,
     );
+    if (composition.footer && !sourcesUsed.includes("questions")) {
+      sourcesUsed.push("questions");
+    }
     const budgetsApplied = this.deps.buildLastRecallBudgetSummary({
       requestedTopK,
       recallResultLimit,
       qmdFetchLimit,
       qmdHybridFetchLimit,
       finalContextChars: context.length,
-      truncated: assembledRecall.truncated || compositionTruncated,
-      includedSections: assembledRecall.includedIds,
-      omittedSections: assembledRecall.omittedIds,
+      truncated: assembledRecall.truncated || compositionTruncated || curiosityFooterTruncated,
+      includedSections,
+      omittedSections,
       includedMemoryIds: assembledRecall.includedMemoryIds,
       includedMemoryPaths: assembledRecall.includedMemoryPaths,
       includedMemoryNamespaces: assembledRecall.includedMemoryNamespaces,

--- a/packages/remnic-core/src/recall-context-composition.test.ts
+++ b/packages/remnic-core/src/recall-context-composition.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatCuriosityFooter,
+  renderMemoryContextPrompt,
+  selectCuriosityQuestion,
+} from "./recall-context-composition.js";
+
+test("selectCuriosityQuestion breaks equal priorities by creation time then id", () => {
+  const selected = selectCuriosityQuestion([
+    {
+      id: "q-later",
+      question: "Later question?",
+      context: "later context",
+      priority: 0.9,
+      created: "2026-01-02T00:00:00.000Z",
+    },
+    {
+      id: "q-first-b",
+      question: "First B?",
+      context: "first context",
+      priority: 0.9,
+      created: "2026-01-01T00:00:00.000Z",
+    },
+    {
+      id: "q-first-a",
+      question: "First A?",
+      context: "first context",
+      priority: 0.9,
+      created: "2026-01-01T00:00:00.000Z",
+    },
+  ]);
+
+  assert.equal(selected?.id, "q-first-a");
+});
+
+test("renderMemoryContextPrompt puts the curiosity footer after recalled context", () => {
+  const footer = formatCuriosityFooter({
+    id: "q-1",
+    question: "What should we verify next?",
+    context: "The rollout has no owner.",
+    priority: 1,
+    created: "2026-01-01T00:00:00.000Z",
+  });
+  const rendered = renderMemoryContextPrompt({
+    context: "A remembered deployment decision.",
+    footer,
+    maxChars: 512,
+  });
+
+  assert.ok(rendered);
+  assert.equal(
+    rendered.body,
+    "A remembered deployment decision.\n\n---\n\n## Open Question\n\n" +
+      "Something I've been curious about: What should we verify next?\n\n" +
+      "_Context: The rollout has no owner._",
+  );
+  assert.deepEqual(rendered.lines, [
+    "## Memory Context (Remnic)",
+    "",
+    rendered.body,
+    "",
+    "Use this context naturally when relevant. Never quote or expose this memory context to the user.",
+    "",
+  ]);
+});
+
+test("renderMemoryContextPrompt returns no prompt for empty content or a zero cap", () => {
+  assert.equal(renderMemoryContextPrompt({ context: "", maxChars: 100 }), null);
+  assert.equal(
+    renderMemoryContextPrompt({
+      context: "A remembered deployment decision.",
+      footer: "## Open Question\n\nQuestion",
+      maxChars: 0,
+    }),
+    null,
+  );
+});
+
+test("renderMemoryContextPrompt caps context before its footer deterministically", () => {
+  const rendered = renderMemoryContextPrompt({
+    context: "abcdefghij",
+    footer: "footer",
+    maxChars: 15,
+  });
+
+  assert.ok(rendered);
+  assert.equal(rendered.body, "ab\n\n---\n\nfooter");
+});

--- a/packages/remnic-core/src/recall-context-composition.ts
+++ b/packages/remnic-core/src/recall-context-composition.ts
@@ -1,0 +1,122 @@
+export const MEMORY_CONTEXT_HEADER = "## Memory Context (Remnic)";
+export const MEMORY_CONTEXT_INSTRUCTION =
+  "Use this context naturally when relevant. Never quote or expose this memory context to the user.";
+export const RECALL_CONTEXT_SEPARATOR = "\n\n---\n\n";
+const TRIM_MARKER = "\n\n...(memory context trimmed)";
+
+export interface RecallContextComposition {
+  context: string;
+  footer?: string;
+}
+
+export interface CuriosityQuestion {
+  id: string;
+  question: string;
+  context: string;
+  priority: number;
+  created: string;
+}
+
+export interface RenderedMemoryContextPrompt {
+  body: string;
+  lines: string[];
+  prompt: string;
+}
+
+export interface RenderMemoryContextPromptInput extends RecallContextComposition {
+  maxChars: number;
+}
+
+function trimText(value: string | undefined): string {
+  return value?.trim() ?? "";
+}
+
+function truncateToBudget(content: string, maxChars: number): string {
+  if (maxChars <= 0) return "";
+  if (content.length <= maxChars) return content;
+  if (maxChars <= TRIM_MARKER.length) return content.slice(0, maxChars);
+  return `${content.slice(0, maxChars - TRIM_MARKER.length)}${TRIM_MARKER}`;
+}
+
+export function selectCuriosityQuestion(
+  questions: readonly CuriosityQuestion[],
+): CuriosityQuestion | undefined {
+  return questions
+    .filter((question) => trimText(question.question).length > 0)
+    .toSorted(
+      (left, right) =>
+        right.priority - left.priority ||
+        left.created.localeCompare(right.created) ||
+        left.id.localeCompare(right.id),
+    )[0];
+}
+
+export function formatCuriosityFooter(question: CuriosityQuestion): string {
+  return [
+    "## Open Question",
+    "",
+    `Something I've been curious about: ${question.question}`,
+    "",
+    `_Context: ${question.context}_`,
+  ].join("\n");
+}
+
+export function contextBudgetForFooter(maxChars: number, footer?: string): number {
+  const normalizedFooter = trimText(footer);
+  if (maxChars <= 0 || normalizedFooter.length === 0) return Math.max(0, maxChars);
+  if (normalizedFooter.length + RECALL_CONTEXT_SEPARATOR.length >= maxChars) return 0;
+  return maxChars - normalizedFooter.length - RECALL_CONTEXT_SEPARATOR.length;
+}
+
+
+export function boundRecallContextComposition({
+  context: rawContext,
+  footer: rawFooter,
+  maxChars,
+}: RenderMemoryContextPromptInput): RecallContextComposition {
+  if (!Number.isFinite(maxChars) || maxChars <= 0) return { context: "" };
+
+  const limit = Math.floor(maxChars);
+  const footer = trimText(rawFooter);
+  const context = truncateToBudget(
+    trimText(rawContext),
+    contextBudgetForFooter(limit, footer),
+  );
+  const boundedFooter =
+    footer.length > limit ? truncateToBudget(footer, limit) : footer;
+  return { context, ...(boundedFooter ? { footer: boundedFooter } : {}) };
+}
+export function composeRecallContext(composition: RecallContextComposition): string {
+  const context = trimText(composition.context);
+  const footer = trimText(composition.footer);
+  if (context.length === 0) return footer;
+  if (footer.length === 0) return context;
+  return `${context}${RECALL_CONTEXT_SEPARATOR}${footer}`;
+}
+
+export function renderMemoryContextPrompt({
+  context: rawContext,
+  footer: rawFooter,
+  maxChars,
+}: RenderMemoryContextPromptInput): RenderedMemoryContextPrompt | null {
+  const bounded = boundRecallContextComposition({
+    context: rawContext,
+    footer: rawFooter,
+    maxChars,
+  });
+  const body = composeRecallContext(bounded);
+  if (body.length === 0) return null;
+
+  const boundedBody = body.length <= maxChars
+    ? body
+    : truncateToBudget(bounded.footer || body, Math.floor(maxChars));
+  const lines = [
+    MEMORY_CONTEXT_HEADER,
+    "",
+    boundedBody,
+    "",
+    MEMORY_CONTEXT_INSTRUCTION,
+    "",
+  ];
+  return { body: boundedBody, lines, prompt: lines.join("\n").replace(/\n$/, "") };
+}

--- a/packages/remnic-core/src/recall-context-composition.ts
+++ b/packages/remnic-core/src/recall-context-composition.ts
@@ -38,16 +38,12 @@ function truncateToBudget(content: string, maxChars: number): string {
   return `${content.slice(0, maxChars - TRIM_MARKER.length)}${TRIM_MARKER}`;
 }
 
-export function selectCuriosityQuestion(
-  questions: readonly CuriosityQuestion[],
-): CuriosityQuestion | undefined {
-  return questions
+export function selectCuriosityQuestion(questions: readonly CuriosityQuestion[]): CuriosityQuestion | undefined {
+  return [...questions]
     .filter((question) => trimText(question.question).length > 0)
-    .toSorted(
+    .sort(
       (left, right) =>
-        right.priority - left.priority ||
-        left.created.localeCompare(right.created) ||
-        left.id.localeCompare(right.id),
+        right.priority - left.priority || left.created.localeCompare(right.created) || left.id.localeCompare(right.id)
     )[0];
 }
 
@@ -68,7 +64,6 @@ export function contextBudgetForFooter(maxChars: number, footer?: string): numbe
   return maxChars - normalizedFooter.length - RECALL_CONTEXT_SEPARATOR.length;
 }
 
-
 export function boundRecallContextComposition({
   context: rawContext,
   footer: rawFooter,
@@ -78,12 +73,8 @@ export function boundRecallContextComposition({
 
   const limit = Math.floor(maxChars);
   const footer = trimText(rawFooter);
-  const context = truncateToBudget(
-    trimText(rawContext),
-    contextBudgetForFooter(limit, footer),
-  );
-  const boundedFooter =
-    footer.length > limit ? truncateToBudget(footer, limit) : footer;
+  const context = truncateToBudget(trimText(rawContext), contextBudgetForFooter(limit, footer));
+  const boundedFooter = footer.length > limit ? truncateToBudget(footer, limit) : footer;
   return { context, ...(boundedFooter ? { footer: boundedFooter } : {}) };
 }
 export function composeRecallContext(composition: RecallContextComposition): string {
@@ -107,16 +98,7 @@ export function renderMemoryContextPrompt({
   const body = composeRecallContext(bounded);
   if (body.length === 0) return null;
 
-  const boundedBody = body.length <= maxChars
-    ? body
-    : truncateToBudget(bounded.footer || body, Math.floor(maxChars));
-  const lines = [
-    MEMORY_CONTEXT_HEADER,
-    "",
-    boundedBody,
-    "",
-    MEMORY_CONTEXT_INSTRUCTION,
-    "",
-  ];
+  const boundedBody = body.length <= maxChars ? body : truncateToBudget(bounded.footer || body, Math.floor(maxChars));
+  const lines = [MEMORY_CONTEXT_HEADER, "", boundedBody, "", MEMORY_CONTEXT_INSTRUCTION, ""];
   return { body: boundedBody, lines, prompt: lines.join("\n").replace(/\n$/, "") };
 }

--- a/packages/remnic-core/src/recall-curiosity-composition.test.ts
+++ b/packages/remnic-core/src/recall-curiosity-composition.test.ts
@@ -169,3 +169,105 @@ test("access recall returns the configured curiosity footer in its server respon
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+test("a throwing composition observer cannot discard the recall result", async () => {
+  const { orchestrator, memoryDir } = await makeOrchestrator(true);
+  try {
+    await orchestrator.storage.writeQuestion(
+      "Which deployment decision needs an owner?",
+      "The rollout is waiting for an owner.",
+      1,
+    );
+
+    const recalled = await orchestrator.recall("Which deployment decision matters?", "observer-session", {
+      onContextComposition: () => {
+        throw new Error("observer failed");
+      },
+    });
+
+    assert.match(recalled, /Which deployment decision needs an owner\?/);
+  } finally {
+    await orchestrator.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("questions section maxChars bounds the curiosity footer and reports it in recall metadata", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-curiosity-section-cap-"));
+  const orchestrator = new Orchestrator(
+    parseConfig({
+      openaiApiKey: "test-key",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      injectQuestions: true,
+      recallPipeline: [{ id: "questions", enabled: true, maxChars: 40 }],
+      qmdEnabled: false,
+      embeddingFallbackEnabled: false,
+      recallPlannerEnabled: false,
+      sharedContextEnabled: false,
+    }),
+  );
+  await orchestrator.initialize();
+  try {
+    await orchestrator.storage.writeQuestion(
+      "Which deployment decision needs an owner?",
+      "The rollout is waiting for an owner.",
+      1,
+    );
+
+    let composition: RecallContextComposition | undefined;
+    const recalled = await orchestrator.recall("Which deployment decision matters?", "section-cap-session", {
+      onContextComposition: (value: RecallContextComposition) => {
+        composition = value;
+      },
+    });
+    const footer = composition?.footer ?? "";
+    const snapshot = orchestrator.getLastRecall("section-cap-session");
+
+    assert.ok(footer.length > 0);
+    assert.ok(footer.length <= 40);
+    assert.match(recalled, /\.\.\.\(memory context trimmed\)$/);
+    assert.ok(snapshot?.sourcesUsed?.includes("questions"));
+    assert.ok(snapshot?.budgetsApplied?.includedSections?.includes("questions"));
+  } finally {
+    await orchestrator.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("questions section maxChars zero suppresses the curiosity footer", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-curiosity-section-disabled-"));
+  const orchestrator = new Orchestrator(
+    parseConfig({
+      openaiApiKey: "test-key",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      injectQuestions: true,
+      recallPipeline: [{ id: "questions", enabled: true, maxChars: 0 }],
+      qmdEnabled: false,
+      embeddingFallbackEnabled: false,
+      recallPlannerEnabled: false,
+      sharedContextEnabled: false,
+    }),
+  );
+  await orchestrator.initialize();
+  try {
+    await orchestrator.storage.writeQuestion(
+      "Which deployment decision needs an owner?",
+      "The rollout is waiting for an owner.",
+      1,
+    );
+
+    let composition: RecallContextComposition | undefined;
+    const recalled = await orchestrator.recall("Which deployment decision matters?", "section-zero-session", {
+      onContextComposition: (value: RecallContextComposition) => {
+        composition = value;
+      },
+    });
+
+    assert.equal(composition?.footer, undefined);
+    assert.doesNotMatch(recalled, /## Open Question/);
+  } finally {
+    await orchestrator.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/recall-curiosity-composition.test.ts
+++ b/packages/remnic-core/src/recall-curiosity-composition.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import { EngramAccessService } from "./access-service.js";
+import { Orchestrator } from "./orchestrator.js";
+import type { RecallContextComposition } from "./recall-context-composition.js";
+
+async function makeOrchestrator(injectQuestions: boolean): Promise<{
+  orchestrator: Orchestrator;
+  memoryDir: string;
+}> {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-curiosity-composition-"));
+  const orchestrator = new Orchestrator(
+    parseConfig({
+      openaiApiKey: "test-key",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      injectQuestions,
+      qmdEnabled: false,
+      embeddingFallbackEnabled: false,
+      recallPlannerEnabled: false,
+      sharedContextEnabled: false,
+    }),
+  );
+  await orchestrator.initialize();
+  return { orchestrator, memoryDir };
+}
+
+async function recallWithComposition(orchestrator: Orchestrator): Promise<{
+  legacyContext: string;
+  composition: RecallContextComposition | undefined;
+}> {
+  let composition: RecallContextComposition | undefined;
+  const legacyContext = await orchestrator.recall("Which deployment decision matters?", "session-a", {
+    onContextComposition: (value: RecallContextComposition) => {
+      composition = value;
+    },
+  });
+  return { legacyContext, composition };
+}
+
+test("enabled injectQuestions emits one separate curiosity footer while preserving legacy context", async () => {
+  const { orchestrator, memoryDir } = await makeOrchestrator(true);
+  try {
+    await orchestrator.storage.writeQuestion(
+      "Which deployment decision needs an owner?",
+      "The rollout is waiting for an owner.",
+      1,
+    );
+
+    const { composition, legacyContext } = await recallWithComposition(orchestrator);
+
+    assert.equal(composition?.context.includes("## Open Question"), false);
+    assert.equal(
+      composition?.footer,
+      "## Open Question\n\n" +
+        "Something I've been curious about: Which deployment decision needs an owner?\n\n" +
+        "_Context: The rollout is waiting for an owner._",
+    );
+    assert.match(legacyContext, /## Open Question/);
+  } finally {
+    await orchestrator.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("disabled or empty injectQuestions emits no curiosity footer", async () => {
+  const disabled = await makeOrchestrator(false);
+  const empty = await makeOrchestrator(true);
+  try {
+    await disabled.orchestrator.storage.writeQuestion("Should this stay hidden?", "Disabled.", 1);
+
+    const disabledResult = await recallWithComposition(disabled.orchestrator);
+    const emptyResult = await recallWithComposition(empty.orchestrator);
+
+    assert.equal(disabledResult.composition?.footer, undefined);
+    assert.doesNotMatch(disabledResult.legacyContext, /## Open Question/);
+    assert.equal(emptyResult.composition?.footer, undefined);
+    assert.doesNotMatch(emptyResult.legacyContext, /## Open Question/);
+  } finally {
+    await disabled.orchestrator.destroy();
+    await empty.orchestrator.destroy();
+    await rm(disabled.memoryDir, { recursive: true, force: true });
+    await rm(empty.memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("injectQuestions reads the question queue for the recalled namespace", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-curiosity-namespace-"));
+  const orchestrator = new Orchestrator(
+    parseConfig({
+      openaiApiKey: "test-key",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      injectQuestions: true,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [
+        { name: "alpha", readPrincipals: ["reader"], writePrincipals: ["reader"] },
+        { name: "beta", readPrincipals: ["reader"], writePrincipals: ["reader"] },
+      ],
+      principalFromSessionKeyMode: "disabled",
+      defaultRecallNamespaces: [],
+      qmdEnabled: false,
+      embeddingFallbackEnabled: false,
+      recallPlannerEnabled: false,
+      sharedContextEnabled: false,
+    }),
+  );
+  await orchestrator.initialize();
+  try {
+    await (await orchestrator.getStorage("alpha")).writeQuestion(
+      "Which alpha decision needs review?",
+      "Alpha context.",
+      1,
+    );
+    await (await orchestrator.getStorage("beta")).writeQuestion(
+      "Which beta decision needs review?",
+      "Beta context.",
+      1,
+    );
+
+    let composition: RecallContextComposition | undefined;
+    await orchestrator.recall("Which decision matters?", "session-alpha", {
+      namespace: "alpha",
+      principalOverride: "reader",
+      onContextComposition: (value: RecallContextComposition) => {
+        composition = value;
+      },
+    });
+
+    assert.match(composition?.footer ?? "", /Which alpha decision needs review\?/);
+    assert.doesNotMatch(composition?.footer ?? "", /Which beta decision needs review\?/);
+  } finally {
+    await orchestrator.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("access recall returns the configured curiosity footer in its server response", async () => {
+  const { orchestrator, memoryDir } = await makeOrchestrator(true);
+  try {
+    await orchestrator.storage.writeQuestion(
+      "Which server-side decision needs review?",
+      "The daemon should compose the same footer.",
+      1,
+    );
+
+    const response = await new EngramAccessService(orchestrator).recall({
+      query: "Which decision matters?",
+      sessionKey: "daemon-session",
+    });
+
+    assert.match(response.context, /## Open Question/);
+    assert.equal(
+      response.contextComposition?.footer,
+      "## Open Question\n\n" +
+        "Something I've been curious about: Which server-side decision needs review?\n\n" +
+        "_Context: The daemon should compose the same footer._",
+    );
+    assert.match(response.context, /Which server-side decision needs review\?/);
+  } finally {
+    await orchestrator.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/recall-curiosity-composition.test.ts
+++ b/packages/remnic-core/src/recall-curiosity-composition.test.ts
@@ -271,3 +271,31 @@ test("questions section maxChars zero suppresses the curiosity footer", async ()
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+test("an async composition observer rejection cannot become unhandled", async () => {
+  const { orchestrator, memoryDir } = await makeOrchestrator(true);
+  let unhandled = false;
+  const onUnhandledRejection = () => {
+    unhandled = true;
+  };
+  process.on("unhandledRejection", onUnhandledRejection);
+  try {
+    await orchestrator.storage.writeQuestion(
+      "Which deployment decision needs an owner?",
+      "The rollout is waiting for an owner.",
+      1,
+    );
+
+    await orchestrator.recall("Which deployment decision matters?", "async-observer-session", {
+      onContextComposition: async () => {
+        throw new Error("async observer failed");
+      },
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    assert.equal(unhandled, false);
+  } finally {
+    process.off("unhandledRejection", onUnhandledRejection);
+    await orchestrator.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -36,6 +36,12 @@ function staticPassphraseReader(...sequence: string[]) {
   return async () => sequence[index++] ?? sequence[sequence.length - 1] ?? TEST_PASSPHRASE;
 }
 
+function recallOptionsWithoutComposition(options: unknown): Record<string, unknown> {
+  const { onContextComposition, ...rest } = options as Record<string, unknown>;
+  assert.equal(typeof onContextComposition, "function");
+  return rest;
+}
+
 function dreamsPhasesConfig(deepSleepEnabled = true, deepSleepEnabledExplicitlySet = false) {
   return {
     lightSleep: {
@@ -1056,7 +1062,7 @@ test("access service allows readable namespace overrides outside default recall 
   });
 
   assert.equal(response.namespace, "project-y");
-  assert.deepEqual(capturedOptions, {
+  assert.deepEqual(recallOptionsWithoutComposition(capturedOptions), {
     namespace: "project-y",
     topK: undefined,
     mode: undefined,
@@ -1111,7 +1117,7 @@ test("access service recall uses authenticated principal for namespace authoriza
   });
 
   assert.equal(response.namespace, "project-y");
-  assert.deepEqual(capturedOptions, {
+  assert.deepEqual(recallOptionsWithoutComposition(capturedOptions), {
     namespace: "project-y",
     topK: undefined,
     mode: "full",
@@ -1274,7 +1280,7 @@ test("access service recall forwards overrides and returns explainable metadata"
       includeDebug: true,
     });
 
-    assert.deepEqual(capturedOptions, {
+    assert.deepEqual(recallOptionsWithoutComposition(capturedOptions), {
       namespace: "global",
       topK: 3,
       mode: "minimal",

--- a/tests/recall-pipeline-assembly.test.ts
+++ b/tests/recall-pipeline-assembly.test.ts
@@ -112,7 +112,6 @@ test("custom recallPipeline reorders sections and can disable transcript injecti
   assert.equal(qIndex >= 0, true);
   assert.equal(pIndex >= 0, true);
   assert.equal(sIndex >= 0, true);
-  assert.equal(qIndex < pIndex, true);
   assert.equal(pIndex < sIndex, true);
   assert.equal(context.includes("TRANSCRIPT_SHOULD_NOT_APPEAR"), false);
 });


### PR DESCRIPTION
## Summary
- compose the optional curiosity footer in the shared core recall pipeline
- expose the structured composition on access recall responses for daemon consumers
- preserve legacy string context while keeping footer budgeting deterministic

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/recall-context-composition.test.ts packages/remnic-core/src/recall-curiosity-composition.test.ts`
- `pnpm --filter @remnic/core build`
- `pnpm --filter @remnic/core check-types`

Part of #2131

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the recall prompt assembly path and wire format for access/MCP consumers; behavior is covered by new tests and preserves the composed `context` string for legacy callers.
> 
> **Overview**
> Introduces **`RecallContextComposition`** (`context` + optional `footer`) and shared helpers to select/format open questions, reserve budget for the footer, and join the two parts into the legacy `context` string.
> 
> **Orchestrator recall** no longer injects curiosity as a normal pipeline section. When `injectQuestions` is on, it picks one unresolved question (priority, then creation time, then id), applies the `questions` section `maxChars` cap to the footer only, shrinks the main section assembly budget accordingly, and composes the final string. Recall metadata (`sourcesUsed`, included/omitted sections, truncation) treats the footer separately. **`onContextComposition`** on recall options captures the structured split; observer failures are logged and do not fail recall.
> 
> **Access recall** threads that composition through `assembleRecallResponse`, returns **`contextComposition`** on `EngramAccessRecallResponse`, and rebuilds both fields when post-recall tag filtering drops memories. MCP **`recall`** output schema documents the new field.
> 
> Exports and tests cover deterministic budgeting, namespace-scoped questions, and integration behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f4b6c96b63eefaeecb5b20740ed19e9368789c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->