### PR TITLE
fix(openclaw): log delegate auth failures once

### DIFF
--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -872,6 +872,98 @@ test("delegate runtime reloads a rotated daemon token without re-registering hoo
   }
 });
 
+test("delegate daemon auth failures log one sanitized error per route and status", async (t) => {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  initLogger(
+    {
+      info() {},
+      warn(message) {
+        warnings.push(message);
+      },
+      error(message) {
+        errors.push(message);
+      },
+    },
+    false,
+    { timestamps: false },
+  );
+  t.after(() => resetLogger());
+
+  let status: 401 | 403 = 401;
+  const paths: string[] = [];
+  const server = http.createServer((req, res) => {
+    paths.push(req.url ?? "");
+    res.writeHead(status, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "unauthorized" }));
+  });
+  const listening = Promise.withResolvers<void>();
+  server.once("error", listening.reject);
+  server.listen(0, "127.0.0.1", listening.resolve);
+  await listening.promise;
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const target: DelegateRuntimeOptions["target"] = {
+    host: "127.0.0.1",
+    port: address.port,
+    resolveAuthToken: () => ({
+      token: "test-token",
+      source: "OPENCLAW_REMNIC_ACCESS_TOKEN",
+    }),
+  };
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(address.port, {
+      target,
+      serviceId: "auth-logging-test",
+    }));
+
+    const recallEvent = { prompt: "what did we decide about the rollout?" };
+    await invoke(api, "before_prompt_build", recallEvent, { sessionKey: "auth" });
+    await invoke(api, "before_prompt_build", recallEvent, { sessionKey: "auth" });
+
+    status = 403;
+    await invoke(api, "before_prompt_build", recallEvent, { sessionKey: "auth" });
+    await invoke(api, "before_prompt_build", recallEvent, { sessionKey: "auth" });
+    const observeEvent = {
+      success: true,
+      messages: [
+        { role: "user", content: "captured question" },
+        { role: "assistant", content: "captured answer" },
+      ],
+    };
+    await invoke(api, "agent_end", observeEvent, { sessionKey: "auth" });
+    await invoke(api, "agent_end", observeEvent, { sessionKey: "auth" });
+    const secondApi = recordingApi();
+    registerDelegateRuntime(secondApi, optionsFor(address.port, {
+      target: { ...target },
+      serviceId: "auth-logging-test",
+    }));
+    await invoke(secondApi, "before_prompt_build", recallEvent, { sessionKey: "auth" });
+
+    await invoke(api, "before_compaction", {}, { sessionKey: "auth" });
+    await invoke(api, "before_compaction", {}, { sessionKey: "auth" });
+
+    assert.deepEqual(new Set(paths), new Set([
+      "/engram/v1/recall",
+      "/engram/v1/observe",
+      "/engram/v1/lcm/compaction/flush",
+    ]));
+    assert.equal(errors.length, 4, "each route/status pair emits one error");
+    assert.equal(warnings.length, 0, "auth failures replace generic degradation warnings");
+    assert.equal(errors.filter((message) => message.includes("(401;")).length, 1);
+    assert.equal(errors.filter((message) => message.includes("(403;")).length, 3);
+    for (const message of errors) {
+      assert.match(message, /token source: OPENCLAW_REMNIC_ACCESS_TOKEN/);
+      assert.doesNotMatch(message, /test-token/);
+    }
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => error ? reject(error) : resolve()),
+    );
+  }
+});
+
 test("delegate authorization probe reports grant, rejection, and network failure without exposing credentials", async () => {
   let responseStatus = 200;
   const receivedAuthorization: Array<string | undefined> = [];

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -112,6 +112,22 @@ function daemonUrl(target: DelegateDaemonTarget, pathname: string): string {
   return `http://${host}:${target.port}${pathname}`;
 }
 
+const daemonAuthFailureLogKeys = new Set<string>();
+
+function reportDaemonAuthorizationFailure(
+  serviceId: string,
+  pathname: string,
+  status: 401 | 403,
+  tokenSource: DaemonAuthToken["source"],
+): void {
+  const key = `${serviceId}:${pathname}:${status}:${tokenSource}`;
+  if (daemonAuthFailureLogKeys.has(key)) return;
+  daemonAuthFailureLogKeys.add(key);
+  log.error(
+    `delegate ${pathname} authorization failed (${status}; token source: ${tokenSource})`,
+  );
+}
+
 export async function probeDelegateAuthorization(
   target: DelegateDaemonTarget,
   namespace = "",
@@ -142,6 +158,7 @@ export async function probeDelegateAuthorization(
 
 async function postJson(
   target: DelegateDaemonTarget,
+  serviceId: string,
   pathname: string,
   body: Record<string, unknown>,
   timeoutMs: number,
@@ -156,6 +173,12 @@ async function postJson(
     signal: AbortSignal.timeout(timeoutMs),
   });
   if (!res.ok) {
+    if (res.status === 401 || res.status === 403) {
+      const status = res.status === 401 ? 401 : 403;
+      await res.body?.cancel();
+      reportDaemonAuthorizationFailure(serviceId, pathname, status, auth.source);
+      return null;
+    }
     throw new Error(`daemon ${pathname} responded ${res.status}`);
   }
   const parsed: unknown = await res.json().catch(() => null);
@@ -272,6 +295,7 @@ export function registerDelegateRuntime(
         const cwd = cwdFrom(event, ctx, options.cwd);
         const response = await postJson(
           target,
+          options.serviceId,
           "/engram/v1/recall",
           withNamespace(namespace, {
             query,
@@ -377,6 +401,7 @@ export function registerDelegateRuntime(
       const cwd = cwdFrom(event, ctx, options.cwd);
       await postJson(
         target,
+        options.serviceId,
         "/engram/v1/observe",
         withNamespace(namespace, {
           sessionKey,
@@ -405,6 +430,7 @@ export function registerDelegateRuntime(
     try {
       await postJson(
         target,
+        options.serviceId,
         "/engram/v1/lcm/compaction/flush",
         withNamespace(namespace, { sessionKey }),
         options.flushTimeoutMs,


### PR DESCRIPTION
Part of #2129.

Emit one sanitized ERROR per delegate daemon route/status/token-source combination when recall, observe, or LCM flush receives HTTP 401/403. Auth failures return through the existing degrade-safe path without generic warning spam; no bearer token is logged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and HTTP error-handling only in the OpenClaw delegate plugin; auth failures still degrade safely without changing successful paths.
> 
> **Overview**
> When the delegate runtime’s daemon calls for **recall**, **observe**, or **LCM compaction flush** return HTTP **401** or **403**, `postJson` now treats them as a controlled degrade path instead of throwing: the response body is cancelled, the hook gets `null` (recall skips injection; observe/flush no-op), and **one** sanitized `log.error` is emitted per **`serviceId` + route + status + token source** combination.
> 
> Log lines include the pathname, status, and which token source was used (e.g. `OPENCLAW_REMNIC_ACCESS_TOKEN`) and **never** the bearer value, so repeated failures on the same route do not spam generic `delegate recall/observe/flush failed` warnings.
> 
> A new integration test drives all three routes with 401/403 and asserts four distinct error lines, zero warnings, and no token leakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f1d17d526a6d9f5eeef8c9fcf4477f21dd84e78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->