### PR TITLE
fix(storage): skip unresolvable entity id collisions instead of failing boot

### DIFF
--- a/.changeset/2179-entity-migration-collision.md
+++ b/.changeset/2179-entity-migration-collision.md
@@ -1,0 +1,9 @@
+---
+"@remnic/core": patch
+---
+
+Entity canonical-id migration no longer aborts startup on an unresolvable id
+collision. A legacy file whose normalized id collides with an existing
+canonical file (or two legacy files claiming one canonical id) is skipped with
+both files preserved and one aggregated warning, instead of throwing during
+directory initialization and crash-looping the daemon.

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -858,12 +858,14 @@ export async function migrateLegacyEntityCanonicalIds(
        * the canonical file, i.e. picking the winner this fix exists to avoid,
        * off stale state rather than what is on disk.
        */
-      const pruneBlocked = async (): Promise<void> => {
+      /** @returns true when a park was promoted back into the mapping set. */
+      const pruneBlocked = async (): Promise<boolean> => {
         const current = state;
-        if (!current) return;
+        if (!current) return false;
         // THIS scan's verdict wins over the journal: normalization can change
         // between runs, so a stale parked target would otherwise be promoted
         // later and rewrite references onto an id that does not exist.
+        let revived = false;
         const parked: Record<string, string> = { ...(current.blocked ?? {}) };
         const active: Record<string, string> = {};
         for (const [legacyId, canonicalId] of Object.entries(current.mappings)) {
@@ -887,6 +889,7 @@ export async function migrateLegacyEntityCanonicalIds(
           // Source gone: the rename is moot, but references still name it and
           // this record is the only thing that can still rewrite them.
           active[legacyId] = canonicalId;
+          revived = true;
         }
         // Reviving a whole chain at once yields A -> B -> C, and each rewrite
         // surface makes a different number of passes over it - so collapse
@@ -901,9 +904,10 @@ export async function migrateLegacyEntityCanonicalIds(
         const same = (a: Record<string, string>, b: Record<string, string>): boolean =>
           Object.keys(a).length === Object.keys(b).length
           && Object.entries(a).every(([key, value]) => b[key] === value);
-        if (same(collapsed, current.mappings) && same(parked, current.blocked ?? {})) return;
+        if (same(collapsed, current.mappings) && same(parked, current.blocked ?? {})) return revived;
         state = { ...current, mappings: collapsed, blocked: parked };
         await writeState(deps, state);
+        return revived;
       };
       const previousMappings = state.mappings;
       const collapsedMappings = collapseMappings(previousMappings);
@@ -952,8 +956,8 @@ export async function migrateLegacyEntityCanonicalIds(
           // park (another writer removed the legacy file), and completing
           // without promoting it strands its references behind a fingerprint
           // that already reflects the deletion - so no later run revisits it.
-          await pruneBlocked();
-          if (Object.keys(discoveredAfter).length === 0 && Object.keys(state.mappings).length === 0) {
+          const revivedInRescan = await pruneBlocked();
+          if (Object.keys(discoveredAfter).length === 0 && !revivedInRescan) {
             await writeState(deps, { ...state, complete: true });
             return finish();
           }
@@ -1006,8 +1010,12 @@ export async function migrateLegacyEntityCanonicalIds(
           state.mappings,
           await discoverMappings(deps, state.mappings, blocked),
         );
-        await pruneBlocked();
-        if (Object.keys(discoveredAfter).length === 0) {
+        // A park resolved after the rewrite pass is promoted here, and a
+        // promotion still has to be APPLIED. Completing on `discoveredAfter`
+        // alone fingerprints the post-deletion corpus, so the runner never
+        // retries and those references stay stranded.
+        const revivedAfterRewrite = await pruneBlocked();
+        if (Object.keys(discoveredAfter).length === 0 && !revivedAfterRewrite) {
           await writeState(deps, { ...state, complete: true });
           return finish();
         }

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -365,6 +365,12 @@ async function discoverMappings(
 ): Promise<Record<string, string>> {
   const mappings: Record<string, string> = {};
   const canonicalOwners = new Map<string, string[]>();
+  // Blocks describe THIS scan of the directory, so they are rebuilt per pass.
+  // Accumulating them across a run would let a collision another writer has
+  // since resolved keep pruning its now-valid mapping: the entity file gets
+  // renamed while the pruned mapping skips the reference rewrite, stranding
+  // memories on a filename that no longer exists.
+  blocked.clear();
   const entityEntries = await readSafeEntityEntries(deps.entitiesDir);
   for (const entry of entityEntries) {
     if (!entry.endsWith(".md")) continue;

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -825,6 +825,23 @@ export async function migrateLegacyEntityCanonicalIds(
         }
         return deps.readMigrationFingerprint?.();
       };
+      /**
+       * Drop blocked pairs from the working set. Discovery only refuses to
+       * ADD them; a mapping persisted by an earlier run would otherwise still
+       * be applied - migrating one claimant and rewriting every reference onto
+       * the canonical file, i.e. picking the winner this fix exists to avoid,
+       * off stale state rather than what is on disk.
+       */
+      const pruneBlocked = async (): Promise<void> => {
+        const current = state;
+        if (blocked.size === 0 || !current) return;
+        const remaining: Record<string, string> = Object.fromEntries(
+          Object.entries(current.mappings).filter(([legacyId]) => !blocked.has(legacyId)),
+        );
+        if (Object.keys(remaining).length === Object.keys(current.mappings).length) return;
+        state = { ...current, mappings: remaining };
+        await writeState(deps, state);
+      };
       const previousMappings = state.mappings;
       const collapsedMappings = collapseMappings(previousMappings);
       const mappingsChanged =
@@ -839,6 +856,7 @@ export async function migrateLegacyEntityCanonicalIds(
           state.mappings,
           await discoverMappings(deps, state.mappings, blocked),
         );
+        await pruneBlocked();
         const mergedBefore = collapseMappings(mergeDiscoveredMappings(state.mappings, discoveredBefore));
         if (state.complete && Object.keys(discoveredBefore).length === 0 && !mappingsChanged) {
           if (Object.keys(state.mappings).length === 0) return finish();
@@ -903,15 +921,7 @@ export async function migrateLegacyEntityCanonicalIds(
           }
           pendingMappings = deferredMappings;
         }
-        if (blocked.size > 0) {
-          const remaining: Record<string, string> = Object.fromEntries(
-            Object.entries(state.mappings).filter(([legacyId]) => !blocked.has(legacyId)),
-          );
-          if (Object.keys(remaining).length !== Object.keys(state.mappings).length) {
-            state = { ...state, mappings: remaining };
-            await writeState(deps, state);
-          }
-        }
+        await pruneBlocked();
 
         const rewroteColdMemory = await rewriteKnownReferences(
           deps,
@@ -928,6 +938,7 @@ export async function migrateLegacyEntityCanonicalIds(
           state.mappings,
           await discoverMappings(deps, state.mappings, blocked),
         );
+        await pruneBlocked();
         if (Object.keys(discoveredAfter).length === 0) {
           await writeState(deps, { ...state, complete: true });
           return finish();

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -15,6 +15,7 @@ import { readFileSync } from "node:fs";
 import { z } from "zod";
 import { computeSupersessionKey, normalizeSupersessionKey } from "../temporal-supersession.js";
 import type { EntityFile, MemoryFile } from "../types.js";
+import { log } from "../logger.js";
 import { isErrnoCode } from "../utils/errno.js";
 import { withHeldFileLock } from "../utils/serialize-mutations.js";
 import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
@@ -348,12 +349,22 @@ async function readSafeEntityEntries(entitiesDir: string): Promise<string[]> {
   return entries;
 }
 
+/**
+ * Legacy ids the migration cannot resolve on its own, mapped to the canonical
+ * id they collide with. Two entity files describing one entity is an ORDINARY
+ * operator state, and picking a winner would silently drop whichever side lost.
+ * So the pair is skipped and reported: reads of the legacy id keep working
+ * exactly as they did before the migration ran.
+ */
+export type BlockedEntityPairs = Map<string, string>;
+
 async function discoverMappings(
   deps: EntityCanonicalIdMigrationDependencies,
   knownMappings: Readonly<Record<string, string>> = {},
+  blocked: BlockedEntityPairs = new Map(),
 ): Promise<Record<string, string>> {
   const mappings: Record<string, string> = {};
-  const canonicalOwners = new Map<string, string>();
+  const canonicalOwners = new Map<string, string[]>();
   const entityEntries = await readSafeEntityEntries(deps.entitiesDir);
   for (const entry of entityEntries) {
     if (!entry.endsWith(".md")) continue;
@@ -386,17 +397,22 @@ async function discoverMappings(
     if (canonicalExists) {
       const canonicalContent = await deps.readStorageSecureFile(canonicalPath);
       if (entityContent !== canonicalContent) {
-        throw new Error(`Cannot migrate legacy entity id ${legacyId}: ${canonicalId} already exists.`);
+        blocked.set(legacyId, canonicalId);
+        continue;
       }
     }
-    const previousOwner = canonicalOwners.get(canonicalId);
-    if (previousOwner !== undefined && previousOwner !== legacyId) {
-      throw new Error(
-        `Cannot migrate legacy entity ids ${previousOwner} and ${legacyId}: both normalize to ${canonicalId}.`,
-      );
-    }
-    canonicalOwners.set(canonicalId, legacyId);
+    canonicalOwners.set(canonicalId, [...(canonicalOwners.get(canonicalId) ?? []), legacyId]);
     mappings[legacyId] = canonicalId;
+  }
+  // A canonical id claimed by more than one legacy file has no non-arbitrary
+  // winner, and readdir order is not stable (§6) - so the "winner" would differ
+  // between hosts reading identical data. Block every claimant instead.
+  for (const [canonicalId, claimants] of canonicalOwners) {
+    if (claimants.length < 2) continue;
+    for (const legacyId of claimants) {
+      blocked.set(legacyId, canonicalId);
+      delete mappings[legacyId];
+    }
   }
   return mappings;
 }
@@ -681,6 +697,8 @@ function collapseMappings(mappings: Readonly<Record<string, string>>): Record<st
 type EntityFileMigrationResult = {
   deferred: boolean;
   progressed: boolean;
+  /** The pair collided on content; skipped and reported, never migrated. */
+  blocked?: boolean;
 };
 
 async function migrateEntityFilePair(
@@ -711,7 +729,9 @@ async function migrateEntityFilePair(
         deps.isEncryptedStorageFile(canonicalPath),
       ]);
       if (legacyContent !== canonicalContent) {
-        throw new Error(`Cannot migrate legacy entity id ${legacyId}: ${canonicalId} already exists.`);
+        // A mapping persisted by an older build, or a file changed since
+        // discovery. Same verdict as discovery: skip the pair, keep both files.
+        return { deferred: false, progressed: false, blocked: true };
       }
       if (legacyEncrypted && !canonicalEncrypted) {
         if (!(await refreshMigrationLock()) || !(await refreshEntityLock())) {
@@ -792,6 +812,19 @@ export async function migrateLegacyEntityCanonicalIds(
           mappings: {},
         };
       }
+      const blocked: BlockedEntityPairs = new Map();
+      // ONE aggregated line per run, not one per pair per restart: this used to
+      // abort the daemon, so the operator needs the whole list and the remedy.
+      const finish = (): Promise<string | undefined> | string | undefined => {
+        if (blocked.size > 0) {
+          const pairs = [...blocked].map(([legacyId, canonicalId]) => `${legacyId} -> ${canonicalId}`).join(", ");
+          log.warn(
+            `entity canonical-id migration skipped ${blocked.size} unresolvable pair(s): ${pairs}. `
+            + "Both files were kept and the legacy id still resolves; merge or delete one side to migrate it.",
+          );
+        }
+        return deps.readMigrationFingerprint?.();
+      };
       const previousMappings = state.mappings;
       const collapsedMappings = collapseMappings(previousMappings);
       const mappingsChanged =
@@ -804,11 +837,11 @@ export async function migrateLegacyEntityCanonicalIds(
         if (!(await lock.refresh())) throw new Error("Lost entity canonical-id migration lock.");
         const discoveredBefore = rejectMappingCycles(
           state.mappings,
-          await discoverMappings(deps, state.mappings),
+          await discoverMappings(deps, state.mappings, blocked),
         );
         const mergedBefore = collapseMappings(mergeDiscoveredMappings(state.mappings, discoveredBefore));
         if (state.complete && Object.keys(discoveredBefore).length === 0 && !mappingsChanged) {
-          if (Object.keys(state.mappings).length === 0) return deps.readMigrationFingerprint?.();
+          if (Object.keys(state.mappings).length === 0) return finish();
           const rewroteColdMemory = await rewriteKnownReferences(
             deps,
             state.mappings,
@@ -818,7 +851,7 @@ export async function migrateLegacyEntityCanonicalIds(
           deps.invalidateAllMemoriesCache();
           if (rewroteColdMemory) deps.invalidateColdMemoriesCache();
           deps.bumpMemoryStatusVersion();
-          return deps.readMigrationFingerprint?.();
+          return finish();
         }
         if (
           state.complete
@@ -832,11 +865,11 @@ export async function migrateLegacyEntityCanonicalIds(
           if (!(await lock.refresh())) throw new Error("Lost entity canonical-id migration lock.");
           const discoveredAfter = rejectMappingCycles(
             state.mappings,
-            await discoverMappings(deps, state.mappings),
+            await discoverMappings(deps, state.mappings, blocked),
           );
           if (Object.keys(discoveredAfter).length === 0) {
             await writeState(deps, { ...state, complete: true });
-            return deps.readMigrationFingerprint?.();
+            return finish();
           }
           state = {
             ...state,
@@ -857,9 +890,8 @@ export async function migrateLegacyEntityCanonicalIds(
               canonicalId,
               () => lock.refresh(),
             );
-            if (result.deferred) {
-              deferredMappings.push([legacyId, canonicalId]);
-            }
+            if (result.blocked) blocked.set(legacyId, canonicalId);
+            else if (result.deferred) deferredMappings.push([legacyId, canonicalId]);
             progressed ||= result.progressed;
           }
           if (deferredMappings.length === 0) break;
@@ -870,6 +902,15 @@ export async function migrateLegacyEntityCanonicalIds(
             );
           }
           pendingMappings = deferredMappings;
+        }
+        if (blocked.size > 0) {
+          const remaining: Record<string, string> = Object.fromEntries(
+            Object.entries(state.mappings).filter(([legacyId]) => !blocked.has(legacyId)),
+          );
+          if (Object.keys(remaining).length !== Object.keys(state.mappings).length) {
+            state = { ...state, mappings: remaining };
+            await writeState(deps, state);
+          }
         }
 
         const rewroteColdMemory = await rewriteKnownReferences(
@@ -885,11 +926,11 @@ export async function migrateLegacyEntityCanonicalIds(
         if (!(await lock.refresh())) throw new Error("Lost entity canonical-id migration lock.");
         const discoveredAfter = rejectMappingCycles(
           state.mappings,
-          await discoverMappings(deps, state.mappings),
+          await discoverMappings(deps, state.mappings, blocked),
         );
         if (Object.keys(discoveredAfter).length === 0) {
           await writeState(deps, { ...state, complete: true });
-          return deps.readMigrationFingerprint?.();
+          return finish();
         }
         state = {
           ...state,

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -873,20 +873,20 @@ export async function migrateLegacyEntityCanonicalIds(
         // A parked pair whose legacy file is gone was resolved by keeping the
         // canonical side. The rename is moot; the reference rewrite is not, and
         // this record is the only thing that can still perform it.
+        // A park survives ONLY while this scan re-establishes the collision.
+        // Anything else - the scan found a real migration, or found the source
+        // needs none (already canonical under a newer normalization) - makes
+        // the record obsolete, and keeping it lets a later deletion promote a
+        // target the entity never occupied.
         for (const [legacyId, canonicalId] of Object.entries(parked)) {
           if (blocked.has(legacyId)) continue;
-          // This scan found a real migration for the same legacy id, so the
-          // park is obsolete - and must not be revived over it. After the file
-          // moves, its absence would otherwise read as operator resolution and
-          // restore the stale target on top of the live one.
-          if (active[legacyId] !== undefined) {
-            delete parked[legacyId];
-            continue;
-          }
+          delete parked[legacyId];
+          if (active[legacyId] !== undefined) continue;
           const legacyPath = deps.resolveEntityFilePath(legacyId);
           if (legacyPath !== null && (await fileExists(legacyPath))) continue;
+          // Source gone: the rename is moot, but references still name it and
+          // this record is the only thing that can still rewrite them.
           active[legacyId] = canonicalId;
-          delete parked[legacyId];
         }
         // Reviving a whole chain at once yields A -> B -> C, and each rewrite
         // surface makes a different number of passes over it - so collapse

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -70,6 +70,14 @@ const EntityCanonicalIdMigrationStateSchema = z.object({
   version: z.literal(ENTITY_CANONICAL_ID_MIGRATION_VERSION),
   complete: z.boolean(),
   mappings: z.record(z.string().min(1)),
+  /**
+   * Pairs the migration refused to resolve, PARKED rather than dropped.
+   * Deleting the record would strand the collision: once an operator removes
+   * the legacy file, no later scan can rediscover the mapping, so references
+   * still naming the legacy id would never be rewritten. Optional so a journal
+   * written by an older build still parses.
+   */
+  blocked: z.record(z.string().min(1)).optional(),
 });
 
 type EntityCanonicalIdMigrationState = z.infer<typeof EntityCanonicalIdMigrationStateSchema>;
@@ -840,12 +848,31 @@ export async function migrateLegacyEntityCanonicalIds(
        */
       const pruneBlocked = async (): Promise<void> => {
         const current = state;
-        if (blocked.size === 0 || !current) return;
-        const remaining: Record<string, string> = Object.fromEntries(
-          Object.entries(current.mappings).filter(([legacyId]) => !blocked.has(legacyId)),
-        );
-        if (Object.keys(remaining).length === Object.keys(current.mappings).length) return;
-        state = { ...current, mappings: remaining };
+        if (!current) return;
+        const remaining: Record<string, string> = {};
+        const parked: Record<string, string> = { ...(current.blocked ?? {}) };
+        for (const [legacyId, canonicalId] of Object.entries(current.mappings)) {
+          if (blocked.has(legacyId)) parked[legacyId] = canonicalId;
+          else remaining[legacyId] = canonicalId;
+        }
+        for (const [legacyId, canonicalId] of blocked) parked[legacyId] ??= canonicalId;
+        // A parked pair whose legacy file is gone was resolved by the operator
+        // keeping the canonical side. The rename no longer needs doing, but the
+        // REWRITE does - references still name the legacy id, and this record
+        // is the only thing that can still map them.
+        for (const [legacyId, canonicalId] of Object.entries(parked)) {
+          if (blocked.has(legacyId)) continue;
+          const legacyPath = deps.resolveEntityFilePath(legacyId);
+          if (legacyPath !== null && (await fileExists(legacyPath))) continue;
+          remaining[legacyId] = canonicalId;
+          delete parked[legacyId];
+        }
+        const sameMappings = Object.keys(remaining).length === Object.keys(current.mappings).length
+          && Object.entries(remaining).every(([legacyId, canonicalId]) => current.mappings[legacyId] === canonicalId);
+        const samePark = Object.keys(parked).length === Object.keys(current.blocked ?? {}).length
+          && Object.entries(parked).every(([legacyId, canonicalId]) => current.blocked?.[legacyId] === canonicalId);
+        if (sameMappings && samePark) return;
+        state = { ...current, mappings: remaining, blocked: parked };
         await writeState(deps, state);
       };
       const previousMappings = state.mappings;

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -875,6 +875,14 @@ export async function migrateLegacyEntityCanonicalIds(
         // this record is the only thing that can still perform it.
         for (const [legacyId, canonicalId] of Object.entries(parked)) {
           if (blocked.has(legacyId)) continue;
+          // This scan found a real migration for the same legacy id, so the
+          // park is obsolete - and must not be revived over it. After the file
+          // moves, its absence would otherwise read as operator resolution and
+          // restore the stale target on top of the live one.
+          if (active[legacyId] !== undefined) {
+            delete parked[legacyId];
+            continue;
+          }
           const legacyPath = deps.resolveEntityFilePath(legacyId);
           if (legacyPath !== null && (await fileExists(legacyPath))) continue;
           active[legacyId] = canonicalId;

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -675,7 +675,19 @@ function mergeDiscoveredMappings(
   for (const [legacyId, canonicalId] of Object.entries(discovered)) {
     const previousMapping = merged[legacyId];
     if (previousMapping !== undefined && previousMapping !== canonicalId) {
-      throw new Error(`Legacy entity id ${legacyId} changed canonical target during migration.`);
+      // A -> B collapses to A -> C once B -> C exists, so a rescan that still
+      // reads A -> B off disk is reporting the same chain, not a new target.
+      // Only a target the chain cannot reach is a real conflict.
+      let hop: string | undefined = canonicalId;
+      const seen = new Set<string>();
+      while (hop !== undefined && hop !== previousMapping && !seen.has(hop)) {
+        seen.add(hop);
+        hop = merged[hop];
+      }
+      if (hop !== previousMapping) {
+        throw new Error(`Legacy entity id ${legacyId} changed canonical target during migration.`);
+      }
+      continue;
     }
     if (previousMapping === undefined && wouldCreateMappingCycle(merged, legacyId, canonicalId)) continue;
     const previousOwner = canonicalOwners.get(canonicalId);
@@ -860,6 +872,17 @@ export async function migrateLegacyEntityCanonicalIds(
         // keeping the canonical side. The rename no longer needs doing, but the
         // REWRITE does - references still name the legacy id, and this record
         // is the only thing that can still map them.
+        // Follow the chain: parking A -> B while B -> C migrates in the same
+        // run would leave the park pointing at an id that no longer exists.
+        for (const [legacyId, canonicalId] of Object.entries(parked)) {
+          let hop = canonicalId;
+          const seen = new Set<string>([legacyId]);
+          while (remaining[hop] !== undefined && !seen.has(hop)) {
+            seen.add(hop);
+            hop = remaining[hop];
+          }
+          parked[legacyId] = hop;
+        }
         for (const [legacyId, canonicalId] of Object.entries(parked)) {
           if (blocked.has(legacyId)) continue;
           const legacyPath = deps.resolveEntityFilePath(legacyId);

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -861,41 +861,40 @@ export async function migrateLegacyEntityCanonicalIds(
       const pruneBlocked = async (): Promise<void> => {
         const current = state;
         if (!current) return;
-        const remaining: Record<string, string> = {};
+        // THIS scan's verdict wins over the journal: normalization can change
+        // between runs, so a stale parked target would otherwise be promoted
+        // later and rewrite references onto an id that does not exist.
         const parked: Record<string, string> = { ...(current.blocked ?? {}) };
+        const active: Record<string, string> = {};
         for (const [legacyId, canonicalId] of Object.entries(current.mappings)) {
-          if (blocked.has(legacyId)) parked[legacyId] = canonicalId;
-          else remaining[legacyId] = canonicalId;
+          if (!blocked.has(legacyId)) active[legacyId] = canonicalId;
         }
-        for (const [legacyId, canonicalId] of blocked) parked[legacyId] ??= canonicalId;
-        // A parked pair whose legacy file is gone was resolved by the operator
-        // keeping the canonical side. The rename no longer needs doing, but the
-        // REWRITE does - references still name the legacy id, and this record
-        // is the only thing that can still map them.
-        // Follow the chain: parking A -> B while B -> C migrates in the same
-        // run would leave the park pointing at an id that no longer exists.
-        for (const [legacyId, canonicalId] of Object.entries(parked)) {
-          let hop = canonicalId;
-          const seen = new Set<string>([legacyId]);
-          while (remaining[hop] !== undefined && !seen.has(hop)) {
-            seen.add(hop);
-            hop = remaining[hop];
-          }
-          parked[legacyId] = hop;
-        }
+        for (const [legacyId, canonicalId] of blocked) parked[legacyId] = canonicalId;
+        // A parked pair whose legacy file is gone was resolved by keeping the
+        // canonical side. The rename is moot; the reference rewrite is not, and
+        // this record is the only thing that can still perform it.
         for (const [legacyId, canonicalId] of Object.entries(parked)) {
           if (blocked.has(legacyId)) continue;
           const legacyPath = deps.resolveEntityFilePath(legacyId);
           if (legacyPath !== null && (await fileExists(legacyPath))) continue;
-          remaining[legacyId] = canonicalId;
+          active[legacyId] = canonicalId;
           delete parked[legacyId];
         }
-        const sameMappings = Object.keys(remaining).length === Object.keys(current.mappings).length
-          && Object.entries(remaining).every(([legacyId, canonicalId]) => current.mappings[legacyId] === canonicalId);
-        const samePark = Object.keys(parked).length === Object.keys(current.blocked ?? {}).length
-          && Object.entries(parked).every(([legacyId, canonicalId]) => current.blocked?.[legacyId] === canonicalId);
-        if (sameMappings && samePark) return;
-        state = { ...current, mappings: remaining, blocked: parked };
+        // Reviving a whole chain at once yields A -> B -> C, and each rewrite
+        // surface makes a different number of passes over it - so collapse
+        // transitively before anything consumes the set.
+        const collapsed = collapseMappings(active);
+        // Parked targets follow ACTIVE moves only: hopping over a still-blocked
+        // link would jump to an id the migration has not been allowed to reach.
+        for (const [legacyId, canonicalId] of Object.entries(parked)) {
+          const moved = collapsed[canonicalId];
+          if (moved !== undefined && moved !== legacyId) parked[legacyId] = moved;
+        }
+        const same = (a: Record<string, string>, b: Record<string, string>): boolean =>
+          Object.keys(a).length === Object.keys(b).length
+          && Object.entries(a).every(([key, value]) => b[key] === value);
+        if (same(collapsed, current.mappings) && same(parked, current.blocked ?? {})) return;
+        state = { ...current, mappings: collapsed, blocked: parked };
         await writeState(deps, state);
       };
       const previousMappings = state.mappings;

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -948,7 +948,12 @@ export async function migrateLegacyEntityCanonicalIds(
             state.mappings,
             await discoverMappings(deps, state.mappings, blocked),
           );
-          if (Object.keys(discoveredAfter).length === 0) {
+          // Reconcile before declaring completion: this rescan can resolve a
+          // park (another writer removed the legacy file), and completing
+          // without promoting it strands its references behind a fingerprint
+          // that already reflects the deletion - so no later run revisits it.
+          await pruneBlocked();
+          if (Object.keys(discoveredAfter).length === 0 && Object.keys(state.mappings).length === 0) {
             await writeState(deps, { ...state, complete: true });
             return finish();
           }

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -371,3 +371,51 @@ test("a park is dropped once its source needs no migration", async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("a park whose legacy file is already gone still rewrites references", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-rescan-park-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const legacy = normalizeEntityName("Weekly Report", "automation");
+    const canonical = normalizeEntityName("Weekly Report", "automation-cron-job");
+    await writeFile(
+      path.join(dir, "entities", `${canonical}.md`),
+      `---\nid: ${canonical}\ncreated: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n---\n\n`
+      + `# Weekly Report\n\n**Type:** automation-cron-job\n\nRuns Mondays.\n`,
+      "utf8",
+    );
+    // The legacy file is already gone (resolved out of band) while the journal
+    // still parks the pair and holds no active mappings - the zero-mapping
+    // path. Completing without reconciling would seal the park behind a
+    // fingerprint that already covers the deletion, so no later run revisits
+    // it. This pins the observable contract; the mid-run race (resolution
+    // landing BETWEEN the initial scan and the rescan) is covered by the
+    // reconcile call in that branch but is not drivable from a test.
+    await writeFile(
+      path.join(dir, "state", "entity-canonical-id-migration-v1.json"),
+      JSON.stringify({ version: 1, complete: false, mappings: {}, blocked: { [legacy]: canonical } }),
+      "utf8",
+    );
+    const factDir = path.join(dir, "facts", "2026-03-01");
+    await mkdir(factDir, { recursive: true });
+    const factPath = path.join(factDir, "fact-rescan-park.md");
+    await writeFile(
+      factPath,
+      `---\nid: fact-rescan-park\ncategory: fact\nconfidence: 0.9\n`
+      + `created: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n`
+      + `entityRef: ${legacy}\nstatus: active\n---\n\nThe report runs weekly.\n`,
+      "utf8",
+    );
+
+    await new StorageManager(dir).ensureDirectories();
+
+    assert.equal(
+      /^entityRef: (.*)$/m.exec(await readFile(factPath, "utf8"))?.[1],
+      canonical,
+      "a park resolved before completion must still rewrite its references",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -167,3 +167,34 @@ test("a mapping persisted by an earlier run cannot outvote a later block", async
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("resolving a collision lets the pair migrate, references included", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-unblocked-"));
+  try {
+    const { legacy, canonical } = await seedCollidingPair(dir);
+    const factDir = path.join(dir, "facts", "2026-03-01");
+    await mkdir(factDir, { recursive: true });
+    const factPath = path.join(factDir, "fact-unblocked.md");
+    await writeFile(
+      factPath,
+      `---\nid: fact-unblocked\ncategory: fact\nconfidence: 0.9\n`
+      + `created: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n`
+      + `entityRef: ${legacy}\nstatus: active\n---\n\nThe ingest runs nightly.\n`,
+      "utf8",
+    );
+    await new StorageManager(dir).ensureDirectories();
+    assert.match(await readFile(factPath, "utf8"), new RegExp(`entityRef: ${legacy}`), "blocked while contested");
+
+    // The operator resolves it the documented way: one side goes.
+    await rm(path.join(dir, "entities", `${canonical}.md`));
+    await new StorageManager(dir).ensureDirectories();
+
+    // A stale block must not survive the resolution: the file moves AND the
+    // reference follows it, or memories point at a filename that is gone.
+    await assert.rejects(() => readFile(path.join(dir, "entities", `${legacy}.md`), "utf8"));
+    assert.match(await readFile(path.join(dir, "entities", `${canonical}.md`), "utf8"), /Runs at 02:00\./);
+    assert.match(await readFile(factPath, "utf8"), new RegExp(`entityRef: ${canonical}`));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -272,3 +272,50 @@ test("a re-normalized collision replaces the journal's stale target", async () =
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("a stale park never outranks a migration this scan discovered", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-stale-vs-active-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const legacy = normalizeEntityName("Weekly Report", "automation");
+    const canonical = normalizeEntityName("Weekly Report", "automation-cron-job");
+    const stale = "automation-cron-job-obsolete-report";
+    // No collision this time: the pair migrates cleanly. The journal's parked
+    // entry is left over from an earlier normalization and must not resurrect
+    // once the rename makes the legacy filename disappear.
+    await writeFile(
+      path.join(dir, "entities", `${legacy}.md`),
+      `---\nid: ${legacy}\ncreated: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n---\n\n`
+      + `# Weekly Report\n\n**Type:** automation-cron-job\n\nRuns Mondays.\n`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(dir, "state", "entity-canonical-id-migration-v1.json"),
+      JSON.stringify({ version: 1, complete: false, mappings: {}, blocked: { [legacy]: stale } }),
+      "utf8",
+    );
+    const factDir = path.join(dir, "facts", "2026-03-01");
+    await mkdir(factDir, { recursive: true });
+    const factPath = path.join(factDir, "fact-active-wins.md");
+    await writeFile(
+      factPath,
+      `---\nid: fact-active-wins\ncategory: fact\nconfidence: 0.9\n`
+      + `created: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n`
+      + `entityRef: ${legacy}\nstatus: active\n---\n\nThe report runs weekly.\n`,
+      "utf8",
+    );
+
+    await new StorageManager(dir).ensureDirectories();
+    await new StorageManager(dir).ensureDirectories();
+
+    assert.match(await readFile(path.join(dir, "entities", `${canonical}.md`), "utf8"), /Runs Mondays\./);
+    assert.equal(
+      /^entityRef: (.*)$/m.exec(await readFile(factPath, "utf8"))?.[1],
+      canonical,
+      "the live migration target must win over a leftover parked one",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -234,3 +234,41 @@ test("deleting the legacy side still rewrites references to the canonical id", a
   }
 });
 
+
+test("a re-normalized collision replaces the journal's stale target", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-stale-target-"));
+  try {
+    const { legacy, canonical } = await seedCollidingPair(dir);
+    const stale = "automation-cron-job-obsolete-target";
+    // The journal remembers a target from before a normalization change. The
+    // pair is contested NOW against `canonical`, so that is the only target
+    // that may ever be promoted — the stale one names no file on disk.
+    await writeFile(
+      path.join(dir, "state", "entity-canonical-id-migration-v1.json"),
+      JSON.stringify({ version: 1, complete: false, mappings: {}, blocked: { [legacy]: stale } }),
+      "utf8",
+    );
+    const factDir = path.join(dir, "facts", "2026-03-01");
+    await mkdir(factDir, { recursive: true });
+    const factPath = path.join(factDir, "fact-stale-target.md");
+    await writeFile(
+      factPath,
+      `---\nid: fact-stale-target\ncategory: fact\nconfidence: 0.9\n`
+      + `created: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n`
+      + `entityRef: ${legacy}\nstatus: active\n---\n\nThe ingest runs nightly.\n`,
+      "utf8",
+    );
+
+    await new StorageManager(dir).ensureDirectories();
+    await rm(path.join(dir, "entities", `${legacy}.md`));
+    await new StorageManager(dir).ensureDirectories();
+
+    assert.equal(
+      /^entityRef: (.*)$/m.exec(await readFile(factPath, "utf8"))?.[1],
+      canonical,
+      "promotion must use the collision detected on disk, not a stale journal target",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -158,9 +158,9 @@ test("a mapping persisted by an earlier run cannot outvote a later block", async
     assert.match(await readFile(path.join(dir, "entities", `${firstLegacy}.md`), "utf8"), /First\./);
     assert.match(await readFile(path.join(dir, "entities", `${secondLegacy}.md`), "utf8"), /Second\./);
     await assert.rejects(() => readFile(path.join(dir, "entities", `${canonicalId}.md`), "utf8"));
-    assert.match(
-      await readFile(path.join(factDir, "fact-contested.md"), "utf8"),
-      new RegExp(`entityRef: ${firstLegacy}`),
+    assert.equal(
+      /^entityRef: (.*)$/m.exec(await readFile(path.join(factDir, "fact-contested.md"), "utf8"))?.[1],
+      firstLegacy,
       "a blocked pair must not have its references redirected to the contested canonical id",
     );
   } finally {
@@ -183,7 +183,9 @@ test("resolving a collision lets the pair migrate, references included", async (
       "utf8",
     );
     await new StorageManager(dir).ensureDirectories();
-    assert.match(await readFile(factPath, "utf8"), new RegExp(`entityRef: ${legacy}`), "blocked while contested");
+    assert.equal(
+      /^entityRef: (.*)$/m.exec(await readFile(factPath, "utf8"))?.[1], legacy, "blocked while contested",
+    );
 
     // The operator resolves it the documented way: one side goes.
     await rm(path.join(dir, "entities", `${canonical}.md`));
@@ -193,7 +195,7 @@ test("resolving a collision lets the pair migrate, references included", async (
     // reference follows it, or memories point at a filename that is gone.
     await assert.rejects(() => readFile(path.join(dir, "entities", `${legacy}.md`), "utf8"));
     assert.match(await readFile(path.join(dir, "entities", `${canonical}.md`), "utf8"), /Runs at 02:00\./);
-    assert.match(await readFile(factPath, "utf8"), new RegExp(`entityRef: ${canonical}`));
+    assert.equal(/^entityRef: (.*)$/m.exec(await readFile(factPath, "utf8"))?.[1], canonical);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -221,12 +223,14 @@ test("deleting the legacy side still rewrites references to the canonical id", a
     await rm(path.join(dir, "entities", `${legacy}.md`));
     await new StorageManager(dir).ensureDirectories();
 
-    assert.match(
-      await readFile(factPath, "utf8"),
-      new RegExp(`entityRef: ${canonical}`),
+    const rewritten = await readFile(factPath, "utf8");
+    assert.equal(
+      /^entityRef: (.*)$/m.exec(rewritten)?.[1],
+      canonical,
       "a reference must not be stranded on a legacy id whose file was removed",
     );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
 });
+

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -198,3 +198,35 @@ test("resolving a collision lets the pair migrate, references included", async (
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("deleting the legacy side still rewrites references to the canonical id", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-legacy-deleted-"));
+  try {
+    const { legacy, canonical } = await seedCollidingPair(dir);
+    const factDir = path.join(dir, "facts", "2026-03-01");
+    await mkdir(factDir, { recursive: true });
+    const factPath = path.join(factDir, "fact-legacy-side.md");
+    await writeFile(
+      factPath,
+      `---\nid: fact-legacy-side\ncategory: fact\nconfidence: 0.9\n`
+      + `created: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n`
+      + `entityRef: ${legacy}\nstatus: active\n---\n\nThe ingest runs nightly.\n`,
+      "utf8",
+    );
+    await new StorageManager(dir).ensureDirectories();
+
+    // The other documented resolution: keep the canonical file, drop the legacy
+    // one. No later scan can rediscover the pair — the legacy filename is gone
+    // — so the parked record is the only thing that can still fix references.
+    await rm(path.join(dir, "entities", `${legacy}.md`));
+    await new StorageManager(dir).ensureDirectories();
+
+    assert.match(
+      await readFile(factPath, "utf8"),
+      new RegExp(`entityRef: ${canonical}`),
+      "a reference must not be stranded on a legacy id whose file was removed",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -319,3 +319,55 @@ test("a stale park never outranks a migration this scan discovered", async () =>
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("a park is dropped once its source needs no migration", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-self-canonical-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const selfCanonical = normalizeEntityName("Nightly Ingest", "automation");
+    const stale = "automation-cron-job-nightly-ingest";
+    // Under the current normalization this file IS its own canonical id, so the
+    // scan reports neither a mapping nor a collision. A park left from an older
+    // normalization must not survive that silence.
+    await writeFile(
+      path.join(dir, "entities", `${selfCanonical}.md`),
+      `---\nid: ${selfCanonical}\ncreated: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n---\n\n`
+      + `# Nightly Ingest\n\n**Type:** automation\n\nRuns at 02:00.\n`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(dir, "entities", `${stale}.md`),
+      `---\nid: ${stale}\ncreated: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n---\n\n`
+      + `# Nightly Ingest\n\n**Type:** automation-cron-job\n\nAn unrelated entity.\n`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(dir, "state", "entity-canonical-id-migration-v1.json"),
+      JSON.stringify({ version: 1, complete: false, mappings: {}, blocked: { [selfCanonical]: stale } }),
+      "utf8",
+    );
+    const factDir = path.join(dir, "facts", "2026-03-01");
+    await mkdir(factDir, { recursive: true });
+    const factPath = path.join(factDir, "fact-self-canonical.md");
+    await writeFile(
+      factPath,
+      `---\nid: fact-self-canonical\ncategory: fact\nconfidence: 0.9\n`
+      + `created: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n`
+      + `entityRef: ${selfCanonical}\nstatus: active\n---\n\nThe ingest runs nightly.\n`,
+      "utf8",
+    );
+
+    await new StorageManager(dir).ensureDirectories();
+    await rm(path.join(dir, "entities", `${selfCanonical}.md`));
+    await new StorageManager(dir).ensureDirectories();
+
+    assert.equal(
+      /^entityRef: (.*)$/m.exec(await readFile(factPath, "utf8"))?.[1],
+      selfCanonical,
+      "deleting a self-canonical entity must not redirect its references to an unrelated one",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+
+import { StorageManager, normalizeEntityName } from "../packages/remnic-core/src/storage.js";
+
+/**
+ * A legacy entity file and its canonical successor can both exist with
+ * DIFFERENT content — two files describing one entity is an ordinary operator
+ * state. The canonical-id migration runs during directory initialization, so
+ * throwing on that collision took the whole daemon down at boot, on every
+ * restart, with no remediation path (AGENTS.md §37, batch renames with
+ * duplicate targets).
+ */
+async function seedCollidingPair(dir: string): Promise<{ legacy: string; canonical: string }> {
+  const storage = new StorageManager(dir);
+  await storage.ensureDirectories();
+  const name = "Nightly Ingest";
+  // The production shape: the file KEEPS its old id as a filename while the
+  // `Type:` inside was retyped, so the legacy file now normalizes onto an id
+  // that a different file already owns.
+  const legacyId = normalizeEntityName(name, "automation");
+  const canonicalId = normalizeEntityName(name, "automation-cron-job");
+  assert.notEqual(legacyId, canonicalId, "fixture must actually straddle the rename");
+  const file = (heading: string, type: string, body: string) =>
+    `---\nid: ${heading}\ncreated: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n---\n\n`
+    + `# ${name}\n\n**Type:** ${type}\n\n${body}\n`;
+  await writeFile(
+    path.join(dir, "entities", `${legacyId}.md`),
+    file(legacyId, "automation-cron-job", "Runs at 02:00."),
+    "utf8",
+  );
+  await writeFile(
+    path.join(dir, "entities", `${canonicalId}.md`),
+    file(canonicalId, "automation-cron-job", "Runs at 02:00. Retries twice."),
+    "utf8",
+  );
+  return { legacy: legacyId, canonical: canonicalId };
+}
+
+test("a legacy/canonical entity collision does not abort startup", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-collision-"));
+  try {
+    const { legacy, canonical } = await seedCollidingPair(dir);
+    // The reproduction: this used to reject with
+    // "Cannot migrate legacy entity id ...: ... already exists." and exit 1.
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    // Neither side is destroyed — the migration must never pick a winner.
+    const legacyBody = await readFile(path.join(dir, "entities", `${legacy}.md`), "utf8");
+    const canonicalBody = await readFile(path.join(dir, "entities", `${canonical}.md`), "utf8");
+    assert.match(legacyBody, /Runs at 02:00\./);
+    assert.match(canonicalBody, /Retries twice\./);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a blocked collision does not stall the rest of the migration", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-collision-mixed-"));
+  try {
+    await seedCollidingPair(dir);
+    // A second legacy entity with NO canonical counterpart must still migrate.
+    const soloLegacy = normalizeEntityName("Weekly Report", "automation");
+    const soloCanonical = normalizeEntityName("Weekly Report", "automation-cron-job");
+    await writeFile(
+      path.join(dir, "entities", `${soloLegacy}.md`),
+      `---\nid: ${soloLegacy}\ncreated: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n---\n\n`
+      + `# Weekly Report\n\n**Type:** automation-cron-job\n\nRuns Mondays.\n`,
+      "utf8",
+    );
+
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const migrated = await readFile(path.join(dir, "entities", `${soloCanonical}.md`), "utf8");
+    assert.match(migrated, /Runs Mondays\./, "an unblocked pair must still reach its canonical id");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("two legacy files claiming one canonical id block each other, deterministically", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-contested-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const canonicalId = normalizeEntityName("Nightly Ingest", "automation-cron-job");
+    const claimants = ["automation-nightly-ingest", "automation-legacy-nightly-ingest"];
+    for (const [i, legacyId] of claimants.entries()) {
+      await writeFile(
+        path.join(dir, "entities", `${legacyId}.md`),
+        `---\nid: ${legacyId}\ncreated: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n---\n\n`
+        + `# Nightly Ingest\n\n**Type:** automation-cron-job\n\nClaimant ${i}.\n`,
+        "utf8",
+      );
+    }
+
+    await new StorageManager(dir).ensureDirectories();
+
+    // Neither may win: readdir order is not stable, so letting one claim the
+    // canonical id would canonicalize a DIFFERENT side on another host reading
+    // identical data (§6). Both stay put until an operator merges them.
+    for (const [i, legacyId] of claimants.entries()) {
+      assert.match(
+        await readFile(path.join(dir, "entities", `${legacyId}.md`), "utf8"),
+        new RegExp(`Claimant ${i}\\.`),
+      );
+    }
+    await assert.rejects(() => readFile(path.join(dir, "entities", `${canonicalId}.md`), "utf8"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 
 import { StorageManager, normalizeEntityName } from "../packages/remnic-core/src/storage.js";
 
@@ -78,6 +78,8 @@ test("a blocked collision does not stall the rest of the migration", async () =>
 
     const migrated = await readFile(path.join(dir, "entities", `${soloCanonical}.md`), "utf8");
     assert.match(migrated, /Runs Mondays\./, "an unblocked pair must still reach its canonical id");
+    // A copy that leaves the legacy file behind is not a migration.
+    await assert.rejects(() => readFile(path.join(dir, "entities", `${soloLegacy}.md`), "utf8"));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -111,6 +113,56 @@ test("two legacy files claiming one canonical id block each other, deterministic
       );
     }
     await assert.rejects(() => readFile(path.join(dir, "entities", `${canonicalId}.md`), "utf8"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a mapping persisted by an earlier run cannot outvote a later block", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-stale-mapping-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const canonicalId = normalizeEntityName("Nightly Ingest", "automation-cron-job");
+    const firstLegacy = "automation-nightly-ingest";
+    const secondLegacy = "automation-legacy-nightly-ingest";
+    const entity = (id: string, body: string) =>
+      `---\nid: ${id}\ncreated: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n---\n\n`
+      + `# Nightly Ingest\n\n**Type:** automation-cron-job\n\n${body}\n`;
+    await writeFile(path.join(dir, "entities", `${firstLegacy}.md`), entity(firstLegacy, "First."), "utf8");
+    await writeFile(path.join(dir, "entities", `${secondLegacy}.md`), entity(secondLegacy, "Second."), "utf8");
+    // Journal from a build that had already chosen a winner. Discovery refuses
+    // to ADD a contested pair; the persisted entry must be dropped too, or the
+    // stale state picks the winner that disk-only discovery declined to pick.
+    await writeFile(
+      path.join(dir, "state", "entity-canonical-id-migration-v1.json"),
+      JSON.stringify({ version: 1, complete: true, mappings: { [firstLegacy]: canonicalId } }),
+      "utf8",
+    );
+
+    // The damage is not to the entity files - the completed-state path leaves
+    // those alone and rewrites REFERENCES, silently pointing memories at the
+    // canonical file, i.e. choosing the winner while both files sit preserved.
+    const factDir = path.join(dir, "facts", "2026-03-01");
+    await mkdir(factDir, { recursive: true });
+    await writeFile(
+      path.join(factDir, "fact-contested.md"),
+      `---\nid: fact-contested\ncategory: fact\nconfidence: 0.9\n`
+      + `created: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n`
+      + `entityRef: ${firstLegacy}\nstatus: active\n---\n\nThe ingest runs nightly.\n`,
+      "utf8",
+    );
+
+    await new StorageManager(dir).ensureDirectories();
+
+    assert.match(await readFile(path.join(dir, "entities", `${firstLegacy}.md`), "utf8"), /First\./);
+    assert.match(await readFile(path.join(dir, "entities", `${secondLegacy}.md`), "utf8"), /Second\./);
+    await assert.rejects(() => readFile(path.join(dir, "entities", `${canonicalId}.md`), "utf8"));
+    assert.match(
+      await readFile(path.join(factDir, "fact-contested.md"), "utf8"),
+      new RegExp(`entityRef: ${firstLegacy}`),
+      "a blocked pair must not have its references redirected to the contested canonical id",
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/entity-synthesis-storage.test.ts
+++ b/tests/entity-synthesis-storage.test.ts
@@ -879,7 +879,7 @@ test("ensureDirectories migrates legacy filenames after display-name normalizati
   }
 });
 
-test("ensureDirectories rejects duplicate canonical targets before migration", async () => {
+test("ensureDirectories skips duplicate canonical targets instead of aborting", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-duplicate-canonical-target-"));
   try {
     const composedName = "Café";
@@ -905,11 +905,12 @@ test("ensureDirectories rejects duplicate canonical targets before migration", a
       "utf-8",
     );
     await rm(path.join(dir, "state", "entity-canonical-id-migration-v1.json"));
+    // Two legacy files normalizing onto one canonical id is an ordinary data
+    // state the migration cannot disambiguate. It must refuse to PICK — never
+    // refuse to BOOT: this ran during directory initialization, so throwing
+    // took the daemon down on every restart with no way out.
     const migrating = new StorageManager(dir);
-    await assert.rejects(
-      () => migrating.ensureDirectories(),
-      /both normalize to project-café/,
-    );
+    await migrating.ensureDirectories();
     assert.match(await readFile(path.join(dir, "entities", `${firstLegacy}.md`), "utf-8"), /# Café/);
     assert.match(
       await readFile(path.join(dir, "entities", `${secondLegacy}.md`), "utf-8"),


### PR DESCRIPTION
Closes #2179

The canonical-id migration runs inside `ensureDirectories()`, so a collision it cannot resolve does not fail the migration — it fails the **boot**, on every restart, permanently.

## What changes

- A legacy/canonical pair with different content is **skipped**, both files kept. The legacy id resolves exactly as before the migration ran, so this is the status quo rather than a regression.
- Every other entity still migrates; one bad pair no longer stalls the batch.
- A canonical id claimed by 2+ legacy files blocks **all** claimants. Letting the first win makes the winner depend on `readdir` order (§6) — two hosts with identical data could canonicalize different sides.
- One aggregated warning per run lists the skipped pairs and the remedy, instead of one fatal line per restart.

## Deliberately unchanged

Malformed entity files (missing name heading or type) still throw. That is unreadable data, not an ambiguous choice between two valid files.

## Behavior change to an existing test

`ensureDirectories rejects duplicate canonical targets before migration` asserted the boot-killing behavior for the sibling case. It is updated, not deleted: same data guarantees (both legacy files preserved, canonical absent), minus the process exit.

## Verification

- New `tests/entity-canonical-id-collision.test.ts` reproduces the production error string and **fails against the old code** (verified by reverting the fix).
- `tests/entity-synthesis-storage.test.ts` 96/96, migration-runner suite green, `preflight:quick` OK, ratchets OK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches boot-time migration, on-disk journal state, and memory/entity reference rewrites; logic is intricate but heavily tested and avoids silent winner-picking on collisions.
> 
> **Overview**
> Entity canonical-id migration during `ensureDirectories()` **no longer throws** when it hits ambiguous collisions. Instead it **skips** those pairs, keeps both entity files, logs **one aggregated warning**, and continues migrating everything else.
> 
> **Skipped cases:** legacy vs canonical files with **different content**, and **multiple legacy files** normalizing to the same canonical id (all claimants blocked so no `readdir`-order winner). Migration journal gains optional **`blocked`** parked pairs; **`pruneBlocked`** drops stale mappings, promotes resolved parks for reference rewrites, and avoids completing while a park still needs work. **`mergeDiscoveredMappings`** treats equivalent mapping chains as non-conflicts.
> 
> Malformed entity files still fail boot. New collision tests and an updated synthesis test expect **boot success** with both legacy files preserved where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aed6fa43ea891524586de4d28f09d706c28ea38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented startup aborts during initialization when legacy entity IDs collide with existing canonical IDs.
  * When collisions are ambiguous or unresolvable, both files are kept and a single aggregated warning is emitted.
  * Continued initialization even with multiple legacy claimants for the same canonical target, skipping contested mappings; avoided incorrect reference rewrites until resolved.
* **Tests**
  * Added/updated coverage for collision scenarios, including multiple claimants, stale journal state, and recovery after manual deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->