### PR TITLE
fix: open readiness gate in degraded mode when startup search warm-up cannot complete

### DIFF
--- a/docs/guides/standalone-server.md
+++ b/docs/guides/standalone-server.md
@@ -76,6 +76,25 @@ binary, unsupported version, or collection probe problem. The API path remains
 
 To bind to all interfaces (e.g., for LAN access from other machines), use `--host 0.0.0.0`. Only do this on trusted networks or behind a reverse proxy.
 
+### Startup readiness and degraded mode
+
+While startup search warm-up is still running, `/engram/v1/health` answers
+`503` with `code: "not_ready"` and a rising `warmupAttempts` counter. Recall
+and every other route serve normally during this window — the gate only
+affects the health signal.
+
+If warm-up cannot complete (for example the `qmd` binary is missing from a
+long-lived service's `PATH`), the server does not stay `not_ready` forever:
+after `server.readinessDegradedAfterAttempts` failed attempts (default `3`,
+roughly two minutes) health switches to `200` with `degraded: true`,
+`warmupAttempts`, and `lastError` merged into the normal health payload, and
+warm-up retries continue in the background until they succeed. Set
+`server.readinessDegradedAfterAttempts` to `0` (or the
+`REMNIC_READY_DEGRADED_AFTER_ATTEMPTS` env var) to keep the strict gate, e.g.
+when an orchestrator must hold traffic until the search index is warm.
+`server.readinessOverride` (`REMNIC_READY_OVERRIDE`) still forces the gate
+open immediately.
+
 ## Connecting agent harnesses
 
 ### OpenClaw (plugin mode)

--- a/docs/guides/standalone-server.md
+++ b/docs/guides/standalone-server.md
@@ -90,8 +90,9 @@ roughly two minutes) health switches to `200` with `degraded: true`,
 `warmupAttempts`, and `lastError` merged into the normal health payload, and
 warm-up retries continue in the background until they succeed. Set
 `server.readinessDegradedAfterAttempts` to `0` (or the
-`REMNIC_READY_DEGRADED_AFTER_ATTEMPTS` env var) to keep the strict gate, e.g.
-when an orchestrator must hold traffic until the search index is warm.
+`REMNIC_READY_DEGRADED_AFTER_ATTEMPTS` env var; legacy `ENGRAM_` prefix also
+supported) to keep the strict gate, e.g. when an orchestrator must hold
+traffic until the search index is warm.
 `server.readinessOverride` (`REMNIC_READY_OVERRIDE`) still forces the gate
 open immediately.
 

--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -121,6 +121,30 @@ test("RemnicClient preserves HTTP status for non-JSON internal server errors", a
   );
 });
 
+test("RemnicHttpError carries the daemon's machine-readable error code (issue #2215)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({ ok: false, ready: false, warmupAttempts: 154, lastError: "StartupSyncPendingError", code: "not_ready" }),
+      { status: 503, statusText: "Service Unavailable" },
+    );
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const client = new RemnicClient(baseConfig());
+
+  await assert.rejects(
+    () => client.health(),
+    (err) => {
+      assert.ok(err instanceof RemnicHttpError);
+      assert.equal(err.status, 503);
+      assert.equal(err.code, "not_ready");
+      return true;
+    },
+  );
+});
+
 
 test("RemnicClient reports invalid JSON clearly for successful daemon responses", async (t) => {
   const originalFetch = globalThis.fetch;

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -57,6 +57,8 @@ export class RemnicHttpError extends Error {
   constructor(
     readonly status: number,
     message: string,
+    /** Machine-readable error code from the daemon's JSON error body (e.g. `not_ready`). */
+    readonly code?: string,
   ) {
     super(message);
   }
@@ -359,12 +361,13 @@ export class RemnicClient {
       }
       if (!response.ok) {
         const message = responseErrorMessage(response, text, payload, parseError);
+        const code = responseErrorCode(payload, parseError);
         if (response.status === 413) {
           // Surface the body size so operators can tune the cap (#1600).
           const bodyBytes = body === undefined ? 0 : jsonBytes(body);
-          throw new RemnicHttpError(response.status, `${message} (observed body ${bodyBytes} bytes; cap via observeMaxBytes)`);
+          throw new RemnicHttpError(response.status, `${message} (observed body ${bodyBytes} bytes; cap via observeMaxBytes)`, code);
         }
-        throw new RemnicHttpError(response.status, message);
+        throw new RemnicHttpError(response.status, message, code);
       }
       if (parseError) {
         const reason = parseError instanceof Error ? parseError.message : String(parseError);
@@ -652,4 +655,12 @@ function responseErrorMessage(response: Response, text: string, payload: unknown
     return response.statusText ? `${response.statusText}: ${snippet}` : snippet;
   }
   return response.statusText || `HTTP ${response.status}`;
+}
+
+function responseErrorCode(payload: unknown, parseError: unknown): string | undefined {
+  if (parseError || !payload || typeof payload !== "object") return undefined;
+  if ("code" in payload && typeof payload.code === "string" && payload.code.trim().length > 0) {
+    return payload.code;
+  }
+  return undefined;
 }

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -254,6 +254,50 @@ test("session_start status probe uses the startup timeout", async (t) => {
   assert.deepEqual(statuses, [["remnic", "Remnic offline"]]);
 });
 
+test("session_start renders 'Remnic starting' when health answers 503 not_ready (issue #2215)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = String(input);
+    if (url.endsWith("/engram/v1/health")) {
+      // The daemon is up but startup search warm-up has not completed — it must
+      // render as starting, not offline, because recall still serves (issue #2215).
+      return new Response(
+        JSON.stringify({ ok: false, ready: false, warmupAttempts: 154, lastError: "StartupSyncPendingError", code: "not_ready" }),
+        { status: 503 },
+      );
+    }
+    return new Response(JSON.stringify({}), { status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const statuses: Array<[string, string]> = [];
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: true,
+    },
+  });
+  await extension(pi as any);
+
+  await emit("session_start", {}, {
+    cwd: "/tmp/remnic-pi",
+    ui: {
+      setStatus: (key: string, value: string) => statuses.push([key, value]),
+    },
+    sessionManager: { getSessionId: () => "starting-status-test", getEntries: () => [] },
+  });
+
+  assert.deepEqual(statuses, [["remnic", "Remnic starting"]]);
+});
+
 test("observeMessages only records dedupe hashes after a successful observe", async () => {
   const observedHashes = new Set<string>();
   const ctx = {

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -1,7 +1,7 @@
 import { Type, type TSchema } from "@sinclair/typebox";
 
 import { loadConfig, type LoadConfigOptions, type RemnicPiConfig } from "./config.js";
-import { RemnicClient, isTransientNetworkError, type McpTool, type ObserveMessage } from "./client.js";
+import { RemnicClient, RemnicHttpError, isTransientNetworkError, type McpTool, type ObserveMessage } from "./client.js";
 import {
   hashObservedMessage,
   latestUserRecallTarget,
@@ -67,12 +67,9 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       // daemon is marked unreachable even when the status UI is off; otherwise
       // the namespace preflight and every later hook each burn a full request
       // budget on a doomed call. The status LABEL stays gated on statusEnabled.
-      const reachable = await probeDaemonHealth(client, config);
+      const probe = await probeDaemonHealth(client, config);
       if (config.statusEnabled) {
-        session.setStatus(
-          "remnic",
-          reachable ? `Remnic ${config.namespace ? `(${config.namespace})` : "ready"}` : "Remnic offline",
-        );
+        session.setStatus("remnic", remnicStatusLabel(probe, config.namespace));
       }
       await runNamespacePreflight(pi, session, client, config);
     });
@@ -593,28 +590,47 @@ function persistObservedState(pi: PiApi, observedHashes: Set<string>): void {
   });
 }
 
+/** Result of the session_start daemon probe. */
+type DaemonProbeResult = "ready" | "starting" | "unreachable";
+
 /**
- * Probe the daemon and update the shared circuit breaker. Returns whether the
- * daemon is reachable so the caller can render a status label. This runs at
- * session_start regardless of `statusEnabled`: the breaker update is a
- * data-path concern (a down daemon must be marked unreachable so the namespace
- * preflight and every later hook fast-skip instead of each burning a full
- * request budget), independent of whether the status UI is shown.
+ * Probe the daemon and update the shared circuit breaker. Returns the probe
+ * outcome so the caller can render a status label. This runs at session_start
+ * regardless of `statusEnabled`: the breaker update is a data-path concern (a
+ * down daemon must be marked unreachable so the namespace preflight and every
+ * later hook fast-skip instead of each burning a full request budget),
+ * independent of whether the status UI is shown.
+ *
+ * A 503 `not_ready` answer is NOT offline (issue #2215): the daemon responded
+ * — it is up and serving recall via fallback retrieval while startup search
+ * warm-up is still running — so it counts as reachable and renders as
+ * "starting" instead of tripping the breaker or claiming the service is down.
  */
-async function probeDaemonHealth(client: RemnicClient, config: RemnicPiConfig): Promise<boolean> {
+async function probeDaemonHealth(client: RemnicClient, config: RemnicPiConfig): Promise<DaemonProbeResult> {
   try {
     await client.health({ timeoutMs: config.startupRequestTimeoutMs });
     // A successful probe means the daemon is reachable, so clear any stale
     // cooldown a prior recall/observe timeout left on the shared client.
     client.markReachable();
-    return true;
+    return "ready";
   } catch (err) {
+    if (err instanceof RemnicHttpError && err.status === 503 && err.code === "not_ready") {
+      client.markReachable();
+      return "starting";
+    }
     // Startup just proved the daemon is unreachable, so trip the fast-skip
     // breaker — otherwise the first live hook spends the full turn budget on a
     // doomed request before the breaker would trip on its own.
     if (isDaemonUnreachableError(err)) client.markUnreachable(config.daemonCooldownMs);
-    return false;
+    return "unreachable";
   }
+}
+
+/** Status-line label for the session_start probe outcome. */
+function remnicStatusLabel(probe: DaemonProbeResult, namespace: string | undefined): string {
+  if (probe === "unreachable") return "Remnic offline";
+  if (probe === "starting") return "Remnic starting";
+  return `Remnic ${namespace ? `(${namespace})` : "ready"}`;
 }
 
 /**

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -66,6 +66,12 @@ export interface AccessHttpReadinessState {
   ready: boolean;
   warmupAttempts: number;
   lastError?: string | null;
+  /**
+   * True when the standalone init gate opened before search warm-up completed
+   * (issue #2215): the service is functional (recall serves via fallback
+   * retrieval), so health answers 200 with degraded info instead of 503.
+   */
+  degraded?: boolean;
 }
 
 export interface EngramAccessHttpServerOptions {
@@ -801,18 +807,13 @@ export class EngramAccessHttpServer {
     }
 
     if (req.method === "GET" && pathname === "/engram/v1/health") {
-      const readiness = this.readiness();
-      if (!readiness.ready) {
+      const { ready, warmupAttempts, lastError } = this.readiness();
+      if (!ready) {
         this.respondJson(res, 503, {
-          ok: false,
-          ready: false,
-          warmupAttempts: readiness.warmupAttempts,
-          lastError: readiness.lastError ?? null,
-          code: "not_ready",
+          ok: false, ready: false, warmupAttempts, lastError: lastError ?? null, code: "not_ready",
         });
         return;
       }
-
     }
 
     // Run any host-supplied pre-auth request handler. It runs AFTER the
@@ -888,7 +889,11 @@ export class EngramAccessHttpServer {
     }
 
     if (req.method === "GET" && pathname === "/engram/v1/health") {
-      this.respondJson(res, 200, await this.service.health());
+      const { degraded, warmupAttempts, lastError } = this.readiness();
+      const health = await this.service.health();
+      this.respondJson(res, 200, degraded !== true ? health : {
+        ...health, degraded: true, warmupAttempts, lastError: lastError ?? null,
+      });
       return;
     }
     if (req.method === "GET" && pathname === "/engram/v1/capabilities") return respondLcmCompactionCapabilitiesHttp(res);

--- a/packages/remnic-server/src/config.test.ts
+++ b/packages/remnic-server/src/config.test.ts
@@ -307,3 +307,28 @@ test("envOverrides write rate limit env: precedence, legacy fallback, invalid re
     }
   }
 });
+
+test("envOverrides honors REMNIC_READY_DEGRADED_AFTER_ATTEMPTS (issue #2215)", () => {
+  const key = "REMNIC_READY_DEGRADED_AFTER_ATTEMPTS";
+  const saved = process.env[key];
+  try {
+    delete process.env[key];
+    assert.equal(parseServerConfig(envOverrides()).readinessDegradedAfterAttempts, 3);
+
+    process.env[key] = "0";
+    assert.equal(parseServerConfig(envOverrides()).readinessDegradedAfterAttempts, 0);
+
+    process.env[key] = "7";
+    assert.equal(parseServerConfig(envOverrides()).readinessDegradedAfterAttempts, 7);
+
+    // Invalid env values reach validation and are rejected, not silently dropped.
+    process.env[key] = "nope";
+    assert.throws(
+      () => parseServerConfig(envOverrides()),
+      /server\.readinessDegradedAfterAttempts: expected a non-negative integer/,
+    );
+  } finally {
+    if (saved === undefined) delete process.env[key];
+    else process.env[key] = saved;
+  }
+});

--- a/packages/remnic-server/src/config.test.ts
+++ b/packages/remnic-server/src/config.test.ts
@@ -308,27 +308,40 @@ test("envOverrides write rate limit env: precedence, legacy fallback, invalid re
   }
 });
 
-test("envOverrides honors REMNIC_READY_DEGRADED_AFTER_ATTEMPTS (issue #2215)", () => {
-  const key = "REMNIC_READY_DEGRADED_AFTER_ATTEMPTS";
-  const saved = process.env[key];
+test("envOverrides honors REMNIC_READY_DEGRADED_AFTER_ATTEMPTS with legacy fallback (issue #2215)", () => {
+  const keys = ["REMNIC_READY_DEGRADED_AFTER_ATTEMPTS", "ENGRAM_READY_DEGRADED_AFTER_ATTEMPTS"];
+  const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+  const clear = () => {
+    for (const k of keys) delete process.env[k];
+  };
   try {
-    delete process.env[key];
+    clear();
     assert.equal(parseServerConfig(envOverrides()).readinessDegradedAfterAttempts, 3);
 
-    process.env[key] = "0";
+    process.env.REMNIC_READY_DEGRADED_AFTER_ATTEMPTS = "0";
     assert.equal(parseServerConfig(envOverrides()).readinessDegradedAfterAttempts, 0);
 
-    process.env[key] = "7";
+    // REMNIC_ wins over a conflicting legacy ENGRAM_ value.
+    process.env.REMNIC_READY_DEGRADED_AFTER_ATTEMPTS = "7";
+    process.env.ENGRAM_READY_DEGRADED_AFTER_ATTEMPTS = "9";
     assert.equal(parseServerConfig(envOverrides()).readinessDegradedAfterAttempts, 7);
 
+    // Legacy ENGRAM_ name is honored when the REMNIC_ name is unset.
+    clear();
+    process.env.ENGRAM_READY_DEGRADED_AFTER_ATTEMPTS = "0";
+    assert.equal(parseServerConfig(envOverrides()).readinessDegradedAfterAttempts, 0);
+
     // Invalid env values reach validation and are rejected, not silently dropped.
-    process.env[key] = "nope";
+    clear();
+    process.env.REMNIC_READY_DEGRADED_AFTER_ATTEMPTS = "nope";
     assert.throws(
       () => parseServerConfig(envOverrides()),
       /server\.readinessDegradedAfterAttempts: expected a non-negative integer/,
     );
   } finally {
-    if (saved === undefined) delete process.env[key];
-    else process.env[key] = saved;
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
   }
 });

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -118,7 +118,11 @@ function parseOptionalBoolean(value: unknown, source: string): boolean | undefin
 
 function parseOptionalNonNegativeInteger(value: unknown, source: string): number | undefined {
   if (value === undefined) return undefined;
-  const parsed = typeof value === "string" ? Number(value.trim()) : value;
+  // Reject blank strings BEFORE coercion: Number("") is 0, which would
+  // silently enable the 0-means-strict-gate semantics (codex review).
+  const parsed = typeof value === "string"
+    ? value.trim() === "" ? Number.NaN : Number(value.trim())
+    : value;
   if (typeof parsed !== "number" || !Number.isInteger(parsed) || parsed < 0) {
     throw new Error(`Invalid ${source}: expected a non-negative integer`);
   }

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -18,7 +18,20 @@ import { parseConfig, isOpenaiApiKeyDisabled, resolveRemnicConfigRecord, Orchest
 import { probeBetterSqlite3Driver } from "@remnic/core/runtime/better-sqlite";
 import { applyOAuthEnvOverrides, buildOAuthRequestHandler } from "./oauth.js";
 import { envOverrides, readCompatEnv } from "./server-env.js";
+import {
+  STARTUP_DEGRADED_AFTER_ATTEMPTS,
+  abortableDelay,
+  completeStartupReadiness,
+  runStartupSearchWarmup,
+  type StartupReadinessState,
+} from "./startup-readiness.js";
 export { envOverrides };
+export {
+  completeStartupReadiness,
+  runStartupSearchWarmup,
+  type StartupReadinessOutcome,
+  type StartupReadinessState,
+} from "./startup-readiness.js";
 
 // ── Config loading ──────────────────────────────────────────────────────────
 
@@ -38,6 +51,12 @@ export interface ServerConfig {
     adminConsolePublicDir?: string;
     adminConsolePrefillToken?: boolean;
     readinessOverride?: boolean;
+    /**
+     * Failed search warm-up attempts before the init gate opens in degraded
+     * mode (issue #2215). 0 keeps the strict gate (health stays 503 until
+     * warm-up completes).
+     */
+    readinessDegradedAfterAttempts?: unknown;
     /** OAuth authorization-server facade for ChatGPT dev-mode apps (parsed by oauth.ts). */
     oauth?: unknown;
   };
@@ -97,6 +116,15 @@ function parseOptionalBoolean(value: unknown, source: string): boolean | undefin
   throw new Error(`Invalid ${source}: expected a boolean`);
 }
 
+function parseOptionalNonNegativeInteger(value: unknown, source: string): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = typeof value === "string" ? Number(value.trim()) : value;
+  if (typeof parsed !== "number" || !Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid ${source}: expected a non-negative integer`);
+  }
+  return parsed;
+}
+
 export interface ParsedServerConfig {
   host: string;
   port: number;
@@ -109,6 +137,7 @@ export interface ParsedServerConfig {
   adminConsolePublicDir?: string;
   adminConsolePrefillToken: boolean;
   readinessOverride: boolean;
+  readinessDegradedAfterAttempts: number;
 }
 
 export function parseServerConfig(
@@ -135,6 +164,11 @@ export function parseServerConfig(
     adminConsolePublicDir: parseOptionalString(raw.adminConsolePublicDir, "server.adminConsolePublicDir"),
     adminConsolePrefillToken: parseOptionalBoolean(raw.adminConsolePrefillToken, "server.adminConsolePrefillToken") ?? false,
     readinessOverride: parseOptionalBoolean(raw.readinessOverride, "server.readinessOverride") ?? false,
+    readinessDegradedAfterAttempts:
+      parseOptionalNonNegativeInteger(
+        raw.readinessDegradedAfterAttempts,
+        "server.readinessDegradedAfterAttempts",
+      ) ?? STARTUP_DEGRADED_AFTER_ATTEMPTS,
   };
 }
 
@@ -660,205 +694,6 @@ export function createAdminControls(
   };
 }
 
-interface PromiseResolvers<T> {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: unknown) => void;
-}
-
-type PromiseConstructorWithResolvers = PromiseConstructor & {
-  withResolvers<T>(): PromiseResolvers<T>;
-};
-
-/**
- * Like `setTimeout` wrapped in a Promise, but respects an `AbortSignal`.
- * Resolves immediately (without throwing) when the signal fires so the
- * caller can check `signal.aborted` and exit cleanly.
- */
-function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
-  if (signal.aborted) return Promise.resolve();
-  const { promise, resolve } = (Promise as PromiseConstructorWithResolvers).withResolvers<void>();
-  const timer = setTimeout(resolve, ms);
-  const onAbort = () => {
-    clearTimeout(timer);
-    resolve();
-  };
-  signal.addEventListener("abort", onAbort, { once: true });
-  return promise.finally(() => signal.removeEventListener("abort", onAbort));
-}
-
-const STARTUP_WARMUP_TIMEOUT_MS = 20_000;
-const STARTUP_WARMUP_RETRY_INTERVAL_MS = 30_000;
-
-export interface StartupReadinessState {
-  ready: boolean;
-  warmupAttempts: number;
-  lastError?: string | null;
-}
-
-export type StartupReadinessOutcome = "warmed" | "cancelled" | "overridden" | "search-disabled";
-
-class StartupWarmupDegradationError extends Error {
-  constructor(code: string) {
-    super(`startup search degraded: ${code}`);
-    this.name = "StartupWarmupDegradationError";
-  }
-}
-
-class StartupSyncPendingError extends Error {
-  constructor() {
-    super("startup search sync is not complete");
-    this.name = "StartupSyncPendingError";
-  }
-}
-
-export async function runStartupSearchWarmup(options: {
-  signal: AbortSignal;
-  isAvailable: () => boolean;
-  search: (onDegradation: (code: string) => void) => Promise<unknown>;
-}): Promise<void> {
-  let degradationCode: string | undefined;
-  await options.search((code) => {
-    degradationCode = code;
-  });
-  if (options.signal.aborted) return;
-  if (degradationCode) throw new StartupWarmupDegradationError(degradationCode);
-  if (!options.isAvailable()) {
-    throw new StartupWarmupDegradationError("backend_unavailable");
-  }
-}
-
-export async function completeStartupReadiness(options: {
-  deferredReady: Promise<void>;
-  warmup: (signal: AbortSignal) => Promise<unknown>;
-  prepareWarmup?: (signal: AbortSignal) => Promise<boolean>;
-  state: StartupReadinessState;
-  timeoutMs?: number;
-  retryIntervalMs?: number;
-  override?: boolean;
-  skipWarmup?: () => boolean;
-  openGate: () => void;
-  shutdownSignal?: AbortSignal;
-  warn?: (message: string) => void;
-  info?: (message: string) => void;
-  error?: (message: string) => void;
-}): Promise<StartupReadinessOutcome> {
-  const timeoutMs = options.timeoutMs ?? STARTUP_WARMUP_TIMEOUT_MS;
-  const retryIntervalMs = options.retryIntervalMs ?? STARTUP_WARMUP_RETRY_INTERVAL_MS;
-  const warn = options.warn ?? ((message: string) => log.warn(message));
-  const info = options.info ?? ((message: string) => log.info(message));
-  const error = options.error ?? ((message: string) => log.error(message));
-
-  options.state.ready = false;
-  options.state.lastError = null;
-  if (options.override) {
-    options.openGate();
-    options.state.ready = true;
-    error(
-      "CRITICAL: emergency readiness override enabled; exposing a cold search backend to traffic",
-    );
-    return "overridden";
-  }
-  if (options.skipWarmup?.()) {
-    options.openGate();
-    options.state.ready = true;
-    info("Standalone init gate opened without search warm-up (search intentionally disabled)");
-    return "search-disabled";
-  }
-
-
-  let removeDeferredShutdownListener: () => void = () => undefined;
-  const deferredShutdown = new Promise<"shutdown">((resolve) => {
-    if (options.shutdownSignal?.aborted) {
-      resolve("shutdown");
-      return;
-    }
-    const onDeferredShutdown = () => resolve("shutdown");
-    options.shutdownSignal?.addEventListener("abort", onDeferredShutdown, { once: true });
-    removeDeferredShutdownListener = () =>
-      options.shutdownSignal?.removeEventListener("abort", onDeferredShutdown);
-  });
-  try {
-    const deferredOutcome = await Promise.race([
-      options.deferredReady.then(() => "ready" as const),
-      deferredShutdown,
-    ]);
-    if (deferredOutcome === "shutdown") return "cancelled";
-  } catch (err) {
-    if (options.shutdownSignal?.aborted) return "cancelled";
-    options.state.lastError = err instanceof Error ? err.name : typeof err;
-    warn(`Standalone deferred initialization failed; warm-up retries will continue: ${err}`);
-  } finally {
-    removeDeferredShutdownListener();
-  }
-  if (options.shutdownSignal?.aborted) return "cancelled";
-
-  const lifecycleAbort = new AbortController();
-  const onShutdown = () => lifecycleAbort.abort(options.shutdownSignal?.reason);
-  options.shutdownSignal?.addEventListener("abort", onShutdown, { once: true });
-
-  try {
-    while (!lifecycleAbort.signal.aborted) {
-      if (options.skipWarmup?.()) {
-        options.openGate();
-        options.state.ready = true;
-        info("Standalone init gate opened without search warm-up (search intentionally disabled)");
-        return "search-disabled";
-      }
-      options.state.warmupAttempts += 1;
-      const warmupAbort = new AbortController();
-      const onLifecycleAbort = () => warmupAbort.abort(lifecycleAbort.signal.reason);
-      lifecycleAbort.signal.addEventListener("abort", onLifecycleAbort, { once: true });
-      const timeout = (Promise as PromiseConstructorWithResolvers).withResolvers<never>();
-      let timedOut = false;
-      const timer = setTimeout(() => {
-        timedOut = true;
-        warmupAbort.abort();
-        timeout.reject(new Error(`startup warm-up timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-      timer.unref();
-
-      try {
-        const attempt = async () => {
-          if (options.prepareWarmup && !await options.prepareWarmup(warmupAbort.signal)) {
-            throw new StartupSyncPendingError();
-          }
-          return options.warmup(warmupAbort.signal);
-        };
-        await Promise.race([attempt(), timeout.promise]);
-        if (lifecycleAbort.signal.aborted) return "cancelled";
-        options.state.lastError = null;
-        options.openGate();
-        options.state.ready = true;
-        info(
-          `Standalone init gate opened after search warm-up attempt ${options.state.warmupAttempts}`,
-        );
-        return "warmed";
-      } catch (err) {
-        if (lifecycleAbort.signal.aborted) return "cancelled";
-        options.state.lastError = timedOut
-          ? "TimeoutError"
-          : err instanceof Error
-            ? err.name
-            : typeof err;
-        warn(
-          timedOut
-            ? `Standalone startup warm-up attempt ${options.state.warmupAttempts} timed out after ${timeoutMs}ms; retrying in ${retryIntervalMs}ms`
-            : `Standalone startup warm-up attempt ${options.state.warmupAttempts} failed (${options.state.lastError}); retrying in ${retryIntervalMs}ms`,
-        );
-      } finally {
-        clearTimeout(timer);
-        lifecycleAbort.signal.removeEventListener("abort", onLifecycleAbort);
-      }
-
-      await abortableDelay(retryIntervalMs, lifecycleAbort.signal);
-    }
-    return "cancelled";
-  } finally {
-    options.shutdownSignal?.removeEventListener("abort", onShutdown);
-  }
-}
-
 async function cleanupFailedStartup(
   orchestrator: Orchestrator,
   httpServer: EngramAccessHttpServer,
@@ -957,7 +792,7 @@ export async function startServer(options?: {
   // Start the HTTP server immediately so health checks, MCP handshakes,
   // and liveness probes can connect while deferred init is still running.
   const service = new EngramAccessService(orchestrator);
-  const readiness: StartupReadinessState = { ready: false, warmupAttempts: 0, lastError: null };
+  const readiness: StartupReadinessState = { ready: false, warmupAttempts: 0, lastError: null, degraded: false };
 
   const authToken = parsedServerConfig.authToken ?? readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN") ?? "";
 
@@ -1062,6 +897,7 @@ export async function startServer(options?: {
     prepareWarmup: ensureStartupSync,
     state: readiness,
     override: parsedServerConfig.readinessOverride,
+    degradedAfterAttempts: parsedServerConfig.readinessDegradedAfterAttempts,
     skipWarmup: () => orchestrator.qmd.debugStatus() === "backend=noop",
     openGate: () => {
       readiness.ready = true;

--- a/packages/remnic-server/src/server-env.ts
+++ b/packages/remnic-server/src/server-env.ts
@@ -31,7 +31,10 @@ export function envOverrides(): Partial<ServerConfig["server"]> & { remnic?: Rec
   const adminConsolePublicDir = readCompatEnv("REMNIC_ADMIN_CONSOLE_PUBLIC_DIR", "ENGRAM_ADMIN_CONSOLE_PUBLIC_DIR");
   const adminConsolePrefillToken = readCompatEnv("REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN", "ENGRAM_ADMIN_CONSOLE_PREFILL_TOKEN");
   const readinessOverride = process.env.REMNIC_READY_OVERRIDE;
-  const readinessDegradedAfterAttempts = process.env.REMNIC_READY_DEGRADED_AFTER_ATTEMPTS;
+  const readinessDegradedAfterAttempts = readCompatEnv(
+    "REMNIC_READY_DEGRADED_AFTER_ATTEMPTS",
+    "ENGRAM_READY_DEGRADED_AFTER_ATTEMPTS",
+  );
   // issue #2029: size the global write rate limit from env. The standalone
   // server already honors `server.writeRateLimit*` in config; this makes it
   // settable via the launchd/systemd environment without editing config.json.

--- a/packages/remnic-server/src/server-env.ts
+++ b/packages/remnic-server/src/server-env.ts
@@ -31,6 +31,7 @@ export function envOverrides(): Partial<ServerConfig["server"]> & { remnic?: Rec
   const adminConsolePublicDir = readCompatEnv("REMNIC_ADMIN_CONSOLE_PUBLIC_DIR", "ENGRAM_ADMIN_CONSOLE_PUBLIC_DIR");
   const adminConsolePrefillToken = readCompatEnv("REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN", "ENGRAM_ADMIN_CONSOLE_PREFILL_TOKEN");
   const readinessOverride = process.env.REMNIC_READY_OVERRIDE;
+  const readinessDegradedAfterAttempts = process.env.REMNIC_READY_DEGRADED_AFTER_ATTEMPTS;
   // issue #2029: size the global write rate limit from env. The standalone
   // server already honors `server.writeRateLimit*` in config; this makes it
   // settable via the launchd/systemd environment without editing config.json.
@@ -49,6 +50,7 @@ export function envOverrides(): Partial<ServerConfig["server"]> & { remnic?: Rec
   if (adminConsolePublicDir) overrides.adminConsolePublicDir = adminConsolePublicDir;
   if (adminConsolePrefillToken) overrides.adminConsolePrefillToken = adminConsolePrefillToken;
   if (readinessOverride !== undefined) overrides.readinessOverride = readinessOverride;
+  if (readinessDegradedAfterAttempts !== undefined) overrides.readinessDegradedAfterAttempts = readinessDegradedAfterAttempts;
   // Use `!== undefined` (not truthiness) so an explicitly-set empty/invalid
   // value still reaches parseServerConfig and is rejected, rather than being
   // silently dropped so file config wins (issue #2029 review).

--- a/packages/remnic-server/src/startup-readiness.ts
+++ b/packages/remnic-server/src/startup-readiness.ts
@@ -1,0 +1,238 @@
+/**
+ * @remnic/server — standalone startup readiness gate.
+ *
+ * Extracted from index.ts (issue #2215): owns the search warm-up loop that
+ * drives `/engram/v1/health` readiness, including the degraded-mode transition
+ * that keeps a functional daemon from reporting itself offline forever when
+ * warm-up cannot complete. Keeps index.ts under its structural size ceiling.
+ */
+
+import { log } from "@remnic/core";
+
+interface PromiseResolvers<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+type PromiseConstructorWithResolvers = PromiseConstructor & {
+  withResolvers<T>(): PromiseResolvers<T>;
+};
+
+/**
+ * Like `setTimeout` wrapped in a Promise, but respects an `AbortSignal`.
+ * Resolves immediately (without throwing) when the signal fires so the
+ * caller can check `signal.aborted` and exit cleanly.
+ */
+export function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  const { promise, resolve } = (Promise as PromiseConstructorWithResolvers).withResolvers<void>();
+  const timer = setTimeout(resolve, ms);
+  const onAbort = () => {
+    clearTimeout(timer);
+    resolve();
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  return promise.finally(() => signal.removeEventListener("abort", onAbort));
+}
+
+const STARTUP_WARMUP_TIMEOUT_MS = 20_000;
+const STARTUP_WARMUP_RETRY_INTERVAL_MS = 30_000;
+/**
+ * Failed warm-up attempts before the init gate opens in degraded mode
+ * (issue #2215). The daemon keeps serving recall via fallback retrieval while
+ * search warm-up cannot complete (e.g. `qmd` missing from the service PATH),
+ * so a permanently-closed gate reports a working service as offline. After
+ * this many failed attempts the gate opens with `degraded: true` and warm-up
+ * retries continue in the background until they succeed.
+ */
+export const STARTUP_DEGRADED_AFTER_ATTEMPTS = 3;
+
+export interface StartupReadinessState {
+  ready: boolean;
+  warmupAttempts: number;
+  lastError?: string | null;
+  /** True when the gate opened before search warm-up completed (issue #2215). */
+  degraded?: boolean;
+}
+
+export type StartupReadinessOutcome = "warmed" | "cancelled" | "overridden" | "search-disabled";
+
+class StartupWarmupDegradationError extends Error {
+  constructor(code: string) {
+    super(`startup search degraded: ${code}`);
+    this.name = "StartupWarmupDegradationError";
+  }
+}
+
+class StartupSyncPendingError extends Error {
+  constructor() {
+    super("startup search sync is not complete");
+    this.name = "StartupSyncPendingError";
+  }
+}
+
+export async function runStartupSearchWarmup(options: {
+  signal: AbortSignal;
+  isAvailable: () => boolean;
+  search: (onDegradation: (code: string) => void) => Promise<unknown>;
+}): Promise<void> {
+  let degradationCode: string | undefined;
+  await options.search((code) => {
+    degradationCode = code;
+  });
+  if (options.signal.aborted) return;
+  if (degradationCode) throw new StartupWarmupDegradationError(degradationCode);
+  if (!options.isAvailable()) {
+    throw new StartupWarmupDegradationError("backend_unavailable");
+  }
+}
+
+export async function completeStartupReadiness(options: {
+  deferredReady: Promise<void>;
+  warmup: (signal: AbortSignal) => Promise<unknown>;
+  prepareWarmup?: (signal: AbortSignal) => Promise<boolean>;
+  state: StartupReadinessState;
+  timeoutMs?: number;
+  retryIntervalMs?: number;
+  /** Failed attempts before the gate opens degraded; 0 disables (strict gate). */
+  degradedAfterAttempts?: number;
+  override?: boolean;
+  skipWarmup?: () => boolean;
+  openGate: () => void;
+  shutdownSignal?: AbortSignal;
+  warn?: (message: string) => void;
+  info?: (message: string) => void;
+  error?: (message: string) => void;
+}): Promise<StartupReadinessOutcome> {
+  const timeoutMs = options.timeoutMs ?? STARTUP_WARMUP_TIMEOUT_MS;
+  const retryIntervalMs = options.retryIntervalMs ?? STARTUP_WARMUP_RETRY_INTERVAL_MS;
+  const degradedAfterAttempts = options.degradedAfterAttempts ?? STARTUP_DEGRADED_AFTER_ATTEMPTS;
+  const warn = options.warn ?? ((message: string) => log.warn(message));
+  const info = options.info ?? ((message: string) => log.info(message));
+  const error = options.error ?? ((message: string) => log.error(message));
+
+  options.state.ready = false;
+  options.state.lastError = null;
+  options.state.degraded = false;
+  if (options.override) {
+    options.openGate();
+    options.state.ready = true;
+    error(
+      "CRITICAL: emergency readiness override enabled; exposing a cold search backend to traffic",
+    );
+    return "overridden";
+  }
+  if (options.skipWarmup?.()) {
+    options.openGate();
+    options.state.ready = true;
+    info("Standalone init gate opened without search warm-up (search intentionally disabled)");
+    return "search-disabled";
+  }
+
+  let removeDeferredShutdownListener: () => void = () => undefined;
+  const deferredShutdown = new Promise<"shutdown">((resolve) => {
+    if (options.shutdownSignal?.aborted) {
+      resolve("shutdown");
+      return;
+    }
+    const onDeferredShutdown = () => resolve("shutdown");
+    options.shutdownSignal?.addEventListener("abort", onDeferredShutdown, { once: true });
+    removeDeferredShutdownListener = () =>
+      options.shutdownSignal?.removeEventListener("abort", onDeferredShutdown);
+  });
+  try {
+    const deferredOutcome = await Promise.race([
+      options.deferredReady.then(() => "ready" as const),
+      deferredShutdown,
+    ]);
+    if (deferredOutcome === "shutdown") return "cancelled";
+  } catch (err) {
+    if (options.shutdownSignal?.aborted) return "cancelled";
+    options.state.lastError = err instanceof Error ? err.name : typeof err;
+    warn(`Standalone deferred initialization failed; warm-up retries will continue: ${err}`);
+  } finally {
+    removeDeferredShutdownListener();
+  }
+  if (options.shutdownSignal?.aborted) return "cancelled";
+
+  const lifecycleAbort = new AbortController();
+  const onShutdown = () => lifecycleAbort.abort(options.shutdownSignal?.reason);
+  options.shutdownSignal?.addEventListener("abort", onShutdown, { once: true });
+
+  try {
+    while (!lifecycleAbort.signal.aborted) {
+      if (options.skipWarmup?.()) {
+        options.state.degraded = false;
+        options.openGate();
+        options.state.ready = true;
+        info("Standalone init gate opened without search warm-up (search intentionally disabled)");
+        return "search-disabled";
+      }
+      options.state.warmupAttempts += 1;
+      const warmupAbort = new AbortController();
+      const onLifecycleAbort = () => warmupAbort.abort(lifecycleAbort.signal.reason);
+      lifecycleAbort.signal.addEventListener("abort", onLifecycleAbort, { once: true });
+      const timeout = (Promise as PromiseConstructorWithResolvers).withResolvers<never>();
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        warmupAbort.abort();
+        timeout.reject(new Error(`startup warm-up timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      timer.unref();
+
+      try {
+        const attempt = async () => {
+          if (options.prepareWarmup && !await options.prepareWarmup(warmupAbort.signal)) {
+            throw new StartupSyncPendingError();
+          }
+          return options.warmup(warmupAbort.signal);
+        };
+        await Promise.race([attempt(), timeout.promise]);
+        if (lifecycleAbort.signal.aborted) return "cancelled";
+        const recovered = options.state.degraded === true;
+        options.state.lastError = null;
+        options.state.degraded = false;
+        options.openGate();
+        options.state.ready = true;
+        info(
+          `Standalone init gate opened after search warm-up attempt ${options.state.warmupAttempts}${recovered ? " (recovered from degraded mode)" : ""}`,
+        );
+        return "warmed";
+      } catch (err) {
+        if (lifecycleAbort.signal.aborted) return "cancelled";
+        options.state.lastError = timedOut
+          ? "TimeoutError"
+          : err instanceof Error
+            ? err.name
+            : typeof err;
+        warn(
+          timedOut
+            ? `Standalone startup warm-up attempt ${options.state.warmupAttempts} timed out after ${timeoutMs}ms; retrying in ${retryIntervalMs}ms`
+            : `Standalone startup warm-up attempt ${options.state.warmupAttempts} failed (${options.state.lastError}); retrying in ${retryIntervalMs}ms`,
+        );
+        if (
+          degradedAfterAttempts > 0 &&
+          !options.state.ready &&
+          options.state.warmupAttempts >= degradedAfterAttempts
+        ) {
+          options.state.degraded = true;
+          options.openGate();
+          options.state.ready = true;
+          warn(
+            `Standalone init gate opened in DEGRADED mode after ${options.state.warmupAttempts} failed search warm-up attempts (${options.state.lastError}); recall keeps serving via fallback retrieval and warm-up retries continue in the background`,
+          );
+        }
+      } finally {
+        clearTimeout(timer);
+        lifecycleAbort.signal.removeEventListener("abort", onLifecycleAbort);
+      }
+
+      await abortableDelay(retryIntervalMs, lifecycleAbort.signal);
+    }
+    return "cancelled";
+  } finally {
+    options.shutdownSignal?.removeEventListener("abort", onShutdown);
+  }
+}

--- a/tests/cold-start-readiness.test.ts
+++ b/tests/cold-start-readiness.test.ts
@@ -467,6 +467,8 @@ test("server config parses the degraded-readiness attempts knob (issue #2215)", 
   assert.equal(parseServerConfig({ readinessDegradedAfterAttempts: 0 }).readinessDegradedAfterAttempts, 0);
   assert.equal(parseServerConfig({ readinessDegradedAfterAttempts: "5" }).readinessDegradedAfterAttempts, 5);
   assert.throws(() => parseServerConfig({ readinessDegradedAfterAttempts: -1 }));
-  assert.throws(() => parseServerConfig({ readinessDegradedAfterAttempts: 2.5 }));
   assert.throws(() => parseServerConfig({ readinessDegradedAfterAttempts: "many" }));
+  // Blank strings must be rejected, not coerced to 0 (= strict gate) by Number("").
+  assert.throws(() => parseServerConfig({ readinessDegradedAfterAttempts: "" }));
+  assert.throws(() => parseServerConfig({ readinessDegradedAfterAttempts: "  " }));
 });

--- a/tests/cold-start-readiness.test.ts
+++ b/tests/cold-start-readiness.test.ts
@@ -91,10 +91,13 @@ test("a successful retry opens readiness on attempt N", async () => {
     ready: true,
     warmupAttempts: 3,
     lastError: null,
+    degraded: false,
   });
 });
 
 test("persistent warm-up failure keeps health at 503 and reports rising attempt state", async () => {
+  // degradedAfterAttempts: 0 pins the strict gate so this test's contract
+  // (health stays 503 forever) survives the degraded-mode default (issue #2215).
   const readiness = { ready: false, warmupAttempts: 0 };
   const shutdown = new AbortController();
   const service = {
@@ -118,6 +121,7 @@ test("persistent warm-up failure keeps health at 503 and reports rising attempt 
     },
     timeoutMs: 100,
     retryIntervalMs: 5,
+    degradedAfterAttempts: 0,
     state: readiness,
     openGate: () => {
       readiness.ready = true;
@@ -142,6 +146,95 @@ test("persistent warm-up failure keeps health at 503 and reports rising attempt 
     assert.equal(await readinessTask, "cancelled");
     await server.stop();
   }
+});
+
+test("persistent warm-up failure opens the gate in degraded mode and health answers 200 with degraded info (issue #2215)", async () => {
+  const readiness = { ready: false, warmupAttempts: 0, degraded: false };
+  const shutdown = new AbortController();
+  const service = {
+    health: async () => ({ ok: true }),
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+    readiness: () => readiness,
+  });
+  const status = await server.start();
+  const gateOpened = Promise.withResolvers<void>();
+
+  const readinessTask = completeStartupReadiness({
+    deferredReady: Promise.resolve(),
+    warmup: async () => {
+      throw new TypeError("search backend unavailable");
+    },
+    timeoutMs: 100,
+    retryIntervalMs: 5,
+    degradedAfterAttempts: 2,
+    state: readiness,
+    openGate: () => {
+      readiness.ready = true;
+      gateOpened.resolve();
+    },
+    shutdownSignal: shutdown.signal,
+  });
+
+  try {
+    await gateOpened.promise;
+    assert.equal(readiness.degraded, true);
+    assert.ok(readiness.warmupAttempts >= 2);
+
+    const response = await fetchHealth(status.port, "Bearer test-token");
+    assert.equal(response.status, 200);
+    const body = await response.json() as {
+      ok: boolean;
+      degraded?: boolean;
+      warmupAttempts?: number;
+      lastError?: string | null;
+    };
+    assert.equal(body.ok, true);
+    assert.equal(body.degraded, true);
+    assert.ok((body.warmupAttempts ?? 0) >= 2);
+    assert.equal(body.lastError, "TypeError");
+
+    // The unauthenticated 503 short-circuit no longer fires once degraded.
+    assert.equal((await fetchHealth(status.port)).status, 401);
+  } finally {
+    shutdown.abort();
+    assert.equal(await readinessTask, "cancelled");
+    await server.stop();
+  }
+});
+
+test("a warm-up success after degraded mode clears the degraded flag", async () => {
+  const readiness = { ready: false, warmupAttempts: 0, degraded: false };
+  let gateOpens = 0;
+
+  const outcome = await completeStartupReadiness({
+    deferredReady: Promise.resolve(),
+    warmup: async () => {
+      if (readiness.warmupAttempts < 3) throw new Error("still cold");
+    },
+    timeoutMs: 100,
+    retryIntervalMs: 1,
+    degradedAfterAttempts: 1,
+    state: readiness,
+    openGate: () => {
+      gateOpens += 1;
+      readiness.ready = true;
+    },
+  });
+
+  assert.equal(outcome, "warmed");
+  assert.deepEqual(readiness, {
+    ready: true,
+    warmupAttempts: 3,
+    lastError: null,
+    degraded: false,
+  });
+  // Opened once for the degraded transition, again on recovery — idempotent.
+  assert.ok(gateOpens >= 2);
 });
 
 test("shutdown during retry delay never opens readiness", async () => {
@@ -282,6 +375,7 @@ test("intentionally disabled search opens readiness without a warm-up", async ()
     ready: true,
     warmupAttempts: 0,
     lastError: null,
+    degraded: false,
   });
 });
 
@@ -358,6 +452,7 @@ test("the emergency override opens readiness at once and logs the exposure", asy
     ready: true,
     warmupAttempts: 0,
     lastError: null,
+    degraded: false,
   });
   assert.equal(errors.length, 1);
   assert.match(errors[0], /emergency readiness override.*cold search backend.*traffic/i);
@@ -365,4 +460,13 @@ test("the emergency override opens readiness at once and logs the exposure", asy
 
 test("server config accepts the emergency readiness override", () => {
   assert.equal(parseServerConfig({ readinessOverride: true }).readinessOverride, true);
+});
+
+test("server config parses the degraded-readiness attempts knob (issue #2215)", () => {
+  assert.equal(parseServerConfig({}).readinessDegradedAfterAttempts, 3);
+  assert.equal(parseServerConfig({ readinessDegradedAfterAttempts: 0 }).readinessDegradedAfterAttempts, 0);
+  assert.equal(parseServerConfig({ readinessDegradedAfterAttempts: "5" }).readinessDegradedAfterAttempts, 5);
+  assert.throws(() => parseServerConfig({ readinessDegradedAfterAttempts: -1 }));
+  assert.throws(() => parseServerConfig({ readinessDegradedAfterAttempts: 2.5 }));
+  assert.throws(() => parseServerConfig({ readinessDegradedAfterAttempts: "many" }));
 });


### PR DESCRIPTION
Resolves #2215.

## Problem

A standalone daemon whose startup search warm-up can never complete (for example `qmd` missing from a long-lived service's `PATH`) stayed permanently `not_ready`: `GET /engram/v1/health` answered 503 with `StartupSyncPendingError` and a climbing `warmupAttempts`, while `POST /engram/v1/recall` kept returning real context via fallback retrieval. Status surfaces (e.g. `@remnic/plugin-pi`) therefore showed **Remnic offline** for a working service. The readiness gate only guards the health signal — recall and every other route serve during warm-up — so a forever-closed gate carries no protective value, only a false offline signal.

## Change

**Server (root cause)** — `completeStartupReadiness` opens the init gate in **degraded** mode after a bounded number of failed warm-up attempts:

- New `server.readinessDegradedAfterAttempts` knob (default `3`; `0` restores the strict always-503 gate; `REMNIC_READY_DEGRADED_AFTER_ATTEMPTS` env override). Validated as a non-negative integer with string coercion at the boundary.
- On the degraded transition the gate opens, `degraded: true` is set, and warm-up retries continue in the background; a later success clears the flag (`(recovered from degraded mode)` logged). `readinessOverride`, `search-disabled`, and shutdown semantics are unchanged.
- The startup readiness gate moved from `packages/remnic-server/src/index.ts` into `startup-readiness.ts` (re-exported from the package entry) to respect the structural size ceiling — same seam as the `server-env.ts` extraction.

**Health surface** — while degraded, `GET /engram/v1/health` answers 200 with `degraded: true`, `warmupAttempts`, and `lastError` merged into the normal payload. The pre-warm-up 503 `not_ready` window (now bounded) is unchanged.

**Plugin-pi** — a 503 `not_ready` health answer means the daemon responded: the session_start probe now renders **Remnic starting** instead of **Remnic offline**, keeps the circuit breaker closed, and `RemnicHttpError` carries the daemon's machine-readable `code` so the check is exact (a proxy 503 without `code: "not_ready"` still renders offline).

## Tests

- `tests/cold-start-readiness.test.ts`: degraded transition over real HTTP (503 → 200 degraded with auth still enforced), recovery clearing the flag, strict-gate opt-out pinning the old contract, config knob parsing (default/0/string/invalid).
- `packages/remnic-server/src/config.test.ts`: env override precedence + invalid rejection.
- `packages/plugin-pi`: error-code propagation; session_start renders "Remnic starting" on 503 `not_ready`.

## Verification

- `npm run preflight:quick` → OK (review patterns + ratchets)
- `tsx --test tests/cold-start-readiness.test.ts` → 15/15
- plugin-pi suite → 153/153; server config tests → 15/15
- Root `tsc --noEmit` + `check-test-types` → clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes load-balancer/orchestrator readiness semantics and health JSON; default behavior shifts from indefinite 503 to degraded 200, though recall paths were already live during warm-up.
> 
> **Overview**
> Fixes standalone daemons that could stay **`503 not_ready`** forever while **recall still worked**, which made clients report **Remnic offline**.
> 
> **Server:** After `server.readinessDegradedAfterAttempts` failed warm-up tries (default **3**, **`0`** = strict gate), the init gate opens with **`degraded: true`** and background retries continue; success clears degraded. Logic moves to **`startup-readiness.ts`**; config/env **`REMNIC_READY_DEGRADED_AFTER_ATTEMPTS`** (legacy **`ENGRAM_`**).
> 
> **Health:** While degraded, **`GET /engram/v1/health`** returns **200** with **`degraded`**, **`warmupAttempts`**, and **`lastError`** on the normal payload; the bounded **`not_ready`** window is unchanged.
> 
> **plugin-pi:** **`RemnicHttpError`** exposes daemon **`code`**; session_start treats **503 + `not_ready`** as **Remnic starting** (reachable, breaker open), not offline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55eb2e06d1af9d56c48d80e9e06c850691dc2f26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->