### PR TITLE
feat(cli): bidirectional resumable converge transport (#2150 increment 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Bidirectional resumable converge transport CLI subcommand (`remnic converge apply`) and durable peer+namespace cursor state (#2150 increment 2).
 - `remnic converge plan` CLI subcommand to preview corpus convergence state across configured or specified peers.
 
 ## [v9.41.0] — 2026-07-30

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -153,6 +153,23 @@ test("remnic converge plan: hydrates durable cursor base files when present", as
   }
 });
 
+test("remnic converge plan: validates a namespace present only in durable cursor state", async () => {
+  const baseMap = new Map<string, ReconcileFileState[]>([
+    [
+      "cursor-only",
+      [
+        { path: "Facts/a.md", sha256: shaA },
+        { path: "facts/A.md", sha256: shaB },
+      ],
+    ],
+  ]);
+
+  await assert.rejects(
+    computeConvergePlan({ baseFilesByNamespace: baseMap }),
+    /aliasing paths/,
+  );
+});
+
 test("remnic converge apply: converged state returns immediate no-op and updates cursor", async () => {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-apply-test-"));
   try {

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -460,3 +460,71 @@ test("remnic converge apply: does not count a local apply conflict as a pull", a
     await fs.rm(rootDir, { recursive: true, force: true });
   }
 });
+
+test("remnic converge apply: peer-wins guards against the planned local revision", async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-peer-wins-test-"));
+  try {
+    const baseSha256 = createHash("sha256").update("base content").digest("hex");
+    const localContent = Buffer.from("local content");
+    const peerContent = Buffer.from("peer content");
+    const localSha256 = createHash("sha256").update(localContent).digest("hex");
+    const peerSha256 = createHash("sha256").update(peerContent).digest("hex");
+    await fs.mkdir(path.join(rootDir, "facts"), { recursive: true });
+    await fs.writeFile(path.join(rootDir, "facts/shared.md"), localContent);
+
+    const result = await executeConvergeApply({
+      config: parseConfig({ memoryDir: rootDir }),
+      peerUrl: "https://peer.example.test",
+      conflictPolicy: "newest-wins",
+      baseFilesByNamespace: new Map([
+        ["default", [{ path: "facts/shared.md", sha256: baseSha256 }]],
+      ]),
+      localFilesByNamespace: new Map([
+        ["default", [{ path: "facts/shared.md", sha256: localSha256, mtimeMs: 1000 }]],
+      ]),
+      peerFilesByNamespace: new Map([
+        ["default", [{ path: "facts/shared.md", sha256: peerSha256, bytes: peerContent.length, mtimeMs: 2000 }]],
+      ]),
+      peerFileBuffers: new Map([["default", new Map([["facts/shared.md", peerContent]])]]),
+    });
+
+    assert.equal(result.transfers.conflictsResolved, 1);
+    assert.equal(result.transfers.failed, 0);
+    assert.equal(await fs.readFile(path.join(rootDir, "facts/shared.md"), "utf8"), "peer content");
+  } finally {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("remnic converge apply: local-wins guards against the planned peer revision", async () => {
+  const baseSha256 = createHash("sha256").update("base content").digest("hex");
+  const localContent = Buffer.from("local content");
+  const peerContent = Buffer.from("peer content");
+  const localSha256 = createHash("sha256").update(localContent).digest("hex");
+  const peerSha256 = createHash("sha256").update(peerContent).digest("hex");
+  let baseHeader: string | null = null;
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    baseHeader = new Headers(init?.headers).get("x-remnic-base-sha256");
+    return Response.json({ done: true, applied: true, skipped: false });
+  };
+
+  const result = await executeConvergeApply({
+    peerUrl: "https://peer.example.test",
+    fetchImpl,
+    conflictPolicy: "newest-wins",
+    baseFilesByNamespace: new Map([
+      ["default", [{ path: "facts/shared.md", sha256: baseSha256 }]],
+    ]),
+    localFilesByNamespace: new Map([
+      ["default", [{ path: "facts/shared.md", sha256: localSha256, bytes: localContent.length, mtimeMs: 2000 }]],
+    ]),
+    peerFilesByNamespace: new Map([
+      ["default", [{ path: "facts/shared.md", sha256: peerSha256, bytes: peerContent.length, mtimeMs: 1000 }]],
+    ]),
+    localFileBuffers: new Map([["default", new Map([["facts/shared.md", localContent]])]]),
+  });
+
+  assert.equal(result.transfers.conflictsResolved, 1);
+  assert.equal(result.transfers.failed, 0);
+  assert.equal(baseHeader, peerSha256);
+});

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -7,6 +7,7 @@ import type { ReconcileFileState } from "@remnic/core/reconcile/plan.js";
 import {
   defaultConvergeCursorPath,
   readConvergeCursor,
+  writeConvergeCursor,
 } from "@remnic/core/reconcile/cursor.js";
 import {
   cmdConverge,
@@ -119,6 +120,37 @@ test("remnic converge plan: read-only operation does not modify inputs or perfor
 
   assert.ok(plan);
   assert.deepEqual(localMap, localMapClone);
+});
+
+test("remnic converge plan: hydrates durable cursor base files when present", async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-cursor-test-"));
+  try {
+    const peerUrl = "http://localhost:4318";
+    const cursorPath = defaultConvergeCursorPath(tmpDir, peerUrl, "default");
+    await writeConvergeCursor(cursorPath, {
+      version: 1,
+      peerUrl,
+      namespace: "default",
+      baseFiles: [{ path: "facts/base.md", sha256: shaA }],
+    });
+
+    const localMap = new Map<string, ReconcileFileState[]>([["default", []]]);
+    const peerMap = new Map<string, ReconcileFileState[]>([["default", [{ path: "facts/base.md", sha256: shaA }]]]);
+
+    const plan = await computeConvergePlan({
+      localFilesByNamespace: localMap,
+      peerFilesByNamespace: peerMap,
+      cursorDir: tmpDir,
+      peerUrl,
+    });
+
+    assert.ok(plan);
+    const entry = plan.entries.find((e) => e.path === "facts/base.md");
+    assert.ok(entry);
+    assert.equal(entry.baseSha256, shaA);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test("remnic converge apply: converged state returns immediate no-op and updates cursor", async () => {

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -1,7 +1,20 @@
 import * as assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { test } from "node:test";
 import type { ReconcileFileState } from "@remnic/core/reconcile/plan.js";
-import { computeConvergePlan, formatConvergeReport } from "./converge.js";
+import {
+  defaultConvergeCursorPath,
+  readConvergeCursor,
+} from "@remnic/core/reconcile/cursor.js";
+import {
+  cmdConverge,
+  computeConvergePlan,
+  executeConvergeApply,
+  formatConvergeApplyReport,
+  formatConvergeReport,
+} from "./converge.js";
 
 const shaA = "a".repeat(64);
 const shaB = "b".repeat(64);
@@ -106,4 +119,113 @@ test("remnic converge plan: read-only operation does not modify inputs or perfor
 
   assert.ok(plan);
   assert.deepEqual(localMap, localMapClone);
+});
+
+test("remnic converge apply: converged state returns immediate no-op and updates cursor", async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-apply-test-"));
+  try {
+    const file1: ReconcileFileState = { path: "facts/a.md", sha256: shaA };
+    const localMap = new Map<string, ReconcileFileState[]>([["default", [file1]]]);
+    const peerMap = new Map<string, ReconcileFileState[]>([["default", [file1]]]);
+
+    const result = await executeConvergeApply({
+      localFilesByNamespace: localMap,
+      peerFilesByNamespace: peerMap,
+      cursorDir: tmpDir,
+      peerUrl: "http://localhost:4318",
+    });
+
+    assert.equal(result.converged, true);
+    assert.equal(result.status, "converged");
+    assert.equal(result.transfers.pulled, 0);
+    assert.equal(result.transfers.pushed, 0);
+
+    const cursorPath = defaultConvergeCursorPath(tmpDir, "http://localhost:4318", "default");
+    const cursor = await readConvergeCursor(cursorPath);
+    assert.ok(cursor);
+    assert.equal(cursor.namespace, "default");
+    assert.equal(cursor.baseFiles.length, 1);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("remnic converge apply: manual conflict policy stops mutation on unresolved conflicts", async () => {
+  const localFile: ReconcileFileState = { path: "facts/shared.md", sha256: shaA, mtimeMs: 1000 };
+  const peerFile: ReconcileFileState = { path: "facts/shared.md", sha256: shaB, mtimeMs: 2000 };
+
+  const localMap = new Map<string, ReconcileFileState[]>([["default", [localFile]]]);
+  const peerMap = new Map<string, ReconcileFileState[]>([["default", [peerFile]]]);
+
+  const result = await executeConvergeApply({
+    localFilesByNamespace: localMap,
+    peerFilesByNamespace: peerMap,
+    conflictPolicy: "manual",
+  });
+
+  assert.equal(result.converged, false);
+  assert.equal(result.status, "stopped_unresolved_conflicts");
+  assert.equal(result.transfers.pulled, 0);
+  assert.equal(result.transfers.pushed, 0);
+  assert.equal(result.transfers.conflictsResolved, 0);
+});
+
+test("remnic converge apply: dry-run mode simulates transfers without disk writes", async () => {
+  const peerFile: ReconcileFileState = { path: "facts/remote.md", sha256: shaA };
+  const localMap = new Map<string, ReconcileFileState[]>([["default", []]]);
+  const peerMap = new Map<string, ReconcileFileState[]>([["default", [peerFile]]]);
+
+  const result = await executeConvergeApply({
+    localFilesByNamespace: localMap,
+    peerFilesByNamespace: peerMap,
+    dryRun: true,
+  });
+
+  assert.equal(result.converged, false);
+  assert.equal(result.status, "dry_run");
+  assert.equal(result.transfers.pulled, 1);
+  assert.equal(result.cursorUpdated, false);
+});
+
+test("remnic converge apply: successful pull & push execution via buffer maps", async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-apply-test-"));
+  try {
+    const localFile: ReconcileFileState = { path: "facts/local_only.md", sha256: shaA };
+    const peerFile: ReconcileFileState = { path: "facts/peer_only.md", sha256: shaB };
+
+    const localMap = new Map<string, ReconcileFileState[]>([["default", [localFile]]]);
+    const peerMap = new Map<string, ReconcileFileState[]>([["default", [peerFile]]]);
+
+    const localBufs = new Map<string, Map<string, Buffer>>([
+      ["default", new Map([["facts/local_only.md", Buffer.from("local content")]])],
+    ]);
+    const peerBufs = new Map<string, Map<string, Buffer>>([
+      ["default", new Map([["facts/peer_only.md", Buffer.from("peer content")]])],
+    ]);
+
+    const result = await executeConvergeApply({
+      localFilesByNamespace: localMap,
+      peerFilesByNamespace: peerMap,
+      localFileBuffers: localBufs,
+      peerFileBuffers: peerBufs,
+      cursorDir: tmpDir,
+      peerUrl: "http://localhost:4318",
+    });
+
+    assert.equal(result.status, "applied");
+    assert.equal(result.transfers.pulled, 1);
+    assert.equal(result.transfers.pushed, 1);
+    assert.equal(result.transfers.failed, 0);
+
+    // Verify local received pulled file and peer received pushed file
+    assert.equal(localBufs.get("default")?.get("facts/peer_only.md")?.toString(), "peer content");
+    assert.equal(peerBufs.get("default")?.get("facts/local_only.md")?.toString(), "local content");
+
+    const formatted = formatConvergeApplyReport(result);
+    assert.match(formatted, /Convergence Execution Status: APPLIED/);
+    assert.match(formatted, /pulled:\s+1/);
+    assert.match(formatted, /pushed:\s+1/);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -1,8 +1,10 @@
 import * as assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { test } from "node:test";
+import { OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES } from "@remnic/core";
 import type { ReconcileFileState } from "@remnic/core/reconcile/plan.js";
 import {
   defaultConvergeCursorPath,
@@ -153,7 +155,7 @@ test("remnic converge plan: hydrates durable cursor base files when present", as
   }
 });
 
-test("remnic converge plan: validates a namespace present only in durable cursor state", async () => {
+test("remnic converge plan: validates a namespace present only in provided base state", async () => {
   const baseMap = new Map<string, ReconcileFileState[]>([
     [
       "cursor-only",
@@ -188,12 +190,38 @@ test("remnic converge apply: converged state returns immediate no-op and updates
     assert.equal(result.status, "converged");
     assert.equal(result.transfers.pulled, 0);
     assert.equal(result.transfers.pushed, 0);
+    assert.equal(result.cursorUpdated, true);
 
     const cursorPath = defaultConvergeCursorPath(tmpDir, "http://localhost:4318", "default");
     const cursor = await readConvergeCursor(cursorPath);
     assert.ok(cursor);
     assert.equal(cursor.namespace, "default");
     assert.equal(cursor.baseFiles.length, 1);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("remnic converge apply: converged dry-run does not write cursor", async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-apply-test-"));
+  try {
+    const file: ReconcileFileState = { path: "facts/a.md", sha256: shaA };
+    const localMap = new Map<string, ReconcileFileState[]>([["default", [file]]]);
+    const peerMap = new Map<string, ReconcileFileState[]>([["default", [file]]]);
+    const peerUrl = "http://localhost:4318";
+    const cursorPath = defaultConvergeCursorPath(tmpDir, peerUrl, "default");
+
+    const result = await executeConvergeApply({
+      localFilesByNamespace: localMap,
+      peerFilesByNamespace: peerMap,
+      cursorDir: tmpDir,
+      peerUrl,
+      dryRun: true,
+    });
+
+    assert.equal(result.status, "dry_run");
+    assert.equal(result.cursorUpdated, false);
+    assert.equal(await readConvergeCursor(cursorPath), null);
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }
@@ -277,4 +305,68 @@ test("remnic converge apply: successful pull & push execution via buffer maps", 
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }
+});
+
+test("remnic converge apply: uses chunked offline-sync HTTP contracts for pull and push", async () => {
+  const peerContent = Buffer.from("peer content");
+  const localContent = Buffer.from("local content");
+  const peerSha = createHash("sha256").update(peerContent).digest("hex");
+  const localSha = createHash("sha256").update(localContent).digest("hex");
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = String(input);
+    requests.push({ url, init });
+    if (url.endsWith("/remnic/v1/offline-sync/file-content")) {
+      return new Response(peerContent, {
+        status: 200,
+        headers: {
+          "content-type": "application/octet-stream",
+          "x-remnic-file-path": encodeURIComponent("facts/peer.md"),
+          "x-remnic-file-sha256": peerSha,
+          "x-remnic-file-bytes": String(peerContent.length),
+          "x-remnic-file-mtime-ms": "2000",
+          "x-remnic-chunk-offset": "0",
+          "x-remnic-chunk-bytes": String(peerContent.length),
+        },
+      });
+    }
+    if (url.includes("/remnic/v1/offline-sync/apply-file-content?namespace=default")) {
+      return Response.json({ done: true, applied: true, skipped: false });
+    }
+    return new Response(null, { status: 404 });
+  };
+  const localBuffers = new Map<string, Map<string, Buffer>>([
+    ["default", new Map([["facts/local.md", localContent]])],
+  ]);
+
+  const result = await executeConvergeApply({
+    peerUrl: "https://peer.example.test",
+    fetchImpl,
+    localFilesByNamespace: new Map([
+      ["default", [{ path: "facts/local.md", sha256: localSha, bytes: localContent.length, mtimeMs: 1000 }]],
+    ]),
+    peerFilesByNamespace: new Map([
+      ["default", [{ path: "facts/peer.md", sha256: peerSha, bytes: peerContent.length, mtimeMs: 2000 }]],
+    ]),
+    localFileBuffers: localBuffers,
+  });
+
+  assert.equal(result.transfers.pulled, 1);
+  assert.equal(result.transfers.pushed, 1);
+  assert.equal(localBuffers.get("default")?.get("facts/peer.md")?.toString(), "peer content");
+  const pullRequest = requests.find((request) => request.url.endsWith("/remnic/v1/offline-sync/file-content"));
+  const pushRequest = requests.find((request) => request.url.includes("/offline-sync/apply-file-content?"));
+  assert.ok(pullRequest);
+  assert.ok(pushRequest);
+  assert.equal(pullRequest.init?.method, "POST");
+  assert.deepEqual(JSON.parse(String(pullRequest.init?.body)), {
+    namespace: "default",
+    includeTranscripts: false,
+    path: "facts/peer.md",
+    offset: 0,
+    length: OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+  });
+  assert.match(pushRequest.url, /offline-sync\/apply-file-content\?namespace=default$/);
+  assert.equal(new Headers(pushRequest.init?.headers).get("x-remnic-file-sha256"), localSha);
+  assert.equal(new Headers(pushRequest.init?.headers).get("x-remnic-file-bytes"), String(localContent.length));
 });

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { test } from "node:test";
-import { OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES } from "@remnic/core";
+import { OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES, parseConfig } from "@remnic/core";
 import type { ReconcileFileState } from "@remnic/core/reconcile/plan.js";
 import {
   defaultConvergeCursorPath,
@@ -369,4 +369,94 @@ test("remnic converge apply: uses chunked offline-sync HTTP contracts for pull a
   assert.match(pushRequest.url, /offline-sync\/apply-file-content\?namespace=default$/);
   assert.equal(new Headers(pushRequest.init?.headers).get("x-remnic-file-sha256"), localSha);
   assert.equal(new Headers(pushRequest.init?.headers).get("x-remnic-file-bytes"), String(localContent.length));
+});
+
+test("remnic converge plan: fails closed when the peer census cannot be fetched", async () => {
+  const fetchImpl: typeof fetch = async () => new Response(null, { status: 503 });
+
+  await assert.rejects(
+    computeConvergePlan({
+      peerUrl: "https://peer.example.test",
+      fetchImpl,
+      localFilesByNamespace: new Map([["default", []]]),
+    }),
+    /failed to fetch peer snapshot/i,
+  );
+});
+
+test("remnic converge plan: rejects malformed peer census records", async () => {
+  const fetchImpl: typeof fetch = async () =>
+    Response.json({ files: [{ path: "facts/incomplete.md" }], tombstones: [] });
+
+  await assert.rejects(
+    computeConvergePlan({
+      peerUrl: "https://peer.example.test",
+      fetchImpl,
+      localFilesByNamespace: new Map([["default", []]]),
+    }),
+    /invalid peer snapshot/i,
+  );
+});
+
+test("remnic converge apply: does not count a remote apply conflict as a push", async () => {
+  const content = Buffer.from("local content");
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  const fetchImpl: typeof fetch = async () =>
+    Response.json({
+      done: true,
+      applied: false,
+      skipped: false,
+      conflict: { reason: "remote_changed_for_local_update" },
+    });
+
+  const result = await executeConvergeApply({
+    peerUrl: "https://peer.example.test",
+    fetchImpl,
+    localFilesByNamespace: new Map([
+      ["default", [{ path: "facts/local.md", sha256, bytes: content.length, mtimeMs: 1000 }]],
+    ]),
+    peerFilesByNamespace: new Map([["default", []]]),
+    localFileBuffers: new Map([["default", new Map([["facts/local.md", content]])]]),
+  });
+
+  assert.equal(result.transfers.pushed, 0);
+  assert.equal(result.transfers.failed, 1);
+  assert.equal(result.converged, false);
+  assert.equal(result.cursorUpdated, false);
+});
+
+test("remnic converge apply: does not count a local apply conflict as a pull", async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-conflict-test-"));
+  try {
+    const baseContent = Buffer.from("base content");
+    const peerContent = Buffer.from("peer content");
+    const changedContent = Buffer.from("changed content");
+    const baseSha256 = createHash("sha256").update(baseContent).digest("hex");
+    const peerSha256 = createHash("sha256").update(peerContent).digest("hex");
+    await fs.mkdir(path.join(rootDir, "facts"), { recursive: true });
+    await fs.writeFile(path.join(rootDir, "facts/shared.md"), changedContent);
+
+    const result = await executeConvergeApply({
+      config: parseConfig({ memoryDir: rootDir }),
+      peerUrl: "https://peer.example.test",
+      baseFilesByNamespace: new Map([
+        ["default", [{ path: "facts/shared.md", sha256: baseSha256 }]],
+      ]),
+      localFilesByNamespace: new Map([
+        ["default", [{ path: "facts/shared.md", sha256: baseSha256 }]],
+      ]),
+      peerFilesByNamespace: new Map([
+        ["default", [{ path: "facts/shared.md", sha256: peerSha256, bytes: peerContent.length, mtimeMs: 2000 }]],
+      ]),
+      peerFileBuffers: new Map([["default", new Map([["facts/shared.md", peerContent]])]]),
+    });
+
+    assert.equal(result.transfers.pulled, 0);
+    assert.equal(result.transfers.failed, 1);
+    assert.equal(result.converged, false);
+    assert.equal(result.cursorUpdated, false);
+    assert.equal(await fs.readFile(path.join(rootDir, "facts/shared.md"), "utf8"), "changed content");
+  } finally {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -615,6 +615,9 @@ export async function executeConvergeApply(
           const rootDir = rootMap.get(entry.namespace);
           if (rootDir) {
             const io = await createOfflineStorageIo(rootDir);
+            const expectedLocalSha256 = entry.action === "conflict"
+              ? entry.localSha256
+              : entry.baseSha256;
             let offset = 0;
             let transferComplete = false;
             do {
@@ -634,7 +637,7 @@ export async function executeConvergeApply(
                 mtimeMs: remoteFile.mtimeMs,
                 offset,
                 content: chunk,
-                ...(entry.baseSha256 ? { baseSha256: entry.baseSha256 } : {}),
+                ...(expectedLocalSha256 ? { baseSha256: expectedLocalSha256 } : {}),
                 readFile: io.readFile,
                 readFileDigest: io.readFileDigest,
                 writeFile: io.writeFile,
@@ -699,6 +702,9 @@ export async function executeConvergeApply(
           if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
           else actualTransfers.pushed += 1;
         } else if (options.peerUrl && entry.localSha256) {
+          const expectedPeerSha256 = entry.action === "conflict"
+            ? entry.peerSha256
+            : entry.baseSha256;
           const ok = await postPeerFileContent(
             options.peerUrl,
             entry.namespace,
@@ -707,7 +713,7 @@ export async function executeConvergeApply(
             {
               sha256: entry.localSha256,
               mtimeMs: mtimeMs ?? 0,
-              ...(entry.baseSha256 ? { baseSha256: entry.baseSha256 } : {}),
+              ...(expectedPeerSha256 ? { baseSha256: expectedPeerSha256 } : {}),
             },
             resolvedToken,
             fetchFn,

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -22,14 +22,15 @@ import {
   type ConvergeCursorState,
 } from "@remnic/core/reconcile/cursor.js";
 import { resolveAgentAccessAuthToken } from "@remnic/core/resolve-auth-token.js";
-
 export interface ConvergePlanOptions {
   config?: PluginConfig;
   peerUrl?: string;
   peerToken?: string;
+  cursorDir?: string;
   conflictPolicy?: ReconcileConflictPolicy;
   fetchImpl?: typeof fetch;
   resolveSecretRef?: ResolveSecretRefFn;
+  baseFilesByNamespace?: Map<string, ReconcileFileState[]>;
   localFilesByNamespace?: Map<string, ReconcileFileState[]>;
   localTombstonesByNamespace?: Map<string, Iterable<string>>;
   peerFilesByNamespace?: Map<string, ReconcileFileState[]>;
@@ -200,12 +201,18 @@ async function postPeerFileContent(
 }
 
 export async function computeConvergePlan(options: ConvergePlanOptions = {}): Promise<ReconcilePlan> {
+  const baseMap = new Map<string, ReconcileFileState[]>();
   const namespacesToPlan = new Set<string>();
   const localMap = new Map<string, ReconcileFileState[]>();
   const localTombstones = new Map<string, Set<string>>();
   const peerMap = new Map<string, ReconcileFileState[]>();
   const peerTombstones = new Map<string, Set<string>>();
 
+  if (options.baseFilesByNamespace) {
+    for (const [ns, files] of options.baseFilesByNamespace) {
+      baseMap.set(ns, files);
+    }
+  }
   if (options.localFilesByNamespace) {
     for (const [ns, files] of options.localFilesByNamespace) {
       namespacesToPlan.add(ns);
@@ -286,12 +293,24 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
     }
   }
 
+  const memoryDir = options.cursorDir ?? config?.memoryDir;
+  if (!options.baseFilesByNamespace && memoryDir && options.peerUrl) {
+    for (const ns of namespacesToPlan) {
+      const cursorPath = defaultConvergeCursorPath(memoryDir, options.peerUrl, ns);
+      const cursor = await readConvergeCursor(cursorPath);
+      if (cursor?.baseFiles && cursor.baseFiles.length > 0) {
+        baseMap.set(ns, cursor.baseFiles);
+      }
+    }
+  }
+
   const inputs: ReconcileNamespaceInput[] = [];
   for (const ns of [...namespacesToPlan].sort()) {
     inputs.push({
       namespace: ns,
       local: localMap.get(ns) ?? [],
       peer: peerMap.get(ns) ?? [],
+      base: baseMap.get(ns),
       tombstonedFileSha256: localTombstones.get(ns) ?? [],
       peerTombstonedFileSha256: peerTombstones.get(ns) ?? [],
     });

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -210,6 +210,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
 
   if (options.baseFilesByNamespace) {
     for (const [ns, files] of options.baseFilesByNamespace) {
+      namespacesToPlan.add(ns);
       baseMap.set(ns, files);
     }
   }

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -10,22 +10,51 @@ import { resolveCorpusNamespaceRoots } from "@remnic/core/corpus-watermark.js";
 import { listNamespaces } from "@remnic/core/namespaces/migrate.js";
 import {
   planReconciliation,
+  type ReconcileConflictPolicy,
   type ReconcileFileState,
   type ReconcileNamespaceInput,
   type ReconcilePlan,
 } from "@remnic/core/reconcile/plan.js";
+import {
+  defaultConvergeCursorPath,
+  readConvergeCursor,
+  writeConvergeCursor,
+  type ConvergeCursorState,
+} from "@remnic/core/reconcile/cursor.js";
 import { resolveAgentAccessAuthToken } from "@remnic/core/resolve-auth-token.js";
 
 export interface ConvergePlanOptions {
   config?: PluginConfig;
   peerUrl?: string;
   peerToken?: string;
+  conflictPolicy?: ReconcileConflictPolicy;
   fetchImpl?: typeof fetch;
   resolveSecretRef?: ResolveSecretRefFn;
   localFilesByNamespace?: Map<string, ReconcileFileState[]>;
   localTombstonesByNamespace?: Map<string, Iterable<string>>;
   peerFilesByNamespace?: Map<string, ReconcileFileState[]>;
   peerTombstonesByNamespace?: Map<string, Iterable<string>>;
+}
+
+export interface ConvergeApplyOptions extends ConvergePlanOptions {
+  dryRun?: boolean;
+  cursorDir?: string;
+  localFileBuffers?: Map<string, Map<string, Buffer>>;
+  peerFileBuffers?: Map<string, Map<string, Buffer>>;
+}
+
+export interface ConvergeApplyResult {
+  converged: boolean;
+  status: "converged" | "applied" | "stopped_unresolved_conflicts" | "dry_run";
+  plan: ReconcilePlan;
+  transfers: {
+    pulled: number;
+    pushed: number;
+    conflictsResolved: number;
+    suppressed: number;
+    failed: number;
+  };
+  cursorUpdated: boolean;
 }
 
 async function readLocalTombstones(rootDir: string): Promise<Set<string>> {
@@ -86,7 +115,7 @@ async function fetchPeerSnapshot(
       const files: ReconcileFileState[] = [];
       if (Array.isArray(data.files)) {
         for (const item of data.files) {
-          if (item && typeof item.path === "string" && typeof item.sha256 === "string") {
+          if (item && typeof item === "object" && typeof item.path === "string" && typeof item.sha256 === "string") {
             files.push({
               path: item.path,
               sha256: item.sha256,
@@ -110,6 +139,64 @@ async function fetchPeerSnapshot(
     }
   }
   return { files: [], tombstones: new Set() };
+}
+
+async function fetchPeerFileContent(
+  peerUrl: string,
+  namespace: string,
+  filePath: string,
+  token?: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<Buffer | null> {
+  const base = peerUrl.replace(/\/+$/, "");
+  const routes = [
+    `/remnic/v1/offline-sync/file-content?namespace=${encodeURIComponent(namespace)}&path=${encodeURIComponent(filePath)}`,
+    `/engram/v1/offline-sync/file-content?namespace=${encodeURIComponent(namespace)}&path=${encodeURIComponent(filePath)}`,
+  ];
+  const headers: Record<string, string> = token ? { authorization: `Bearer ${token}` } : {};
+  for (const route of routes) {
+    try {
+      const res = await fetchImpl(`${base}${route}`, { headers });
+      if (!res.ok) continue;
+      const buf = await res.arrayBuffer();
+      return Buffer.from(buf);
+    } catch {
+      // try next route
+    }
+  }
+  return null;
+}
+
+async function postPeerFileContent(
+  peerUrl: string,
+  namespace: string,
+  filePath: string,
+  content: Buffer,
+  token?: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<boolean> {
+  const base = peerUrl.replace(/\/+$/, "");
+  const routes = [
+    `/remnic/v1/offline-sync/file-content?namespace=${encodeURIComponent(namespace)}&path=${encodeURIComponent(filePath)}`,
+    `/engram/v1/offline-sync/file-content?namespace=${encodeURIComponent(namespace)}&path=${encodeURIComponent(filePath)}`,
+  ];
+  const headers: Record<string, string> = {
+    "content-type": "application/octet-stream",
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+  for (const route of routes) {
+    try {
+      const res = await fetchImpl(`${base}${route}`, {
+        method: "POST",
+        headers,
+        body: new Uint8Array(content),
+      });
+      if (res.ok) return true;
+    } catch {
+      // try next route
+    }
+  }
+  return false;
 }
 
 export async function computeConvergePlan(options: ConvergePlanOptions = {}): Promise<ReconcilePlan> {
@@ -210,9 +297,262 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
     });
   }
 
-  return planReconciliation(inputs);
+  return planReconciliation(inputs, { conflictPolicy: options.conflictPolicy });
 }
 
+export async function executeConvergeApply(
+  options: ConvergeApplyOptions = {},
+): Promise<ConvergeApplyResult> {
+  const conflictPolicy = options.conflictPolicy ?? "manual";
+  const plan = await computeConvergePlan({ ...options, conflictPolicy });
+
+  if (plan.converged) {
+    await updateCursorsForPlan(plan, options);
+    return {
+      converged: true,
+      status: "converged",
+      plan,
+      transfers: { pulled: 0, pushed: 0, conflictsResolved: 0, suppressed: 0, failed: 0 },
+      cursorUpdated: true,
+    };
+  }
+
+  const unresolvedCount = plan.byNamespace.reduce((acc, report) => acc + report.unresolved, 0);
+  if (unresolvedCount > 0 && conflictPolicy === "manual") {
+    // DEFAULT: unresolved conflicts STOP mutation (never auto-resolve a conflict).
+    return {
+      converged: false,
+      status: "stopped_unresolved_conflicts",
+      plan,
+      transfers: { pulled: 0, pushed: 0, conflictsResolved: 0, suppressed: 0, failed: 0 },
+      cursorUpdated: false,
+    };
+  }
+
+  const plannedTransfers = {
+    pulled: 0,
+    pushed: 0,
+    conflictsResolved: 0,
+    suppressed: 0,
+    failed: 0,
+  };
+
+  for (const entry of plan.entries) {
+    if (entry.action === "pull") plannedTransfers.pulled += 1;
+    else if (entry.action === "push") plannedTransfers.pushed += 1;
+    else if (entry.action === "conflict") plannedTransfers.conflictsResolved += 1;
+    else if (entry.action === "suppress") plannedTransfers.suppressed += 1;
+  }
+
+  if (options.dryRun) {
+    return {
+      converged: false,
+      status: "dry_run",
+      plan,
+      transfers: plannedTransfers,
+      cursorUpdated: false,
+    };
+  }
+
+  const actualTransfers = {
+    pulled: 0,
+    pushed: 0,
+    conflictsResolved: 0,
+    suppressed: 0,
+    failed: 0,
+  };
+
+  let resolvedToken: string | undefined;
+  if (options.peerToken) {
+    try {
+      resolvedToken = await resolveAgentAccessAuthToken(options.peerToken, {
+        resolveSecretRef: options.resolveSecretRef,
+      });
+    } catch {
+      resolvedToken = options.peerToken;
+    }
+  }
+  const fetchFn = options.fetchImpl ?? globalThis.fetch;
+
+  let config = options.config;
+  if (!config) {
+    try {
+      config = parseConfig({});
+    } catch {
+      // ignore
+    }
+  }
+
+  const rootMap = new Map<string, string>();
+  if (config) {
+    try {
+      const roots = await resolveCorpusNamespaceRoots({ config });
+      for (const r of roots) {
+        rootMap.set(r.namespace, r.rootDir);
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  for (const entry of plan.entries) {
+    if (entry.action === "identical") continue;
+
+    let transferType: "pull" | "push" | "suppress" | "none" = "none";
+    if (entry.action === "pull") {
+      transferType = "pull";
+    } else if (entry.action === "push") {
+      transferType = "push";
+    } else if (entry.action === "suppress") {
+      transferType = "suppress";
+    } else if (entry.action === "conflict") {
+      if (entry.resolution === "peer-wins") {
+        transferType = "pull";
+      } else if (entry.resolution === "local-wins") {
+        transferType = "push";
+      } else if (entry.resolution === "supersede-link") {
+        if (entry.newerSide === "peer") transferType = "pull";
+        else if (entry.newerSide === "local") transferType = "push";
+      }
+    }
+
+    if (transferType === "pull") {
+      let content: Buffer | null = null;
+      if (options.peerFileBuffers?.get(entry.namespace)?.has(entry.path)) {
+        content = options.peerFileBuffers.get(entry.namespace)!.get(entry.path)!;
+      } else if (options.peerUrl) {
+        content = await fetchPeerFileContent(
+          options.peerUrl,
+          entry.namespace,
+          entry.path,
+          resolvedToken,
+          fetchFn,
+        );
+      }
+
+      if (content !== null) {
+        if (options.localFileBuffers) {
+          let nsMap = options.localFileBuffers.get(entry.namespace);
+          if (!nsMap) {
+            nsMap = new Map();
+            options.localFileBuffers.set(entry.namespace, nsMap);
+          }
+          nsMap.set(entry.path, content);
+          if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
+          else actualTransfers.pulled += 1;
+        } else {
+          const rootDir = rootMap.get(entry.namespace);
+          if (rootDir) {
+            const absPath = path.join(rootDir, entry.path);
+            await fs.promises.mkdir(path.dirname(absPath), { recursive: true });
+            await fs.promises.writeFile(absPath, content);
+            if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
+            else actualTransfers.pulled += 1;
+          } else {
+            actualTransfers.failed += 1;
+          }
+        }
+      } else {
+        actualTransfers.failed += 1;
+      }
+    } else if (transferType === "push") {
+      let content: Buffer | null = null;
+      if (options.localFileBuffers?.get(entry.namespace)?.has(entry.path)) {
+        content = options.localFileBuffers.get(entry.namespace)!.get(entry.path)!;
+      } else {
+        const rootDir = rootMap.get(entry.namespace);
+        if (rootDir) {
+          try {
+            content = await fs.promises.readFile(path.join(rootDir, entry.path));
+          } catch {
+            content = null;
+          }
+        }
+      }
+
+      if (content !== null) {
+        if (options.peerFileBuffers) {
+          let nsMap = options.peerFileBuffers.get(entry.namespace);
+          if (!nsMap) {
+            nsMap = new Map();
+            options.peerFileBuffers.set(entry.namespace, nsMap);
+          }
+          nsMap.set(entry.path, content);
+          if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
+          else actualTransfers.pushed += 1;
+        } else if (options.peerUrl) {
+          const ok = await postPeerFileContent(
+            options.peerUrl,
+            entry.namespace,
+            entry.path,
+            content,
+            resolvedToken,
+            fetchFn,
+          );
+          if (ok) {
+            if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
+            else actualTransfers.pushed += 1;
+          } else {
+            actualTransfers.failed += 1;
+          }
+        } else {
+          actualTransfers.failed += 1;
+        }
+      } else {
+        actualTransfers.failed += 1;
+      }
+    } else if (transferType === "suppress") {
+      actualTransfers.suppressed += 1;
+    }
+  }
+
+  await updateCursorsForPlan(plan, options);
+
+  return {
+    converged: actualTransfers.failed === 0,
+    status: "applied",
+    plan,
+    transfers: actualTransfers,
+    cursorUpdated: true,
+  };
+}
+
+async function updateCursorsForPlan(
+  plan: ReconcilePlan,
+  options: ConvergeApplyOptions,
+): Promise<void> {
+  const peerUrl = options.peerUrl ?? "local";
+  let memoryDir: string | undefined;
+  if (options.cursorDir) {
+    memoryDir = options.cursorDir;
+  } else if (options.config) {
+    memoryDir = options.config.memoryDir;
+  }
+  if (!memoryDir) return;
+
+  const namespaces = new Set(plan.byNamespace.map((n) => n.namespace));
+  for (const ns of namespaces) {
+    const cursorPath = defaultConvergeCursorPath(memoryDir, peerUrl, ns);
+    const nsEntries = plan.entries.filter((e) => e.namespace === ns);
+    const baseFiles = nsEntries.map((e) => ({
+      path: e.path,
+      sha256: e.localSha256 ?? e.peerSha256 ?? "unknown",
+    }));
+
+    const cursorState: ConvergeCursorState = {
+      version: 1,
+      peerUrl,
+      namespace: ns,
+      lastConvergedAt: new Date().toISOString(),
+      baseFiles,
+    };
+    try {
+      await writeConvergeCursor(cursorPath, cursorState);
+    } catch {
+      // ignore write errors in fallback environments
+    }
+  }
+}
 
 export function formatConvergeReport(plan: ReconcilePlan): string {
   const lines: string[] = [];
@@ -235,26 +575,51 @@ export function formatConvergeReport(plan: ReconcilePlan): string {
   return lines.join("\n");
 }
 
+export function formatConvergeApplyReport(result: ConvergeApplyResult): string {
+  const lines: string[] = [];
+  lines.push(`Convergence Execution Status: ${result.status.toUpperCase()}`);
+  lines.push(`Converged: ${result.converged ? "YES" : "NO"}`);
+  lines.push("");
+  lines.push("Transfers Executed:");
+  lines.push(`  pulled:             ${result.transfers.pulled}`);
+  lines.push(`  pushed:             ${result.transfers.pushed}`);
+  lines.push(`  conflictsResolved:  ${result.transfers.conflictsResolved}`);
+  lines.push(`  suppressed:         ${result.transfers.suppressed}`);
+  lines.push(`  failed:             ${result.transfers.failed}`);
+  lines.push("");
+  lines.push(formatConvergeReport(result.plan));
+  return lines.join("\n");
+}
+
 export async function cmdConverge(action: string, rest: string[], json: boolean): Promise<void> {
   if (action === "help" || action === "--help" || action === "-h" || rest.includes("--help") || rest.includes("-h")) {
-    console.log(`Usage: remnic converge plan [--peer <url>] [--token <token>] [--json]
+    console.log(`Usage: remnic converge <plan|apply> [options]
+
+Subcommands:
+  plan              Compute and display reconciliation plan
+  apply             Execute bidirectional converge transport (alias: transport, sync)
 
 Options:
   --peer <url>      Peer server URL (or --remote-url / --remote)
   --token <token>   Bearer token or SecretRef for peer authentication
+  --conflict-policy <policy>
+                    Conflict resolution policy (manual|newest-wins|keep-both)
+  --dry-run         Simulate transfers without mutating disk or remote peer
   --json            Output detailed JSON plan report
 `);
     return;
   }
 
-  if (action !== "plan") {
-    process.stderr.write(`converge: unknown action "${action}". Use: plan [options].\n`);
+  if (action !== "plan" && action !== "apply" && action !== "transport" && action !== "sync") {
+    process.stderr.write(`converge: unknown action "${action}". Use: plan or apply [options].\n`);
     process.exitCode = 2;
     return;
   }
 
   let peerUrl: string | undefined;
   let peerToken: string | undefined;
+  let dryRun = false;
+  let conflictPolicy: ReconcileConflictPolicy | undefined;
 
   for (let i = 0; i < rest.length; i += 1) {
     const arg = rest[i];
@@ -264,14 +629,37 @@ Options:
     } else if (arg === "--token" && rest[i + 1]) {
       peerToken = rest[i + 1];
       i += 1;
+    } else if (arg === "--dry-run") {
+      dryRun = true;
+    } else if (arg === "--conflict-policy" && rest[i + 1]) {
+      const pol = rest[i + 1];
+      if (pol === "manual" || pol === "newest-wins" || pol === "keep-both") {
+        conflictPolicy = pol;
+      }
+      i += 1;
     }
   }
 
-  const plan = await computeConvergePlan({ peerUrl, peerToken });
+  if (action === "plan") {
+    const plan = await computeConvergePlan({ peerUrl, peerToken, conflictPolicy });
+    if (json) {
+      console.log(JSON.stringify(plan, null, 2));
+    } else {
+      console.log(formatConvergeReport(plan));
+    }
+    return;
+  }
+
+  const result = await executeConvergeApply({
+    peerUrl,
+    peerToken,
+    dryRun,
+    conflictPolicy,
+  });
 
   if (json) {
-    console.log(JSON.stringify(plan, null, 2));
+    console.log(JSON.stringify(result, null, 2));
   } else {
-    console.log(formatConvergeReport(plan));
+    console.log(formatConvergeApplyReport(result));
   }
 }

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -1,10 +1,14 @@
 import * as fs from "node:fs";
+import { createHash } from "node:crypto";
 import * as path from "node:path";
 import {
   type PluginConfig,
   parseConfig,
   type ResolveSecretRefFn,
   buildOfflineSyncSnapshotFromBase,
+  OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+  OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
+  applyOfflineSyncFileContentChunk,
 } from "@remnic/core";
 import { resolveCorpusNamespaceRoots } from "@remnic/core/corpus-watermark.js";
 import { listNamespaces } from "@remnic/core/namespaces/migrate.js";
@@ -21,6 +25,7 @@ import {
   writeConvergeCursor,
   type ConvergeCursorState,
 } from "@remnic/core/reconcile/cursor.js";
+import { createOfflineStorageIo } from "./offline-storage-io.js";
 import { resolveAgentAccessAuthToken } from "@remnic/core/resolve-auth-token.js";
 export interface ConvergePlanOptions {
   config?: PluginConfig;
@@ -142,25 +147,101 @@ async function fetchPeerSnapshot(
   return { files: [], tombstones: new Set() };
 }
 
+interface PeerFileContent {
+  content: Buffer;
+  sha256: string;
+  bytes: number;
+  mtimeMs: number;
+}
+
+function requiredResponseNumber(response: Response, name: string): number {
+  const raw = response.headers.get(name);
+  const value = raw === null ? Number.NaN : Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`offline file content response had invalid ${name}`);
+  }
+  return value;
+}
+
 async function fetchPeerFileContent(
   peerUrl: string,
   namespace: string,
   filePath: string,
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
-): Promise<Buffer | null> {
+): Promise<PeerFileContent | null> {
   const base = peerUrl.replace(/\/+$/, "");
   const routes = [
-    `/remnic/v1/offline-sync/file-content?namespace=${encodeURIComponent(namespace)}&path=${encodeURIComponent(filePath)}`,
-    `/engram/v1/offline-sync/file-content?namespace=${encodeURIComponent(namespace)}&path=${encodeURIComponent(filePath)}`,
+    "/remnic/v1/offline-sync/file-content",
+    "/engram/v1/offline-sync/file-content",
   ];
-  const headers: Record<string, string> = token ? { authorization: `Bearer ${token}` } : {};
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
   for (const route of routes) {
     try {
-      const res = await fetchImpl(`${base}${route}`, { headers });
-      if (!res.ok) continue;
-      const buf = await res.arrayBuffer();
-      return Buffer.from(buf);
+      const chunks: Buffer[] = [];
+      const hash = createHash("sha256");
+      let offset = 0;
+      let expectedBytes: number | undefined;
+      let expectedSha256: string | undefined;
+      let mtimeMs: number | undefined;
+      do {
+        const response = await fetchImpl(`${base}${route}`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            namespace,
+            includeTranscripts: false,
+            path: filePath,
+            offset,
+            length: OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+          }),
+        });
+        if (!response.ok) throw new Error(`offline file content request failed: ${response.status}`);
+        const content = Buffer.from(await response.arrayBuffer());
+        const chunkOffset = requiredResponseNumber(response, "x-remnic-chunk-offset");
+        const chunkBytes = requiredResponseNumber(response, "x-remnic-chunk-bytes");
+        const totalBytes = requiredResponseNumber(response, "x-remnic-file-bytes");
+        const responseMtimeMs = requiredResponseNumber(response, "x-remnic-file-mtime-ms");
+        const sha256 = response.headers.get("x-remnic-file-sha256");
+        const encodedPath = response.headers.get("x-remnic-file-path");
+        if (
+          !sha256
+          || chunkOffset !== offset
+          || chunkBytes !== content.length
+          || (encodedPath !== null && decodeURIComponent(encodedPath) !== filePath)
+          || (expectedBytes !== undefined && expectedBytes !== totalBytes)
+          || (expectedSha256 !== undefined && expectedSha256 !== sha256)
+        ) {
+          throw new Error(`offline file content response changed during transfer: ${filePath}`);
+        }
+        if (content.length === 0 && offset < totalBytes) {
+          throw new Error(`offline file content chunk was empty before EOF: ${filePath}`);
+        }
+        expectedBytes = totalBytes;
+        expectedSha256 = sha256;
+        mtimeMs = responseMtimeMs;
+        chunks.push(content);
+        hash.update(content);
+        offset += content.length;
+      } while (expectedBytes === undefined || offset < expectedBytes);
+      if (
+        expectedBytes === undefined
+        || expectedSha256 === undefined
+        || mtimeMs === undefined
+        || offset !== expectedBytes
+        || hash.digest("hex") !== expectedSha256
+      ) {
+        throw new Error(`offline file content checksum mismatch: ${filePath}`);
+      }
+      return {
+        content: Buffer.concat(chunks, expectedBytes),
+        sha256: expectedSha256,
+        bytes: expectedBytes,
+        mtimeMs,
+      };
     } catch {
       // try next route
     }
@@ -173,26 +254,44 @@ async function postPeerFileContent(
   namespace: string,
   filePath: string,
   content: Buffer,
+  metadata: { sha256: string; mtimeMs: number; baseSha256?: string },
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<boolean> {
   const base = peerUrl.replace(/\/+$/, "");
   const routes = [
-    `/remnic/v1/offline-sync/file-content?namespace=${encodeURIComponent(namespace)}&path=${encodeURIComponent(filePath)}`,
-    `/engram/v1/offline-sync/file-content?namespace=${encodeURIComponent(namespace)}&path=${encodeURIComponent(filePath)}`,
+    `/remnic/v1/offline-sync/apply-file-content?namespace=${encodeURIComponent(namespace)}`,
+    `/engram/v1/offline-sync/apply-file-content?namespace=${encodeURIComponent(namespace)}`,
   ];
-  const headers: Record<string, string> = {
-    "content-type": "application/octet-stream",
-    ...(token ? { authorization: `Bearer ${token}` } : {}),
-  };
   for (const route of routes) {
     try {
-      const res = await fetchImpl(`${base}${route}`, {
-        method: "POST",
-        headers,
-        body: new Uint8Array(content),
-      });
-      if (res.ok) return true;
+      let offset = 0;
+      do {
+        const chunk = content.subarray(
+          offset,
+          Math.min(content.length, offset + OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES),
+        );
+        const headers: Record<string, string> = {
+          "content-type": "application/octet-stream",
+          "x-remnic-include-transcripts": "false",
+          "x-remnic-source-id": encodeURIComponent("remnic-converge"),
+          "x-remnic-file-path": encodeURIComponent(filePath),
+          "x-remnic-file-sha256": metadata.sha256,
+          "x-remnic-file-bytes": String(content.length),
+          "x-remnic-file-mtime-ms": String(metadata.mtimeMs),
+          "x-remnic-chunk-offset": String(offset),
+          ...(metadata.baseSha256 ? { "x-remnic-base-sha256": metadata.baseSha256 } : {}),
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+        };
+        const response = await fetchImpl(`${base}${route}`, {
+          method: "POST",
+          headers,
+          body: new Uint8Array(chunk),
+        });
+        if (!response.ok) throw new Error(`offline apply-file-content request failed: ${response.status}`);
+        offset += chunk.length;
+      } while (offset < content.length);
+      return true;
     } catch {
       // try next route
     }
@@ -326,7 +425,7 @@ export async function executeConvergeApply(
   const conflictPolicy = options.conflictPolicy ?? "manual";
   const plan = await computeConvergePlan({ ...options, conflictPolicy });
 
-  if (plan.converged) {
+  if (plan.converged && !options.dryRun) {
     await updateCursorsForPlan(plan, options);
     return {
       converged: true,
@@ -437,11 +536,20 @@ export async function executeConvergeApply(
     }
 
     if (transferType === "pull") {
-      let content: Buffer | null = null;
-      if (options.peerFileBuffers?.get(entry.namespace)?.has(entry.path)) {
-        content = options.peerFileBuffers.get(entry.namespace)!.get(entry.path)!;
+      let remoteFile: PeerFileContent | null = null;
+      const buffered = options.peerFileBuffers?.get(entry.namespace)?.get(entry.path);
+      if (buffered) {
+        const state = options.peerFilesByNamespace
+          ?.get(entry.namespace)
+          ?.find((file) => file.path === entry.path);
+        remoteFile = {
+          content: buffered,
+          sha256: state?.sha256 ?? entry.peerSha256 ?? createHash("sha256").update(buffered).digest("hex"),
+          bytes: buffered.length,
+          mtimeMs: state?.mtimeMs ?? 0,
+        };
       } else if (options.peerUrl) {
-        content = await fetchPeerFileContent(
+        remoteFile = await fetchPeerFileContent(
           options.peerUrl,
           entry.namespace,
           entry.path,
@@ -450,22 +558,47 @@ export async function executeConvergeApply(
         );
       }
 
-      if (content !== null) {
+      if (remoteFile !== null && (!entry.peerSha256 || remoteFile.sha256 === entry.peerSha256)) {
         if (options.localFileBuffers) {
           let nsMap = options.localFileBuffers.get(entry.namespace);
           if (!nsMap) {
             nsMap = new Map();
             options.localFileBuffers.set(entry.namespace, nsMap);
           }
-          nsMap.set(entry.path, content);
+          nsMap.set(entry.path, remoteFile.content);
           if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
           else actualTransfers.pulled += 1;
         } else {
           const rootDir = rootMap.get(entry.namespace);
           if (rootDir) {
-            const absPath = path.join(rootDir, entry.path);
-            await fs.promises.mkdir(path.dirname(absPath), { recursive: true });
-            await fs.promises.writeFile(absPath, content);
+            const io = await createOfflineStorageIo(rootDir);
+            let offset = 0;
+            do {
+              const chunk = remoteFile.content.subarray(
+                offset,
+                Math.min(
+                  remoteFile.content.length,
+                  offset + OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
+                ),
+              );
+              await applyOfflineSyncFileContentChunk({
+                root: rootDir,
+                sourceId: "remnic-converge",
+                path: entry.path,
+                sha256: remoteFile.sha256,
+                bytes: remoteFile.bytes,
+                mtimeMs: remoteFile.mtimeMs,
+                offset,
+                content: chunk,
+                ...(entry.baseSha256 ? { baseSha256: entry.baseSha256 } : {}),
+                readFile: io.readFile,
+                readFileDigest: io.readFileDigest,
+                writeFile: io.writeFile,
+                writeStagingFile: io.writeStagingFile,
+                writeFileChunks: io.writeFileChunks,
+              });
+              offset += chunk.length;
+            } while (offset < remoteFile.content.length);
             if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
             else actualTransfers.pulled += 1;
           } else {
@@ -477,13 +610,20 @@ export async function executeConvergeApply(
       }
     } else if (transferType === "push") {
       let content: Buffer | null = null;
+      let mtimeMs = options.localFilesByNamespace
+        ?.get(entry.namespace)
+        ?.find((file) => file.path === entry.path)
+        ?.mtimeMs;
       if (options.localFileBuffers?.get(entry.namespace)?.has(entry.path)) {
         content = options.localFileBuffers.get(entry.namespace)!.get(entry.path)!;
       } else {
         const rootDir = rootMap.get(entry.namespace);
         if (rootDir) {
+          const filePath = path.join(rootDir, entry.path);
           try {
-            content = await fs.promises.readFile(path.join(rootDir, entry.path));
+            const io = await createOfflineStorageIo(rootDir);
+            content = await io.readFile!({ root: rootDir, path: entry.path, filePath });
+            mtimeMs ??= (await fs.promises.stat(filePath)).mtimeMs;
           } catch {
             content = null;
           }
@@ -500,12 +640,17 @@ export async function executeConvergeApply(
           nsMap.set(entry.path, content);
           if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
           else actualTransfers.pushed += 1;
-        } else if (options.peerUrl) {
+        } else if (options.peerUrl && entry.localSha256) {
           const ok = await postPeerFileContent(
             options.peerUrl,
             entry.namespace,
             entry.path,
             content,
+            {
+              sha256: entry.localSha256,
+              mtimeMs: mtimeMs ?? 0,
+              ...(entry.baseSha256 ? { baseSha256: entry.baseSha256 } : {}),
+            },
             resolvedToken,
             fetchFn,
           );

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -109,42 +109,65 @@ async function fetchPeerSnapshot(
     `/engram/v1/offline-sync/snapshot?namespace=${encodeURIComponent(namespace)}&content=false`,
   ];
   const headers: Record<string, string> = token ? { authorization: `Bearer ${token}` } : {};
+  let lastFailure = "no snapshot route responded";
 
   for (const route of routes) {
+    let response: Response;
     try {
-      const res = await fetchImpl(`${base}${route}`, { headers });
-      if (!res.ok) continue;
-      const data = (await res.json()) as {
-        files?: Array<{ path?: string; sha256?: string; mtimeMs?: number; bytes?: number }>;
-        tombstones?: string[];
-      };
-      const files: ReconcileFileState[] = [];
-      if (Array.isArray(data.files)) {
-        for (const item of data.files) {
-          if (item && typeof item === "object" && typeof item.path === "string" && typeof item.sha256 === "string") {
-            files.push({
-              path: item.path,
-              sha256: item.sha256,
-              mtimeMs: typeof item.mtimeMs === "number" ? item.mtimeMs : undefined,
-              bytes: typeof item.bytes === "number" ? item.bytes : undefined,
-            });
-          }
-        }
-      }
-      const tombstones = new Set<string>();
-      if (Array.isArray(data.tombstones)) {
-        for (const tomb of data.tombstones) {
-          if (typeof tomb === "string" && /^[0-9a-f]{64}$/i.test(tomb)) {
-            tombstones.add(tomb.toLowerCase());
-          }
-        }
-      }
-      return { files, tombstones };
-    } catch {
-      // try next route on network failure or 404
+      response = await fetchImpl(`${base}${route}`, { headers });
+    } catch (error) {
+      lastFailure = error instanceof Error ? error.message : String(error);
+      continue;
     }
+    if (!response.ok) {
+      lastFailure = `HTTP ${response.status}`;
+      continue;
+    }
+
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      throw new Error(`invalid peer snapshot for namespace ${namespace}: response was not JSON`);
+    }
+    if (!data || typeof data !== "object" || !("files" in data) || !Array.isArray(data.files)) {
+      throw new Error(`invalid peer snapshot for namespace ${namespace}: files must be an array`);
+    }
+
+    const files: ReconcileFileState[] = data.files.map((item, index) => {
+      if (
+        !item
+        || typeof item !== "object"
+        || !("path" in item)
+        || typeof item.path !== "string"
+        || !("sha256" in item)
+        || typeof item.sha256 !== "string"
+      ) {
+        throw new Error(`invalid peer snapshot for namespace ${namespace}: malformed file at index ${index}`);
+      }
+      return {
+        path: item.path,
+        sha256: item.sha256,
+        mtimeMs: "mtimeMs" in item && typeof item.mtimeMs === "number" ? item.mtimeMs : undefined,
+        bytes: "bytes" in item && typeof item.bytes === "number" ? item.bytes : undefined,
+      };
+    });
+
+    const rawTombstones = "tombstones" in data ? data.tombstones : undefined;
+    if (rawTombstones !== undefined && !Array.isArray(rawTombstones)) {
+      throw new Error(`invalid peer snapshot for namespace ${namespace}: tombstones must be an array`);
+    }
+    const tombstones = new Set<string>();
+    for (const tombstone of rawTombstones ?? []) {
+      if (typeof tombstone !== "string" || !/^[0-9a-f]{64}$/i.test(tombstone)) {
+        throw new Error(`invalid peer snapshot for namespace ${namespace}: malformed tombstone`);
+      }
+      tombstones.add(tombstone.toLowerCase());
+    }
+    return { files, tombstones };
   }
-  return { files: [], tombstones: new Set() };
+
+  throw new Error(`failed to fetch peer snapshot for namespace ${namespace}: ${lastFailure}`);
 }
 
 interface PeerFileContent {
@@ -289,9 +312,29 @@ async function postPeerFileContent(
           body: new Uint8Array(chunk),
         });
         if (!response.ok) throw new Error(`offline apply-file-content request failed: ${response.status}`);
+        const result: unknown = await response.json().catch(() => null);
+        if (
+          !result
+          || typeof result !== "object"
+          || !("done" in result)
+          || typeof result.done !== "boolean"
+          || !("applied" in result)
+          || typeof result.applied !== "boolean"
+          || !("skipped" in result)
+          || typeof result.skipped !== "boolean"
+          || ("conflict" in result && result.conflict)
+        ) {
+          return false;
+        }
+        if (result.done) {
+          return result.skipped || (result.applied && offset + chunk.length === content.length);
+        }
+        if (result.applied || result.skipped || chunk.length === 0) {
+          return false;
+        }
         offset += chunk.length;
       } while (offset < content.length);
-      return true;
+      return false;
     } catch {
       // try next route
     }
@@ -573,6 +616,7 @@ export async function executeConvergeApply(
           if (rootDir) {
             const io = await createOfflineStorageIo(rootDir);
             let offset = 0;
+            let transferComplete = false;
             do {
               const chunk = remoteFile.content.subarray(
                 offset,
@@ -581,7 +625,7 @@ export async function executeConvergeApply(
                   offset + OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
                 ),
               );
-              await applyOfflineSyncFileContentChunk({
+              const chunkResult = await applyOfflineSyncFileContentChunk({
                 root: rootDir,
                 sourceId: "remnic-converge",
                 path: entry.path,
@@ -597,10 +641,24 @@ export async function executeConvergeApply(
                 writeStagingFile: io.writeStagingFile,
                 writeFileChunks: io.writeFileChunks,
               });
+              if (chunkResult.conflict) {
+                break;
+              }
+              if (chunkResult.done) {
+                transferComplete = chunkResult.applied || chunkResult.skipped;
+                break;
+              }
+              if (chunkResult.applied || chunkResult.skipped || chunk.length === 0) {
+                break;
+              }
               offset += chunk.length;
             } while (offset < remoteFile.content.length);
-            if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
-            else actualTransfers.pulled += 1;
+            if (transferComplete) {
+              if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
+              else actualTransfers.pulled += 1;
+            } else {
+              actualTransfers.failed += 1;
+            }
           } else {
             actualTransfers.failed += 1;
           }
@@ -671,14 +729,18 @@ export async function executeConvergeApply(
     }
   }
 
-  await updateCursorsForPlan(plan, options);
+  let cursorUpdated = false;
+  if (actualTransfers.failed === 0) {
+    await updateCursorsForPlan(plan, options);
+    cursorUpdated = true;
+  }
 
   return {
     converged: actualTransfers.failed === 0,
     status: "applied",
     plan,
     transfers: actualTransfers,
-    cursorUpdated: true,
+    cursorUpdated,
   };
 }
 

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -166,6 +166,16 @@
       "remnic-source": "./src/reconcile/plan.ts",
       "import": "./dist/reconcile/plan.js"
     },
+    "./reconcile/cursor": {
+      "types": "./dist/reconcile/cursor.d.ts",
+      "remnic-source": "./src/reconcile/cursor.ts",
+      "import": "./dist/reconcile/cursor.js"
+    },
+    "./reconcile/cursor.js": {
+      "types": "./dist/reconcile/cursor.d.ts",
+      "remnic-source": "./src/reconcile/cursor.ts",
+      "import": "./dist/reconcile/cursor.js"
+    },
     "./adapters/codex": {
       "types": "./dist/adapters/codex.d.ts",
       "remnic-source": "./src/adapters/codex.ts",

--- a/packages/remnic-core/src/reconcile/cursor.test.ts
+++ b/packages/remnic-core/src/reconcile/cursor.test.ts
@@ -1,0 +1,104 @@
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { test } from "node:test";
+import {
+  defaultConvergeCursorPath,
+  hashPeerNamespace,
+  normalizeConvergeCursor,
+  readConvergeCursor,
+  writeConvergeCursor,
+  type ConvergeCursorState,
+} from "./cursor.js";
+
+const shaA = "a".repeat(64);
+
+test("hashPeerNamespace: deterministic key normalization", () => {
+  const k1 = hashPeerNamespace("http://peer.example.com/", "default");
+  const k2 = hashPeerNamespace("http://peer.example.com", "DEFAULT ");
+  assert.equal(k1, k2);
+  assert.equal(k1.length, 16);
+});
+
+test("defaultConvergeCursorPath: constructs path under memoryDir state", () => {
+  const p = defaultConvergeCursorPath("/tmp/mem", "http://localhost:4318", "general");
+  assert.ok(p.includes(path.join(".remnic", "state", "converge-cursors")));
+  assert.ok(p.endsWith(".json"));
+});
+
+test("normalizeConvergeCursor: validates envelope shape", () => {
+  assert.throws(() => normalizeConvergeCursor(null), /must be an object/);
+  assert.throws(() => normalizeConvergeCursor({ version: 2 }), /version must be 1/);
+  assert.throws(
+    () => normalizeConvergeCursor({ version: 1, peerUrl: "" }),
+    /missing peerUrl/,
+  );
+  assert.throws(
+    () => normalizeConvergeCursor({ version: 1, peerUrl: "http://peer", namespace: "" }),
+    /missing namespace/,
+  );
+
+  const valid = normalizeConvergeCursor({
+    version: 1,
+    peerUrl: "http://peer",
+    namespace: "default",
+    baseFiles: [{ path: "a.md", sha256: shaA }],
+  });
+  assert.equal(valid.peerUrl, "http://peer");
+  assert.equal(valid.namespace, "default");
+  assert.equal(valid.baseFiles.length, 1);
+  assert.equal(valid.baseFiles[0]?.path, "a.md");
+});
+
+test("readConvergeCursor: returns null when file is missing or invalid", async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-cursor-test-"));
+  try {
+    const missing = await readConvergeCursor(path.join(tmpDir, "missing.json"));
+    assert.equal(missing, null);
+
+    const invalidPath = path.join(tmpDir, "invalid.json");
+    await fs.writeFile(invalidPath, "{ invalid json", "utf-8");
+    const invalid = await readConvergeCursor(invalidPath);
+    assert.equal(invalid, null);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("writeConvergeCursor & readConvergeCursor: atomic write roundtrip", async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-cursor-test-"));
+  const cursorPath = path.join(tmpDir, "state", "cursor.json");
+  try {
+    const cursor: ConvergeCursorState = {
+      version: 1,
+      peerUrl: "http://localhost:4318",
+      namespace: "default",
+      lastConvergedAt: new Date().toISOString(),
+      baseFiles: [{ path: "facts/a.md", sha256: shaA, bytes: 120, mtimeMs: 1000 }],
+      completedPaths: ["facts/a.md"],
+    };
+
+    await writeConvergeCursor(cursorPath, cursor);
+    const read = await readConvergeCursor(cursorPath);
+    assert.ok(read);
+    assert.equal(read.peerUrl, "http://localhost:4318");
+    assert.equal(read.namespace, "default");
+    assert.equal(read.baseFiles.length, 1);
+    assert.equal(read.baseFiles[0]?.sha256, shaA);
+    assert.deepEqual(read.completedPaths, ["facts/a.md"]);
+
+    // Update existing cursor atomically
+    const updated: ConvergeCursorState = {
+      ...read,
+      lastConvergedAt: new Date().toISOString(),
+      completedPaths: ["facts/a.md", "facts/b.md"],
+    };
+    await writeConvergeCursor(cursorPath, updated);
+    const readUpdated = await readConvergeCursor(cursorPath);
+    assert.ok(readUpdated);
+    assert.equal(readUpdated.completedPaths?.length, 2);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/reconcile/cursor.test.ts
+++ b/packages/remnic-core/src/reconcile/cursor.test.ts
@@ -21,6 +21,25 @@ test("hashPeerNamespace: deterministic key normalization", () => {
   assert.equal(k1.length, 16);
 });
 
+test("hashPeerNamespace: accepts non-URL local peer identifiers", () => {
+  assert.equal(hashPeerNamespace("local", "default").length, 16);
+});
+
+test("hashPeerNamespace: preserves path case while normalizing URL authority and trailing slash", () => {
+  const uppercasePath = hashPeerNamespace("HTTP://PEER.EXAMPLE.COM/Memory/", "default");
+  const lowercasePath = hashPeerNamespace("http://peer.example.com/memory", "default");
+
+  assert.notEqual(uppercasePath, lowercasePath);
+  assert.equal(
+    uppercasePath,
+    hashPeerNamespace("http://peer.example.com/Memory", "DEFAULT "),
+  );
+  assert.equal(
+    lowercasePath,
+    hashPeerNamespace("HTTP://PEER.EXAMPLE.COM/memory/", "default"),
+  );
+});
+
 test("defaultConvergeCursorPath: constructs path under memoryDir state", () => {
   const p = defaultConvergeCursorPath("/tmp/mem", "http://localhost:4318", "general");
   assert.ok(p.includes(path.join(".remnic", "state", "converge-cursors")));

--- a/packages/remnic-core/src/reconcile/cursor.ts
+++ b/packages/remnic-core/src/reconcile/cursor.ts
@@ -19,7 +19,19 @@ export interface ConvergeCursorState {
 }
 
 export function hashPeerNamespace(peerUrl: string, namespace: string): string {
-  const normalizedUrl = peerUrl.replace(/\/+$/, "").toLowerCase();
+  let normalizedUrl: string;
+  try {
+    const url = new URL(peerUrl);
+    const credentials =
+      url.username || url.password
+        ? `${url.username}${url.password ? `:${url.password}` : ""}@`
+        : "";
+    normalizedUrl =
+      `${url.protocol.toLowerCase()}//${credentials}${url.hostname.toLowerCase()}` +
+      `${url.port ? `:${url.port}` : ""}${url.pathname.replace(/\/+$/, "")}${url.search}${url.hash}`;
+  } catch {
+    normalizedUrl = peerUrl.trim().replace(/\/+$/, "").toLowerCase();
+  }
   const normalizedNs = namespace.trim().toLowerCase();
   return createHash("sha256")
     .update(`${normalizedUrl}\0${normalizedNs}`)

--- a/packages/remnic-core/src/reconcile/cursor.ts
+++ b/packages/remnic-core/src/reconcile/cursor.ts
@@ -1,0 +1,118 @@
+import { createHash, randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+export interface ConvergeCursorFileState {
+  path: string;
+  sha256: string;
+  mtimeMs?: number;
+  bytes?: number;
+}
+
+export interface ConvergeCursorState {
+  version: 1;
+  peerUrl: string;
+  namespace: string;
+  lastConvergedAt?: string;
+  baseFiles: ConvergeCursorFileState[];
+  completedPaths?: string[];
+}
+
+export function hashPeerNamespace(peerUrl: string, namespace: string): string {
+  const normalizedUrl = peerUrl.replace(/\/+$/, "").toLowerCase();
+  const normalizedNs = namespace.trim().toLowerCase();
+  return createHash("sha256")
+    .update(`${normalizedUrl}\0${normalizedNs}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export function defaultConvergeCursorPath(
+  memoryDir: string,
+  peerUrl: string,
+  namespace: string,
+): string {
+  const key = hashPeerNamespace(peerUrl, namespace);
+  return path.join(path.resolve(memoryDir), ".remnic", "state", "converge-cursors", `${key}.json`);
+}
+
+export function normalizeConvergeCursor(input: unknown): ConvergeCursorState {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("converge cursor must be an object");
+  }
+  const obj = input as Record<string, unknown>;
+  if (obj.version !== 1) {
+    throw new Error("converge cursor version must be 1");
+  }
+  if (typeof obj.peerUrl !== "string" || !obj.peerUrl.trim()) {
+    throw new Error("converge cursor missing peerUrl");
+  }
+  if (typeof obj.namespace !== "string" || !obj.namespace.trim()) {
+    throw new Error("converge cursor missing namespace");
+  }
+  const baseFiles: ConvergeCursorFileState[] = [];
+  if (Array.isArray(obj.baseFiles)) {
+    for (const item of obj.baseFiles) {
+      if (item && typeof item === "object") {
+        const fileItem = item as Record<string, unknown>;
+        if (typeof fileItem.path === "string" && typeof fileItem.sha256 === "string") {
+          baseFiles.push({
+            path: fileItem.path,
+            sha256: fileItem.sha256,
+            mtimeMs: typeof fileItem.mtimeMs === "number" ? fileItem.mtimeMs : undefined,
+            bytes: typeof fileItem.bytes === "number" ? fileItem.bytes : undefined,
+          });
+        }
+      }
+    }
+  }
+  const completedPaths: string[] = [];
+  if (Array.isArray(obj.completedPaths)) {
+    for (const item of obj.completedPaths) {
+      if (typeof item === "string") {
+        completedPaths.push(item);
+      }
+    }
+  }
+  return {
+    version: 1,
+    peerUrl: obj.peerUrl.trim(),
+    namespace: obj.namespace.trim(),
+    lastConvergedAt: typeof obj.lastConvergedAt === "string" ? obj.lastConvergedAt : undefined,
+    baseFiles,
+    completedPaths,
+  };
+}
+
+export async function readConvergeCursor(
+  cursorPath: string,
+): Promise<ConvergeCursorState | null> {
+  try {
+    const raw = await fs.readFile(path.resolve(cursorPath), "utf-8");
+    const parsed = JSON.parse(raw);
+    return normalizeConvergeCursor(parsed);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    return null;
+  }
+}
+
+export async function writeConvergeCursor(
+  cursorPath: string,
+  cursor: ConvergeCursorState,
+): Promise<void> {
+  const normalized = normalizeConvergeCursor(cursor);
+  const target = path.resolve(cursorPath);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  const tmp = path.join(
+    path.dirname(target),
+    `.converge-cursor.${process.pid}.${randomUUID()}.tmp`,
+  );
+  await fs.writeFile(tmp, JSON.stringify(normalized, null, 2) + "\n", "utf-8");
+  try {
+    await fs.rename(tmp, target);
+  } catch (error) {
+    await fs.unlink(tmp).catch(() => {});
+    throw error;
+  }
+}


### PR DESCRIPTION
Part of #2150. Implements increment-2 (bidirectional resumable converge transport) with durable peer+namespace cursor state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bidirectional corpus sync and on-disk cursor state with conflict-sensitive apply semantics; mistakes could corrupt or mis-report peer/local convergence, though manual default and base-SHA guards limit blast radius.
> 
> **Overview**
> Adds **`remnic converge apply`** (aliases `transport` / `sync`) to execute reconciliation plans: pull/push corpus files over chunked **offline-sync** HTTP, optional **`--dry-run`** and **`--conflict-policy`**, and apply reporting via `formatConvergeApplyReport`.
> 
> Introduces durable **per peer+namespace converge cursors** in `@remnic/core/reconcile/cursor` (hashed paths under `.remnic/state/converge-cursors/`). **`computeConvergePlan`** now loads cursor **`baseFiles`** for three-way reconcile, accepts explicit base maps, passes **`conflictPolicy`** into `planReconciliation`, and **fails closed** on peer snapshot fetch/validation errors instead of returning empty peer state.
> 
> **`executeConvergeApply`** stops on unresolved conflicts when policy is **`manual`**, uses **`x-remnic-base-sha256`** on apply for optimistic concurrency, updates cursors only when transfers succeed (or on already-converged apply), and counts remote/local apply conflicts as **failed**, not successful pushes/pulls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b98d5abc3494f7967d9d675a58559a88ad4d7af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `remnic converge apply` for bidirectional, resumable file synchronization with durable peer+namespace cursor state.
  - Enhanced `converge` with `plan`/`apply` modes, including `--dry-run` and `--conflict-policy`, plus improved apply reporting.
- **Bug Fixes**
  - More robust peer snapshot/census fetching and stricter validation to fail closed on bad/malformed responses.
  - Corrected transfer counting and cursor updates to account for partial failures and conflict outcomes.
- **Tests**
  - Expanded coverage for cursor persistence/normalization and for plan/apply failure handling, conflict accounting, and offline-sync request/response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->