### PR TITLE
feat(plugin-pi): circuit-break automatic recalls after repeated timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Recall-timeout circuit breaker for the Pi plugin's automatic between-tool
+  context recalls (`packages/plugin-pi`). When `recallTimeoutThreshold` (default
+  `7`) of the last `recallTimeoutWindow` (default `10`) recall calls fail with an
+  explicit request timeout, automatic recall is disabled for the remainder of the
+  process: subsequent calls are neither retried nor awaited, in-flight recalls are
+  aborted, and the session status reports that recall is off until restart. The
+  breaker is in-memory, never re-enables itself after a cooldown, and adds no
+  latency on the healthy path. Only explicit request timeouts count toward
+  tripping; other failures still occupy window slots so stale timeouts age out.
+
 ## [v9.8.0] — 2026-07-21
 
 ### Added

--- a/packages/plugin-pi/README.md
+++ b/packages/plugin-pi/README.md
@@ -87,6 +87,8 @@ Supported config keys:
 | `statusEnabled` | `true` | Set Pi UI status from daemon health |
 | `requestTimeoutMs` | `60000` | HTTP/MCP request timeout for recall/observe/compaction/commands |
 | `startupRequestTimeoutMs` | `1000` | Shorter timeout for startup-sensitive probes (MCP `tools/list` registration and the `session_start` health/status check) so a slow or offline daemon can't stall Pi boot |
+| `recallTimeoutThreshold` | `7` | Permanently disable recall after this many explicit recall timeouts within the rolling window |
+| `recallTimeoutWindow` | `10` | Number of most recent recall calls included in the rolling timeout window |
 
 Boolean-like strings such as `"false"`, `"0"`, `"no"`, and `"off"` are treated as false.
 
@@ -107,7 +109,9 @@ Example:
   "mcpToolsEnabled": true,
   "statusEnabled": true,
   "requestTimeoutMs": 60000,
-  "startupRequestTimeoutMs": 1000
+  "startupRequestTimeoutMs": 1000,
+  "recallTimeoutThreshold": 7,
+  "recallTimeoutWindow": 10
 }
 ```
 

--- a/packages/plugin-pi/README.md
+++ b/packages/plugin-pi/README.md
@@ -87,8 +87,8 @@ Supported config keys:
 | `statusEnabled` | `true` | Set Pi UI status from daemon health |
 | `requestTimeoutMs` | `60000` | HTTP/MCP request timeout for recall/observe/compaction/commands |
 | `startupRequestTimeoutMs` | `1000` | Shorter timeout for startup-sensitive probes (MCP `tools/list` registration and the `session_start` health/status check) so a slow or offline daemon can't stall Pi boot |
-| `recallTimeoutThreshold` | `7` | Permanently disable recall after this many explicit recall timeouts within the rolling window |
-| `recallTimeoutWindow` | `10` | Number of most recent recall calls included in the rolling timeout window |
+| `recallTimeoutThreshold` | `7` | Permanently disable recall after this many explicit recall timeouts within the rolling window; must be a positive integer no greater than `recallTimeoutWindow` |
+| `recallTimeoutWindow` | `10` | Number of most recent recall calls included in the rolling timeout window; must be a positive integer at least `recallTimeoutThreshold`. Invalid settings fail config loading. |
 
 Boolean-like strings such as `"false"`, `"0"`, `"no"`, and `"off"` are treated as false.
 

--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { RemnicClient, RemnicHttpError, chunkObservePayload, isTransientNetworkError, type ObserveMessage } from "./client.js";
+import {
+  RemnicClient,
+  RemnicHttpError,
+  RemnicRequestAbortedError,
+  chunkObservePayload,
+  isTransientNetworkError,
+  type ObserveMessage,
+} from "./client.js";
 import type { RemnicPiConfig } from "./config.js";
 
 test("RemnicClient reports request timeouts with actionable context", async (t) => {
@@ -40,7 +47,18 @@ test("RemnicClient allows startup callers to use a shorter timeout", async (t) =
   );
 });
 
-test("RemnicClient ignores a non-positive timeout override and uses the general budget", async (t) => {
+test("RemnicClient rejects invalid timeout overrides", async () => {
+  const client = new RemnicClient(baseConfig());
+
+  for (const timeoutMs of [0, -1, Number.NaN, 1.5]) {
+    await assert.rejects(
+      () => client.health({ timeoutMs }),
+      /Request timeoutMs must be a positive integer/,
+    );
+  }
+});
+
+test("RemnicClient forwards caller aborts to MCP tool requests", async (t) => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (_input, init) =>
     new Promise<Response>((_resolve, reject) => {
@@ -50,13 +68,17 @@ test("RemnicClient ignores a non-positive timeout override and uses the general 
     globalThis.fetch = originalFetch;
   });
 
-  const client = new RemnicClient({ ...baseConfig(), requestTimeoutMs: 7 });
+  const controller = new AbortController();
+  const client = new RemnicClient({ ...baseConfig(), requestTimeoutMs: 100 });
+  const request = client.mcpTool("remnic.recall", {}, { signal: controller.signal });
+  controller.abort();
 
-  // A 0/negative/NaN override would make setTimeout abort immediately; the client
-  // must reject it and fall back to requestTimeoutMs (reported as 7ms here).
   await assert.rejects(
-    () => client.health({ timeoutMs: 0 }),
-    /Remnic request timed out after 7ms/,
+    () => request,
+    (err) => {
+      assert.ok(err instanceof RemnicRequestAbortedError);
+      return true;
+    },
   );
 });
 

--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -82,6 +82,32 @@ test("RemnicClient forwards caller aborts to MCP tool requests", async (t) => {
   );
 });
 
+test("RemnicClient forwards caller aborts to observe requests", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })));
+    });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const controller = new AbortController();
+  const client = new RemnicClient({ ...baseConfig(), requestTimeoutMs: 100 });
+  const request = client.observe("session", "/cwd", [{ role: "user", content: "observe" }], {
+    signal: controller.signal,
+  });
+  controller.abort();
+
+  await assert.rejects(
+    () => request,
+    (err) => {
+      assert.ok(err instanceof RemnicRequestAbortedError);
+      return true;
+    },
+  );
+});
+
 function baseConfig(): RemnicPiConfig {
   return {
     remnicDaemonUrl: "http://127.0.0.1:4318",

--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -78,6 +78,8 @@ function baseConfig(): RemnicPiConfig {
     observeMaxBytes: 102400,
     observeMaxRetries: 2,
     daemonCooldownMs: 5000,
+    recallTimeoutThreshold: 7,
+    recallTimeoutWindow: 10,
   };
 }
 

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -244,6 +244,7 @@ export class RemnicClient {
     const turnBudgetMs = options.timeoutMs ?? this.config.turnRequestTimeoutMs;
     const retryOptions: RequestOptions = {
       timeoutMs: turnBudgetMs,
+      signal: options.signal,
       maxRetries: options.maxRetries ?? this.config.observeMaxRetries,
     };
     const chunks = chunkObservePayload(this.config, sessionKey, cwd, messages, maxBytes);

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -327,11 +327,15 @@ export class RemnicClient {
     return Array.isArray(tools) ? tools.filter(isMcpTool) : [];
   }
 
-  async mcpTool(name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  async mcpTool(
+    name: string,
+    args: Record<string, unknown>,
+    options: RequestOptions = {},
+  ): Promise<Record<string, unknown>> {
     return this.mcpRequest("tools/call", {
       name,
       arguments: args,
-    });
+    }, options);
   }
 
   /**
@@ -353,9 +357,14 @@ export class RemnicClient {
     options.signal?.addEventListener("abort", onExternalAbort, { once: true });
     const override = options.timeoutMs;
     const timeoutMs =
-      typeof override === "number" && Number.isFinite(override) && override > 0
-        ? override
-        : this.config.requestTimeoutMs;
+      override === undefined
+        ? this.config.requestTimeoutMs
+        : (() => {
+            if (!Number.isInteger(override) || override <= 0) {
+              throw new TypeError("Request timeoutMs must be a positive integer");
+            }
+            return override;
+          })();
     const timeout = setTimeout(() => {
       timedOut = true;
       controller.abort();

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -31,6 +31,8 @@ export interface McpTool {
 
 export interface RequestOptions {
   timeoutMs?: number;
+  /** Optional caller abort signal (e.g. shared breaker trip). */
+  signal?: AbortSignal;
   /** Transient-retry budget for connection-level failures (socket close, ECONNRESET). */
   maxRetries?: number;
 }
@@ -61,6 +63,23 @@ export class RemnicHttpError extends Error {
     readonly code?: string,
   ) {
     super(message);
+  }
+}
+
+export class RemnicRequestTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(`Remnic request timed out after ${timeoutMs}ms`);
+    this.name = "RemnicRequestTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export class RemnicRequestAbortedError extends Error {
+  constructor() {
+    super("Remnic request aborted");
+    this.name = "RemnicRequestAbortedError";
   }
 }
 
@@ -326,18 +345,21 @@ export class RemnicClient {
     options: RequestOptions = {},
   ): Promise<T> {
     const controller = new AbortController();
-    // A per-request override is honored only when it is a finite positive number;
-    // 0, negative, NaN, or non-finite values would make setTimeout abort
-    // immediately (or behave erratically), so fall back to the general budget.
-    // In practice the override is always sourced from the validated
-    // `startupRequestTimeoutMs` / `turnRequestTimeoutMs` config, but this keeps
-    // the client robust to any future caller (Copilot review).
+    let timedOut = false;
+    const onExternalAbort = () => controller.abort();
+    if (options.signal?.aborted) {
+      throw new RemnicRequestAbortedError();
+    }
+    options.signal?.addEventListener("abort", onExternalAbort, { once: true });
     const override = options.timeoutMs;
     const timeoutMs =
       typeof override === "number" && Number.isFinite(override) && override > 0
         ? override
         : this.config.requestTimeoutMs;
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeoutMs);
     try {
       const response = await fetch(`${this.config.remnicDaemonUrl}${pathname}`, {
         method,
@@ -363,7 +385,6 @@ export class RemnicClient {
         const message = responseErrorMessage(response, text, payload, parseError);
         const code = responseErrorCode(payload, parseError);
         if (response.status === 413) {
-          // Surface the body size so operators can tune the cap (#1600).
           const bodyBytes = body === undefined ? 0 : jsonBytes(body);
           throw new RemnicHttpError(response.status, `${message} (observed body ${bodyBytes} bytes; cap via observeMaxBytes)`, code);
         }
@@ -375,12 +396,12 @@ export class RemnicClient {
       }
       return payload as T;
     } catch (err) {
-      if (isAbortError(err)) {
-        throw new Error(`Remnic request timed out after ${timeoutMs}ms`);
-      }
+      if (timedOut) throw new RemnicRequestTimeoutError(timeoutMs);
+      if (options.signal?.aborted) throw new RemnicRequestAbortedError();
       throw err;
     } finally {
       clearTimeout(timeout);
+      options.signal?.removeEventListener("abort", onExternalAbort);
     }
   }
 
@@ -418,7 +439,6 @@ export class RemnicClient {
         if (attempt >= maxRetries || !isTransientNetworkError(err)) throw err;
         const delayMs = RETRY_BASE_DELAY_MS * 2 ** attempt;
         if (hasDeadline) {
-          // The backoff sleep counts against the shared deadline; bail BEFORE
           // sleeping if the sleep alone would overshoot the remaining budget,
           // so a sub-backoff timeoutMs never blocks for the full backoff only
           // to then throw (cursor review).
@@ -429,7 +449,7 @@ export class RemnicClient {
             );
           }
         }
-        await sleep(delayMs);
+        await sleep(delayMs, options.signal);
         attempt += 1;
         if (hasDeadline) {
           const remaining = deadline - Date.now();
@@ -481,17 +501,12 @@ export function isTransientNetworkError(err: unknown): boolean {
   if (isAbortError(err)) return false;
   if (err instanceof RemnicHttpError) return false;
   const lower = (err.message ?? "").toLowerCase();
-  // Bun fetch: "The socket connection was closed unexpectedly."
   if (lower.includes("socket connection was closed")) return true;
   if (lower.includes("socket closed")) return true;
-  // Node undici / OS codes surfaced in the message.
   if (lower.includes("econnreset")) return true;
   if (lower.includes("epipe")) return true;
   if (lower.includes("und_err_socket")) return true;
-  // Node wraps the real cause in err.cause (TypeError: fetch failed).
   if (lower.includes("fetch failed")) return true;
-  // Inspect the cause chain without an unchecked cast. Error.cause is
-  // `unknown` in the ES2022 lib; narrow it before reading `.code`.
   const cause = err.cause;
   if (cause && typeof cause === "object" && "code" in cause) {
     const code = cause.code;
@@ -502,10 +517,19 @@ export function isTransientNetworkError(err: unknown): boolean {
   return false;
 }
 
-function sleep(ms: number): Promise<void> {
-  // Plain Promise constructor: avoids Promise.withResolvers (ES2024 / Node 22+),
-  // so retry backoff works on Node 20 and other runtimes that load plugin-pi.
-  return new Promise<void>(resolve => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(new RemnicRequestAbortedError());
+  return new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new RemnicRequestAbortedError());
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function jsonBytes(value: unknown): number {

--- a/packages/plugin-pi/src/config.test.ts
+++ b/packages/plugin-pi/src/config.test.ts
@@ -128,6 +128,8 @@ test("loadConfig defaults request timeout high enough for warmed-up recall", () 
 
     assert.equal(config.requestTimeoutMs, 60000);
     assert.equal(config.startupRequestTimeoutMs, 1000);
+    assert.equal(config.recallTimeoutThreshold, 7);
+    assert.equal(config.recallTimeoutWindow, 10);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -149,6 +151,8 @@ test("loadConfig merges file values and coerces boolean-like strings", () => {
         recallTopK: "50",
         requestTimeoutMs: "10",
         startupRequestTimeoutMs: "20",
+        recallTimeoutThreshold: "3",
+        recallTimeoutWindow: "5",
       }),
     );
 
@@ -163,6 +167,8 @@ test("loadConfig merges file values and coerces boolean-like strings", () => {
     assert.equal(config.recallTopK, 50);
     assert.equal(config.requestTimeoutMs, 10);
     assert.equal(config.startupRequestTimeoutMs, 20);
+    assert.equal(config.recallTimeoutThreshold, 3);
+    assert.equal(config.recallTimeoutWindow, 5);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -307,6 +313,23 @@ test("loadConfig fails closed on invalid numeric values", () => {
     assert.throws(
       () => loadConfig({ configPath, env: {} }),
       /Invalid numeric value for Remnic Pi config field recallTopK/,
+    );
+    fs.writeFileSync(configPath, JSON.stringify({ recallTimeoutThreshold: 0 }));
+    assert.throws(
+      () => loadConfig({ configPath, env: {} }),
+      /Invalid numeric value for Remnic Pi config field recallTimeoutThreshold/,
+    );
+
+    fs.writeFileSync(configPath, JSON.stringify({ recallTimeoutWindow: "slow" }));
+    assert.throws(
+      () => loadConfig({ configPath, env: {} }),
+      /Invalid numeric value for Remnic Pi config field recallTimeoutWindow/,
+    );
+
+    fs.writeFileSync(configPath, JSON.stringify({ recallTimeoutThreshold: 6, recallTimeoutWindow: 5 }));
+    assert.throws(
+      () => loadConfig({ configPath, env: {} }),
+      /threshold \(6\) cannot exceed window \(5\)/,
     );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/packages/plugin-pi/src/config.test.ts
+++ b/packages/plugin-pi/src/config.test.ts
@@ -334,6 +334,11 @@ test("loadConfig fails closed on invalid numeric values", () => {
 
     fs.writeFileSync(configPath, JSON.stringify({ recallTimeoutThreshold: 5, recallTimeoutWindow: 5 }));
     assert.equal(loadConfig({ configPath, env: {} }).recallTimeoutThreshold, 5);
+
+    fs.writeFileSync(configPath, JSON.stringify({ recallTimeoutThreshold: 1, recallTimeoutWindow: 1 }));
+    const minimumBreakerConfig = loadConfig({ configPath, env: {} });
+    assert.equal(minimumBreakerConfig.recallTimeoutThreshold, 1);
+    assert.equal(minimumBreakerConfig.recallTimeoutWindow, 1);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/packages/plugin-pi/src/config.test.ts
+++ b/packages/plugin-pi/src/config.test.ts
@@ -331,6 +331,9 @@ test("loadConfig fails closed on invalid numeric values", () => {
       () => loadConfig({ configPath, env: {} }),
       /threshold \(6\) cannot exceed window \(5\)/,
     );
+
+    fs.writeFileSync(configPath, JSON.stringify({ recallTimeoutThreshold: 5, recallTimeoutWindow: 5 }));
+    assert.equal(loadConfig({ configPath, env: {} }).recallTimeoutThreshold, 5);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/packages/plugin-pi/src/config.ts
+++ b/packages/plugin-pi/src/config.ts
@@ -66,7 +66,7 @@ export interface LoadConfigOptions {
   env?: NodeJS.ProcessEnv;
 }
 
-const DEFAULT_CONFIG: RemnicPiConfig = {
+export const DEFAULT_CONFIG: RemnicPiConfig = {
   remnicDaemonUrl: "http://127.0.0.1:4318",
   recallMode: "auto",
   recallTopK: 8,

--- a/packages/plugin-pi/src/config.ts
+++ b/packages/plugin-pi/src/config.ts
@@ -49,6 +49,16 @@ export interface RemnicPiConfig {
    * for an exponentially growing window starting at this value (issue #1626).
    */
   daemonCooldownMs: number;
+  /**
+   * Number of explicit recall timeout errors in the last {@link recallTimeoutWindow}
+   * recall calls that permanently disables automatic recall for the process lifetime.
+   */
+  recallTimeoutThreshold: number;
+  /**
+   * Size of the rolling window of recent recall calls used by the recall-timeout
+   * circuit breaker.
+   */
+  recallTimeoutWindow: number;
 }
 
 export interface LoadConfigOptions {
@@ -76,6 +86,9 @@ const DEFAULT_CONFIG: RemnicPiConfig = {
   observeMaxRetries: 2,
   // Base cooldown for the circuit breaker; doubles on consecutive failures (#1626).
   daemonCooldownMs: 5000,
+  // Recall-timeout circuit breaker: 7 timeouts in the last 10 recall calls trip permanently.
+  recallTimeoutThreshold: 7,
+  recallTimeoutWindow: 10,
 };
 
 function defaultConfigPath(env: NodeJS.ProcessEnv): string {
@@ -246,6 +259,23 @@ export function loadConfig(options: LoadConfigOptions = {}): RemnicPiConfig {
     25_000,
     "turnRequestTimeoutMs",
   );
+  const recallTimeoutThreshold = coercePositiveInt(
+    fileConfig.recallTimeoutThreshold,
+    DEFAULT_CONFIG.recallTimeoutThreshold,
+    1000,
+    "recallTimeoutThreshold",
+  );
+  const recallTimeoutWindow = coercePositiveInt(
+    fileConfig.recallTimeoutWindow,
+    DEFAULT_CONFIG.recallTimeoutWindow,
+    1000,
+    "recallTimeoutWindow",
+  );
+  if (recallTimeoutThreshold > recallTimeoutWindow) {
+    throw new Error(
+      `Invalid recall timeout circuit breaker config: threshold (${recallTimeoutThreshold}) cannot exceed window (${recallTimeoutWindow})`,
+    );
+  }
 
   return {
     remnicDaemonUrl: daemonUrl,
@@ -276,5 +306,7 @@ export function loadConfig(options: LoadConfigOptions = {}): RemnicPiConfig {
     ),
     observeMaxRetries: coerceNonNegativeInt(fileConfig.observeMaxRetries, DEFAULT_CONFIG.observeMaxRetries, 5, "observeMaxRetries"),
     daemonCooldownMs: coercePositiveInt(fileConfig.daemonCooldownMs, DEFAULT_CONFIG.daemonCooldownMs, 60_000, "daemonCooldownMs"),
+    recallTimeoutThreshold,
+    recallTimeoutWindow,
   };
 }

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1956,7 +1956,15 @@ test("session_start preserves the recall-disabled status after a successful heal
       );
     });
   };
-  t.after(() => { globalThis.fetch = originalFetch; });
+  t.after(() => {
+    resetProcessRecallBreakerForTest({
+      ...baseConfig(),
+      authToken: "test-token",
+      recallTimeoutThreshold: 1,
+      recallTimeoutWindow: 1,
+    });
+    globalThis.fetch = originalFetch;
+  });
 
   const { pi, emit } = makePiHarness();
   const statuses: Array<[string, string]> = [];

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -15,7 +15,11 @@ import remnicPiExtension, {
   stripSessionOwnedRuntimeFields,
   toPiToolParametersSchema,
 } from "./index.js";
+import type { PiApi } from "./index.js";
 import type { RemnicPiConfig } from "./config.js";
+
+type TestPiEventHandler = Parameters<PiApi["on"]>[1];
+type TestPiCommandHandler = Parameters<PiApi["registerCommand"]>[1]["handler"];
 
 test("stripSessionOwnedSchemaFields hides session routing fields from Pi tools", () => {
   const schema = stripSessionOwnedSchemaFields({
@@ -1365,21 +1369,23 @@ function baseConfig(): RemnicPiConfig {
     observeMaxBytes: 102400,
     observeMaxRetries: 2,
     daemonCooldownMs: 5000,
+    recallTimeoutThreshold: 7,
+    recallTimeoutWindow: 10,
   };
 }
 
 function makePiHarness(): {
-  pi: Record<string, unknown>;
+  pi: PiApi;
   emit: (event: string, payload: unknown, ctx: unknown) => Promise<unknown>;
   runCommand: (name: string, args: string, ctx: unknown) => Promise<void>;
 } {
-  const handlers = new Map<string, Array<(event: unknown, ctx: unknown) => unknown | Promise<unknown>>>();
-  const commands = new Map<string, (args: string, ctx: unknown) => Promise<void>>();
-  const pi = {
-    on: (event: string, handler: (event: unknown, ctx: unknown) => unknown | Promise<unknown>) => {
+  const handlers = new Map<string, TestPiEventHandler[]>();
+  const commands = new Map<string, TestPiCommandHandler>();
+  const pi: PiApi = {
+    on: (event, handler) => {
       handlers.set(event, [...(handlers.get(event) ?? []), handler]);
     },
-    registerCommand: (name: string, options: { handler: (args: string, ctx: unknown) => Promise<void> }) => {
+    registerCommand: (name, options) => {
       commands.set(name, options.handler);
     },
     registerTool: () => undefined,

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1474,7 +1474,15 @@ test("MCP recall diagnostics remain available after the recall timeout breaker t
     }
     return new Response(JSON.stringify({ result: { summary: "last recall" } }), { status: 200 });
   };
-  t.after(() => { globalThis.fetch = originalFetch; });
+  t.after(() => {
+    resetProcessRecallBreakerForTest({
+      ...baseConfig(),
+      authToken: "test-token",
+      recallTimeoutThreshold: 1,
+      recallTimeoutWindow: 1,
+    });
+    globalThis.fetch = originalFetch;
+  });
 
   const registeredTools: Record<string, unknown>[] = [];
   const extension = createRemnicPiExtension({
@@ -1516,6 +1524,50 @@ test("MCP recall diagnostics remain available after the recall timeout breaker t
   );
   const diagnosticResult = await explainExecute("call-2", {}, undefined, undefined, context);
   assert.match(JSON.stringify(diagnosticResult), /last recall/);
+});
+
+test("remnic-why remains available after the recall timeout breaker trips", async (t) => {
+  const config = {
+    ...baseConfig(),
+    authToken: "why-test-token",
+    recallEnabled: false,
+    observeEnabled: false,
+    compactionEnabled: false,
+    mcpToolsEnabled: false,
+    statusEnabled: false,
+    requestTimeoutMs: 2,
+    recallTimeoutThreshold: 1,
+    recallTimeoutWindow: 1,
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    if (String(input).endsWith("/engram/v1/recall")) {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
+        );
+      });
+    }
+    return new Response(JSON.stringify({ summary: "last recall" }), { status: 200 });
+  };
+  t.after(() => {
+    resetProcessRecallBreakerForTest(config);
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, runCommand } = makePiHarness();
+  await createRemnicPiExtension({ config })(pi);
+  const notifications: Array<{ message: string; level: string }> = [];
+  const context = {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: (message: string, level: string) => notifications.push({ message, level }) },
+    sessionManager: { getSessionId: () => "why-diagnostic" },
+  };
+
+  await runCommand("remnic-recall", "trip", context);
+  await runCommand("remnic-why", "", context);
+
+  assert.deepEqual(notifications.at(-1), { message: JSON.stringify({ summary: "last recall" }, null, 2), level: "info" });
 });
 
 function baseConfig(): RemnicPiConfig {

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -920,10 +920,7 @@ test("before_agent_start injects cached recall across successive turns in the sa
 });
 
 test("direct legacy config receives recall breaker defaults", () => {
-  const config = { ...baseConfig() } as Record<string, unknown>;
-  delete config.recallTimeoutThreshold;
-  delete config.recallTimeoutWindow;
-  const legacyConfig = config as unknown as RemnicPiConfig;
+  const { recallTimeoutThreshold: _threshold, recallTimeoutWindow: _window, ...legacyConfig } = baseConfig();
 
   assert.doesNotThrow(() => createRemnicPiExtension({ config: legacyConfig }));
 });

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -233,6 +233,7 @@ test("default Pi extension preserves a tripped breaker across reloads", async (t
   };
   t.after(() => {
     resetProcessRecallBreakerForTest(reloadConfig);
+    resetProcessRecallBreakerForTest({ ...reloadConfig, authToken: "other-token" });
     resetProcessRecallBreakerForTest({ ...reloadConfig, recallTimeoutThreshold: 2, recallTimeoutWindow: 2 });
     if (previousConfig === undefined) delete process.env.REMNIC_PI_CONFIG;
     else process.env.REMNIC_PI_CONFIG = previousConfig;
@@ -263,19 +264,30 @@ test("default Pi extension preserves a tripped breaker across reloads", async (t
 
   assert.deepEqual(secondStatuses.at(-1), ["remnic", "Remnic recall disabled until restart (timeouts delayed operations)"]);
 
+  fs.writeFileSync(configPath, JSON.stringify({ ...reloadConfig, authToken: "other-token" }));
+  const differentCredential = makePiHarness();
+  const differentCredentialStatuses: Array<[string, string]> = [];
+  await remnicPiExtension(differentCredential.pi);
+  await differentCredential.emit("session_start", {}, {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: (key: string, value: string) => differentCredentialStatuses.push([key, value]), notify: () => {} },
+    sessionManager: { getSessionId: () => "breaker-reload-different-credential" },
+  });
+  assert.deepEqual(differentCredentialStatuses.at(-1), ["remnic", "Remnic ready"]);
+
   fs.writeFileSync(
     configPath,
     JSON.stringify({ ...reloadConfig, recallTimeoutThreshold: 2, recallTimeoutWindow: 2 }),
   );
-  const third = makePiHarness();
-  const thirdStatuses: Array<[string, string]> = [];
-  await remnicPiExtension(third.pi);
-  await third.emit("session_start", {}, {
+  const changedPolicy = makePiHarness();
+  const changedPolicyStatuses: Array<[string, string]> = [];
+  await remnicPiExtension(changedPolicy.pi);
+  await changedPolicy.emit("session_start", {}, {
     cwd: "/tmp/remnic-pi",
-    ui: { setStatus: (key: string, value: string) => thirdStatuses.push([key, value]), notify: () => {} },
+    ui: { setStatus: (key: string, value: string) => changedPolicyStatuses.push([key, value]), notify: () => {} },
     sessionManager: { getSessionId: () => "breaker-reload-policy-change" },
   });
-  assert.deepEqual(thirdStatuses.at(-1), ["remnic", "Remnic ready"]);
+  assert.deepEqual(changedPolicyStatuses.at(-1), ["remnic", "Remnic ready"]);
 });
 
 test("MCP tool registration uses the startup timeout instead of the general request timeout", async (t) => {

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -827,6 +827,14 @@ test("before_agent_start injects cached recall across successive turns in the sa
   assert.ok(third?.systemPrompt?.includes("remembered context"));
 });
 
+test("direct legacy config receives recall breaker defaults", () => {
+  const config = { ...baseConfig() } as Record<string, unknown>;
+  delete config.recallTimeoutThreshold;
+  delete config.recallTimeoutWindow;
+  const legacyConfig = config as unknown as RemnicPiConfig;
+
+  assert.doesNotThrow(() => createRemnicPiExtension({ config: legacyConfig }));
+});
 test("empty recall at first before_agent_start does not inject context but a later session with content does", async (t) => {
   const originalFetch = globalThis.fetch;
   let recallCallIndex = 0;

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1733,6 +1733,49 @@ test("an offline startup health probe trips the circuit breaker so the first tur
   await emit("before_agent_start", event, ctx);
   assert.equal(recallCalls, 0, "recall fast-skipped after the offline startup probe tripped the breaker");
 });
+test("session_start preserves the recall-disabled status after a successful health probe", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    if (String(input).endsWith("/engram/v1/health")) {
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    return new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () =>
+        reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
+      );
+    });
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const { pi, emit } = makePiHarness();
+  const statuses: Array<[string, string]> = [];
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: true,
+      turnRequestTimeoutMs: 2,
+      recallTimeoutThreshold: 1,
+      recallTimeoutWindow: 1,
+    },
+  });
+  await extension(pi);
+
+  const context = (sessionKey: string) => ({
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: (key: string, value: string) => statuses.push([key, value]), notify: () => {} },
+    sessionManager: { getSessionId: () => sessionKey },
+  });
+
+  await emit("session_start", {}, context("breaker-first"));
+  await emit("before_agent_start", { prompt: "hi", systemPrompt: "" }, context("breaker-first"));
+  await emit("session_start", {}, context("breaker-second"));
+
+  assert.deepEqual(statuses.at(-1), ["remnic", "Remnic recall disabled until restart (timeouts delayed operations)"]);
+});
 
 test("/remnic-recall bounds retry to the general request budget instead of unbounded retries (review cursor)", async (t) => {
   const originalFetch = globalThis.fetch;

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -198,6 +198,68 @@ test("default Pi extension creates isolated state for each host invocation", asy
   assert.equal(recallBodies.length, 2);
 });
 
+test("default Pi extension preserves a tripped breaker across reloads", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-pi-breaker-reload-"));
+  const configPath = path.join(root, "remnic.config.json");
+  fs.writeFileSync(configPath, JSON.stringify({
+    remnicDaemonUrl: "http://127.0.0.1:4319",
+    authToken: "test-token",
+    observeEnabled: false,
+    compactionEnabled: false,
+    mcpToolsEnabled: false,
+    statusEnabled: true,
+    turnRequestTimeoutMs: 2,
+    recallTimeoutThreshold: 1,
+    recallTimeoutWindow: 1,
+  }));
+
+  const previousConfig = process.env.REMNIC_PI_CONFIG;
+  const originalFetch = globalThis.fetch;
+  process.env.REMNIC_PI_CONFIG = configPath;
+  globalThis.fetch = async (input, init) => {
+    if (String(input).endsWith("/engram/v1/health")) {
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    if (String(input).includes("/engram/v1/namespace/writable")) {
+      return new Response(JSON.stringify({ ok: true, status: "ok", namespace: "default" }), { status: 200 });
+    }
+    return new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () =>
+        reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
+      );
+    });
+  };
+  t.after(() => {
+    if (previousConfig === undefined) delete process.env.REMNIC_PI_CONFIG;
+    else process.env.REMNIC_PI_CONFIG = previousConfig;
+    globalThis.fetch = originalFetch;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  const first = makePiHarness();
+  const firstStatuses: Array<[string, string]> = [];
+  const firstContext = {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: (key: string, value: string) => firstStatuses.push([key, value]), notify: () => {} },
+    sessionManager: { getSessionId: () => "breaker-reload-first" },
+  };
+  await remnicPiExtension(first.pi);
+  await first.emit("session_start", {}, firstContext);
+  await first.emit("before_agent_start", { prompt: "trip", systemPrompt: "" }, firstContext);
+
+  const second = makePiHarness();
+  const secondStatuses: Array<[string, string]> = [];
+  const secondContext = {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: (key: string, value: string) => secondStatuses.push([key, value]), notify: () => {} },
+    sessionManager: { getSessionId: () => "breaker-reload-second" },
+  };
+  await remnicPiExtension(second.pi);
+  await second.emit("session_start", {}, secondContext);
+
+  assert.deepEqual(secondStatuses.at(-1), ["remnic", "Remnic recall disabled until restart (timeouts delayed operations)"]);
+});
+
 test("MCP tool registration uses the startup timeout instead of the general request timeout", async (t) => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (_input, init) =>

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -11,6 +11,7 @@ import remnicPiExtension, {
   createRemnicPiExtension,
   isDaemonUnreachableError,
   observeMessages,
+  resetProcessRecallBreakerForTest,
   stripSessionOwnedSchemaFields,
   stripSessionOwnedRuntimeFields,
   toPiToolParametersSchema,
@@ -201,7 +202,7 @@ test("default Pi extension creates isolated state for each host invocation", asy
 test("default Pi extension preserves a tripped breaker across reloads", async (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-pi-breaker-reload-"));
   const configPath = path.join(root, "remnic.config.json");
-  fs.writeFileSync(configPath, JSON.stringify({
+  const reloadConfig = {
     remnicDaemonUrl: "http://127.0.0.1:4319",
     authToken: "test-token",
     observeEnabled: false,
@@ -211,7 +212,8 @@ test("default Pi extension preserves a tripped breaker across reloads", async (t
     turnRequestTimeoutMs: 2,
     recallTimeoutThreshold: 1,
     recallTimeoutWindow: 1,
-  }));
+  };
+  fs.writeFileSync(configPath, JSON.stringify(reloadConfig));
 
   const previousConfig = process.env.REMNIC_PI_CONFIG;
   const originalFetch = globalThis.fetch;
@@ -230,6 +232,8 @@ test("default Pi extension preserves a tripped breaker across reloads", async (t
     });
   };
   t.after(() => {
+    resetProcessRecallBreakerForTest(reloadConfig);
+    resetProcessRecallBreakerForTest({ ...reloadConfig, recallTimeoutThreshold: 2, recallTimeoutWindow: 2 });
     if (previousConfig === undefined) delete process.env.REMNIC_PI_CONFIG;
     else process.env.REMNIC_PI_CONFIG = previousConfig;
     globalThis.fetch = originalFetch;
@@ -258,6 +262,20 @@ test("default Pi extension preserves a tripped breaker across reloads", async (t
   await second.emit("session_start", {}, secondContext);
 
   assert.deepEqual(secondStatuses.at(-1), ["remnic", "Remnic recall disabled until restart (timeouts delayed operations)"]);
+
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({ ...reloadConfig, recallTimeoutThreshold: 2, recallTimeoutWindow: 2 }),
+  );
+  const third = makePiHarness();
+  const thirdStatuses: Array<[string, string]> = [];
+  await remnicPiExtension(third.pi);
+  await third.emit("session_start", {}, {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: (key: string, value: string) => thirdStatuses.push([key, value]), notify: () => {} },
+    sessionManager: { getSessionId: () => "breaker-reload-policy-change" },
+  });
+  assert.deepEqual(thirdStatuses.at(-1), ["remnic", "Remnic ready"]);
 });
 
 test("MCP tool registration uses the startup timeout instead of the general request timeout", async (t) => {

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1359,6 +1359,73 @@ test("registered MCP tools strip nested session-owned params before forwarding",
   ]);
 });
 
+test("MCP recall diagnostics remain available after the recall timeout breaker trips", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    if (body.method === "tools/list") {
+      return new Response(JSON.stringify({
+        result: {
+          tools: [
+            { name: "remnic.recall", inputSchema: { type: "object" } },
+            { name: "remnic.recall_explain", inputSchema: { type: "object" } },
+          ],
+        },
+      }), { status: 200 });
+    }
+    if (body.params?.name === "remnic.recall") {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
+        );
+      });
+    }
+    return new Response(JSON.stringify({ result: { summary: "last recall" } }), { status: 200 });
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const registeredTools: Record<string, unknown>[] = [];
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      statusEnabled: false,
+      mcpToolsEnabled: true,
+      requestTimeoutMs: 2,
+      recallTimeoutThreshold: 1,
+      recallTimeoutWindow: 1,
+    },
+  });
+  const pi: PiApi = {
+    on: () => undefined,
+    registerCommand: () => undefined,
+    registerTool: (tool) => registeredTools.push(tool),
+    appendEntry: () => undefined,
+  };
+  await extension(pi);
+
+  const recallTool = registeredTools.find((tool) => tool.name === "remnic_recall");
+  const explainTool = registeredTools.find((tool) => tool.name === "remnic_recall_explain");
+  assert.ok(recallTool);
+  assert.ok(explainTool);
+  const recallExecute = recallTool.execute;
+  const explainExecute = explainTool.execute;
+  if (typeof recallExecute !== "function" || typeof explainExecute !== "function") {
+    throw new Error("expected registered MCP tools to provide execute handlers");
+  }
+
+  const context = { cwd: "/tmp/remnic-pi", sessionManager: { getSessionId: () => "mcp-diagnostics" } };
+  await assert.rejects(
+    () => recallExecute("call-1", { query: "trip" }, undefined, undefined, context),
+    /timed out/,
+  );
+  const diagnosticResult = await explainExecute("call-2", {}, undefined, undefined, context);
+  assert.match(JSON.stringify(diagnosticResult), /last recall/);
+});
+
 function baseConfig(): RemnicPiConfig {
   return {
     remnicDaemonUrl: "http://127.0.0.1:4318",

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -1,4 +1,6 @@
 import { Type, type TSchema } from "@sinclair/typebox";
+import { createHash } from "node:crypto";
+
 
 import { DEFAULT_CONFIG, loadConfig, type LoadConfigOptions, type RemnicPiConfig } from "./config.js";
 import {
@@ -72,18 +74,19 @@ type PiContextSnapshotOptions = {
 };
 
 function recallTimeoutBreakerCacheKey(
-  config: Pick<RemnicPiConfig, "remnicDaemonUrl" | "namespace" | "recallTimeoutThreshold" | "recallTimeoutWindow">,
+  config: Pick<RemnicPiConfig, "remnicDaemonUrl" | "namespace" | "authToken" | "recallTimeoutThreshold" | "recallTimeoutWindow">,
 ): string {
   return JSON.stringify([
     config.remnicDaemonUrl,
     config.namespace ?? "",
+    createHash("sha256").update(config.authToken ?? "").digest("hex"),
     config.recallTimeoutThreshold,
     config.recallTimeoutWindow,
   ]);
 }
 
 export function resetProcessRecallBreakerForTest(
-  config: Pick<RemnicPiConfig, "remnicDaemonUrl" | "namespace" | "recallTimeoutThreshold" | "recallTimeoutWindow">,
+  config: Pick<RemnicPiConfig, "remnicDaemonUrl" | "namespace" | "authToken" | "recallTimeoutThreshold" | "recallTimeoutWindow">,
 ): void {
   PROCESS_SCOPED_RECALL_BREAKERS.delete(recallTimeoutBreakerCacheKey(config));
 }

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -36,7 +36,7 @@ const MAX_SESSION_STATES = 50;
 const MAX_CONTEXT_CHARS = 12000;
 const TRUNCATION_NOTICE = "\n\n[Remnic context truncated]";
 const SESSION_OWNED_FIELDS = new Set(["sessionKey", "namespace", "cwd"]);
-const DEFAULT_PI_RECALL_BREAKERS = new Map<string, RecallTimeoutBreaker>();
+const PROCESS_SCOPED_RECALL_BREAKERS = new Map<string, RecallTimeoutBreaker>();
 const RECALL_PRODUCING_TOOL_NAMES: Record<string, true> = {
   "remnic.recall": true,
   "remnic.recall_xray": true,
@@ -68,17 +68,36 @@ type PiContextSnapshotOptions = {
   includeSessionHistory?: boolean;
 };
 
-export function createRemnicPiExtension(
-  options: RemnicPiExtensionOptions = {},
-  sharedRecallTimeoutBreaker?: RecallTimeoutBreaker,
-) {
+function recallTimeoutBreakerCacheKey(
+  config: Pick<RemnicPiConfig, "remnicDaemonUrl" | "namespace" | "recallTimeoutThreshold" | "recallTimeoutWindow">,
+): string {
+  return JSON.stringify([
+    config.remnicDaemonUrl,
+    config.namespace ?? "",
+    config.recallTimeoutThreshold,
+    config.recallTimeoutWindow,
+  ]);
+}
+
+export function resetProcessRecallBreakerForTest(
+  config: Pick<RemnicPiConfig, "remnicDaemonUrl" | "namespace" | "recallTimeoutThreshold" | "recallTimeoutWindow">,
+): void {
+  PROCESS_SCOPED_RECALL_BREAKERS.delete(recallTimeoutBreakerCacheKey(config));
+}
+
+export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) {
   const config = { ...DEFAULT_CONFIG, ...(options.config ?? loadConfig(options)) };
   const client = new RemnicClient(config);
   const sessionStates = new Map<string, PiSessionState>();
-  const recallTimeoutBreaker = sharedRecallTimeoutBreaker ?? new RecallTimeoutBreaker({
-    threshold: config.recallTimeoutThreshold,
-    window: config.recallTimeoutWindow,
-  });
+  const breakerKey = recallTimeoutBreakerCacheKey(config);
+  let recallTimeoutBreaker = PROCESS_SCOPED_RECALL_BREAKERS.get(breakerKey);
+  if (!recallTimeoutBreaker) {
+    recallTimeoutBreaker = new RecallTimeoutBreaker({
+      threshold: config.recallTimeoutThreshold,
+      window: config.recallTimeoutWindow,
+    });
+    PROCESS_SCOPED_RECALL_BREAKERS.set(breakerKey, recallTimeoutBreaker);
+  }
 
   return async function remnicPiExtension(pi: PiApi): Promise<void> {
     pi.on("session_start", async (_event, ctx) => {
@@ -236,17 +255,7 @@ export function createRemnicPiExtension(
 }
 
 export default async function remnicPiExtension(pi: PiApi): Promise<void> {
-  const config = loadConfig();
-  const breakerKey = `${config.remnicDaemonUrl}\u0000${config.namespace ?? ""}`;
-  let recallTimeoutBreaker = DEFAULT_PI_RECALL_BREAKERS.get(breakerKey);
-  if (!recallTimeoutBreaker) {
-    recallTimeoutBreaker = new RecallTimeoutBreaker({
-      threshold: config.recallTimeoutThreshold,
-      window: config.recallTimeoutWindow,
-    });
-    DEFAULT_PI_RECALL_BREAKERS.set(breakerKey, recallTimeoutBreaker);
-  }
-  await createRemnicPiExtension({ config }, recallTimeoutBreaker)(pi);
+  await createRemnicPiExtension()(pi);
 }
 
 function registerCommands(

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -28,8 +28,11 @@ export type PiApi = {
   appendEntry<T = unknown>(customType: string, data?: T): void;
 };
 
+export type RemnicPiConfigInput = Omit<RemnicPiConfig, "recallTimeoutThreshold" | "recallTimeoutWindow"> &
+  Partial<Pick<RemnicPiConfig, "recallTimeoutThreshold" | "recallTimeoutWindow">>;
+
 export interface RemnicPiExtensionOptions extends LoadConfigOptions {
-  config?: RemnicPiConfig;
+  config?: RemnicPiConfigInput;
 }
 
 const STATE_CUSTOM_TYPE = "remnic_state";
@@ -92,7 +95,7 @@ export function resetProcessRecallBreakerForTest(
 }
 
 export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) {
-  const config = { ...DEFAULT_CONFIG, ...(options.config ?? loadConfig(options)) };
+  const config: RemnicPiConfig = { ...DEFAULT_CONFIG, ...(options.config ?? loadConfig(options)) };
   const client = new RemnicClient(config);
   const sessionStates = new Map<string, PiSessionState>();
   const breakerKey = recallTimeoutBreakerCacheKey(config);

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -36,6 +36,10 @@ const MAX_SESSION_STATES = 50;
 const MAX_CONTEXT_CHARS = 12000;
 const TRUNCATION_NOTICE = "\n\n[Remnic context truncated]";
 const SESSION_OWNED_FIELDS = new Set(["sessionKey", "namespace", "cwd"]);
+const RECALL_PRODUCING_TOOL_NAMES: Record<string, true> = {
+  "remnic.recall": true,
+  "remnic.recall_xray": true,
+};
 
 type PiSessionState = {
   observedHashes: Set<string>;
@@ -366,7 +370,7 @@ async function registerMcpTools(
             details: { skipped: true, reason: "stale_context" },
           };
         }
-        if (recallTimeoutBreaker.isTripped() && isRecallToolName(tool.name)) {
+        if (recallTimeoutBreaker.isTripped() && RECALL_PRODUCING_TOOL_NAMES[tool.name] === true) {
           const message = notifyRecallDisabled(session);
           return {
             content: [{ type: "text", text: message }],
@@ -380,7 +384,7 @@ async function registerMcpTools(
           namespace: config.namespace,
           cwd: session.cwd,
         };
-        const result = isRecallToolName(tool.name)
+        const result = RECALL_PRODUCING_TOOL_NAMES[tool.name] === true
           ? await executeRecallWithBreaker(
               (breakerSignal) =>
                 client.mcpTool(tool.name, toolArguments, {
@@ -923,9 +927,6 @@ function notifyRecallDisabled(session: PiContextSnapshot): string {
   return message;
 }
 
-function isRecallToolName(name: string): boolean {
-  return name === "remnic.recall" || name.startsWith("remnic.recall_") || name.startsWith("remnic.recall.");
-}
 const RECALL_DISABLED_STATUS = "Remnic recall disabled until restart (timeouts delayed operations)";
 
 function emitRecallTimeoutTrip(pi: PiApi, session: PiContextSnapshot, config: RemnicPiConfig, err: unknown): void {

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -36,6 +36,7 @@ const MAX_SESSION_STATES = 50;
 const MAX_CONTEXT_CHARS = 12000;
 const TRUNCATION_NOTICE = "\n\n[Remnic context truncated]";
 const SESSION_OWNED_FIELDS = new Set(["sessionKey", "namespace", "cwd"]);
+const DEFAULT_PI_RECALL_BREAKERS = new Map<string, RecallTimeoutBreaker>();
 const RECALL_PRODUCING_TOOL_NAMES: Record<string, true> = {
   "remnic.recall": true,
   "remnic.recall_xray": true,
@@ -67,11 +68,14 @@ type PiContextSnapshotOptions = {
   includeSessionHistory?: boolean;
 };
 
-export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) {
+export function createRemnicPiExtension(
+  options: RemnicPiExtensionOptions = {},
+  sharedRecallTimeoutBreaker?: RecallTimeoutBreaker,
+) {
   const config = { ...DEFAULT_CONFIG, ...(options.config ?? loadConfig(options)) };
   const client = new RemnicClient(config);
   const sessionStates = new Map<string, PiSessionState>();
-  const recallTimeoutBreaker = new RecallTimeoutBreaker({
+  const recallTimeoutBreaker = sharedRecallTimeoutBreaker ?? new RecallTimeoutBreaker({
     threshold: config.recallTimeoutThreshold,
     window: config.recallTimeoutWindow,
   });
@@ -232,7 +236,17 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
 }
 
 export default async function remnicPiExtension(pi: PiApi): Promise<void> {
-  await createRemnicPiExtension()(pi);
+  const config = loadConfig();
+  const breakerKey = `${config.remnicDaemonUrl}\u0000${config.namespace ?? ""}`;
+  let recallTimeoutBreaker = DEFAULT_PI_RECALL_BREAKERS.get(breakerKey);
+  if (!recallTimeoutBreaker) {
+    recallTimeoutBreaker = new RecallTimeoutBreaker({
+      threshold: config.recallTimeoutThreshold,
+      window: config.recallTimeoutWindow,
+    });
+    DEFAULT_PI_RECALL_BREAKERS.set(breakerKey, recallTimeoutBreaker);
+  }
+  await createRemnicPiExtension({ config }, recallTimeoutBreaker)(pi);
 }
 
 function registerCommands(

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -339,10 +339,6 @@ function registerCommands(
   pi.registerCommand("remnic-why", {
     description: "Explain the last Remnic recall",
     handler: commandHandler(async (_args, _ctx, session) => {
-      if (recallTimeoutBreaker.isTripped()) {
-        notifyRecallDisabled(session);
-        return;
-      }
       const result = await client.recallExplain(session.sessionKey);
       session.notify(JSON.stringify(result, null, 2), "info");
     }),

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -11,7 +11,7 @@ import {
   toObserveMessage,
 } from "./messages.js";
 
-type PiApi = {
+export type PiApi = {
   on(event: string, handler: (event: any, ctx: any) => unknown | Promise<unknown>): void;
   registerCommand(name: string, options: { description?: string; handler: (args: string, ctx: any) => Promise<void> }): void;
   registerTool(tool: Record<string, unknown>): void;
@@ -59,6 +59,10 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
   const config = options.config ?? loadConfig(options);
   const client = new RemnicClient(config);
   const sessionStates = new Map<string, PiSessionState>();
+  const recallTimeoutBreaker = new RecallTimeoutBreaker({
+    threshold: config.recallTimeoutThreshold,
+    window: config.recallTimeoutWindow,
+  });
 
   return async function remnicPiExtension(pi: PiApi): Promise<void> {
     pi.on("session_start", async (_event, ctx) => {
@@ -196,9 +200,9 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       };
     });
 
-    registerCommands(pi, client, config);
+    registerCommands(pi, client, config, recallTimeoutBreaker);
     if (config.mcpToolsEnabled && config.authToken) {
-      await registerMcpTools(pi, client, config);
+      await registerMcpTools(pi, client, config, recallTimeoutBreaker);
     }
   };
 }
@@ -207,10 +211,19 @@ export default async function remnicPiExtension(pi: PiApi): Promise<void> {
   await createRemnicPiExtension()(pi);
 }
 
-function registerCommands(pi: PiApi, client: RemnicClient, config: RemnicPiConfig): void {
+function registerCommands(
+  pi: PiApi,
+  client: RemnicClient,
+  config: RemnicPiConfig,
+  recallTimeoutBreaker: RecallTimeoutBreaker,
+): void {
   pi.registerCommand("remnic-status", {
     description: "Check Remnic daemon status",
     handler: commandHandler(async (_args, _ctx, session) => {
+      if (recallTimeoutBreaker.isTripped()) {
+        notifyRecallDisabled(session);
+        return;
+      }
       const health = await client.health();
       // The daemon responded (any HTTP result), so clear any stale cooldown a
       // prior timeout left on the shared client (cursor review).
@@ -227,15 +240,21 @@ function registerCommands(pi: PiApi, client: RemnicClient, config: RemnicPiConfi
         session.notify("Usage: /remnic-recall <query>", "warning");
         return;
       }
-      // Pass the general request budget so requestWithRetry shares ONE deadline
-      // across retries (total <= requestTimeoutMs) instead of looping through
-      // observeMaxRetries full timeouts and blocking the interactive command
-      // for several minutes on a flaky connection (cursor review).
-      const result = await client.recall(query, session.sessionKey, session.cwd, {
-        timeoutMs: config.requestTimeoutMs,
-      });
-      // The daemon responded, so clear any stale cooldown a prior timeout left
-      // on the shared client (cursor review).
+      if (recallTimeoutBreaker.isTripped()) {
+        notifyRecallDisabled(session);
+        return;
+      }
+      const result = await executeRecallWithBreaker(
+        (signal) =>
+          client.recall(query, session.sessionKey, session.cwd, {
+            timeoutMs: config.requestTimeoutMs,
+            signal,
+          }),
+        recallTimeoutBreaker,
+        pi,
+        session,
+        config,
+      );
       client.markReachable();
       session.notify(trimContext(result.context ?? "(no Remnic context)", MAX_CONTEXT_CHARS), "info");
     }),
@@ -270,6 +289,10 @@ function registerCommands(pi: PiApi, client: RemnicClient, config: RemnicPiConfi
   pi.registerCommand("remnic-why", {
     description: "Explain the last Remnic recall",
     handler: commandHandler(async (_args, _ctx, session) => {
+      if (recallTimeoutBreaker.isTripped()) {
+        notifyRecallDisabled(session);
+        return;
+      }
       const result = await client.recallExplain(session.sessionKey);
       session.notify(JSON.stringify(result, null, 2), "info");
     }),
@@ -298,7 +321,12 @@ function commandHandler(
   };
 }
 
-async function registerMcpTools(pi: PiApi, client: RemnicClient, config: RemnicPiConfig): Promise<void> {
+async function registerMcpTools(
+  pi: PiApi,
+  client: RemnicClient,
+  config: RemnicPiConfig,
+  recallTimeoutBreaker: RecallTimeoutBreaker,
+): Promise<void> {
   let tools: McpTool[] = [];
   try {
     tools = await client.mcpListTools({ timeoutMs: config.startupRequestTimeoutMs });
@@ -319,6 +347,13 @@ async function registerMcpTools(pi: PiApi, client: RemnicClient, config: RemnicP
           return {
             content: [{ type: "text", text: "Remnic tool skipped because the Pi context is no longer active." }],
             details: { skipped: true, reason: "stale_context" },
+          };
+        }
+        if (recallTimeoutBreaker.isTripped() && isRecallToolName(tool.name)) {
+          const message = notifyRecallDisabled(session);
+          return {
+            content: [{ type: "text", text: message }],
+            details: { skipped: true, reason: "recall_timeout_breaker" },
           };
         }
         const safeParams = stripSessionOwnedRuntimeFields(params ?? {}) as Record<string, unknown>;
@@ -850,6 +885,68 @@ export function isDaemonUnreachableError(err: unknown): boolean {
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
+
+function notifyRecallDisabled(session: PiContextSnapshot): string {
+  const message =
+    "Remnic recall is disabled for this process because timeouts delayed operations; " +
+    "memory recall is unavailable until restart.";
+  session.notify(message, "warning");
+  return message;
+}
+
+function isRecallToolName(name: string): boolean {
+  return (
+    name === "remnic.recall" ||
+    name.startsWith("remnic.recall_") ||
+    name.startsWith("remnic.recall.") ||
+    name === "engram.recall" ||
+    name.startsWith("engram.recall_") ||
+    name.startsWith("engram.recall.")
+  );
+}
+function emitRecallTimeoutTrip(pi: PiApi, session: PiContextSnapshot, config: RemnicPiConfig, err: unknown): void {
+  const message =
+    `Remnic recall has been disabled for this session because repeated timeouts were delaying operations. ` +
+    `Memory recall is unavailable until restart (${config.recallTimeoutThreshold} timeouts in the last ` +
+    `${config.recallTimeoutWindow} recall attempts).`;
+  session.notify(message, "warning");
+  if (config.statusEnabled) {
+    session.setStatus("remnic", "Remnic recall disabled until restart (timeouts delayed operations)");
+  }
+  pi.appendEntry(STATE_CUSTOM_TYPE, {
+    level: "warning",
+    code: "RECALL_TIMEOUT_TRIP",
+    threshold: config.recallTimeoutThreshold,
+    window: config.recallTimeoutWindow,
+    reason: "Recall disabled until restart because timeouts delayed operations",
+    message,
+    error: errorMessage(err),
+    disabledAt: new Date().toISOString(),
+    persistent: true,
+  });
+}
+
+async function executeRecallWithBreaker<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  breaker: RecallTimeoutBreaker,
+  pi: PiApi,
+  session: PiContextSnapshot,
+  config: RemnicPiConfig,
+): Promise<T> {
+  try {
+    const result = await operation(breaker.signal);
+    breaker.recordSuccess();
+    if (breaker.isTripped()) throw new RemnicRequestAbortedError();
+    return result;
+  } catch (err) {
+    if (!(breaker.isTripped() && err instanceof RemnicRequestAbortedError)) {
+      const tripped = breaker.record(isRecallTimeoutError(err) ? "timeout" : "failure");
+      if (tripped) emitRecallTimeoutTrip(pi, session, config, err);
+    }
+    throw err;
+  }
+}
+
 
 function finiteTokenCount(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -1,7 +1,14 @@
 import { Type, type TSchema } from "@sinclair/typebox";
 
-import { loadConfig, type LoadConfigOptions, type RemnicPiConfig } from "./config.js";
-import { RemnicClient, RemnicHttpError, isTransientNetworkError, type McpTool, type ObserveMessage } from "./client.js";
+import { DEFAULT_CONFIG, loadConfig, type LoadConfigOptions, type RemnicPiConfig } from "./config.js";
+import {
+  RemnicClient,
+  RemnicHttpError,
+  RemnicRequestAbortedError,
+  isTransientNetworkError,
+  type McpTool,
+  type ObserveMessage,
+} from "./client.js";
 import {
   hashObservedMessage,
   observedMessageDedupeKey,
@@ -10,6 +17,7 @@ import {
   textFromMessage,
   toObserveMessage,
 } from "./messages.js";
+import { RecallTimeoutBreaker, isRecallTimeoutError } from "./recall-timeout-breaker.js";
 
 export type PiApi = {
   on(event: string, handler: (event: any, ctx: any) => unknown | Promise<unknown>): void;
@@ -56,7 +64,7 @@ type PiContextSnapshotOptions = {
 };
 
 export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) {
-  const config = options.config ?? loadConfig(options);
+  const config = { ...DEFAULT_CONFIG, ...(options.config ?? loadConfig(options)) };
   const client = new RemnicClient(config);
   const sessionStates = new Map<string, PiSessionState>();
   const recallTimeoutBreaker = new RecallTimeoutBreaker({
@@ -98,15 +106,24 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
         if (promptText) {
           state.recallCompleted = true;
           try {
-            const recalled = await client.recall(promptText, session.sessionKey, session.cwd, {
-              timeoutMs: config.turnRequestTimeoutMs,
-            });
+            const recalled = await executeRecallWithBreaker(
+              (signal) =>
+                client.recall(promptText, session.sessionKey, session.cwd, {
+                  timeoutMs: config.turnRequestTimeoutMs,
+                  signal,
+                }),
+              recallTimeoutBreaker,
+              pi,
+              session,
+              config,
+            );
             client.markReachable();
             const context = trimContext(recalled.context ?? "", config.recallBudgetChars);
             if (context) {
               state.cachedContext = context;
             }
           } catch (err) {
+            if (recallTimeoutBreaker.isTripped()) return;
             if (isDaemonUnreachableError(err)) client.markUnreachable(config.daemonCooldownMs);
             session.notify(`Remnic recall unavailable: ${errorMessage(err)}`, "warning");
           }
@@ -220,10 +237,7 @@ function registerCommands(
   pi.registerCommand("remnic-status", {
     description: "Check Remnic daemon status",
     handler: commandHandler(async (_args, _ctx, session) => {
-      if (recallTimeoutBreaker.isTripped()) {
-        notifyRecallDisabled(session);
-        return;
-      }
+      if (recallTimeoutBreaker.isTripped()) notifyRecallDisabled(session);
       const health = await client.health();
       // The daemon responded (any HTTP result), so clear any stale cooldown a
       // prior timeout left on the shared client (cursor review).
@@ -341,7 +355,7 @@ async function registerMcpTools(
       label: tool.name,
       description: tool.description ?? `Call ${tool.name}`,
       parameters: toPiToolParametersSchema(tool.inputSchema),
-      async execute(_toolCallId: string, params: Record<string, unknown>, _signal: AbortSignal | undefined, _onUpdate: unknown, ctx: any) {
+      async execute(_toolCallId: string, params: Record<string, unknown>, signal: AbortSignal | undefined, _onUpdate: unknown, ctx: any) {
         const session = snapshotPiContext(ctx);
         if (!session) {
           return {
@@ -357,12 +371,24 @@ async function registerMcpTools(
           };
         }
         const safeParams = stripSessionOwnedRuntimeFields(params ?? {}) as Record<string, unknown>;
-        const result = await client.mcpTool(tool.name, {
+        const toolArguments = {
           ...safeParams,
           sessionKey: session.sessionKey,
           namespace: config.namespace,
           cwd: session.cwd,
-        });
+        };
+        const result = isRecallToolName(tool.name)
+          ? await executeRecallWithBreaker(
+              (breakerSignal) =>
+                client.mcpTool(tool.name, toolArguments, {
+                  signal: signal ? AbortSignal.any([signal, breakerSignal]) : breakerSignal,
+                }),
+              recallTimeoutBreaker,
+              pi,
+              session,
+              config,
+            )
+          : await client.mcpTool(tool.name, toolArguments, { signal });
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
           details: result,
@@ -895,23 +921,18 @@ function notifyRecallDisabled(session: PiContextSnapshot): string {
 }
 
 function isRecallToolName(name: string): boolean {
-  return (
-    name === "remnic.recall" ||
-    name.startsWith("remnic.recall_") ||
-    name.startsWith("remnic.recall.") ||
-    name === "engram.recall" ||
-    name.startsWith("engram.recall_") ||
-    name.startsWith("engram.recall.")
-  );
+  return name === "remnic.recall" || name.startsWith("remnic.recall_") || name.startsWith("remnic.recall.");
 }
+const RECALL_DISABLED_STATUS = "Remnic recall disabled until restart (timeouts delayed operations)";
+
 function emitRecallTimeoutTrip(pi: PiApi, session: PiContextSnapshot, config: RemnicPiConfig, err: unknown): void {
   const message =
-    `Remnic recall has been disabled for this session because repeated timeouts were delaying operations. ` +
+    `Remnic recall has been disabled for this process because repeated timeouts delayed operations. ` +
     `Memory recall is unavailable until restart (${config.recallTimeoutThreshold} timeouts in the last ` +
     `${config.recallTimeoutWindow} recall attempts).`;
   session.notify(message, "warning");
   if (config.statusEnabled) {
-    session.setStatus("remnic", "Remnic recall disabled until restart (timeouts delayed operations)");
+    session.setStatus("remnic", RECALL_DISABLED_STATUS);
   }
   pi.appendEntry(STATE_CUSTOM_TYPE, {
     level: "warning",
@@ -936,7 +957,6 @@ async function executeRecallWithBreaker<T>(
   try {
     const result = await operation(breaker.signal);
     breaker.recordSuccess();
-    if (breaker.isTripped()) throw new RemnicRequestAbortedError();
     return result;
   } catch (err) {
     if (!(breaker.isTripped() && err instanceof RemnicRequestAbortedError)) {

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -36,7 +36,10 @@ const MAX_SESSION_STATES = 50;
 const MAX_CONTEXT_CHARS = 12000;
 const TRUNCATION_NOTICE = "\n\n[Remnic context truncated]";
 const SESSION_OWNED_FIELDS = new Set(["sessionKey", "namespace", "cwd"]);
-const PROCESS_SCOPED_RECALL_BREAKERS = new Map<string, RecallTimeoutBreaker>();
+const RECALL_BREAKER_REGISTRY_KEY = Symbol.for("remnic.plugin-pi.recall-timeout-breakers");
+const recallBreakerRegistry = globalThis as { [key: symbol]: Map<string, RecallTimeoutBreaker> | undefined };
+const PROCESS_SCOPED_RECALL_BREAKERS =
+  recallBreakerRegistry[RECALL_BREAKER_REGISTRY_KEY] ??= new Map<string, RecallTimeoutBreaker>();
 const RECALL_PRODUCING_TOOL_NAMES: Record<string, true> = {
   "remnic.recall": true,
   "remnic.recall_xray": true,

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -87,7 +87,10 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       // budget on a doomed call. The status LABEL stays gated on statusEnabled.
       const probe = await probeDaemonHealth(client, config);
       if (config.statusEnabled) {
-        session.setStatus("remnic", remnicStatusLabel(probe, config.namespace));
+        session.setStatus(
+          "remnic",
+          recallTimeoutBreaker.isTripped() ? RECALL_DISABLED_STATUS : remnicStatusLabel(probe, config.namespace),
+        );
       }
       await runNamespacePreflight(pi, session, client, config);
     });

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -261,6 +261,8 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
         statusEnabled: true,
         requestTimeoutMs: 60000,
         startupRequestTimeoutMs: 1000,
+        recallTimeoutThreshold: 7,
+        recallTimeoutWindow: 10,
         ...priorConfig,
         remnicDaemonUrl: resolveDaemonUrl(ctx),
       };

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -22,6 +22,7 @@ import {
   resolvePiAgentHome,
   resolvePiExtensionRoot,
 } from "./paths.js";
+import { DEFAULT_CONFIG } from "./config.js";
 
 const DEFAULT_DAEMON_PORT = 4318;
 const BASE_OWNED_FILES = ["remnic.config.json", "index.ts", "README.md"] as const;
@@ -261,8 +262,8 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
         statusEnabled: true,
         requestTimeoutMs: 60000,
         startupRequestTimeoutMs: 1000,
-        recallTimeoutThreshold: 7,
-        recallTimeoutWindow: 10,
+        recallTimeoutThreshold: DEFAULT_CONFIG.recallTimeoutThreshold,
+        recallTimeoutWindow: DEFAULT_CONFIG.recallTimeoutWindow,
         ...priorConfig,
         remnicDaemonUrl: resolveDaemonUrl(ctx),
       };

--- a/packages/plugin-pi/src/recall-timeout-breaker.test.ts
+++ b/packages/plugin-pi/src/recall-timeout-breaker.test.ts
@@ -1,14 +1,21 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { RemnicRequestTimeoutError } from "./client.js";
 import { RecallTimeoutBreaker, isRecallTimeoutError } from "./recall-timeout-breaker.js";
 
-test("isRecallTimeoutError recognizes explicit abort-to-timeout messages", () => {
-  assert.ok(isRecallTimeoutError(new Error("Remnic request timed out after 30ms")), "timeout message");
-  assert.ok(isRecallTimeoutError(new Error("Remnic request timed out after 1ms")), "short timeout");
-  assert.ok(!isRecallTimeoutError(new Error("Remnic request exceeded the 30ms budget before retry 1")), "budget exceeded");
-  assert.ok(!isRecallTimeoutError(new Error("The socket connection was closed unexpectedly.")), "network error");
-  assert.ok(!isRecallTimeoutError(new Error("Internal Server Error")), "HTTP error");
+test("isRecallTimeoutError accepts only typed client timeout errors", () => {
+  assert.ok(isRecallTimeoutError(new RemnicRequestTimeoutError(30)));
+  assert.ok(!isRecallTimeoutError(new Error("Remnic request timed out after 30ms")));
+  assert.ok(!isRecallTimeoutError(new Error("Remnic request exceeded the 30ms budget before retry 1")));
+  assert.ok(!isRecallTimeoutError(new Error("The socket connection was closed unexpectedly.")));
+  assert.ok(!isRecallTimeoutError(new Error("Internal Server Error")));
+});
+
+test("rejects invalid threshold and window values", () => {
+  assert.throws(() => new RecallTimeoutBreaker({ threshold: 0, window: 10 }), /positive integers/);
+  assert.throws(() => new RecallTimeoutBreaker({ threshold: 2.5, window: 10 }), /positive integers/);
+  assert.throws(() => new RecallTimeoutBreaker({ threshold: 11, window: 10 }), /threshold <= window/);
 });
 
 test("6 timeouts in a window of 10 do not trip the breaker", () => {

--- a/packages/plugin-pi/src/recall-timeout-breaker.test.ts
+++ b/packages/plugin-pi/src/recall-timeout-breaker.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { RecallTimeoutBreaker, isRecallTimeoutError } from "./recall-timeout-breaker.js";
+
+test("isRecallTimeoutError recognizes explicit abort-to-timeout messages", () => {
+  assert.ok(isRecallTimeoutError(new Error("Remnic request timed out after 30ms")), "timeout message");
+  assert.ok(isRecallTimeoutError(new Error("Remnic request timed out after 1ms")), "short timeout");
+  assert.ok(!isRecallTimeoutError(new Error("Remnic request exceeded the 30ms budget before retry 1")), "budget exceeded");
+  assert.ok(!isRecallTimeoutError(new Error("The socket connection was closed unexpectedly.")), "network error");
+  assert.ok(!isRecallTimeoutError(new Error("Internal Server Error")), "HTTP error");
+});
+
+test("6 timeouts in a window of 10 do not trip the breaker", () => {
+  const breaker = new RecallTimeoutBreaker({ threshold: 7, window: 10 });
+  for (let i = 0; i < 6; i++) {
+    assert.equal(breaker.record("timeout"), false, `timeout ${i + 1} should not trip`);
+  }
+  assert.equal(breaker.isTripped(), false);
+  assert.equal(breaker.timeoutCount(), 6);
+});
+
+test("7 timeouts in a window of 10 trip the breaker", () => {
+  const breaker = new RecallTimeoutBreaker({ threshold: 7, window: 10 });
+  for (let i = 0; i < 6; i++) {
+    breaker.record("timeout");
+  }
+  assert.equal(breaker.record("timeout"), true, "7th timeout should trip");
+  assert.equal(breaker.isTripped(), true);
+  assert.equal(breaker.timeoutCount(), 7);
+});
+
+test("sliding window ages out older timeouts", () => {
+  const breaker = new RecallTimeoutBreaker({ threshold: 3, window: 4 });
+  // Two timeouts followed by two successes: window is [T, T, S, S].
+  breaker.record("timeout");
+  breaker.record("timeout");
+  breaker.record("success");
+  breaker.record("success");
+  // Two more timeouts replace the original two timeouts as the successes age them out.
+  breaker.record("timeout"); // [T, S, S, T]
+  breaker.record("timeout"); // [S, S, T, T]
+  assert.equal(breaker.timeoutCount(), 2, "older timeouts aged out of the window");
+  assert.equal(breaker.isTripped(), false);
+  // The next timeout finally reaches the threshold.
+  breaker.record("timeout"); // [S, T, T, T]
+  assert.equal(breaker.isTripped(), true, "new timeouts refill the window");
+});
+
+test("permanent trip survives later successes", () => {
+  const breaker = new RecallTimeoutBreaker({ threshold: 7, window: 10 });
+  for (let i = 0; i < 7; i++) {
+    breaker.record("timeout");
+  }
+  assert.equal(breaker.isTripped(), true);
+  for (let i = 0; i < 20; i++) {
+    assert.equal(breaker.record("success"), false, "post-trip records are ignored");
+  }
+  assert.equal(breaker.isTripped(), true);
+  assert.equal(breaker.timeoutCount(), 7);
+});
+
+test("non-timeout failures age the window without counting toward the threshold", () => {
+  const breaker = new RecallTimeoutBreaker({ threshold: 7, window: 10 });
+  for (let i = 0; i < 6; i++) {
+    breaker.record("timeout");
+  }
+  breaker.record("failure");
+  assert.equal(breaker.timeoutCount(), 6);
+  assert.equal(breaker.isTripped(), false);
+  breaker.record("timeout");
+  assert.equal(breaker.isTripped(), true);
+});
+
+test("trip aborts in-flight recall signals and never clears them", () => {
+  const breaker = new RecallTimeoutBreaker({ threshold: 2, window: 2 });
+  let aborted = false;
+  breaker.signal.addEventListener("abort", () => {
+    aborted = true;
+  });
+  breaker.record("timeout");
+  assert.equal(aborted, false);
+  breaker.record("timeout");
+  assert.equal(aborted, true, "trip aborts active recall requests");
+  assert.equal(breaker.signal.aborted, true);
+  breaker.record("success");
+  assert.equal(breaker.signal.aborted, true, "later results cannot re-enable recall");
+});

--- a/packages/plugin-pi/src/recall-timeout-breaker.ts
+++ b/packages/plugin-pi/src/recall-timeout-breaker.ts
@@ -1,0 +1,103 @@
+import { RemnicRequestTimeoutError } from "./client.js";
+
+/**
+ * In-memory rolling-window circuit breaker for automatic Pi context recalls.
+ *
+ * Only explicit Remnic request timeouts (the abort-to-timeout conversion from
+ * {@link RemnicClient.request}) count toward the trip threshold. Other recall
+ * failures (HTTP responses, auth errors, transient network failures) are still
+ * recorded in the rolling window so they age out older timeouts, but they do
+ * not increment the timeout counter.
+ *
+ * Once tripped, the breaker stays open for the lifetime of the process; it is
+ * intentionally not reset by later successes.
+ */
+export type RecallResult = "success" | "timeout" | "failure";
+
+/**
+ * True when an error is the explicit abort-to-timeout error produced by the
+ * HTTP request layer. This deliberately excludes budget-exceeded, network,
+ * HTTP/auth failures, and lookalike server-controlled messages.
+ */
+export function isRecallTimeoutError(err: unknown): boolean {
+  if (err instanceof RemnicRequestTimeoutError) return true;
+  return err instanceof Error && /^Remnic request timed out after \d+ms$/.test(err.message);
+}
+
+export interface RecallTimeoutBreakerOptions {
+  /** Number of timeouts in the last {@link window} recall calls that trips the breaker. */
+  threshold: number;
+  /** Number of recent recall calls kept in the rolling window. */
+  window: number;
+}
+
+export class RecallTimeoutBreaker {
+  private tripped = false;
+  private readonly results: boolean[] = [];
+  private readonly threshold: number;
+  private readonly windowSize: number;
+  private readonly abortController = new AbortController();
+
+  constructor(options: RecallTimeoutBreakerOptions) {
+    const { threshold, window } = options;
+    if (
+      typeof threshold !== "number" ||
+      !Number.isInteger(threshold) ||
+      threshold <= 0 ||
+      typeof window !== "number" ||
+      !Number.isInteger(window) ||
+      window <= 0 ||
+      threshold > window
+    ) {
+      throw new Error(
+        `Invalid RecallTimeoutBreaker options: threshold and window must be positive integers with threshold <= window (got threshold=${threshold}, window=${window})`,
+      );
+    }
+    this.threshold = threshold;
+    this.windowSize = window;
+  }
+
+  get signal(): AbortSignal {
+    return this.abortController.signal;
+  }
+
+  isTripped(): boolean {
+    return this.tripped;
+  }
+
+  recordSuccess(): void {
+    this.record("success");
+  }
+
+  recordTimeout(): boolean {
+    return this.record("timeout");
+  }
+
+  recordFailure(): void {
+    this.record("failure");
+  }
+
+  record(result: RecallResult): boolean {
+    if (this.tripped) return false;
+
+    this.results.push(result === "timeout");
+    if (this.results.length > this.windowSize) this.results.shift();
+
+    if (this.timeoutCount() >= this.threshold) {
+      this.tripped = true;
+      this.abortController.abort();
+      return true;
+    }
+
+    return false;
+  }
+
+  timeoutCount(): number {
+    let count = 0;
+    for (const timedOut of this.results) {
+      if (timedOut) count += 1;
+    }
+    return count;
+  }
+}
+

--- a/packages/plugin-pi/src/recall-timeout-breaker.ts
+++ b/packages/plugin-pi/src/recall-timeout-breaker.ts
@@ -20,8 +20,7 @@ export type RecallResult = "success" | "timeout" | "failure";
  * HTTP/auth failures, and lookalike server-controlled messages.
  */
 export function isRecallTimeoutError(err: unknown): boolean {
-  if (err instanceof RemnicRequestTimeoutError) return true;
-  return err instanceof Error && /^Remnic request timed out after \d+ms$/.test(err.message);
+  return err instanceof RemnicRequestTimeoutError;
 }
 
 export interface RecallTimeoutBreakerOptions {


### PR DESCRIPTION
## Summary

Automatic between-tool context recalls in the Pi plugin block the agent on every tool call. When the Remnic daemon is slow or unreachable, each of those recalls waits out its full timeout, so a degraded daemon silently taxes every step of the user's session — there was no mechanism to stop paying that cost.

This adds a rolling-window circuit breaker for those automatic recalls. When `recallTimeoutThreshold` (default `7`) of the last `recallTimeoutWindow` (default `10`) recall calls fail with an explicit request timeout, automatic recall is disabled for the remainder of the process:

- subsequent recalls are neither retried **nor awaited** — the agent stops blocking on Remnic entirely;
- in-flight recalls are aborted via a shared `AbortSignal`, so no straggler keeps the turn waiting;
- the session status reports that recall is disabled until restart, so the user understands why memory went quiet rather than silently losing recall.

Design decisions worth flagging for review:

- **Permanent for the process lifetime, by design.** No cooldown and no self re-enable. A breaker that reopens on a timer would re-block the user every cycle against a daemon that is still down.
- **Only explicit request timeouts count toward tripping.** HTTP/auth/connection failures are a different fault and should not trip a *timeout* breaker. They still occupy a slot in the rolling window, so they age out stale timeouts rather than letting an old burst linger.
- **Timeout detection is type-based, not message-based.** `isRecallTimeoutError` matches the client's own abort-to-timeout error, so a misbehaving or hostile server cannot trip — or suppress — the breaker with a crafted error string.
- **No effect on the healthy path.** No extra awaits, no added latency; state is in-memory and per-process, never persisted.

Config is wired end-to-end (schema → defaults → loader → client), with `threshold > window` rejected at load time rather than silently coerced.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Security / hardening

## Validation

- [x] `npm run check-types` — passed (`[test-typecheck] OK`, all workspace jobs)
- [ ] `npm test` — **not run in full.** Ran the plugin's own suite instead: `npx tsx --test 'src/**/*.test.ts'` → **159 passed, 0 failed**
- [ ] `npm run build` — not run
- [ ] `bash scripts/check-review-patterns.sh` — not run
- [x] Added/updated tests for behavior changes
- [ ] For retrieval/planner/cache/config changes: ran `docs/ops/pr-review-hardening-playbook.md` — not run
- [ ] For high-risk memory/retrieval paths: ran `npm run test:entity-hardening` — not run; this changes recall *scheduling*, not retrieval or memory-write semantics
- [ ] Ran `npm run review:cursor` locally — not available in this environment

New tests cover the behaviour directly:

- 6 timeouts in a window of 10 do **not** trip the breaker
- 7 timeouts in a window of 10 **do** trip it
- the sliding window genuinely ages out older timeouts
- a trip survives later successes (never self-heals)
- non-timeout failures age the window without counting toward the threshold
- tripping aborts in-flight recall signals and never clears them

## Changelog

- [x] Added/updated `CHANGELOG.md` under `## [Unreleased]`

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered — defaults preserve current behaviour until 7 timeouts occur in 10 calls; no config change required
- [x] Migration/config impact documented — two new optional keys, documented in the plugin README
- [x] Zero-value semantics validated — both values are validated as positive integers; `0` is rejected at load rather than coerced
- [x] Invalid user input rejected, not silently defaulted — `threshold > window` throws at config load
- [ ] Cache invalidation/coherency — n/a, breaker state is per-process and in-memory
- [ ] Namespace consistency — n/a, no read/write path changes
- [ ] Direct-write paths trigger reindex — n/a, no writes
- [ ] File replace operations are atomic — n/a, nothing persisted
- [x] Documented config properties wired end-to-end (schema → defaults → loader → client → test)

## Notes for reviewers

Two judgement calls I would most like a second opinion on:

1. **Permanent-until-restart** is deliberate, but it is the most opinionated part of this change. If you would prefer a long cooldown over a hard stop, that is a small change to `RecallTimeoutBreaker.record`.
2. **Non-timeout failures occupy window slots but do not count toward the threshold.** The alternative — excluding them from the window entirely — would make an old burst of timeouts linger indefinitely across a long run of connection errors. I think ageing them out is right, but it is a defensible either way.

Also worth a look: `isRecallTimeoutError` keeps a narrow anchored message fallback alongside the `instanceof` check, for timeouts that cross a boundary losing prototype identity. If you would rather drop the fallback entirely and rely on the type alone, say so.

## PR workflow

- [x] PR scope is narrow — one feature, confined to `packages/plugin-pi`
- [x] Synced with latest `main` before requesting AI review — branched from `main` at v9.28.0
- [x] Batched review fixes by subsystem instead of micro-pushing

🤖 *This content was generated with AI assistance using Claude Opus 5.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-memory recall-timeout circuit breaker for Pi automatic between-tool recalls; once tripped, recall is disabled until restart.
  * Added `recallTimeoutThreshold` and `recallTimeoutWindow` configuration (documented and persisted), and exported the `PiApi` type.
* **Bug Fixes**
  * Improved caller abort handling: timeouts, retries/backoff, and in-flight recalls now cancel promptly and propagate abort errors correctly.
  * Recall tooling now consistently respects the breaker (skipping recall-producing tools and showing a “disabled until restart” notice).
* **Documentation**
  * Updated Pi plugin README and configuration examples for the new keys.
* **Tests**
  * Expanded validation, breaker rolling-window behavior, timeout classification, abort propagation, and recall-disable persistence across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->