### PR TITLE
fix(local-llm): a timed-out availability probe is not a dead backend (#2210)

### DIFF
--- a/.changeset/2210-availability-probe-timeout.md
+++ b/.changeset/2210-availability-probe-timeout.md
@@ -1,0 +1,11 @@
+---
+"@remnic/core": patch
+---
+
+A local-LLM availability probe that TIMES OUT no longer marks the backend
+unavailable. The probe budget is a fixed 2s, and a busy event loop can burn it
+before the socket is scheduled — so a loaded daemon could cache itself into an
+extraction blackout while the backend answered other callers in milliseconds. A
+timed-out probe now leaves availability unknown and re-probes on the next
+request, probe failures log their actual cause, and the transition to
+unavailable is surfaced at warn instead of debug.

--- a/packages/remnic-core/src/local-llm-helpers.ts
+++ b/packages/remnic-core/src/local-llm-helpers.ts
@@ -156,3 +156,68 @@ export async function probeFetch(
     return { ok: false, data: null, status: null, aborted };
   }
 }
+
+interface PendingProbe {
+  promise: Promise<boolean>;
+  controller: AbortController;
+  /** Callers still awaiting this sequence; at zero the sequence is aborted. */
+  waiters: number;
+}
+
+/**
+ * Collapses concurrent probe sequences onto one in-flight run.
+ *
+ * A timed-out availability probe deliberately caches nothing (issue #2210),
+ * which removed the false verdict that used to absorb concurrent callers:
+ * every queued request would then run its own full probe sequence, on a host
+ * already slow enough to blow the probe budget.
+ *
+ * Cancellation is refcounted rather than shared: one caller walking away must
+ * not abort a sequence the others are still waiting on, so the underlying task
+ * is aborted only once every waiter has gone.
+ */
+export class SingleFlightProbe {
+  private pending: PendingProbe | null = null;
+
+  run(task: (signal: AbortSignal) => Promise<boolean>, signal?: AbortSignal): Promise<boolean> {
+    let active = this.pending;
+    if (!active) {
+      const controller = new AbortController();
+      const created: PendingProbe = { promise: Promise.resolve(false), controller, waiters: 0 };
+      created.promise = task(controller.signal).finally(() => {
+        if (this.pending === created) this.pending = null;
+      });
+      this.pending = created;
+      active = created;
+    }
+    const entry = active;
+    entry.waiters += 1;
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      entry.waiters -= 1;
+      if (entry.waiters <= 0) entry.controller.abort();
+    };
+    if (!signal) return entry.promise.finally(release);
+    return new Promise<boolean>((resolve, reject) => {
+      const onAbort = () => {
+        release();
+        resolve(false);
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      entry.promise.then(
+        (value) => {
+          signal.removeEventListener("abort", onAbort);
+          release();
+          resolve(value);
+        },
+        (err: unknown) => {
+          signal.removeEventListener("abort", onAbort);
+          release();
+          reject(err instanceof Error ? err : new Error(String(err)));
+        },
+      );
+    });
+  }
+}

--- a/packages/remnic-core/src/local-llm-helpers.ts
+++ b/packages/remnic-core/src/local-llm-helpers.ts
@@ -197,7 +197,13 @@ export class SingleFlightProbe {
       if (released) return;
       released = true;
       entry.waiters -= 1;
-      if (entry.waiters <= 0) entry.controller.abort();
+      if (entry.waiters > 0) return;
+      // Detach BEFORE aborting. `pending` would otherwise still point at this
+      // doomed entry until the task's own `finally` runs a microtask later, and
+      // a caller arriving in that window would join an aborted sequence and
+      // read its `false` as a verdict.
+      if (this.pending === entry) this.pending = null;
+      entry.controller.abort();
     };
     if (!signal) return entry.promise.finally(release);
     return new Promise<boolean>((resolve, reject) => {

--- a/packages/remnic-core/src/local-llm-helpers.ts
+++ b/packages/remnic-core/src/local-llm-helpers.ts
@@ -1,3 +1,4 @@
+import { log } from "./logger.js";
 export function isAbortError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
   const maybe = err as { name?: string; message?: string };
@@ -54,5 +55,104 @@ export function extractNonRecoverableBackendReasonFromErrorText(errorText: strin
     return extractNonRecoverableBackendReason(parsed?.error?.message ?? "");
   } catch {
     return null;
+  }
+}
+
+/**
+ * Flatten a fetch rejection into one line, including the `cause` undici hides
+ * the real reason behind (`fetch failed` alone says nothing).
+ */
+export function describeFetchFailure(err: unknown): string {
+  const name = err instanceof Error ? err.name : "";
+  const message = err instanceof Error ? err.message : String(err);
+  const cause: unknown = err instanceof Error ? (err as Error & { cause?: unknown }).cause : undefined;
+  const causeText = cause instanceof Error
+    ? ` (cause: ${cause.name}: ${cause.message}${
+      typeof (cause as Error & { code?: unknown }).code === "string"
+        ? ` [${String((cause as Error & { code?: unknown }).code)}]`
+        : ""
+    })`
+    : cause === undefined
+      ? ""
+      : ` (cause: ${String(cause)})`;
+  return `${name ? `${name}: ` : ""}${message}${causeText}`;
+}
+
+/**
+ * What to record when every availability probe failed.
+ *
+ * A probe that TIMED OUT is not evidence the backend is down: the budget is a
+ * fixed 2s and a busy event loop can burn it before the socket is scheduled,
+ * so the backend looks dead while it answers other callers in single-digit ms.
+ * Caching that verdict took extraction offline for a whole health-check
+ * interval at a time (issue #2210), so a timeout leaves availability UNKNOWN —
+ * this call fails, the next one re-probes instead of reading a stale false.
+ *
+ * A backend that ANSWERED and said no is a real verdict and stays cached, or
+ * the daemon re-probes a known-bad endpoint on every request.
+ */
+export function resolveUnavailableVerdict(args: {
+  baseUrl: string;
+  sawAbortedProbe: boolean;
+  wasAvailable: boolean | null;
+}): { cacheVerdict: boolean; warning: string | null } {
+  if (args.sawAbortedProbe) {
+    return {
+      cacheVerdict: false,
+      warning:
+        `local LLM availability probe timed out at ${args.baseUrl} (event loop busy?); treating availability as ` +
+        "unknown and re-probing on the next request rather than marking the backend down",
+    };
+  }
+  return {
+    cacheVerdict: true,
+    // Surfaced at warn, not debug: extraction stops silently when this flips,
+    // and the daemon emits no debug at all unless configured for it.
+    warning: args.wasAvailable !== false ? `local LLM became unavailable at ${args.baseUrl}` : null,
+  };
+}
+
+export interface ProbeFetchResult {
+  ok: boolean;
+  data: unknown;
+  status: number | null;
+  /** The probe hit its own budget rather than getting an answer. */
+  aborted?: boolean;
+}
+
+/**
+ * One health-probe request.
+ *
+ * Every failure is logged with its cause: a transport error and a 404 both
+ * returned `ok: false` with nothing recorded, so an unreachable backend was
+ * indistinguishable from a wrong path and an availability failure had no
+ * diagnosable reason at all (§22, issue #2210).
+ */
+export async function probeFetch(
+  url: string,
+  options: { timeoutMs: number; headers: Record<string, string>; signal?: AbortSignal },
+): Promise<ProbeFetchResult> {
+  const controller = new AbortController();
+  const requestSignal = options.signal
+    ? AbortSignal.any([options.signal, controller.signal])
+    : controller.signal;
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs);
+  try {
+    const response = await fetch(url, { signal: requestSignal, headers: options.headers });
+    clearTimeout(timeout);
+    if (!response.ok) {
+      log.debug(`local LLM probe: ${url} returned HTTP ${response.status}`);
+      return { ok: false, data: null, status: response.status };
+    }
+    const contentType = response.headers.get("content-type");
+    const data = contentType?.includes("application/json") ? await response.json() : await response.text();
+    return { ok: true, data, status: response.status };
+  } catch (err) {
+    clearTimeout(timeout);
+    const aborted = isAbortError(err);
+    log.debug(
+      `local LLM probe: ${url} ${aborted ? `timed out after ${options.timeoutMs}ms` : "failed"}: ${describeFetchFailure(err)}`,
+    );
+    return { ok: false, data: null, status: null, aborted };
   }
 }

--- a/packages/remnic-core/src/local-llm.ts
+++ b/packages/remnic-core/src/local-llm.ts
@@ -12,6 +12,9 @@ import {
   extractNonRecoverableBackendReason,
   extractNonRecoverableBackendReasonFromErrorText,
   isAbortError,
+  probeFetch,
+  resolveUnavailableVerdict,
+  type ProbeFetchResult,
   normalizeBackendTripReason,
   waitForRetryBackoff,
 } from "./local-llm-helpers.js";
@@ -371,39 +374,20 @@ export class LocalLlmClient {
 
 
   /**
-   * Fetch with timeout for health checks
+   * Fetch with timeout for health checks. Body lives in the sibling helper so
+   * this file stays under its size ceiling (issue #1995).
    */
   private async fetchWithTimeout(
     url: string,
     timeoutMs: number = 2000,
     headers?: Record<string, string>,
     signal?: AbortSignal,
-  ): Promise<{ ok: boolean; data: unknown; status: number | null }> {
-    const controller = new AbortController();
-    const requestSignal = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal;
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-    try {
-      const response = await fetch(url, {
-        signal: requestSignal,
-        headers: this.buildRequestHeaders({ Accept: "application/json", ...(headers ?? {}) }),
-      });
-      clearTimeout(timeout);
-
-      if (!response.ok) {
-        return { ok: false, data: null, status: response.status };
-      }
-
-      const contentType = response.headers.get("content-type");
-      if (contentType?.includes("application/json")) {
-        return { ok: true, data: await response.json(), status: response.status };
-      } else {
-        return { ok: true, data: await response.text(), status: response.status };
-      }
-    } catch (err) {
-      clearTimeout(timeout);
-      return { ok: false, data: null, status: null };
-    }
+  ): Promise<ProbeFetchResult> {
+    return await probeFetch(url, {
+      timeoutMs,
+      headers: this.buildRequestHeaders({ Accept: "application/json", ...(headers ?? {}) }),
+      signal,
+    });
   }
 
   private async probeLmStudioNativeModels(
@@ -454,6 +438,10 @@ export class LocalLlmClient {
     );
     const probeBaseUrl = stripTrailingV1Path(configuredBaseUrl);
     let sawUnauthorizedProbe = false;
+    // A probe that TIMED OUT says the event loop was busy, not that the backend
+    // is down (issue #2210). Tracked separately so a loaded daemon cannot cache
+    // itself into a blackout.
+    let sawAbortedProbe = false;
 
     // Try to detect which server type is running
     if (signal?.aborted) return false;
@@ -462,6 +450,7 @@ export class LocalLlmClient {
       log.debug(`checking ${serverConfig.type} at ${healthUrl}`);
 
       const result = await this.fetchWithTimeout(healthUrl, 2000, undefined, signal);
+      if (result.aborted) sawAbortedProbe = true;
       if (signal?.aborted) return false;
       if (result.ok && serverConfig.detectFn(result.data)) {
         if (serverConfig.type === "mlx") {
@@ -481,6 +470,7 @@ export class LocalLlmClient {
         if (serverConfig.type === "llamacpp") {
           let sawLlamaCppSignal = false;
           const propsProbe = await this.fetchWithTimeout(`${probeBaseUrl}/props`, 2000, undefined, signal);
+          if (propsProbe.aborted) sawAbortedProbe = true;
           if (signal?.aborted) return false;
           if (propsProbe.ok && isLlamaCppPropsResponse(propsProbe.data)) {
             sawLlamaCppSignal = true;
@@ -491,6 +481,7 @@ export class LocalLlmClient {
 
           const modelsUrl = `${probeBaseUrl}${serverConfig.modelsEndpoint}`;
           const modelsProbe = await this.fetchWithTimeout(modelsUrl, 2000, undefined, signal);
+          if (modelsProbe.aborted) sawAbortedProbe = true;
           if (signal?.aborted) return false;
           if (modelsProbe.ok && isLlamaCppModelsResponse(modelsProbe.data)) {
             sawLlamaCppSignal = true;
@@ -523,6 +514,7 @@ export class LocalLlmClient {
     try {
       const modelsUrl = `${probeBaseUrl}/v1/models`;
       const result = await this.fetchWithTimeout(modelsUrl, 2000, undefined, signal);
+      if (result.aborted) sawAbortedProbe = true;
       if (signal?.aborted) return false;
       if (result.ok) {
         this.isAvailable = true;
@@ -538,14 +530,21 @@ export class LocalLlmClient {
       // Fall through to unavailable
     }
 
-    this.isAvailable = false;
+    const wasAvailable = this.isAvailable;
     this.detectedType = null;
-    this.lastHealthCheck = now;
     if (sawUnauthorizedProbe) {
       log.warn(
         `local LLM availability probe was unauthorized at ${configuredBaseUrl}; verify localLlmApiKey and localLlmAuthHeader settings`,
       );
     }
+    const verdict = resolveUnavailableVerdict({
+      baseUrl: configuredBaseUrl,
+      sawAbortedProbe,
+      wasAvailable,
+    });
+    this.isAvailable = verdict.cacheVerdict ? false : null;
+    this.lastHealthCheck = verdict.cacheVerdict ? now : 0;
+    if (verdict.warning) log.warn(verdict.warning);
     log.debug("local LLM not available at", configuredBaseUrl);
     return false;
   }

--- a/packages/remnic-core/src/local-llm.ts
+++ b/packages/remnic-core/src/local-llm.ts
@@ -17,6 +17,7 @@ import {
   type ProbeFetchResult,
   normalizeBackendTripReason,
   waitForRetryBackoff,
+  SingleFlightProbe,
 } from "./local-llm-helpers.js";
 
 /** Trim trailing slash characters without backtracking regex. */
@@ -259,6 +260,7 @@ export class LocalLlmClient {
   private config: PluginConfig;
   private isAvailable: boolean | null = null;
   private lastHealthCheck: number = 0;
+  private readonly availabilityProbe = new SingleFlightProbe();
   private detectedType: LocalLlmType | null = null;
   private cachedModelInfo: LocalModelInfo | null = null;
   private cachedLmsContext: number | null = null;
@@ -429,8 +431,11 @@ export class LocalLlmClient {
     if (this.isAvailable !== null && now - this.lastHealthCheck < LocalLlmClient.HEALTH_CHECK_INTERVAL_MS) {
       return this.isAvailable;
     }
+    return await this.availabilityProbe.run((probeSignal) => this.probeAvailability(probeSignal), signal);
+  }
 
-    // Normalize URL - replace localhost with 127.0.0.1, remove trailing slashes.
+  private async probeAvailability(signal?: AbortSignal): Promise<boolean> {
+    const now = Date.now();
     // Probe server-native endpoints from the server root even when users configure
     // the OpenAI-compatible `/v1` base URL for chat completions.
     const configuredBaseUrl = trimTrailingSlashes(

--- a/tests/local-llm.test.ts
+++ b/tests/local-llm.test.ts
@@ -907,3 +907,58 @@ test("LocalLlmClient getLoadedModelInfo sends auth headers to models probe", asy
     globalThis.fetch = originalFetch;
   }
 });
+
+/**
+ * Issue #2210: a busy event loop can burn the health probe's fixed 2s budget
+ * before the socket is even scheduled. The probe aborts, and the client used to
+ * record that as "backend unavailable" and cache it — taking extraction offline
+ * while the backend was answering other callers in single-digit milliseconds.
+ */
+test("a timed-out availability probe leaves availability unknown instead of caching a blackout", async () => {
+  initLogger(undefined, false);
+  const client = new LocalLlmClient(buildConfig());
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    calls += 1;
+    throw abortError();
+  }) as typeof fetch;
+  try {
+    assert.equal(await client.checkAvailability(), false, "this call still fails");
+    const afterFirst = calls;
+    assert.ok(afterFirst > 0, "probes ran");
+
+    // The point: the next call must RE-PROBE. A cached false would serve the
+    // stale verdict for the whole health-check interval with no new requests.
+    assert.equal(await client.checkAvailability(), false);
+    assert.ok(calls > afterFirst, "a timed-out probe must not be cached as a verdict");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a definitive probe failure IS cached for the health-check interval", async () => {
+  initLogger(undefined, false);
+  const client = new LocalLlmClient(buildConfig());
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = (async () =>
+    new Response("nope", { status: 500, headers: { "content-type": "text/plain" } })) as unknown as typeof fetch;
+  const counting: typeof fetch = (async (...args: Parameters<typeof fetch>) => {
+    calls += 1;
+    return await (globalThis.fetch as typeof fetch)(...args);
+  }) as typeof fetch;
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = counting;
+  try {
+    assert.equal(await client.checkAvailability(), false);
+    const afterFirst = calls;
+    // A backend that answered and said 500 is a real verdict — cache it, or the
+    // daemon hammers a known-bad endpoint on every request.
+    assert.equal(await client.checkAvailability(), false);
+    assert.equal(calls, afterFirst, "a definitive failure must be cached");
+  } finally {
+    globalThis.fetch = originalFetch;
+    void realFetch;
+  }
+});

--- a/tests/local-llm.test.ts
+++ b/tests/local-llm.test.ts
@@ -942,23 +942,18 @@ test("a definitive probe failure IS cached for the health-check interval", async
   const client = new LocalLlmClient(buildConfig());
   const originalFetch = globalThis.fetch;
   let calls = 0;
-  globalThis.fetch = (async () =>
-    new Response("nope", { status: 500, headers: { "content-type": "text/plain" } })) as unknown as typeof fetch;
-  const counting: typeof fetch = (async (...args: Parameters<typeof fetch>) => {
+  // A backend that ANSWERS and says no is a real verdict, unlike a timeout.
+  globalThis.fetch = (async () => {
     calls += 1;
-    return await (globalThis.fetch as typeof fetch)(...args);
-  }) as typeof fetch;
-  const realFetch = globalThis.fetch;
-  globalThis.fetch = counting;
+    return new Response("nope", { status: 500, headers: { "content-type": "text/plain" } });
+  }) as unknown as typeof fetch;
   try {
     assert.equal(await client.checkAvailability(), false);
     const afterFirst = calls;
-    // A backend that answered and said 500 is a real verdict — cache it, or the
-    // daemon hammers a known-bad endpoint on every request.
+    assert.ok(afterFirst > 0, "probes ran");
     assert.equal(await client.checkAvailability(), false);
-    assert.equal(calls, afterFirst, "a definitive failure must be cached");
+    assert.equal(calls, afterFirst, "a definitive failure must be cached, not re-probed every request");
   } finally {
     globalThis.fetch = originalFetch;
-    void realFetch;
   }
 });

--- a/tests/local-llm.test.ts
+++ b/tests/local-llm.test.ts
@@ -957,3 +957,69 @@ test("a definitive probe failure IS cached for the health-check interval", async
     globalThis.fetch = originalFetch;
   }
 });
+
+test("concurrent availability checks share one probe sequence", async () => {
+  initLogger(undefined, false);
+  const client = new LocalLlmClient(buildConfig());
+  const originalFetch = globalThis.fetch;
+  let probes = 0;
+  let releaseProbes!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    releaseProbes = resolve;
+  });
+  // Hold every probe open so all five callers are genuinely in flight at once.
+  globalThis.fetch = (async () => {
+    probes += 1;
+    await gate;
+    return new Response("nope", { status: 500, headers: { "content-type": "text/plain" } });
+  }) as unknown as typeof fetch;
+  try {
+    const callers = [1, 2, 3, 4, 5].map(() => client.checkAvailability());
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const concurrentProbes = probes;
+    releaseProbes();
+    const results = await Promise.all(callers);
+    assert.deepEqual(results, [false, false, false, false, false]);
+    assert.equal(
+      concurrentProbes,
+      1,
+      "five concurrent callers must not each start their own probe sequence",
+    );
+  } finally {
+    releaseProbes();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("one caller cancelling does not abort a probe the others still await", async () => {
+  initLogger(undefined, false);
+  const client = new LocalLlmClient(buildConfig());
+  const originalFetch = globalThis.fetch;
+  let releaseProbes!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    releaseProbes = resolve;
+  });
+  let completedProbes = 0;
+  globalThis.fetch = (async () => {
+    await gate;
+    completedProbes += 1;
+    return new Response(JSON.stringify({ models: [{ id: "m" }] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  const quitter = new AbortController();
+  try {
+    const abandoned = client.checkAvailability(quitter.signal);
+    const stayer = client.checkAvailability();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    quitter.abort();
+    assert.equal(await abandoned, false, "the cancelling caller gets a prompt negative");
+    releaseProbes();
+    assert.equal(await stayer, true, "the remaining caller still gets a real verdict");
+    assert.ok(completedProbes > 0, "the shared probe was not aborted out from under the stayer");
+  } finally {
+    releaseProbes();
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/local-llm.test.ts
+++ b/tests/local-llm.test.ts
@@ -1023,3 +1023,32 @@ test("one caller cancelling does not abort a probe the others still await", asyn
     globalThis.fetch = originalFetch;
   }
 });
+
+test("a caller arriving after the last waiter cancels starts a fresh probe", async () => {
+  initLogger(undefined, false);
+  const client = new LocalLlmClient(buildConfig());
+  const originalFetch = globalThis.fetch;
+  let sequences = 0;
+  // Ignore cancellation entirely: the doomed sequence stays pending, which is
+  // exactly the window where a late caller could join it.
+  globalThis.fetch = (async () => {
+    sequences += 1;
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    return new Response(JSON.stringify({ models: [{ id: "m" }] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  const quitter = new AbortController();
+  try {
+    const abandoned = client.checkAvailability(quitter.signal);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    quitter.abort();
+    assert.equal(await abandoned, false);
+    const late = await client.checkAvailability();
+    assert.equal(late, true, "a late caller must get a real verdict, not the aborted one's false");
+    assert.ok(sequences >= 2, "the late caller must start its own sequence, not join the doomed one");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
Closes #2210.

## Root cause (reproduced, not inferred)

The availability probe gives every request a fixed **2s** budget. On a loaded daemon the event loop can burn that before the socket is even scheduled, so the fetch aborts — and `fetchWithTimeout` folded the abort into the exact same `{ok: false, status: null}` a genuine failure produces. `checkAvailability` cached "unavailable", and every extraction then returned `local LLM unavailable` **instantly** for the rest of the interval.

Measured on the affected host, seconds apart, identical config:

| | probes | result |
|---|---|---|
| daemon | 4, each ~0–1 ms | all fail → `checkAvailability returned false` |
| fresh process | 3, each 8–12 ms | `detected mlx` → `true` |

~0 ms means the requests never reached the network. Confirmed by reproduction — scheduling a probe and then blocking the loop past the budget:

```
idle loop    : HTTP 200 in 27ms
starved loop : FAILED in 2601ms AbortError: This operation was aborted
```

Ruled out first, each with a probe rather than inspection: rate limiting (40/40 × 200), socket-reuse decay (4 min of loops, no degradation), a custom global dispatcher, OTel/proxy env, the #2148 dispatcher (per-request, never global), the 400-cooldown, the backend circuit breaker, and config drift.

## Fix

- **A timeout produces no verdict.** Availability is left `null` and the next request re-probes, instead of serving a stale `false` for the whole health-check interval.
- **A definitive answer is still cached.** A backend that replied and said no stays cached, or the daemon re-probes a known-bad endpoint on every request.
- **Probe failures log their cause** — status, or error plus undici's `cause` (where `fetch failed` hides the real reason). Previously a transport error and a 404 were indistinguishable and unlogged (§22). This is the main reason the bug survived so long.
- **The flip to unavailable is a `warn`.** Extraction stops silently when it happens, and until #2209 the daemon could not emit debug at all.

## Verification

- Two unit tests: a timed-out probe must re-probe on the next call; a definitive failure must stay cached.
- **Revert-checked**: removing the abort branch fails the first (`not ok 19`) and leaves the second passing, so the pair brackets exactly this behavior.
- 54 tests across the local-llm suites pass; `preflight:quick` OK, ratchets OK.

## Note on structure

`probeFetch` and the verdict decision moved to the existing `local-llm-helpers.ts` sibling — `local-llm.ts` is at its #1995 ceiling. The verdict is now a pure function, which is what makes both branches unit-testable.

Depends on #2211 (#2209) only for field diagnosis; the fix itself is independent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core local-LLM availability caching and concurrent probe behavior; wrong logic could still mis-route extraction, but scope is narrow and well covered by new tests.
> 
> **Overview**
> Fixes **false “local LLM unavailable” blackouts** when health probes hit the fixed **2s** timeout on a busy event loop instead of getting a real backend answer.
> 
> **Probe verdicts:** timeouts no longer cache `isAvailable = false`—availability stays **unknown** (`null`) so the next call re-probes. Definitive probe failures (e.g. HTTP errors) are still cached for the health-check interval.
> 
> **Orchestration & observability:** `checkAvailability` runs through **`SingleFlightProbe`** so concurrent callers share one probe sequence; refcounted cancellation avoids one aborted caller killing probes others still await. Probe failures log HTTP status or transport errors (including undici `cause`); flipping to unavailable is **`warn`** instead of **`debug`**. Probe HTTP logic lives in **`probeFetch`** / **`resolveUnavailableVerdict`** in `local-llm-helpers.ts`.
> 
> Regression tests cover timeout vs cached failure, shared probes, and cancel/late-caller edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41fa09b133c2d4ff3dbc67f932428187341b8495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Local-LLM availability checks no longer permanently mark the backend as unavailable when a probe times out or aborts; availability remains unknown and the next request retries the probe.
  * Definitive failures (e.g., non-timeout responses) are still cached for the health-check interval.
  * “Unavailable” transitions are now surfaced at warning level, and probe failures report the actual failure cause.
* **Tests**
  * Added regression and concurrency/abort coverage to verify timeout retry behavior, correct caching, and shared in-flight probing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->