### PR TITLE
fix(profile): cover extraction and consolidation timestamp paths

### DIFF
--- a/packages/remnic-core/src/storage-profile-timestamp.test.ts
+++ b/packages/remnic-core/src/storage-profile-timestamp.test.ts
@@ -819,6 +819,38 @@ test("writeProfile recognizes a completed indented code block before metadata", 
     t.mock.timers.reset();
   }
 });
+test("writeProfile treats generic HTML after completed indented code as opaque", async (t) => {
+  t.mock.timers.enable({ apis: ["Date"], now: Date.parse(WRITE_TIME) });
+  try {
+    await withMemoryDir(async (dir) => {
+      const storage = new StorageManager(dir);
+      const profile = [
+        "# Behavioral Profile",
+        "",
+        "    code example",
+        "<custom>",
+        "# Embedded heading",
+        "",
+        "*Last updated: literal inside HTML*",
+        "</custom>",
+        "",
+        STALE_HEADER,
+        "",
+        "- Keeps metadata after generic HTML.",
+        "",
+      ].join("\n");
+
+      await storage.writeProfile(profile);
+
+      assert.equal(
+        await storage.readProfile(),
+        profile.replace(STALE_HEADER, FRESH_HEADER),
+      );
+    });
+  } finally {
+    t.mock.timers.reset();
+  }
+});
 test("writeProfile recognizes standalone headers with Markdown indentation", async (t) => {
   t.mock.timers.enable({ apis: ["Date"], now: Date.parse(WRITE_TIME) });
   try {
@@ -1256,6 +1288,42 @@ test("writeProfile recognizes link reference definitions as metadata boundaries"
           FRESH_HEADER,
           "",
           "- Keeps link-reference content.",
+          "",
+        ].join("\n"),
+      );
+    });
+  } finally {
+    t.mock.timers.reset();
+  }
+});
+test("writeProfile ignores non-breaking spaces as link-reference separators", async (t) => {
+  t.mock.timers.enable({ apis: ["Date"], now: Date.parse(WRITE_TIME) });
+  try {
+    await withMemoryDir(async (dir) => {
+      const storage = new StorageManager(dir);
+      const profile = [
+        "# Behavioral Profile",
+        "",
+        "[docs]:\u00a0/url",
+        STALE_HEADER,
+        "",
+        "- Keeps ordinary paragraph content.",
+        "",
+      ].join("\n");
+
+      await storage.writeProfile(profile);
+
+      assert.equal(
+        await storage.readProfile(),
+        [
+          "# Behavioral Profile",
+          "",
+          FRESH_HEADER,
+          "",
+          "[docs]:\u00a0/url",
+          STALE_HEADER,
+          "",
+          "- Keeps ordinary paragraph content.",
           "",
         ].join("\n"),
       );

--- a/packages/remnic-core/src/storage/profile-header.ts
+++ b/packages/remnic-core/src/storage/profile-header.ts
@@ -7,12 +7,12 @@ const MARKDOWN_THEMATIC_BREAK = /^(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*
 const MARKDOWN_SETEXT_UNDERLINE = /^(?:=+|-+)$/;
 const MARKDOWN_BLOCK_QUOTE = /^>/;
 const MARKDOWN_LINK_REFERENCE =
-  /^\[(?:\\.|[^\\\[\]])+\]:\s*(?:<[^>\n]*>|([^\s]+))(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?$/;
-const MARKDOWN_LINK_REFERENCE_LABEL = /^\[(?:\\.|[^\\\[\]])+\]:\s*$/;
+  /^\[(?:\\.|[^\\\[\]])+\]:[ \t]*(?:<[^>\n]*>|([^\s]+))(?:[ \t]+(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?$/;
+const MARKDOWN_LINK_REFERENCE_LABEL = /^\[(?:\\.|[^\\\[\]])+\]:[ \t]*$/;
 const MARKDOWN_LINK_REFERENCE_CONTINUATION =
   /^ {1,3}(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\))$/;
 const MARKDOWN_LINK_REFERENCE_DESTINATION_CONTINUATION =
-  /^ {1,3}(?:<[^>\n]*>|(?!["'(])[^\s]+(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?)$/;
+  /^ {1,3}(?:<[^>\n]*>|(?!["'(])[^\s]+(?:[ \t]+(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?)$/;
 const UTF8_BOM = "\uFEFF";
 
 type FenceMarker = {
@@ -440,10 +440,11 @@ function canStartGenericHtmlBlock(
   const previousLine = lines[index - 1]?.content.trim() ?? "";
   if (previousLine === "") return true;
   return (
-    isMetadataBoundary(previousLine, previousHtmlTerminator) &&
-    !isLastUpdatedHeader(previousLine) &&
-    !MARKDOWN_LIST_ITEM.test(previousLine) &&
-    !MARKDOWN_BLOCK_QUOTE.test(previousLine)
+    isCompletedIndentedCodeBlock(lines, index) ||
+    (isMetadataBoundary(previousLine, previousHtmlTerminator) &&
+      !isLastUpdatedHeader(previousLine) &&
+      !MARKDOWN_LIST_ITEM.test(previousLine) &&
+      !MARKDOWN_BLOCK_QUOTE.test(previousLine))
   );
 }
 

--- a/tests/profile-header-pipeline.test.ts
+++ b/tests/profile-header-pipeline.test.ts
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { parseConfig } from "../src/config.js";
+import { Orchestrator } from "../src/orchestrator.js";
+import type { ExtractionResult } from "../src/types.js";
+
+const WRITE_TIME = "2030-01-02T03:04:05.000Z";
+const STALE_HEADER = "*Last updated: 2024-01-02T03:04:05.000Z*";
+const FRESH_HEADER = `*Last updated: ${WRITE_TIME}*`;
+
+function makeConfig(memoryDir: string) {
+  return parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    chunkingEnabled: false,
+    topicExtractionEnabled: false,
+    summarizationEnabled: false,
+    identityEnabled: false,
+    entitySummaryEnabled: false,
+    semanticConsolidationEnabled: false,
+    factArchivalEnabled: false,
+    lifecyclePolicyEnabled: false,
+  });
+}
+
+async function seedStaleProfile(memoryDir: string): Promise<void> {
+  await writeFile(
+    path.join(memoryDir, "profile.md"),
+    [
+      "# Behavioral Profile",
+      "",
+      STALE_HEADER,
+      "",
+      "- Existing profile note.",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+test("extraction persistence refreshes profile.md before appending profile updates", async (t) => {
+  t.mock.timers.enable({ apis: ["Date"], now: Date.parse(WRITE_TIME) });
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-profile-extraction-"));
+  try {
+    const orchestrator = new Orchestrator(makeConfig(memoryDir));
+    const storage = await orchestrator.getStorage("default");
+    await storage.ensureDirectories();
+    await seedStaleProfile(memoryDir);
+
+    const result: ExtractionResult = {
+      facts: [],
+      entities: [],
+      relationships: [],
+      questions: [],
+      profileUpdates: ["Prefers concise updates."],
+    } as ExtractionResult;
+
+    await orchestrator.persistExtraction(
+      result,
+      storage,
+      null,
+      { sessionKey: "profile-extraction", principal: "test" },
+    );
+
+    assert.equal(
+      await readFile(path.join(memoryDir, "profile.md"), "utf8"),
+      [
+        "# Behavioral Profile",
+        "",
+        FRESH_HEADER,
+        "",
+        "- Existing profile note.",
+        "- Prefers concise updates.",
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    t.mock.timers.reset();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("smart consolidation refreshes profile.md before appending consolidated updates", async (t) => {
+  t.mock.timers.enable({ apis: ["Date"], now: Date.parse(WRITE_TIME) });
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-profile-consolidation-"));
+  try {
+    const orchestrator = new Orchestrator(makeConfig(memoryDir));
+    const storage = await orchestrator.getStorage("default");
+    await storage.ensureDirectories();
+    await seedStaleProfile(memoryDir);
+
+    for (let index = 0; index < 5; index += 1) {
+      await storage.writeMemory("fact", `seed fact ${index}`, { source: "test" });
+    }
+    Object.defineProperty(orchestrator, "extraction", {
+      configurable: true,
+      value: {
+        consolidate: async () => ({
+          items: [],
+          profileUpdates: ["Prefers consolidated updates."],
+          entityUpdates: [],
+        }),
+      },
+    });
+
+    const stats = await orchestrator.runConsolidationNow();
+
+    assert.equal(stats.memoriesProcessed, 5);
+    assert.equal(
+      await readFile(path.join(memoryDir, "profile.md"), "utf8"),
+      [
+        "# Behavioral Profile",
+        "",
+        FRESH_HEADER,
+        "",
+        "- Existing profile note.",
+        "- Prefers consolidated updates.",
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    t.mock.timers.reset();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Part of #2134

Covers the deferred profile-header boundary findings from #2164 and adds integration coverage for extraction persistence and smart consolidation.

Verification:
- pnpm --filter @remnic/core exec tsx --test src/storage-profile-timestamp.test.ts
- pnpm exec tsx --test tests/profile-header-pipeline.test.ts
- pnpm --filter @remnic/core run check-types
- pnpm exec tsc --noEmit --project tsconfig.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to profile markdown parsing and test coverage; behavior shifts only for NBSP link refs and HTML-after-indented-code edge cases, with no auth or persistence contract changes beyond header placement.
> 
> **Overview**
> Tightens **profile `*Last updated*` header** placement in `profile-header.ts` so edge-case Markdown is handled correctly, with matching unit tests and new **orchestrator pipeline** coverage.
> 
> **Link-reference boundaries** now require ASCII space or tab after `]:` (not arbitrary whitespace). Lines like `[docs]: /url` with a non-breaking space are no longer treated as reference definitions, so a following stale header is not refreshed in the wrong place.
> 
> **Generic HTML blocks** may start immediately after a **completed indented code block**, keeping following custom tags and embedded `*Last updated*` lines opaque during metadata scanning instead of mis-identifying headers inside HTML.
> 
> Adds **`tests/profile-header-pipeline.test.ts`** to assert that **`persistExtraction`** and **`runConsolidationNow`** refresh `profile.md`’s timestamp before appending profile updates when the file already has a stale header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff86a406ff4ad7a1a099579d35f2a03ab376532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile timestamp refresh handling when profiles contain HTML, indented code blocks, or link references.
  * Preserved embedded HTML and link-reference content while updating stale “Last updated” headers.
  * Ensured profile headers refresh correctly when saving extraction results or consolidated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->