### PR TITLE
feat(core): bootstrap reconciliation planner for diverged peers (part of #2150)

### DIFF
--- a/.changeset/2150-reconcile-plan.md
+++ b/.changeset/2150-reconcile-plan.md
@@ -1,0 +1,10 @@
+---
+"@remnic/core": minor
+---
+
+Add the bootstrap reconciliation planner for diverged peer daemons (#2150).
+`planReconciliation()` takes two corpus censuses (plus an optional cursor from a
+prior converged run) and returns what must move in each direction, how each
+both-modified path is settled under the chosen conflict policy, and a
+per-namespace convergence report. Converged peers plan no work, which is the
+idempotency contract reconciliation transport can short-circuit on.

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -156,6 +156,16 @@
       "remnic-source": "./src/adapters/claude-code.ts",
       "import": "./dist/adapters/claude-code.js"
     },
+    "./reconcile/plan": {
+      "types": "./dist/reconcile/plan.d.ts",
+      "remnic-source": "./src/reconcile/plan.ts",
+      "import": "./dist/reconcile/plan.js"
+    },
+    "./reconcile/plan.js": {
+      "types": "./dist/reconcile/plan.d.ts",
+      "remnic-source": "./src/reconcile/plan.ts",
+      "import": "./dist/reconcile/plan.js"
+    },
     "./adapters/codex": {
       "types": "./dist/adapters/codex.d.ts",
       "remnic-source": "./src/adapters/codex.ts",

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  planNamespaceReconciliation,
+  planReconciliation,
+  summarizeReconcilePlan,
+  type ReconcileFileState,
+  type ReconcilePlanEntry,
+} from "./plan.js";
+
+function file(path: string, sha256: string, mtimeMs?: number): ReconcileFileState {
+  return mtimeMs === undefined ? { path, sha256 } : { path, sha256, mtimeMs };
+}
+
+function entryFor(entries: readonly ReconcilePlanEntry[], path: string): ReconcilePlanEntry {
+  const found = entries.find((e) => e.path === path);
+  assert.ok(found, `no plan entry for ${path}`);
+  return found;
+}
+
+test("converged corpora produce no work and report converged", () => {
+  const files = [file("facts/2026-03-01/a.md", "aaa"), file("facts/2026-03-01/b.md", "bbb")];
+  const plan = planReconciliation([{ namespace: "default", local: files, peer: files }]);
+  assert.equal(plan.converged, true);
+  assert.deepEqual(
+    plan.entries.map((e) => e.action),
+    ["identical", "identical"],
+  );
+  assert.deepEqual(plan.byNamespace, [
+    { namespace: "default", pull: 0, push: 0, identical: 2, conflict: 0, unresolved: 0 },
+  ]);
+});
+
+test("a bootstrap merge moves unique data both ways and deletes nothing", () => {
+  // The #2150 shape: no common base, both sides hold months the other never saw.
+  const plan = planReconciliation([
+    {
+      namespace: "default",
+      local: [file("facts/2026-01-01/local-only.md", "l1"), file("facts/2026-05-01/shared.md", "s1")],
+      peer: [file("facts/2026-04-01/peer-only.md", "p1"), file("facts/2026-05-01/shared.md", "s1")],
+    },
+  ]);
+  assert.equal(plan.converged, false);
+  assert.equal(entryFor(plan.entries, "facts/2026-01-01/local-only.md").action, "push");
+  assert.equal(entryFor(plan.entries, "facts/2026-04-01/peer-only.md").action, "pull");
+  assert.equal(entryFor(plan.entries, "facts/2026-05-01/shared.md").action, "identical");
+  assert.equal(
+    plan.entries.filter((e) => e.action === "conflict").length,
+    0,
+    "absent on one side without a base means never seen, not deleted",
+  );
+});
+
+test("manual is the default policy: a both-modified path is reported, never auto-picked", () => {
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [file("facts/a.md", "local", 2000)],
+    peer: [file("facts/a.md", "peer", 1000)],
+  });
+  const conflict = entryFor(entries, "facts/a.md");
+  assert.equal(conflict.action, "conflict");
+  assert.equal(conflict.reason, "both_modified");
+  assert.equal(conflict.resolution, "unresolved", "equally authoritative sides must not be settled by default");
+});
+
+test("newest-wins picks the later side by mtime", () => {
+  const entries = planNamespaceReconciliation(
+    {
+      namespace: "default",
+      local: [file("facts/a.md", "local", 2000), file("facts/b.md", "local", 1000)],
+      peer: [file("facts/a.md", "peer", 1000), file("facts/b.md", "peer", 2000)],
+    },
+    { conflictPolicy: "newest-wins" },
+  );
+  assert.equal(entryFor(entries, "facts/a.md").resolution, "local-wins");
+  assert.equal(entryFor(entries, "facts/b.md").resolution, "peer-wins");
+});
+
+test("newest-wins degrades to keeping both when the order is not decidable", () => {
+  // No timestamp on one side, and an exact tie. Either way "newest" is a coin
+  // flip, and a coin flip here discards a fact the other corpus may be alone in
+  // holding — the whole failure #2150 exists to prevent.
+  const entries = planNamespaceReconciliation(
+    {
+      namespace: "default",
+      local: [file("facts/untimed.md", "local"), file("facts/tied.md", "local", 5000)],
+      peer: [file("facts/untimed.md", "peer", 1000), file("facts/tied.md", "peer", 5000)],
+    },
+    { conflictPolicy: "newest-wins" },
+  );
+  assert.equal(entryFor(entries, "facts/untimed.md").resolution, "supersede-link");
+  assert.equal(entryFor(entries, "facts/tied.md").resolution, "supersede-link");
+});
+
+test("keep-both never designates a loser", () => {
+  const entries = planNamespaceReconciliation(
+    {
+      namespace: "default",
+      local: [file("facts/a.md", "local", 2000)],
+      peer: [file("facts/a.md", "peer", 1000)],
+    },
+    { conflictPolicy: "keep-both" },
+  );
+  assert.equal(entryFor(entries, "facts/a.md").resolution, "supersede-link");
+});
+
+test("a base turns a one-sided change back into an ordinary transfer", () => {
+  const base = [file("facts/a.md", "v1"), file("facts/b.md", "v1")];
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [file("facts/a.md", "v1"), file("facts/b.md", "v2-local")],
+    peer: [file("facts/a.md", "v2-peer"), file("facts/b.md", "v1")],
+    base,
+  });
+  // Only the peer moved on a.md, only we moved on b.md — neither is a conflict.
+  assert.equal(entryFor(entries, "facts/a.md").action, "pull");
+  assert.equal(entryFor(entries, "facts/b.md").action, "push");
+  assert.equal(entries.filter((e) => e.action === "conflict").length, 0);
+});
+
+test("a base proves a deletion, and a deletion against a live edit needs an operator", () => {
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [file("facts/kept.md", "v1")],
+    peer: [file("facts/dropped.md", "v1")],
+    base: [file("facts/kept.md", "v1"), file("facts/dropped.md", "v1")],
+  });
+  // The peer no longer has kept.md and the base says it had exactly our copy:
+  // that is a real deletion, not a gap. Re-pushing would resurrect it.
+  const kept = entryFor(entries, "facts/kept.md");
+  assert.equal(kept.action, "conflict");
+  assert.equal(kept.reason, "peer_deleted");
+  assert.equal(kept.resolution, "unresolved");
+  const dropped = entryFor(entries, "facts/dropped.md");
+  assert.equal(dropped.action, "conflict");
+  assert.equal(dropped.reason, "local_deleted");
+  assert.equal(dropped.resolution, "unresolved");
+});
+
+test("a locally tombstoned fact is not resurrected from the peer", () => {
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [],
+    peer: [file("facts/retracted.md", "retracted-hash"), file("facts/fresh.md", "fresh-hash")],
+    tombstonedSha256: ["retracted-hash"],
+  });
+  const retracted = entryFor(entries, "facts/retracted.md");
+  assert.equal(retracted.action, "identical", "a retraction must survive every future reconcile");
+  assert.equal(retracted.reason, "tombstoned");
+  assert.equal(entryFor(entries, "facts/fresh.md").action, "pull");
+});
+
+test("namespaces are planned independently and reported separately", () => {
+  const plan = planReconciliation([
+    { namespace: "alpha", local: [file("facts/a.md", "x")], peer: [] },
+    { namespace: "beta", local: [], peer: [file("facts/a.md", "y")] },
+  ]);
+  // Same path in two namespaces must not collapse into one decision.
+  assert.equal(plan.entries.length, 2);
+  assert.equal(plan.entries.filter((e) => e.namespace === "alpha")[0]?.action, "push");
+  assert.equal(plan.entries.filter((e) => e.namespace === "beta")[0]?.action, "pull");
+  assert.deepEqual(plan.byNamespace.map((r) => r.namespace), ["alpha", "beta"]);
+});
+
+test("the plan is byte-stable across runs regardless of input order", () => {
+  const local = [file("facts/c.md", "1"), file("facts/a.md", "2"), file("facts/b.md", "3")];
+  const peer = [file("facts/b.md", "3"), file("facts/z.md", "9")];
+  const first = planReconciliation([
+    { namespace: "beta", local, peer },
+    { namespace: "alpha", local, peer },
+  ]);
+  const second = planReconciliation([
+    { namespace: "alpha", local: [...local].reverse(), peer: [...peer].reverse() },
+    { namespace: "beta", local: [...local].reverse(), peer: [...peer].reverse() },
+  ]);
+  // A convergence report an operator diffs between runs is only useful if the
+  // ordering is total (§12) — no incidental readdir order may leak in.
+  assert.deepEqual(first.entries, second.entries);
+  assert.deepEqual(
+    first.entries.map((e) => `${e.namespace}:${e.path}`),
+    ["alpha:facts/a.md", "alpha:facts/b.md", "alpha:facts/c.md", "alpha:facts/z.md",
+      "beta:facts/a.md", "beta:facts/b.md", "beta:facts/c.md", "beta:facts/z.md"],
+  );
+});
+
+test("the report counts every action and isolates the unresolved ones", () => {
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [file("facts/push.md", "l"), file("facts/same.md", "s"), file("facts/clash.md", "l")],
+    peer: [file("facts/pull.md", "p"), file("facts/same.md", "s"), file("facts/clash.md", "p")],
+  });
+  assert.deepEqual(summarizeReconcilePlan(entries), [
+    { namespace: "default", pull: 1, push: 1, identical: 1, conflict: 1, unresolved: 1 },
+  ]);
+});
+
+test("planning an empty pair is converged, not a crash", () => {
+  const plan = planReconciliation([{ namespace: "default", local: [], peer: [] }]);
+  assert.equal(plan.converged, true);
+  assert.deepEqual(plan.entries, []);
+  assert.deepEqual(plan.byNamespace, []);
+});
+
+test("entries carry the hashes a transport needs to verify what it moved", () => {
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [file("facts/a.md", "local-hash")],
+    peer: [file("facts/a.md", "peer-hash"), file("facts/b.md", "peer-b")],
+    base: [file("facts/a.md", "base-hash")],
+  });
+  const a = entryFor(entries, "facts/a.md");
+  assert.equal(a.localSha256, "local-hash");
+  assert.equal(a.peerSha256, "peer-hash");
+  assert.equal(a.baseSha256, "base-hash");
+  const b = entryFor(entries, "facts/b.md");
+  assert.equal(b.peerSha256, "peer-b");
+  assert.equal(b.localSha256, undefined);
+});

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -28,7 +28,7 @@ test("converged corpora produce no work and report converged", () => {
     ["identical", "identical"],
   );
   assert.deepEqual(plan.byNamespace, [
-    { namespace: "default", pull: 0, push: 0, identical: 2, conflict: 0, unresolved: 0 },
+    { namespace: "default", pull: 0, push: 0, identical: 2, conflict: 0, suppress: 0, unresolved: 0 },
   ]);
 });
 
@@ -138,7 +138,7 @@ test("a base proves a deletion, and a deletion against a live edit needs an oper
   assert.equal(dropped.resolution, "unresolved");
 });
 
-test("a locally tombstoned fact is not resurrected from the peer", () => {
+test("a locally tombstoned fact is suppressed on the peer, not pulled back", () => {
   const entries = planNamespaceReconciliation({
     namespace: "default",
     local: [],
@@ -146,9 +146,46 @@ test("a locally tombstoned fact is not resurrected from the peer", () => {
     tombstonedSha256: ["retracted-hash"],
   });
   const retracted = entryFor(entries, "facts/retracted.md");
-  assert.equal(retracted.action, "identical", "a retraction must survive every future reconcile");
+  assert.equal(retracted.action, "suppress", "a retraction must survive every future reconcile");
   assert.equal(retracted.reason, "tombstoned");
   assert.equal(entryFor(entries, "facts/fresh.md").action, "pull");
+});
+
+test("a peer still serving a retracted fact is NOT converged", () => {
+  // Marking it `identical` would let transport skip the whole run on
+  // plan.converged, so the peer would keep serving the retracted fact forever.
+  const plan = planReconciliation([
+    {
+      namespace: "default",
+      local: [],
+      peer: [file("facts/retracted.md", "retracted-hash")],
+      tombstonedSha256: ["retracted-hash"],
+    },
+  ]);
+  assert.equal(plan.converged, false, "propagating the retraction is work, not agreement");
+  assert.deepEqual(plan.byNamespace, [
+    { namespace: "default", pull: 0, push: 0, identical: 0, conflict: 0, suppress: 1, unresolved: 0 },
+  ]);
+});
+
+test("delete-versus-modify stays a conflict in both directions", () => {
+  // The surviving side edited since the base, so its hash no longer equals the
+  // base. Keying on equality would emit a plain push/pull and silently
+  // resurrect a deliberate deletion.
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [file("facts/we-edited.md", "local-v2")],
+    peer: [file("facts/peer-edited.md", "peer-v2")],
+    base: [file("facts/we-edited.md", "v1"), file("facts/peer-edited.md", "v1")],
+  });
+  const weEdited = entryFor(entries, "facts/we-edited.md");
+  assert.equal(weEdited.action, "conflict");
+  assert.equal(weEdited.reason, "local_modified_peer_deleted");
+  assert.equal(weEdited.resolution, "unresolved");
+  const peerEdited = entryFor(entries, "facts/peer-edited.md");
+  assert.equal(peerEdited.action, "conflict");
+  assert.equal(peerEdited.reason, "local_deleted_peer_modified");
+  assert.equal(peerEdited.resolution, "unresolved");
 });
 
 test("namespaces are planned independently and reported separately", () => {
@@ -191,7 +228,7 @@ test("the report counts every action and isolates the unresolved ones", () => {
     peer: [file("facts/pull.md", "p"), file("facts/same.md", "s"), file("facts/clash.md", "p")],
   });
   assert.deepEqual(summarizeReconcilePlan(entries), [
-    { namespace: "default", pull: 1, push: 1, identical: 1, conflict: 1, unresolved: 1 },
+    { namespace: "default", pull: 1, push: 1, identical: 1, conflict: 1, suppress: 0, unresolved: 1 },
   ]);
 });
 

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -124,6 +124,10 @@ test("a base turns a one-sided change back into an ordinary transfer", () => {
   // Only the peer moved on a.md, only we moved on b.md — neither is a conflict.
   assert.equal(entryFor(entries, "facts/a.md").action, "pull");
   assert.equal(entryFor(entries, "facts/b.md").action, "push");
+  // Both censuses still hold the path, so these are NOT the bootstrap
+  // "one side has never seen it" reasons.
+  assert.equal(entryFor(entries, "facts/a.md").reason, "peer_changed");
+  assert.equal(entryFor(entries, "facts/b.md").reason, "local_changed");
   assert.equal(entries.filter((e) => e.action === "conflict").length, 0);
 });
 
@@ -911,4 +915,44 @@ test("non-plain objects are not accepted as envelopes", () => {
       Object.assign(Object.create(null), { conflictPolicy: "manual" }) as Record<string, never>,
     ),
   );
+});
+
+test("an empty namespace list still validates its options", () => {
+  // The same call must not pass or fail depending on list length.
+  for (const bad of [null, new Date(), { conflictPolicy: "nope" }]) {
+    assert.throws(
+      () => planReconciliation([], bad as unknown as Record<string, never>),
+      ReconcilePlanInputError,
+      `options ${Object.prototype.toString.call(bad)}`,
+    );
+  }
+  assert.equal(planReconciliation([], { conflictPolicy: "keep-both" }).converged, true);
+});
+
+test("sharp-S aliases fold together", () => {
+  assert.throws(
+    () =>
+      planNamespaceReconciliation({
+        namespace: "default",
+        local: [file("facts/stra\u00dfe.md", "one")],
+        peer: [file("facts/stra\u1e9ee.md", "two")],
+      }),
+    /aliasing paths/,
+  );
+});
+
+test("a malformed tombstone collection raises the planner's error, not a TypeError", () => {
+  for (const bad of [null, 42, { a: 1 }]) {
+    assert.throws(
+      () =>
+        planNamespaceReconciliation({
+          namespace: "default",
+          local: [],
+          peer: [],
+          tombstonedFileSha256: bad as unknown as string[],
+        }),
+      ReconcilePlanInputError,
+      `tombstonedFileSha256 ${JSON.stringify(bad)}`,
+    );
+  }
 });

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -875,3 +875,40 @@ test("superscript COM and LPT device aliases are rejected", () => {
     );
   }
 });
+
+test("a full caseless fold catches sigma-style aliases", () => {
+  // Unicode-case-insensitive filesystems treat final and medial sigma as one
+  // name; a bare toLowerCase() keeps them distinct.
+  assert.throws(
+    () =>
+      planNamespaceReconciliation({
+        namespace: "default",
+        local: [file("facts/\u03c2.md", "one")],
+        peer: [file("facts/\u03c3.md", "two")],
+      }),
+    /aliasing paths/,
+  );
+});
+
+test("non-plain objects are not accepted as envelopes", () => {
+  // Each passes typeof === "object" and is not an array, exposes no
+  // conflictPolicy, and would silently run under the default policy.
+  for (const bad of [new Date(), new Map(), /re/]) {
+    assert.throws(
+      () =>
+        planNamespaceReconciliation(
+          { namespace: "default", local: [], peer: [] },
+          bad as unknown as Record<string, never>,
+        ),
+      /options must be a plain object/,
+      `options ${Object.prototype.toString.call(bad)}`,
+    );
+  }
+  // A null-prototype record is still a record.
+  assert.doesNotThrow(() =>
+    planNamespaceReconciliation(
+      { namespace: "default", local: [], peer: [] },
+      Object.assign(Object.create(null), { conflictPolicy: "manual" }) as Record<string, never>,
+    ),
+  );
+});

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -608,7 +608,9 @@ test("the same namespace supplied twice is rejected", () => {
 });
 
 test("an out-of-range mtimeMs cannot decide newest-wins", () => {
-  for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -1, 1.5, 8_640_000_000_000_001, "2000"]) {
+  // 1.5 is deliberately absent: fs.stat reports fractional mtimes and
+  // offline-sync forwards them unrounded, so they are valid input.
+  for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -1, 8_640_000_000_000_001, "2000"]) {
     for (const side of ["local", "peer", "base"] as const) {
       const record = { path: "facts/a.md", sha256: digest("x"), mtimeMs: bad as unknown as number };
       assert.throws(
@@ -646,5 +648,49 @@ test("malformed public API envelopes raise ReconcilePlanInputError, not TypeErro
         null as unknown as Record<string, never>,
       ),
     ReconcilePlanInputError,
+  );
+});
+
+test("a fractional mtime from fs.stat is accepted", () => {
+  // Node reports sub-millisecond mtimes on common filesystems; rejecting them
+  // would fail every normally generated census before planning could start.
+  const entries = planNamespaceReconciliation(
+    {
+      namespace: "default",
+      local: [file("facts/a.md", "local", 1_700_000_000_123.456)],
+      peer: [file("facts/a.md", "peer", 1_700_000_000_999.789)],
+    },
+    { conflictPolicy: "newest-wins" },
+  );
+  assert.equal(entryFor(entries, "facts/a.md").resolution, "peer-wins");
+});
+
+test("a non-canonical namespace is rejected so duplicates cannot slip past", () => {
+  assert.throws(
+    () => planNamespaceReconciliation({ namespace: " team ", local: [], peer: [] }),
+    /is not canonical; pass "team"/,
+  );
+  // The dedup guard would otherwise see two distinct keys for one namespace.
+  assert.throws(
+    () =>
+      planReconciliation([
+        { namespace: "team", local: [file("facts/a.md", "one")], peer: [] },
+        { namespace: " team ", local: [], peer: [file("facts/a.md", "two")] },
+      ]),
+    ReconcilePlanInputError,
+  );
+});
+
+test("a null base cursor is rejected rather than read as a bootstrap", () => {
+  // Silently bootstrapping would turn the peer's deletion into a push.
+  assert.throws(
+    () =>
+      planNamespaceReconciliation({
+        namespace: "default",
+        local: [file("facts/a.md", "v1")],
+        peer: [],
+        base: null as unknown as undefined,
+      }),
+    /must be iterable/,
   );
 });

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -694,3 +694,32 @@ test("a null base cursor is rejected rather than read as a bootstrap", () => {
     /must be iterable/,
   );
 });
+
+test("canonically equivalent Unicode paths are treated as one file", () => {
+  // macOS stores decomposed names and compares canonically, so these are the
+  // same file there; planning a push AND a pull would race them.
+  assert.throws(
+    () =>
+      planNamespaceReconciliation({
+        namespace: "default",
+        local: [file("facts/\u00e9.md", "one")],
+        peer: [file("facts/e\u0301.md", "two")],
+      }),
+    /differing only by case/,
+  );
+});
+
+test("an array is not a valid options or input envelope", () => {
+  assert.throws(
+    () =>
+      planNamespaceReconciliation(
+        { namespace: "default", local: [], peer: [] },
+        [] as unknown as Record<string, never>,
+      ),
+    /options must be a plain object/,
+  );
+  assert.throws(
+    () => planNamespaceReconciliation([] as unknown as { namespace: string; local: []; peer: [] }),
+    /namespace input must be a plain object/,
+  );
+});

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -606,3 +606,45 @@ test("the same namespace supplied twice is rejected", () => {
     /namespace default appears twice/,
   );
 });
+
+test("an out-of-range mtimeMs cannot decide newest-wins", () => {
+  for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -1, 1.5, 8_640_000_000_000_001, "2000"]) {
+    for (const side of ["local", "peer", "base"] as const) {
+      const record = { path: "facts/a.md", sha256: digest("x"), mtimeMs: bad as unknown as number };
+      assert.throws(
+        () =>
+          planNamespaceReconciliation({
+            namespace: "default",
+            local: side === "local" ? [record] : [],
+            peer: side === "peer" ? [record] : [],
+            base: side === "base" ? [record] : undefined,
+          }),
+        /out-of-range mtimeMs/,
+        `${side} census mtimeMs ${String(bad)} must be rejected`,
+      );
+    }
+  }
+});
+
+test("malformed public API envelopes raise ReconcilePlanInputError, not TypeError", () => {
+  for (const bad of [undefined, null, "nope", 7]) {
+    assert.throws(
+      () => planReconciliation(bad as unknown as []),
+      ReconcilePlanInputError,
+      `planReconciliation(${JSON.stringify(bad)})`,
+    );
+    assert.throws(
+      () => planNamespaceReconciliation(bad as unknown as { namespace: string; local: []; peer: [] }),
+      ReconcilePlanInputError,
+      `planNamespaceReconciliation(${JSON.stringify(bad)})`,
+    );
+  }
+  assert.throws(
+    () =>
+      planNamespaceReconciliation(
+        { namespace: "default", local: [], peer: [] },
+        null as unknown as Record<string, never>,
+      ),
+    ReconcilePlanInputError,
+  );
+});

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  ReconcilePlanInputError,
   planNamespaceReconciliation,
   planReconciliation,
   summarizeReconcilePlan,
@@ -276,5 +277,90 @@ test("streaming the local side still reports every peer-only path exactly once",
   assert.deepEqual(
     entries.filter((e) => e.action === "pull").map((e) => e.path),
     ["facts/p1.md", "facts/p2.md"],
+  );
+});
+
+test("a retracted digest present on BOTH sides is suppressed, not called identical", () => {
+  // Same path, same digest, retracted here. Calling it identical converges the
+  // plan and the peer keeps serving the retracted fact.
+  const plan = planReconciliation([
+    {
+      namespace: "default",
+      local: [file("facts/retracted.md", "gone")],
+      peer: [file("facts/retracted.md", "gone")],
+      tombstonedFileSha256: ["gone"],
+    },
+  ]);
+  assert.equal(plan.entries[0]?.action, "suppress");
+  assert.equal(plan.converged, false);
+});
+
+test("a retracted peer revision cannot win a conflict", () => {
+  // Same path, different content, peer's copy is the retracted one and is
+  // NEWER. Reaching the conflict ladder at all would let newest-wins resurrect
+  // precisely what was retracted.
+  const entries = planNamespaceReconciliation(
+    {
+      namespace: "default",
+      local: [file("facts/a.md", "live", 1000)],
+      peer: [file("facts/a.md", "retracted", 9000)],
+      tombstonedFileSha256: ["retracted"],
+    },
+    { conflictPolicy: "newest-wins" },
+  );
+  const entry = entryFor(entries, "facts/a.md");
+  assert.equal(entry.action, "suppress");
+  assert.equal(entry.resolution, undefined, "a retraction is not a conflict to be won");
+});
+
+test("a malformed census record fails the plan instead of vanishing from it", () => {
+  for (const side of ["local", "peer"] as const) {
+    assert.throws(
+      () =>
+        planNamespaceReconciliation({
+          namespace: "default",
+          local: side === "local" ? [{ path: "", sha256: "x" }] : [],
+          peer: side === "peer" ? [{ path: "", sha256: "x" }] : [],
+        }),
+      ReconcilePlanInputError,
+      `${side} census with an empty path must reject`,
+    );
+  }
+});
+
+test("a path listed twice with different digests is rejected on every census", () => {
+  const dupe = [file("facts/a.md", "one"), file("facts/a.md", "two")];
+  for (const side of ["local", "peer", "base"] as const) {
+    assert.throws(
+      () =>
+        planNamespaceReconciliation({
+          namespace: "default",
+          local: side === "local" ? dupe : [],
+          peer: side === "peer" ? dupe : [],
+          base: side === "base" ? dupe : undefined,
+        }),
+      /lists facts\/a\.md twice with different digests/,
+      `${side} census must not silently pick a winner by arrival order`,
+    );
+  }
+  // An exact repeat is unambiguous and stays acceptable.
+  assert.doesNotThrow(() =>
+    planNamespaceReconciliation({
+      namespace: "default",
+      local: [file("facts/a.md", "one"), file("facts/a.md", "one")],
+      peer: [],
+    }),
+  );
+});
+
+test("an unknown conflictPolicy is rejected rather than silently treated as manual", () => {
+  assert.throws(
+    () =>
+      planNamespaceReconciliation(
+        { namespace: "default", local: [file("facts/a.md", "l")], peer: [file("facts/a.md", "p")] },
+        // Deserialized config or an untyped JS caller can produce this.
+        { conflictPolicy: "newest_wins" as unknown as "newest-wins" },
+      ),
+    ReconcilePlanInputError,
   );
 });

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -563,3 +563,46 @@ test("the base census participates in case-collision detection", () => {
     /differing only by case/,
   );
 });
+
+test("the streamed local census rejects an mtime-only duplicate like the indexed ones", () => {
+  assert.throws(
+    () =>
+      planNamespaceReconciliation({
+        namespace: "default",
+        local: [file("facts/a.md", "same", 1000), file("facts/a.md", "same", 2000)],
+        peer: [],
+      }),
+    /local census for namespace default lists facts\/a\.md twice with different mtimeMs/,
+  );
+});
+
+test("newest-wins cannot be flipped by local census ordering", () => {
+  // The duplicate is rejected outright, so neither arrival order can supply
+  // the timestamp that decides the winner.
+  for (const order of [
+    [file("facts/a.md", "local", 1000), file("facts/a.md", "local", 9000)],
+    [file("facts/a.md", "local", 9000), file("facts/a.md", "local", 1000)],
+  ]) {
+    assert.throws(
+      () =>
+        planNamespaceReconciliation(
+          { namespace: "default", local: order, peer: [file("facts/a.md", "peer", 5000)] },
+          { conflictPolicy: "newest-wins" },
+        ),
+      ReconcilePlanInputError,
+    );
+  }
+});
+
+test("the same namespace supplied twice is rejected", () => {
+  // Planned independently, one (namespace, path) could draw both push and pull,
+  // and the two entries sort equal so batch order would pick the survivor.
+  assert.throws(
+    () =>
+      planReconciliation([
+        { namespace: "default", local: [file("facts/a.md", "one")], peer: [] },
+        { namespace: "default", local: [], peer: [file("facts/a.md", "two")] },
+      ]),
+    /namespace default appears twice/,
+  );
+});

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -831,3 +831,47 @@ test("Windows-unstorable and reserved path names are rejected", () => {
     }),
   );
 });
+
+test("a directionless supersede link is reported as unresolved", () => {
+  // The policy nominally settled it, but with no orderable timestamp the link
+  // direction is an operator call — reporting unresolved: 0 would hide that.
+  const entries = planNamespaceReconciliation(
+    {
+      namespace: "default",
+      local: [file("facts/a.md", "local", 5000)],
+      peer: [file("facts/a.md", "peer", 5000)],
+    },
+    { conflictPolicy: "keep-both" },
+  );
+  assert.equal(entryFor(entries, "facts/a.md").newerSide, undefined);
+  assert.deepEqual(summarizeReconcilePlan(entries), [
+    { namespace: "default", pull: 0, push: 0, identical: 0, conflict: 1, suppress: 0, unresolved: 1 },
+  ]);
+});
+
+test("an ordered supersede link is not counted as unresolved", () => {
+  const entries = planNamespaceReconciliation(
+    {
+      namespace: "default",
+      local: [file("facts/a.md", "local", 1000)],
+      peer: [file("facts/a.md", "peer", 2000)],
+    },
+    { conflictPolicy: "keep-both" },
+  );
+  assert.equal(summarizeReconcilePlan(entries)[0]?.unresolved, 0);
+});
+
+test("superscript COM and LPT device aliases are rejected", () => {
+  for (const bad of ["facts/COM\u00b9.txt", "facts/LPT\u00b2", "facts/com\u00b3.md"]) {
+    assert.throws(
+      () =>
+        planNamespaceReconciliation({
+          namespace: "default",
+          local: [{ path: bad, sha256: digest("x") }],
+          peer: [],
+        }),
+      /reserved Windows device name/,
+      `path ${JSON.stringify(bad)} must be rejected`,
+    );
+  }
+});

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -143,7 +143,7 @@ test("a locally tombstoned fact is suppressed on the peer, not pulled back", () 
     namespace: "default",
     local: [],
     peer: [file("facts/retracted.md", "retracted-hash"), file("facts/fresh.md", "fresh-hash")],
-    tombstonedSha256: ["retracted-hash"],
+    tombstonedFileSha256: ["retracted-hash"],
   });
   const retracted = entryFor(entries, "facts/retracted.md");
   assert.equal(retracted.action, "suppress", "a retraction must survive every future reconcile");
@@ -159,7 +159,7 @@ test("a peer still serving a retracted fact is NOT converged", () => {
       namespace: "default",
       local: [],
       peer: [file("facts/retracted.md", "retracted-hash")],
-      tombstonedSha256: ["retracted-hash"],
+      tombstonedFileSha256: ["retracted-hash"],
     },
   ]);
   assert.equal(plan.converged, false, "propagating the retraction is work, not agreement");
@@ -253,4 +253,28 @@ test("entries carry the hashes a transport needs to verify what it moved", () =>
   const b = entryFor(entries, "facts/b.md");
   assert.equal(b.peerSha256, "peer-b");
   assert.equal(b.localSha256, undefined);
+});
+
+test("a duplicate path in the streamed local census does not double-count", () => {
+  // The local side is consumed as a stream, so a repeated path must not emit
+  // two entries or reappear as peer-only after the index entry was consumed.
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [file("facts/a.md", "same"), file("facts/a.md", "same")],
+    peer: [file("facts/a.md", "same")],
+  });
+  assert.equal(entries.filter((e) => e.path === "facts/a.md").length, 1);
+  assert.equal(entries[0]?.action, "identical");
+});
+
+test("streaming the local side still reports every peer-only path exactly once", () => {
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [file("facts/shared.md", "s")],
+    peer: [file("facts/shared.md", "s"), file("facts/p1.md", "1"), file("facts/p2.md", "2")],
+  });
+  assert.deepEqual(
+    entries.filter((e) => e.action === "pull").map((e) => e.path),
+    ["facts/p1.md", "facts/p2.md"],
+  );
 });

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -426,7 +426,7 @@ test("paths differing only by case are rejected across censuses", () => {
         local: [file("Facts/A.md", "one")],
         peer: [file("facts/a.md", "two")],
       }),
-    /differing only by case/,
+    /aliasing paths/,
   );
 });
 
@@ -560,7 +560,7 @@ test("the base census participates in case-collision detection", () => {
         peer: [],
         base: [file("Facts/A.md", "one")],
       }),
-    /differing only by case/,
+    /aliasing paths/,
   );
 });
 
@@ -705,7 +705,7 @@ test("canonically equivalent Unicode paths are treated as one file", () => {
         local: [file("facts/\u00e9.md", "one")],
         peer: [file("facts/e\u0301.md", "two")],
       }),
-    /differing only by case/,
+    /aliasing paths/,
   );
 });
 
@@ -722,4 +722,50 @@ test("an array is not a valid options or input envelope", () => {
     () => planNamespaceReconciliation([] as unknown as { namespace: string; local: []; peer: [] }),
     /namespace input must be a plain object/,
   );
+});
+
+test("a peer retraction suppresses our surviving copy instead of pushing it back", () => {
+  // Bootstrap: the peer census simply OMITS what it retracted, so without its
+  // tombstone set this is indistinguishable from "never had it" and we push
+  // the file back, undoing the peer's retraction.
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [file("facts/retracted-there.md", "gone"), file("facts/mine.md", "keep")],
+    peer: [],
+    peerTombstonedFileSha256: [digest("gone")],
+  });
+  const suppressed = entryFor(entries, "facts/retracted-there.md");
+  assert.equal(suppressed.action, "suppress");
+  assert.equal(suppressed.suppressSide, "local", "the copy to remove is ours");
+  assert.equal(entryFor(entries, "facts/mine.md").action, "push", "unretracted files still push");
+});
+
+test("the peer tombstone set is validated like our own", () => {
+  assert.throws(
+    () =>
+      planNamespaceReconciliation({
+        namespace: "default",
+        local: [],
+        peer: [],
+        peerTombstonedFileSha256: digest("x") as unknown as string[],
+      }),
+    /peerTombstonedFileSha256 for namespace default must be a collection of digests/,
+  );
+});
+
+test("Win32-aliasing path segments are rejected", () => {
+  // Windows strips trailing dots and spaces, so `a.md.` and `a.md` are one
+  // file there while the fold key keeps them distinct.
+  for (const bad of ["facts/a.md.", "facts/a.md ", "facts/dir./a.md"]) {
+    assert.throws(
+      () =>
+        planNamespaceReconciliation({
+          namespace: "default",
+          local: [{ path: bad, sha256: digest("x") }],
+          peer: [],
+        }),
+      /dot or space/,
+      `path ${JSON.stringify(bad)} must be rejected`,
+    );
+  }
 });

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -1002,3 +1002,12 @@ test("the base cursor is validated with the same rules as the other censuses", (
   assert.equal(entryFor(entries, "facts/a.md").action, "pull");
   assert.equal(entryFor(entries, "facts/a.md").baseSha256, digest("v1"));
 });
+
+test("a namespace with an unpaired surrogate is rejected", () => {
+  // namespaceIdentityToken() encodes through TextEncoder, so this and a
+  // literal U+FFFD namespace are one directory on disk.
+  assert.throws(
+    () => planNamespaceReconciliation({ namespace: "\ud800", local: [], peer: [] }),
+    /unpaired surrogate/,
+  );
+});

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -448,3 +448,118 @@ test("a missing namespace or a non-iterable census is rejected", () => {
     );
   }
 });
+
+test("digest casing is canonicalized, not compared verbatim", () => {
+  const upper = digest("same").toUpperCase();
+  const plan = planReconciliation([
+    {
+      namespace: "default",
+      local: [{ path: "facts/a.md", sha256: upper }],
+      peer: [file("facts/a.md", "same")],
+    },
+  ]);
+  assert.equal(plan.entries[0]?.action, "identical", "one digest in two spellings is one digest");
+  assert.equal(plan.entries[0]?.localSha256, digest("same"));
+  assert.equal(plan.converged, true);
+});
+
+test("tombstone membership survives digest casing", () => {
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [],
+    peer: [file("facts/r.md", "gone")],
+    tombstonedFileSha256: [digest("gone").toUpperCase()],
+  });
+  assert.equal(entryFor(entries, "facts/r.md").action, "suppress");
+});
+
+test("suppress names the side holding the retracted revision", () => {
+  const cases = [
+    { tomb: "local-rev", expect: "local" },
+    { tomb: "peer-rev", expect: "peer" },
+  ] as const;
+  for (const { tomb, expect } of cases) {
+    const entries = planNamespaceReconciliation({
+      namespace: "default",
+      local: [file("facts/a.md", "local-rev")],
+      peer: [file("facts/a.md", "peer-rev")],
+      tombstonedFileSha256: [digest(tomb)],
+    });
+    // Without this, transport cannot tell which copy to remove and may delete
+    // the live revision instead of the retracted one.
+    assert.equal(entryFor(entries, "facts/a.md").suppressSide, expect);
+  }
+  const both = planNamespaceReconciliation({
+    namespace: "default",
+    local: [file("facts/a.md", "gone")],
+    peer: [file("facts/a.md", "gone")],
+    tombstonedFileSha256: [digest("gone")],
+  });
+  assert.equal(entryFor(both, "facts/a.md").suppressSide, "both");
+});
+
+test("a single digest string is rejected instead of being split into characters", () => {
+  assert.throws(
+    () =>
+      planNamespaceReconciliation({
+        namespace: "default",
+        local: [],
+        peer: [file("facts/r.md", "gone")],
+        // Satisfies Iterable<string>; new Set() would make 64 one-char members.
+        tombstonedFileSha256: digest("gone") as unknown as string[],
+      }),
+    /must be a collection of digests, not a single string/,
+  );
+  assert.throws(
+    () =>
+      planNamespaceReconciliation({
+        namespace: "default",
+        local: [],
+        peer: [file("facts/r.md", "gone")],
+        tombstonedFileSha256: ["not-a-digest"],
+      }),
+    /64-character sha256 hex digest/,
+  );
+});
+
+test("an unsafe census path is rejected before it becomes transfer work", () => {
+  for (const bad of ["/outside.md", "../outside.md", "facts\\win.md"]) {
+    assert.throws(
+      () =>
+        planNamespaceReconciliation({
+          namespace: "default",
+          local: [],
+          peer: [{ path: bad, sha256: digest("x") }],
+        }),
+      ReconcilePlanInputError,
+      `peer census path ${bad} must be rejected`,
+    );
+  }
+});
+
+test("a duplicate record disagreeing only on mtime is rejected", () => {
+  // newest-wins reads that timestamp, so first-arrival-wins would let input
+  // order pick the winner.
+  assert.throws(
+    () =>
+      planNamespaceReconciliation({
+        namespace: "default",
+        local: [],
+        peer: [file("facts/a.md", "same", 1000), file("facts/a.md", "same", 2000)],
+      }),
+    /lists facts\/a\.md twice with different mtimeMs/,
+  );
+});
+
+test("the base census participates in case-collision detection", () => {
+  assert.throws(
+    () =>
+      planNamespaceReconciliation({
+        namespace: "default",
+        local: [file("facts/a.md", "one")],
+        peer: [],
+        base: [file("Facts/A.md", "one")],
+      }),
+    /differing only by case/,
+  );
+});

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -956,3 +956,49 @@ test("a malformed tombstone collection raises the planner's error, not a TypeErr
     );
   }
 });
+
+test("an unpaired surrogate path is rejected", () => {
+  // Node encodes it as U+FFFD, so it and a literal U+FFFD path are one file on
+  // disk while comparing as two.
+  for (const bad of ["facts/\ud800.md", "facts/\udc00.md"]) {
+    assert.throws(
+      () =>
+        planNamespaceReconciliation({
+          namespace: "default",
+          local: [{ path: bad, sha256: digest("x") }],
+          peer: [],
+        }),
+      /unpaired surrogate/,
+    );
+  }
+  // A well-formed pair is fine.
+  assert.doesNotThrow(() =>
+    planNamespaceReconciliation({
+      namespace: "default",
+      local: [file("facts/\ud83d\ude00.md", "x")],
+      peer: [],
+    }),
+  );
+});
+
+test("the base cursor is validated with the same rules as the other censuses", () => {
+  assert.throws(
+    () =>
+      planNamespaceReconciliation({
+        namespace: "default",
+        local: [],
+        peer: [],
+        base: [file("facts/a.md", "one"), file("facts/a.md", "two")],
+      }),
+    /base census for namespace default lists facts\/a\.md twice with different digests/,
+  );
+  // And it still drives the one-sided-change decision it exists for.
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [file("facts/a.md", "v1")],
+    peer: [file("facts/a.md", "v2")],
+    base: [file("facts/a.md", "v1")],
+  });
+  assert.equal(entryFor(entries, "facts/a.md").action, "pull");
+  assert.equal(entryFor(entries, "facts/a.md").baseSha256, digest("v1"));
+});

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -769,3 +769,65 @@ test("Win32-aliasing path segments are rejected", () => {
     );
   }
 });
+
+test("a supersede link names the newer revision", () => {
+  // Without a direction transport must re-derive it or guess which side is
+  // linked as superseding the other.
+  const newerPeer = planNamespaceReconciliation(
+    {
+      namespace: "default",
+      local: [file("facts/a.md", "local", 1000)],
+      peer: [file("facts/a.md", "peer", 2000)],
+    },
+    { conflictPolicy: "keep-both" },
+  );
+  assert.equal(entryFor(newerPeer, "facts/a.md").newerSide, "peer");
+
+  const newerLocal = planNamespaceReconciliation(
+    {
+      namespace: "default",
+      local: [file("facts/a.md", "local", 2000)],
+      peer: [file("facts/a.md", "peer", 1000)],
+    },
+    { conflictPolicy: "keep-both" },
+  );
+  assert.equal(entryFor(newerLocal, "facts/a.md").newerSide, "local");
+});
+
+test("an unorderable supersede link says so instead of picking a side", () => {
+  for (const pair of [
+    [file("facts/a.md", "local", 5000), file("facts/a.md", "peer", 5000)],
+    [file("facts/a.md", "local"), file("facts/a.md", "peer", 5000)],
+  ] as const) {
+    const entries = planNamespaceReconciliation(
+      { namespace: "default", local: [pair[0]], peer: [pair[1]] },
+      { conflictPolicy: "keep-both" },
+    );
+    const entry = entryFor(entries, "facts/a.md");
+    assert.equal(entry.resolution, "supersede-link");
+    assert.equal(entry.newerSide, undefined, "an unordered link must be visibly unordered");
+  }
+});
+
+test("Windows-unstorable and reserved path names are rejected", () => {
+  for (const bad of ["facts/a:b.md", "facts/CON.md", "facts/com1.txt", 'facts/a"b.md', "facts/a\u0001b.md"]) {
+    assert.throws(
+      () =>
+        planNamespaceReconciliation({
+          namespace: "default",
+          local: [{ path: bad, sha256: digest("x") }],
+          peer: [],
+        }),
+      ReconcilePlanInputError,
+      `path ${JSON.stringify(bad)} must be rejected`,
+    );
+  }
+  // A name that merely CONTAINS a reserved word is fine.
+  assert.doesNotThrow(() =>
+    planNamespaceReconciliation({
+      namespace: "default",
+      local: [file("facts/console.md", "x")],
+      peer: [],
+    }),
+  );
+});

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import test from "node:test";
 
 import {
@@ -10,7 +11,13 @@ import {
   type ReconcilePlanEntry,
 } from "./plan.js";
 
-function file(path: string, sha256: string, mtimeMs?: number): ReconcileFileState {
+/** Readable labels stay in the tests; the planner sees real sha256 hex. */
+function digest(label: string): string {
+  return createHash("sha256").update(label).digest("hex");
+}
+
+function file(path: string, label: string, mtimeMs?: number): ReconcileFileState {
+  const sha256 = digest(label);
   return mtimeMs === undefined ? { path, sha256 } : { path, sha256, mtimeMs };
 }
 
@@ -144,7 +151,7 @@ test("a locally tombstoned fact is suppressed on the peer, not pulled back", () 
     namespace: "default",
     local: [],
     peer: [file("facts/retracted.md", "retracted-hash"), file("facts/fresh.md", "fresh-hash")],
-    tombstonedFileSha256: ["retracted-hash"],
+    tombstonedFileSha256: [digest("retracted-hash")],
   });
   const retracted = entryFor(entries, "facts/retracted.md");
   assert.equal(retracted.action, "suppress", "a retraction must survive every future reconcile");
@@ -160,7 +167,7 @@ test("a peer still serving a retracted fact is NOT converged", () => {
       namespace: "default",
       local: [],
       peer: [file("facts/retracted.md", "retracted-hash")],
-      tombstonedFileSha256: ["retracted-hash"],
+      tombstonedFileSha256: [digest("retracted-hash")],
     },
   ]);
   assert.equal(plan.converged, false, "propagating the retraction is work, not agreement");
@@ -248,11 +255,11 @@ test("entries carry the hashes a transport needs to verify what it moved", () =>
     base: [file("facts/a.md", "base-hash")],
   });
   const a = entryFor(entries, "facts/a.md");
-  assert.equal(a.localSha256, "local-hash");
-  assert.equal(a.peerSha256, "peer-hash");
-  assert.equal(a.baseSha256, "base-hash");
+  assert.equal(a.localSha256, digest("local-hash"));
+  assert.equal(a.peerSha256, digest("peer-hash"));
+  assert.equal(a.baseSha256, digest("base-hash"));
   const b = entryFor(entries, "facts/b.md");
-  assert.equal(b.peerSha256, "peer-b");
+  assert.equal(b.peerSha256, digest("peer-b"));
   assert.equal(b.localSha256, undefined);
 });
 
@@ -288,7 +295,7 @@ test("a retracted digest present on BOTH sides is suppressed, not called identic
       namespace: "default",
       local: [file("facts/retracted.md", "gone")],
       peer: [file("facts/retracted.md", "gone")],
-      tombstonedFileSha256: ["gone"],
+      tombstonedFileSha256: [digest("gone")],
     },
   ]);
   assert.equal(plan.entries[0]?.action, "suppress");
@@ -304,7 +311,7 @@ test("a retracted peer revision cannot win a conflict", () => {
       namespace: "default",
       local: [file("facts/a.md", "live", 1000)],
       peer: [file("facts/a.md", "retracted", 9000)],
-      tombstonedFileSha256: ["retracted"],
+      tombstonedFileSha256: [digest("retracted")],
     },
     { conflictPolicy: "newest-wins" },
   );
@@ -319,8 +326,8 @@ test("a malformed census record fails the plan instead of vanishing from it", ()
       () =>
         planNamespaceReconciliation({
           namespace: "default",
-          local: side === "local" ? [{ path: "", sha256: "x" }] : [],
-          peer: side === "peer" ? [{ path: "", sha256: "x" }] : [],
+          local: side === "local" ? [{ path: "", sha256: digest("x") }] : [],
+          peer: side === "peer" ? [{ path: "", sha256: digest("x") }] : [],
         }),
       ReconcilePlanInputError,
       `${side} census with an empty path must reject`,
@@ -363,4 +370,81 @@ test("an unknown conflictPolicy is rejected rather than silently treated as manu
       ),
     ReconcilePlanInputError,
   );
+});
+
+test("a retracted LOCAL revision is suppressed, never pushed", () => {
+  // Without this the suppression undoes itself: transport drops the peer copy,
+  // and the next run pushes our surviving retracted copy straight back.
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [file("facts/retracted.md", "gone")],
+    peer: [],
+    tombstonedFileSha256: [digest("gone")],
+  });
+  const entry = entryFor(entries, "facts/retracted.md");
+  assert.equal(entry.action, "suppress");
+  assert.equal(entry.peerSha256, undefined);
+});
+
+test("a retracted local revision does not win a conflict either", () => {
+  const entries = planNamespaceReconciliation(
+    {
+      namespace: "default",
+      local: [file("facts/a.md", "retracted", 9000)],
+      peer: [file("facts/a.md", "live", 1000)],
+      tombstonedFileSha256: [digest("retracted")],
+    },
+    { conflictPolicy: "newest-wins" },
+  );
+  assert.equal(entryFor(entries, "facts/a.md").action, "suppress");
+});
+
+test("a census record without a usable digest is rejected", () => {
+  // Two records that both omit sha256 compare equal and would plan `identical`,
+  // converging a corpus that was never actually read.
+  for (const bad of [undefined, "", "not-a-digest", 42] as const) {
+    assert.throws(
+      () =>
+        planNamespaceReconciliation({
+          namespace: "default",
+          local: [{ path: "facts/a.md", sha256: bad as unknown as string }],
+          peer: [],
+        }),
+      /64-character sha256 hex digest/,
+      `digest ${JSON.stringify(bad)} must be rejected`,
+    );
+  }
+});
+
+test("paths differing only by case are rejected across censuses", () => {
+  // One file on a case-insensitive peer; planning a push AND a pull would let
+  // application order pick the survivor.
+  assert.throws(
+    () =>
+      planNamespaceReconciliation({
+        namespace: "default",
+        local: [file("Facts/A.md", "one")],
+        peer: [file("facts/a.md", "two")],
+      }),
+    /differing only by case/,
+  );
+});
+
+test("a missing namespace or a non-iterable census is rejected", () => {
+  assert.throws(
+    () => planNamespaceReconciliation({ namespace: "", local: [], peer: [] }),
+    ReconcilePlanInputError,
+  );
+  for (const side of ["local", "peer"] as const) {
+    assert.throws(
+      () =>
+        planNamespaceReconciliation({
+          namespace: "default",
+          local: side === "local" ? (undefined as unknown as ReconcileFileState[]) : [],
+          peer: side === "peer" ? (undefined as unknown as ReconcileFileState[]) : [],
+        }),
+      /must be iterable/,
+      `${side} census`,
+    );
+  }
 });

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -1,3 +1,4 @@
+import { normalizeNamespaceIdentity } from "../namespaces/identity.js";
 import { OFFLINE_SYNC_MAX_MTIME_MS } from "../offline-sync.js";
 import { validateArchiveRelativePath } from "../transfer/fs-utils.js";
 import type { OfflineSyncFileState } from "../offline-sync.js";
@@ -187,20 +188,23 @@ function assertCensusRecord(
 }
 
 /**
- * `newest-wins` decides which corpus keeps its history from this number, so it
- * gets the same bounds offline-sync applies: a NaN, an Infinity or a value past
- * the Date range must not be allowed to pick the winner.
+ * `newest-wins` decides which corpus keeps its history from this number, so a
+ * NaN, an Infinity or a value past the Date range must not pick the winner.
+ *
+ * Fractional values ARE valid: `fs.stat()` reports sub-millisecond mtimes on
+ * common filesystems and offline-sync forwards them unrounded, so this matches
+ * its `assertOfflineSyncMtimeMs` — non-negative finite within Date range — and
+ * deliberately does not require an integer.
  */
 function assertMtimeMs(value: unknown, context: string): number {
   if (
     typeof value !== "number"
     || !Number.isFinite(value)
-    || !Number.isInteger(value)
     || value < 0
     || value > OFFLINE_SYNC_MAX_MTIME_MS
   ) {
     throw new ReconcilePlanInputError(
-      `reconcile: ${context} has an out-of-range mtimeMs; expected an integer between 0 and ${OFFLINE_SYNC_MAX_MTIME_MS}`,
+      `reconcile: ${context} has an out-of-range mtimeMs; expected a finite value between 0 and ${OFFLINE_SYNC_MAX_MTIME_MS}`,
     );
   }
   return value;
@@ -224,6 +228,15 @@ function assertDigest(value: unknown, context: string): string {
 function assertNamespace(namespace: unknown): string {
   if (typeof namespace !== "string" || namespace.length === 0) {
     throw new ReconcilePlanInputError("reconcile: every namespace input needs a non-empty namespace");
+  }
+  // `team` and ` team ` are one namespace to the rest of core, so accepting
+  // both here would slip two inputs past the duplicate check and let them plan
+  // contradictory actions for the same path. Rejected rather than silently
+  // rewritten, so the namespace on every entry is the caller's own string.
+  if (normalizeNamespaceIdentity(namespace) !== namespace) {
+    throw new ReconcilePlanInputError(
+      `reconcile: namespace ${JSON.stringify(namespace)} is not canonical; pass ${JSON.stringify(normalizeNamespaceIdentity(namespace))}`,
+    );
   }
   return namespace;
 }
@@ -396,9 +409,12 @@ export function planNamespaceReconciliation(
   const peer = indexByPath(assertIterable(input.peer, "peer", namespace), "peer", namespace);
   // Only `base.sha256` is ever read, so the base is compacted to path -> digest
   // instead of a second full record index (round 7, codex P2).
-  const base = input.base
-    ? compactDigests(indexByPath(assertIterable(input.base, "base", namespace), "base", namespace))
-    : null;
+  // Only an ABSENT base means bootstrap. A null/invalid cursor silently read as
+  // "no prior agreement" would turn a peer-side deletion into a push and
+  // resurrect it.
+  const base = input.base === undefined
+    ? null
+    : compactDigests(indexByPath(assertIterable(input.base, "base", namespace), "base", namespace));
   const tombstoned = parseTombstonedDigests(input.tombstonedFileSha256, namespace);
   const entries: ReconcilePlanEntry[] = [];
 

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -92,7 +92,10 @@ export interface ReconcileNamespaceReport {
   conflict: number;
   /** Local retractions the peer must be told about before the pair agrees. */
   suppress: number;
-  /** Conflicts the policy could not settle; these need an operator. */
+  /**
+   * Conflicts still needing an operator: those the policy declined to settle,
+   * plus supersede links whose direction could not be determined.
+   */
   unresolved: number;
 }
 
@@ -278,7 +281,8 @@ function assertIterable(value: unknown, side: string, namespace: string): Iterab
  */
 // eslint-disable-next-line no-control-regex -- control characters are exactly what this rejects
 const WIN32_INVALID_CHARS = /[<>:"|?*\u0000-\u001f]/;
-const WIN32_RESERVED_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+// Windows treats the superscripts as their digits in COM/LPT device names.
+const WIN32_RESERVED_NAMES = /^(con|prn|aux|nul|(com|lpt)[1-9\u00b9\u00b2\u00b3])$/i;
 
 function assertPortablePathSegments(path: string, side: string, namespace: string): void {
   for (const segment of path.split("/")) {
@@ -682,7 +686,13 @@ export function summarizeReconcilePlan(entries: readonly ReconcilePlanEntry[]): 
       byNamespace.set(entry.namespace, report);
     }
     report[entry.action] += 1;
-    if (entry.action === "conflict" && entry.resolution === "unresolved") report.unresolved += 1;
+    // A supersede link with no `newerSide` could not be ordered, and the link
+    // direction is then an operator decision - so it counts as unresolved even
+    // though the policy nominally settled it.
+    const needsOperator =
+      entry.resolution === "unresolved"
+      || (entry.resolution === "supersede-link" && entry.newerSide === undefined);
+    if (entry.action === "conflict" && needsOperator) report.unresolved += 1;
   }
   return [...byNamespace.values()].sort((a, b) => (a.namespace === b.namespace ? 0 : a.namespace < b.namespace ? -1 : 1));
 }

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -61,6 +61,15 @@ export interface ReconcilePlanEntry {
    * delete the live copy instead of the retracted one.
    */
   suppressSide?: "local" | "peer" | "both";
+  /**
+   * Which revision is newer, set only for a `supersede-link` resolution.
+   *
+   * The contract is that the older revision is linked as superseded by the
+   * newer one, so transport needs the direction. Absent when the timestamps
+   * cannot order the two - which is exactly when `newest-wins` degrades to
+   * `supersede-link` - and the link direction is then an operator decision.
+   */
+  newerSide?: "local" | "peer";
 }
 
 export type ReconcileReason =
@@ -267,6 +276,10 @@ function assertIterable(value: unknown, side: string, namespace: string): Iterab
  * compares canonically), and Win32 trailing dots/spaces, which the Windows API
  * strips before touching disk.
  */
+// eslint-disable-next-line no-control-regex -- control characters are exactly what this rejects
+const WIN32_INVALID_CHARS = /[<>:"|?*\u0000-\u001f]/;
+const WIN32_RESERVED_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+
 function assertPortablePathSegments(path: string, side: string, namespace: string): void {
   for (const segment of path.split("/")) {
     if (segment.length === 0) continue;
@@ -274,6 +287,19 @@ function assertPortablePathSegments(path: string, side: string, namespace: strin
       throw new ReconcilePlanInputError(
         `reconcile: ${side} census for namespace ${namespace} path ${path} has a segment ending in a dot or space; ` +
           "Windows strips those and would alias it onto another file",
+      );
+    }
+    // `:` opens an alternate data stream, the rest cannot be created at all,
+    // and a reserved device name resolves to hardware. A plan containing any of
+    // them cannot be applied on a Windows participant.
+    if (WIN32_INVALID_CHARS.test(segment)) {
+      throw new ReconcilePlanInputError(
+        `reconcile: ${side} census for namespace ${namespace} path ${path} contains a character Windows cannot store`,
+      );
+    }
+    if (WIN32_RESERVED_NAMES.test(segment.split(".")[0] ?? "")) {
+      throw new ReconcilePlanInputError(
+        `reconcile: ${side} census for namespace ${namespace} path ${path} uses a reserved Windows device name`,
       );
     }
   }
@@ -394,6 +420,21 @@ function compareEntries(a: ReconcilePlanEntry, b: ReconcilePlanEntry): number {
   if (a.namespace !== b.namespace) return a.namespace < b.namespace ? -1 : 1;
   if (a.path !== b.path) return a.path < b.path ? -1 : 1;
   return 0;
+}
+
+/**
+ * Direction for a supersede link, when the timestamps can order the pair.
+ * Omitted otherwise so an unordered link is visibly unordered rather than
+ * silently defaulted to one side.
+ */
+function newerSideOf(
+  local: ReconcileFileState,
+  peer: ReconcileFileState,
+): { newerSide?: "local" | "peer" } {
+  const localMs = local.mtimeMs;
+  const peerMs = peer.mtimeMs;
+  if (typeof localMs !== "number" || typeof peerMs !== "number" || localMs === peerMs) return {};
+  return { newerSide: localMs > peerMs ? "local" : "peer" };
 }
 
 function resolveConflict(
@@ -573,6 +614,7 @@ export function planNamespaceReconciliation(
       });
       continue;
     }
+    const resolution = resolveConflict(policy, localFile, peerFile);
     entries.push({
       path,
       namespace,
@@ -581,7 +623,8 @@ export function planNamespaceReconciliation(
       localSha256: localFile.sha256,
       peerSha256: peerFile.sha256,
       ...(baseSha256 === undefined ? {} : { baseSha256 }),
-      resolution: resolveConflict(policy, localFile, peerFile),
+      resolution,
+      ...(resolution === "supersede-link" ? newerSideOf(localFile, peerFile) : {}),
     });
   }
 

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -1,3 +1,4 @@
+import { validateArchiveRelativePath } from "../transfer/fs-utils.js";
 import type { OfflineSyncFileState } from "../offline-sync.js";
 
 /**
@@ -51,6 +52,13 @@ export interface ReconcilePlanEntry {
   baseSha256?: string;
   /** Set only when `action` is `conflict`. */
   resolution?: ReconcileResolution;
+  /**
+   * Which side holds the retracted revision. Set only when `action` is
+   * `suppress`: with different digests on each side and only one retracted,
+   * the entry would otherwise be identical either way and transport could
+   * delete the live copy instead of the retracted one.
+   */
+  suppressSide?: "local" | "peer" | "both";
 }
 
 export type ReconcileReason =
@@ -152,20 +160,41 @@ function assertCensusRecord(
   file: ReconcileFileState | undefined,
   side: string,
   namespace: string,
-): { path: string; sha256: string } {
+): ReconcileFileState {
   const path = file?.path;
   if (typeof path !== "string" || path.length === 0) {
     throw new ReconcilePlanInputError(
       `reconcile: ${side} census for namespace ${namespace} contains a record with no path`,
     );
   }
-  const sha256 = file?.sha256;
-  if (typeof sha256 !== "string" || !SHA256_PATTERN.test(sha256)) {
+  // Same boundary offline-sync applies to this field: a peer census is
+  // untrusted input, and an absolute or traversal path would otherwise become
+  // a transfer instruction pointing outside the corpus root.
+  try {
+    validateArchiveRelativePath(path, `reconcile: ${side} census for namespace ${namespace}`);
+  } catch (err) {
+    throw new ReconcilePlanInputError(err instanceof Error ? err.message : String(err));
+  }
+  return {
+    ...file,
+    path,
+    sha256: assertDigest(file?.sha256, `${side} census for namespace ${namespace} entry ${path}`),
+  };
+}
+
+/**
+ * Digests are canonicalized to lowercase, exactly as offline-sync's
+ * `assertSha256` does. Keeping the caller's spelling would make two forms of
+ * one digest compare unequal, so identical files would plan `both_modified`
+ * and tombstone lookups would silently miss.
+ */
+function assertDigest(value: unknown, context: string): string {
+  if (typeof value !== "string" || !SHA256_PATTERN.test(value)) {
     throw new ReconcilePlanInputError(
-      `reconcile: ${side} census for namespace ${namespace} entry ${path} must carry a 64-character sha256 hex digest`,
+      `reconcile: ${context} must carry a 64-character sha256 hex digest`,
     );
   }
-  return { path, sha256 };
+  return value.toLowerCase();
 }
 
 function assertNamespace(namespace: unknown): string {
@@ -217,10 +246,20 @@ function rejectConflictingDuplicate(
   namespace: string,
 ): boolean {
   if (!existing) return false;
-  if (existing.sha256 === incoming.sha256) return true;
-  throw new ReconcilePlanInputError(
-    `reconcile: ${side} census for namespace ${namespace} lists ${path} twice with different digests`,
-  );
+  if (existing.sha256 !== incoming.sha256) {
+    throw new ReconcilePlanInputError(
+      `reconcile: ${side} census for namespace ${namespace} lists ${path} twice with different digests`,
+    );
+  }
+  // Same bytes but a different mtime is still ambiguous: `newest-wins` reads
+  // that timestamp, so accepting the first arrival would let input order decide
+  // the winner.
+  if (existing.mtimeMs !== incoming.mtimeMs) {
+    throw new ReconcilePlanInputError(
+      `reconcile: ${side} census for namespace ${namespace} lists ${path} twice with different mtimeMs`,
+    );
+  }
+  return true;
 }
 
 function indexByPath(
@@ -229,12 +268,32 @@ function indexByPath(
   namespace: string,
 ): Map<string, ReconcileFileState> {
   const index = new Map<string, ReconcileFileState>();
-  for (const file of files) {
-    const { path } = assertCensusRecord(file, side, namespace);
-    if (rejectConflictingDuplicate(index.get(path), file, path, side, namespace)) continue;
-    index.set(path, file);
+  for (const raw of files) {
+    const file = assertCensusRecord(raw, side, namespace);
+    if (rejectConflictingDuplicate(index.get(file.path), file, file.path, side, namespace)) continue;
+    index.set(file.path, file);
   }
   return index;
+}
+
+/**
+ * A bare string satisfies `Iterable<string>`, and `new Set("abc…")` would split
+ * it into 64 one-character members — every membership test then misses and each
+ * retracted file is planned as `pull` and resurrected. Reject the scalar and
+ * canonicalize every member.
+ */
+function parseTombstonedDigests(value: Iterable<string> | undefined, namespace: string): Set<string> {
+  if (value === undefined) return new Set();
+  if (typeof value === "string") {
+    throw new ReconcilePlanInputError(
+      `reconcile: tombstonedFileSha256 for namespace ${namespace} must be a collection of digests, not a single string`,
+    );
+  }
+  const digests = new Set<string>();
+  for (const entry of value) {
+    digests.add(assertDigest(entry, `tombstonedFileSha256 for namespace ${namespace}`));
+  }
+  return digests;
 }
 
 const RECONCILE_CONFLICT_POLICIES: readonly ReconcileConflictPolicy[] = ["manual", "newest-wins", "keep-both"];
@@ -298,16 +357,23 @@ export function planNamespaceReconciliation(
   // each match as it is consumed. Peak residency is one index plus the entry
   // list rather than two full censuses (round 2, codex P2).
   const peer = indexByPath(assertIterable(input.peer, "peer", namespace), "peer", namespace);
-  const base = input.base ? indexByPath(input.base, "base", namespace) : null;
-  const tombstoned = new Set(input.tombstonedFileSha256 ?? []);
+  const base = input.base
+    ? indexByPath(assertIterable(input.base, "base", namespace), "base", namespace)
+    : null;
+  const tombstoned = parseTombstonedDigests(input.tombstonedFileSha256, namespace);
   const entries: ReconcilePlanEntry[] = [];
 
   // Path -> digest only, never the file objects: enough to make the stream
   // idempotent and to catch contradictory duplicates without materializing the
   // second census.
+  // Base paths participate in the collision check: a base `Facts/A.md` against
+  // a local `facts/a.md` is the same delete/change ambiguity on a
+  // case-insensitive participant.
+  if (base) for (const basePath of base.keys()) assertNoCaseCollision(caseFold, basePath, namespace);
   const seenLocal = new Map<string, string>();
-  for (const localFile of localCensus) {
-    const { path } = assertCensusRecord(localFile, "local", namespace);
+  for (const rawLocal of localCensus) {
+    const localFile = assertCensusRecord(rawLocal, "local", namespace);
+    const path = localFile.path;
     assertNoCaseCollision(caseFold, path, namespace);
     const seenDigest = seenLocal.get(path);
     if (seenDigest !== undefined) {
@@ -329,7 +395,9 @@ export function planNamespaceReconciliation(
     // retracted LOCAL revision would otherwise be pushed - which is also how a
     // suppression undoes itself on the next run, since the local copy survives
     // the peer-side delete (round 4).
-    if ((peerFile && tombstoned.has(peerFile.sha256)) || tombstoned.has(localFile.sha256)) {
+    const localRetracted = tombstoned.has(localFile.sha256);
+    const peerRetracted = peerFile !== undefined && tombstoned.has(peerFile.sha256);
+    if (localRetracted || peerRetracted) {
       entries.push({
         path,
         namespace,
@@ -338,6 +406,7 @@ export function planNamespaceReconciliation(
         localSha256: localFile.sha256,
         ...(peerFile ? { peerSha256: peerFile.sha256 } : {}),
         ...(baseSha256 === undefined ? {} : { baseSha256 }),
+        suppressSide: localRetracted && peerRetracted ? "both" : localRetracted ? "local" : "peer",
       });
       continue;
     }
@@ -434,6 +503,7 @@ export function planNamespaceReconciliation(
         reason: "tombstoned",
         peerSha256: peerFile.sha256,
         ...(baseSha256 === undefined ? {} : { baseSha256 }),
+        suppressSide: "peer",
       });
       continue;
     }

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -138,14 +138,70 @@ export class ReconcilePlanInputError extends Error {
   }
 }
 
-function assertCensusPath(file: ReconcileFileState | undefined, side: string, namespace: string): string {
+/** Matches `assertSha256` in offline-sync so both surfaces reject the same values (§40). */
+const SHA256_PATTERN = /^[a-f0-9]{64}$/i;
+
+/**
+ * Validate a census record's identity fields.
+ *
+ * The digest matters as much as the path: two records that both omit `sha256`
+ * compare `undefined === undefined` and plan as `identical`, converging a
+ * corpus the planner never actually read.
+ */
+function assertCensusRecord(
+  file: ReconcileFileState | undefined,
+  side: string,
+  namespace: string,
+): { path: string; sha256: string } {
   const path = file?.path;
   if (typeof path !== "string" || path.length === 0) {
     throw new ReconcilePlanInputError(
       `reconcile: ${side} census for namespace ${namespace} contains a record with no path`,
     );
   }
-  return path;
+  const sha256 = file?.sha256;
+  if (typeof sha256 !== "string" || !SHA256_PATTERN.test(sha256)) {
+    throw new ReconcilePlanInputError(
+      `reconcile: ${side} census for namespace ${namespace} entry ${path} must carry a 64-character sha256 hex digest`,
+    );
+  }
+  return { path, sha256 };
+}
+
+function assertNamespace(namespace: unknown): string {
+  if (typeof namespace !== "string" || namespace.length === 0) {
+    throw new ReconcilePlanInputError("reconcile: every namespace input needs a non-empty namespace");
+  }
+  return namespace;
+}
+
+function assertIterable(value: unknown, side: string, namespace: string): Iterable<ReconcileFileState> {
+  if (value === null || typeof value !== "object" || typeof (value as Iterable<ReconcileFileState>)[Symbol.iterator] !== "function") {
+    throw new ReconcilePlanInputError(`reconcile: ${side} census for namespace ${namespace} must be iterable`);
+  }
+  return value as Iterable<ReconcileFileState>;
+}
+
+/**
+ * Paths that differ only by case are the SAME file on a case-insensitive
+ * participant (macOS, Windows), so planning a push AND a pull for them lets
+ * application order decide which revision survives. Remnic is explicitly
+ * multi-platform, so the collision is rejected rather than raced.
+ */
+function assertNoCaseCollision(
+  seen: Map<string, string>,
+  path: string,
+  namespace: string,
+): void {
+  const folded = path.toLowerCase();
+  const existing = seen.get(folded);
+  if (existing !== undefined && existing !== path) {
+    throw new ReconcilePlanInputError(
+      `reconcile: namespace ${namespace} has paths differing only by case (${existing}, ${path}); ` +
+        "they are one file on a case-insensitive peer",
+    );
+  }
+  seen.set(folded, path);
 }
 
 /**
@@ -174,7 +230,7 @@ function indexByPath(
 ): Map<string, ReconcileFileState> {
   const index = new Map<string, ReconcileFileState>();
   for (const file of files) {
-    const path = assertCensusPath(file, side, namespace);
+    const { path } = assertCensusRecord(file, side, namespace);
     if (rejectConflictingDuplicate(index.get(path), file, path, side, namespace)) continue;
     index.set(path, file);
   }
@@ -234,12 +290,14 @@ export function planNamespaceReconciliation(
   input: ReconcileNamespaceInput,
   options: ReconcileOptions = {},
 ): ReconcilePlanEntry[] {
-  const namespace = input.namespace;
+  const namespace = assertNamespace(input?.namespace);
   const policy = assertConflictPolicy(options.conflictPolicy);
+  const localCensus = assertIterable(input.local, "local", namespace);
+  const caseFold = new Map<string, string>();
   // Index the peer census only, then stream the local one against it, removing
   // each match as it is consumed. Peak residency is one index plus the entry
   // list rather than two full censuses (round 2, codex P2).
-  const peer = indexByPath(input.peer, "peer", namespace);
+  const peer = indexByPath(assertIterable(input.peer, "peer", namespace), "peer", namespace);
   const base = input.base ? indexByPath(input.base, "base", namespace) : null;
   const tombstoned = new Set(input.tombstonedFileSha256 ?? []);
   const entries: ReconcilePlanEntry[] = [];
@@ -248,8 +306,9 @@ export function planNamespaceReconciliation(
   // idempotent and to catch contradictory duplicates without materializing the
   // second census.
   const seenLocal = new Map<string, string>();
-  for (const localFile of input.local) {
-    const path = assertCensusPath(localFile, "local", namespace);
+  for (const localFile of localCensus) {
+    const { path } = assertCensusRecord(localFile, "local", namespace);
+    assertNoCaseCollision(caseFold, path, namespace);
     const seenDigest = seenLocal.get(path);
     if (seenDigest !== undefined) {
       if (seenDigest !== localFile.sha256) {
@@ -264,18 +323,20 @@ export function planNamespaceReconciliation(
     // Consumed: whatever remains in the index afterwards is peer-only.
     peer.delete(path);
     const baseSha256 = base?.get(path)?.sha256;
-    // Retraction outranks every other decision for this path. Checked BEFORE
-    // hash comparison and conflict resolution: otherwise a retracted peer
-    // revision reaches the conflict ladder and `newest-wins` can hand it the
-    // win, resurrecting exactly what was retracted (round 3).
-    if (peerFile && tombstoned.has(peerFile.sha256)) {
+    // Retraction outranks every other decision for this path, on EITHER side.
+    // Checked before hash comparison and conflict resolution: a retracted peer
+    // revision reaching the conflict ladder can win under `newest-wins`, and a
+    // retracted LOCAL revision would otherwise be pushed - which is also how a
+    // suppression undoes itself on the next run, since the local copy survives
+    // the peer-side delete (round 4).
+    if ((peerFile && tombstoned.has(peerFile.sha256)) || tombstoned.has(localFile.sha256)) {
       entries.push({
         path,
         namespace,
         action: "suppress",
         reason: "tombstoned",
         localSha256: localFile.sha256,
-        peerSha256: peerFile.sha256,
+        ...(peerFile ? { peerSha256: peerFile.sha256 } : {}),
         ...(baseSha256 === undefined ? {} : { baseSha256 }),
       });
       continue;
@@ -358,6 +419,7 @@ export function planNamespaceReconciliation(
   }
 
   for (const [path, peerFile] of peer) {
+    assertNoCaseCollision(caseFold, path, namespace);
     const baseSha256 = base?.get(path)?.sha256;
     if (tombstoned.has(peerFile.sha256)) {
       // Retracted here on purpose, and the peer still serves it. Pulling it

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -75,6 +75,9 @@ export interface ReconcilePlanEntry {
 export type ReconcileReason =
   | "peer_only"
   | "local_only"
+  /** Cursor showed only that side moved since agreement; both still hold the path. */
+  | "peer_changed"
+  | "local_changed"
   | "same_content"
   | "both_modified"
   | "peer_deleted"
@@ -325,7 +328,9 @@ function assertNoPathAlias(
   // fold - upper-then-lower, which collapses forms a bare toLowerCase() keeps
   // apart, such as final sigma `ς` against `σ`. Lowercasing alone would leave
   // those distinct and the planner would emit both a push and a pull.
-  const folded = path.normalize("NFC").toUpperCase().toLowerCase();
+  // `ß` upper-folds to `ss` while `ẞ` folds to `ß`, so one more pass equalizes
+  // the pair that a single upper-then-lower still leaves apart.
+  const folded = path.normalize("NFC").toUpperCase().toLowerCase().replace(/\u00df/g, "ss");
   const existing = seen.get(folded);
   if (existing !== undefined && existing !== path) {
     throw new ReconcilePlanInputError(
@@ -394,6 +399,13 @@ function parseTombstonedDigests(
   if (typeof value === "string") {
     throw new ReconcilePlanInputError(
       `reconcile: ${field} for namespace ${namespace} must be a collection of digests, not a single string`,
+    );
+  }
+  if (value === null || typeof value !== "object" || typeof value[Symbol.iterator] !== "function") {
+    // Otherwise the for...of below throws a raw TypeError and a caller handling
+    // ReconcilePlanInputError cannot tell a bad request from a planner bug.
+    throw new ReconcilePlanInputError(
+      `reconcile: ${field} for namespace ${namespace} must be an iterable collection of digests`,
     );
   }
   const digests = new Set<string>();
@@ -608,7 +620,7 @@ export function planNamespaceReconciliation(
         path,
         namespace,
         action: "pull",
-        reason: "peer_only",
+        reason: "peer_changed",
         localSha256: localFile.sha256,
         peerSha256: peerFile.sha256,
         baseSha256,
@@ -620,7 +632,7 @@ export function planNamespaceReconciliation(
         path,
         namespace,
         action: "push",
-        reason: "local_only",
+        reason: "local_changed",
         localSha256: localFile.sha256,
         peerSha256: peerFile.sha256,
         baseSha256,
@@ -720,6 +732,13 @@ export function planReconciliation(
   if (!Array.isArray(namespaces)) {
     throw new ReconcilePlanInputError("reconcile: planReconciliation expects an array of namespace inputs");
   }
+  // Validated here too: with an empty array the per-namespace path never runs,
+  // and a malformed options envelope would return `converged` instead of
+  // raising - the same call failing or succeeding based on list length.
+  if (!isPlainObject(options)) {
+    throw new ReconcilePlanInputError("reconcile: options must be a plain object");
+  }
+  assertConflictPolicy(options.conflictPolicy);
   const entries: ReconcilePlanEntry[] = [];
   // Two inputs for one namespace are planned independently, so the same
   // (namespace, path) can draw contradictory actions - and because those

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -259,7 +259,10 @@ function assertNoCaseCollision(
   path: string,
   namespace: string,
 ): void {
-  const folded = path.toLowerCase();
+  // NFC first: macOS stores decomposed names and compares canonically, so
+  // `é` (U+00E9) and `é` (e + U+0301) are ONE file there. Case folding alone
+  // leaves them distinct and the planner would emit both a push and a pull.
+  const folded = path.normalize("NFC").toLowerCase();
   const existing = seen.get(folded);
   if (existing !== undefined && existing !== path) {
     throw new ReconcilePlanInputError(
@@ -393,11 +396,13 @@ export function planNamespaceReconciliation(
   input: ReconcileNamespaceInput,
   options: ReconcileOptions = {},
 ): ReconcilePlanEntry[] {
-  if (input === null || typeof input !== "object") {
-    throw new ReconcilePlanInputError("reconcile: namespace input must be an object");
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    throw new ReconcilePlanInputError("reconcile: namespace input must be a plain object");
   }
-  if (options === null || typeof options !== "object") {
-    throw new ReconcilePlanInputError("reconcile: options must be an object");
+  if (options === null || typeof options !== "object" || Array.isArray(options)) {
+    // An array passes a bare typeof check and would silently take the default
+    // policy, hiding a malformed request behind `manual`.
+    throw new ReconcilePlanInputError("reconcile: options must be a plain object");
   }
   const namespace = assertNamespace(input.namespace);
   const policy = assertConflictPolicy(options.conflictPolicy);

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -1,0 +1,306 @@
+import type { OfflineSyncFileState } from "../offline-sync.js";
+
+/**
+ * Bootstrap reconciliation planner for two peer daemons whose corpora have
+ * already diverged (issue #2150).
+ *
+ * The offline-sync protocol assumes a satellite that shares a common base with
+ * one daemon: every path it does not know about is a pull, and a conflict is
+ * rare. Two long-lived daemons are the opposite case — each side holds months
+ * of history the other never saw, both sides are authoritative, and there is
+ * NO common base on the first run. That is a different decision problem, so it
+ * gets its own planner rather than another mode flag inside `applyOfflineSync*`.
+ *
+ * This module is deliberately pure: it takes two file censuses and returns what
+ * to do. No I/O, no transport, no clock. Everything that makes reconciliation
+ * risky — which side wins, what counts as converged, what is reported — is
+ * decided here where it can be exhaustively tested, and the transport layer is
+ * left to carry out an already-settled plan.
+ */
+
+/** Which way a path must move for the two corpora to agree. */
+export type ReconcileAction = "pull" | "push" | "identical" | "conflict";
+
+/**
+ * How a path present on BOTH sides with different content is settled.
+ *
+ * `manual` is the safe default: on a bootstrap merge the two sides are equally
+ * authoritative, so silently picking one is data loss with extra steps. An
+ * operator opts into an automatic rule once they know the shape of their split.
+ */
+export type ReconcileConflictPolicy = "manual" | "newest-wins" | "keep-both";
+
+/**
+ * What the planner decided for a conflicting path.
+ *
+ * `keep-both` never overwrites: the older side is retained and linked as
+ * superseded by the newer one, which is the only resolution that cannot lose a
+ * fact neither corpus has seen.
+ */
+export type ReconcileResolution = "local-wins" | "peer-wins" | "supersede-link" | "unresolved";
+
+export interface ReconcilePlanEntry {
+  path: string;
+  namespace: string;
+  action: ReconcileAction;
+  /** Stable machine-readable cause, safe to assert on and to aggregate. */
+  reason: ReconcileReason;
+  localSha256?: string;
+  peerSha256?: string;
+  /** Present only when a prior converged run left a cursor covering this path. */
+  baseSha256?: string;
+  /** Set only when `action` is `conflict`. */
+  resolution?: ReconcileResolution;
+}
+
+export type ReconcileReason =
+  | "peer_only"
+  | "local_only"
+  | "same_content"
+  | "both_modified"
+  | "peer_deleted"
+  | "local_deleted"
+  | "tombstoned";
+
+export interface ReconcileNamespaceReport {
+  namespace: string;
+  pull: number;
+  push: number;
+  identical: number;
+  conflict: number;
+  /** Conflicts the policy could not settle; these need an operator. */
+  unresolved: number;
+}
+
+export interface ReconcilePlan {
+  entries: ReconcilePlanEntry[];
+  byNamespace: ReconcileNamespaceReport[];
+  /**
+   * True when the two corpora already agree — every shared path matches and
+   * neither side holds a path the other lacks.
+   *
+   * This is the idempotency contract from #2150: running reconciliation against
+   * an already-converged peer must be a no-op, and a caller can skip the whole
+   * transfer phase on this flag alone.
+   */
+  converged: boolean;
+}
+
+/** Minimal shape the planner needs; `OfflineSyncFileState` satisfies it. */
+export type ReconcileFileState = Pick<OfflineSyncFileState, "path" | "sha256"> &
+  Partial<Pick<OfflineSyncFileState, "mtimeMs" | "bytes">>;
+
+export interface ReconcileNamespaceInput {
+  namespace: string;
+  local: Iterable<ReconcileFileState>;
+  peer: Iterable<ReconcileFileState>;
+  /**
+   * File states agreed at the end of the last converged run with THIS peer.
+   * Absent on a bootstrap merge, which is why a path missing from one side is
+   * read as "never seen" rather than "deleted".
+   */
+  base?: Iterable<ReconcileFileState>;
+  /**
+   * Content hashes tombstoned locally. A peer that still holds a fact this side
+   * deliberately retracted must not resurrect it, so those paths are dropped
+   * from the pull set instead of being re-imported.
+   */
+  tombstonedSha256?: Iterable<string>;
+}
+
+export interface ReconcileOptions {
+  conflictPolicy?: ReconcileConflictPolicy;
+}
+
+function indexByPath(files: Iterable<ReconcileFileState>): Map<string, ReconcileFileState> {
+  const index = new Map<string, ReconcileFileState>();
+  for (const file of files) {
+    if (typeof file?.path !== "string" || file.path.length === 0) continue;
+    index.set(file.path, file);
+  }
+  return index;
+}
+
+/**
+ * Total ordering for plan entries (§12): namespace, then path. Both are unique
+ * per entry, so equal keys are impossible and the comparator never has to
+ * return 0 for distinct rows — the output is byte-identical across runs, which
+ * is what makes a convergence report diffable.
+ */
+function compareEntries(a: ReconcilePlanEntry, b: ReconcilePlanEntry): number {
+  if (a.namespace !== b.namespace) return a.namespace < b.namespace ? -1 : 1;
+  if (a.path !== b.path) return a.path < b.path ? -1 : 1;
+  return 0;
+}
+
+function resolveConflict(
+  policy: ReconcileConflictPolicy,
+  local: ReconcileFileState,
+  peer: ReconcileFileState,
+): ReconcileResolution {
+  if (policy === "keep-both") return "supersede-link";
+  if (policy !== "newest-wins") return "unresolved";
+  const localMs = typeof local.mtimeMs === "number" && Number.isFinite(local.mtimeMs) ? local.mtimeMs : null;
+  const peerMs = typeof peer.mtimeMs === "number" && Number.isFinite(peer.mtimeMs) ? peer.mtimeMs : null;
+  // Without a usable timestamp on both sides "newest" is not decidable, and a
+  // coin flip here silently discards one side's history. Fall back to keeping
+  // both rather than inventing an order.
+  if (localMs === null || peerMs === null) return "supersede-link";
+  if (localMs === peerMs) return "supersede-link";
+  return localMs > peerMs ? "local-wins" : "peer-wins";
+}
+
+/**
+ * Plan one namespace. Exposed for callers that stream namespaces one at a time
+ * so a 100k-file corpus never has two full censuses resident at once.
+ */
+export function planNamespaceReconciliation(
+  input: ReconcileNamespaceInput,
+  options: ReconcileOptions = {},
+): ReconcilePlanEntry[] {
+  const policy = options.conflictPolicy ?? "manual";
+  const namespace = input.namespace;
+  const local = indexByPath(input.local);
+  const peer = indexByPath(input.peer);
+  const base = input.base ? indexByPath(input.base) : null;
+  const tombstoned = new Set(input.tombstonedSha256 ?? []);
+  const entries: ReconcilePlanEntry[] = [];
+
+  for (const [path, localFile] of local) {
+    const peerFile = peer.get(path);
+    const baseSha256 = base?.get(path)?.sha256;
+    if (!peerFile) {
+      // Only a base proves the peer once had this path and dropped it. Without
+      // one, the peer simply never saw it, and a bootstrap merge must push
+      // rather than delete — the whole point is that both sides hold unique
+      // valid data.
+      const deletedByPeer = baseSha256 !== undefined && baseSha256 === localFile.sha256;
+      entries.push({
+        path,
+        namespace,
+        action: deletedByPeer ? "conflict" : "push",
+        reason: deletedByPeer ? "peer_deleted" : "local_only",
+        localSha256: localFile.sha256,
+        ...(baseSha256 === undefined ? {} : { baseSha256 }),
+        ...(deletedByPeer ? { resolution: "unresolved" as const } : {}),
+      });
+      continue;
+    }
+    if (peerFile.sha256 === localFile.sha256) {
+      entries.push({
+        path,
+        namespace,
+        action: "identical",
+        reason: "same_content",
+        localSha256: localFile.sha256,
+        peerSha256: peerFile.sha256,
+        ...(baseSha256 === undefined ? {} : { baseSha256 }),
+      });
+      continue;
+    }
+    // A base that matches one side turns a "conflict" into an ordinary
+    // one-sided change: that side is the only one that moved since agreement.
+    if (baseSha256 !== undefined && baseSha256 === localFile.sha256) {
+      entries.push({
+        path,
+        namespace,
+        action: "pull",
+        reason: "peer_only",
+        localSha256: localFile.sha256,
+        peerSha256: peerFile.sha256,
+        baseSha256,
+      });
+      continue;
+    }
+    if (baseSha256 !== undefined && baseSha256 === peerFile.sha256) {
+      entries.push({
+        path,
+        namespace,
+        action: "push",
+        reason: "local_only",
+        localSha256: localFile.sha256,
+        peerSha256: peerFile.sha256,
+        baseSha256,
+      });
+      continue;
+    }
+    entries.push({
+      path,
+      namespace,
+      action: "conflict",
+      reason: "both_modified",
+      localSha256: localFile.sha256,
+      peerSha256: peerFile.sha256,
+      ...(baseSha256 === undefined ? {} : { baseSha256 }),
+      resolution: resolveConflict(policy, localFile, peerFile),
+    });
+  }
+
+  for (const [path, peerFile] of peer) {
+    if (local.has(path)) continue;
+    const baseSha256 = base?.get(path)?.sha256;
+    if (tombstoned.has(peerFile.sha256)) {
+      // Retracted here on purpose. Pulling it back would undo the retraction
+      // every time the peers reconcile.
+      entries.push({
+        path,
+        namespace,
+        action: "identical",
+        reason: "tombstoned",
+        peerSha256: peerFile.sha256,
+        ...(baseSha256 === undefined ? {} : { baseSha256 }),
+      });
+      continue;
+    }
+    const deletedLocally = baseSha256 !== undefined && baseSha256 === peerFile.sha256;
+    entries.push({
+      path,
+      namespace,
+      action: deletedLocally ? "conflict" : "pull",
+      reason: deletedLocally ? "local_deleted" : "peer_only",
+      peerSha256: peerFile.sha256,
+      ...(baseSha256 === undefined ? {} : { baseSha256 }),
+      ...(deletedLocally ? { resolution: "unresolved" as const } : {}),
+    });
+  }
+
+  return entries.sort(compareEntries);
+}
+
+/** Aggregate entries into the per-namespace convergence report (#2150). */
+export function summarizeReconcilePlan(entries: readonly ReconcilePlanEntry[]): ReconcileNamespaceReport[] {
+  const byNamespace = new Map<string, ReconcileNamespaceReport>();
+  for (const entry of entries) {
+    let report = byNamespace.get(entry.namespace);
+    if (!report) {
+      report = { namespace: entry.namespace, pull: 0, push: 0, identical: 0, conflict: 0, unresolved: 0 };
+      byNamespace.set(entry.namespace, report);
+    }
+    report[entry.action] += 1;
+    if (entry.action === "conflict" && entry.resolution === "unresolved") report.unresolved += 1;
+  }
+  return [...byNamespace.values()].sort((a, b) => (a.namespace === b.namespace ? 0 : a.namespace < b.namespace ? -1 : 1));
+}
+
+/**
+ * Plan a full reconciliation across namespaces.
+ *
+ * `converged` is an affirmative claim that nothing needs to move, so it is
+ * derived from the entries rather than tracked alongside them: any action other
+ * than `identical` disproves it.
+ */
+export function planReconciliation(
+  namespaces: readonly ReconcileNamespaceInput[],
+  options: ReconcileOptions = {},
+): ReconcilePlan {
+  const entries: ReconcilePlanEntry[] = [];
+  for (const namespace of namespaces) {
+    entries.push(...planNamespaceReconciliation(namespace, options));
+  }
+  entries.sort(compareEntries);
+  return {
+    entries,
+    byNamespace: summarizeReconcilePlan(entries),
+    converged: entries.every((entry) => entry.action === "identical"),
+  };
+}

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -106,11 +106,17 @@ export interface ReconcileNamespaceInput {
    */
   base?: Iterable<ReconcileFileState>;
   /**
-   * Content hashes tombstoned locally. A peer that still holds a fact this side
-   * deliberately retracted must not resurrect it, so those paths are dropped
-   * from the pull set instead of being re-imported.
+   * Digests of FILES this side has retracted, in the same form as
+   * `ReconcileFileState.sha256` — a hash of the serialized file.
+   *
+   * Deliberately NOT `TombstoneEntry.contentHash`, which hashes the canonical
+   * raw fact text and therefore never equals a file digest (§13: one content
+   * form, everywhere). Mapping retracted fact hashes onto the file digests that
+   * carry them is the caller's job, because only the caller can read its own
+   * corpus; handing this the wrong form would silently plan `pull` and
+   * resurrect every retracted fact, so the parameter name states the form.
    */
-  tombstonedSha256?: Iterable<string>;
+  tombstonedFileSha256?: Iterable<string>;
 }
 
 export interface ReconcileOptions {
@@ -156,8 +162,12 @@ function resolveConflict(
 }
 
 /**
- * Plan one namespace. Exposed for callers that stream namespaces one at a time
- * so a 100k-file corpus never has two full censuses resident at once.
+ * Plan one namespace. Exposed for callers that stream namespaces one at a time.
+ *
+ * Residency is one peer index + a set of local paths + the entry list. The
+ * local census is consumed as a stream and never materialized, so a 100k-file
+ * corpus does not hold two full censuses at once — but this is NOT constant
+ * memory, and a caller holding its own census arrays adds to that.
  */
 export function planNamespaceReconciliation(
   input: ReconcileNamespaceInput,
@@ -165,14 +175,25 @@ export function planNamespaceReconciliation(
 ): ReconcilePlanEntry[] {
   const policy = options.conflictPolicy ?? "manual";
   const namespace = input.namespace;
-  const local = indexByPath(input.local);
+  // Index the peer census only, then stream the local one against it, removing
+  // each match as it is consumed. Peak residency is one index plus the entry
+  // list rather than two full censuses (round 2, codex P2).
   const peer = indexByPath(input.peer);
   const base = input.base ? indexByPath(input.base) : null;
-  const tombstoned = new Set(input.tombstonedSha256 ?? []);
+  const tombstoned = new Set(input.tombstonedFileSha256 ?? []);
   const entries: ReconcilePlanEntry[] = [];
 
-  for (const [path, localFile] of local) {
+  // Paths only, not file objects: enough to make the stream idempotent without
+  // materializing the second census.
+  const seenLocal = new Set<string>();
+  for (const localFile of input.local) {
+    const path = localFile?.path;
+    if (typeof path !== "string" || path.length === 0) continue;
+    if (seenLocal.has(path)) continue;
+    seenLocal.add(path);
     const peerFile = peer.get(path);
+    // Consumed: whatever remains in the index afterwards is peer-only.
+    peer.delete(path);
     const baseSha256 = base?.get(path)?.sha256;
     if (!peerFile) {
       // Base PRESENCE is what proves a deletion, not equality with whatever the
@@ -252,7 +273,6 @@ export function planNamespaceReconciliation(
   }
 
   for (const [path, peerFile] of peer) {
-    if (local.has(path)) continue;
     const baseSha256 = base?.get(path)?.sha256;
     if (tombstoned.has(peerFile.sha256)) {
       // Retracted here on purpose, and the peer still serves it. Pulling it

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -127,6 +127,15 @@ export interface ReconcileNamespaceInput {
    * resurrect every retracted fact, so the parameter name states the form.
    */
   tombstonedFileSha256?: Iterable<string>;
+  /**
+   * Digests the PEER has retracted, same form.
+   *
+   * Without this a bootstrap merge cannot tell "the peer never had it" from
+   * "the peer deliberately retracted it": the peer census simply omits both,
+   * so a file we still hold is planned `push` and the peer's retraction is
+   * undone. Reconciliation is symmetric, so retraction has to be too.
+   */
+  peerTombstonedFileSha256?: Iterable<string>;
 }
 
 export interface ReconcileOptions {
@@ -177,6 +186,7 @@ function assertCensusRecord(
   } catch (err) {
     throw new ReconcilePlanInputError(err instanceof Error ? err.message : String(err));
   }
+  assertPortablePathSegments(path, side, namespace);
   return {
     ...file,
     path,
@@ -249,12 +259,27 @@ function assertIterable(value: unknown, side: string, namespace: string): Iterab
 }
 
 /**
- * Paths that differ only by case are the SAME file on a case-insensitive
- * participant (macOS, Windows), so planning a push AND a pull for them lets
- * application order decide which revision survives. Remnic is explicitly
- * multi-platform, so the collision is rejected rather than raced.
+ * Two paths that a participant's filesystem resolves to ONE file must not draw
+ * separate push/pull work, or application order decides which revision
+ * survives. Remnic is explicitly multi-platform, so all three aliasing rules
+ * are folded together and a collision is rejected rather than raced:
+ * case (macOS, Windows), Unicode normalization (macOS stores decomposed and
+ * compares canonically), and Win32 trailing dots/spaces, which the Windows API
+ * strips before touching disk.
  */
-function assertNoCaseCollision(
+function assertPortablePathSegments(path: string, side: string, namespace: string): void {
+  for (const segment of path.split("/")) {
+    if (segment.length === 0) continue;
+    if (segment.endsWith(".") || segment.endsWith(" ")) {
+      throw new ReconcilePlanInputError(
+        `reconcile: ${side} census for namespace ${namespace} path ${path} has a segment ending in a dot or space; ` +
+          "Windows strips those and would alias it onto another file",
+      );
+    }
+  }
+}
+
+function assertNoPathAlias(
   seen: Map<string, string>,
   path: string,
   namespace: string,
@@ -266,8 +291,8 @@ function assertNoCaseCollision(
   const existing = seen.get(folded);
   if (existing !== undefined && existing !== path) {
     throw new ReconcilePlanInputError(
-      `reconcile: namespace ${namespace} has paths differing only by case (${existing}, ${path}); ` +
-        "they are one file on a case-insensitive peer",
+      `reconcile: namespace ${namespace} has aliasing paths (${existing}, ${path}); ` +
+        "they resolve to one file on a case-insensitive or Unicode-normalizing peer",
     );
   }
   seen.set(folded, path);
@@ -322,16 +347,20 @@ function indexByPath(
  * retracted file is planned as `pull` and resurrected. Reject the scalar and
  * canonicalize every member.
  */
-function parseTombstonedDigests(value: Iterable<string> | undefined, namespace: string): Set<string> {
+function parseTombstonedDigests(
+  value: Iterable<string> | undefined,
+  namespace: string,
+  field = "tombstonedFileSha256",
+): Set<string> {
   if (value === undefined) return new Set();
   if (typeof value === "string") {
     throw new ReconcilePlanInputError(
-      `reconcile: tombstonedFileSha256 for namespace ${namespace} must be a collection of digests, not a single string`,
+      `reconcile: ${field} for namespace ${namespace} must be a collection of digests, not a single string`,
     );
   }
   const digests = new Set<string>();
   for (const entry of value) {
-    digests.add(assertDigest(entry, `tombstonedFileSha256 for namespace ${namespace}`));
+    digests.add(assertDigest(entry, `${field} for namespace ${namespace}`));
   }
   return digests;
 }
@@ -421,6 +450,11 @@ export function planNamespaceReconciliation(
     ? null
     : compactDigests(indexByPath(assertIterable(input.base, "base", namespace), "base", namespace));
   const tombstoned = parseTombstonedDigests(input.tombstonedFileSha256, namespace);
+  const peerTombstoned = parseTombstonedDigests(
+    input.peerTombstonedFileSha256,
+    namespace,
+    "peerTombstonedFileSha256",
+  );
   const entries: ReconcilePlanEntry[] = [];
 
   // Path -> digest only, never the file objects: enough to make the stream
@@ -429,7 +463,7 @@ export function planNamespaceReconciliation(
   // Base paths participate in the collision check: a base `Facts/A.md` against
   // a local `facts/a.md` is the same delete/change ambiguity on a
   // case-insensitive participant.
-  if (base) for (const basePath of base.keys()) assertNoCaseCollision(caseFold, basePath, namespace);
+  if (base) for (const basePath of base.keys()) assertNoPathAlias(caseFold, basePath, namespace);
   // Path -> decision-relevant fields only, never the whole record: enough to
   // make the stream idempotent and to catch contradictory duplicates without
   // materializing the second census.
@@ -437,7 +471,7 @@ export function planNamespaceReconciliation(
   for (const rawLocal of localCensus) {
     const localFile = assertCensusRecord(rawLocal, "local", namespace);
     const path = localFile.path;
-    assertNoCaseCollision(caseFold, path, namespace);
+    assertNoPathAlias(caseFold, path, namespace);
     const seen = seenLocal.get(path);
     if (seen !== undefined) {
       // Same rule the indexed censuses get: mtimeMs is decision-relevant under
@@ -455,8 +489,12 @@ export function planNamespaceReconciliation(
     // retracted LOCAL revision would otherwise be pushed - which is also how a
     // suppression undoes itself on the next run, since the local copy survives
     // the peer-side delete (round 4).
-    const localRetracted = tombstoned.has(localFile.sha256);
-    const peerRetracted = peerFile !== undefined && tombstoned.has(peerFile.sha256);
+    // Either side's retraction removes the copy that carries the digest, so a
+    // peer retraction of something we still hold suppresses OUR copy rather
+    // than pushing it back.
+    const localRetracted = tombstoned.has(localFile.sha256) || peerTombstoned.has(localFile.sha256);
+    const peerRetracted =
+      peerFile !== undefined && (tombstoned.has(peerFile.sha256) || peerTombstoned.has(peerFile.sha256));
     if (localRetracted || peerRetracted) {
       entries.push({
         path,
@@ -548,9 +586,9 @@ export function planNamespaceReconciliation(
   }
 
   for (const [path, peerFile] of peer) {
-    assertNoCaseCollision(caseFold, path, namespace);
+    assertNoPathAlias(caseFold, path, namespace);
     const baseSha256 = base?.get(path);
-    if (tombstoned.has(peerFile.sha256)) {
+    if (tombstoned.has(peerFile.sha256) || peerTombstoned.has(peerFile.sha256)) {
       // Retracted here on purpose, and the peer still serves it. Pulling it
       // back would undo the retraction; calling it `identical` would be worse,
       // because a converged plan lets transport skip everything and the peer

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -1,3 +1,4 @@
+import { OFFLINE_SYNC_MAX_MTIME_MS } from "../offline-sync.js";
 import { validateArchiveRelativePath } from "../transfer/fs-utils.js";
 import type { OfflineSyncFileState } from "../offline-sync.js";
 
@@ -179,7 +180,30 @@ function assertCensusRecord(
     ...file,
     path,
     sha256: assertDigest(file?.sha256, `${side} census for namespace ${namespace} entry ${path}`),
+    ...(file?.mtimeMs === undefined
+      ? {}
+      : { mtimeMs: assertMtimeMs(file.mtimeMs, `${side} census for namespace ${namespace} entry ${path}`) }),
   };
+}
+
+/**
+ * `newest-wins` decides which corpus keeps its history from this number, so it
+ * gets the same bounds offline-sync applies: a NaN, an Infinity or a value past
+ * the Date range must not be allowed to pick the winner.
+ */
+function assertMtimeMs(value: unknown, context: string): number {
+  if (
+    typeof value !== "number"
+    || !Number.isFinite(value)
+    || !Number.isInteger(value)
+    || value < 0
+    || value > OFFLINE_SYNC_MAX_MTIME_MS
+  ) {
+    throw new ReconcilePlanInputError(
+      `reconcile: ${context} has an out-of-range mtimeMs; expected an integer between 0 and ${OFFLINE_SYNC_MAX_MTIME_MS}`,
+    );
+  }
+  return value;
 }
 
 /**
@@ -296,6 +320,13 @@ function parseTombstonedDigests(value: Iterable<string> | undefined, namespace: 
   return digests;
 }
 
+function compactDigests(index: Map<string, ReconcileFileState>): Map<string, string> {
+  const compact = new Map<string, string>();
+  for (const [path, file] of index) compact.set(path, file.sha256);
+  index.clear();
+  return compact;
+}
+
 const RECONCILE_CONFLICT_POLICIES: readonly ReconcileConflictPolicy[] = ["manual", "newest-wins", "keep-both"];
 
 function assertConflictPolicy(value: ReconcileConflictPolicy | undefined): ReconcileConflictPolicy {
@@ -349,7 +380,13 @@ export function planNamespaceReconciliation(
   input: ReconcileNamespaceInput,
   options: ReconcileOptions = {},
 ): ReconcilePlanEntry[] {
-  const namespace = assertNamespace(input?.namespace);
+  if (input === null || typeof input !== "object") {
+    throw new ReconcilePlanInputError("reconcile: namespace input must be an object");
+  }
+  if (options === null || typeof options !== "object") {
+    throw new ReconcilePlanInputError("reconcile: options must be an object");
+  }
+  const namespace = assertNamespace(input.namespace);
   const policy = assertConflictPolicy(options.conflictPolicy);
   const localCensus = assertIterable(input.local, "local", namespace);
   const caseFold = new Map<string, string>();
@@ -357,8 +394,10 @@ export function planNamespaceReconciliation(
   // each match as it is consumed. Peak residency is one index plus the entry
   // list rather than two full censuses (round 2, codex P2).
   const peer = indexByPath(assertIterable(input.peer, "peer", namespace), "peer", namespace);
+  // Only `base.sha256` is ever read, so the base is compacted to path -> digest
+  // instead of a second full record index (round 7, codex P2).
   const base = input.base
-    ? indexByPath(assertIterable(input.base, "base", namespace), "base", namespace)
+    ? compactDigests(indexByPath(assertIterable(input.base, "base", namespace), "base", namespace))
     : null;
   const tombstoned = parseTombstonedDigests(input.tombstonedFileSha256, namespace);
   const entries: ReconcilePlanEntry[] = [];
@@ -388,7 +427,7 @@ export function planNamespaceReconciliation(
     const peerFile = peer.get(path);
     // Consumed: whatever remains in the index afterwards is peer-only.
     peer.delete(path);
-    const baseSha256 = base?.get(path)?.sha256;
+    const baseSha256 = base?.get(path);
     // Retraction outranks every other decision for this path, on EITHER side.
     // Checked before hash comparison and conflict resolution: a retracted peer
     // revision reaching the conflict ladder can win under `newest-wins`, and a
@@ -489,7 +528,7 @@ export function planNamespaceReconciliation(
 
   for (const [path, peerFile] of peer) {
     assertNoCaseCollision(caseFold, path, namespace);
-    const baseSha256 = base?.get(path)?.sha256;
+    const baseSha256 = base?.get(path);
     if (tombstoned.has(peerFile.sha256)) {
       // Retracted here on purpose, and the peer still serves it. Pulling it
       // back would undo the retraction; calling it `identical` would be worse,
@@ -557,6 +596,9 @@ export function planReconciliation(
   namespaces: readonly ReconcileNamespaceInput[],
   options: ReconcileOptions = {},
 ): ReconcilePlan {
+  if (!Array.isArray(namespaces)) {
+    throw new ReconcilePlanInputError("reconcile: planReconciliation expects an array of namespace inputs");
+  }
   const entries: ReconcilePlanEntry[] = [];
   // Two inputs for one namespace are planned independently, so the same
   // (namespace, path) can draw contradictory actions - and because those

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -123,13 +123,74 @@ export interface ReconcileOptions {
   conflictPolicy?: ReconcileConflictPolicy;
 }
 
-function indexByPath(files: Iterable<ReconcileFileState>): Map<string, ReconcileFileState> {
+/**
+ * A census the planner refuses to reason about.
+ *
+ * Dropping a malformed or contradictory record would let the planner return
+ * `converged: true` for a corpus it could not actually read, and transport is
+ * invited to skip everything on that flag — so bad input fails loudly instead
+ * (§1/§39).
+ */
+export class ReconcilePlanInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReconcilePlanInputError";
+  }
+}
+
+function assertCensusPath(file: ReconcileFileState | undefined, side: string, namespace: string): string {
+  const path = file?.path;
+  if (typeof path !== "string" || path.length === 0) {
+    throw new ReconcilePlanInputError(
+      `reconcile: ${side} census for namespace ${namespace} contains a record with no path`,
+    );
+  }
+  return path;
+}
+
+/**
+ * Duplicate paths are accepted only when they agree. Two digests for one path
+ * make the plan depend on which record arrived last, which would break the
+ * byte-stable ordering the convergence report relies on.
+ */
+function rejectConflictingDuplicate(
+  existing: ReconcileFileState | undefined,
+  incoming: ReconcileFileState,
+  path: string,
+  side: string,
+  namespace: string,
+): boolean {
+  if (!existing) return false;
+  if (existing.sha256 === incoming.sha256) return true;
+  throw new ReconcilePlanInputError(
+    `reconcile: ${side} census for namespace ${namespace} lists ${path} twice with different digests`,
+  );
+}
+
+function indexByPath(
+  files: Iterable<ReconcileFileState>,
+  side: string,
+  namespace: string,
+): Map<string, ReconcileFileState> {
   const index = new Map<string, ReconcileFileState>();
   for (const file of files) {
-    if (typeof file?.path !== "string" || file.path.length === 0) continue;
-    index.set(file.path, file);
+    const path = assertCensusPath(file, side, namespace);
+    if (rejectConflictingDuplicate(index.get(path), file, path, side, namespace)) continue;
+    index.set(path, file);
   }
   return index;
+}
+
+const RECONCILE_CONFLICT_POLICIES: readonly ReconcileConflictPolicy[] = ["manual", "newest-wins", "keep-both"];
+
+function assertConflictPolicy(value: ReconcileConflictPolicy | undefined): ReconcileConflictPolicy {
+  if (value === undefined) return "manual";
+  if (!RECONCILE_CONFLICT_POLICIES.includes(value)) {
+    throw new ReconcilePlanInputError(
+      `reconcile: unknown conflictPolicy ${JSON.stringify(value)}; expected one of ${RECONCILE_CONFLICT_POLICIES.join(", ")}`,
+    );
+  }
+  return value;
 }
 
 /**
@@ -173,28 +234,52 @@ export function planNamespaceReconciliation(
   input: ReconcileNamespaceInput,
   options: ReconcileOptions = {},
 ): ReconcilePlanEntry[] {
-  const policy = options.conflictPolicy ?? "manual";
   const namespace = input.namespace;
+  const policy = assertConflictPolicy(options.conflictPolicy);
   // Index the peer census only, then stream the local one against it, removing
   // each match as it is consumed. Peak residency is one index plus the entry
   // list rather than two full censuses (round 2, codex P2).
-  const peer = indexByPath(input.peer);
-  const base = input.base ? indexByPath(input.base) : null;
+  const peer = indexByPath(input.peer, "peer", namespace);
+  const base = input.base ? indexByPath(input.base, "base", namespace) : null;
   const tombstoned = new Set(input.tombstonedFileSha256 ?? []);
   const entries: ReconcilePlanEntry[] = [];
 
-  // Paths only, not file objects: enough to make the stream idempotent without
-  // materializing the second census.
-  const seenLocal = new Set<string>();
+  // Path -> digest only, never the file objects: enough to make the stream
+  // idempotent and to catch contradictory duplicates without materializing the
+  // second census.
+  const seenLocal = new Map<string, string>();
   for (const localFile of input.local) {
-    const path = localFile?.path;
-    if (typeof path !== "string" || path.length === 0) continue;
-    if (seenLocal.has(path)) continue;
-    seenLocal.add(path);
+    const path = assertCensusPath(localFile, "local", namespace);
+    const seenDigest = seenLocal.get(path);
+    if (seenDigest !== undefined) {
+      if (seenDigest !== localFile.sha256) {
+        throw new ReconcilePlanInputError(
+          `reconcile: local census for namespace ${namespace} lists ${path} twice with different digests`,
+        );
+      }
+      continue;
+    }
+    seenLocal.set(path, localFile.sha256);
     const peerFile = peer.get(path);
     // Consumed: whatever remains in the index afterwards is peer-only.
     peer.delete(path);
     const baseSha256 = base?.get(path)?.sha256;
+    // Retraction outranks every other decision for this path. Checked BEFORE
+    // hash comparison and conflict resolution: otherwise a retracted peer
+    // revision reaches the conflict ladder and `newest-wins` can hand it the
+    // win, resurrecting exactly what was retracted (round 3).
+    if (peerFile && tombstoned.has(peerFile.sha256)) {
+      entries.push({
+        path,
+        namespace,
+        action: "suppress",
+        reason: "tombstoned",
+        localSha256: localFile.sha256,
+        peerSha256: peerFile.sha256,
+        ...(baseSha256 === undefined ? {} : { baseSha256 }),
+      });
+      continue;
+    }
     if (!peerFile) {
       // Base PRESENCE is what proves a deletion, not equality with whatever the
       // surviving side now holds. If we also edited since the base, this is

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -452,11 +452,21 @@ function indexDigestsByPath(
   namespace: string,
 ): Map<string, string> {
   const index = new Map<string, string>();
-  const seen = new Map<string, { sha256: string; mtimeMs?: number }>();
   for (const raw of files) {
     const file = assertCensusRecord(raw, side, namespace);
-    if (rejectConflictingDuplicate(seen.get(file.path), file, file.path, side, namespace)) continue;
-    seen.set(file.path, { sha256: file.sha256, mtimeMs: file.mtimeMs });
+    const existing = index.get(file.path);
+    // One map, not a parallel `seen`: the base's own mtimeMs is never a
+    // decision input (only the local and peer timestamps order a conflict), so
+    // a duplicate that agrees on the digest is unambiguous here regardless of
+    // its timestamp, and the digest alone is enough to detect a real clash.
+    if (existing !== undefined) {
+      if (existing !== file.sha256) {
+        throw new ReconcilePlanInputError(
+          `reconcile: ${side} census for namespace ${namespace} lists ${file.path} twice with different digests`,
+        );
+      }
+      continue;
+    }
     index.set(file.path, file.sha256);
   }
   return index;

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -239,8 +239,8 @@ function assertNoCaseCollision(
  * byte-stable ordering the convergence report relies on.
  */
 function rejectConflictingDuplicate(
-  existing: ReconcileFileState | undefined,
-  incoming: ReconcileFileState,
+  existing: { sha256: string; mtimeMs?: number } | undefined,
+  incoming: { sha256: string; mtimeMs?: number },
   path: string,
   side: string,
   namespace: string,
@@ -370,21 +370,21 @@ export function planNamespaceReconciliation(
   // a local `facts/a.md` is the same delete/change ambiguity on a
   // case-insensitive participant.
   if (base) for (const basePath of base.keys()) assertNoCaseCollision(caseFold, basePath, namespace);
-  const seenLocal = new Map<string, string>();
+  // Path -> decision-relevant fields only, never the whole record: enough to
+  // make the stream idempotent and to catch contradictory duplicates without
+  // materializing the second census.
+  const seenLocal = new Map<string, { sha256: string; mtimeMs?: number }>();
   for (const rawLocal of localCensus) {
     const localFile = assertCensusRecord(rawLocal, "local", namespace);
     const path = localFile.path;
     assertNoCaseCollision(caseFold, path, namespace);
-    const seenDigest = seenLocal.get(path);
-    if (seenDigest !== undefined) {
-      if (seenDigest !== localFile.sha256) {
-        throw new ReconcilePlanInputError(
-          `reconcile: local census for namespace ${namespace} lists ${path} twice with different digests`,
-        );
-      }
-      continue;
+    const seen = seenLocal.get(path);
+    if (seen !== undefined) {
+      // Same rule the indexed censuses get: mtimeMs is decision-relevant under
+      // `newest-wins`, so a duplicate that disagrees on it is ambiguous too.
+      if (rejectConflictingDuplicate(seen, localFile, path, "local", namespace)) continue;
     }
-    seenLocal.set(path, localFile.sha256);
+    seenLocal.set(path, { sha256: localFile.sha256, mtimeMs: localFile.mtimeMs });
     const peerFile = peer.get(path);
     // Consumed: whatever remains in the index afterwards is peer-only.
     peer.delete(path);
@@ -558,7 +558,18 @@ export function planReconciliation(
   options: ReconcileOptions = {},
 ): ReconcilePlan {
   const entries: ReconcilePlanEntry[] = [];
+  // Two inputs for one namespace are planned independently, so the same
+  // (namespace, path) can draw contradictory actions - and because those
+  // entries also sort equal, batch order would decide which revision survives.
+  const seenNamespaces = new Set<string>();
   for (const namespace of namespaces) {
+    const name = assertNamespace(namespace?.namespace);
+    if (seenNamespaces.has(name)) {
+      throw new ReconcilePlanInputError(
+        `reconcile: namespace ${name} appears twice; merge its censuses before planning`,
+      );
+    }
+    seenNamespaces.add(name);
     entries.push(...planNamespaceReconciliation(namespace, options));
   }
   entries.sort(compareEntries);

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -19,7 +19,7 @@ import type { OfflineSyncFileState } from "../offline-sync.js";
  */
 
 /** Which way a path must move for the two corpora to agree. */
-export type ReconcileAction = "pull" | "push" | "identical" | "conflict";
+export type ReconcileAction = "pull" | "push" | "identical" | "conflict" | "suppress";
 
 /**
  * How a path present on BOTH sides with different content is settled.
@@ -60,6 +60,9 @@ export type ReconcileReason =
   | "both_modified"
   | "peer_deleted"
   | "local_deleted"
+  /** Peer deleted it while this side edited it — the offline-sync delete/modify pair. */
+  | "local_modified_peer_deleted"
+  | "local_deleted_peer_modified"
   | "tombstoned";
 
 export interface ReconcileNamespaceReport {
@@ -68,6 +71,8 @@ export interface ReconcileNamespaceReport {
   push: number;
   identical: number;
   conflict: number;
+  /** Local retractions the peer must be told about before the pair agrees. */
+  suppress: number;
   /** Conflicts the policy could not settle; these need an operator. */
   unresolved: number;
 }
@@ -170,19 +175,29 @@ export function planNamespaceReconciliation(
     const peerFile = peer.get(path);
     const baseSha256 = base?.get(path)?.sha256;
     if (!peerFile) {
-      // Only a base proves the peer once had this path and dropped it. Without
-      // one, the peer simply never saw it, and a bootstrap merge must push
-      // rather than delete — the whole point is that both sides hold unique
-      // valid data.
-      const deletedByPeer = baseSha256 !== undefined && baseSha256 === localFile.sha256;
+      // Base PRESENCE is what proves a deletion, not equality with whatever the
+      // surviving side now holds. If we also edited since the base, this is
+      // delete-versus-modify: still a conflict, and pushing it would resurrect
+      // a deliberate deletion. Without a base the peer simply never saw the
+      // path, and a bootstrap merge must push — both sides hold unique data.
+      if (baseSha256 !== undefined) {
+        entries.push({
+          path,
+          namespace,
+          action: "conflict",
+          reason: baseSha256 === localFile.sha256 ? "peer_deleted" : "local_modified_peer_deleted",
+          localSha256: localFile.sha256,
+          baseSha256,
+          resolution: "unresolved",
+        });
+        continue;
+      }
       entries.push({
         path,
         namespace,
-        action: deletedByPeer ? "conflict" : "push",
-        reason: deletedByPeer ? "peer_deleted" : "local_only",
+        action: "push",
+        reason: "local_only",
         localSha256: localFile.sha256,
-        ...(baseSha256 === undefined ? {} : { baseSha256 }),
-        ...(deletedByPeer ? { resolution: "unresolved" as const } : {}),
       });
       continue;
     }
@@ -240,27 +255,39 @@ export function planNamespaceReconciliation(
     if (local.has(path)) continue;
     const baseSha256 = base?.get(path)?.sha256;
     if (tombstoned.has(peerFile.sha256)) {
-      // Retracted here on purpose. Pulling it back would undo the retraction
-      // every time the peers reconcile.
+      // Retracted here on purpose, and the peer still serves it. Pulling it
+      // back would undo the retraction; calling it `identical` would be worse,
+      // because a converged plan lets transport skip everything and the peer
+      // keeps serving the retracted fact forever. It is work: propagate the
+      // tombstone.
       entries.push({
         path,
         namespace,
-        action: "identical",
+        action: "suppress",
         reason: "tombstoned",
         peerSha256: peerFile.sha256,
         ...(baseSha256 === undefined ? {} : { baseSha256 }),
       });
       continue;
     }
-    const deletedLocally = baseSha256 !== undefined && baseSha256 === peerFile.sha256;
+    if (baseSha256 !== undefined) {
+      entries.push({
+        path,
+        namespace,
+        action: "conflict",
+        reason: baseSha256 === peerFile.sha256 ? "local_deleted" : "local_deleted_peer_modified",
+        peerSha256: peerFile.sha256,
+        baseSha256,
+        resolution: "unresolved",
+      });
+      continue;
+    }
     entries.push({
       path,
       namespace,
-      action: deletedLocally ? "conflict" : "pull",
-      reason: deletedLocally ? "local_deleted" : "peer_only",
+      action: "pull",
+      reason: "peer_only",
       peerSha256: peerFile.sha256,
-      ...(baseSha256 === undefined ? {} : { baseSha256 }),
-      ...(deletedLocally ? { resolution: "unresolved" as const } : {}),
     });
   }
 
@@ -273,7 +300,7 @@ export function summarizeReconcilePlan(entries: readonly ReconcilePlanEntry[]): 
   for (const entry of entries) {
     let report = byNamespace.get(entry.namespace);
     if (!report) {
-      report = { namespace: entry.namespace, pull: 0, push: 0, identical: 0, conflict: 0, unresolved: 0 };
+      report = { namespace: entry.namespace, pull: 0, push: 0, identical: 0, conflict: 0, suppress: 0, unresolved: 0 };
       byNamespace.set(entry.namespace, report);
     }
     report[entry.action] += 1;

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -149,6 +149,14 @@ export interface ReconcileNamespaceInput {
    * "the peer deliberately retracted it": the peer census simply omits both,
    * so a file we still hold is planned `push` and the peer's retraction is
    * undone. Reconciliation is symmetric, so retraction has to be too.
+   *
+   * SCOPE: these sets decide what happens to files that still EXIST on one
+   * side. Sharing the retraction records themselves is not modelled here -
+   * tombstones are corpus files (`state/tombstones.jsonl`), so they reconcile
+   * as ordinary paths through this same plan. A digest both censuses have
+   * already dropped therefore produces no entry, by design: there is no file
+   * left to act on, and synthesizing a path-less entry would hand transport
+   * something it cannot apply.
    */
   peerTombstonedFileSha256?: Iterable<string>;
 }
@@ -264,6 +272,14 @@ function assertNamespace(namespace: unknown): string {
   // both here would slip two inputs past the duplicate check and let them plan
   // contradictory actions for the same path. Rejected rather than silently
   // rewritten, so the namespace on every entry is the caller's own string.
+  if (LONE_SURROGATE.test(namespace)) {
+    // `namespaceIdentityToken()` encodes through TextEncoder, so a lone
+    // surrogate and a literal U+FFFD collapse to ONE storage identity while
+    // comparing as two here - slipping both past the duplicate-namespace guard.
+    throw new ReconcilePlanInputError(
+      "reconcile: namespace contains an unpaired surrogate; it would collide with another namespace on disk",
+    );
+  }
   if (normalizeNamespaceIdentity(namespace) !== namespace) {
     throw new ReconcilePlanInputError(
       `reconcile: namespace ${JSON.stringify(namespace)} is not canonical; pass ${JSON.stringify(normalizeNamespaceIdentity(namespace))}`,

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -247,6 +247,12 @@ function assertDigest(value: unknown, context: string): string {
   return value.toLowerCase();
 }
 
+function isPlainObject(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto: unknown = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
 function assertNamespace(namespace: unknown): string {
   if (typeof namespace !== "string" || namespace.length === 0) {
     throw new ReconcilePlanInputError("reconcile: every namespace input needs a non-empty namespace");
@@ -315,9 +321,11 @@ function assertNoPathAlias(
   namespace: string,
 ): void {
   // NFC first: macOS stores decomposed names and compares canonically, so
-  // `é` (U+00E9) and `é` (e + U+0301) are ONE file there. Case folding alone
-  // leaves them distinct and the planner would emit both a push and a pull.
-  const folded = path.normalize("NFC").toLowerCase();
+  // `é` (U+00E9) and `é` (e + U+0301) are ONE file there. Then a FULL caseless
+  // fold - upper-then-lower, which collapses forms a bare toLowerCase() keeps
+  // apart, such as final sigma `ς` against `σ`. Lowercasing alone would leave
+  // those distinct and the planner would emit both a push and a pull.
+  const folded = path.normalize("NFC").toUpperCase().toLowerCase();
   const existing = seen.get(folded);
   if (existing !== undefined && existing !== path) {
     throw new ReconcilePlanInputError(
@@ -470,12 +478,13 @@ export function planNamespaceReconciliation(
   input: ReconcileNamespaceInput,
   options: ReconcileOptions = {},
 ): ReconcilePlanEntry[] {
-  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+  if (!isPlainObject(input)) {
     throw new ReconcilePlanInputError("reconcile: namespace input must be a plain object");
   }
-  if (options === null || typeof options !== "object" || Array.isArray(options)) {
-    // An array passes a bare typeof check and would silently take the default
-    // policy, hiding a malformed request behind `manual`.
+  if (!isPlainObject(options)) {
+    // A Date, Map or RegExp passes a bare typeof check, exposes no
+    // `conflictPolicy`, and would silently take the default policy - hiding a
+    // malformed request behind `manual`.
     throw new ReconcilePlanInputError("reconcile: options must be a plain object");
   }
   const namespace = assertNamespace(input.namespace);

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -291,6 +291,7 @@ function assertIterable(value: unknown, side: string, namespace: string): Iterab
 // eslint-disable-next-line no-control-regex -- control characters are exactly what this rejects
 const WIN32_INVALID_CHARS = /[<>:"|?*\u0000-\u001f]/;
 // Windows treats the superscripts as their digits in COM/LPT device names.
+const LONE_SURROGATE = /[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/;
 const WIN32_RESERVED_NAMES = /^(con|prn|aux|nul|(com|lpt)[1-9\u00b9\u00b2\u00b3])$/i;
 
 function assertPortablePathSegments(path: string, side: string, namespace: string): void {
@@ -305,6 +306,13 @@ function assertPortablePathSegments(path: string, side: string, namespace: strin
     // `:` opens an alternate data stream, the rest cannot be created at all,
     // and a reserved device name resolves to hardware. A plan containing any of
     // them cannot be applied on a Windows participant.
+    if (LONE_SURROGATE.test(segment)) {
+      // Node encodes an unpaired surrogate as U+FFFD, so this path and a
+      // literal U+FFFD path are one file on disk while comparing as distinct.
+      throw new ReconcilePlanInputError(
+        `reconcile: ${side} census for namespace ${namespace} path ${path} contains an unpaired surrogate`,
+      );
+    }
     if (WIN32_INVALID_CHARS.test(segment)) {
       throw new ReconcilePlanInputError(
         `reconcile: ${side} census for namespace ${namespace} path ${path} contains a character Windows cannot store`,
@@ -415,11 +423,27 @@ function parseTombstonedDigests(
   return digests;
 }
 
-function compactDigests(index: Map<string, ReconcileFileState>): Map<string, string> {
-  const compact = new Map<string, string>();
-  for (const [path, file] of index) compact.set(path, file.sha256);
-  index.clear();
-  return compact;
+/**
+ * Validate a census while keeping ONLY path -> digest.
+ *
+ * The base cursor is read for digests alone, so indexing full records and
+ * compacting afterwards would hold a corpus-sized record map and its copy at
+ * once - the peak this avoids.
+ */
+function indexDigestsByPath(
+  files: Iterable<ReconcileFileState>,
+  side: string,
+  namespace: string,
+): Map<string, string> {
+  const index = new Map<string, string>();
+  const seen = new Map<string, { sha256: string; mtimeMs?: number }>();
+  for (const raw of files) {
+    const file = assertCensusRecord(raw, side, namespace);
+    if (rejectConflictingDuplicate(seen.get(file.path), file, file.path, side, namespace)) continue;
+    seen.set(file.path, { sha256: file.sha256, mtimeMs: file.mtimeMs });
+    index.set(file.path, file.sha256);
+  }
+  return index;
 }
 
 const RECONCILE_CONFLICT_POLICIES: readonly ReconcileConflictPolicy[] = ["manual", "newest-wins", "keep-both"];
@@ -514,7 +538,7 @@ export function planNamespaceReconciliation(
   // resurrect it.
   const base = input.base === undefined
     ? null
-    : compactDigests(indexByPath(assertIterable(input.base, "base", namespace), "base", namespace));
+    : indexDigestsByPath(assertIterable(input.base, "base", namespace), "base", namespace);
   const tombstoned = parseTombstonedDigests(input.tombstonedFileSha256, namespace);
   const peerTombstoned = parseTombstonedDigests(
     input.peerTombstonedFileSha256,


### PR DESCRIPTION
Part of #2150 — the decision layer. Transport and CLI wiring follow in separate PRs (see below), per the repo's split-before-review rule.

## Why a new planner instead of an offline-sync mode

Offline-sync assumes a satellite sharing a base with one daemon: anything it lacks is a pull, conflicts are rare, and the daemon is the authority. Two long-lived daemons invert every one of those: **no common base on the first run**, both sides authoritative, each holding months the other never saw. Bolting that onto `applyOfflineSync*` as another mode flag would put two incompatible conflict models in one function.

So the decision is separated from the transfer. `planReconciliation()` is pure — no I/O, no transport, no clock — which puts the risky part (who wins, what counts as converged, what gets reported) somewhere it can be tested exhaustively.

## Semantics

| Situation | Decision | Why |
|---|---|---|
| Absent one side, **no base** | push / pull | Never seen is not deleted. Bootstrap exists because both sides hold unique valid data. |
| Absent one side, **base matches** | `conflict` / unresolved | Only a base proves a deletion. Re-pushing would resurrect it; deleting would destroy a live edit. |
| Both modified, base matches one side | pull / push | Only one side moved since agreement — not a conflict. |
| Both modified, no base | `conflict` | Settled by policy. |
| Peer holds a locally tombstoned hash | not pulled | A retraction must survive every future reconcile. |

Conflict policies: **`manual` (default)** reports and applies nothing — on a bootstrap merge both sides are equally authoritative, so auto-picking is data loss with extra steps. **`newest-wins`** uses mtime but **degrades to keeping both on a tie or a missing timestamp** rather than flipping a coin over which corpus keeps its history. **`keep-both`** never designates a loser.

## Issue bullets covered here

- Defined conflict semantics (same id both sides, newest-wins vs supersede-link, tombstone handling)
- Convergence report — `{pull, push, identical, conflict, unresolved}` per namespace
- Idempotency — converged peers plan zero work; `plan.converged` lets transport short-circuit before moving anything
- Bounded memory — accepts `Iterable`s, and `planNamespaceReconciliation` runs one namespace at a time so a 100k-file corpus never holds two full censuses at once

## Deferred to follow-ups (issue stays open)

- Daemon-side peer client + `remnic reconcile` wiring onto the existing offline-sync chunked transfer
- Post-merge hooks: `qmd.updateCollectionStrict()` + `rebuildMemoryProjection({dryRun: false})`, and fact-level dedup via `ContentHashIndex.addByHash()`
- Per-peer cursor persistence reusing `OfflineSyncState`

## Verification

- 14 tests, all passing; `preflight:quick` OK, ratchets OK, config contract OK.
- **Mutation-checked**: forcing `converged: true`, and treating every peer-absent path as a deletion, each fail the suite (1 and 3 failures respectively).
- Built artifact smoke-tested: importing `@remnic/core/reconcile/plan` from `dist` returns `converged: true` for identical corpora and `push,pull` for disjoint ones.

## Note on the export

Exported as the `@remnic/core/reconcile/plan` subpath, not from `index.ts` — that file is at its #1995 ratchet ceiling and any addition trips it. tsup derives the build entry from the exports map, so the subpath builds automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Planner decisions directly control what memory files move, merge, or stay in conflict; wrong tombstone/base semantics could resurrect retracted facts or skip needed work, though transport is not wired yet and behavior is heavily tested.
> 
> **Overview**
> Adds a **pure planning layer** for peer-to-peer corpus reconciliation (#2150), separate from offline-sync transfer: `planReconciliation()` / `planNamespaceReconciliation()` compare local and peer file censuses (optional `base` cursor, local/peer tombstone digest sets) and return per-path **pull/push/identical/conflict/suppress** actions, machine-readable reasons, optional conflict resolutions, and a **`converged`** flag transport can short-circuit on.
> 
> Bootstrap semantics treat paths missing on one side **without a base** as never-seen (bidirectional merge), while a base distinguishes real deletions and one-sided edits from true conflicts. Default **`manual`** policy leaves both-modified paths unresolved; **`newest-wins`** and **`keep-both`** (supersede-link with `newerSide`) apply when opted in, with newest-wins degrading to keep-both when mtimes are missing or tied. **Tombstoned file digests** override conflicts and prevent retracted content from being planned as identical or re-pushed.
> 
> Exposed as **`@remnic/core/reconcile/plan`** (package export + changeset); extensive tests cover semantics, streaming local censuses, determinism, and strict census/path validation aligned with offline-sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7959eb4ab21dcd42324aaf8a370e1de23864ccf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bootstrap reconciliation planner that generates a bidirectional work plan to reconcile divergent peer file collections.
  * Deterministic planning with per-namespace convergence reporting and idempotent “already converged” short-circuiting.
  * Conflict handling with `manual`, `newest-wins` (mtime-based), and `keep-both`, including tombstone suppression behavior.
  * Exposed as new public subpath exports (`./reconcile/plan`).

* **Tests**
  * Added comprehensive coverage for planning semantics, conflicts/deletions/tombstones, streamed-input behavior, determinism, plan summaries, and strict input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->