### PR TITLE
fix(core): bound local LLM response bodies

### DIFF
--- a/packages/remnic-core/src/local-llm-headers-timeout.test.ts
+++ b/packages/remnic-core/src/local-llm-headers-timeout.test.ts
@@ -68,6 +68,11 @@ function primeClient(client: LocalLlmClient): void {
   internals.detectedType = "generic";
 }
 
+function clientIsAvailable(client: LocalLlmClient): boolean {
+  const internals = client as unknown as { isAvailable: boolean };
+  return internals.isAvailable;
+}
+
 /** Test seam: the pool is private, but its budget is what we assert on. */
 function dispatcherOf(client: LocalLlmClient): Agent {
   const seam = client as unknown as {
@@ -116,6 +121,63 @@ async function startSlowHeaderServer(delayMs: number): Promise<{
     url: `http://127.0.0.1:${port}/v1`,
     close: async () => {
       for (const timer of pending) clearTimeout(timer);
+      pending.clear();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function startTricklingBodyServer(chunkIntervalMs: number, status = 200): Promise<{
+  url: string;
+  requestBodies: string[];
+  close: () => Promise<void>;
+}> {
+  const pending = new Set<NodeJS.Timeout>();
+  const requestBodies: string[] = [];
+  const payload = JSON.stringify({
+    choices: [{ message: { content: "late completion" } }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  });
+  const chunkSize = Math.ceil(payload.length / 16);
+  const chunks = Array.from(
+    { length: 16 },
+    (_, index) => payload.slice(index * chunkSize, (index + 1) * chunkSize),
+  ).filter((chunk) => chunk.length > 0);
+  const server = http.createServer((req, res) => {
+    let requestBody = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => {
+      requestBody += chunk;
+    });
+    req.on("end", () => {
+      requestBodies.push(requestBody);
+      res.writeHead(status, { "content-type": "application/json" });
+      res.flushHeaders();
+      let index = 0;
+      const interval = setInterval(() => {
+        const chunk = chunks[index];
+        index += 1;
+        if (chunk !== undefined) res.write(chunk);
+        if (index >= chunks.length) {
+          clearInterval(interval);
+          pending.delete(interval);
+          res.end();
+        }
+      }, chunkIntervalMs);
+      pending.add(interval);
+      res.once("close", () => {
+        clearInterval(interval);
+        pending.delete(interval);
+      });
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/v1`,
+    requestBodies,
+    close: async () => {
+      for (const interval of pending) clearInterval(interval);
       pending.clear();
       await new Promise<void>((resolve) => server.close(() => resolve()));
     },
@@ -241,6 +303,138 @@ test("a completion whose headers lag the request still succeeds", async () => {
   } finally {
     await dispatcherOf(client).close();
     await server.close();
+  }
+});
+
+test("the request budget covers a trickling response body", async () => {
+  const timeoutMs = 250;
+  const server = await startTricklingBodyServer(75);
+  const client = new LocalLlmClient(
+    createConfig({ localLlmUrl: server.url, localLlmTimeoutMs: timeoutMs }),
+  );
+  try {
+    primeClient(client);
+    const startedAt = Date.now();
+    const result = await client.chatCompletion([
+      { role: "user", content: "extract facts" },
+    ]);
+    const elapsedMs = Date.now() - startedAt;
+
+    assert.equal(result, null);
+    assert.ok(
+      elapsedMs < 800,
+      `response body must abort near the ${timeoutMs}ms request budget; elapsed ${elapsedMs}ms`,
+    );
+    const requestBody: unknown = JSON.parse(server.requestBodies[0] ?? "{}");
+    assert.ok(requestBody && typeof requestBody === "object" && "stream" in requestBody);
+    assert.equal(requestBody.stream, false);
+  } finally {
+    await dispatcherOf(client).close();
+    await server.close();
+  }
+});
+
+test("caller abort during body consumption remains cancellation for an arbitrary reason", async () => {
+  const original = globalThis.fetch;
+  const caller = new AbortController();
+  let calls = 0;
+  globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+    calls += 1;
+    const signal = init?.signal;
+    assert.ok(signal);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        signal.addEventListener("abort", () => controller.error(signal.reason), { once: true });
+      },
+    });
+    queueMicrotask(() => caller.abort(new Error("caller cancelled")));
+    return new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  const client = new LocalLlmClient(createConfig({ localLlmRetry5xxCount: 2 }));
+  try {
+    primeClient(client);
+    const result = await client.chatCompletion(
+      [{ role: "user", content: "extract facts" }],
+      { signal: caller.signal },
+    );
+    assert.equal(result, null);
+    assert.equal(calls, 1);
+    assert.equal(clientIsAvailable(client), true);
+  } finally {
+    globalThis.fetch = original;
+    await dispatcherOf(client).close();
+  }
+});
+
+test("a timed-out 400 body is accounted once and enters cooldown", async () => {
+  const server = await startTricklingBodyServer(75, 400);
+  const client = new LocalLlmClient(
+    createConfig({
+      localLlmUrl: server.url,
+      localLlmTimeoutMs: 250,
+      localLlmRetry5xxCount: 2,
+      localLlm400TripThreshold: 1,
+    }),
+  );
+  try {
+    primeClient(client);
+    assert.equal(
+      await client.chatCompletion([{ role: "user", content: "extract facts" }]),
+      null,
+    );
+    assert.equal(server.requestBodies.length, 1);
+    assert.equal(
+      await client.chatCompletion([{ role: "user", content: "extract facts again" }]),
+      null,
+    );
+    assert.equal(server.requestBodies.length, 1, "cooldown must stop a second request");
+  } finally {
+    await dispatcherOf(client).close();
+    await server.close();
+  }
+});
+
+test("a truncated 503 body retains the configured retry", async () => {
+  const original = globalThis.fetch;
+  const encoder = new TextEncoder();
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    calls += 1;
+    if (calls === 1) {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode('{"error":'));
+          controller.error(new TypeError("terminated"));
+        },
+      });
+      return new Response(body, {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(
+      JSON.stringify({ choices: [{ message: { content: "retry succeeded" } }] }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof fetch;
+
+  const client = new LocalLlmClient(
+    createConfig({ localLlmRetry5xxCount: 1, localLlmRetryBackoffMs: 1 }),
+  );
+  try {
+    primeClient(client);
+    const result = await client.chatCompletion([
+      { role: "user", content: "extract facts" },
+    ]);
+    assert.equal(result?.content, "retry succeeded");
+    assert.equal(calls, 2);
+  } finally {
+    globalThis.fetch = original;
+    await dispatcherOf(client).close();
   }
 });
 

--- a/packages/remnic-core/src/local-llm.ts
+++ b/packages/remnic-core/src/local-llm.ts
@@ -962,6 +962,7 @@ export class LocalLlmClient {
         temperature: options.temperature ?? 0.7,
         // Use max_tokens consistent with cloud models
         max_tokens: options.maxTokens ?? 4096,
+        stream: false,
       };
 
       // Skip response_format for local LLMs - they don't support json_object type
@@ -1034,9 +1035,11 @@ export class LocalLlmClient {
           ? Math.min(this.config.localLlmTimeoutMs, options.timeoutMs)
           : this.config.localLlmTimeoutMs;
       const maxAttempts = 1 + Math.max(0, this.config.localLlmRetry5xxCount);
-      let response: Response | null = null;
+      let response: Response | null = null, responseBody = "";
       let lastAbortError: Error | null = null;
       for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        response = null;
+        responseBody = "";
         const attemptAbort = new AbortController();
         const onCallerAbort = (): void => {
           attemptAbort.abort(options.signal?.reason);
@@ -1059,18 +1062,28 @@ export class LocalLlmClient {
             signal: attemptAbort.signal,
             budgetMs: this.config.localLlmTimeoutMs,
           });
+          responseBody = await response.text();
         } catch (err) {
-          if (!isAbortError(err)) throw err;
-          lastAbortError = err instanceof Error ? err : new Error(String(err));
-          if (options.signal?.aborted || attempt >= maxAttempts) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          if (options.signal?.aborted) {
+            response = null;
+            lastAbortError = error;
             break;
           }
-          const backoffMs = this.config.localLlmRetryBackoffMs * attempt;
-          log.warn(
-            `local LLM request aborted: op=${operation} attempt=${attempt}/${maxAttempts} timeoutMs=${effectiveTimeoutMs} model=${this.config.localLlmModel}; retrying after ${backoffMs}ms`,
-          );
-          if (!(await waitForRetryBackoff(backoffMs, options.signal))) return null;
-          continue;
+          if (response && !response.ok) {
+            log.debug(`local LLM failed to read ${response.status} response body: ${error.message}`);
+          } else {
+            response = null;
+            if (!isAbortError(err)) throw err;
+            lastAbortError = error;
+            if (attempt >= maxAttempts) break;
+            const backoffMs = this.config.localLlmRetryBackoffMs * attempt;
+            log.warn(
+              `local LLM request aborted: op=${operation} attempt=${attempt}/${maxAttempts} timeoutMs=${effectiveTimeoutMs} model=${this.config.localLlmModel}; retrying after ${backoffMs}ms`,
+            );
+            if (!(await waitForRetryBackoff(backoffMs, options.signal))) return null;
+            continue;
+          }
         } finally {
           clearTimeout(attemptTimeout);
           options.signal?.removeEventListener("abort", onCallerAbort);
@@ -1078,20 +1091,15 @@ export class LocalLlmClient {
 
         if (response.ok) break;
         if (response.status >= 500 && attempt < maxAttempts) {
-          try {
-            const errorText = await response.clone().text();
-            const nonRecoverableReason =
-              extractNonRecoverableBackendReasonFromErrorText(errorText);
-            if (nonRecoverableReason) {
-              this.markBackendUnavailable(
-                nonRecoverableReason,
-                this.config.localLlm400CooldownMs,
-              );
-              this.consecutive400s = 0;
-              return null;
-            }
-          } catch (e) {
-            log.debug(`local LLM failed to inspect retryable error body: ${e}`);
+          const nonRecoverableReason =
+            extractNonRecoverableBackendReasonFromErrorText(responseBody);
+          if (nonRecoverableReason) {
+            this.markBackendUnavailable(
+              nonRecoverableReason,
+              this.config.localLlm400CooldownMs,
+            );
+            this.consecutive400s = 0;
+            return null;
           }
         }
         if (response.status < 500 || attempt >= maxAttempts) break;
@@ -1120,19 +1128,11 @@ export class LocalLlmClient {
 
       if (!response.ok) {
         let reason = "";
-        let errorText = "";
         try {
-          errorText = await response.text();
-          // Try to extract a stable error message without logging content.
-          try {
-            const parsed = JSON.parse(errorText) as { error?: { message?: string } };
-            reason = parsed?.error?.message ? ` — ${parsed.error.message}` : "";
-          } catch {
-            // Keep a short preview in debug only.
-            log.debug(`local LLM error body: ${errorText.slice(0, 500)}`);
-          }
-        } catch (e) {
-          log.debug(`local LLM failed to read error body: ${e}`);
+          const parsed = JSON.parse(responseBody) as { error?: { message?: string } };
+          reason = parsed?.error?.message ? ` — ${parsed.error.message}` : "";
+        } catch {
+          log.debug(`local LLM error body: ${responseBody.slice(0, 500)}`);
         }
         log.warn(
           `local LLM request failed: ${response.status} ${response.statusText}${reason} ` +
@@ -1140,7 +1140,7 @@ export class LocalLlmClient {
         );
         const nonRecoverableReason =
           extractNonRecoverableBackendReason(reason) ??
-          extractNonRecoverableBackendReasonFromErrorText(errorText);
+          extractNonRecoverableBackendReasonFromErrorText(responseBody);
         if (nonRecoverableReason) {
           this.markBackendUnavailable(
             nonRecoverableReason,
@@ -1166,7 +1166,7 @@ export class LocalLlmClient {
       }
       this.consecutive400s = 0;
 
-      const data = (await response.json()) as {
+      const data = JSON.parse(responseBody) as {
         choices?: Array<{
           message?: { content?: string; reasoning_content?: string };
         }>;


### PR DESCRIPTION
## Summary
- keep each local-LLM attempt timeout active through full response-body consumption
- request non-streaming completions explicitly so finite bodies match the client contract
- preserve caller cancellation, 400 cooldown accounting, and 5xx retries when body reads fail

## Root cause
The fetch timeout was cleared as soon as response headers arrived. A backend could then return HTTP 200 and trickle or stall the body indefinitely, leaving background local-LLM queue work occupied beyond `localLlmTimeoutMs`.

## Verification
- `pnpm --filter @remnic/core exec tsx --test src/local-llm-headers-timeout.test.ts` (12/12)
- `pnpm --filter @remnic/core run check-types`
- `npm run preflight:quick`

The regression suite uses a real HTTP server whose body outlives the configured budget, plus focused coverage for arbitrary caller abort reasons, timed-out 400 bodies, and truncated 503 retries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core local-LLM request lifecycle (body buffering, timeout, retries, and 400 cooldown), which can affect background queue occupancy and failure handling under slow or malformed backends.
> 
> **Overview**
> **Local LLM chat completions** now keep the attempt timeout active through full **response-body** read, not only until headers arrive—so a server that returns HTTP 200 then trickles or stalls the body can no longer hold queue work past `localLlmTimeoutMs`.
> 
> Requests explicitly set **`stream: false`** so backends return a finite JSON body that matches the non-streaming client contract. Each retry attempt reads the body once via **`response.text()`** and reuses that buffer for error parsing, 5xx retry decisions, and success **`JSON.parse`**, instead of separate **`clone().text()`** / **`response.json()`** calls.
> 
> **Error-path behavior** is tightened: caller **`AbortSignal`** aborts during body read without treating it as a transport retry; partial reads on failed status codes are logged without discarding the response for retry logic; timed-out **400** bodies still count toward the consecutive-400 cooldown; truncated **503** bodies still allow configured **5xx** retries.
> 
> Regression tests add a trickling-body HTTP server plus cases for caller cancel, 400 cooldown after body timeout, and 503 retry after truncated body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b618be1df94ee650eaffc79c5bd7dac82d04c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved local LLM request timeout handling, including responses whose body arrives gradually.
  - Preserved caller cancellation behavior during response processing.
  - Prevented timed-out error responses from triggering duplicate requests.
  - Improved retry behavior for interrupted service-unavailable responses.
  - Enhanced local LLM error reporting and response handling for more reliable completion results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->