### PR TITLE
fix(server): honor debug config on the standalone daemon (#2209)

### DIFF
--- a/.changeset/2209-daemon-debug-logging.md
+++ b/.changeset/2209-daemon-debug-logging.md
@@ -1,0 +1,8 @@
+---
+"@remnic/server": patch
+---
+
+The standalone daemon now honors `debug: true` from its config file. `initLogger()`
+ran before the config was read, so the flag was accepted and silently ignored —
+leaving no way to raise log verbosity on the one surface where you need it when
+the daemon is misbehaving.

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -944,6 +944,13 @@ export async function startServer(options?: {
   const parsedServerConfig = parseServerConfig(serverConfig, { portSource });
 
   const config = parseConfig(remnicConfig);
+  // Re-init now that config is known. The call at the top of startServer runs
+  // BEFORE the config file is read, so it could only ever default `debug` to
+  // false — `debug: true` was accepted, documented, and silently inert on the
+  // standalone daemon, which is exactly the flag you reach for when the daemon
+  // is misbehaving (issue #2209).
+  initLogger(undefined, config.debug);
+  log.debug(`debug logging enabled from config (${resolvedConfigPath.source})`);
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
 

--- a/tests/remnic-server-cli.test.ts
+++ b/tests/remnic-server-cli.test.ts
@@ -651,3 +651,59 @@ test("startServer destroys the orchestrator when HTTP bind fails after initializ
   );
   assert.equal(destroyCalls, 1);
 });
+
+/**
+ * The daemon calls `initLogger()` at the top of `startServer`, before the
+ * config file has been read, so `debug: true` was accepted and then silently
+ * ignored (issue #2209) — the one flag an operator reaches for when the daemon
+ * is misbehaving. These assert the flag reaches the logger either way.
+ */
+async function startServerWithDebug(
+  t: TestContext,
+  debug: boolean,
+): Promise<{ debugLines: string[] }> {
+  restoreEnv(t, ["REMNIC_PORT", "ENGRAM_PORT", "REMNIC_MEMORY_DIR", "ENGRAM_MEMORY_DIR", "REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN"]);
+  for (const key of ["REMNIC_PORT", "ENGRAM_PORT", "REMNIC_MEMORY_DIR", "ENGRAM_MEMORY_DIR"]) delete process.env[key];
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-debug-flag-"));
+  t.after(() => rm(tempDir, { recursive: true, force: true }));
+  const configPath = path.join(tempDir, "config.json");
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      remnic: { memoryDir: tempDir, qmdEnabled: false, qmdDaemonEnabled: false, searchBackend: "noop", debug },
+    }),
+    "utf8",
+  );
+
+  const debugLines: string[] = [];
+  const originalDebug = console.debug;
+  console.debug = (...args: unknown[]) => {
+    debugLines.push(args.map((a) => String(a)).join(" "));
+  };
+  const port = await getFreePort();
+  try {
+    const result = await startServer({ configPath, port });
+    result.cancelStartupSync();
+    result.abortDeferredInit();
+    await result.httpServer.stop();
+  } finally {
+    console.debug = originalDebug;
+  }
+  return { debugLines };
+}
+
+test("startServer honors debug:true from the config file", async (t) => {
+  const { debugLines } = await startServerWithDebug(t, true);
+  assert.ok(
+    debugLines.some((line) => line.includes("debug logging enabled from config")),
+    `expected a debug line, got ${debugLines.length} line(s)`,
+  );
+});
+
+test("startServer stays quiet when debug is not set", async (t) => {
+  const { debugLines } = await startServerWithDebug(t, false);
+  assert.equal(
+    debugLines.filter((line) => line.includes("debug logging enabled from config")).length,
+    0,
+  );
+});

--- a/tests/remnic-server-cli.test.ts
+++ b/tests/remnic-server-cli.test.ts
@@ -675,12 +675,14 @@ async function startServerWithDebug(
     "utf8",
   );
 
+  // Resolve the port BEFORE patching console: a rejection here would otherwise
+  // leave the global patched for every later test in the file.
+  const port = await getFreePort();
   const debugLines: string[] = [];
   const originalDebug = console.debug;
   console.debug = (...args: unknown[]) => {
     debugLines.push(args.map((a) => String(a)).join(" "));
   };
-  const port = await getFreePort();
   try {
     const result = await startServer({ configPath, port });
     result.cancelStartupSync();
@@ -700,10 +702,9 @@ test("startServer honors debug:true from the config file", async (t) => {
   );
 });
 
-test("startServer stays quiet when debug is not set", async (t) => {
+test("startServer emits no debug output when debug:false", async (t) => {
   const { debugLines } = await startServerWithDebug(t, false);
-  assert.equal(
-    debugLines.filter((line) => line.includes("debug logging enabled from config")).length,
-    0,
-  );
+  // Assert the whole channel is silent, not just that our marker is absent:
+  // filtering for one message would pass while every other debug line leaked.
+  assert.deepEqual(debugLines, []);
 });


### PR DESCRIPTION
Closes #2209.

## The bug

`startServer` calls `initLogger()` as its **first statement** — about 20 lines before `loadResolvedConfig()` runs. `initLogger(backend?, debug?)` defaults `_debug` to `false`, so on the standalone daemon `debug: true` was parsed, stored, and never reached the logger.

That makes it worse than a dead config key: `debug` is the flag you reach for *when the daemon is misbehaving*, so its silence closes the diagnostic route to other bugs. #2210 is currently undiagnosable for exactly this reason.

## The fix

The early `initLogger()` stays — the better-sqlite3 driver probe logs before any config exists. The logger is re-initialized once `config` is parsed:

```ts
const config = parseConfig(remnicConfig);
initLogger(undefined, config.debug);
```

That point is also *after* `mergeRemnicConfigForServer(fileConfig.remnic, envRemnic)`, so env-sourced overrides reach the logger too, and re-init is safe: backend, timestamps and clock all resolve to the same defaults the first call produced.

## Scope

Deliberately just the wiring. I did **not** add a `REMNIC_DEBUG` env var — `debug` already flows from config and env through the existing merge, and inventing a second switch would be extra surface the issue did not ask for.

## Verification

- Two tests drive the **real `startServer`** (ephemeral port, temp memory dir, `searchBackend: "noop"`) with `debug` true and false, capturing `console.debug`.
- **Revert-checked**: removing the `initLogger(undefined, config.debug)` line fails the enabled case (`not ok 20 - startServer honors debug:true from the config file`) and passes the disabled one, so the pair brackets the actual bug.
- `preflight:quick` OK, ratchets OK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only logger re-init with no auth, data, or API behavior changes; covered by targeted tests.
> 
> **Overview**
> Fixes **#2209**: the standalone daemon now applies **`debug: true`** from config (and env merge) to the logger instead of ignoring it.
> 
> `startServer` still calls **`initLogger()`** before config load so early startup (e.g. better-sqlite3 probe) can log; after **`parseConfig`**, it **re-initializes** the logger with **`config.debug`** and emits a one-line debug marker noting the config source.
> 
> Adds **integration tests** that run real **`startServer`** with **`debug`** true/false and assert **`console.debug`** output; documents the fix in a **changeset** for **`@remnic/server`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b0d7d191a48f152ce0855bf26921bc02b540d0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standalone server deployments now correctly honor `debug: true` from the configuration file, enabling the intended verbose logging.
* **Tests**
  * Added automated coverage to confirm debug output is emitted only when the config enables it, and suppressed when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->