### PR TITLE
Pi plugin: single context injection at session start for KV cache stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ model-lab/**/runs/
 model-lab/.venv/
 *.safetensors
 *.gguf
+
+graphify-out/

--- a/docs/integration/omp.md
+++ b/docs/integration/omp.md
@@ -261,7 +261,7 @@ Running both means two disjoint memories; pick Remnic (shared) or Mnemopi
 
 ## What The Extension Does
 
-- Uses the `context` hook to recall relevant Remnic context before an agent turn.
+- Uses the `before_agent_start` hook to inject recalled Remnic context into the system prompt.
 - Uses `message_end`, `turn_end`, and `session_shutdown` hooks to observe user, assistant, and tool activity with `sourceFormat: "pi"`.
 - Uses `session_before_compact` to flush Remnic LCM for the active session before omp compacts context, then records the compaction token delta.
 - Registers Remnic MCP tools as omp tools when the Remnic daemon token is configured.
@@ -298,7 +298,7 @@ Supported config keys:
 | `recallMode` | `auto` | Recall mode: `auto`, `minimal`, `full`, `graph_mode`, or `no_recall` |
 | `recallTopK` | `8` | Max recalled results |
 | `recallBudgetChars` | `12000` | Max recalled context injected into omp |
-| `recallEnabled` | `true` | Enable context-hook recall |
+| `recallEnabled` | `true` | Enable semantic recall before each user turn |
 | `observeEnabled` | `true` | Enable turn observation |
 | `observeSkipExtraction` | `false` | Archive observed messages without extraction |
 | `compactionEnabled` | `true` | Enable LCM flush/checkpoint coordination |

--- a/docs/integration/pi.md
+++ b/docs/integration/pi.md
@@ -37,7 +37,7 @@ remnic connectors install pi \
 
 ## What The Extension Does
 
-- Uses Pi's `context` hook to recall relevant Remnic context before an agent turn.
+- Uses Pi's `before_agent_start` hook to inject recalled Remnic context into the system prompt.
 - Uses `agent_end`, `turn_end`, and `session_shutdown` hooks to observe Pi messages and tool activity with `sourceFormat: "pi"`.
 - Uses `session_before_compact` to flush Remnic LCM for the active session before Pi compacts context.
 - Records the compaction token delta after Pi produces the compacted checkpoint.
@@ -72,7 +72,7 @@ Supported config keys:
 | `recallMode` | `auto` | Recall mode: `auto`, `minimal`, `full`, `graph_mode`, or `no_recall` |
 | `recallTopK` | `8` | Max recalled results |
 | `recallBudgetChars` | `12000` | Max recalled context injected into Pi |
-| `recallEnabled` | `true` | Enable context-hook recall |
+| `recallEnabled` | `true` | Enable semantic recall before each user turn |
 | `observeEnabled` | `true` | Enable Pi turn observation |
 | `observeSkipExtraction` | `false` | Archive observed messages without extraction |
 | `compactionEnabled` | `true` | Enable LCM flush/checkpoint coordination |

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -141,7 +141,6 @@ test("default Pi extension creates isolated state for each host invocation", asy
   const configPath = path.join(root, "remnic.config.json");
   fs.writeFileSync(configPath, JSON.stringify({
     authToken: "test-token",
-    recallEnabled: false,
     observeEnabled: false,
     compactionEnabled: false,
     mcpToolsEnabled: false,
@@ -150,10 +149,16 @@ test("default Pi extension creates isolated state for each host invocation", asy
 
   const previousConfig = process.env.REMNIC_PI_CONFIG;
   const originalFetch = globalThis.fetch;
-  const fetchBodies: unknown[] = [];
+  const recallBodies: unknown[] = [];
   process.env.REMNIC_PI_CONFIG = configPath;
-  globalThis.fetch = async (_input, init) => {
-    fetchBodies.push(JSON.parse(String(init?.body ?? "{}")));
+  globalThis.fetch = async (input, init) => {
+    if (String(input).endsWith("/engram/v1/health")) {
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    if (String(input).includes("/engram/v1/namespace/writable")) {
+      return new Response(JSON.stringify({ ok: true, status: "ok", namespace: "default" }), { status: 200 });
+    }
+    recallBodies.push(JSON.parse(String(init?.body ?? "{}")));
     return new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
   };
   t.after(() => {
@@ -173,12 +178,19 @@ test("default Pi extension creates isolated state for each host invocation", asy
     sessionManager: { getSessionId: () => "shared-session" },
   };
 
-  // Both extensions registered and can process events without error —
-  // each manages its own session state independently.
-  await first.emit("context", { messages: [{ role: "user", content: "hi" }] }, ctx);
-  await second.emit("context", { messages: [{ role: "user", content: "hi" }] }, ctx);
+  // Each extension independently recalls at session_start — state maps are
+  // isolated so the same session key produces fetch calls on both instances.
+  await first.emit("session_start", {}, ctx);
+  await second.emit("session_start", {}, ctx);
+  assert.equal(recallBodies.length, 2, "each extension independently recalled");
 
-  assert.equal(fetchBodies.length, 0);
+  // Context injection reads from each extension's isolated cachedContext.
+  const firstResult = await first.emit("context", { messages: [{ role: "user", content: "hi" }] }, ctx) as { messages?: Array<Record<string, unknown>> };
+  const secondResult = await second.emit("context", { messages: [{ role: "user", content: "hi" }] }, ctx) as { messages?: Array<Record<string, unknown>> };
+  assert.ok(firstResult.messages?.[0]?.remnicInjected);
+  assert.ok(secondResult.messages?.[0]?.remnicInjected);
+  // No additional recall calls from context injection.
+  assert.equal(recallBodies.length, 2);
 });
 
 test("MCP tool registration uses the startup timeout instead of the general request timeout", async (t) => {

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -765,7 +765,7 @@ test("empty recall responses do not suppress retry for same query", async (t) =>
   const result = await emit("context", event, ctx) as { messages?: Array<{ content?: Array<{ text?: string }> }> };
 
   assert.equal(calls, 2);
-  const injected = result.messages?.at(-1);
+  const injected = result.messages?.[0];
   assert.ok(injected?.content?.[0]?.text?.includes("remembered context"));
   assert.equal(
     (injected as { excludeFromContext?: unknown } | undefined)?.excludeFromContext,
@@ -777,37 +777,36 @@ test("empty recall responses do not suppress retry for same query", async (t) =>
   );
 });
 
-test("context recall appends injected context after stable conversation history", async (t) => {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () =>
-    new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
+test("context recall prepends injected context before conversation history", async (t) => {
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = async () =>
+		new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
 
-  const { pi, emit } = makePiHarness();
-  const extension = createRemnicPiExtension({
-    config: {
-      ...baseConfig(),
-      authToken: "test-token",
-      observeEnabled: false,
-      compactionEnabled: false,
-      mcpToolsEnabled: false,
-      statusEnabled: false,
-    },
-  });
-  await extension(pi as any);
+	const { pi, emit } = makePiHarness();
+	const extension = createRemnicPiExtension({
+		config: {
+			...baseConfig(),
+			authToken: "test-token",
+			observeEnabled: false,
+			compactionEnabled: false,
+		},
+	});
+	await extension(pi as any);
 
-  const firstMessage = { role: "system", content: "stable prefix" };
-  const userMessage = { role: "user", content: "same prompt" };
-  const result = await emit("context", { messages: [firstMessage, userMessage] }, {
-    cwd: "/tmp/remnic-pi",
-    sessionManager: { getSessionId: () => "append-recall-test" },
-  }) as { messages?: Array<Record<string, unknown>> };
+	const firstMessage = { role: "system", content: "stable prefix" };
+	const userMessage = { role: "user", content: "same prompt" };
+	const result = await emit("context", { messages: [firstMessage, userMessage] }, {
+		cwd: "/tmp/remnic-pi",
+		sessionManager: { getSessionId: () => "append-recall-test" },
+	}) as { messages?: Array<Record<string, unknown>> };
 
-  assert.equal(result.messages?.[0], firstMessage);
-  assert.equal(result.messages?.[1], userMessage);
-  assert.equal(result.messages?.[2]?.remnicInjected, true);
+	// Injected system message is now at index 0 (prepended)
+	assert.equal(result.messages?.[0]?.remnicInjected, true);
+	assert.equal(result.messages?.[1], firstMessage);
+	assert.equal(result.messages?.[2], userMessage);
 });
 
 test("context recall does not load full session history", async (t) => {
@@ -846,7 +845,7 @@ test("context recall does not load full session history", async (t) => {
     sessionManager,
   }) as { messages?: Array<Record<string, unknown>> };
 
-  assert.equal(result.messages?.at(-1)?.remnicInjected, true);
+  assert.equal(result.messages?.[0]?.remnicInjected, true);
 });
 
 test("context recall skips stale Pi ctx before snapshot", async (t) => {
@@ -911,7 +910,7 @@ test("context recall keeps pi:default fallback when session manager is missing",
     cwd: "/tmp/remnic-pi",
   }) as { messages?: Array<Record<string, unknown>> };
 
-  assert.equal(result.messages?.at(-1)?.remnicInjected, true);
+  assert.equal(result.messages?.[0]?.remnicInjected, true);
   assert.equal(recallBodies[0]?.sessionKey, "pi:default");
   assert.equal(recallBodies[0]?.cwd, "/tmp/remnic-pi");
 });
@@ -943,7 +942,7 @@ test("recall context truncation stays within the configured budget", async (t) =
     sessionManager: { getSessionId: () => "recall-budget-test" },
   }) as { messages?: Array<{ content?: Array<{ text?: string }> }> };
 
-  const text = result.messages?.at(-1)?.content?.[0]?.text ?? "";
+  const text = result.messages?.[0]?.content?.[0]?.text ?? "";
   const context = text.split("Remnic recalled context for this turn:\n\n")[1] ?? "";
   assert.equal(context.length, 40);
   assert.ok(context.endsWith("[Remnic context truncated]"));

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -178,19 +178,19 @@ test("default Pi extension creates isolated state for each host invocation", asy
     sessionManager: { getSessionId: () => "shared-session" },
   };
 
-  // Each extension independently recalls at first context event — state maps are
+  // Each extension independently recalls at first before_agent_start — state maps are
   // isolated so the same session key produces fetch calls on both instances.
-  // Zero recall calls at session_start; recall fires on first context.
+  // Zero recall calls at session_start; recall fires on first before_agent_start.
   await first.emit("session_start", {}, ctx);
   await second.emit("session_start", {}, ctx);
   assert.equal(recallBodies.length, 0, "no recall at session_start");
 
   // Context injection reads from each extension's isolated cachedContext.
-  const firstResult = await first.emit("context", { messages: [{ role: "user", content: "hi" }] }, ctx) as { messages?: Array<Record<string, unknown>> };
-  const secondResult = await second.emit("context", { messages: [{ role: "user", content: "hi" }] }, ctx) as { messages?: Array<Record<string, unknown>> };
-  assert.ok(firstResult.messages?.[0]?.remnicInjected);
-  assert.ok(secondResult.messages?.[0]?.remnicInjected);
-  // One recall call per extension from the first context event.
+  const firstResult = await first.emit("before_agent_start", { prompt: "hi", systemPrompt: "" }, ctx) as { systemPrompt?: string };
+  const secondResult = await second.emit("before_agent_start", { prompt: "hi", systemPrompt: "" }, ctx) as { systemPrompt?: string };
+  assert.ok(firstResult?.systemPrompt?.includes("remembered context"));
+  assert.ok(secondResult?.systemPrompt?.includes("remembered context"));
+  // One recall call per extension from the first before_agent_start event.
   assert.equal(recallBodies.length, 2);
 });
 
@@ -674,7 +674,7 @@ test("session_before_compact surfaces checkpoint write failures without dropping
   );
 });
 
-test("singleton extension refreshes recall context across sessions", async (t) => {
+test("before_agent_start refreshes recall context across sessions", async (t) => {
   const originalFetch = globalThis.fetch;
   const recallBodies: Array<{ sessionKey?: string }> = [];
   let recallCalls = 0;
@@ -712,28 +712,28 @@ test("singleton extension refreshes recall context across sessions", async (t) =
     cwd: "/tmp/remnic-pi",
     sessionManager: { getSessionId: () => "session-2" },
   };
-  const event = { messages: [{ role: "user", content: "same prompt" }] };
+  const event = { prompt: "same prompt", systemPrompt: "" };
 
-  // Session 1: recall fires on first context, not session_start
+  // Session 1: recall fires on first before_agent_start, not session_start
   await emit("session_start", {}, session1Ctx);
   assert.equal(recallCalls, 0);
 
-  const first = await emit("context", event, session1Ctx) as { messages?: Array<Record<string, unknown>> };
+  const first = await emit("before_agent_start", event, session1Ctx) as { systemPrompt?: string };
   assert.equal(recallCalls, 1);
-  assert.ok(first.messages?.[0]?.remnicInjected);
+  assert.ok(first?.systemPrompt?.includes("remembered context"));
 
   await emit("session_shutdown", {}, session1Ctx);
 
-  // Session 2: recall fires again on first context
+  // Session 2: recall fires again on first before_agent_start
   await emit("session_start", {}, session2Ctx);
   assert.equal(recallCalls, 1);
 
-  const second = await emit("context", event, session2Ctx) as { messages?: Array<Record<string, unknown>> };
+  const second = await emit("before_agent_start", event, session2Ctx) as { systemPrompt?: string };
   assert.equal(recallCalls, 2);
-  assert.ok(second.messages?.[0]?.remnicInjected);
+  assert.ok(second?.systemPrompt?.includes("remembered context"));
 });
 
-test("context injects cached recall across successive context events in the same session", async (t) => {
+test("before_agent_start injects cached recall across successive turns in the same session", async (t) => {
   const originalFetch = globalThis.fetch;
   let recallCalls = 0;
   globalThis.fetch = async (input, init) => {
@@ -763,23 +763,23 @@ test("context injects cached recall across successive context events in the same
     cwd: "/tmp/remnic-pi",
     sessionManager: { getSessionId: () => "repeat-context-test" },
   };
-  const event = { messages: [{ role: "user", content: "continue" }] };
+  const event = { prompt: "continue", systemPrompt: "" };
 
   await emit("session_start", {}, ctx);
   assert.equal(recallCalls, 0);
 
-  const first = await emit("context", event, ctx) as { messages?: Array<Record<string, unknown>> };
-  assert.equal(recallCalls, 1, "recall fired on first context event");
-  const second = await emit("context", event, ctx) as { messages?: Array<Record<string, unknown>> };
-  const third = await emit("context", event, ctx) as { messages?: Array<Record<string, unknown>> };
+  const first = await emit("before_agent_start", event, ctx) as { systemPrompt?: string };
+  assert.equal(recallCalls, 1, "recall fired on first before_agent_start");
+  const second = await emit("before_agent_start", event, ctx) as { systemPrompt?: string };
+  const third = await emit("before_agent_start", event, ctx) as { systemPrompt?: string };
 
-  assert.equal(recallCalls, 1, "no additional recall on subsequent context events");
-  assert.ok(first.messages?.[0]?.remnicInjected);
-  assert.ok(second.messages?.[0]?.remnicInjected);
-  assert.ok(third.messages?.[0]?.remnicInjected);
+  assert.equal(recallCalls, 1, "no additional recall on subsequent before_agent_start events");
+  assert.ok(first?.systemPrompt?.includes("remembered context"));
+  assert.ok(second?.systemPrompt?.includes("remembered context"));
+  assert.ok(third?.systemPrompt?.includes("remembered context"));
 });
 
-test("empty recall at first context does not inject context but a later session with content does", async (t) => {
+test("empty recall at first before_agent_start does not inject context but a later session with content does", async (t) => {
   const originalFetch = globalThis.fetch;
   let recallCallIndex = 0;
   globalThis.fetch = async (input) => {
@@ -818,30 +818,21 @@ test("empty recall at first context does not inject context but a later session 
     cwd: "/tmp/remnic-pi",
     sessionManager: { getSessionId: () => "content-recall-session" },
   };
-  const event = { messages: [{ role: "user", content: "same prompt" }] };
+  const event = { prompt: "same prompt", systemPrompt: "" };
 
-  // Session 1: recall returns empty → no cached context → context returns undefined
+  // Session 1: recall returns empty → no cached context → before_agent_start returns undefined
   await emit("session_start", {}, session1Ctx);
-  assert.equal(await emit("context", event, session1Ctx), undefined);
+  assert.equal(await emit("before_agent_start", event, session1Ctx), undefined);
   await emit("session_shutdown", {}, session1Ctx);
 
-  // Session 2: recall returns content → cachedContext populated → context injects
+  // Session 2: recall returns content → cachedContext populated → before_agent_start injects
   await emit("session_start", {}, session2Ctx);
-  const result = await emit("context", event, session2Ctx) as { messages?: Array<{ content?: Array<{ text?: string }> }> };
+  const result = await emit("before_agent_start", event, session2Ctx) as { systemPrompt?: string };
 
-  const injected = result.messages?.[0];
-  assert.ok(injected?.content?.[0]?.text?.includes("remembered context"));
-  assert.equal(
-    (injected as { excludeFromContext?: unknown } | undefined)?.excludeFromContext,
-    undefined,
-  );
-  assert.equal(
-    (injected as { remnicInjected?: unknown } | undefined)?.remnicInjected,
-    true,
-  );
+  assert.ok(result?.systemPrompt?.includes("remembered context"));
 });
 
-test("context recall prepends injected context before conversation history", async (t) => {
+test("before_agent_start appends cached context to the system prompt", async (t) => {
 	const originalFetch = globalThis.fetch;
 	globalThis.fetch = async () =>
 		new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
@@ -867,17 +858,13 @@ test("context recall prepends injected context before conversation history", asy
 
 	await emit("session_start", {}, ctx);
 
-	const firstMessage = { role: "system", content: "stable prefix" };
-	const userMessage = { role: "user", content: "same prompt" };
-	const result = await emit("context", { messages: [firstMessage, userMessage] }, ctx) as { messages?: Array<Record<string, unknown>> };
+	const result = await emit("before_agent_start", { prompt: "same prompt", systemPrompt: "base system prompt" }, ctx) as { systemPrompt?: string };
 
-	// Injected message is now at index 0 (prepended)
-	assert.equal(result.messages?.[0]?.remnicInjected, true);
-	assert.equal(result.messages?.[1], firstMessage);
-	assert.equal(result.messages?.[2], userMessage);
+	assert.ok(result?.systemPrompt?.includes("remembered context"));
+	assert.ok(result?.systemPrompt?.startsWith("base system prompt"));
 });
 
-test("context recall does not load full session history", async (t) => {
+test("before_agent_start does not load full session history", async (t) => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () =>
     new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
@@ -911,12 +898,12 @@ test("context recall does not load full session history", async (t) => {
   const ctx = { cwd: "/tmp/remnic-pi", sessionManager };
   await emit("session_start", {}, ctx);
 
-  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, ctx) as { messages?: Array<Record<string, unknown>> };
+  const result = await emit("before_agent_start", { prompt: "same prompt", systemPrompt: "" }, ctx) as { systemPrompt?: string };
 
-  assert.equal(result.messages?.[0]?.remnicInjected, true);
+  assert.ok(result?.systemPrompt?.includes("remembered context"));
 });
 
-test("context recall skips stale Pi ctx before snapshot", async (t) => {
+test("before_agent_start skips stale Pi ctx before snapshot", async (t) => {
   const originalFetch = globalThis.fetch;
   let calls = 0;
   globalThis.fetch = async () => {
@@ -943,14 +930,14 @@ test("context recall skips stale Pi ctx before snapshot", async (t) => {
   const stale = makeStaleCtx({ sessionId: "stale-before-snapshot" });
   stale.markStale();
 
-  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, stale.ctx);
+  const result = await emit("before_agent_start", { prompt: "same prompt", systemPrompt: "" }, stale.ctx);
 
   assert.equal(result, undefined);
   assert.equal(calls, 0);
   assert.deepEqual(stale.notifications, []);
 });
 
-test("context recall keeps pi:default fallback when session manager is missing", async (t) => {
+test("before_agent_start keeps pi:default fallback when session manager is missing", async (t) => {
   const originalFetch = globalThis.fetch;
   const recallBodies: Array<Record<string, unknown>> = [];
   globalThis.fetch = async (input, init) => {
@@ -979,15 +966,15 @@ test("context recall keeps pi:default fallback when session manager is missing",
   const noopCtx = { cwd: "/tmp/remnic-pi" };
   await emit("session_start", {}, noopCtx);
 
-  // Recall fires on first context, not session_start
+  // Recall fires on first before_agent_start, not session_start
   assert.equal(recallBodies.length, 0);
 
-  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, noopCtx) as { messages?: Array<Record<string, unknown>> };
+  const result = await emit("before_agent_start", { prompt: "same prompt", systemPrompt: "" }, noopCtx) as { systemPrompt?: string };
 
   assert.equal(recallBodies.length, 1);
   assert.equal(recallBodies[0]?.sessionKey, "pi:default");
   assert.equal(recallBodies[0]?.cwd, "/tmp/remnic-pi");
-  assert.equal(result.messages?.[0]?.remnicInjected, true);
+  assert.ok(result?.systemPrompt?.includes("remembered context"));
 });
 
 test("recall context truncation stays within the configured budget", async (t) => {
@@ -1018,16 +1005,17 @@ test("recall context truncation stays within the configured budget", async (t) =
   };
   await emit("session_start", {}, ctx);
 
-  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, ctx) as { messages?: Array<{ content?: Array<{ text?: string }> }> };
+  const result = await emit("before_agent_start", { prompt: "same prompt", systemPrompt: "" }, ctx) as { systemPrompt?: string };
 
-  const text = result.messages?.[0]?.content?.[0]?.text ?? "";
+  const text = result?.systemPrompt ?? "";
   const startMarker = "\n\n[Remnic context truncated]";
   const truncatedAt = text.indexOf(startMarker);
-  assert.notEqual(truncatedAt, -1);
-  assert.equal(truncatedAt + startMarker.length, 40);
+  assert.notEqual(truncatedAt, -1, "truncation marker present");
+  // The cached context meets its budget; the \n\n separator adds 2 chars to systemPrompt.
+  assert.ok(text.length <= 42, `system prompt length ${text.length} ≤ 42`);
 });
 
-test("context recall fires on first context event and caches the result", async (t) => {
+test("before_agent_start fires recall on first event and caches the result", async (t) => {
   const originalFetch = globalThis.fetch;
   let recallCalls = 0;
   globalThis.fetch = async (input) => {
@@ -1057,25 +1045,25 @@ test("context recall fires on first context event and caches the result", async 
     cwd: "/tmp/remnic-pi",
     sessionManager: { getSessionId: () => "first-context-recall" },
   };
-  const event = { messages: [{ role: "user", content: "same prompt" }] };
+  const event = { prompt: "same prompt", systemPrompt: "" };
 
   // No recall at session_start
   await emit("session_start", {}, ctx);
   assert.equal(recallCalls, 0);
 
-  // First context event fires recall and caches the result
-  const result = await emit("context", event, ctx) as { messages?: Array<Record<string, unknown>> };
-  assert.equal(recallCalls, 1, "recall fired on first context event");
-  assert.ok(result.messages?.[0]?.remnicInjected, "context was injected");
+  // First before_agent_start fires recall and caches the result
+  const result = await emit("before_agent_start", event, ctx) as { systemPrompt?: string };
+  assert.equal(recallCalls, 1, "recall fired on first before_agent_start");
+  assert.ok(result?.systemPrompt?.includes("remembered context"), "context was injected");
 });
 
-test("context recall failure notification survives stale Pi ctx after await", async (t) => {
+test("before_agent_start recall failure notification survives stale Pi ctx after await", async (t) => {
   const originalFetch = globalThis.fetch;
   const stale = makeStaleCtx({ sessionId: "stale-context-recall" });
   globalThis.fetch = async (input) => {
     const url = String(input);
     // Let health and namespace probes succeed so snapshotPiContext works
-    // during the context handler.  Only the recall call marks the ctx stale.
+    // during the before_agent_start handler.  Only the recall call marks the ctx stale.
     if (url.endsWith("/engram/v1/health")) {
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
     }
@@ -1107,9 +1095,9 @@ test("context recall failure notification survives stale Pi ctx after await", as
     emit("session_start", {}, stale.ctx)
   );
 
-  // Context recall fires and fails; notification survives stale ctx.
+  // before_agent_start recall fires and fails; notification survives stale ctx.
   await assert.doesNotReject(() =>
-    emit("context", { messages: [{ role: "user", content: "hi" }] }, stale.ctx)
+    emit("before_agent_start", { prompt: "hi", systemPrompt: "" }, stale.ctx)
   );
   assert.deepEqual(stale.notifications, [
     { message: "Remnic recall unavailable: offline", level: "warning" },
@@ -1467,15 +1455,15 @@ test("circuit breaker prevents context recall after a startup health probe timeo
     cwd: "/tmp/remnic-pi",
     sessionManager: { getSessionId: () => "cb-session" },
   };
-  const event = { messages: [{ role: "user", content: "any prompt" }] };
+  const event = { prompt: "any prompt", systemPrompt: "" };
 
   // First session_start: health probe times out → daemon enters cooldown.
   await emit("session_start", {}, ctx);
   const healthProbeCalls = fetchCalls;
   assert.ok(healthProbeCalls >= 1, "health probe timed out");
 
-  // Context sees no cached recall (daemon was unreachable at startup).
-  assert.equal(await emit("context", event, ctx), undefined);
+  // before_agent_start sees no cached recall (daemon was unreachable at startup).
+  assert.equal(await emit("before_agent_start", event, ctx), undefined);
 
   // Second session_start while breaker is still in cooldown: health probe runs
   // but recall is skipped because isReachable() is false.
@@ -1483,8 +1471,8 @@ test("circuit breaker prevents context recall after a startup health probe timeo
   const totalCalls = fetchCalls;
   assert.ok(totalCalls > healthProbeCalls, "health probe ran again");
 
-  // Context still sees no cached recall (breaker prevented the one-shot).
-  assert.equal(await emit("context", event, ctx), undefined);
+  // before_agent_start still sees no cached recall (breaker prevented the one-shot).
+  assert.equal(await emit("before_agent_start", event, ctx), undefined);
 });
 
 test("session_shutdown replays the branch even when the daemon breaker is tripped (#1626, review codex)", async (t) => {
@@ -1678,13 +1666,13 @@ test("an offline startup health probe trips the circuit breaker so the first tur
     ui: { setStatus: () => {}, notify: () => {} },
     sessionManager: { getSessionId: () => "status-trip-breaker" },
   };
-  const event = { messages: [{ role: "user", content: "hi" }] };
+  const event = { prompt: "hi", systemPrompt: "" };
 
   // 1) session_start health fails because the daemon is offline -> trips the breaker.
   await emit("session_start", {}, ctx);
-  // 2) context (recall) fast-skips because the breaker is tripped, so the doomed
+  // 2) before_agent_start (recall) fast-skips because the breaker is tripped, so the doomed
   //    recall never costs the full turn budget.
-  await emit("context", event, ctx);
+  await emit("before_agent_start", event, ctx);
   assert.equal(recallCalls, 0, "recall fast-skipped after the offline startup probe tripped the breaker");
 });
 
@@ -1782,10 +1770,10 @@ test("a successful /remnic-recall clears a stale circuit breaker (review cursor)
   // 2) Manual recall succeeds → markReachable() on the shared client.
   await runCommand("remnic-recall", "manual", ctx);
 
-  // 3) Context event: automatic recall fires now that the daemon is reachable.
+  // 3) before_agent_start event: automatic recall fires now that the daemon is reachable.
   //    Count only recall requests so health/preflight noise is excluded.
   const recallCallsBeforeAuto = recallCalls;
-  await emit("context", { messages: [{ role: "user", content: "auto" }] }, ctx);
+  await emit("before_agent_start", { prompt: "auto", systemPrompt: "" }, ctx);
   assert.ok(recallCalls > recallCallsBeforeAuto, "automatic recall ran after manual recall cleared the breaker");
 });
 
@@ -2096,7 +2084,7 @@ test("session_start trips the circuit breaker on an offline daemon even when sta
   // the preflight then fast-skips (indeterminate) instead of fetching.
   await emit("session_start", {}, ctx);
   // The live recall hook fast-skips because the breaker is tripped.
-  await emit("context", { messages: [{ role: "user", content: "hi" }] }, ctx);
+  await emit("before_agent_start", { prompt: "hi", systemPrompt: "" }, ctx);
   assert.equal(nonHealthCalls, 0, "an offline probe must trip the breaker even with the status UI disabled");
 });
 

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -141,6 +141,7 @@ test("default Pi extension creates isolated state for each host invocation", asy
   const configPath = path.join(root, "remnic.config.json");
   fs.writeFileSync(configPath, JSON.stringify({
     authToken: "test-token",
+    recallEnabled: false,
     observeEnabled: false,
     compactionEnabled: false,
     mcpToolsEnabled: false,
@@ -149,10 +150,10 @@ test("default Pi extension creates isolated state for each host invocation", asy
 
   const previousConfig = process.env.REMNIC_PI_CONFIG;
   const originalFetch = globalThis.fetch;
-  const recallBodies: unknown[] = [];
+  const fetchBodies: unknown[] = [];
   process.env.REMNIC_PI_CONFIG = configPath;
   globalThis.fetch = async (_input, init) => {
-    recallBodies.push(JSON.parse(String(init?.body ?? "{}")));
+    fetchBodies.push(JSON.parse(String(init?.body ?? "{}")));
     return new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
   };
   t.after(() => {
@@ -167,16 +168,17 @@ test("default Pi extension creates isolated state for each host invocation", asy
   await remnicPiExtension(first.pi as any);
   await remnicPiExtension(second.pi as any);
 
-  const event = { messages: [{ role: "user", content: "same prompt" }] };
   const ctx = {
     cwd: "/tmp/remnic-pi",
     sessionManager: { getSessionId: () => "shared-session" },
   };
 
-  await first.emit("context", event, ctx);
-  await second.emit("context", event, ctx);
+  // Both extensions registered and can process events without error —
+  // each manages its own session state independently.
+  await first.emit("context", { messages: [{ role: "user", content: "hi" }] }, ctx);
+  await second.emit("context", { messages: [{ role: "user", content: "hi" }] }, ctx);
 
-  assert.equal(recallBodies.length, 2);
+  assert.equal(fetchBodies.length, 0);
 });
 
 test("MCP tool registration uses the startup timeout instead of the general request timeout", async (t) => {
@@ -659,11 +661,17 @@ test("session_before_compact surfaces checkpoint write failures without dropping
   );
 });
 
-test("singleton extension clears per-session recall suppression on shutdown", async (t) => {
+test("singleton extension refreshes recall context across sessions via session_start", async (t) => {
   const originalFetch = globalThis.fetch;
-  const recallBodies: unknown[] = [];
-  globalThis.fetch = async (_input, init) => {
-    recallBodies.push(JSON.parse(String(init?.body ?? "{}")));
+  const recallBodies: Array<{ sessionKey?: string }> = [];
+  let recallCalls = 0;
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    const body = init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {};
+    if (url.endsWith("/engram/v1/recall")) {
+      recallBodies.push(body as { sessionKey?: string });
+      recallCalls += 1;
+    }
     return new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
   };
   t.after(() => {
@@ -683,23 +691,38 @@ test("singleton extension clears per-session recall suppression on shutdown", as
   });
   await extension(pi as any);
 
-  const firstCtx = { cwd: "/tmp/remnic-pi" };
-  const secondCtx = { cwd: "/tmp/remnic-pi" };
+  const session1Ctx = {
+    cwd: "/tmp/remnic-pi",
+    sessionManager: { getSessionId: () => "session-1" },
+  };
+  const session2Ctx = {
+    cwd: "/tmp/remnic-pi",
+    sessionManager: { getSessionId: () => "session-2" },
+  };
   const event = { messages: [{ role: "user", content: "same prompt" }] };
 
-  await emit("context", event, firstCtx);
-  await emit("context", event, firstCtx);
-  await emit("session_shutdown", {}, firstCtx);
-  await emit("context", event, secondCtx);
+  await emit("session_start", {}, session1Ctx);
+  assert.equal(recallCalls, 1);
 
-  assert.equal(recallBodies.length, 2);
+  const first = await emit("context", event, session1Ctx) as { messages?: Array<Record<string, unknown>> };
+  assert.ok(first.messages?.[0]?.remnicInjected);
+
+  await emit("session_shutdown", {}, session1Ctx);
+
+  await emit("session_start", {}, session2Ctx);
+  assert.equal(recallCalls, 2);
+
+  const second = await emit("context", event, session2Ctx) as { messages?: Array<Record<string, unknown>> };
+  assert.ok(second.messages?.[0]?.remnicInjected);
 });
 
-test("recall suppression distinguishes repeated user text with different message ids", async (t) => {
+test("context injects cached recall across successive context events in the same session", async (t) => {
   const originalFetch = globalThis.fetch;
-  const recallBodies: unknown[] = [];
-  globalThis.fetch = async (_input, init) => {
-    recallBodies.push(JSON.parse(String(init?.body ?? "{}")));
+  let recallCalls = 0;
+  globalThis.fetch = async (input, init) => {
+    if (String(input).endsWith("/engram/v1/recall")) {
+      recallCalls += 1;
+    }
     return new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
   };
   t.after(() => {
@@ -721,22 +744,36 @@ test("recall suppression distinguishes repeated user text with different message
 
   const ctx = {
     cwd: "/tmp/remnic-pi",
-    sessionManager: { getSessionId: () => "repeat-user-text-recall" },
+    sessionManager: { getSessionId: () => "repeat-context-test" },
   };
+  const event = { messages: [{ role: "user", content: "continue" }] };
 
-  await emit("context", { messages: [{ id: "m1", role: "user", content: "continue" }] }, ctx);
-  await emit("context", { messages: [{ id: "m2", role: "user", content: "continue" }] }, ctx);
-  await emit("context", { messages: [{ id: "m2", role: "user", content: "continue" }] }, ctx);
+  await emit("session_start", {}, ctx);
+  assert.equal(recallCalls, 1);
 
-  assert.equal(recallBodies.length, 2);
+  const first = await emit("context", event, ctx) as { messages?: Array<Record<string, unknown>> };
+  const second = await emit("context", event, ctx) as { messages?: Array<Record<string, unknown>> };
+  const third = await emit("context", event, ctx) as { messages?: Array<Record<string, unknown>> };
+
+  assert.equal(recallCalls, 1);
+  assert.ok(first.messages?.[0]?.remnicInjected);
+  assert.ok(second.messages?.[0]?.remnicInjected);
+  assert.ok(third.messages?.[0]?.remnicInjected);
 });
 
-test("empty recall responses do not suppress retry for same query", async (t) => {
+test("empty recall at session_start does not inject context but a later session with content does", async (t) => {
   const originalFetch = globalThis.fetch;
-  let calls = 0;
-  globalThis.fetch = async () => {
-    calls += 1;
-    return new Response(JSON.stringify({ context: calls === 1 ? "" : "remembered context" }), { status: 200 });
+  let recallCallIndex = 0;
+  globalThis.fetch = async (input) => {
+    const url = String(input);
+    if (url.endsWith("/engram/v1/health")) {
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    if (url.includes("/engram/v1/namespace/writable")) {
+      return new Response(JSON.stringify({ ok: true, status: "ok", namespace: "default" }), { status: 200 });
+    }
+    recallCallIndex += 1;
+    return new Response(JSON.stringify({ context: recallCallIndex === 1 ? "" : "remembered context" }), { status: 200 });
   };
   t.after(() => {
     globalThis.fetch = originalFetch;
@@ -755,16 +792,25 @@ test("empty recall responses do not suppress retry for same query", async (t) =>
   });
   await extension(pi as any);
 
-  const ctx = {
+  const session1Ctx = {
     cwd: "/tmp/remnic-pi",
-    sessionManager: { getSessionId: () => "empty-recall-retry" },
+    sessionManager: { getSessionId: () => "empty-recall-session" },
+  };
+  const session2Ctx = {
+    cwd: "/tmp/remnic-pi",
+    sessionManager: { getSessionId: () => "content-recall-session" },
   };
   const event = { messages: [{ role: "user", content: "same prompt" }] };
 
-  assert.equal(await emit("context", event, ctx), undefined);
-  const result = await emit("context", event, ctx) as { messages?: Array<{ content?: Array<{ text?: string }> }> };
+  // Session 1: recall returns empty → no cached context → context returns undefined
+  await emit("session_start", {}, session1Ctx);
+  assert.equal(await emit("context", event, session1Ctx), undefined);
+  await emit("session_shutdown", {}, session1Ctx);
 
-  assert.equal(calls, 2);
+  // Session 2: recall returns content → cachedContext populated → context injects
+  await emit("session_start", {}, session2Ctx);
+  const result = await emit("context", event, session2Ctx) as { messages?: Array<{ content?: Array<{ text?: string }> }> };
+
   const injected = result.messages?.[0];
   assert.ok(injected?.content?.[0]?.text?.includes("remembered context"));
   assert.equal(
@@ -796,14 +842,18 @@ test("context recall prepends injected context before conversation history", asy
 	});
 	await extension(pi as any);
 
-	const firstMessage = { role: "system", content: "stable prefix" };
-	const userMessage = { role: "user", content: "same prompt" };
-	const result = await emit("context", { messages: [firstMessage, userMessage] }, {
+	const ctx = {
 		cwd: "/tmp/remnic-pi",
 		sessionManager: { getSessionId: () => "append-recall-test" },
-	}) as { messages?: Array<Record<string, unknown>> };
+	};
 
-	// Injected system message is now at index 0 (prepended)
+	await emit("session_start", {}, ctx);
+
+	const firstMessage = { role: "system", content: "stable prefix" };
+	const userMessage = { role: "user", content: "same prompt" };
+	const result = await emit("context", { messages: [firstMessage, userMessage] }, ctx) as { messages?: Array<Record<string, unknown>> };
+
+	// Injected message is now at index 0 (prepended)
 	assert.equal(result.messages?.[0]?.remnicInjected, true);
 	assert.equal(result.messages?.[1], firstMessage);
 	assert.equal(result.messages?.[2], userMessage);
@@ -840,10 +890,10 @@ test("context recall does not load full session history", async (t) => {
     },
   };
 
-  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, {
-    cwd: "/tmp/remnic-pi",
-    sessionManager,
-  }) as { messages?: Array<Record<string, unknown>> };
+  const ctx = { cwd: "/tmp/remnic-pi", sessionManager };
+  await emit("session_start", {}, ctx);
+
+  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, ctx) as { messages?: Array<Record<string, unknown>> };
 
   assert.equal(result.messages?.[0]?.remnicInjected, true);
 });
@@ -885,8 +935,10 @@ test("context recall skips stale Pi ctx before snapshot", async (t) => {
 test("context recall keeps pi:default fallback when session manager is missing", async (t) => {
   const originalFetch = globalThis.fetch;
   const recallBodies: Array<Record<string, unknown>> = [];
-  globalThis.fetch = async (_input, init) => {
-    recallBodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+  globalThis.fetch = async (input, init) => {
+    if (String(input).endsWith("/engram/v1/recall")) {
+      recallBodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+    }
     return new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
   };
   t.after(() => {
@@ -906,13 +958,15 @@ test("context recall keeps pi:default fallback when session manager is missing",
   });
   await extension(pi as any);
 
-  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, {
-    cwd: "/tmp/remnic-pi",
-  }) as { messages?: Array<Record<string, unknown>> };
+  const noopCtx = { cwd: "/tmp/remnic-pi" };
+  await emit("session_start", {}, noopCtx);
 
-  assert.equal(result.messages?.[0]?.remnicInjected, true);
   assert.equal(recallBodies[0]?.sessionKey, "pi:default");
   assert.equal(recallBodies[0]?.cwd, "/tmp/remnic-pi");
+
+  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, noopCtx) as { messages?: Array<Record<string, unknown>> };
+
+  assert.equal(result.messages?.[0]?.remnicInjected, true);
 });
 
 test("recall context truncation stays within the configured budget", async (t) => {
@@ -937,23 +991,30 @@ test("recall context truncation stays within the configured budget", async (t) =
   });
   await extension(pi as any);
 
-  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, {
+  const ctx = {
     cwd: "/tmp/remnic-pi",
     sessionManager: { getSessionId: () => "recall-budget-test" },
-  }) as { messages?: Array<{ content?: Array<{ text?: string }> }> };
+  };
+  await emit("session_start", {}, ctx);
+
+  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, ctx) as { messages?: Array<{ content?: Array<{ text?: string }> }> };
 
   const text = result.messages?.[0]?.content?.[0]?.text ?? "";
-  const context = text.split("Remnic recalled context for this turn:\n\n")[1] ?? "";
-  assert.equal(context.length, 40);
-  assert.ok(context.endsWith("[Remnic context truncated]"));
+  const startMarker = "\n\n[Remnic context truncated]";
+  const truncatedAt = text.indexOf(startMarker);
+  assert.notEqual(truncatedAt, -1);
+  assert.equal(truncatedAt + startMarker.length, 40);
 });
 
-test("failed recall does not suppress retry for same query", async (t) => {
+test("startup recall retries a transient failure and caches the context on success", async (t) => {
   const originalFetch = globalThis.fetch;
-  let calls = 0;
-  globalThis.fetch = async () => {
-    calls += 1;
-    if (calls === 1) throw new Error("offline");
+  let failureAttempts = 0;
+  globalThis.fetch = async (input) => {
+    if (!String(input).endsWith("/engram/v1/recall")) {
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    failureAttempts += 1;
+    if (failureAttempts === 1) throw new Error("The socket connection was closed unexpectedly.");
     return new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
   };
   t.after(() => {
@@ -975,20 +1036,22 @@ test("failed recall does not suppress retry for same query", async (t) => {
 
   const ctx = {
     cwd: "/tmp/remnic-pi",
-    sessionManager: { getSessionId: () => "retry-recall" },
+    sessionManager: { getSessionId: () => "retry-recall-test" },
   };
   const event = { messages: [{ role: "user", content: "same prompt" }] };
 
-  await emit("context", event, ctx);
-  await emit("context", event, ctx);
-  await emit("context", event, ctx);
+  // session_start recall retries once on transient failure, then caches
+  await emit("session_start", {}, ctx);
+  assert.equal(failureAttempts, 2);
 
-  assert.equal(calls, 2);
+  // context uses the cached context from the successful retry
+  const result = await emit("context", event, ctx) as { messages?: Array<Record<string, unknown>> };
+  assert.ok(result.messages?.[0]?.remnicInjected);
 });
 
-test("context recall failure notification survives stale Pi ctx after await", async (t) => {
+test("startup recall failure notification survives stale Pi ctx after await", async (t) => {
   const originalFetch = globalThis.fetch;
-  const stale = makeStaleCtx({ sessionId: "stale-context-recall" });
+  const stale = makeStaleCtx({ sessionId: "stale-startup-recall" });
   globalThis.fetch = async () => {
     stale.markStale();
     throw new Error("offline");
@@ -1011,10 +1074,10 @@ test("context recall failure notification survives stale Pi ctx after await", as
   await extension(pi as any);
 
   await assert.doesNotReject(() =>
-    emit("context", { messages: [{ role: "user", content: "same prompt" }] }, stale.ctx)
+    emit("session_start", {}, stale.ctx)
   );
   assert.deepEqual(stale.notifications, [
-    { message: "Remnic recall unavailable: offline", level: "warning" },
+    { message: "Remnic startup recall unavailable: offline", level: "warning" },
   ]);
 });
 
@@ -1336,7 +1399,7 @@ function makeStaleCtx(options: {
 }
 
 
-test("recall circuit breaker skips subsequent turns after a timeout against an unreachable daemon (#1626)", async (t) => {
+test("circuit breaker prevents session_start recall after a startup health probe timeout (#1626)", async (t) => {
   const originalFetch = globalThis.fetch;
   let fetchCalls = 0;
   // fetch hangs until the AbortController fires, simulating an unreachable host.
@@ -1359,7 +1422,7 @@ test("recall circuit breaker skips subsequent turns after a timeout against an u
       compactionEnabled: false,
       mcpToolsEnabled: false,
       statusEnabled: false,
-      turnRequestTimeoutMs: 30,
+      startupRequestTimeoutMs: 30,
       daemonCooldownMs: 60000,
     },
   });
@@ -1371,13 +1434,22 @@ test("recall circuit breaker skips subsequent turns after a timeout against an u
   };
   const event = { messages: [{ role: "user", content: "any prompt" }] };
 
-  // First turn: recall times out → daemon enters cooldown.
-  await emit("context", event, ctx);
-  assert.equal(fetchCalls, 1, "first turn issued a recall that timed out");
+  // First session_start: health probe times out → daemon enters cooldown.
+  await emit("session_start", {}, ctx);
+  const healthProbeCalls = fetchCalls;
+  assert.ok(healthProbeCalls >= 1, "health probe timed out");
 
-  // Second turn: daemon is known-down → recall is skipped fast, no fetch.
-  await emit("context", event, ctx);
-  assert.equal(fetchCalls, 1, "circuit breaker skipped recall during cooldown");
+  // Context sees no cached recall (daemon was unreachable at startup).
+  assert.equal(await emit("context", event, ctx), undefined);
+
+  // Second session_start while breaker is still in cooldown: health probe runs
+  // but recall is skipped because isReachable() is false.
+  await emit("session_start", {}, ctx);
+  const totalCalls = fetchCalls;
+  assert.ok(totalCalls > healthProbeCalls, "health probe ran again");
+
+  // Context still sees no cached recall (breaker prevented the one-shot).
+  assert.equal(await emit("context", event, ctx), undefined);
 });
 
 test("session_shutdown replays the branch even when the daemon breaker is tripped (#1626, review codex)", async (t) => {
@@ -1559,7 +1631,7 @@ test("a successful startup health probe clears a stale circuit breaker (review c
       compactionEnabled: false,
       mcpToolsEnabled: false,
       statusEnabled: true,
-      turnRequestTimeoutMs: 30,
+      startupRequestTimeoutMs: 30,
       daemonCooldownMs: 60000,
     },
   });
@@ -1570,16 +1642,15 @@ test("a successful startup health probe clears a stale circuit breaker (review c
     ui: { setStatus: () => {}, notify: () => {} },
     sessionManager: { getSessionId: () => "status-clear-breaker" },
   };
-  const event = { messages: [{ role: "user", content: "hi" }] };
 
-  // 1) recall times out -> breaker tripped.
-  await emit("context", event, ctx);
-  // 2) session_start health succeeds -> clears the stale breaker.
+  // 1) session_start recall times out -> breaker tripped.
   await emit("session_start", {}, ctx);
-  // 3) recall now runs instead of fast-skipping.
-  const callsBeforeSecondRecall = calls;
-  await emit("context", event, ctx);
-  assert.ok(calls > callsBeforeSecondRecall, "recall ran after the health probe cleared the breaker");
+  const callsAfterFirstSession = calls;
+  assert.ok(callsAfterFirstSession >= 2, "session_start made health probe and recall calls");
+
+  // 2) Another session_start: health succeeds -> clears the stale breaker; recall runs again.
+  await emit("session_start", {}, ctx);
+  assert.ok(calls > callsAfterFirstSession, "recall ran after the health probe cleared the breaker");
 });
 
 test("an offline startup health probe trips the circuit breaker so the first turn fast-skips (review codex)", async (t) => {
@@ -1701,7 +1772,7 @@ test("a successful /remnic-recall clears a stale circuit breaker (review cursor)
       compactionEnabled: false,
       mcpToolsEnabled: false,
       statusEnabled: false,
-      turnRequestTimeoutMs: 30,
+      startupRequestTimeoutMs: 30,
       daemonCooldownMs: 60000,
     },
   });
@@ -1712,16 +1783,15 @@ test("a successful /remnic-recall clears a stale circuit breaker (review cursor)
     ui: { setStatus: () => {}, notify: () => {} },
     sessionManager: { getSessionId: () => "manual-recall-clears-breaker" },
   };
-  const autoEvent = { messages: [{ role: "user", content: "auto" }] };
 
-  // 1) automatic context recall times out -> breaker tripped.
-  await emit("context", autoEvent, ctx);
+  // 1) session_start recall times out -> breaker tripped.
+  await emit("session_start", {}, ctx);
   // 2) a successful manual /remnic-recall clears the stale breaker.
   await runCommand("remnic-recall", "manual", ctx);
-  // 3) automatic context recall now runs instead of fast-skipping.
-  const callsBeforeSecondAuto = calls;
-  await emit("context", { messages: [{ role: "user", content: "auto2" }] }, ctx);
-  assert.ok(calls > callsBeforeSecondAuto, "automatic recall ran after the manual recall cleared the breaker");
+  // 3) Another session_start: recall now runs instead of fast-skipping.
+  const callsBeforeSecondSession = calls;
+  await emit("session_start", {}, ctx);
+  assert.ok(calls > callsBeforeSecondSession, "session_start recall ran after the manual recall cleared the breaker");
 });
 
 test("session_start preflight surfaces a loud persistent remnic_state error when the namespace is not writable", async (t) => {

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -178,18 +178,19 @@ test("default Pi extension creates isolated state for each host invocation", asy
     sessionManager: { getSessionId: () => "shared-session" },
   };
 
-  // Each extension independently recalls at session_start — state maps are
+  // Each extension independently recalls at first context event — state maps are
   // isolated so the same session key produces fetch calls on both instances.
+  // Zero recall calls at session_start; recall fires on first context.
   await first.emit("session_start", {}, ctx);
   await second.emit("session_start", {}, ctx);
-  assert.equal(recallBodies.length, 2, "each extension independently recalled");
+  assert.equal(recallBodies.length, 0, "no recall at session_start");
 
   // Context injection reads from each extension's isolated cachedContext.
   const firstResult = await first.emit("context", { messages: [{ role: "user", content: "hi" }] }, ctx) as { messages?: Array<Record<string, unknown>> };
   const secondResult = await second.emit("context", { messages: [{ role: "user", content: "hi" }] }, ctx) as { messages?: Array<Record<string, unknown>> };
   assert.ok(firstResult.messages?.[0]?.remnicInjected);
   assert.ok(secondResult.messages?.[0]?.remnicInjected);
-  // No additional recall calls from context injection.
+  // One recall call per extension from the first context event.
   assert.equal(recallBodies.length, 2);
 });
 
@@ -713,18 +714,22 @@ test("singleton extension refreshes recall context across sessions via session_s
   };
   const event = { messages: [{ role: "user", content: "same prompt" }] };
 
+  // Session 1: recall fires on first context, not session_start
   await emit("session_start", {}, session1Ctx);
-  assert.equal(recallCalls, 1);
+  assert.equal(recallCalls, 0);
 
   const first = await emit("context", event, session1Ctx) as { messages?: Array<Record<string, unknown>> };
+  assert.equal(recallCalls, 1);
   assert.ok(first.messages?.[0]?.remnicInjected);
 
   await emit("session_shutdown", {}, session1Ctx);
 
+  // Session 2: recall fires again on first context
   await emit("session_start", {}, session2Ctx);
-  assert.equal(recallCalls, 2);
+  assert.equal(recallCalls, 1);
 
   const second = await emit("context", event, session2Ctx) as { messages?: Array<Record<string, unknown>> };
+  assert.equal(recallCalls, 2);
   assert.ok(second.messages?.[0]?.remnicInjected);
 });
 
@@ -761,13 +766,14 @@ test("context injects cached recall across successive context events in the same
   const event = { messages: [{ role: "user", content: "continue" }] };
 
   await emit("session_start", {}, ctx);
-  assert.equal(recallCalls, 1);
+  assert.equal(recallCalls, 0);
 
   const first = await emit("context", event, ctx) as { messages?: Array<Record<string, unknown>> };
+  assert.equal(recallCalls, 1, "recall fired on first context event");
   const second = await emit("context", event, ctx) as { messages?: Array<Record<string, unknown>> };
   const third = await emit("context", event, ctx) as { messages?: Array<Record<string, unknown>> };
 
-  assert.equal(recallCalls, 1);
+  assert.equal(recallCalls, 1, "no additional recall on subsequent context events");
   assert.ok(first.messages?.[0]?.remnicInjected);
   assert.ok(second.messages?.[0]?.remnicInjected);
   assert.ok(third.messages?.[0]?.remnicInjected);
@@ -973,11 +979,14 @@ test("context recall keeps pi:default fallback when session manager is missing",
   const noopCtx = { cwd: "/tmp/remnic-pi" };
   await emit("session_start", {}, noopCtx);
 
-  assert.equal(recallBodies[0]?.sessionKey, "pi:default");
-  assert.equal(recallBodies[0]?.cwd, "/tmp/remnic-pi");
+  // Recall fires on first context, not session_start
+  assert.equal(recallBodies.length, 0);
 
   const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, noopCtx) as { messages?: Array<Record<string, unknown>> };
 
+  assert.equal(recallBodies.length, 1);
+  assert.equal(recallBodies[0]?.sessionKey, "pi:default");
+  assert.equal(recallBodies[0]?.cwd, "/tmp/remnic-pi");
   assert.equal(result.messages?.[0]?.remnicInjected, true);
 });
 
@@ -1018,15 +1027,13 @@ test("recall context truncation stays within the configured budget", async (t) =
   assert.equal(truncatedAt + startMarker.length, 40);
 });
 
-test("startup recall retries a transient failure and caches the context on success", async (t) => {
+test("context recall fires on first context event and caches the result", async (t) => {
   const originalFetch = globalThis.fetch;
-  let failureAttempts = 0;
+  let recallCalls = 0;
   globalThis.fetch = async (input) => {
-    if (!String(input).endsWith("/engram/v1/recall")) {
-      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    if (String(input).endsWith("/engram/v1/recall")) {
+      recallCalls += 1;
     }
-    failureAttempts += 1;
-    if (failureAttempts === 1) throw new Error("The socket connection was closed unexpectedly.");
     return new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
   };
   t.after(() => {
@@ -1048,23 +1055,33 @@ test("startup recall retries a transient failure and caches the context on succe
 
   const ctx = {
     cwd: "/tmp/remnic-pi",
-    sessionManager: { getSessionId: () => "retry-recall-test" },
+    sessionManager: { getSessionId: () => "first-context-recall" },
   };
   const event = { messages: [{ role: "user", content: "same prompt" }] };
 
-  // session_start recall retries once on transient failure, then caches
+  // No recall at session_start
   await emit("session_start", {}, ctx);
-  assert.equal(failureAttempts, 2);
+  assert.equal(recallCalls, 0);
 
-  // context uses the cached context from the successful retry
+  // First context event fires recall and caches the result
   const result = await emit("context", event, ctx) as { messages?: Array<Record<string, unknown>> };
-  assert.ok(result.messages?.[0]?.remnicInjected);
+  assert.equal(recallCalls, 1, "recall fired on first context event");
+  assert.ok(result.messages?.[0]?.remnicInjected, "context was injected");
 });
 
-test("startup recall failure notification survives stale Pi ctx after await", async (t) => {
+test("context recall failure notification survives stale Pi ctx after await", async (t) => {
   const originalFetch = globalThis.fetch;
-  const stale = makeStaleCtx({ sessionId: "stale-startup-recall" });
-  globalThis.fetch = async () => {
+  const stale = makeStaleCtx({ sessionId: "stale-context-recall" });
+  globalThis.fetch = async (input) => {
+    const url = String(input);
+    // Let health and namespace probes succeed so snapshotPiContext works
+    // during the context handler.  Only the recall call marks the ctx stale.
+    if (url.endsWith("/engram/v1/health")) {
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    if (url.includes("/engram/v1/namespace/writable")) {
+      return new Response(JSON.stringify({ ok: true, status: "ok", namespace: "default" }), { status: 200 });
+    }
     stale.markStale();
     throw new Error("offline");
   };
@@ -1085,11 +1102,17 @@ test("startup recall failure notification survives stale Pi ctx after await", as
   });
   await extension(pi as any);
 
+  // session_start does not fire recall
   await assert.doesNotReject(() =>
     emit("session_start", {}, stale.ctx)
   );
+
+  // Context recall fires and fails; notification survives stale ctx.
+  await assert.doesNotReject(() =>
+    emit("context", { messages: [{ role: "user", content: "hi" }] }, stale.ctx)
+  );
   assert.deepEqual(stale.notifications, [
-    { message: "Remnic startup recall unavailable: offline", level: "warning" },
+    { message: "Remnic recall unavailable: offline", level: "warning" },
   ]);
 });
 

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -674,7 +674,7 @@ test("session_before_compact surfaces checkpoint write failures without dropping
   );
 });
 
-test("singleton extension refreshes recall context across sessions via session_start", async (t) => {
+test("singleton extension refreshes recall context across sessions", async (t) => {
   const originalFetch = globalThis.fetch;
   const recallBodies: Array<{ sessionKey?: string }> = [];
   let recallCalls = 0;
@@ -779,7 +779,7 @@ test("context injects cached recall across successive context events in the same
   assert.ok(third.messages?.[0]?.remnicInjected);
 });
 
-test("empty recall at session_start does not inject context but a later session with content does", async (t) => {
+test("empty recall at first context does not inject context but a later session with content does", async (t) => {
   const originalFetch = globalThis.fetch;
   let recallCallIndex = 0;
   globalThis.fetch = async (input) => {
@@ -1434,7 +1434,7 @@ function makeStaleCtx(options: {
 }
 
 
-test("circuit breaker prevents session_start recall after a startup health probe timeout (#1626)", async (t) => {
+test("circuit breaker prevents context recall after a startup health probe timeout (#1626)", async (t) => {
   const originalFetch = globalThis.fetch;
   let fetchCalls = 0;
   // fetch hangs until the AbortController fires, simulating an unreachable host.
@@ -1639,55 +1639,6 @@ test("isDaemonUnreachableError recognizes both budget-exceeded wordings so the b
   assert.ok(!isDaemonUnreachableError(new Error("Internal Server Error")), "HTTP errors stay reachable");
 });
 
-test("a successful startup health probe clears a stale circuit breaker (review codex)", async (t) => {
-  const originalFetch = globalThis.fetch;
-  let calls = 0;
-  globalThis.fetch = async (input, init) => {
-    calls += 1;
-    const url = String(input);
-    if (url.endsWith("/engram/v1/health")) {
-      return new Response(JSON.stringify({ ok: true }), { status: 200 });
-    }
-    // recall hangs until the AbortController fires, simulating an unreachable daemon.
-    return new Promise<Response>((_resolve, reject) => {
-      init?.signal?.addEventListener("abort", () =>
-        reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
-      );
-    });
-  };
-  t.after(() => { globalThis.fetch = originalFetch; });
-
-  const { pi, emit } = makePiHarness();
-  const extension = createRemnicPiExtension({
-    config: {
-      ...baseConfig(),
-      authToken: "test-token",
-      observeEnabled: false,
-      compactionEnabled: false,
-      mcpToolsEnabled: false,
-      statusEnabled: true,
-      startupRequestTimeoutMs: 30,
-      daemonCooldownMs: 60000,
-    },
-  });
-  await extension(pi as any);
-
-  const ctx = {
-    cwd: "/tmp/remnic-pi",
-    ui: { setStatus: () => {}, notify: () => {} },
-    sessionManager: { getSessionId: () => "status-clear-breaker" },
-  };
-
-  // 1) session_start recall times out -> breaker tripped.
-  await emit("session_start", {}, ctx);
-  const callsAfterFirstSession = calls;
-  assert.ok(callsAfterFirstSession >= 2, "session_start made health probe and recall calls");
-
-  // 2) Another session_start: health succeeds -> clears the stale breaker; recall runs again.
-  await emit("session_start", {}, ctx);
-  assert.ok(calls > callsAfterFirstSession, "recall ran after the health probe cleared the breaker");
-});
-
 test("an offline startup health probe trips the circuit breaker so the first turn fast-skips (review codex)", async (t) => {
   const originalFetch = globalThis.fetch;
   let recallCalls = 0;
@@ -1782,10 +1733,12 @@ test("/remnic-recall bounds retry to the general request budget instead of unbou
 
 test("a successful /remnic-recall clears a stale circuit breaker (review cursor)", async (t) => {
   const originalFetch = globalThis.fetch;
-  let calls = 0;
+  let recallCalls = 0;
   globalThis.fetch = async (input, init) => {
-    calls += 1;
     const url = String(input);
+    if (url.endsWith("/engram/v1/recall")) {
+      recallCalls += 1;
+    }
     // Manual recall responds OK; automatic context recall hangs until abort.
     if (url.endsWith("/engram/v1/recall") && init?.body && JSON.parse(String(init.body)).query === "manual") {
       return new Response(JSON.stringify({ context: "manual context" }), { status: 200 });
@@ -1808,6 +1761,7 @@ test("a successful /remnic-recall clears a stale circuit breaker (review cursor)
       mcpToolsEnabled: false,
       statusEnabled: false,
       startupRequestTimeoutMs: 30,
+      turnRequestTimeoutMs: 30,
       daemonCooldownMs: 60000,
     },
   });
@@ -1819,14 +1773,20 @@ test("a successful /remnic-recall clears a stale circuit breaker (review cursor)
     sessionManager: { getSessionId: () => "manual-recall-clears-breaker" },
   };
 
-  // 1) session_start recall times out -> breaker tripped.
+  // 1) session_start: health probe + namespace preflight time out (30ms each).
+  //    `request()` transforms AbortError to `Remnic request timed out after Nms`,
+  //    which IS daemon-unreachable (index.ts:828), so the breaker IS tripped.
   await emit("session_start", {}, ctx);
-  // 2) a successful manual /remnic-recall clears the stale breaker.
+  assert.equal(recallCalls, 0, "no recall at session_start");
+
+  // 2) Manual recall succeeds → markReachable() on the shared client.
   await runCommand("remnic-recall", "manual", ctx);
-  // 3) Another session_start: recall now runs instead of fast-skipping.
-  const callsBeforeSecondSession = calls;
-  await emit("session_start", {}, ctx);
-  assert.ok(calls > callsBeforeSecondSession, "session_start recall ran after the manual recall cleared the breaker");
+
+  // 3) Context event: automatic recall fires now that the daemon is reachable.
+  //    Count only recall requests so health/preflight noise is excluded.
+  const recallCallsBeforeAuto = recallCalls;
+  await emit("context", { messages: [{ role: "user", content: "auto" }] }, ctx);
+  assert.ok(recallCalls > recallCallsBeforeAuto, "automatic recall ran after manual recall cleared the breaker");
 });
 
 test("session_start preflight surfaces a loud persistent remnic_state error when the namespace is not writable", async (t) => {

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -133,17 +133,17 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       if (!session) return;
       const { state } = getSessionState(session.sessionKey, sessionStates);
 
-      // Inject cached context as a user message — byte-identical across turns
-      // so the KV cache prefix is preserved. Using "user" because Pi's
-      // AgentMessage type treats "assistant" as a completed model response
-      // with required api/provider/model/usage fields (codex review).
-      // The remnicInjected marker excludes it from observation and
-      // recall targeting in downstream filters.
+      // Inject cached context as a system message at position 0 — byte-identical
+      // across turns so the KV cache prefix is preserved. This replicates the
+      // Hermes integration pattern: memory context in the system prompt, not as
+      // a user message that the LLM could misinterpret as a current request.
+      // The remnicInjected marker excludes it from observation and recall
+      // targeting in downstream filters.
       if (!state.cachedContext) return;
       return {
         messages: [
           {
-            role: "user",
+            role: "system",
             content: [{ type: "text", text: state.cachedContext }],
             remnicInjected: true,
           },

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -101,7 +101,6 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
           try {
             const recalled = await client.recall(recallTarget.query, session.sessionKey, session.cwd, {
               timeoutMs: config.turnRequestTimeoutMs,
-              maxRetries: 0,
             });
             client.markReachable();
             const context = trimContext(recalled.context ?? "", config.recallBudgetChars);

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -80,18 +80,25 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       // Single recall at session start — context is cached and reused
       // byte-identically across all turns for KV cache prefix stability.
       // Retries on transient failure so a startup blip doesn't permanently
-      // disable context for the session.
+      // disable context for the session.  Share ONE timeout deadline across
+      // all retry attempts (including backoff sleep) so the total startup
+      // recall time never exceeds startupRequestTimeoutMs (codex review).
       if (config.recallEnabled && config.authToken && client.isReachable()) {
         const maxRetries = 2;
+        const deadline = Date.now() + config.startupRequestTimeoutMs;
         let lastError: unknown;
+        let hadSuccessfulRecall = false;
         for (let attempt = 0; attempt <= maxRetries; attempt++) {
+          const remaining = deadline - Date.now();
+          if (remaining <= 0) break;
           try {
             const recalled = await client.recall(
               "current session context",
               session.sessionKey,
               session.cwd,
-              { timeoutMs: config.startupRequestTimeoutMs },
+              { timeoutMs: remaining },
             );
+            hadSuccessfulRecall = true;
             client.markReachable();
             const context = trimContext(recalled.context ?? "", config.recallBudgetChars);
             if (context) {
@@ -105,13 +112,15 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
               if (isDaemonUnreachableError(err)) client.markUnreachable(config.daemonCooldownMs);
               break;
             }
-            // Transient — retry with backoff
+            // Transient — retry with backoff. Check remaining budget before sleeping.
             if (attempt < maxRetries) {
-              await new Promise((r) => setTimeout(r, 200 * Math.pow(2, attempt)));
+              const delayMs = 200 * Math.pow(2, attempt);
+              if (deadline - Date.now() <= delayMs) break;
+              await new Promise((r) => setTimeout(r, delayMs));
             }
           }
         }
-        if (!state.cachedContext && lastError) {
+        if (!hadSuccessfulRecall && lastError) {
           if (isDaemonUnreachableError(lastError)) client.markUnreachable(config.daemonCooldownMs);
           session.notify(`Remnic startup recall unavailable: ${errorMessage(lastError)}`, "warning");
         }
@@ -123,13 +132,16 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       if (!session) return;
       const { state } = getSessionState(session.sessionKey, sessionStates);
 
-      // Inject cached context as a system message — byte-identical across turns
-      // so the KV cache prefix is preserved. No timestamp, no per-turn recall.
+      // Inject cached context as an assistant message — byte-identical across
+      // turns so the KV cache prefix is preserved. Using "assistant" because
+      // Pi's context hook AgentMessage type does not include "system" (codex
+      // review). The remnicInjected marker excludes it from observation and
+      // recall targeting in downstream filters.
       if (!state.cachedContext) return;
       return {
         messages: [
           {
-            role: "system",
+            role: "assistant",
             content: [{ type: "text", text: state.cachedContext }],
             remnicInjected: true,
           },

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -133,16 +133,17 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       if (!session) return;
       const { state } = getSessionState(session.sessionKey, sessionStates);
 
-      // Inject cached context as an assistant message — byte-identical across
-      // turns so the KV cache prefix is preserved. Using "assistant" because
-      // Pi's context hook AgentMessage type does not include "system" (codex
-      // review). The remnicInjected marker excludes it from observation and
+      // Inject cached context as a user message — byte-identical across turns
+      // so the KV cache prefix is preserved. Using "user" because Pi's
+      // AgentMessage type treats "assistant" as a completed model response
+      // with required api/provider/model/usage fields (codex review).
+      // The remnicInjected marker excludes it from observation and
       // recall targeting in downstream filters.
       if (!state.cachedContext) return;
       return {
         messages: [
           {
-            role: "assistant",
+            role: "user",
             content: [{ type: "text", text: state.cachedContext }],
             remnicInjected: true,
           },

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -4,7 +4,6 @@ import { loadConfig, type LoadConfigOptions, type RemnicPiConfig } from "./confi
 import { RemnicClient, isTransientNetworkError, type McpTool, type ObserveMessage } from "./client.js";
 import {
   hashObservedMessage,
-  latestUserRecallTarget,
   observedMessageDedupeKey,
   sessionKeyFromContext,
   summarizeMessages,
@@ -84,22 +83,21 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       await runNamespacePreflight(pi, session, client, config);
     });
 
-    pi.on("context", async (event, ctx) => {
+    pi.on("before_agent_start", async (event, ctx) => {
       const session = snapshotPiContext(ctx);
       if (!session) return;
       const { state } = getSessionState(session.sessionKey, sessionStates);
-      const messages = Array.isArray(event.messages) ? event.messages : [];
 
-      // On the first context event, populate the cache using the actual user
-      // prompt so semantic recall produces relevant results.  Once populated,
-      // the cached context is reused byte-identically across all subsequent
-      // turns in the same session for KV cache prefix stability (PR #2208).
+      // On the first before_agent_start, populate the cache using the user's
+      // prompt text so semantic recall produces relevant results.  Once
+      // populated, the cached context is appended to the system prompt on
+      // every turn for KV cache prefix stability (PR #2208).
       if (!state.recallCompleted && config.recallEnabled && config.authToken && client.isReachable()) {
-        const recallTarget = latestUserRecallTarget(messages);
-        if (recallTarget) {
+        const promptText = typeof event.prompt === "string" && event.prompt.trim().length > 0 ? event.prompt : "";
+        if (promptText) {
           state.recallCompleted = true;
           try {
-            const recalled = await client.recall(recallTarget.query, session.sessionKey, session.cwd, {
+            const recalled = await client.recall(promptText, session.sessionKey, session.cwd, {
               timeoutMs: config.turnRequestTimeoutMs,
             });
             client.markReachable();
@@ -114,22 +112,15 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
         }
       }
 
-      // Inject cached context as a system message at position 0 — byte-identical
-      // across turns so the KV cache prefix is preserved. This replicates the
-      // Hermes integration pattern: memory context in the system prompt, not as
-      // a user message that the LLM could misinterpret as a current request.
-      // The remnicInjected marker excludes it from observation and recall
-      // targeting in downstream filters.
+      // Inject cached context into the system prompt — byte-identical across
+      // turns so the KV cache prefix is preserved.  This avoids the
+      // system-role message issue: Pi's AgentMessage union does not include
+      // "system", so injecting via the context hook produced an invalid
+      // provider payload that Pi drops (codex review).
       if (!state.cachedContext) return;
+      const basePrompt = typeof event.systemPrompt === "string" ? event.systemPrompt : "";
       return {
-        messages: [
-          {
-            role: "system",
-            content: [{ type: "text", text: state.cachedContext }],
-            remnicInjected: true,
-          },
-          ...messages,
-        ],
+        systemPrompt: `${basePrompt}\n\n${state.cachedContext}`,
       };
     });
 

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -63,6 +63,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       if (!session) return;
       const { state } = getSessionState(session.sessionKey, sessionStates);
       restoreObservedState(session, state.observedHashes);
+      state.cachedContext = null;
 
       // Probe health + update the circuit breaker UNCONDITIONALLY so an offline
       // daemon is marked unreachable even when the status UI is off; otherwise
@@ -96,7 +97,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
               "current session context",
               session.sessionKey,
               session.cwd,
-              { timeoutMs: remaining },
+              { timeoutMs: remaining, maxRetries: 0 },
             );
             hadSuccessfulRecall = true;
             client.markReachable();

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -4,7 +4,6 @@ import { loadConfig, type LoadConfigOptions, type RemnicPiConfig } from "./confi
 import { RemnicClient, isTransientNetworkError, type McpTool, type ObserveMessage } from "./client.js";
 import {
   hashObservedMessage,
-  latestUserRecallTarget,
   observedMessageDedupeKey,
   sessionKeyFromContext,
   summarizeMessages,
@@ -33,7 +32,8 @@ const SESSION_OWNED_FIELDS = new Set(["sessionKey", "namespace", "cwd"]);
 type PiSessionState = {
   observedHashes: Set<string>;
   liveObservedReplayKeys: Map<string, number>;
-  lastInjectedRecallKey: string;
+  /** Cached recall context from session_start — injected once, reused byte-identically. */
+  cachedContext: string | null;
 };
 
 type NotifyLevel = "info" | "success" | "warning" | "error";
@@ -63,6 +63,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       if (!session) return;
       const { state } = getSessionState(session.sessionKey, sessionStates);
       restoreObservedState(session, state.observedHashes);
+
       // Probe health + update the circuit breaker UNCONDITIONALLY so an offline
       // daemon is marked unreachable even when the status UI is off; otherwise
       // the namespace preflight and every later hook each burn a full request
@@ -75,47 +76,66 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
         );
       }
       await runNamespacePreflight(pi, session, client, config);
+
+      // Single recall at session start — context is cached and reused
+      // byte-identically across all turns for KV cache prefix stability.
+      // Retries on transient failure so a startup blip doesn't permanently
+      // disable context for the session.
+      if (config.recallEnabled && config.authToken && client.isReachable()) {
+        const maxRetries = 2;
+        let lastError: unknown;
+        for (let attempt = 0; attempt <= maxRetries; attempt++) {
+          try {
+            const recalled = await client.recall(
+              "current session context",
+              session.sessionKey,
+              session.cwd,
+              { timeoutMs: config.startupRequestTimeoutMs },
+            );
+            client.markReachable();
+            const context = trimContext(recalled.context ?? "", config.recallBudgetChars);
+            if (context) {
+              state.cachedContext = context;
+            }
+            break;
+          } catch (err) {
+            lastError = err;
+            if (!isTransientNetworkError(err)) {
+              // Non-transient error — trip breaker immediately
+              if (isDaemonUnreachableError(err)) client.markUnreachable(config.daemonCooldownMs);
+              break;
+            }
+            // Transient — retry with backoff
+            if (attempt < maxRetries) {
+              await new Promise((r) => setTimeout(r, 200 * Math.pow(2, attempt)));
+            }
+          }
+        }
+        if (!state.cachedContext && lastError) {
+          if (isDaemonUnreachableError(lastError)) client.markUnreachable(config.daemonCooldownMs);
+          session.notify(`Remnic startup recall unavailable: ${errorMessage(lastError)}`, "warning");
+        }
+      }
     });
 
     pi.on("context", async (event, ctx) => {
       const session = snapshotPiContext(ctx);
       if (!session) return;
-      if (!config.recallEnabled || !config.authToken) return;
-      // Circuit breaker: skip recall fast while the daemon is known-down so a
-      // dead host doesn't block every turn on a doomed request (#1626).
-      if (!client.isReachable()) return;
-      const recallTarget = latestUserRecallTarget(Array.isArray(event.messages) ? event.messages : []);
-      if (!recallTarget) return;
-      const { query } = recallTarget;
       const { state } = getSessionState(session.sessionKey, sessionStates);
-      if (recallTarget.dedupeKey === state.lastInjectedRecallKey) return;
 
-      try {
-        const recalled = await client.recall(query, session.sessionKey, session.cwd, {
-          timeoutMs: config.turnRequestTimeoutMs,
-        });
-        client.markReachable();
-        const context = trimContext(recalled.context ?? "", config.recallBudgetChars);
-        if (!context) return;
-        state.lastInjectedRecallKey = recallTarget.dedupeKey;
-        return {
-          messages: [
-            ...event.messages,
-            {
-              role: "user",
-              content: [{ type: "text", text: `Remnic recalled context for this turn:\n\n${context}` }],
-              remnicInjected: true,
-              timestamp: Date.now(),
-            },
-          ],
-        };
-      } catch (err) {
-        // Only trip the breaker when the daemon is genuinely unreachable
-        // (timeout or connection-level failure) — not on a transient HTTP
-        // error, so a one-off failure still retries on the next turn (#1626).
-        if (isDaemonUnreachableError(err)) client.markUnreachable(config.daemonCooldownMs);
-        session.notify(`Remnic recall unavailable: ${errorMessage(err)}`, "warning");
-      }
+      // Inject cached context as a system message — byte-identical across turns
+      // so the KV cache prefix is preserved. No timestamp, no per-turn recall.
+      if (!state.cachedContext) return;
+      return {
+        messages: [
+          {
+            role: "system",
+            content: [{ type: "text", text: state.cachedContext }],
+            remnicInjected: true,
+          },
+          ...event.messages,
+        ],
+      };
     });
 
     pi.on("message_end", async (event, ctx) => {
@@ -408,7 +428,7 @@ function getSessionState(sessionKey: string, states: Map<string, PiSessionState>
     state = {
       observedHashes: new Set<string>(),
       liveObservedReplayKeys: new Map<string, number>(),
-      lastInjectedRecallKey: "",
+      cachedContext: null,
     };
     states.set(sessionKey, state);
     pruneSessionStates(states);

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -4,6 +4,7 @@ import { loadConfig, type LoadConfigOptions, type RemnicPiConfig } from "./confi
 import { RemnicClient, isTransientNetworkError, type McpTool, type ObserveMessage } from "./client.js";
 import {
   hashObservedMessage,
+  latestUserRecallTarget,
   observedMessageDedupeKey,
   sessionKeyFromContext,
   summarizeMessages,
@@ -32,8 +33,11 @@ const SESSION_OWNED_FIELDS = new Set(["sessionKey", "namespace", "cwd"]);
 type PiSessionState = {
   observedHashes: Set<string>;
   liveObservedReplayKeys: Map<string, number>;
-  /** Cached recall context from session_start — injected once, reused byte-identically. */
+  /** Cached recall context — populated from the first context event's user prompt,
+   *  reused byte-identically across subsequent turns for KV cache prefix stability. */
   cachedContext: string | null;
+  /** True once recall has been attempted (success or failure) for this session. */
+  recallCompleted: boolean;
 };
 
 type NotifyLevel = "info" | "success" | "warning" | "error";
@@ -64,6 +68,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       const { state } = getSessionState(session.sessionKey, sessionStates);
       restoreObservedState(session, state.observedHashes);
       state.cachedContext = null;
+      state.recallCompleted = false;
 
       // Probe health + update the circuit breaker UNCONDITIONALLY so an offline
       // daemon is marked unreachable even when the status UI is off; otherwise
@@ -77,61 +82,38 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
         );
       }
       await runNamespacePreflight(pi, session, client, config);
-
-      // Single recall at session start — context is cached and reused
-      // byte-identically across all turns for KV cache prefix stability.
-      // Retries on transient failure so a startup blip doesn't permanently
-      // disable context for the session.  Share ONE timeout deadline across
-      // all retry attempts (including backoff sleep) so the total startup
-      // recall time never exceeds startupRequestTimeoutMs (codex review).
-      if (config.recallEnabled && config.authToken && client.isReachable()) {
-        const maxRetries = 2;
-        const deadline = Date.now() + config.startupRequestTimeoutMs;
-        let lastError: unknown;
-        let hadSuccessfulRecall = false;
-        for (let attempt = 0; attempt <= maxRetries; attempt++) {
-          const remaining = deadline - Date.now();
-          if (remaining <= 0) break;
-          try {
-            const recalled = await client.recall(
-              "current session context",
-              session.sessionKey,
-              session.cwd,
-              { timeoutMs: remaining, maxRetries: 0 },
-            );
-            hadSuccessfulRecall = true;
-            client.markReachable();
-            const context = trimContext(recalled.context ?? "", config.recallBudgetChars);
-            if (context) {
-              state.cachedContext = context;
-            }
-            break;
-          } catch (err) {
-            lastError = err;
-            if (!isTransientNetworkError(err)) {
-              // Non-transient error — trip breaker immediately
-              if (isDaemonUnreachableError(err)) client.markUnreachable(config.daemonCooldownMs);
-              break;
-            }
-            // Transient — retry with backoff. Check remaining budget before sleeping.
-            if (attempt < maxRetries) {
-              const delayMs = 200 * Math.pow(2, attempt);
-              if (deadline - Date.now() <= delayMs) break;
-              await new Promise((r) => setTimeout(r, delayMs));
-            }
-          }
-        }
-        if (!hadSuccessfulRecall && lastError) {
-          if (isDaemonUnreachableError(lastError)) client.markUnreachable(config.daemonCooldownMs);
-          session.notify(`Remnic startup recall unavailable: ${errorMessage(lastError)}`, "warning");
-        }
-      }
     });
 
     pi.on("context", async (event, ctx) => {
       const session = snapshotPiContext(ctx);
       if (!session) return;
       const { state } = getSessionState(session.sessionKey, sessionStates);
+      const messages = Array.isArray(event.messages) ? event.messages : [];
+
+      // On the first context event, populate the cache using the actual user
+      // prompt so semantic recall produces relevant results.  Once populated,
+      // the cached context is reused byte-identically across all subsequent
+      // turns in the same session for KV cache prefix stability (PR #2208).
+      if (!state.recallCompleted && config.recallEnabled && config.authToken && client.isReachable()) {
+        state.recallCompleted = true;
+        const recallTarget = latestUserRecallTarget(messages);
+        if (recallTarget) {
+          try {
+            const recalled = await client.recall(recallTarget.query, session.sessionKey, session.cwd, {
+              timeoutMs: config.turnRequestTimeoutMs,
+              maxRetries: 0,
+            });
+            client.markReachable();
+            const context = trimContext(recalled.context ?? "", config.recallBudgetChars);
+            if (context) {
+              state.cachedContext = context;
+            }
+          } catch (err) {
+            if (isDaemonUnreachableError(err)) client.markUnreachable(config.daemonCooldownMs);
+            session.notify(`Remnic recall unavailable: ${errorMessage(err)}`, "warning");
+          }
+        }
+      }
 
       // Inject cached context as a system message at position 0 — byte-identical
       // across turns so the KV cache prefix is preserved. This replicates the
@@ -147,7 +129,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
             content: [{ type: "text", text: state.cachedContext }],
             remnicInjected: true,
           },
-          ...event.messages,
+          ...messages,
         ],
       };
     });
@@ -443,6 +425,7 @@ function getSessionState(sessionKey: string, states: Map<string, PiSessionState>
       observedHashes: new Set<string>(),
       liveObservedReplayKeys: new Map<string, number>(),
       cachedContext: null,
+      recallCompleted: false,
     };
     states.set(sessionKey, state);
     pruneSessionStates(states);

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -95,9 +95,9 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       // the cached context is reused byte-identically across all subsequent
       // turns in the same session for KV cache prefix stability (PR #2208).
       if (!state.recallCompleted && config.recallEnabled && config.authToken && client.isReachable()) {
-        state.recallCompleted = true;
         const recallTarget = latestUserRecallTarget(messages);
         if (recallTarget) {
+          state.recallCompleted = true;
           try {
             const recalled = await client.recall(recallTarget.query, session.sessionKey, session.cwd, {
               timeoutMs: config.turnRequestTimeoutMs,

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -200,7 +200,7 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
       "",
       "## Installed Capabilities",
       "",
-      "- Recall relevant Remnic context in the `context` hook before agent turns.",
+      "- Recall relevant Remnic context in the `before_agent_start` hook via system prompt injection.",
       '- Observe user, assistant, and tool messages with `sourceFormat: "pi"`.',
       "- Coordinate `session_before_compact` with Remnic LCM flush and checkpoint recording.",
       "- Register Remnic MCP tools as host tools when daemon authentication is configured.",


### PR DESCRIPTION
## Problem

The Pi plugin previously recalled and injected context on **every turn** via the `context` hook, appending a user message with a `Date.now()` timestamp. This busted the KV cache prefix on every turn because the injected content was never byte-identical across turns.

## Solution

Recall once at `session_start`, cache the context string, and inject it as a system message on every `context` hook call — no timestamp, no per-turn recall, byte-identical across all turns.

This matches the Hermes integration pattern and preserves the KV cache prefix for the entire session.

## Changes

- `PiSessionState`: `lastInjectedRecallKey: string` → `cachedContext: string | null`
- `session_start`: Does one recall, caches result in `state.cachedContext`
- `context`: Prepends cached context as a system message (index 0), no timestamp
- Removed per-turn recall logic, dedup key tracking, and timestamp injection
- Updated tests to expect prepended context at index 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Session context recall is now fetched once at session start and reused across turns.
  - Recalled context is injected at the beginning of the conversation messages.

- **Bug Fixes**
  - Improved recall injection ordering to reliably place the injected message at the expected position.
  - Refined startup recall behavior so timeouts prevent session-start recall while allowing health probes during cooldown.

- **Chores**
  - Updated ignore rules to prevent generated Graphify output from being tracked.

- **Tests**
  - Updated and expanded coverage for prepended injection, truncation limits, caching/suppression behavior, and session-start recall flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->