### PR TITLE
feat(adapters): preserve curiosity footer parity

### DIFF
--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -169,6 +169,35 @@ test("delegate recall injects daemon context under the memory header", async () 
   }
 });
 
+test("delegate preserves the daemon's curiosity footer when applying a tighter budget", async () => {
+  const footer =
+    "## Open Question\n\n" +
+    "Something I've been curious about: Which release needs an owner?\n\n" +
+    "_Context: The rollout is blocked._";
+  const body = "Remember the release plan. ".repeat(12);
+  const stub = await startDaemonStub(() => ({
+    context: `${body}\n\n---\n\n${footer}`,
+    contextComposition: { context: body, footer },
+  }));
+  try {
+    const api = recordingApi();
+    registerDelegateRuntime(api, optionsFor(stub.port, { recallBudgetChars: footer.length + 30 }));
+
+    const result = await invoke(
+      api,
+      "before_prompt_build",
+      { prompt: "Which release decision needs review?" },
+      { sessionKey: "footer-session" },
+    );
+
+    assert.ok(result && typeof result === "object");
+    assert.ok("prependSystemContext" in result);
+    assert.match(String(result.prependSystemContext), /Which release needs an owner\?/);
+  } finally {
+    await stub.close();
+  }
+});
+
 test("delegate recall degrades to no injection when the daemon fails", async () => {
   const stub = await startDaemonStub(() => {
     throw new Error("unreachable"); // respond() throwing crashes the handler; use 500 instead
@@ -368,25 +397,27 @@ test("delegate observe skips heartbeat-triggered turns when gated", async () => 
   }
 });
 
-test("delegate recall trims injected context to recallBudgetChars", async () => {
+test("delegate bounds context through the shared prompt renderer", async () => {
   const stub = await startDaemonStub(() => ({ context: "x".repeat(500) }));
   try {
     const api = recordingApi();
     registerDelegateRuntime(api, optionsFor(stub.port, { recallBudgetChars: 100 }));
-    const result = (await invoke(
+    const result = await invoke(
       api,
       "before_prompt_build",
       { prompt: "long enough query" },
       { sessionKey: "budget" },
-    )) as Record<string, unknown>;
-    const injected = String(result.prependSystemContext);
-    const marker = "\n\n...(memory context trimmed)";
-    assert.ok(
-      injected.length <= 100 + "## Memory Context (Remnic)\n\n".length + marker.length,
-      `injection stays within budget (+header +marker): got ${injected.length}`,
     );
-    assert.match(injected, /x{100}/, "trim retains the leading 100 budget chars of context");
-    assert.ok(injected.endsWith(marker), "embedded-parity trim marker appended");
+    assert.ok(result && typeof result === "object" && "prependSystemContext" in result);
+    const injected = String(result.prependSystemContext);
+    const header = "## Memory Context (Remnic)\n\n";
+    const instruction =
+      "\n\nUse this context naturally when relevant. Never quote or expose this memory context to the user.";
+    const marker = "\n\n...(memory context trimmed)";
+    assert.equal(
+      injected.slice(header.length, injected.indexOf(instruction)),
+      "x".repeat(100 - marker.length) + marker,
+    );
   } finally {
     await stub.close();
   }

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -20,8 +20,12 @@
  * SQLite contention).
  */
 
-import { log } from "@remnic/core/logger";
 import path from "node:path";
+import {
+  type RecallContextComposition,
+  renderMemoryContextPrompt,
+} from "@remnic/core";
+import { log } from "@remnic/core/logger";
 import { createFileToggleStore } from "@remnic/core/session-toggles";
 import {
   checkDaemonHealthSync,
@@ -139,7 +143,6 @@ export async function probeDelegateAuthorization(
   }
   return { state: "unavailable", tokenSource: auth.source };
 }
-
 async function postJson(
   target: DelegateDaemonTarget,
   pathname: string,
@@ -217,6 +220,25 @@ function withNamespace(
   return namespace.length > 0 ? { ...body, namespace } : body;
 }
 
+function readContextComposition(
+  response: Record<string, unknown>,
+  fallbackContext: string,
+): RecallContextComposition {
+  const candidate = response.contextComposition;
+  if (
+    typeof candidate !== "object" ||
+    candidate === null ||
+    !("context" in candidate) ||
+    typeof candidate.context !== "string"
+  ) {
+    return { context: fallbackContext };
+  }
+  if ("footer" in candidate && typeof candidate.footer === "string") {
+    return { context: candidate.context, footer: candidate.footer };
+  }
+  return { context: candidate.context };
+}
+
 /**
  * Register the delegate runtime against a healthy daemon.
  *
@@ -286,19 +308,17 @@ export function registerDelegateRuntime(
         if (typeof rawContext !== "string" || rawContext.trim().length === 0) {
           return undefined;
         }
-        // Mirror the embedded recallBudgetChars trim — including the visible
-        // trim marker — so delegate mode cannot exceed the configured
-        // injection budget (0 never reaches here; it disables the handler).
-        const context =
-          rawContext.length > options.recallBudgetChars
-            ? rawContext.slice(0, options.recallBudgetChars) + "\n\n...(memory context trimmed)"
-            : rawContext;
-        const prompt = `${MEMORY_CONTEXT_HEADER}\n\n${context}`;
+        const rendered = renderMemoryContextPrompt({
+          ...readContextComposition(response ?? {}, rawContext),
+          maxChars: options.recallBudgetChars,
+        });
+        if (!rendered) return undefined;
+        const prompt = rendered.prompt;
         if (useSectionBuilder) {
           // Section-builder hosts inject through the registered builder; the
           // hook only pre-computes. Returning injection fields here too would
           // double-inject.
-          promptLinesBySession.set(sessionKey, prompt.split("\n"));
+          promptLinesBySession.set(sessionKey, rendered.lines);
           return undefined;
         }
         // Embedded parity: before_prompt_build consumes ONLY

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,9 +94,11 @@ import {
 } from "./codex-compat.js";
 import { planRecallMode } from "@remnic/core/intent";
 import {
-  resolvePrincipal,
-  resolveAgentAccessAuthToken,
   expandTildePath,
+  renderMemoryContextPrompt as renderSharedMemoryContextPrompt,
+  resolveAgentAccessAuthToken,
+  resolvePrincipal,
+  type RecallContextComposition,
 } from "@remnic/core";
 import {
   normalizeHostEmbeddingVector,
@@ -2692,28 +2694,11 @@ const pluginDefinition = {
       return `${logicalSessionKey}::principal:${principal}`;
     }
 
-    // Single source of truth for the structured memory section: every code path
-    // that populates `cachedMemoryBySession` MUST use this helper so the cache
-    // format stays consistent regardless of which registration path produced it.
-    function buildMemoryContextLines(trimmed: string): string[] {
-      return [
-        "## Memory Context (Remnic)",
-        "",
-        trimmed,
-        "",
-        "Use this context naturally when relevant. Never quote or expose this memory context to the user.",
-        "",
-      ];
-    }
-
-    // Flat-string rendering for the gateway `prependSystemContext` slot.
-    // Derives from `buildMemoryContextLines` so the wording stays in lock-step
-    // with the capability/section builder cache. The trailing empty element
-    // produced by `buildMemoryContextLines` would become a trailing newline
-    // after joining — strip it to preserve the exact format the gateway
-    // expects for `prependSystemContext`.
-    function renderMemoryContextPrompt(trimmed: string): string {
-      return buildMemoryContextLines(trimmed).join("\n").replace(/\n$/, "");
+    function renderMemoryContext(composition: RecallContextComposition) {
+      return renderSharedMemoryContextPrompt({
+        ...composition,
+        maxChars: cfg.recallBudgetChars,
+      });
     }
 
     async function loadRecentDreamLines(runtimeWorkspaceDir?: string): Promise<string[]> {
@@ -3145,7 +3130,13 @@ const pluginDefinition = {
         const dreamLines = await loadRecentDreamLines(
           ctx?.workspaceDir as string | undefined,
         ).catch(() => []);
-        const context = await orchestrator.recall(prompt, sessionKey);
+        let recallComposition: RecallContextComposition | undefined;
+        const context = await orchestrator.recall(prompt, sessionKey, {
+          onContextComposition: (composition) => {
+            recallComposition = composition;
+          },
+        });
+        recallComposition ??= { context };
         log.debug(
           `${hookLabel}: recall returned ${context?.length ?? 0} chars`,
         );
@@ -3157,7 +3148,7 @@ const pluginDefinition = {
           ? []
           : activeRecallLines;
         const memoryIds = lastRecall?.memoryIds ?? [];
-        if (!context) {
+        if (!recallComposition.context && !recallComposition.footer) {
           const auxiliarySummary =
             summarizeRecallTextForStatus(activeRecallResult?.summary ?? null) ??
             summarizeRecallTextForStatus(
@@ -3219,12 +3210,9 @@ const pluginDefinition = {
           };
         }
 
-        const maxChars = cfg.recallBudgetChars;
-        if (maxChars === 0) return;
-        const trimmed =
-          context.length > maxChars
-            ? context.slice(0, maxChars) + "\n\n...(memory context trimmed)"
-            : context;
+        const memoryContext = renderMemoryContext(recallComposition);
+        if (!memoryContext) return;
+        const trimmed = memoryContext.body;
         const summaryText =
           summarizeRecallTextForStatus(activeRecallResult?.summary ?? null) ??
           summarizeRecallTextForStatus(trimmed);
@@ -3271,7 +3259,7 @@ const pluginDefinition = {
           ...auxiliaryDreamLines,
           ...auxiliaryActiveRecallLines,
         ];
-        const memorySectionLines = buildMemoryContextLines(trimmed);
+        const memorySectionLines = memoryContext.lines;
         const memoryLines = useMemoryPromptSection
           ? memorySectionLines
           : [...auxiliaryLines, ...memorySectionLines];
@@ -3282,7 +3270,7 @@ const pluginDefinition = {
                 : undefined)
             : auxiliaryLines.length > 0
               ? [...auxiliaryLines, ...memorySectionLines].join("\n").replace(/\n$/, "")
-              : renderMemoryContextPrompt(trimmed);
+              : memoryContext.prompt;
 
         log.debug(
             `${hookLabel}: returning memory context with ${trimmed.length} chars`,

--- a/tests/openclaw-adapter-scenarios.test.ts
+++ b/tests/openclaw-adapter-scenarios.test.ts
@@ -321,10 +321,26 @@ test("scenario: native corpus supplement searches and reads Remnic memory", asyn
 test("scenario: prompt injection precomputes recall and serves the cached prompt-section builder", async () => {
   await withScenarioRegistration(async ({ capture, orchestrator }) => {
     let recallCount = 0;
-    orchestrator.recall = async (query: string, sessionKey: string) => {
+    orchestrator.recall = async (
+      query: string,
+      sessionKey: string,
+      options?: {
+        onContextComposition?: (composition: {
+          context: string;
+          footer?: string;
+        }) => void;
+      },
+    ) => {
       recallCount += 1;
       assert.match(query, /dashboard/);
       assert.equal(sessionKey, "prompt-session");
+      options?.onContextComposition?.({
+        context: "Remember that the user prefers compact dashboards.",
+        footer:
+          "## Open Question\n\n" +
+          "Something I've been curious about: Which dashboard decision needs an owner?\n\n" +
+          "_Context: The team is waiting for an owner._",
+      });
       return "Remember that the user prefers compact dashboards.";
     };
 
@@ -349,6 +365,8 @@ test("scenario: prompt injection precomputes recall and serves the cached prompt
     assert.equal(hookResult, undefined);
     assert.match(lines.join("\n"), /Memory Context \(Remnic\)/);
     assert.match(lines.join("\n"), /compact dashboards/);
+    assert.match(lines.join("\n"), /## Open Question/);
+    assert.match(lines.join("\n"), /Which dashboard decision needs an owner\?/);
   });
 });
 


### PR DESCRIPTION
## Summary
- consume the shared recall context renderer in the OpenClaw delegate bridge
- preserve the daemon curiosity footer under adapter budgets and section-builder injection
- route embedded OpenClaw prompt injection through the shared composition callback

Part of #2131

## Verification
- `pnpm exec tsx --test packages/plugin-openclaw/src/delegate-runtime.test.ts tests/openclaw-adapter-scenarios.test.ts`
- `pnpm run check-types`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how recall text is trimmed and composed before system prompt injection; risk is behavioral parity rather than security, with tests locking budget and footer behavior.
> 
> **Overview**
> **Unifies memory prompt injection** across embedded OpenClaw and delegate bridge by routing both through `@remnic/core`’s `renderMemoryContextPrompt`, using structured `RecallContextComposition` (`context` plus optional **curiosity footer**) instead of local string slicing and duplicate section builders.
> 
> The **delegate** path now parses `contextComposition` from daemon `/engram/v1/recall` responses and applies `recallBudgetChars` via the shared renderer so tight budgets still keep the open-question footer when the daemon supplies it. The **embedded** adapter captures composition via `orchestrator.recall`’s `onContextComposition` callback and feeds the same helper for hook injection and prompt-section caching.
> 
> Tests cover footer preservation under budget, shared trim semantics, and scenario injection of `## Open Question` content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e643bf0d1a5f1d5f97f3ae194e24077c3a3a8bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->