### PR TITLE
fix(core): measure projection lag against lifecycle ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Memory timeline fallback telemetry now measures projection lag against unique
+  lifecycle-ledger events, survives ledger compaction, and warns only when the
+  lag exceeds its event threshold while retaining projection-age context.
+
 ## [v9.38.0] — 2026-07-29
 
 ### Added

--- a/packages/remnic-core/src/maintenance/projection-support.ts
+++ b/packages/remnic-core/src/maintenance/projection-support.ts
@@ -16,8 +16,12 @@ import {
   type ProjectedEntityMentionRow,
   type ProjectedNativeKnowledgeChunkRow,
 } from "../memory-projection-store.js";
-import { memoryLifecycleEventProjectionIdentity } from "../memory-lifecycle-ledger-utils.js";
+import {
+  isFrontmatterDerivedLifecycleEventType,
+  memoryLifecycleEventProjectionIdentity,
+} from "../memory-lifecycle-ledger-utils.js";
 import type { MemoryLifecycleEvent } from "../types.js";
+import type { BetterSqlite3Database } from "../runtime/better-sqlite.js";
 
 /** Read the projection meta rebuiltAt timestamp; null when absent/unopenable. */
 export function readProjectionRebuiltAt(memoryDir: string): string | null {
@@ -48,7 +52,27 @@ export function formatProjectionAge(rebuiltAt: string | null): string {
 export interface ProjectionLifecycleLedgerHighWater {
   eventCount: number;
   sourceEventCount: number;
-  projectedEventIdentities: ReadonlySet<string>;
+}
+
+function readProjectionHighWaterFromDb(
+  db: BetterSqlite3Database,
+): ProjectionLifecycleLedgerHighWater | null {
+  const sourceRow = db.prepare(
+    "SELECT value FROM meta WHERE key = 'sourceLifecycleLedgerEventCount'",
+  ).get() as { value?: unknown } | undefined;
+  const projectedRow = db.prepare(
+    "SELECT value FROM meta WHERE key = 'projectedLifecycleLedgerEventCount'",
+  ).get() as { value?: unknown } | undefined;
+  if (
+    typeof sourceRow?.value !== "string"
+    || !/^\d+$/.test(sourceRow.value)
+    || typeof projectedRow?.value !== "string"
+    || !/^\d+$/.test(projectedRow.value)
+  ) return null;
+  const sourceEventCount = Number(sourceRow.value);
+  const eventCount = Number(projectedRow.value);
+  if (!Number.isSafeInteger(sourceEventCount) || !Number.isSafeInteger(eventCount)) return null;
+  return { eventCount, sourceEventCount };
 }
 
 export function readProjectionLifecycleLedgerHighWater(
@@ -57,45 +81,67 @@ export function readProjectionLifecycleLedgerHighWater(
   const db = openProjectionReadonly(memoryDir);
   if (!db) return null;
   try {
-    const sourceRow = db.prepare(
-      "SELECT value FROM meta WHERE key = 'sourceLifecycleLedgerEventCount'",
-    ).get() as { value?: unknown } | undefined;
-    const projectedRow = db.prepare(
-      "SELECT value FROM meta WHERE key = 'projectedLifecycleLedgerEventCount'",
-    ).get() as { value?: unknown } | undefined;
-    if (
-      typeof sourceRow?.value !== "string"
-      || !/^\d+$/.test(sourceRow.value)
-      || typeof projectedRow?.value !== "string"
-      || !/^\d+$/.test(projectedRow.value)
-    ) return null;
-    const sourceEventCount = Number(sourceRow.value);
-    const eventCount = Number(projectedRow.value);
-    if (!Number.isSafeInteger(sourceEventCount) || !Number.isSafeInteger(eventCount)) return null;
-    const eventRows = db.prepare(`
-      SELECT
-        event_id AS eventId,
-        memory_id AS memoryId,
-        event_type AS eventType,
-        timestamp
-      FROM memory_timeline
-    `).all() as Array<{
-      eventId: string;
-      memoryId: string;
-      eventType: string;
-      timestamp: string;
-    }>;
-    return {
-      eventCount,
-      sourceEventCount,
-      projectedEventIdentities: new Set(
-        eventRows.map(memoryLifecycleEventProjectionIdentity),
-      ),
-    };
+    return readProjectionHighWaterFromDb(db);
   } catch {
     return null;
   } finally {
     db.close();
+  }
+}
+
+export interface ProjectionLifecycleLedgerLagTracker {
+  highWater: ProjectionLifecycleLedgerHighWater;
+  record(event: MemoryLifecycleEvent): { unique: boolean; projected: boolean };
+  close(): void;
+}
+
+export function openProjectionLifecycleLedgerLagTracker(
+  memoryDir: string,
+): ProjectionLifecycleLedgerLagTracker | null {
+  const db = openProjectionReadonly(memoryDir);
+  if (!db) return null;
+  try {
+    const highWater = readProjectionHighWaterFromDb(db);
+    if (!highWater) {
+      db.close();
+      return null;
+    }
+    db.pragma("temp_store = FILE");
+    db.exec(`
+      CREATE TEMP TABLE projection_lag_current_identity (
+        identity TEXT PRIMARY KEY
+      ) WITHOUT ROWID;
+    `);
+    db.pragma("temp.cache_size = -1024");
+    const insertCurrent = db.prepare(
+      "INSERT OR IGNORE INTO projection_lag_current_identity(identity) VALUES (?)",
+    );
+    const findProjectedEvent = db.prepare(
+      "SELECT 1 FROM memory_timeline WHERE event_id = ? LIMIT 1",
+    );
+    const findProjectedFrontmatterEvent = db.prepare(`
+      SELECT 1
+      FROM memory_timeline
+      WHERE memory_id = ? AND event_type = ? AND timestamp = ?
+      LIMIT 1
+    `);
+    return {
+      highWater,
+      record(event) {
+        if (!event.memoryId.trim()) return { unique: false, projected: false };
+        const identity = memoryLifecycleEventProjectionIdentity(event);
+        const inserted = insertCurrent.run(identity);
+        if (inserted.changes === 0) return { unique: false, projected: false };
+        const projected = isFrontmatterDerivedLifecycleEventType(event.eventType)
+          ? findProjectedFrontmatterEvent.get(event.memoryId, event.eventType, event.timestamp)
+          : findProjectedEvent.get(event.eventId);
+        return { unique: true, projected: projected !== undefined };
+      },
+      close: () => db.close(),
+    };
+  } catch {
+    db.close();
+    return null;
   }
 }
 /** Write the high-water ledger marker counts to projection meta store. */

--- a/packages/remnic-core/src/maintenance/projection-support.ts
+++ b/packages/remnic-core/src/maintenance/projection-support.ts
@@ -7,6 +7,7 @@
 
 import path from "node:path";
 import { openProjectionReadonly } from "../memory-projection-store.js";
+import { memoryLifecycleEventProjectionIdentity } from "../memory-lifecycle-ledger-utils.js";
 
 /** Read the projection meta rebuiltAt timestamp; null when absent/unopenable. */
 export function readProjectionRebuiltAt(memoryDir: string): string | null {
@@ -17,6 +18,60 @@ export function readProjectionRebuiltAt(memoryDir: string): string | null {
       | { value?: unknown }
       | undefined;
     return typeof row?.value === "string" && row.value.length > 0 ? row.value : null;
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+export interface ProjectionLifecycleLedgerHighWater {
+  eventCount: number;
+  sourceEventCount: number;
+  projectedEventIdentities: ReadonlySet<string>;
+}
+
+export function readProjectionLifecycleLedgerHighWater(
+  memoryDir: string,
+): ProjectionLifecycleLedgerHighWater | null {
+  const db = openProjectionReadonly(memoryDir);
+  if (!db) return null;
+  try {
+    const sourceRow = db.prepare(
+      "SELECT value FROM meta WHERE key = 'sourceLifecycleLedgerEventCount'",
+    ).get() as { value?: unknown } | undefined;
+    const projectedRow = db.prepare(
+      "SELECT value FROM meta WHERE key = 'projectedLifecycleLedgerEventCount'",
+    ).get() as { value?: unknown } | undefined;
+    if (
+      typeof sourceRow?.value !== "string"
+      || !/^\d+$/.test(sourceRow.value)
+      || typeof projectedRow?.value !== "string"
+      || !/^\d+$/.test(projectedRow.value)
+    ) return null;
+    const sourceEventCount = Number(sourceRow.value);
+    const eventCount = Number(projectedRow.value);
+    if (!Number.isSafeInteger(sourceEventCount) || !Number.isSafeInteger(eventCount)) return null;
+    const eventRows = db.prepare(`
+      SELECT
+        event_id AS eventId,
+        memory_id AS memoryId,
+        event_type AS eventType,
+        timestamp
+      FROM memory_timeline
+    `).all() as Array<{
+      eventId: string;
+      memoryId: string;
+      eventType: string;
+      timestamp: string;
+    }>;
+    return {
+      eventCount,
+      sourceEventCount,
+      projectedEventIdentities: new Set(
+        eventRows.map(memoryLifecycleEventProjectionIdentity),
+      ),
+    };
   } catch {
     return null;
   } finally {

--- a/packages/remnic-core/src/maintenance/projection-support.ts
+++ b/packages/remnic-core/src/maintenance/projection-support.ts
@@ -6,8 +6,18 @@
  */
 
 import path from "node:path";
-import { openProjectionReadonly } from "../memory-projection-store.js";
+import {
+  openProjectionReadonly,
+  readProjectedEntityMentions,
+  readProjectedGovernanceRecord,
+  readProjectedNativeKnowledgeChunks,
+  type MemoryProjectionGovernanceAppliedActionRow,
+  type MemoryProjectionGovernanceReviewQueueRow,
+  type ProjectedEntityMentionRow,
+  type ProjectedNativeKnowledgeChunkRow,
+} from "../memory-projection-store.js";
 import { memoryLifecycleEventProjectionIdentity } from "../memory-lifecycle-ledger-utils.js";
+import type { MemoryLifecycleEvent } from "../types.js";
 
 /** Read the projection meta rebuiltAt timestamp; null when absent/unopenable. */
 export function readProjectionRebuiltAt(memoryDir: string): string | null {
@@ -23,6 +33,16 @@ export function readProjectionRebuiltAt(memoryDir: string): string | null {
   } finally {
     db.close();
   }
+}
+
+/** Format projection age description string for fallback warning telemetry. */
+export function formatProjectionAge(rebuiltAt: string | null): string {
+  if (!rebuiltAt) return "projection never rebuilt";
+  const ageMs = Date.now() - Date.parse(rebuiltAt);
+  if (!Number.isFinite(ageMs)) return `projection rebuiltAt=${rebuiltAt}`;
+  const ageMin = Math.max(0, Math.round(ageMs / 60_000));
+  const age = ageMin >= 120 ? `${Math.round(ageMin / 60)}h` : `${ageMin}m`;
+  return `projection ${age} stale, last rebuilt ${rebuiltAt}`;
 }
 
 export interface ProjectionLifecycleLedgerHighWater {
@@ -78,6 +98,66 @@ export function readProjectionLifecycleLedgerHighWater(
     db.close();
   }
 }
+/** Write the high-water ledger marker counts to projection meta store. */
+export function writeProjectionMetaHighWater(
+  insertMeta: { run: (key: string, value: string) => void },
+  sourceLifecycleLedgerEventCount: number,
+  timelineRows: MemoryLifecycleEvent[],
+): void {
+  insertMeta.run("sourceLifecycleLedgerEventCount", String(sourceLifecycleLedgerEventCount));
+  insertMeta.run(
+    "projectedLifecycleLedgerEventCount",
+    String(new Set(timelineRows.map(memoryLifecycleEventProjectionIdentity)).size),
+  );
+}
+
+export function readProjectedEntityMentionRows(
+  memoryDir: string,
+): { projectionExists: boolean; rows: ProjectedEntityMentionRow[] } {
+  const rows = readProjectedEntityMentions(memoryDir);
+  if (rows === null) return { projectionExists: false, rows: [] };
+  return { projectionExists: true, rows };
+}
+
+export function readProjectedNativeKnowledgeRows(
+  memoryDir: string,
+): { projectionExists: boolean; rows: ProjectedNativeKnowledgeChunkRow[] } {
+  const rows = readProjectedNativeKnowledgeChunks(memoryDir);
+  if (rows === null) return { projectionExists: false, rows: [] };
+  return { projectionExists: true, rows };
+}
+
+export function readProjectedGovernanceRows(memoryDir: string): {
+  projectionExists: boolean;
+  runId: string | null;
+  summary: unknown;
+  metrics: unknown;
+  reviewQueueRows: MemoryProjectionGovernanceReviewQueueRow[];
+  appliedActionRows: MemoryProjectionGovernanceAppliedActionRow[];
+  report: string;
+} {
+  const record = readProjectedGovernanceRecord(memoryDir);
+  if (record === null) {
+    return {
+      projectionExists: false,
+      runId: null,
+      summary: undefined,
+      metrics: undefined,
+      reviewQueueRows: [],
+      appliedActionRows: [],
+      report: "",
+    };
+  }
+  return {
+    projectionExists: true,
+    runId: record.runId,
+    summary: record.summary,
+    metrics: record.metrics,
+    reviewQueueRows: record.reviewQueueRows,
+    appliedActionRows: record.appliedActionRows,
+    report: record.report,
+  };
+}
 
 /**
  * Assert an optionally injected storage (e.g. the daemon's live unlocked
@@ -107,5 +187,15 @@ export interface SkippedDuplicateMemory {
 }
 
 export interface SkippedBlankIdMemory {
+  path: string;
+}
+export interface SkippedDuplicateTimelineEvent {
+  eventId: string;
+  keptPath: string;
+  skippedPath: string;
+}
+
+export interface SkippedBlankIdTimelineEvent {
+  eventId: string;
   path: string;
 }

--- a/packages/remnic-core/src/maintenance/rebuild-memory-lifecycle-ledger.ts
+++ b/packages/remnic-core/src/maintenance/rebuild-memory-lifecycle-ledger.ts
@@ -11,23 +11,14 @@ import {
   buildLifecycleEventsForMemory,
   compareMemoryLifecycleEvents,
   sortMemoryLifecycleEvents,
+  isFrontmatterDerivedLifecycleEventType,
+  memoryLifecycleEventProjectionIdentity,
   memoryLifecycleLedgerLockPath,
   MEMORY_LIFECYCLE_LEDGER_LOCK_STALE_MS,
 } from "../memory-lifecycle-ledger-utils.js";
 import { withHeldFileLock, type HeldFileLockOptions, type HeldFileLockController } from "../utils/serialize-mutations.js";
 import { probeEncryptedRegularFileHeader } from "../secure-store/secure-fs.js";
 
-/**
- * Event types `buildLifecycleEventsForMemory` reconstructs from frontmatter.
- * Everything else in the ledger is append-only history with no frontmatter
- * equivalent and must be carried over by a preserving rebuild (issue #1910).
- */
-const FRONTMATTER_DERIVED_EVENT_TYPES: Record<string, true> = {
-  created: true,
-  updated: true,
-  superseded: true,
-  archived: true,
-};
 
 export interface RebuildMemoryLifecycleLedgerOptions {
   memoryDir: string;
@@ -322,17 +313,15 @@ export async function rebuildMemoryLifecycleLedger(
       // retried append of the same logical event still collapses to one. Rows
       // that are not frontmatter-derived are append-only history with no
       // reconstruction — always carried over, deduped by eventId in the merge.
-      const contentKey = (event: MemoryLifecycleEvent): string =>
-        `${event.memoryId}\u0000${event.eventType}\u0000${event.timestamp}`;
-      const reconstructedKeys = new Set(events.map(contentKey));
+      const reconstructedKeys = new Set(events.map(memoryLifecycleEventProjectionIdentity));
       const racedFrontmatterByKey = new Map<string, MemoryLifecycleEvent>();
       const appendOnly: MemoryLifecycleEvent[] = [];
       for (const event of existing) {
-        if (!FRONTMATTER_DERIVED_EVENT_TYPES[event.eventType]) {
+        if (!isFrontmatterDerivedLifecycleEventType(event.eventType)) {
           appendOnly.push(event);
           continue;
         }
-        const key = contentKey(event);
+        const key = memoryLifecycleEventProjectionIdentity(event);
         if (reconstructedKeys.has(key)) continue; // collapsed into reconstruction
         if (!racedFrontmatterByKey.has(key)) racedFrontmatterByKey.set(key, event);
       }

--- a/packages/remnic-core/src/maintenance/rebuild-memory-projection.ts
+++ b/packages/remnic-core/src/maintenance/rebuild-memory-projection.ts
@@ -18,6 +18,7 @@ import {
   buildLifecycleEventsForMemory,
   inferMemoryStatus,
   MEMORY_LIFECYCLE_EVENT_SORT_ORDER,
+  memoryLifecycleEventProjectionIdentity,
   sortMemoryLifecycleEvents,
   toMemoryPathRel,
 } from "../memory-lifecycle-ledger-utils.js";
@@ -569,6 +570,7 @@ async function loadAuthoritativeProjectionSnapshot(options: {
     }
     | null;
   usedLifecycleLedger: boolean;
+  sourceLifecycleLedgerEventCount: number;
   scope: {
     updatedAfter: string | null;
     updatedBefore: string | null;
@@ -607,6 +609,9 @@ async function loadAuthoritativeProjectionSnapshot(options: {
   );
   const events = deduplicatedTimeline.events;
   const usedLifecycleLedger = timeline.usedLifecycleLedger;
+  const sourceLifecycleLedgerEventCount = new Set(
+    lifecycleEvents.map(memoryLifecycleEventProjectionIdentity),
+  ).size;
   const currentRows = projectionMemories.map((memory) => toCurrentStateRow(options.memoryDir, memory));
   const scope = normalizeProjectionScope(options);
   const scopedMemories = filterMemoriesForProjectionScope(projectionMemories, scope);
@@ -645,6 +650,7 @@ async function loadAuthoritativeProjectionSnapshot(options: {
     nativeKnowledgeRows,
     governance,
     usedLifecycleLedger,
+    sourceLifecycleLedgerEventCount,
     scope,
     skippedDuplicateMemories: selected.skippedDuplicateMemories,
     skippedBlankIdMemories: selected.skippedBlankIdMemories,
@@ -790,6 +796,7 @@ function writeProjectionDb(
   nativeKnowledgeRows: ProjectedNativeKnowledgeChunkRow[],
   governance: Awaited<ReturnType<typeof loadLatestGovernanceProjection>>,
   usedLifecycleLedger: boolean,
+  sourceLifecycleLedgerEventCount: number,
 ): void {
   const db = openBetterSqlite3(dbPath);
   const memoryDir = path.dirname(path.dirname(dbPath));
@@ -800,6 +807,11 @@ function writeProjectionDb(
     insertMeta.run("schemaVersion", String(MEMORY_PROJECTION_SCHEMA_VERSION));
     insertMeta.run("rebuiltAt", nowIso);
     insertMeta.run("usedLifecycleLedger", usedLifecycleLedger ? "true" : "false");
+    insertMeta.run("sourceLifecycleLedgerEventCount", String(sourceLifecycleLedgerEventCount));
+    insertMeta.run(
+      "projectedLifecycleLedgerEventCount",
+      String(new Set(timelineRows.map(memoryLifecycleEventProjectionIdentity)).size),
+    );
     insertMeta.run("latestGovernanceRunId", governance?.runId ?? "");
 
     const insertCurrent = db.prepare(`
@@ -1161,6 +1173,7 @@ export async function rebuildMemoryProjection(
       nextNativeKnowledgeRows,
       nextGovernance,
       snapshot.usedLifecycleLedger,
+      snapshot.sourceLifecycleLedgerEventCount,
     );
     backupPath = await backupExistingProjection(options.memoryDir, outputPath, now);
     backupPath = await commitPreparedFileAtomically(tempPath, outputPath, backupPath);

--- a/packages/remnic-core/src/maintenance/rebuild-memory-projection.ts
+++ b/packages/remnic-core/src/maintenance/rebuild-memory-projection.ts
@@ -56,20 +56,26 @@ export interface RebuildMemoryProjectionOptions {
   updatedBefore?: string;
 }
 
-export type { SkippedBlankIdMemory, SkippedDuplicateMemory } from "./projection-support.js";
-import { assertInjectedStorageRooted } from "./projection-support.js";
-import type { SkippedBlankIdMemory, SkippedDuplicateMemory } from "./projection-support.js";
+export type {
+  SkippedBlankIdMemory,
+  SkippedBlankIdTimelineEvent,
+  SkippedDuplicateMemory,
+  SkippedDuplicateTimelineEvent,
+} from "./projection-support.js";
+import {
+  assertInjectedStorageRooted,
+  readProjectedEntityMentionRows,
+  readProjectedGovernanceRows,
+  readProjectedNativeKnowledgeRows,
+  writeProjectionMetaHighWater,
+} from "./projection-support.js";
+import type {
+  SkippedBlankIdMemory,
+  SkippedBlankIdTimelineEvent,
+  SkippedDuplicateMemory,
+  SkippedDuplicateTimelineEvent,
+} from "./projection-support.js";
 
-export interface SkippedDuplicateTimelineEvent {
-  eventId: string;
-  keptPath: string;
-  skippedPath: string;
-}
-
-export interface SkippedBlankIdTimelineEvent {
-  eventId: string;
-  path: string;
-}
 
 export interface RebuildMemoryProjectionResult {
   dryRun: boolean;
@@ -739,53 +745,6 @@ function readProjectedTimelineRows(
   }
 }
 
-function readProjectedEntityMentionRows(
-  memoryDir: string,
-): { projectionExists: boolean; rows: ProjectedEntityMentionRow[] } {
-  const rows = readProjectedEntityMentions(memoryDir);
-  if (rows === null) return { projectionExists: false, rows: [] };
-  return { projectionExists: true, rows };
-}
-
-function readProjectedNativeKnowledgeRows(
-  memoryDir: string,
-): { projectionExists: boolean; rows: ProjectedNativeKnowledgeChunkRow[] } {
-  const rows = readProjectedNativeKnowledgeChunks(memoryDir);
-  if (rows === null) return { projectionExists: false, rows: [] };
-  return { projectionExists: true, rows };
-}
-
-function readProjectedGovernanceRows(memoryDir: string): {
-  projectionExists: boolean;
-  runId: string | null;
-  summary: unknown;
-  metrics: unknown;
-  reviewQueueRows: MemoryProjectionGovernanceReviewQueueRow[];
-  appliedActionRows: MemoryProjectionGovernanceAppliedActionRow[];
-  report: string;
-} {
-  const record = readProjectedGovernanceRecord(memoryDir);
-  if (record === null) {
-    return {
-      projectionExists: false,
-      runId: null,
-      summary: undefined,
-      metrics: undefined,
-      reviewQueueRows: [],
-      appliedActionRows: [],
-      report: "",
-    };
-  }
-  return {
-    projectionExists: true,
-    runId: record.runId,
-    summary: record.summary,
-    metrics: record.metrics,
-    reviewQueueRows: record.reviewQueueRows,
-    appliedActionRows: record.appliedActionRows,
-    report: record.report,
-  };
-}
 
 function writeProjectionDb(
   dbPath: string,
@@ -807,11 +766,7 @@ function writeProjectionDb(
     insertMeta.run("schemaVersion", String(MEMORY_PROJECTION_SCHEMA_VERSION));
     insertMeta.run("rebuiltAt", nowIso);
     insertMeta.run("usedLifecycleLedger", usedLifecycleLedger ? "true" : "false");
-    insertMeta.run("sourceLifecycleLedgerEventCount", String(sourceLifecycleLedgerEventCount));
-    insertMeta.run(
-      "projectedLifecycleLedgerEventCount",
-      String(new Set(timelineRows.map(memoryLifecycleEventProjectionIdentity)).size),
-    );
+    writeProjectionMetaHighWater(insertMeta, sourceLifecycleLedgerEventCount, timelineRows);
     insertMeta.run("latestGovernanceRunId", governance?.runId ?? "");
 
     const insertCurrent = db.prepare(`

--- a/packages/remnic-core/src/memory-lifecycle-ledger-utils.ts
+++ b/packages/remnic-core/src/memory-lifecycle-ledger-utils.ts
@@ -24,6 +24,27 @@ export const MEMORY_LIFECYCLE_EVENT_SORT_ORDER: Record<MemoryLifecycleEventType,
   archived: 10,
 };
 
+const FRONTMATTER_DERIVED_EVENT_TYPES: Record<string, true> = {
+  created: true,
+  updated: true,
+  superseded: true,
+  archived: true,
+};
+
+export function isFrontmatterDerivedLifecycleEventType(eventType: string): boolean {
+  return FRONTMATTER_DERIVED_EVENT_TYPES[eventType] === true;
+}
+
+export function memoryLifecycleEventProjectionIdentity(event: {
+  eventId: string;
+  memoryId: string;
+  eventType: string;
+  timestamp: string;
+}): string {
+  if (!isFrontmatterDerivedLifecycleEventType(event.eventType)) return `event\u0000${event.eventId}`;
+  return `frontmatter\u0000${event.memoryId}\u0000${event.eventType}\u0000${event.timestamp}`;
+}
+
 /**
  * Deterministic sort rank for a lifecycle event type. The ledger readers admit
  * any structurally valid row (permissive `eventType`, issue #1910), so an

--- a/packages/remnic-core/src/orchestration/maintenance.test.ts
+++ b/packages/remnic-core/src/orchestration/maintenance.test.ts
@@ -21,6 +21,7 @@ import path from "node:path";
 import { readProjectionRebuiltAt } from "../maintenance/projection-support.js";
 import { lstat, mkdir, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
 
 import { MaintenanceScheduler } from "./maintenance.js";
 import {
@@ -2949,6 +2950,35 @@ test("scheduled projection rebuild skips when the projection was rebuilt within 
       "no backup means no rebuild occurred",
     );
   } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("maintenance tool request invokes the scheduled projection rebuild wiring (#2119)", async () => {
+  const memoryDir = await seedMemoryDirWithOneFact();
+  const scheduler = new MaintenanceScheduler({
+    config: fixtureConfig({
+      memoryDir,
+      projectionRebuildEnabled: true,
+      projectionRebuildIntervalMs: 6 * 60 * 60 * 1000,
+    }),
+    getQmd: () => ({ isAvailable: () => false }) as unknown as SearchBackend,
+    namespaceSearchRouter: {} as unknown as NamespaceSearchRouter,
+    namespaceCatalog: {} as unknown as NamespaceCatalog,
+  });
+  try {
+    scheduler.requestQmdMaintenanceForTool("test");
+    for (let attempt = 0; attempt < 100 && probeProjectionHealth(memoryDir).state === "absent"; attempt += 1) {
+      await delay(10);
+    }
+    assert.equal(
+      probeProjectionHealth(memoryDir).state,
+      "openable",
+      "the public maintenance request entrypoint must reach the projection rebuild",
+    );
+    assert.equal(readProjectedMemoryBrowse(memoryDir, { limit: 5, offset: 0 })?.total, 1);
+  } finally {
+    await scheduler.dispose();
     await rm(memoryDir, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/storage-guards.ts
+++ b/packages/remnic-core/src/storage-guards.ts
@@ -1,6 +1,7 @@
 import { log } from "./logger.js";
 
 const PROJECTION_FALLBACK_WARN_INTERVAL_MS = 5 * 60_000;
+export const PROJECTION_LEDGER_LAG_WARN_THRESHOLD_EVENTS = 100;
 const projectionFallbackWarnedAt = new Map<string, number>();
 
 export function assertMemoryFrontmatterId(
@@ -18,23 +19,43 @@ export function assertMemoryFrontmatterId(
   }
 }
 
+export interface ProjectionLedgerLagTelemetry {
+  projectedEvents: number;
+  currentLedgerEvents: number;
+  deltaEvents: number;
+  warnThresholdEvents?: number;
+}
+
 export function warnProjectionFallback(
   memoryDir: string,
   consumer: string,
-  // Lazy so the (potentially I/O-bound) lag computation runs only when this
-  // call actually logs, not on every rate-limited-suppressed fallback (#2119).
   detail?: () => string | undefined,
+  ledgerLag?: ProjectionLedgerLagTelemetry,
 ): null {
+  const fallback = `storage.${consumer}: memory projection absent or empty; falling back to full corpus`;
+  const thresholdEvents = Math.max(
+    0,
+    Math.floor(ledgerLag?.warnThresholdEvents ?? PROJECTION_LEDGER_LAG_WARN_THRESHOLD_EVENTS),
+  );
+  const lag = ledgerLag
+    ? `projected_events=${ledgerLag.projectedEvents} current_ledger_events=${ledgerLag.currentLedgerEvents} `
+      + `delta_events=${ledgerLag.deltaEvents} threshold_events=${thresholdEvents} `
+      + "fallback_action=full-ledger-scan"
+    : undefined;
+
+  if (ledgerLag && ledgerLag.deltaEvents <= thresholdEvents) {
+    const suffix = [detail?.(), lag].filter(Boolean).join("; ");
+    log.debug(`${fallback}${suffix ? ` (${suffix})` : ""}`);
+    return null;
+  }
+
   const key = `${memoryDir}\0${consumer}`;
   const now = Date.now();
   const warnedAt = projectionFallbackWarnedAt.get(key) ?? 0;
   if (now - warnedAt >= PROJECTION_FALLBACK_WARN_INTERVAL_MS) {
     projectionFallbackWarnedAt.set(key, now);
-    const suffix = detail?.();
-    log.warn(
-      `storage.${consumer}: memory projection absent or empty; falling back to full corpus`
-      + (suffix ? ` (${suffix})` : ""),
-    );
+    const suffix = [detail?.(), lag].filter(Boolean).join("; ");
+    log.warn(`${fallback}${suffix ? ` (${suffix})` : ""}`);
   }
   return null;
 }

--- a/packages/remnic-core/src/storage-memory-lifecycle-ledger.test.ts
+++ b/packages/remnic-core/src/storage-memory-lifecycle-ledger.test.ts
@@ -1368,6 +1368,27 @@ test("getMemoryTimeline fallback emits below-threshold ledger lag telemetry with
   }
 });
 
+test("projection lag excludes blank memory ids and deduplicates identities on disk (#2119 review)", async () => {
+  const debug: string[] = [];
+  initLogger({ info() {}, warn() {}, error() {}, debug: (message) => debug.push(message) }, true);
+  __resetProjectionFallbackWarnSuppressionForTest();
+  try {
+    const projected = lifecycleEvent("projected-1", "memory-existing", "2026-01-01T00:01:00.000Z");
+    const appended = lifecycleEvent("current-1", "memory-target", "2026-01-01T00:02:00.000Z");
+    const blank = { ...lifecycleEvent("blank-1", "unused", "2026-01-01T00:03:00.000Z"), memoryId: "   " };
+    await withStaleLifecycleProjection([projected], [blank, appended, appended], async (storage) => {
+      await storage.getMemoryTimeline("memory-target", 5);
+      const telemetry = debug.find((message) => message.includes("storage.getMemoryTimeline"));
+      assert.ok(telemetry);
+      assert.match(telemetry, /current_ledger_events=2/);
+      assert.match(telemetry, /delta_events=1/);
+    });
+  } finally {
+    resetLogger();
+    __resetProjectionFallbackWarnSuppressionForTest();
+  }
+});
+
 test("getMemoryTimeline fallback WARNS above the ledger lag threshold and rate-limits repeats (#2119)", async () => {
   const warns: string[] = [];
   initLogger({ info() {}, warn: (message) => warns.push(message), error() {}, debug() {} }, false);

--- a/packages/remnic-core/src/storage-memory-lifecycle-ledger.test.ts
+++ b/packages/remnic-core/src/storage-memory-lifecycle-ledger.test.ts
@@ -1523,3 +1523,17 @@ test("scoped rebuild metadata distinguishes source-ledger high-water from projec
     assert.equal(highWater?.sourceEventCount, 2, "source high-water still records the full ledger snapshot");
   });
 });
+test("getMemoryTimeline identity probe failure falls back to ledger without rejecting (#2119 review)", async () => {
+  const projected = lifecycleEvent("projected-1", "memory-target", "2026-01-01T00:00:00.000Z");
+  const appended = lifecycleEvent("appended-1", "memory-target", "2026-01-02T00:00:00.000Z");
+  await withStaleLifecycleProjection([projected], [appended], async (storage, memoryDir) => {
+    const projectionPath = path.join(memoryDir, "state", "memory-projection.sqlite");
+    await chmod(projectionPath, 0o000).catch(() => {});
+    try {
+      const timeline = await storage.getMemoryTimeline("memory-target", 5);
+      assert.ok(timeline.length > 0, "timeline read succeeds via ledger fallback when identity probe fails");
+    } finally {
+      await chmod(projectionPath, 0o644).catch(() => {});
+    }
+  });
+});

--- a/packages/remnic-core/src/storage-memory-lifecycle-ledger.test.ts
+++ b/packages/remnic-core/src/storage-memory-lifecycle-ledger.test.ts
@@ -19,6 +19,7 @@ import {
   appendLifecycleEventsSerialized,
   drainPendingLifecycleAppendsSerialized,
   pendingLifecycleLedgerDir,
+  ProjectionLedgerLagManager,
   readAllLifecycleEventsFromLedgerBuffer,
   type LifecyclePendingIo,
 } from "./storage/memory-lifecycle-ledger-access.js";
@@ -1523,17 +1524,24 @@ test("scoped rebuild metadata distinguishes source-ledger high-water from projec
     assert.equal(highWater?.sourceEventCount, 2, "source high-water still records the full ledger snapshot");
   });
 });
-test("getMemoryTimeline identity probe failure falls back to ledger without rejecting (#2119 review)", async () => {
-  const projected = lifecycleEvent("projected-1", "memory-target", "2026-01-01T00:00:00.000Z");
-  const appended = lifecycleEvent("appended-1", "memory-target", "2026-01-02T00:00:00.000Z");
-  await withStaleLifecycleProjection([projected], [appended], async (storage, memoryDir) => {
-    const projectionPath = path.join(memoryDir, "state", "memory-projection.sqlite");
-    await chmod(projectionPath, 0o000).catch(() => {});
-    try {
-      const timeline = await storage.getMemoryTimeline("memory-target", 5);
-      assert.ok(timeline.length > 0, "timeline read succeeds via ledger fallback when identity probe fails");
-    } finally {
-      await chmod(projectionPath, 0o644).catch(() => {});
-    }
-  });
+test("timeline lag resolver keeps ledger fallback when projection identity probing fails (#2119 review)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lifecycle-probe-failure-"));
+  const ledgerPath = path.join(memoryDir, "memory-lifecycle-ledger.jsonl");
+  const event = lifecycleEvent("current-1", "memory-target", "2026-01-02T00:00:00.000Z");
+  await writeFile(path.join(memoryDir, "state"), "not a directory", "utf8");
+  await writeFile(ledgerPath, `${JSON.stringify(event)}\n`, "utf8");
+  try {
+    const manager = new ProjectionLedgerLagManager();
+    const timeline = await manager.resolveTimelineWithLag({
+      baseDir: memoryDir,
+      ledgerPath,
+      memoryId: "memory-target",
+      cappedLimit: 5,
+      readSecureFile: (filePath) => readFile(filePath, "utf8"),
+      projectionAge: () => "projection unavailable",
+    });
+    assert.deepEqual(timeline, [event]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-core/src/storage-memory-lifecycle-ledger.test.ts
+++ b/packages/remnic-core/src/storage-memory-lifecycle-ledger.test.ts
@@ -21,6 +21,7 @@ import {
   pendingLifecycleLedgerDir,
   ProjectionLedgerLagManager,
   readAllLifecycleEventsFromLedgerBuffer,
+  readBoundedLifecycleEventsWithProjectionLag,
   type LifecyclePendingIo,
 } from "./storage/memory-lifecycle-ledger-access.js";
 import { withHeldFileLock } from "./utils/serialize-mutations.js";
@@ -1562,6 +1563,32 @@ test("timeline lag resolver keeps ledger fallback when projection identity probi
       projectionAge: () => "projection unavailable",
     });
     assert.deepEqual(timeline, [event]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("lag tracker failures do not drop valid fallback timeline rows (#2119 review)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lifecycle-tracker-failure-"));
+  const ledgerPath = path.join(memoryDir, "memory-lifecycle-ledger.jsonl");
+  const event = lifecycleEvent("current-1", "memory-target", "2026-01-02T00:00:00.000Z");
+  await writeFile(ledgerPath, `${JSON.stringify(event)}\n`, "utf8");
+  try {
+    const result = await readBoundedLifecycleEventsWithProjectionLag(
+      ledgerPath,
+      (filePath) => readFile(filePath, "utf8"),
+      5,
+      "memory-target",
+      {
+        highWater: { eventCount: 0, sourceEventCount: 0 },
+        record() {
+          throw new Error("projection tracker unavailable");
+        },
+        close() {},
+      },
+    );
+    assert.deepEqual(result.events, [event]);
+    assert.equal(result.telemetryAvailable, false);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/storage-memory-lifecycle-ledger.test.ts
+++ b/packages/remnic-core/src/storage-memory-lifecycle-ledger.test.ts
@@ -5,9 +5,14 @@ import path from "node:path";
 import test from "node:test";
 import { randomUUID } from "node:crypto";
 
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { StorageManager } from "./storage.js";
 import { initLogger, resetLogger } from "./logger.js";
-import { __resetProjectionFallbackWarnSuppressionForTest } from "./storage-guards.js";
+import {
+  __resetProjectionFallbackWarnSuppressionForTest,
+  PROJECTION_LEDGER_LAG_WARN_THRESHOLD_EVENTS,
+  warnProjectionFallback,
+} from "./storage-guards.js";
 import { encryptFileBody, filePathAad, isEncryptedFile, readMaybeEncryptedFile, readMaybeEncryptedFileBuffer } from "./secure-store/secure-fs.js";
 import type { MemoryLifecycleEvent } from "./types.js";
 import {
@@ -26,6 +31,10 @@ import {
   MEMORY_LIFECYCLE_LEDGER_LOCK_STALE_MS,
   MEMORY_LIFECYCLE_LEDGER_APPEND_LOCK_MAX_WAIT_MS,
 } from "./memory-lifecycle-ledger-utils.js";
+import {
+  readProjectionLifecycleLedgerHighWater,
+} from "./maintenance/projection-support.js";
+import { rebuildMemoryProjection } from "./maintenance/rebuild-memory-projection.js";
 
 function lifecycleEvent(
   eventId: string,
@@ -52,6 +61,32 @@ async function withLifecycleLedger(
   await writeFile(ledgerPath, `${rows.join("\n")}\n`, "utf8");
   try {
     await run(new StorageManager(memoryDir), ledgerPath);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+}
+
+async function withStaleLifecycleProjection(
+  projectedRows: MemoryLifecycleEvent[],
+  appendedRows: MemoryLifecycleEvent[],
+  run: (storage: StorageManager, memoryDir: string) => Promise<void>,
+): Promise<void> {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lifecycle-projection-"));
+  const ledgerPath = path.join(memoryDir, "state", "memory-lifecycle-ledger.jsonl");
+  await mkdir(path.dirname(ledgerPath), { recursive: true });
+  await writeFile(
+    ledgerPath,
+    `${projectedRows.map((event) => JSON.stringify(event)).join("\n")}\n`,
+    "utf8",
+  );
+  await rebuildMemoryProjection({ memoryDir, dryRun: false });
+  await appendFile(
+    ledgerPath,
+    `${appendedRows.map((event) => JSON.stringify(event)).join("\n")}\n`,
+    "utf8",
+  );
+  try {
+    await run(new StorageManager(memoryDir), memoryDir);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
@@ -1302,4 +1337,189 @@ test("getMemoryTimeline fallback WARN is loud with lag and rate-limited when the
     resetLogger();
     __resetProjectionFallbackWarnSuppressionForTest();
   }
+});
+
+test("getMemoryTimeline fallback emits below-threshold ledger lag telemetry without a WARN (#2119)", async () => {
+  const warns: string[] = [];
+  const debug: string[] = [];
+  initLogger({ info() {}, warn: (message) => warns.push(message), error() {}, debug: (message) => debug.push(message) }, true);
+  __resetProjectionFallbackWarnSuppressionForTest();
+  try {
+    const projected = lifecycleEvent("projected-1", "memory-existing", "2026-01-01T00:01:00.000Z");
+    const appended = lifecycleEvent("current-1", "memory-target", "2026-01-01T00:02:00.000Z");
+    await withStaleLifecycleProjection([projected], [appended], async (storage, memoryDir) => {
+      const highWater = readProjectionLifecycleLedgerHighWater(memoryDir);
+      assert.equal(highWater?.eventCount, 1, "rebuild persists the source-ledger event-count high-water");
+
+      const timeline = await storage.getMemoryTimeline("memory-target", 5);
+      assert.deepEqual(timeline.map((event) => event.eventId), ["current-1"]);
+      assert.equal(warns.length, 0, "lag at or below the threshold must not WARN");
+      const telemetry = debug.find((message) => message.includes("storage.getMemoryTimeline"));
+      assert.ok(telemetry, "fallback emits ledger-relative lag telemetry below the WARN threshold");
+      assert.match(telemetry, /projected_events=1/);
+      assert.match(telemetry, /current_ledger_events=2/);
+      assert.match(telemetry, /delta_events=1/);
+      assert.match(telemetry, /fallback_action=full-ledger-scan/);
+    });
+  } finally {
+    resetLogger();
+    __resetProjectionFallbackWarnSuppressionForTest();
+  }
+});
+
+test("getMemoryTimeline fallback WARNS above the ledger lag threshold and rate-limits repeats (#2119)", async () => {
+  const warns: string[] = [];
+  initLogger({ info() {}, warn: (message) => warns.push(message), error() {}, debug() {} }, false);
+  __resetProjectionFallbackWarnSuppressionForTest();
+  try {
+    const projected = lifecycleEvent("projected-1", "memory-existing", "2026-01-01T00:00:00.000Z");
+    const delta = PROJECTION_LEDGER_LAG_WARN_THRESHOLD_EVENTS + 1;
+    const appended = Array.from({ length: delta }, (_, index) =>
+      lifecycleEvent(
+        `current-${index}`,
+        "memory-target",
+        `2026-01-01T00:${String(Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}.000Z`,
+      ));
+    await withStaleLifecycleProjection([projected], appended, async (storage) => {
+      const first = await storage.getMemoryTimeline("memory-target", 5);
+      const second = await storage.getMemoryTimeline("memory-target", 5);
+      assert.equal(first.length, 5);
+      assert.deepEqual(second, first);
+
+      const timelineWarns = warns.filter((message) => message.includes("storage.getMemoryTimeline"));
+      assert.equal(timelineWarns.length, 1, "two above-threshold fallbacks emit one WARN per suppression interval");
+      const warning = timelineWarns[0]!;
+      assert.match(warning, /falling back to full corpus/);
+      assert.match(warning, /projected_events=1/);
+      assert.match(warning, new RegExp(`current_ledger_events=${delta + 1}`));
+      assert.match(warning, new RegExp(`delta_events=${delta}`));
+      assert.match(warning, new RegExp(`threshold_events=${PROJECTION_LEDGER_LAG_WARN_THRESHOLD_EVENTS}`));
+      assert.match(warning, /fallback_action=full-ledger-scan/);
+      assert.match(warning, /last rebuilt/);
+    });
+  } finally {
+    resetLogger();
+    __resetProjectionFallbackWarnSuppressionForTest();
+  }
+});
+
+test("projection fallback threshold zero still WARNS for positive ledger lag (#2119)", () => {
+  const warns: string[] = [];
+  initLogger({ info() {}, warn: (message) => warns.push(message), error() {}, debug() {} }, false);
+  __resetProjectionFallbackWarnSuppressionForTest();
+  try {
+    warnProjectionFallback(
+      "memory-dir",
+      "getMemoryTimeline",
+      undefined,
+      {
+        projectedEvents: 0,
+        currentLedgerEvents: 1,
+        deltaEvents: 1,
+        warnThresholdEvents: 0,
+      },
+    );
+    assert.equal(warns.length, 1, "zero is an active threshold, not a disabled sentinel");
+    assert.match(warns[0]!, /threshold_events=0/);
+  } finally {
+    resetLogger();
+    __resetProjectionFallbackWarnSuppressionForTest();
+  }
+});
+
+test("ledger lag stays event-relative when compaction shrinks and rewrites the ledger (#2119)", async () => {
+  const warns: string[] = [];
+  initLogger({ info() {}, warn: (message) => warns.push(message), error() {}, debug() {} }, false);
+  __resetProjectionFallbackWarnSuppressionForTest();
+  try {
+    const projectedCount = PROJECTION_LEDGER_LAG_WARN_THRESHOLD_EVENTS + 50;
+    const projected = Array.from({ length: projectedCount }, (_, index) =>
+      lifecycleEvent(
+        `projected-${index}`,
+        "memory-existing",
+        `2026-01-01T${String(Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}:00.000Z`,
+      ));
+    const delta = PROJECTION_LEDGER_LAG_WARN_THRESHOLD_EVENTS + 1;
+    const appended = Array.from({ length: delta }, (_, index) =>
+      lifecycleEvent(
+        `current-${index}`,
+        "memory-target",
+        `2026-01-02T00:${String(Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}.000Z`,
+      ));
+    await withStaleLifecycleProjection(projected, [], async (storage, memoryDir) => {
+      const retained = projected.at(-1)!;
+      const compactedRows = [{
+        ...retained,
+        eventId: `rebuild-${retained.memoryId}-${retained.eventType}-${retained.timestamp}`,
+      }, ...appended];
+      await writeFile(
+        path.join(memoryDir, "state", "memory-lifecycle-ledger.jsonl"),
+        `${compactedRows.map((event) => JSON.stringify(event)).join("\n")}\n`,
+        "utf8",
+      );
+
+      const timeline = await storage.getMemoryTimeline("memory-target", 5);
+      assert.equal(timeline.length, 5);
+      const warning = warns.find((message) => message.includes("storage.getMemoryTimeline"));
+      assert.ok(warning);
+      assert.match(warning, new RegExp(`projected_events=${projectedCount}`));
+      assert.match(warning, new RegExp(`current_ledger_events=${delta + 1}`));
+      assert.match(warning, new RegExp(`delta_events=${delta}`));
+    });
+  } finally {
+    resetLogger();
+    __resetProjectionFallbackWarnSuppressionForTest();
+  }
+});
+
+test("concurrent cold fallbacks singleflight the full ledger lag scan (#2119)", async () => {
+  const projected = lifecycleEvent("projected-1", "memory-existing", "2026-01-01T00:00:00.000Z");
+  const appended = lifecycleEvent("current-1", "memory-target", "2026-01-02T00:00:00.000Z");
+  await withStaleLifecycleProjection([projected], [appended], async (storage, memoryDir) => {
+    const ledgerPath = path.join(memoryDir, "state", "memory-lifecycle-ledger.jsonl");
+    const key = Buffer.alloc(32, 11);
+    const plaintext = await readFile(ledgerPath, "utf8");
+    await writeFile(ledgerPath, encryptFileBody(plaintext, key, filePathAad(ledgerPath, memoryDir)));
+    storage.setSecureStoreKey(key);
+
+    const secureStorage = storage as unknown as {
+      readStorageSecureFile(filePath: string): Promise<string>;
+    };
+    const originalRead = secureStorage.readStorageSecureFile.bind(storage);
+    const readRelease = Promise.withResolvers<void>();
+    const readStart = Promise.withResolvers<void>();
+    let secureReads = 0;
+    secureStorage.readStorageSecureFile = async (filePath) => {
+      secureReads += 1;
+      readStart.resolve();
+      await readRelease.promise;
+      return originalRead(filePath);
+    };
+
+    const first = storage.getMemoryTimeline("memory-target", 5);
+    await readStart.promise;
+    const second = storage.getMemoryTimeline("memory-target", 5);
+    await yieldToEventLoop();
+    await yieldToEventLoop();
+    readRelease.resolve();
+    const timelines = await Promise.all([first, second]);
+
+    assert.deepEqual(timelines[0], timelines[1]);
+    assert.equal(secureReads, 1, "concurrent callers share the generation's full ledger scan");
+  });
+});
+
+test("scoped rebuild metadata distinguishes source-ledger high-water from projected events (#2119)", async () => {
+  const projected = lifecycleEvent("projected-1", "memory-existing", "2026-01-01T00:00:00.000Z");
+  const outsideScope = lifecycleEvent("current-1", "memory-outside-scope", "2026-01-02T00:00:00.000Z");
+  await withStaleLifecycleProjection([projected], [outsideScope], async (_storage, memoryDir) => {
+    await rebuildMemoryProjection({
+      memoryDir,
+      dryRun: false,
+      updatedAfter: "2026-01-03T00:00:00.000Z",
+    });
+    const highWater = readProjectionLifecycleLedgerHighWater(memoryDir);
+    assert.equal(highWater?.eventCount, 1, "projected count reflects the rows written by the scoped merge");
+    assert.equal(highWater?.sourceEventCount, 2, "source high-water still records the full ledger snapshot");
+  });
 });

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1,4 +1,8 @@
-import { readProjectionRebuiltAt } from "./maintenance/projection-support.js";
+import {
+  readProjectionLifecycleLedgerHighWater,
+  readProjectionRebuiltAt,
+  type ProjectionLifecycleLedgerHighWater,
+} from "./maintenance/projection-support.js";
 import {
   lstat,
   readdir,
@@ -16,7 +20,11 @@ import { createHash } from "node:crypto";
 import { normalizeContent, computeContentHash } from "./content-hash.js";
 import path from "node:path";
 import { log } from "./logger.js";
-import { assertMemoryFrontmatterId, warnProjectionFallback } from "./storage-guards.js";
+import {
+  assertMemoryFrontmatterId,
+  type ProjectionLedgerLagTelemetry,
+  warnProjectionFallback,
+} from "./storage-guards.js";
 import { MemoryReadStore } from "./storage/memory-read-store.js";
 import { renderProfileWithLastUpdated } from "./storage/profile-header.js";
 import { readMaybeEncryptedLines, readMemoryActionEventRowsFromLines } from "./storage/secure-line-reader.js";
@@ -28,6 +36,7 @@ import {
   readAllLifecycleEventsFromLedger,
   readAllLifecycleEventsFromLedgerBuffer,
   readBoundedLifecycleEventsFromLedger,
+  readBoundedLifecycleEventsWithProjectionLag,
   serializeLifecycleAppendPayload,
 } from "./storage/memory-lifecycle-ledger-access.js";
 import { selfDeps } from "./orchestration/self-deps.js";
@@ -203,6 +212,7 @@ import {
   type ProjectedMemoryBrowseOptions,
   type ProjectedMemoryBrowsePage,
   markProjectedMemoryPathInvalid,
+  getMemoryProjectionPath,
   readProjectedMemoryState,
   readProjectedMemoryBrowse,
   readProjectedGovernanceRecord,
@@ -1729,9 +1739,28 @@ export type SealedWriteExtras = Omit<
   "confidence" | "tags" | "entityRef" | "source" | "expiresAt" | "validAt" | "structuredAttributes" | "sourceConnector"
 >;
 
+interface ProjectionLedgerLagScan {
+  telemetry: ProjectionLedgerLagTelemetry;
+  events: MemoryLifecycleEvent[];
+  memoryId: string;
+  limit: number;
+}
+
 export class StorageManager extends TombstoneBlockedCaptureIndexHost {
   private knowledgeIndexCache: { result: string; builtAt: number } | null = null;
   private artifactIndexCache: { memories: MemoryFile[]; loadedAtMs: number; writeVersion: number } | null = null;
+  private projectionLedgerHighWaterCache: {
+    projectionIdentity: string;
+    highWater: ProjectionLifecycleLedgerHighWater;
+  } | null = null;
+  private projectionLedgerLagCache: {
+    generation: string;
+    telemetry: ProjectionLedgerLagTelemetry;
+  } | null = null;
+  private projectionLedgerLagInFlight: {
+    generation: string;
+    scan: Promise<ProjectionLedgerLagScan>;
+  } | null = null;
   /** Read by storage/entity-store.ts (decomposition), hence not `private`. */
   static readonly KNOWLEDGE_INDEX_CACHE_TTL_MS = 600_000; // 10 minutes (entity mutations invalidate)
   /** Read by storage/memory-read-store.ts (decomposition). */
@@ -6543,25 +6572,100 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
 
     const projected = readProjectedMemoryTimeline(this.baseDir, memoryId, cappedLimit);
     if (projected && projected.length > 0) return projected;
-    // Loud, rate-limited staleness telemetry (#2119): a fallback here means the
-    // projection is missing/empty/stale, so surface HOW stale it is. The lag is
-    // computed lazily — only when warnProjectionFallback actually logs (once per
-    // interval) — so a hot fallback path pays for a projection meta read at most
-    // once per suppression window, not per call.
-    warnProjectionFallback(this.baseDir, "getMemoryTimeline", () => {
-      const rebuiltAt = readProjectionRebuiltAt(this.baseDir);
+    const rebuiltAt = readProjectionRebuiltAt(this.baseDir);
+    const projectionAge = (): string => {
       if (!rebuiltAt) return "projection never rebuilt";
       const ageMs = Date.now() - Date.parse(rebuiltAt);
       if (!Number.isFinite(ageMs)) return `projection rebuiltAt=${rebuiltAt}`;
       const ageMin = Math.max(0, Math.round(ageMs / 60_000));
       const age = ageMin >= 120 ? `${Math.round(ageMin / 60)}h` : `${ageMin}m`;
       return `projection ${age} stale, last rebuilt ${rebuiltAt}`;
-    });
+    };
+    const [projectionIdentity, ledgerIdentity] = await Promise.all(
+      [getMemoryProjectionPath(this.baseDir), this.memoryLifecycleLedgerPath].map(async (filePath) => {
+        try {
+          const file = await lstat(filePath);
+          return `${file.dev}:${file.ino}:${file.size}:${file.mtimeMs}:${file.ctimeMs}`;
+        } catch (err) {
+          if (isErrnoCode(err, "ENOENT")) return "absent";
+          throw err;
+        }
+      }),
+    );
+    const generation = `${projectionIdentity}\0${ledgerIdentity}`;
+    const cachedLag = this.projectionLedgerLagCache?.generation === generation
+      ? this.projectionLedgerLagCache.telemetry
+      : null;
+    if (cachedLag) {
+      warnProjectionFallback(this.baseDir, "getMemoryTimeline", projectionAge, cachedLag);
+      return readBoundedLifecycleEventsFromLedger(
+        this.memoryLifecycleLedgerPath,
+        (p) => this.readStorageSecureFile(p),
+        cappedLimit,
+        memoryId,
+      );
+    }
+    const inFlight = this.projectionLedgerLagInFlight?.generation === generation
+      ? this.projectionLedgerLagInFlight.scan
+      : null;
+    if (inFlight) {
+      const result = await inFlight;
+      this.projectionLedgerLagCache = { generation, telemetry: result.telemetry };
+      warnProjectionFallback(this.baseDir, "getMemoryTimeline", projectionAge, result.telemetry);
+      if (result.memoryId === memoryId && result.limit === cappedLimit) return result.events;
+      return readBoundedLifecycleEventsFromLedger(
+        this.memoryLifecycleLedgerPath,
+        (p) => this.readStorageSecureFile(p),
+        cappedLimit,
+        memoryId,
+      );
+    }
+
+
+    let highWater = this.projectionLedgerHighWaterCache?.projectionIdentity === projectionIdentity
+      ? this.projectionLedgerHighWaterCache.highWater
+      : null;
+    if (!highWater) {
+      highWater = readProjectionLifecycleLedgerHighWater(this.baseDir);
+      if (highWater) {
+        this.projectionLedgerHighWaterCache = { projectionIdentity, highWater };
+      }
+    }
+    if (highWater) {
+      const scan = readBoundedLifecycleEventsWithProjectionLag(
+        this.memoryLifecycleLedgerPath,
+        (p) => this.readStorageSecureFile(p),
+        cappedLimit,
+        memoryId,
+        highWater.projectedEventIdentities,
+      ).then((fallback): ProjectionLedgerLagScan => ({
+        telemetry: {
+          projectedEvents: highWater.eventCount,
+          currentLedgerEvents: fallback.currentEventCount,
+          deltaEvents: fallback.deltaEvents,
+        },
+        events: fallback.events,
+        memoryId,
+        limit: cappedLimit,
+      }));
+      this.projectionLedgerLagInFlight = { generation, scan };
+      try {
+        const result = await scan;
+        this.projectionLedgerLagCache = { generation, telemetry: result.telemetry };
+        warnProjectionFallback(this.baseDir, "getMemoryTimeline", projectionAge, result.telemetry);
+        return result.events;
+      } finally {
+        if (this.projectionLedgerLagInFlight?.scan === scan) {
+          this.projectionLedgerLagInFlight = null;
+        }
+      }
+    }
+    warnProjectionFallback(this.baseDir, "getMemoryTimeline", projectionAge);
     return readBoundedLifecycleEventsFromLedger(
       this.memoryLifecycleLedgerPath,
       (p) => this.readStorageSecureFile(p),
       cappedLimit,
-      memoryId
+      memoryId,
     );
   }
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -16,11 +16,7 @@ import { createHash } from "node:crypto";
 import { normalizeContent, computeContentHash } from "./content-hash.js";
 import path from "node:path";
 import { log } from "./logger.js";
-import {
-  assertMemoryFrontmatterId,
-  type ProjectionLedgerLagTelemetry,
-  warnProjectionFallback,
-} from "./storage-guards.js";
+import { assertMemoryFrontmatterId, warnProjectionFallback } from "./storage-guards.js";
 import { MemoryReadStore } from "./storage/memory-read-store.js";
 import { renderProfileWithLastUpdated } from "./storage/profile-header.js";
 import { readMaybeEncryptedLines, readMemoryActionEventRowsFromLines } from "./storage/secure-line-reader.js";
@@ -34,7 +30,6 @@ import {
   readAllLifecycleEventsFromLedger,
   readAllLifecycleEventsFromLedgerBuffer,
   readBoundedLifecycleEventsFromLedger,
-  readBoundedLifecycleEventsWithProjectionLag,
   serializeLifecycleAppendPayload,
 } from "./storage/memory-lifecycle-ledger-access.js";
 import { selfDeps } from "./orchestration/self-deps.js";
@@ -210,7 +205,6 @@ import {
   type ProjectedMemoryBrowseOptions,
   type ProjectedMemoryBrowsePage,
   markProjectedMemoryPathInvalid,
-  getMemoryProjectionPath,
   readProjectedMemoryState,
   readProjectedMemoryBrowse,
   readProjectedGovernanceRecord,

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1,8 +1,4 @@
-import {
-  readProjectionLifecycleLedgerHighWater,
-  readProjectionRebuiltAt,
-  type ProjectionLifecycleLedgerHighWater,
-} from "./maintenance/projection-support.js";
+import { formatProjectionAge, readProjectionRebuiltAt } from "./maintenance/projection-support.js";
 import {
   lstat,
   readdir,
@@ -33,6 +29,8 @@ import {
   type DrainPendingLifecycleForSyncResult,
   drainPendingLifecycleLedgerForSync,
   drainPendingLifecycleLedgerIfAny,
+  pendingLifecycleLedgerDir,
+  ProjectionLedgerLagManager,
   readAllLifecycleEventsFromLedger,
   readAllLifecycleEventsFromLedgerBuffer,
   readBoundedLifecycleEventsFromLedger,
@@ -1739,29 +1737,10 @@ export type SealedWriteExtras = Omit<
   "confidence" | "tags" | "entityRef" | "source" | "expiresAt" | "validAt" | "structuredAttributes" | "sourceConnector"
 >;
 
-interface ProjectionLedgerLagScan {
-  telemetry: ProjectionLedgerLagTelemetry;
-  events: MemoryLifecycleEvent[];
-  memoryId: string;
-  limit: number;
-}
-
 export class StorageManager extends TombstoneBlockedCaptureIndexHost {
   private knowledgeIndexCache: { result: string; builtAt: number } | null = null;
   private artifactIndexCache: { memories: MemoryFile[]; loadedAtMs: number; writeVersion: number } | null = null;
-  private projectionLedgerHighWaterCache: {
-    projectionIdentity: string;
-    highWater: ProjectionLifecycleLedgerHighWater;
-  } | null = null;
-  private projectionLedgerLagCache: {
-    generation: string;
-    telemetry: ProjectionLedgerLagTelemetry;
-  } | null = null;
-  private projectionLedgerLagInFlight: {
-    generation: string;
-    scan: Promise<ProjectionLedgerLagScan>;
-  } | null = null;
-  /** Read by storage/entity-store.ts (decomposition), hence not `private`. */
+  private projectionLedgerLagManager = new ProjectionLedgerLagManager();
   static readonly KNOWLEDGE_INDEX_CACHE_TTL_MS = 600_000; // 10 minutes (entity mutations invalidate)
   /** Read by storage/memory-read-store.ts (decomposition). */
   static readonly ARTIFACT_INDEX_CACHE_TTL_MS = 60_000; // 1 minute
@@ -6572,101 +6551,14 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
 
     const projected = readProjectedMemoryTimeline(this.baseDir, memoryId, cappedLimit);
     if (projected && projected.length > 0) return projected;
-    const rebuiltAt = readProjectionRebuiltAt(this.baseDir);
-    const projectionAge = (): string => {
-      if (!rebuiltAt) return "projection never rebuilt";
-      const ageMs = Date.now() - Date.parse(rebuiltAt);
-      if (!Number.isFinite(ageMs)) return `projection rebuiltAt=${rebuiltAt}`;
-      const ageMin = Math.max(0, Math.round(ageMs / 60_000));
-      const age = ageMin >= 120 ? `${Math.round(ageMin / 60)}h` : `${ageMin}m`;
-      return `projection ${age} stale, last rebuilt ${rebuiltAt}`;
-    };
-    const [projectionIdentity, ledgerIdentity] = await Promise.all(
-      [getMemoryProjectionPath(this.baseDir), this.memoryLifecycleLedgerPath].map(async (filePath) => {
-        try {
-          const file = await lstat(filePath);
-          return `${file.dev}:${file.ino}:${file.size}:${file.mtimeMs}:${file.ctimeMs}`;
-        } catch (err) {
-          if (isErrnoCode(err, "ENOENT")) return "absent";
-          throw err;
-        }
-      }),
-    );
-    const generation = `${projectionIdentity}\0${ledgerIdentity}`;
-    const cachedLag = this.projectionLedgerLagCache?.generation === generation
-      ? this.projectionLedgerLagCache.telemetry
-      : null;
-    if (cachedLag) {
-      warnProjectionFallback(this.baseDir, "getMemoryTimeline", projectionAge, cachedLag);
-      return readBoundedLifecycleEventsFromLedger(
-        this.memoryLifecycleLedgerPath,
-        (p) => this.readStorageSecureFile(p),
-        cappedLimit,
-        memoryId,
-      );
-    }
-    const inFlight = this.projectionLedgerLagInFlight?.generation === generation
-      ? this.projectionLedgerLagInFlight.scan
-      : null;
-    if (inFlight) {
-      const result = await inFlight;
-      this.projectionLedgerLagCache = { generation, telemetry: result.telemetry };
-      warnProjectionFallback(this.baseDir, "getMemoryTimeline", projectionAge, result.telemetry);
-      if (result.memoryId === memoryId && result.limit === cappedLimit) return result.events;
-      return readBoundedLifecycleEventsFromLedger(
-        this.memoryLifecycleLedgerPath,
-        (p) => this.readStorageSecureFile(p),
-        cappedLimit,
-        memoryId,
-      );
-    }
-
-
-    let highWater = this.projectionLedgerHighWaterCache?.projectionIdentity === projectionIdentity
-      ? this.projectionLedgerHighWaterCache.highWater
-      : null;
-    if (!highWater) {
-      highWater = readProjectionLifecycleLedgerHighWater(this.baseDir);
-      if (highWater) {
-        this.projectionLedgerHighWaterCache = { projectionIdentity, highWater };
-      }
-    }
-    if (highWater) {
-      const scan = readBoundedLifecycleEventsWithProjectionLag(
-        this.memoryLifecycleLedgerPath,
-        (p) => this.readStorageSecureFile(p),
-        cappedLimit,
-        memoryId,
-        highWater.projectedEventIdentities,
-      ).then((fallback): ProjectionLedgerLagScan => ({
-        telemetry: {
-          projectedEvents: highWater.eventCount,
-          currentLedgerEvents: fallback.currentEventCount,
-          deltaEvents: fallback.deltaEvents,
-        },
-        events: fallback.events,
-        memoryId,
-        limit: cappedLimit,
-      }));
-      this.projectionLedgerLagInFlight = { generation, scan };
-      try {
-        const result = await scan;
-        this.projectionLedgerLagCache = { generation, telemetry: result.telemetry };
-        warnProjectionFallback(this.baseDir, "getMemoryTimeline", projectionAge, result.telemetry);
-        return result.events;
-      } finally {
-        if (this.projectionLedgerLagInFlight?.scan === scan) {
-          this.projectionLedgerLagInFlight = null;
-        }
-      }
-    }
-    warnProjectionFallback(this.baseDir, "getMemoryTimeline", projectionAge);
-    return readBoundedLifecycleEventsFromLedger(
-      this.memoryLifecycleLedgerPath,
-      (p) => this.readStorageSecureFile(p),
-      cappedLimit,
+    return this.projectionLedgerLagManager.resolveTimelineWithLag({
+      baseDir: this.baseDir,
+      ledgerPath: this.memoryLifecycleLedgerPath,
       memoryId,
-    );
+      cappedLimit,
+      readSecureFile: (p) => this.readStorageSecureFile(p),
+      projectionAge: () => formatProjectionAge(readProjectionRebuiltAt(this.baseDir)),
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/storage/memory-lifecycle-ledger-access.ts
+++ b/packages/remnic-core/src/storage/memory-lifecycle-ledger-access.ts
@@ -1,7 +1,7 @@
 import { SecureStoreLockedError } from "../secure-store/secure-fs.js";
 import { isErrnoCode } from "../utils/errno.js";
 import { displayErrorDetail } from "../runtime/better-sqlite.js";
-import { rename, stat, unlink } from "node:fs/promises";
+import { lstat, rename, stat, unlink } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type { MemoryLifecycleEvent } from "../types.js";
@@ -20,6 +20,15 @@ import {
   readMemoryLifecycleEventsFromLines,
   STATE_FILE_MAX_DECRYPT_BYTES,
 } from "./secure-line-reader.js";
+import { getMemoryProjectionPath } from "../memory-projection-store.js";
+import {
+  readProjectionLifecycleLedgerHighWater,
+  type ProjectionLifecycleLedgerHighWater,
+} from "../maintenance/projection-support.js";
+import {
+  type ProjectionLedgerLagTelemetry,
+  warnProjectionFallback,
+} from "../storage-guards.js";
 
 /** Reads a lifecycle-ledger file through the secure whole-file/plaintext line source. */
 export type LedgerSecureReader = (filePath: string) => Promise<string>;
@@ -232,6 +241,140 @@ export async function readBoundedLifecycleEventsWithProjectionLag(
     if (err instanceof SecureStoreLockedError) throw err;
     if (!isErrnoCode(err, "ENOENT")) throw err;
     return { events: [], currentEventCount: 0, deltaEvents: 0 };
+  }
+}
+/**
+ * Probe filesystem identity stamps (dev:ino:size:mtimeMs:ctimeMs) for the
+ * projection database and lifecycle-ledger file. Returns `null` when either
+ * file is missing or unstatable so caller can disable the lag cache without
+ * throwing on transient I/O or permission errors (#2119 / review).
+ */
+export async function probeProjectionLedgerIdentities(
+  projectionPath: string,
+  ledgerPath: string,
+): Promise<{ projectionIdentity: string; ledgerIdentity: string } | null> {
+  try {
+    const [projectionIdentity, ledgerIdentity] = await Promise.all(
+      [projectionPath, ledgerPath].map(async (filePath) => {
+        try {
+          const file = await lstat(filePath);
+          return `${file.dev}:${file.ino}:${file.size}:${file.mtimeMs}:${file.ctimeMs}`;
+        } catch (err) {
+          if (isErrnoCode(err, "ENOENT")) return "absent";
+          // Probe failure: disable lag cache, do not block the primary timeline read (#2119 review).
+          return null;
+        }
+      }),
+    );
+    if (!projectionIdentity || !ledgerIdentity) return null;
+    return { projectionIdentity, ledgerIdentity };
+  } catch {
+    return null;
+  }
+}
+
+export interface ProjectionLedgerLagScan {
+  telemetry: ProjectionLedgerLagTelemetry;
+  events: MemoryLifecycleEvent[];
+  memoryId: string;
+  limit: number;
+}
+
+export class ProjectionLedgerLagManager {
+  private highWaterCache: {
+    projectionIdentity: string;
+    highWater: ProjectionLifecycleLedgerHighWater;
+  } | null = null;
+  private lagCache: {
+    generation: string;
+    telemetry: ProjectionLedgerLagTelemetry;
+  } | null = null;
+  private lagInFlight: {
+    generation: string;
+    scan: Promise<ProjectionLedgerLagScan>;
+  } | null = null;
+
+  async resolveTimelineWithLag(options: {
+    baseDir: string;
+    ledgerPath: string;
+    memoryId: string;
+    cappedLimit: number;
+    readSecureFile: LedgerSecureReader;
+    projectionAge: () => string;
+  }): Promise<MemoryLifecycleEvent[]> {
+    const { baseDir, ledgerPath, memoryId, cappedLimit, readSecureFile, projectionAge } = options;
+    const projectionPath = getMemoryProjectionPath(baseDir);
+    const identities = await probeProjectionLedgerIdentities(projectionPath, ledgerPath);
+
+    if (!identities) {
+      warnProjectionFallback(baseDir, "getMemoryTimeline", projectionAge);
+      return readBoundedLifecycleEventsFromLedger(ledgerPath, readSecureFile, cappedLimit, memoryId);
+    }
+
+    const { projectionIdentity, ledgerIdentity } = identities;
+    const generation = `${projectionIdentity}\0${ledgerIdentity}`;
+
+    const cachedLag = this.lagCache?.generation === generation
+      ? this.lagCache.telemetry
+      : null;
+    if (cachedLag) {
+      warnProjectionFallback(baseDir, "getMemoryTimeline", projectionAge, cachedLag);
+      return readBoundedLifecycleEventsFromLedger(ledgerPath, readSecureFile, cappedLimit, memoryId);
+    }
+
+    const inFlight = this.lagInFlight?.generation === generation
+      ? this.lagInFlight.scan
+      : null;
+    if (inFlight) {
+      const result = await inFlight;
+      this.lagCache = { generation, telemetry: result.telemetry };
+      warnProjectionFallback(baseDir, "getMemoryTimeline", projectionAge, result.telemetry);
+      if (result.memoryId === memoryId && result.limit === cappedLimit) return result.events;
+      return readBoundedLifecycleEventsFromLedger(ledgerPath, readSecureFile, cappedLimit, memoryId);
+    }
+
+    let highWater = this.highWaterCache?.projectionIdentity === projectionIdentity
+      ? this.highWaterCache.highWater
+      : null;
+    if (!highWater) {
+      highWater = readProjectionLifecycleLedgerHighWater(baseDir);
+      if (highWater) {
+        this.highWaterCache = { projectionIdentity, highWater };
+      }
+    }
+
+    if (highWater) {
+      const scan = readBoundedLifecycleEventsWithProjectionLag(
+        ledgerPath,
+        readSecureFile,
+        cappedLimit,
+        memoryId,
+        highWater.projectedEventIdentities,
+      ).then((fallback): ProjectionLedgerLagScan => ({
+        telemetry: {
+          projectedEvents: highWater.eventCount,
+          currentLedgerEvents: fallback.currentEventCount,
+          deltaEvents: fallback.deltaEvents,
+        },
+        events: fallback.events,
+        memoryId,
+        limit: cappedLimit,
+      }));
+      this.lagInFlight = { generation, scan };
+      try {
+        const result = await scan;
+        this.lagCache = { generation, telemetry: result.telemetry };
+        warnProjectionFallback(baseDir, "getMemoryTimeline", projectionAge, result.telemetry);
+        return result.events;
+      } finally {
+        if (this.lagInFlight?.scan === scan) {
+          this.lagInFlight = null;
+        }
+      }
+    }
+
+    warnProjectionFallback(baseDir, "getMemoryTimeline", projectionAge);
+    return readBoundedLifecycleEventsFromLedger(ledgerPath, readSecureFile, cappedLimit, memoryId);
   }
 }
 

--- a/packages/remnic-core/src/storage/memory-lifecycle-ledger-access.ts
+++ b/packages/remnic-core/src/storage/memory-lifecycle-ledger-access.ts
@@ -203,6 +203,7 @@ export interface LifecycleLedgerProjectionLagRead {
   events: MemoryLifecycleEvent[];
   currentEventCount: number;
   deltaEvents: number;
+  telemetryAvailable: boolean;
 }
 
 export async function readBoundedLifecycleEventsWithProjectionLag(
@@ -214,6 +215,7 @@ export async function readBoundedLifecycleEventsWithProjectionLag(
 ): Promise<LifecycleLedgerProjectionLagRead> {
   let currentEventCount = 0;
   let deltaEvents = 0;
+  let telemetryAvailable = true;
   try {
     const events = await readMemoryLifecycleEventsFromLines(
       readMaybeEncryptedLines(
@@ -225,17 +227,24 @@ export async function readBoundedLifecycleEventsWithProjectionLag(
       memoryId,
       compareMemoryLifecycleEvents,
       (event) => {
-        const tracked = tracker.record(event);
-        if (!tracked.unique) return;
-        currentEventCount += 1;
-        if (!tracked.projected) deltaEvents += 1;
+        if (!telemetryAvailable) return;
+        try {
+          const tracked = tracker.record(event);
+          if (!tracked.unique) return;
+          currentEventCount += 1;
+          if (!tracked.projected) deltaEvents += 1;
+        } catch {
+          telemetryAvailable = false;
+          currentEventCount = 0;
+          deltaEvents = 0;
+        }
       },
     );
-    return { events, currentEventCount, deltaEvents };
+    return { events, currentEventCount, deltaEvents, telemetryAvailable };
   } catch (err) {
     if (err instanceof SecureStoreLockedError) throw err;
     if (!isErrnoCode(err, "ENOENT")) throw err;
-    return { events: [], currentEventCount: 0, deltaEvents: 0 };
+    return { events: [], currentEventCount: 0, deltaEvents: 0, telemetryAvailable: false };
   }
 }
 /**
@@ -269,7 +278,7 @@ export async function probeProjectionLedgerIdentities(
 }
 
 export interface ProjectionLedgerLagScan {
-  telemetry: ProjectionLedgerLagTelemetry;
+  telemetry: ProjectionLedgerLagTelemetry | null;
   events: MemoryLifecycleEvent[];
   memoryId: string;
   limit: number;
@@ -318,8 +327,10 @@ export class ProjectionLedgerLagManager {
       : null;
     if (inFlight) {
       const result = await inFlight;
-      this.lagCache = { generation, telemetry: result.telemetry };
-      warnProjectionFallback(baseDir, "getMemoryTimeline", projectionAge, result.telemetry);
+      if (result.telemetry) {
+        this.lagCache = { generation, telemetry: result.telemetry };
+      }
+      warnProjectionFallback(baseDir, "getMemoryTimeline", projectionAge, result.telemetry ?? undefined);
       if (result.memoryId === memoryId && result.limit === cappedLimit) return result.events;
       return readBoundedLifecycleEventsFromLedger(ledgerPath, readSecureFile, cappedLimit, memoryId);
     }
@@ -337,24 +348,32 @@ export class ProjectionLedgerLagManager {
             tracker,
           );
           return {
-            telemetry: {
-              projectedEvents: highWater.eventCount,
-              currentLedgerEvents: fallback.currentEventCount,
-              deltaEvents: fallback.deltaEvents,
-            },
+            telemetry: fallback.telemetryAvailable
+              ? {
+                  projectedEvents: highWater.eventCount,
+                  currentLedgerEvents: fallback.currentEventCount,
+                  deltaEvents: fallback.deltaEvents,
+                }
+              : null,
             events: fallback.events,
             memoryId,
             limit: cappedLimit,
           };
         } finally {
-          tracker.close();
+          try {
+            tracker.close();
+          } catch {
+            // Lag telemetry cleanup must not replace a successful ledger fallback.
+          }
         }
       })();
       this.lagInFlight = { generation, scan };
       try {
         const result = await scan;
-        this.lagCache = { generation, telemetry: result.telemetry };
-        warnProjectionFallback(baseDir, "getMemoryTimeline", projectionAge, result.telemetry);
+        if (result.telemetry) {
+          this.lagCache = { generation, telemetry: result.telemetry };
+        }
+        warnProjectionFallback(baseDir, "getMemoryTimeline", projectionAge, result.telemetry ?? undefined);
         return result.events;
       } finally {
         if (this.lagInFlight?.scan === scan) {

--- a/packages/remnic-core/src/storage/memory-lifecycle-ledger-access.ts
+++ b/packages/remnic-core/src/storage/memory-lifecycle-ledger-access.ts
@@ -8,6 +8,7 @@ import type { MemoryLifecycleEvent } from "../types.js";
 import {
   compareMemoryLifecycleEvents,
   sortMemoryLifecycleEvents,
+  memoryLifecycleEventProjectionIdentity,
   memoryLifecycleLedgerLockPath,
   MEMORY_LIFECYCLE_LEDGER_LOCK_STALE_MS,
   MEMORY_LIFECYCLE_LEDGER_APPEND_LOCK_MAX_WAIT_MS,
@@ -187,6 +188,50 @@ export async function readBoundedLifecycleEventsFromLedger(
     if (err instanceof SecureStoreLockedError) throw err;
     if (!isErrnoCode(err, "ENOENT")) throw err;
     return [];
+  }
+}
+
+export interface LifecycleLedgerProjectionLagRead {
+  events: MemoryLifecycleEvent[];
+  currentEventCount: number;
+  deltaEvents: number;
+}
+
+export async function readBoundedLifecycleEventsWithProjectionLag(
+  ledgerPath: string,
+  readSecureFile: LedgerSecureReader,
+  limit: number,
+  memoryId: string,
+  projectedEventIdentities: ReadonlySet<string>,
+): Promise<LifecycleLedgerProjectionLagRead> {
+  const currentEventIdentities = new Set<string>();
+  let deltaEvents = 0;
+  try {
+    const events = await readMemoryLifecycleEventsFromLines(
+      readMaybeEncryptedLines(
+        ledgerPath,
+        () => readSecureFile(ledgerPath),
+        STATE_FILE_MAX_DECRYPT_BYTES,
+      ),
+      Math.max(0, Math.floor(limit)),
+      memoryId,
+      compareMemoryLifecycleEvents,
+      (event) => {
+        const identity = memoryLifecycleEventProjectionIdentity(event);
+        if (currentEventIdentities.has(identity)) return;
+        currentEventIdentities.add(identity);
+        if (!projectedEventIdentities.has(identity)) deltaEvents += 1;
+      },
+    );
+    return {
+      events,
+      currentEventCount: currentEventIdentities.size,
+      deltaEvents,
+    };
+  } catch (err) {
+    if (err instanceof SecureStoreLockedError) throw err;
+    if (!isErrnoCode(err, "ENOENT")) throw err;
+    return { events: [], currentEventCount: 0, deltaEvents: 0 };
   }
 }
 

--- a/packages/remnic-core/src/storage/memory-lifecycle-ledger-access.ts
+++ b/packages/remnic-core/src/storage/memory-lifecycle-ledger-access.ts
@@ -8,7 +8,6 @@ import type { MemoryLifecycleEvent } from "../types.js";
 import {
   compareMemoryLifecycleEvents,
   sortMemoryLifecycleEvents,
-  memoryLifecycleEventProjectionIdentity,
   memoryLifecycleLedgerLockPath,
   MEMORY_LIFECYCLE_LEDGER_LOCK_STALE_MS,
   MEMORY_LIFECYCLE_LEDGER_APPEND_LOCK_MAX_WAIT_MS,
@@ -22,8 +21,8 @@ import {
 } from "./secure-line-reader.js";
 import { getMemoryProjectionPath } from "../memory-projection-store.js";
 import {
-  readProjectionLifecycleLedgerHighWater,
-  type ProjectionLifecycleLedgerHighWater,
+  openProjectionLifecycleLedgerLagTracker,
+  type ProjectionLifecycleLedgerLagTracker,
 } from "../maintenance/projection-support.js";
 import {
   type ProjectionLedgerLagTelemetry,
@@ -211,9 +210,9 @@ export async function readBoundedLifecycleEventsWithProjectionLag(
   readSecureFile: LedgerSecureReader,
   limit: number,
   memoryId: string,
-  projectedEventIdentities: ReadonlySet<string>,
+  tracker: ProjectionLifecycleLedgerLagTracker,
 ): Promise<LifecycleLedgerProjectionLagRead> {
-  const currentEventIdentities = new Set<string>();
+  let currentEventCount = 0;
   let deltaEvents = 0;
   try {
     const events = await readMemoryLifecycleEventsFromLines(
@@ -226,17 +225,13 @@ export async function readBoundedLifecycleEventsWithProjectionLag(
       memoryId,
       compareMemoryLifecycleEvents,
       (event) => {
-        const identity = memoryLifecycleEventProjectionIdentity(event);
-        if (currentEventIdentities.has(identity)) return;
-        currentEventIdentities.add(identity);
-        if (!projectedEventIdentities.has(identity)) deltaEvents += 1;
+        const tracked = tracker.record(event);
+        if (!tracked.unique) return;
+        currentEventCount += 1;
+        if (!tracked.projected) deltaEvents += 1;
       },
     );
-    return {
-      events,
-      currentEventCount: currentEventIdentities.size,
-      deltaEvents,
-    };
+    return { events, currentEventCount, deltaEvents };
   } catch (err) {
     if (err instanceof SecureStoreLockedError) throw err;
     if (!isErrnoCode(err, "ENOENT")) throw err;
@@ -281,10 +276,6 @@ export interface ProjectionLedgerLagScan {
 }
 
 export class ProjectionLedgerLagManager {
-  private highWaterCache: {
-    projectionIdentity: string;
-    highWater: ProjectionLifecycleLedgerHighWater;
-  } | null = null;
   private lagCache: {
     generation: string;
     telemetry: ProjectionLedgerLagTelemetry;
@@ -333,33 +324,32 @@ export class ProjectionLedgerLagManager {
       return readBoundedLifecycleEventsFromLedger(ledgerPath, readSecureFile, cappedLimit, memoryId);
     }
 
-    let highWater = this.highWaterCache?.projectionIdentity === projectionIdentity
-      ? this.highWaterCache.highWater
-      : null;
-    if (!highWater) {
-      highWater = readProjectionLifecycleLedgerHighWater(baseDir);
-      if (highWater) {
-        this.highWaterCache = { projectionIdentity, highWater };
-      }
-    }
-
-    if (highWater) {
-      const scan = readBoundedLifecycleEventsWithProjectionLag(
-        ledgerPath,
-        readSecureFile,
-        cappedLimit,
-        memoryId,
-        highWater.projectedEventIdentities,
-      ).then((fallback): ProjectionLedgerLagScan => ({
-        telemetry: {
-          projectedEvents: highWater.eventCount,
-          currentLedgerEvents: fallback.currentEventCount,
-          deltaEvents: fallback.deltaEvents,
-        },
-        events: fallback.events,
-        memoryId,
-        limit: cappedLimit,
-      }));
+    const tracker = openProjectionLifecycleLedgerLagTracker(baseDir);
+    if (tracker) {
+      const highWater = tracker.highWater;
+      const scan = (async (): Promise<ProjectionLedgerLagScan> => {
+        try {
+          const fallback = await readBoundedLifecycleEventsWithProjectionLag(
+            ledgerPath,
+            readSecureFile,
+            cappedLimit,
+            memoryId,
+            tracker,
+          );
+          return {
+            telemetry: {
+              projectedEvents: highWater.eventCount,
+              currentLedgerEvents: fallback.currentEventCount,
+              deltaEvents: fallback.deltaEvents,
+            },
+            events: fallback.events,
+            memoryId,
+            limit: cappedLimit,
+          };
+        } finally {
+          tracker.close();
+        }
+      })();
       this.lagInFlight = { generation, scan };
       try {
         const result = await scan;

--- a/packages/remnic-core/src/storage/secure-line-reader.ts
+++ b/packages/remnic-core/src/storage/secure-line-reader.ts
@@ -227,6 +227,7 @@ export async function readMemoryLifecycleEventsFromLines(
   limit: number,
   memoryId?: string,
   compare?: (a: MemoryLifecycleEvent, b: MemoryLifecycleEvent) => number,
+  onEvent?: (event: MemoryLifecycleEvent) => void,
 ): Promise<MemoryLifecycleEvent[]> {
   if (limit <= 0) return [];
   const top = compare ? new BoundedLifecycleTopN(limit, compare) : null;
@@ -238,8 +239,9 @@ export async function readMemoryLifecycleEventsFromLines(
     if (!line) continue;
     try {
       const parsed = JSON.parse(line) as Partial<MemoryLifecycleEvent>;
-      if (memoryId !== undefined && parsed.memoryId !== memoryId) continue;
       if (!isValidLifecycleEventRow(parsed)) continue;
+      onEvent?.(parsed);
+      if (memoryId !== undefined && parsed.memoryId !== memoryId) continue;
       if (top) {
         top.add(parsed, seq++);
       } else if (ring.length < limit) {


### PR DESCRIPTION
## Summary

- Persist source-ledger and projected lifecycle-event high-water metadata during projection rebuilds.
- Measure timeline fallback lag by logical event identity so compaction and scoped rebuilds remain correct.
- Emit thresholded, rate-limited WARN telemetry with projection age, projected/current values, delta, and fallback action.
- Share cold full-ledger lag scans across concurrent callers, while retaining bounded per-memory reads after the generation cache is warm.
- Cover runtime maintenance entrypoint wiring, threshold boundaries, warning suppression, telemetry, compaction, scoped metadata, and concurrent fallback scans.

Closes #2119

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Security / hardening

## Validation

- [x] `npm run check-types`
- [ ] `npm test`
- [x] `npm run build`
- [x] `bash scripts/check-review-patterns.sh`
- [x] Added/updated tests for behavior changes
- [x] For retrieval/planner/cache/config changes: ran `docs/ops/pr-review-hardening-playbook.md`
- [x] For high-risk memory/retrieval paths: ran `npm run test:entity-hardening`
- [ ] Ran `npm run review:cursor` locally, or documented why it was unavailable

## Changelog

- [x] Added/updated `CHANGELOG.md` under `## [Unreleased]`
- [ ] Not needed (explain why)

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered
- [x] Migration/config impact documented (if applicable)
- [x] Zero-value semantics validated (`0` limits stay disabled, never coerced)
- [ ] Flag symmetry validated (`enabled=false` disables both write and read-path effects)
- [x] Cache invalidation/coherency reviewed (cross-instance + concurrent updates)
- [x] Promise chain resilience verified (serialized `.then()` chains recover from rejection)
- [ ] Loop iterator matches needed data (`.entries()` if key is used, not `.values()`)
- [ ] Namespace consistency verified (read/write paths use same resolution layer)
- [ ] Direct-write paths trigger reindex (bypassing extraction pipeline must update search index)
- [ ] Index-only additions confirmed after persistence (no phantom entries for rejected content)
- [ ] Config schema minimums honor documented disable-at-zero values
- [ ] Template-derived regexes escape literal parts (no match-everything patterns)
- [ ] Invalid user input rejected, not silently defaulted (CLI flags, MCP params, format values)
- [ ] Validation allow-lists match handled code paths (no accepted-but-unhandled values)
- [ ] Status filters cover ALL non-active states (superseded, archived, quarantined, rejected, pending_review)
- [x] File replace operations are atomic (write-to-temp then rename, not delete-then-write)
- [ ] Documented config properties wired end-to-end (schema → provider → client → test)
- [ ] CI publish workflows have branch protection on workflow_dispatch

## Notes for reviewers

The full workspace runner completed with 16,982 passing tests and three unrelated Codex CLI preflight failures that occur only during the shared concurrent run. The affected integration file passes 19/19 in isolation. The focused changed-path suites pass 85/85, and the high-risk hardening suite passes 322/322. Local Cursor review was unavailable; an independent adversarial review covered compaction identity, metadata semantics, cache invalidation, concurrent singleflight behavior, warning suppression, and runtime scheduler wiring.

## PR workflow

- [x] PR scope is narrow, or the split justification is explained here
- [x] Synced with latest `main` before requesting AI review
- [x] Batched review fixes by subsystem instead of micro-pushing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path `getMemoryTimeline` fallback and full-ledger scans when the projection is stale; behavior is heavily tested but adds SQLite reads and caching semantics operators must trust.
> 
> **Overview**
> **Memory timeline fallback** now compares the live lifecycle ledger to the SQLite projection using **logical event identity** (frontmatter-derived events keyed by memory/type/timestamp; others by `eventId`), so compaction and scoped rebuilds do not skew lag metrics.
> 
> Projection rebuilds **persist high-water meta** (`sourceLifecycleLedgerEventCount`, `projectedLifecycleLedgerEventCount`). A readonly **lag tracker** dedupes current ledger identities and checks `memory_timeline` while scanning. `getMemoryTimeline` routes through **`ProjectionLedgerLagManager`**, which caches lag per projection/ledger file generation, **singleflights** cold full-ledger scans, and still serves bounded per-memory reads after warm-up.
> 
> **`warnProjectionFallback`** only **WARNs** when `delta_events` exceeds the default threshold (100); smaller lag is **debug** with structured fields (`projected_events`, `current_ledger_events`, `delta_events`, `fallback_action`) plus projection age via `formatProjectionAge`. Tracker/probe failures keep ledger fallback without dropping rows.
> 
> Shared helpers move into `projection-support` and `memory-lifecycle-ledger-utils`; ledger rebuild merge logic uses the same identity helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33af8d236382a24ebfbeb4f1d99e75fa0109b58e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory timeline fallback diagnostics by measuring projection lag against unique lifecycle events.
  * Lag warnings now appear only when the configured event threshold is exceeded, while retaining projection-age context.
  * Diagnostics remain accurate after lifecycle-ledger compaction and scoped projection rebuilds.
  * Concurrent fallback requests now share ledger scans for more consistent performance.

* **Maintenance**
  * Projection rebuilds now preserve lifecycle event identity and track source versus projected progress more accurately.

* **Tests**
  * Added coverage for lag thresholds, warning rate limits, compaction, concurrent fallbacks, and maintenance-triggered rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->