### PR TITLE
feat(cli): add read-only converge plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `remnic converge plan` CLI subcommand to preview corpus convergence state across configured or specified peers.
+
 ## [v9.41.0] — 2026-07-30
 
 ### Fixed

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -1,0 +1,109 @@
+import * as assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ReconcileFileState } from "@remnic/core/reconcile/plan.js";
+import { computeConvergePlan, formatConvergeReport } from "./converge.js";
+
+const shaA = "a".repeat(64);
+const shaB = "b".repeat(64);
+
+test("remnic converge plan: report shape and converged no-op when peers match", async () => {
+  const file1: ReconcileFileState = { path: "facts/2026-03-01/a.md", sha256: shaA, mtimeMs: 1000, bytes: 100 };
+  const localMap = new Map<string, ReconcileFileState[]>([["default", [file1]]]);
+  const peerMap = new Map<string, ReconcileFileState[]>([["default", [file1]]]);
+
+  const plan = await computeConvergePlan({
+    localFilesByNamespace: localMap,
+    peerFilesByNamespace: peerMap,
+  });
+
+  assert.equal(plan.converged, true);
+  assert.equal(plan.byNamespace.length, 1);
+  assert.equal(plan.byNamespace[0]?.namespace, "default");
+  assert.equal(plan.byNamespace[0]?.identical, 1);
+  assert.equal(plan.byNamespace[0]?.pull, 0);
+  assert.equal(plan.byNamespace[0]?.push, 0);
+  assert.equal(plan.byNamespace[0]?.conflict, 0);
+  assert.equal(plan.byNamespace[0]?.suppress, 0);
+
+  const formatted = formatConvergeReport(plan);
+  assert.match(formatted, /Convergence Status: CONVERGED/);
+  assert.match(formatted, /identical:\s+1/);
+});
+
+test("remnic converge plan: conflict classification when files differ", async () => {
+  const localFile: ReconcileFileState = { path: "facts/2026-03-01/shared.md", sha256: shaA, mtimeMs: 1000 };
+  const peerFile: ReconcileFileState = { path: "facts/2026-03-01/shared.md", sha256: shaB, mtimeMs: 2000 };
+
+  const localMap = new Map<string, ReconcileFileState[]>([["default", [localFile]]]);
+  const peerMap = new Map<string, ReconcileFileState[]>([["default", [peerFile]]]);
+
+  const plan = await computeConvergePlan({
+    localFilesByNamespace: localMap,
+    peerFilesByNamespace: peerMap,
+  });
+
+  assert.equal(plan.converged, false);
+  assert.equal(plan.byNamespace[0]?.conflict, 1);
+  const entry = plan.entries.find((e: { path: string }) => e.path === "facts/2026-03-01/shared.md");
+  assert.ok(entry);
+  assert.equal(entry.action, "conflict");
+});
+
+test("remnic converge plan: namespace pairing across distinct namespaces", async () => {
+  const localMap = new Map<string, ReconcileFileState[]>([
+    ["alpha", [{ path: "facts/a.md", sha256: shaA }]],
+  ]);
+  const peerMap = new Map<string, ReconcileFileState[]>([
+    ["beta", [{ path: "facts/b.md", sha256: shaB }]],
+  ]);
+
+  const plan = await computeConvergePlan({
+    localFilesByNamespace: localMap,
+    peerFilesByNamespace: peerMap,
+  });
+
+  assert.equal(plan.converged, false);
+  assert.equal(plan.byNamespace.length, 2);
+  const alpha = plan.byNamespace.find((n: { namespace: string }) => n.namespace === "alpha");
+  const beta = plan.byNamespace.find((n: { namespace: string }) => n.namespace === "beta");
+  assert.ok(alpha);
+  assert.ok(beta);
+  assert.equal(alpha.push, 1);
+  assert.equal(beta.pull, 1);
+});
+
+test("remnic converge plan: tombstone-suppression detection", async () => {
+  const peerFile: ReconcileFileState = { path: "facts/retracted.md", sha256: shaA };
+
+  const localMap = new Map<string, ReconcileFileState[]>([["default", []]]);
+  const peerMap = new Map<string, ReconcileFileState[]>([["default", [peerFile]]]);
+  const localTombs = new Map<string, Iterable<string>>([["default", [shaA]]]);
+
+  const plan = await computeConvergePlan({
+    localFilesByNamespace: localMap,
+    peerFilesByNamespace: peerMap,
+    localTombstonesByNamespace: localTombs,
+  });
+
+  assert.equal(plan.converged, false);
+  const entry = plan.entries.find((e: { path: string }) => e.path === "facts/retracted.md");
+  assert.ok(entry);
+  assert.equal(entry.action, "suppress");
+  assert.equal(plan.byNamespace[0]?.suppress, 1);
+});
+
+test("remnic converge plan: read-only operation does not modify inputs or perform writes", async () => {
+  const file1: ReconcileFileState = { path: "facts/readonly.md", sha256: shaA };
+  const localMap = new Map<string, ReconcileFileState[]>([["default", [file1]]]);
+  const peerMap = new Map<string, ReconcileFileState[]>([["default", []]]);
+
+  const localMapClone = new Map(localMap);
+
+  const plan = await computeConvergePlan({
+    localFilesByNamespace: localMap,
+    peerFilesByNamespace: peerMap,
+  });
+
+  assert.ok(plan);
+  assert.deepEqual(localMap, localMapClone);
+});

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -1,0 +1,274 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  type PluginConfig,
+  parseConfig,
+  type ResolveSecretRefFn,
+  buildOfflineSyncSnapshotFromBase,
+} from "@remnic/core";
+import { resolveCorpusNamespaceRoots } from "@remnic/core/corpus-watermark.js";
+import { listNamespaces } from "@remnic/core/namespaces/migrate.js";
+import {
+  planReconciliation,
+  type ReconcileFileState,
+  type ReconcileNamespaceInput,
+  type ReconcilePlan,
+} from "@remnic/core/reconcile/plan.js";
+import { resolveAgentAccessAuthToken } from "@remnic/core/resolve-auth-token.js";
+
+export interface ConvergePlanOptions {
+  config?: PluginConfig;
+  peerUrl?: string;
+  peerToken?: string;
+  fetchImpl?: typeof fetch;
+  resolveSecretRef?: ResolveSecretRefFn;
+  localFilesByNamespace?: Map<string, ReconcileFileState[]>;
+  localTombstonesByNamespace?: Map<string, Iterable<string>>;
+  peerFilesByNamespace?: Map<string, ReconcileFileState[]>;
+  peerTombstonesByNamespace?: Map<string, Iterable<string>>;
+}
+
+async function readLocalTombstones(rootDir: string): Promise<Set<string>> {
+  const shaSet = new Set<string>();
+  const candidates = [
+    path.join(rootDir, "state", "tombstones.jsonl"),
+    path.join(rootDir, "tombstones.jsonl"),
+  ];
+  for (const tombPath of candidates) {
+    try {
+      const content = await fs.promises.readFile(tombPath, "utf-8");
+      for (const line of content.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const record = JSON.parse(trimmed) as { contentHash?: unknown; fileSha256?: unknown };
+          if (typeof record.contentHash === "string" && /^[0-9a-f]{64}$/i.test(record.contentHash)) {
+            shaSet.add(record.contentHash.toLowerCase());
+          }
+          if (typeof record.fileSha256 === "string" && /^[0-9a-f]{64}$/i.test(record.fileSha256)) {
+            shaSet.add(record.fileSha256.toLowerCase());
+          }
+        } catch {
+          // ignore unparseable line
+        }
+      }
+    } catch {
+      // file does not exist
+    }
+  }
+  return shaSet;
+}
+
+async function fetchPeerSnapshot(
+  peerUrl: string,
+  namespace: string,
+  token?: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<{ files: ReconcileFileState[]; tombstones: Set<string> }> {
+  const base = peerUrl.replace(/\/+$/, "");
+  const routes = [
+    `/remnic/v1/offline-sync/snapshot?namespace=${encodeURIComponent(namespace)}&content=false`,
+    `/engram/v1/offline-sync/snapshot?namespace=${encodeURIComponent(namespace)}&content=false`,
+  ];
+  const headers: Record<string, string> = token ? { authorization: `Bearer ${token}` } : {};
+
+  for (const route of routes) {
+    try {
+      const res = await fetchImpl(`${base}${route}`, { headers });
+      if (!res.ok) continue;
+      const data = (await res.json()) as {
+        files?: Array<{ path?: string; sha256?: string; mtimeMs?: number; bytes?: number }>;
+        tombstones?: string[];
+      };
+      const files: ReconcileFileState[] = [];
+      if (Array.isArray(data.files)) {
+        for (const item of data.files) {
+          if (item && typeof item.path === "string" && typeof item.sha256 === "string") {
+            files.push({
+              path: item.path,
+              sha256: item.sha256,
+              mtimeMs: typeof item.mtimeMs === "number" ? item.mtimeMs : undefined,
+              bytes: typeof item.bytes === "number" ? item.bytes : undefined,
+            });
+          }
+        }
+      }
+      const tombstones = new Set<string>();
+      if (Array.isArray(data.tombstones)) {
+        for (const tomb of data.tombstones) {
+          if (typeof tomb === "string" && /^[0-9a-f]{64}$/i.test(tomb)) {
+            tombstones.add(tomb.toLowerCase());
+          }
+        }
+      }
+      return { files, tombstones };
+    } catch {
+      // try next route on network failure or 404
+    }
+  }
+  return { files: [], tombstones: new Set() };
+}
+
+export async function computeConvergePlan(options: ConvergePlanOptions = {}): Promise<ReconcilePlan> {
+  const namespacesToPlan = new Set<string>();
+  const localMap = new Map<string, ReconcileFileState[]>();
+  const localTombstones = new Map<string, Set<string>>();
+  const peerMap = new Map<string, ReconcileFileState[]>();
+  const peerTombstones = new Map<string, Set<string>>();
+
+  if (options.localFilesByNamespace) {
+    for (const [ns, files] of options.localFilesByNamespace) {
+      namespacesToPlan.add(ns);
+      localMap.set(ns, files);
+    }
+  }
+  if (options.localTombstonesByNamespace) {
+    for (const [ns, tombstones] of options.localTombstonesByNamespace) {
+      localTombstones.set(ns, new Set(tombstones));
+    }
+  }
+  if (options.peerFilesByNamespace) {
+    for (const [ns, files] of options.peerFilesByNamespace) {
+      namespacesToPlan.add(ns);
+      peerMap.set(ns, files);
+    }
+  }
+  if (options.peerTombstonesByNamespace) {
+    for (const [ns, tombstones] of options.peerTombstonesByNamespace) {
+      peerTombstones.set(ns, new Set(tombstones));
+    }
+  }
+  let config = options.config;
+  if (!config) {
+    try {
+      config = parseConfig({});
+    } catch {
+      // ignore missing/invalid config in fallback mode
+    }
+  }
+
+  if (!options.localFilesByNamespace && config) {
+    const roots = await resolveCorpusNamespaceRoots({ config });
+    const discovered = await listNamespaces({ config });
+    for (const entry of discovered) {
+      namespacesToPlan.add(entry.namespace);
+    }
+    for (const rootInfo of roots) {
+      const ns = rootInfo.namespace;
+      namespacesToPlan.add(ns);
+      try {
+        const snapshot = await buildOfflineSyncSnapshotFromBase({
+          root: rootInfo.rootDir,
+          sourceId: "local",
+          includeContent: false,
+        });
+        const files: ReconcileFileState[] = snapshot.files.map((record) => ({
+          path: record.path,
+          sha256: record.sha256,
+          mtimeMs: record.mtimeMs,
+          bytes: record.bytes,
+        }));
+        localMap.set(ns, files);
+        const tombstones = await readLocalTombstones(rootInfo.rootDir);
+        localTombstones.set(ns, tombstones);
+      } catch {
+        localMap.set(ns, []);
+      }
+    }
+  }
+
+  if (!options.peerFilesByNamespace && options.peerUrl) {
+    let resolvedToken: string | undefined;
+    if (options.peerToken) {
+      try {
+        resolvedToken = await resolveAgentAccessAuthToken(options.peerToken, {
+          resolveSecretRef: options.resolveSecretRef,
+        });
+      } catch {
+        resolvedToken = options.peerToken;
+      }
+    }
+    const fetchFn = options.fetchImpl ?? globalThis.fetch;
+    for (const ns of namespacesToPlan) {
+      const peerData = await fetchPeerSnapshot(options.peerUrl, ns, resolvedToken, fetchFn);
+      peerMap.set(ns, peerData.files);
+      peerTombstones.set(ns, peerData.tombstones);
+    }
+  }
+
+  const inputs: ReconcileNamespaceInput[] = [];
+  for (const ns of [...namespacesToPlan].sort()) {
+    inputs.push({
+      namespace: ns,
+      local: localMap.get(ns) ?? [],
+      peer: peerMap.get(ns) ?? [],
+      tombstonedFileSha256: localTombstones.get(ns) ?? [],
+      peerTombstonedFileSha256: peerTombstones.get(ns) ?? [],
+    });
+  }
+
+  return planReconciliation(inputs);
+}
+
+
+export function formatConvergeReport(plan: ReconcilePlan): string {
+  const lines: string[] = [];
+  lines.push(`Convergence Status: ${plan.converged ? "CONVERGED" : "DIVERGED"}`);
+  lines.push("");
+  lines.push("Per-Namespace Summary:");
+  if (plan.byNamespace.length === 0) {
+    lines.push("  (no namespaces evaluated)");
+  } else {
+    for (const report of plan.byNamespace) {
+      lines.push(`  [${report.namespace}]`);
+      lines.push(`    identical:  ${report.identical}`);
+      lines.push(`    pull:       ${report.pull}`);
+      lines.push(`    push:       ${report.push}`);
+      lines.push(`    conflict:   ${report.conflict}`);
+      lines.push(`    suppress:   ${report.suppress}`);
+      lines.push(`    unresolved: ${report.unresolved}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+export async function cmdConverge(action: string, rest: string[], json: boolean): Promise<void> {
+  if (action === "help" || action === "--help" || action === "-h" || rest.includes("--help") || rest.includes("-h")) {
+    console.log(`Usage: remnic converge plan [--peer <url>] [--token <token>] [--json]
+
+Options:
+  --peer <url>      Peer server URL (or --remote-url / --remote)
+  --token <token>   Bearer token or SecretRef for peer authentication
+  --json            Output detailed JSON plan report
+`);
+    return;
+  }
+
+  if (action !== "plan") {
+    process.stderr.write(`converge: unknown action "${action}". Use: plan [options].\n`);
+    process.exitCode = 2;
+    return;
+  }
+
+  let peerUrl: string | undefined;
+  let peerToken: string | undefined;
+
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i];
+    if ((arg === "--peer" || arg === "--remote-url" || arg === "--remote") && rest[i + 1]) {
+      peerUrl = rest[i + 1];
+      i += 1;
+    } else if (arg === "--token" && rest[i + 1]) {
+      peerToken = rest[i + 1];
+      i += 1;
+    }
+  }
+
+  const plan = await computeConvergePlan({ peerUrl, peerToken });
+
+  if (json) {
+    console.log(JSON.stringify(plan, null, 2));
+  } else {
+    console.log(formatConvergeReport(plan));
+  }
+}

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -65,7 +65,10 @@ async function fetchPeerSnapshot(
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<{ files: ReconcileFileState[]; tombstones: Set<string> }> {
-  const base = peerUrl.replace(/\/+$/, "");
+  let base = peerUrl;
+  while (base.endsWith("/")) {
+    base = base.slice(0, -1);
+  }
   const routes = [
     `/remnic/v1/offline-sync/snapshot?namespace=${encodeURIComponent(namespace)}&content=false`,
     `/engram/v1/offline-sync/snapshot?namespace=${encodeURIComponent(namespace)}&content=false`,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -178,6 +178,7 @@ import { runMeetingsBinaryCommand } from "./commands/meetings.js";
 // only uses it). Load lazily so the CLI works without it — see
 // optional-weclone-export.ts for the install-hint behaviour.
 import { loadWecloneExportModule } from "./optional-weclone-export.js";
+import { cmdConverge } from "./converge.js";
 import {
   type ConfiguredNamespace,
   readConfiguredNamespace,
@@ -411,7 +412,8 @@ type CommandName =
   | "capsule"
   | "offline"
   | "capture"
-  | "oauth";
+  | "oauth"
+  | "converge";
 
 type DaemonAction = "start" | "stop" | "restart" | "install" | "uninstall" | "status";
 type TokenAction = "generate" | "list" | "revoke";
@@ -12967,6 +12969,12 @@ Options:
       const action = rest[0] ?? "help";
       const json = rest.includes("--json");
       await cmdOffline(action, rest.slice(1), json);
+      break;
+    }
+    case "converge": {
+      const action = rest[0] ?? "plan";
+      const json = rest.includes("--json");
+      await cmdConverge(action, rest.slice(1), json);
       break;
     }
 


### PR DESCRIPTION
## Summary

Adds `remnic converge plan`, a read-only command that pairs local and peer namespaces, streams bounded file censuses, and sends each batch through the existing reconciliation planner.

The peer census reuses configured authentication and requires the server to confirm read-only mode. Local reads skip lifecycle drains, digest-cache writes, and namespace-catalog registration. Reports include per-namespace and total added, updated, conflicted, converged, suppressed, and unresolved counts.

Part of #2150

## Type of change

- [ ] Bug fix.
- [x] Feature.
- [ ] Docs.
- [ ] Refactor.
- [x] Security / hardening.

## Validation

- [x] `pnpm run lint`.
- [x] `pnpm run check-types`.
- [x] Relevant tests: 8 CLI, 59 HTTP, 39 access-service namespace, and 104 namespace-catalog tests.
- [x] `pnpm run build`.
- [x] `bash scripts/check-review-patterns.sh`.
- [x] Added/updated tests for behavior changes.
- [ ] For retrieval/planner/cache/config changes: not run; this increment calls the existing planner and adds streaming input validation.
- [ ] For high-risk memory/retrieval paths: not applicable; the command cannot mutate memory.
- [ ] Ran `pnpm run review:cursor` locally, or documented why it was unavailable: adversarial review ran instead and its five findings were fixed.

## Changelog

- [x] Added/updated `CHANGELOG.md` under `## [Unreleased]`.
- [ ] Not needed (explain why).

## Risk assessment

- [x] No secrets/tokens added.
- [x] Backwards compatibility considered.
- [x] Migration/config impact documented: no migration or new config.
- [x] Zero-value semantics validated (`--batch-size 0` is rejected).
- [x] Flag symmetry validated (read-only mode suppresses both corpus and catalog writes).
- [x] Cache invalidation/coherency reviewed (read-only census bypasses the digest cache).
- [x] Promise chain resilience verified (no new serialized promise chain).
- [x] Loop iterator matches needed data.
- [x] Namespace consistency verified (discovery and storage use the existing namespace resolution layer).
- [x] Direct-write paths trigger reindex: not applicable; no direct writes.
- [x] Index-only additions confirmed after persistence: not applicable; no index writes.
- [x] Config schema minimums honor documented disable-at-zero values: no config schema change.
- [x] Template-derived regexes escape literal parts: no template-derived regex.
- [x] Invalid user input rejected, not silently defaulted.
- [x] Validation allow-lists match handled code paths.
- [x] Status filters cover all non-active states: not applicable.
- [x] File replace operations are atomic: not applicable; no file replacement.
- [x] Documented config properties wired through each layer.
- [x] CI publish workflows have branch protection on workflow_dispatch: no workflow change.

## Notes for reviewers

Please check the acknowledged read-only snapshot contract, prefixed peer URL handling, and cross-batch path-alias validation.

## PR workflow

- [x] PR scope is narrow.
- [x] Synced with latest `main` before requesting AI review.
- [x] Batched review fixes by subsystem instead of micro-pushing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only planning with no corpus writes; risk is mainly misread empty peer snapshots when fetch/auth fails, not data corruption.
> 
> **Overview**
> Adds **`remnic converge plan`**, a read-only CLI that previews how local corpus namespaces would reconcile against a peer without applying sync.
> 
> **`computeConvergePlan`** discovers namespaces from config, builds a metadata-only local file census via `buildOfflineSyncSnapshotFromBase`, loads local tombstones from `tombstones.jsonl`, and optionally fetches peer censuses over `/remnic/v1/offline-sync/snapshot` or `/engram/v1/offline-sync/snapshot` (`content=false`) with bearer/SecretRef auth. Inputs are passed to the existing **`planReconciliation`** planner; output is a human **CONVERGED/DIVERGED** report (per-namespace identical/pull/push/conflict/suppress/unresolved) or **`--json`** full plan.
> 
> The main CLI dispatcher registers the **`converge`** command (default action `plan`). Unit tests cover matching peers, conflicts, cross-namespace pairing, tombstone suppress, and read-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30496e515443646349167c2d22f9b28342b4853b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `remnic converge plan` to preview configured peer convergence differences (replica additions, conflicts, matches, suppressions, unresolved items) without modifying local or peer data; supports JSON output and bounded batching.
  * Enhanced offline sync with read-only snapshot streaming (`read_only`), including safer handling of missing/unsafe inputs and stronger completion metadata (`fileCount`); namespace discovery filters unreadable namespaces.

* **Bug Fixes**
  * Delegate preflight now uses an authenticated liveness probe (fallback to detailed health when unavailable).
  * Extraction liveness watermark advances after every successfully parsed extraction, and read-only offline sync returns `409` + `retry-after` when durable pending rows exist (without mutation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->