### PR TITLE
Fix Docker health checks for token-store auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,6 @@ VOLUME ["/data"]
 EXPOSE 4318
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=5 \
-  CMD node -e "const headers={}; if (process.env.REMNIC_AUTH_TOKEN) headers.authorization='Bearer '+process.env.REMNIC_AUTH_TOKEN; fetch('http://127.0.0.1:4318/engram/v1/health',{headers}).then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+  CMD ["node", "packages/remnic-server/bin/remnic-server.js", "--healthcheck", "--port", "4318"]
 
 CMD ["node", "packages/remnic-server/bin/remnic-server.js", "--host", "0.0.0.0", "--port", "4318"]

--- a/packages/remnic-server/README.md
+++ b/packages/remnic-server/README.md
@@ -33,12 +33,16 @@ npx --package @remnic/server remnic-server --port 4318
 Run the container image:
 
 ```bash
+export REMNIC_AUTH_TOKEN="$(openssl rand -hex 32)"
+
 docker run --rm \
   -p 4318:4318 \
   -v remnic-data:/data \
-  -e REMNIC_AUTH_TOKEN=change-me \
+  -e REMNIC_AUTH_TOKEN \
   ghcr.io/joshuaswarren/remnic:latest
 ```
+
+Use the exported token to sign in to the admin console at `/engram/ui/` and to connect API and MCP clients. Print it with `echo "$REMNIC_AUTH_TOKEN"`.
 
 The image stores memory and runtime configuration under `/data`. The container
 enables the admin console explicitly and serves it at `/engram/ui/`. Package

--- a/packages/remnic-server/bin/server-bin.js
+++ b/packages/remnic-server/bin/server-bin.js
@@ -15,6 +15,7 @@ Options:
   --host <addr>       Bind address (default: 127.0.0.1)
   --port <number>     Port number (default: 4318)
   --auth-token <tok>  Bearer token for auth (or set REMNIC_AUTH_TOKEN)
+  --healthcheck       Probe the protected health endpoint and exit
   --help              Show this help
 
 Environment:

--- a/packages/remnic-server/src/healthcheck.test.ts
+++ b/packages/remnic-server/src/healthcheck.test.ts
@@ -294,3 +294,9 @@ test("cliMain healthcheck throws on unhealthy server so process exits non-zero",
     await rm(fixtureDir, { recursive: true, force: true });
   }
 });
+test("cliMain healthcheck rejects --host option", async () => {
+  await assert.rejects(
+    () => cliMain(["--healthcheck", "--host", "127.0.0.1"]),
+    /Option --host cannot be used with --healthcheck/,
+  );
+});

--- a/packages/remnic-server/src/healthcheck.test.ts
+++ b/packages/remnic-server/src/healthcheck.test.ts
@@ -199,13 +199,15 @@ test("healthcheck does not reuse a revoked persisted token", async () => {
   const harness = await listenForHealthRequest({ expectedToken: ORDINARY_TOKEN });
   const configPath = await writeConfig(fixtureDir, { port: harness.port });
   await writeTokenStore(fixtureDir, [{ token: ORDINARY_TOKEN, connector: "generic-mcp" }]);
-  await writeTokenStore(fixtureDir, []);
 
   try {
     await withHealthEnvironment({ HOME: fixtureDir }, async () => {
+      assert.equal(await runServerHealthcheck({ configPath }), true);
+      await writeTokenStore(fixtureDir, []);
       assert.equal(await runServerHealthcheck({ configPath }), false);
     });
-    assert.deepEqual(harness.requests, []);
+    assert.equal(harness.requests.length, 1);
+    assert.equal(harness.requests[0]?.authorization, `Bearer ${ORDINARY_TOKEN}`);
   } finally {
     await harness.close();
     await rm(fixtureDir, { recursive: true, force: true });
@@ -259,6 +261,30 @@ test("healthcheck fails boundedly on timeout and network error", async () => {
       assert.equal(await runServerHealthcheck({ configPath: networkConfig, timeoutMs: 100 }), false);
     });
   } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test("healthcheck rejects invalid timeoutMs before making a request", async () => {
+  const fixtureDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-health-"));
+  const harness = await listenForHealthRequest({ expectedToken: CONFIG_TOKEN });
+  const configPath = await writeConfig(fixtureDir, {
+    authToken: CONFIG_TOKEN,
+    port: harness.port,
+  });
+
+  try {
+    await withHealthEnvironment({ HOME: fixtureDir }, async () => {
+      for (const timeoutMs of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+        await assert.rejects(
+          () => runServerHealthcheck({ configPath, timeoutMs }),
+          /Invalid timeoutMs: expected a positive integer/,
+        );
+      }
+    });
+    assert.deepEqual(harness.requests, []);
+  } finally {
+    await harness.close();
     await rm(fixtureDir, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-server/src/healthcheck.test.ts
+++ b/packages/remnic-server/src/healthcheck.test.ts
@@ -262,3 +262,35 @@ test("healthcheck fails boundedly on timeout and network error", async () => {
     await rm(fixtureDir, { recursive: true, force: true });
   }
 });
+test("cliMain healthcheck rejects --auth-token flag to avoid secret in argv", async () => {
+  await assert.rejects(
+    () => cliMain(["--healthcheck", "--auth-token", "synthetic-token"]),
+    /Option --auth-token cannot be used with --healthcheck/,
+  );
+});
+
+test("cliMain healthcheck throws on unhealthy server so process exits non-zero", async () => {
+  const fixtureDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-health-"));
+  const closedServer = createServer();
+  await listen(closedServer);
+  const address = closedServer.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind a TCP port");
+  const closedPort = address.port;
+  await closeServer(closedServer);
+
+  const configPath = await writeConfig(fixtureDir, {
+    authToken: CONFIG_TOKEN,
+    port: closedPort,
+  });
+
+  try {
+    await withHealthEnvironment({ HOME: fixtureDir }, async () => {
+      await assert.rejects(
+        () => cliMain(["--healthcheck", "--config", configPath]),
+        /Server healthcheck failed/,
+      );
+    });
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-server/src/healthcheck.test.ts
+++ b/packages/remnic-server/src/healthcheck.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { cliMain, runServerHealthcheck } from "./index.js";
+
+const CONFIG_TOKEN = "config-health-token";
+const ENV_TOKEN = "env-health-token";
+const ORDINARY_TOKEN = "remnic_gm_test-health-token";
+const CHATGPT_TOKEN = "remnic_cg_test-health-token";
+const HEALTH_ENV_KEYS = [
+  "REMNIC_AUTH_TOKEN",
+  "ENGRAM_AUTH_TOKEN",
+  "REMNIC_PORT",
+  "ENGRAM_PORT",
+  "HOME",
+] as const;
+
+type HealthHarness = {
+  port: number;
+  requests: Array<{ authorization: string | undefined; url: string | undefined }>;
+  close: () => Promise<void>;
+};
+
+async function listenForHealthRequest(options: {
+  expectedToken: string;
+  status?: number;
+  hang?: boolean;
+}): Promise<HealthHarness> {
+  const requests: HealthHarness["requests"] = [];
+  const server = createServer((incoming, response) => {
+    requests.push({ authorization: incoming.headers.authorization, url: incoming.url });
+    if (options.hang) return;
+    const status = incoming.headers.authorization === `Bearer ${options.expectedToken}`
+      ? (options.status ?? 200)
+      : 401;
+    response.writeHead(status).end();
+  });
+  await listen(server);
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind a TCP port");
+  return {
+    port: address.port,
+    requests,
+    close: () => closeServer(server),
+  };
+}
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+    server.closeAllConnections();
+  });
+}
+
+async function writeConfig(
+  fixtureDir: string,
+  server: Record<string, unknown>,
+): Promise<string> {
+  const configPath = path.join(fixtureDir, "remnic.config.json");
+  await writeFile(configPath, JSON.stringify({ server }));
+  return configPath;
+}
+
+async function writeTokenStore(
+  homeDir: string,
+  tokens: Array<{ token: string; connector: string }>,
+): Promise<void> {
+  const storeDir = path.join(homeDir, ".remnic");
+  await mkdir(storeDir, { recursive: true });
+  await writeFile(
+    path.join(storeDir, "tokens.json"),
+    JSON.stringify({
+      tokens: tokens.map((entry) => ({
+        ...entry,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      })),
+    }),
+  );
+}
+
+async function withHealthEnvironment(
+  values: Partial<Record<(typeof HEALTH_ENV_KEYS)[number], string>>,
+  callback: () => Promise<void>,
+): Promise<void> {
+  const original = Object.fromEntries(HEALTH_ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of HEALTH_ENV_KEYS) delete process.env[key];
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined) process.env[key] = value;
+  }
+  try {
+    await callback();
+  } finally {
+    for (const key of HEALTH_ENV_KEYS) {
+      const value = original[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test("healthcheck authenticates with server.authToken from config", async () => {
+  const fixtureDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-health-"));
+  const harness = await listenForHealthRequest({ expectedToken: CONFIG_TOKEN });
+  const configPath = await writeConfig(fixtureDir, { authToken: CONFIG_TOKEN, port: harness.port });
+
+  try {
+    await withHealthEnvironment({ HOME: fixtureDir }, async () => {
+      await cliMain(["--healthcheck", "--config", configPath]);
+    });
+    assert.deepEqual(harness.requests, [{
+      url: "/engram/v1/health",
+      authorization: `Bearer ${CONFIG_TOKEN}`,
+    }]);
+  } finally {
+    await harness.close();
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test("healthcheck applies env token and port over config", async () => {
+  const fixtureDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-health-"));
+  const harness = await listenForHealthRequest({ expectedToken: ENV_TOKEN });
+  const configPath = await writeConfig(fixtureDir, { authToken: CONFIG_TOKEN, port: 1 });
+
+  try {
+    await withHealthEnvironment({
+      HOME: fixtureDir,
+      REMNIC_AUTH_TOKEN: ENV_TOKEN,
+      REMNIC_PORT: String(harness.port),
+    }, async () => {
+      assert.equal(await runServerHealthcheck({ configPath }), true);
+    });
+    assert.equal(harness.requests[0]?.authorization, `Bearer ${ENV_TOKEN}`);
+  } finally {
+    await harness.close();
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test("healthcheck uses an eligible ordinary persisted connector token", async () => {
+  const fixtureDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-health-"));
+  const harness = await listenForHealthRequest({ expectedToken: ORDINARY_TOKEN });
+  const configPath = await writeConfig(fixtureDir, {
+    authToken: "${REMNIC_AUTH_TOKEN}",
+    port: harness.port,
+  });
+  await writeTokenStore(fixtureDir, [{ token: ORDINARY_TOKEN, connector: "generic-mcp" }]);
+
+  try {
+    await withHealthEnvironment({ HOME: fixtureDir }, async () => {
+      assert.equal(await runServerHealthcheck({ configPath }), true);
+    });
+    assert.equal(harness.requests[0]?.authorization, `Bearer ${ORDINARY_TOKEN}`);
+  } finally {
+    await harness.close();
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test("healthcheck rejects missing, placeholder, and ChatGPT-only tokens without a request", async () => {
+  for (const fixture of [
+    { authToken: undefined, tokens: [] },
+    { authToken: "${REMNIC_AUTH_TOKEN}", tokens: [] },
+    { authToken: "change-me", tokens: [] },
+    { authToken: undefined, tokens: [{ token: CHATGPT_TOKEN, connector: "chatgpt" }] },
+  ]) {
+    const fixtureDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-health-"));
+    const harness = await listenForHealthRequest({ expectedToken: fixture.authToken ?? CHATGPT_TOKEN });
+    const configPath = await writeConfig(fixtureDir, {
+      port: harness.port,
+      ...(fixture.authToken === undefined ? {} : { authToken: fixture.authToken }),
+    });
+    await writeTokenStore(fixtureDir, fixture.tokens);
+    try {
+      await withHealthEnvironment({ HOME: fixtureDir }, async () => {
+        assert.equal(await runServerHealthcheck({ configPath }), false);
+      });
+      assert.deepEqual(harness.requests, []);
+    } finally {
+      await harness.close();
+      await rm(fixtureDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("healthcheck does not reuse a revoked persisted token", async () => {
+  const fixtureDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-health-"));
+  const harness = await listenForHealthRequest({ expectedToken: ORDINARY_TOKEN });
+  const configPath = await writeConfig(fixtureDir, { port: harness.port });
+  await writeTokenStore(fixtureDir, [{ token: ORDINARY_TOKEN, connector: "generic-mcp" }]);
+  await writeTokenStore(fixtureDir, []);
+
+  try {
+    await withHealthEnvironment({ HOME: fixtureDir }, async () => {
+      assert.equal(await runServerHealthcheck({ configPath }), false);
+    });
+    assert.deepEqual(harness.requests, []);
+  } finally {
+    await harness.close();
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test("healthcheck accepts only HTTP 200", async () => {
+  for (const status of [401, 503]) {
+    const fixtureDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-health-"));
+    const harness = await listenForHealthRequest({ expectedToken: CONFIG_TOKEN, status });
+    const configPath = await writeConfig(fixtureDir, { authToken: CONFIG_TOKEN, port: harness.port });
+    try {
+      await withHealthEnvironment({ HOME: fixtureDir }, async () => {
+        assert.equal(await runServerHealthcheck({ configPath }), false);
+      });
+    } finally {
+      await harness.close();
+      await rm(fixtureDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("healthcheck fails boundedly on timeout and network error", async () => {
+  const fixtureDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-health-"));
+  const hangingHarness = await listenForHealthRequest({ expectedToken: CONFIG_TOKEN, hang: true });
+  const timeoutConfig = await writeConfig(fixtureDir, {
+    authToken: CONFIG_TOKEN,
+    port: hangingHarness.port,
+  });
+
+  try {
+    await withHealthEnvironment({ HOME: fixtureDir }, async () => {
+      assert.equal(await runServerHealthcheck({ configPath: timeoutConfig, timeoutMs: 25 }), false);
+    });
+  } finally {
+    await hangingHarness.close();
+  }
+
+  const closedServer = createServer();
+  await listen(closedServer);
+  const address = closedServer.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind a TCP port");
+  const closedPort = address.port;
+  await closeServer(closedServer);
+  const networkConfig = await writeConfig(fixtureDir, {
+    authToken: CONFIG_TOKEN,
+    port: closedPort,
+  });
+  try {
+    await withHealthEnvironment({ HOME: fixtureDir }, async () => {
+      assert.equal(await runServerHealthcheck({ configPath: networkConfig, timeoutMs: 100 }), false);
+    });
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -1053,6 +1053,10 @@ export async function runServerHealthcheck(options?: {
   port?: number;
   timeoutMs?: number;
 }): Promise<boolean> {
+  const timeoutMs = options?.timeoutMs ?? HEALTHCHECK_TIMEOUT_MS;
+  if (!Number.isFinite(timeoutMs) || !Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error("Invalid timeoutMs: expected a positive integer");
+  }
   const { parsedServerConfig } = resolveEffectiveServerRuntimeConfig({
     configPath: options?.configPath,
     port: options?.port,
@@ -1060,7 +1064,6 @@ export async function runServerHealthcheck(options?: {
   const token = resolveHealthcheckToken(parsedServerConfig.authToken);
   if (!token) return false;
 
-  const timeoutMs = options?.timeoutMs ?? HEALTHCHECK_TIMEOUT_MS;
   try {
     const response = await fetch(
       `http://127.0.0.1:${parsedServerConfig.port}/engram/v1/health`,

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -1158,6 +1158,9 @@ Environment:
     if (args["auth-token"] !== undefined) {
       throw new Error("Option --auth-token cannot be used with --healthcheck; use config or REMNIC_AUTH_TOKEN");
     }
+    if (args.host !== undefined) {
+      throw new Error("Option --host cannot be used with --healthcheck; loopback probing is automatic");
+    }
     const healthy = await runServerHealthcheck({
       configPath: args.config,
       port: args.port === undefined ? undefined : parseServerPort(args.port, "--port"),

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -14,7 +14,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { parseConfig, isOpenaiApiKeyDisabled, resolveRemnicConfigRecord, Orchestrator, EngramAccessService, EngramAccessHttpServer, initLogger, log, getAllValidTokens, getAllValidTokensCached, getAllValidTokenEntriesCached, expandTildePath, type PluginConfig, type RemnicAdminControls, type RemnicAdminDashboardStatus, type RemnicAdminModelOption, type RemnicAdminConfigPatch } from "@remnic/core";
+import { parseConfig, isOpenaiApiKeyDisabled, resolveRemnicConfigRecord, Orchestrator, EngramAccessService, EngramAccessHttpServer, initLogger, log, getAllValidTokens, getAllValidTokenEntriesCached, loadTokenStore, expandTildePath, type PluginConfig, type RemnicAdminControls, type RemnicAdminDashboardStatus, type RemnicAdminModelOption, type RemnicAdminConfigPatch } from "@remnic/core";
 import { probeBetterSqlite3Driver } from "@remnic/core/runtime/better-sqlite";
 import { applyOAuthEnvOverrides, buildOAuthRequestHandler } from "./oauth.js";
 import { envOverrides, readCompatEnv } from "./server-env.js";
@@ -260,6 +260,51 @@ function loadResolvedConfig(resolved: ResolvedConfigPath): ServerConfig {
   }
 
   return loadConfigFile(resolved.path);
+}
+type ServerRuntimeOptions = {
+  configPath?: string;
+  host?: string;
+  port?: number;
+  authToken?: string;
+};
+
+type EffectiveServerRuntimeConfig = {
+  resolvedConfigPath: ResolvedConfigPath;
+  fileConfig: ServerConfig;
+  envRemnic: Record<string, unknown> | undefined;
+  serverConfig: Partial<ServerConfig["server"]>;
+  parsedServerConfig: ParsedServerConfig;
+};
+
+function resolveEffectiveServerRuntimeConfig(
+  options?: ServerRuntimeOptions,
+): EffectiveServerRuntimeConfig {
+  const resolvedConfigPath = resolveConfigPath(options?.configPath);
+  const fileConfig = loadResolvedConfig(resolvedConfigPath);
+  const { remnic: envRemnic, ...envServer } = envOverrides();
+  const cliServerConfig: Partial<ServerConfig["server"]> = {};
+  if (options?.host !== undefined) cliServerConfig.host = options.host;
+  if (options?.port !== undefined) cliServerConfig.port = parseServerPort(options.port, "options.port");
+  if (options?.authToken !== undefined) cliServerConfig.authToken = options.authToken;
+
+  const serverConfig = {
+    ...fileConfig.server,
+    ...envServer,
+    ...cliServerConfig,
+  };
+  const portSource = cliServerConfig.port !== undefined
+    ? "options.port"
+    : envServer.port !== undefined
+      ? "REMNIC_PORT/ENGRAM_PORT"
+      : "server.port";
+
+  return {
+    resolvedConfigPath,
+    fileConfig,
+    envRemnic,
+    serverConfig,
+    parsedServerConfig: parseServerConfig(serverConfig, { portSource }),
+  };
 }
 
 export function mergeRemnicConfigForServer(
@@ -731,12 +776,7 @@ export interface ServerResult {
   abortDeferredInit: () => void;
 }
 
-export async function startServer(options?: {
-  configPath?: string;
-  host?: string;
-  port?: number;
-  authToken?: string;
-}): Promise<ServerResult> {
+export async function startServer(options?: ServerRuntimeOptions): Promise<ServerResult> {
   initLogger();
 
   // Startup driver-load check (issue #1829): attempt to load the better-sqlite3
@@ -757,30 +797,14 @@ export async function startServer(options?: {
     );
   }
 
-  const resolvedConfigPath = resolveConfigPath(options?.configPath);
-  const fileConfig = loadResolvedConfig(resolvedConfigPath);
-
-  const env = envOverrides();
-  const { remnic: envRemnic, ...envServer } = env;
-
-  // Merge: file < env < cli flags
+  const {
+    resolvedConfigPath,
+    fileConfig,
+    envRemnic,
+    serverConfig,
+    parsedServerConfig,
+  } = resolveEffectiveServerRuntimeConfig(options);
   const remnicConfig = mergeRemnicConfigForServer(fileConfig.remnic, envRemnic);
-  const cliServerConfig: Partial<ServerConfig["server"]> = {};
-  if (options?.host !== undefined) cliServerConfig.host = options.host;
-  if (options?.port !== undefined) cliServerConfig.port = parseServerPort(options.port, "options.port");
-  if (options?.authToken !== undefined) cliServerConfig.authToken = options.authToken;
-
-  const serverConfig = {
-    ...fileConfig.server,
-    ...envServer,
-    ...cliServerConfig,
-  };
-  const portSource = cliServerConfig.port !== undefined
-    ? "options.port"
-    : envServer.port !== undefined
-      ? "REMNIC_PORT/ENGRAM_PORT"
-      : "server.port";
-  const parsedServerConfig = parseServerConfig(serverConfig, { portSource });
 
   const config = parseConfig(remnicConfig);
   // Re-init now that config is known. The call at the top of startServer runs
@@ -997,9 +1021,63 @@ export async function startServer(options?: {
   return { config, service, httpServer, host, port, stop, cancelStartupSync: () => startupSyncAbort.abort(), abortDeferredInit: () => orchestrator.abortDeferredInit() };
 }
 
+const HEALTHCHECK_TIMEOUT_MS = 5_000;
+const HEALTHCHECK_PLACEHOLDER_TOKENS = new Set([
+  "change-me",
+  "changeme",
+  "replace-me",
+  "replace-this-token",
+  "your-token",
+  "your-token-here",
+]);
+
+function usableHealthcheckToken(value: string | undefined): string | undefined {
+  const token = value?.trim();
+  if (!token) return undefined;
+  if (HEALTHCHECK_PLACEHOLDER_TOKENS.has(token.toLowerCase())) return undefined;
+  if (/\$\{[^}]+\}|<[^>]+>/.test(token)) return undefined;
+  return token;
+}
+
+function resolveHealthcheckToken(configuredToken: string | undefined): string | undefined {
+  const configured = usableHealthcheckToken(configuredToken);
+  if (configured) return configured;
+  const entry = loadTokenStore().tokens.find(
+    ({ connector, token }) => connector !== "chatgpt" && usableHealthcheckToken(token) !== undefined,
+  );
+  return usableHealthcheckToken(entry?.token);
+}
+
+export async function runServerHealthcheck(options?: {
+  configPath?: string;
+  port?: number;
+  timeoutMs?: number;
+}): Promise<boolean> {
+  const { parsedServerConfig } = resolveEffectiveServerRuntimeConfig({
+    configPath: options?.configPath,
+    port: options?.port,
+  });
+  const token = resolveHealthcheckToken(parsedServerConfig.authToken);
+  if (!token) return false;
+
+  const timeoutMs = options?.timeoutMs ?? HEALTHCHECK_TIMEOUT_MS;
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${parsedServerConfig.port}/engram/v1/health`,
+      {
+        headers: { authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(timeoutMs),
+      },
+    );
+    return response.status === 200;
+  } catch {
+    return false;
+  }
+}
+
 // ── CLI entry point ──────────────────────────────────────────────────────────
 
-const BOOLEAN_CLI_OPTIONS = new Set(["help"]);
+const BOOLEAN_CLI_OPTIONS = new Set(["help", "healthcheck"]);
 const VALUE_CLI_OPTIONS = new Set(["config", "host", "port", "auth-token"]);
 
 function parseCliArgs(argv: string[]): Record<string, string | undefined> {
@@ -1060,6 +1138,7 @@ Options:
   --host <addr>       Bind address (default: 127.0.0.1)
   --port <number>     Port number (default: 4318)
   --auth-token <tok>  Bearer token for auth (or set REMNIC_AUTH_TOKEN)
+  --healthcheck       Probe the protected health endpoint and exit
   --help              Show this help
 
 Environment:
@@ -1073,6 +1152,18 @@ Environment:
   OPENAI_API_KEY       OpenAI API key for extraction; ignored when config sets openaiApiKey=false
 `);
     process.exit(0);
+  }
+
+  if (args.healthcheck) {
+    if (args["auth-token"] !== undefined) {
+      throw new Error("Option --auth-token cannot be used with --healthcheck; use config or REMNIC_AUTH_TOKEN");
+    }
+    const healthy = await runServerHealthcheck({
+      configPath: args.config,
+      port: args.port === undefined ? undefined : parseServerPort(args.port, "--port"),
+    });
+    if (!healthy) throw new Error("Server healthcheck failed");
+    return;
   }
 
   const result = await startServer({


### PR DESCRIPTION
## Summary

- Replace the Docker image's inline probe with the server's `--healthcheck` mode. It reads the server config. It gets a token from the config or token store, then calls the protected loopback endpoint.
- Fail when no token can be used. Skip known sample tokens. Keep the probe on loopback. Healthcheck mode rejects `--auth-token` and `--host`, so secrets stay out of argv.
- Issue #2113 is valid only for Docker config and token-store auth. CLI status and Hermes already handled auth. This PR does not change them.

Part of #2113

## Test plan

Run `pnpm exec tsx --test packages/remnic-server/src/healthcheck.test.ts`: 10/10 passed.

Run `pnpm exec tsx --test packages/remnic-server/src/config.test.ts`: 14/14 passed.

Run `pnpm exec tsx --test tests/remnic-server-cli.test.ts`: 21/21 passed.

Run `pnpm exec tsx --test packages/remnic-cli/src/status-health-auth.test.ts`: 9/9 passed.

Run `pnpm exec tsx --test tests/integration/connectors-hermes.test.ts`: 102/102 passed.

Run `pnpm --filter @remnic/server build`. It passed typecheck, ESM, and DTS, then checked 2 bin entries.

The built-bin test hit a mock protected health endpoint and exited 0.

Run `npm run preflight:quick`. It exited 0 with `[preflight] OK (quick)`.

An OCI runtime was not available locally, so image-level health still needs verification in CI or another OCI-capable environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches container liveness and auth token resolution for probes; behavior is well-tested but misconfigured tokens could mark healthy containers unhealthy until CI/OCI verification.
> 
> **Overview**
> Fixes Docker health checks when auth comes from **config** or the **token store** rather than only `REMNIC_AUTH_TOKEN` in the environment.
> 
> The image **HEALTHCHECK** now runs `remnic-server --healthcheck --port 4318` instead of an inline `node -e fetch(...)`. The new mode resolves port and bearer token the same way as normal startup (file config, env overrides, then an eligible non-ChatGPT persisted connector token), skips placeholder/unexpanded tokens, GETs `http://127.0.0.1:<port>/engram/v1/health`, and exits non-zero on failure. **`--auth-token` and `--host` are rejected** in healthcheck mode so secrets stay out of argv.
> 
> Server startup config merging is refactored into **`resolveEffectiveServerRuntimeConfig`** shared by `startServer` and `runServerHealthcheck`. README container instructions now show generating and passing **`REMNIC_AUTH_TOKEN`** at runtime. A dedicated **`healthcheck.test.ts`** suite covers token selection, timeouts, and CLI guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91e78992ae754f18e4245b1f8dba9c749d05947c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a server healthcheck mode that probes the protected health endpoint and exits with success/failure.
  * Healthcheck supports configured authentication, environment overrides, and selecting an eligible persisted token.
  * Added a `--healthcheck` CLI option with updated help text.

* **Bug Fixes**
  * Enforced healthcheck timeouts and robust handling of missing/invalid/unusable tokens and non-200 responses.

* **Documentation**
  * Updated container instructions to generate and pass a runtime `REMNIC_AUTH_TOKEN`.

* **Tests**
  * Added a comprehensive healthcheck test suite covering CLI behavior and healthcheck edge cases.

* **Chores**
  * Simplified the container startup healthcheck command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->