### PR TITLE
feat(converge): refresh receiver indexes after batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- After a converge batch writes files, the receiver updates search and rebuilds the memory view. It runs once for each changed namespace (#2150 increment 4).
+
 ## [v9.42.0] — 2026-07-30
 
 ### Added

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -691,6 +691,77 @@ test("remnic converge apply: does not finalize a peer namespace when every write
   assert.equal(finalizeCalls, 0);
 });
 
+test("remnic converge apply: finalization falls back to the engram route", async () => {
+  const content = Buffer.from("local");
+  const finalizePaths: string[] = [];
+  const fetchImpl: typeof fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname.endsWith("/offline-sync/apply-file-content")) {
+      return Response.json({ done: true, applied: true, skipped: false });
+    }
+    if (url.pathname.endsWith("/offline-sync/convergence-complete")) {
+      finalizePaths.push(url.pathname);
+      if (url.pathname.startsWith("/remnic/")) return new Response(null, { status: 404 });
+      return Response.json({ namespaces: ["team"], refreshed: true });
+    }
+    return new Response(null, { status: 404 });
+  };
+
+  const result = await executeConvergeApply({
+    peerUrl: "https://peer.example.test/",
+    fetchImpl,
+    localFilesByNamespace: new Map([
+      ["team", [{
+        path: "facts/a.md",
+        sha256: createHash("sha256").update(content).digest("hex"),
+      }]],
+    ]),
+    peerFilesByNamespace: new Map([["team", []]]),
+    localFileBuffers: new Map([["team", new Map([["facts/a.md", content]])]]),
+  });
+
+  assert.equal(result.transfers.failed, 0);
+  assert.deepEqual(finalizePaths, [
+    "/remnic/v1/offline-sync/convergence-complete",
+    "/engram/v1/offline-sync/convergence-complete",
+  ]);
+});
+
+test("remnic converge apply: finalizes after an ambiguous alias retry", async () => {
+  const content = Buffer.from("local");
+  let finalizeCalls = 0;
+  const fetchImpl: typeof fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/remnic/v1/offline-sync/apply-file-content") {
+      throw new Error("response lost");
+    }
+    if (url.pathname === "/engram/v1/offline-sync/apply-file-content") {
+      return Response.json({ done: true, applied: false, skipped: true });
+    }
+    if (url.pathname.endsWith("/offline-sync/convergence-complete")) {
+      finalizeCalls += 1;
+      return Response.json({ namespaces: ["team"], refreshed: true });
+    }
+    return new Response(null, { status: 404 });
+  };
+
+  const result = await executeConvergeApply({
+    peerUrl: "https://peer.example.test",
+    fetchImpl,
+    localFilesByNamespace: new Map([
+      ["team", [{
+        path: "facts/a.md",
+        sha256: createHash("sha256").update(content).digest("hex"),
+      }]],
+    ]),
+    peerFilesByNamespace: new Map([["team", []]]),
+    localFileBuffers: new Map([["team", new Map([["facts/a.md", content]])]]),
+  });
+
+  assert.equal(result.transfers.failed, 0);
+  assert.equal(finalizeCalls, 1);
+});
+
 test("remnic converge apply: a failed peer refresh prevents convergence and cursor advancement", async () => {
   const content = Buffer.from("local");
   let finalizeCalls = 0;
@@ -718,5 +789,5 @@ test("remnic converge apply: a failed peer refresh prevents convergence and curs
   assert.equal(result.transfers.failed, 1);
   assert.equal(result.converged, false);
   assert.equal(result.cursorUpdated, false);
-  assert.equal(finalizeCalls, 1);
+  assert.equal(finalizeCalls, 2);
 });

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -333,6 +333,9 @@ test("remnic converge apply: uses chunked offline-sync HTTP contracts for pull a
     if (url.includes("/remnic/v1/offline-sync/apply-file-content?namespace=default")) {
       return Response.json({ done: true, applied: true, skipped: false });
     }
+    if (url.includes("/remnic/v1/offline-sync/convergence-complete?namespace=default")) {
+      return Response.json({ namespaces: ["default"], refreshed: true });
+    }
     return new Response(null, { status: 404 });
   };
   const localBuffers = new Map<string, Map<string, Buffer>>([
@@ -503,7 +506,10 @@ test("remnic converge apply: local-wins guards against the planned peer revision
   const localSha256 = createHash("sha256").update(localContent).digest("hex");
   const peerSha256 = createHash("sha256").update(peerContent).digest("hex");
   let baseHeader: string | null = null;
-  const fetchImpl: typeof fetch = async (_input, init) => {
+  const fetchImpl: typeof fetch = async (input, init) => {
+    if (String(input).includes("/offline-sync/convergence-complete")) {
+      return Response.json({ namespaces: ["default"], refreshed: true });
+    }
     baseHeader = new Headers(init?.headers).get("x-remnic-base-sha256");
     return Response.json({ done: true, applied: true, skipped: false });
   };
@@ -527,4 +533,190 @@ test("remnic converge apply: local-wins guards against the planned peer revision
   assert.equal(result.transfers.conflictsResolved, 1);
   assert.equal(result.transfers.failed, 0);
   assert.equal(baseHeader, peerSha256);
+});
+
+test("remnic converge apply: finalizes each mutated peer namespace once after a successful batch", async () => {
+  const teamA = Buffer.from("team a");
+  const teamB = Buffer.from("team b");
+  const shared = Buffer.from("shared");
+  const buffers = new Map<string, Map<string, Buffer>>([
+    ["team", new Map([
+      ["facts/a.md", teamA],
+      ["facts/b.md", teamB],
+    ])],
+    ["shared", new Map([["facts/c.md", shared]])],
+  ]);
+  const localFiles = new Map<string, ReconcileFileState[]>([
+    ["team", [
+      { path: "facts/a.md", sha256: createHash("sha256").update(teamA).digest("hex") },
+      { path: "facts/b.md", sha256: createHash("sha256").update(teamB).digest("hex") },
+    ]],
+    ["shared", [
+      { path: "facts/c.md", sha256: createHash("sha256").update(shared).digest("hex") },
+    ]],
+  ]);
+  const finalized: string[][] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname.endsWith("/offline-sync/apply-file-content")) {
+      return Response.json({ done: true, applied: true, skipped: false });
+    }
+    if (url.pathname.endsWith("/offline-sync/convergence-complete")) {
+      assert.equal(new Headers(init?.headers).get("x-remnic-source-id"), "remnic-converge");
+      const namespaces = url.searchParams.getAll("namespace");
+      finalized.push(namespaces);
+      return Response.json({ namespaces, refreshed: true });
+    }
+    return new Response(null, { status: 404 });
+  };
+
+  const result = await executeConvergeApply({
+    peerUrl: "https://peer.example.test",
+    fetchImpl,
+    localFilesByNamespace: localFiles,
+    peerFilesByNamespace: new Map([
+      ["team", []],
+      ["shared", []],
+    ]),
+    localFileBuffers: buffers,
+  });
+
+  assert.equal(result.transfers.pushed, 3);
+  assert.equal(result.transfers.failed, 0);
+  assert.deepEqual(finalized, [["shared", "team"]]);
+});
+
+test("remnic converge apply: does not finalize peer namespaces after an incomplete batch", async () => {
+  const content = Buffer.from("local");
+  let finalizeCalls = 0;
+  const fetchImpl: typeof fetch = async (input) => {
+    const url = String(input);
+    if (url.includes("/offline-sync/convergence-complete")) {
+      finalizeCalls += 1;
+      return Response.json({ namespaces: ["team"], refreshed: true });
+    }
+    return Response.json({
+      done: true,
+      applied: false,
+      skipped: false,
+      conflict: { path: "facts/a.md", reason: "both_modified" },
+    });
+  };
+
+  const result = await executeConvergeApply({
+    peerUrl: "https://peer.example.test",
+    fetchImpl,
+    localFilesByNamespace: new Map([
+      ["team", [{
+        path: "facts/a.md",
+        sha256: createHash("sha256").update(content).digest("hex"),
+      }]],
+    ]),
+    peerFilesByNamespace: new Map([["team", []]]),
+    localFileBuffers: new Map([["team", new Map([["facts/a.md", content]])]]),
+  });
+
+  assert.equal(result.transfers.failed, 1);
+  assert.equal(finalizeCalls, 0);
+});
+
+test("remnic converge apply: finalizes completed namespaces when another namespace fails", async () => {
+  const team = Buffer.from("team");
+  const shared = Buffer.from("shared");
+  const finalized: string[][] = [];
+  const fetchImpl: typeof fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname.endsWith("/offline-sync/convergence-complete")) {
+      const namespaces = url.searchParams.getAll("namespace");
+      finalized.push(namespaces);
+      return Response.json({ namespaces, refreshed: true });
+    }
+    if (url.searchParams.get("namespace") === "team") {
+      return Response.json({ done: true, applied: true, skipped: false });
+    }
+    return Response.json({
+      done: true,
+      applied: false,
+      skipped: false,
+      conflict: { path: "facts/shared.md", reason: "both_modified" },
+    });
+  };
+
+  const result = await executeConvergeApply({
+    peerUrl: "https://peer.example.test",
+    fetchImpl,
+    localFilesByNamespace: new Map([
+      ["team", [{ path: "facts/team.md", sha256: createHash("sha256").update(team).digest("hex") }]],
+      ["shared", [{ path: "facts/shared.md", sha256: createHash("sha256").update(shared).digest("hex") }]],
+    ]),
+    peerFilesByNamespace: new Map([
+      ["team", []],
+      ["shared", []],
+    ]),
+    localFileBuffers: new Map([
+      ["team", new Map([["facts/team.md", team]])],
+      ["shared", new Map([["facts/shared.md", shared]])],
+    ]),
+  });
+
+  assert.equal(result.transfers.failed, 1);
+  assert.deepEqual(finalized, [["team"]]);
+});
+
+test("remnic converge apply: does not finalize a peer namespace when every write is skipped", async () => {
+  const content = Buffer.from("already present");
+  let finalizeCalls = 0;
+  const fetchImpl: typeof fetch = async (input) => {
+    if (String(input).includes("/offline-sync/convergence-complete")) {
+      finalizeCalls += 1;
+      return Response.json({ namespaces: ["team"], refreshed: true });
+    }
+    return Response.json({ done: true, applied: false, skipped: true });
+  };
+
+  const result = await executeConvergeApply({
+    peerUrl: "https://peer.example.test",
+    fetchImpl,
+    localFilesByNamespace: new Map([
+      ["team", [{
+        path: "facts/a.md",
+        sha256: createHash("sha256").update(content).digest("hex"),
+      }]],
+    ]),
+    peerFilesByNamespace: new Map([["team", []]]),
+    localFileBuffers: new Map([["team", new Map([["facts/a.md", content]])]]),
+  });
+
+  assert.equal(result.transfers.failed, 0);
+  assert.equal(finalizeCalls, 0);
+});
+
+test("remnic converge apply: a failed peer refresh prevents convergence and cursor advancement", async () => {
+  const content = Buffer.from("local");
+  let finalizeCalls = 0;
+  const fetchImpl: typeof fetch = async (input) => {
+    if (String(input).includes("/offline-sync/convergence-complete")) {
+      finalizeCalls += 1;
+      return new Response(null, { status: 503 });
+    }
+    return Response.json({ done: true, applied: true, skipped: false });
+  };
+
+  const result = await executeConvergeApply({
+    peerUrl: "https://peer.example.test",
+    fetchImpl,
+    localFilesByNamespace: new Map([
+      ["team", [{
+        path: "facts/a.md",
+        sha256: createHash("sha256").update(content).digest("hex"),
+      }]],
+    ]),
+    peerFilesByNamespace: new Map([["team", []]]),
+    localFileBuffers: new Map([["team", new Map([["facts/a.md", content]])]]),
+  });
+
+  assert.equal(result.transfers.failed, 1);
+  assert.equal(result.converged, false);
+  assert.equal(result.cursorUpdated, false);
+  assert.equal(finalizeCalls, 1);
 });

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -272,6 +272,12 @@ async function fetchPeerFileContent(
   return null;
 }
 
+function withoutTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
+  return value.slice(0, end);
+}
+
 async function postPeerFileContent(
   peerUrl: string,
   namespace: string,
@@ -281,11 +287,12 @@ async function postPeerFileContent(
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<"applied" | "skipped" | false> {
-  const base = peerUrl.replace(/\/+$/, "");
+  const base = withoutTrailingSlashes(peerUrl);
   const routes = [
     `/remnic/v1/offline-sync/apply-file-content?namespace=${encodeURIComponent(namespace)}`,
     `/engram/v1/offline-sync/apply-file-content?namespace=${encodeURIComponent(namespace)}`,
   ];
+  let previousAttemptFailed = false;
   for (const route of routes) {
     try {
       let offset = 0;
@@ -327,7 +334,7 @@ async function postPeerFileContent(
           return false;
         }
         if (result.done) {
-          if (result.skipped) return "skipped";
+          if (result.skipped) return previousAttemptFailed ? "applied" : "skipped";
           if (result.applied && offset + chunk.length === content.length) return "applied";
           return false;
         }
@@ -338,7 +345,7 @@ async function postPeerFileContent(
       } while (offset < content.length);
       return false;
     } catch {
-      // try next route
+      previousAttemptFailed = true;
     }
   }
   return false;
@@ -350,23 +357,25 @@ async function postPeerConvergenceComplete(
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<boolean> {
+  const base = withoutTrailingSlashes(peerUrl);
   const query = namespaces
     .map((namespace) => `namespace=${encodeURIComponent(namespace)}`)
     .join("&");
-  try {
-    const response = await fetchImpl(
-      `${peerUrl.replace(/\/+$/, "")}/remnic/v1/offline-sync/convergence-complete?${query}`,
-      {
-        method: "POST",
-        headers: {
-          "x-remnic-source-id": encodeURIComponent("remnic-converge"),
-          ...(token ? { authorization: `Bearer ${token}` } : {}),
-        },
+  const routes = [
+    "/remnic/v1/offline-sync/convergence-complete",
+    "/engram/v1/offline-sync/convergence-complete",
+  ];
+  for (const route of routes) {
+    const response = await fetchImpl(`${base}${route}?${query}`, {
+      method: "POST",
+      headers: {
+        "x-remnic-source-id": encodeURIComponent("remnic-converge"),
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
       },
-    );
-    if (!response.ok) return false;
+    }).catch(() => null);
+    if (!response?.ok) continue;
     const result: unknown = await response.json().catch(() => null);
-    return Boolean(
+    if (
       result
       && typeof result === "object"
       && "namespaces" in result
@@ -375,10 +384,11 @@ async function postPeerConvergenceComplete(
       && result.namespaces.every((namespace, index) => namespace === namespaces[index])
       && "refreshed" in result
       && result.refreshed === true
-    );
-  } catch {
-    return false;
+    ) {
+      return true;
+    }
   }
+  return false;
 }
 
 export async function computeConvergePlan(options: ConvergePlanOptions = {}): Promise<ReconcilePlan> {

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -280,7 +280,7 @@ async function postPeerFileContent(
   metadata: { sha256: string; mtimeMs: number; baseSha256?: string },
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
-): Promise<boolean> {
+): Promise<"applied" | "skipped" | false> {
   const base = peerUrl.replace(/\/+$/, "");
   const routes = [
     `/remnic/v1/offline-sync/apply-file-content?namespace=${encodeURIComponent(namespace)}`,
@@ -327,7 +327,9 @@ async function postPeerFileContent(
           return false;
         }
         if (result.done) {
-          return result.skipped || (result.applied && offset + chunk.length === content.length);
+          if (result.skipped) return "skipped";
+          if (result.applied && offset + chunk.length === content.length) return "applied";
+          return false;
         }
         if (result.applied || result.skipped || chunk.length === 0) {
           return false;
@@ -340,6 +342,43 @@ async function postPeerFileContent(
     }
   }
   return false;
+}
+
+async function postPeerConvergenceComplete(
+  peerUrl: string,
+  namespaces: readonly string[],
+  token?: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<boolean> {
+  const query = namespaces
+    .map((namespace) => `namespace=${encodeURIComponent(namespace)}`)
+    .join("&");
+  try {
+    const response = await fetchImpl(
+      `${peerUrl.replace(/\/+$/, "")}/remnic/v1/offline-sync/convergence-complete?${query}`,
+      {
+        method: "POST",
+        headers: {
+          "x-remnic-source-id": encodeURIComponent("remnic-converge"),
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+        },
+      },
+    );
+    if (!response.ok) return false;
+    const result: unknown = await response.json().catch(() => null);
+    return Boolean(
+      result
+      && typeof result === "object"
+      && "namespaces" in result
+      && Array.isArray(result.namespaces)
+      && result.namespaces.length === namespaces.length
+      && result.namespaces.every((namespace, index) => namespace === namespaces[index])
+      && "refreshed" in result
+      && result.refreshed === true
+    );
+  } catch {
+    return false;
+  }
 }
 
 export async function computeConvergePlan(options: ConvergePlanOptions = {}): Promise<ReconcilePlan> {
@@ -523,6 +562,7 @@ export async function executeConvergeApply(
     suppressed: 0,
     failed: 0,
   };
+  const peerMutatedNamespaces = new Set<string>();
 
   let resolvedToken: string | undefined;
   if (options.peerToken) {
@@ -705,7 +745,7 @@ export async function executeConvergeApply(
           const expectedPeerSha256 = entry.action === "conflict"
             ? entry.peerSha256
             : entry.baseSha256;
-          const ok = await postPeerFileContent(
+          const applied = await postPeerFileContent(
             options.peerUrl,
             entry.namespace,
             entry.path,
@@ -718,7 +758,8 @@ export async function executeConvergeApply(
             resolvedToken,
             fetchFn,
           );
-          if (ok) {
+          if (applied) {
+            if (applied === "applied") peerMutatedNamespaces.add(entry.namespace);
             if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
             else actualTransfers.pushed += 1;
           } else {
@@ -732,6 +773,18 @@ export async function executeConvergeApply(
       }
     } else if (transferType === "suppress") {
       actualTransfers.suppressed += 1;
+    }
+  }
+
+  if (options.peerUrl && peerMutatedNamespaces.size > 0) {
+    const namespaces = [...peerMutatedNamespaces].sort();
+    if (!await postPeerConvergenceComplete(
+      options.peerUrl,
+      namespaces,
+      resolvedToken,
+      fetchFn,
+    )) {
+      actualTransfers.failed += 1;
     }
   }
 

--- a/packages/remnic-core/src/access-http-query.ts
+++ b/packages/remnic-core/src/access-http-query.ts
@@ -1,0 +1,25 @@
+import { EngramAccessInputError } from "./access-service.js";
+
+/** Optional string field from a JSON body: absent/null/"" → undefined. */
+export function optionalQueryString(value: unknown, label: string): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "string") {
+    throw new EngramAccessInputError(`${label} must be a string (got ${JSON.stringify(value)})`);
+  }
+  return value;
+}
+
+/** Optional non-empty query param: null/"" → undefined. */
+export function nonEmptyQueryParam(value: string | null): string | undefined {
+  return value !== null && value.length > 0 ? value : undefined;
+}
+
+/** Optional positive-integer query param; rejects invalid values. */
+export function positiveIntQueryParam(value: string | null, label: string): number | undefined {
+  if (value === null || value.length === 0) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+    throw new EngramAccessInputError(`${label} expects a positive integer`);
+  }
+  return parsed;
+}

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -3648,3 +3648,55 @@ test("HTTP authorization probe verifies requested operation grants without invok
     await server.stop();
   }
 });
+
+test("HTTP convergence completion forwards one authenticated namespace batch refresh", async () => {
+  const calls: Array<{ namespaces: string[]; principal?: string; sourceId: string }> = [];
+  const service = {
+    offlineSyncFinalizeConvergence: async (options: {
+      namespaces: string[];
+      principal?: string;
+      sourceId: string;
+    }) => {
+      calls.push(options);
+      return { namespaces: options.namespaces, refreshed: true as const };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "writer",
+    adminConsoleEnabled: false,
+  });
+  const route = "/remnic/v1/offline-sync/convergence-complete?namespace=team&namespace=shared";
+
+  const status = await server.start();
+  try {
+    const denied = await fetch(`http://127.0.0.1:${status.port}${route}`, {
+      method: "POST",
+      headers: { "x-remnic-source-id": encodeURIComponent("remnic-converge") },
+    });
+    assert.equal(denied.status, 401);
+
+    const response = await fetch(`http://127.0.0.1:${status.port}${route}`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "x-remnic-source-id": encodeURIComponent("remnic-converge"),
+      },
+    });
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      namespaces: ["team", "shared"],
+      refreshed: true,
+    });
+    assert.deepEqual(calls, [{
+      namespaces: ["team", "shared"],
+      principal: "writer",
+      sourceId: "remnic-converge",
+    }]);
+  } finally {
+    await server.stop();
+  }
+});

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -3700,3 +3700,87 @@ test("HTTP convergence completion forwards one authenticated namespace batch ref
     await server.stop();
   }
 });
+
+test("HTTP convergence completion enforces the per-principal write rate limit", async () => {
+  let completions = 0;
+  const service = {
+    offlineSyncFinalizeConvergence: async () => {
+      completions += 1;
+      return { namespaces: ["team"], refreshed: true as const };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+    writeRateLimitMaxRequests: 1,
+  });
+  const status = await server.start();
+  const route = `http://127.0.0.1:${status.port}/remnic/v1/offline-sync/convergence-complete?namespace=team`;
+  const requestOptions: RequestInit = {
+    method: "POST",
+    headers: {
+      authorization: "Bearer test-token",
+      "x-remnic-source-id": encodeURIComponent("remnic-converge"),
+    },
+  };
+
+  try {
+    const first = await fetch(route, requestOptions);
+    assert.equal(first.status, 200);
+    await first.text();
+
+    const second = await fetch(route, requestOptions);
+    assert.equal(second.status, 429);
+    const rateLimited: unknown = await second.json();
+    assert.ok(rateLimited && typeof rateLimited === "object" && "code" in rateLimited);
+    assert.equal(rateLimited.code, "write_rate_limited");
+    assert.equal(completions, 1, "the rate-limited completion must not reach the service");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP convergence completion denies scoped tokens that omit the namespace", async () => {
+  let completions = 0;
+  const service = {
+    configRef: parseConfig({
+      memoryDir: "/tmp/remnic-http-convergence-completion-namespace",
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+    }),
+    offlineSyncFinalizeConvergence: async () => {
+      completions += 1;
+      return { namespaces: ["default"], refreshed: true as const };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authTokenEntriesGetter: () => [
+      { token: "scoped-token", capabilities: { version: 1, namespaces: ["team"] } },
+    ],
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${status.port}/remnic/v1/offline-sync/convergence-complete`,
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer scoped-token",
+          "x-remnic-source-id": encodeURIComponent("remnic-converge"),
+        },
+      },
+    );
+
+    assert.equal(response.status, 403);
+    await response.text();
+    assert.equal(completions, 0, "the denied completion must not reach the service");
+  } finally {
+    await server.stop();
+  }
+});

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -18,6 +18,7 @@ import {
   type EngramAccessWriteResponse,
 } from "./access-service.js";
 import { maybeHandleLifecycleFlush, type LifecycleFlushHttpDeps } from "./access-http-lifecycle-flush.js";
+import { nonEmptyQueryParam, optionalQueryString, positiveIntQueryParam } from "./access-http-query.js";
 import { CorrectionContractError } from "./correction/correction-contract.js";
 import { WearablesInputError } from "./wearables/errors.js"; import { respondMeetingsList, respondMeetingsGet, respondMeetingsBuild } from "./meetings/http-glue.js";
 import { EngramMcpServer, MCP_SUPPORTED_PROTOCOL_VERSIONS } from "./access-mcp.js";
@@ -1317,6 +1318,27 @@ export class EngramAccessHttpServer {
         offset,
         baseSha256: this.readOptionalHeader(req, "x-remnic-base-sha256"),
         content,
+      });
+      this.respondJson(res, 200, result);
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      (
+        pathname === "/engram/v1/offline-sync/convergence-complete" ||
+        pathname === "/remnic/v1/offline-sync/convergence-complete"
+      )
+    ) {
+      this.enforceTokenOp("offline_sync_apply_file_content");
+      const namespaceParams = parsed.searchParams.getAll("namespace").filter(Boolean);
+      const namespaces = namespaceParams
+        .map((namespace) => this.resolveNamespace(req, namespace))
+        .filter((namespace): namespace is string => namespace !== undefined);
+      const result = await this.service.offlineSyncFinalizeConvergence({
+        ...(namespaces.length > 0 ? { namespaces } : {}),
+        principal: this.resolveRequestPrincipal(req),
+        sourceId: this.readRequiredDecodedHeader(req, "x-remnic-source-id"),
       });
       this.respondJson(res, 200, result);
       return;
@@ -3924,30 +3946,4 @@ export class EngramAccessHttpServer {
     }
     return false;
   }
-}
-
-/** Optional string field from a JSON body: absent/null/"" → undefined. */
-function optionalQueryString(value: unknown, label: string): string | undefined {
-  if (value === undefined || value === null || value === "") return undefined;
-  if (typeof value !== "string") {
-    throw new EngramAccessInputError(
-      `${label} must be a string (got ${JSON.stringify(value)})`,
-    );
-  }
-  return value;
-}
-
-/** Optional non-empty query param: null/"" → undefined. */
-function nonEmptyQueryParam(value: string | null): string | undefined {
-  return value !== null && value.length > 0 ? value : undefined;
-}
-
-/** Optional positive-integer query param; rejects invalid values. */
-function positiveIntQueryParam(value: string | null, label: string): number | undefined {
-  if (value === null || value.length === 0) return undefined;
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
-    throw new EngramAccessInputError(`${label} expects a positive integer`);
-  }
-  return parsed;
 }

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1332,14 +1332,18 @@ export class EngramAccessHttpServer {
     ) {
       this.enforceTokenOp("offline_sync_apply_file_content");
       const namespaceParams = parsed.searchParams.getAll("namespace").filter(Boolean);
-      const namespaces = namespaceParams
+      const requestedNamespaces: Array<string | undefined> =
+        namespaceParams.length > 0 ? namespaceParams : [undefined];
+      const namespaces = requestedNamespaces
         .map((namespace) => this.resolveNamespace(req, namespace))
         .filter((namespace): namespace is string => namespace !== undefined);
+      this.ensureWriteRateLimitAvailable(req);
       const result = await this.service.offlineSyncFinalizeConvergence({
         ...(namespaces.length > 0 ? { namespaces } : {}),
         principal: this.resolveRequestPrincipal(req),
         sourceId: this.readRequiredDecodedHeader(req, "x-remnic-source-id"),
       });
+      this.recordWriteRateLimitHit(req);
       this.respondJson(res, 200, result);
       return;
     }

--- a/packages/remnic-core/src/access-service-offline-file-content.test.ts
+++ b/packages/remnic-core/src/access-service-offline-file-content.test.ts
@@ -52,3 +52,43 @@ test("offline apply-file-content reports invalid metadata as input errors", asyn
       /mtimeMs must be within JavaScript Date range/.test(error.message),
   );
 });
+
+test("offline convergence completion refreshes authorized namespaces as one batch and rejects other sources", async () => {
+  const refreshed: string[][] = [];
+  const orchestratorStub = {
+    config: {
+      memoryDir: "/tmp/remnic-access-service-convergence-test",
+      namespacesEnabled: false,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+    },
+    refreshNamespacesAfterConvergence: async (namespaces: readonly string[]) => {
+      refreshed.push([...namespaces]);
+    },
+  };
+  const service = new EngramAccessService(
+    orchestratorStub as unknown as ConstructorParameters<typeof EngramAccessService>[0],
+  );
+  const convergenceService = service as unknown as {
+    offlineSyncFinalizeConvergence(options: {
+      namespaces?: string[];
+      principal?: string;
+      sourceId: string;
+    }): Promise<{ namespaces: string[]; refreshed: true }>;
+  };
+
+  await assert.rejects(
+    () => convergenceService.offlineSyncFinalizeConvergence({ sourceId: "laptop" }),
+    (error) =>
+      error instanceof EngramAccessInputError
+      && /sourceId must be remnic-converge/.test(error.message),
+  );
+  assert.deepEqual(refreshed, []);
+
+  const result = await convergenceService.offlineSyncFinalizeConvergence({
+    sourceId: "remnic-converge",
+  });
+
+  assert.deepEqual(result, { namespaces: ["global"], refreshed: true });
+  assert.deepEqual(refreshed, [["global"]]);
+});

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -818,6 +818,12 @@ export interface EngramAccessOfflineSyncApplyRequest {
   returnCurrentFiles?: boolean;
 }
 
+export interface EngramAccessOfflineSyncFinalizeConvergenceRequest {
+  namespaces?: string[];
+  principal?: string;
+  sourceId: string;
+}
+
 export interface EngramAccessOfflineSyncSnapshotResponse extends OfflineSyncSnapshot {
   namespace: string;
 }
@@ -841,6 +847,11 @@ export interface EngramAccessOfflineSyncApplyFileContentResponse extends Offline
 
 export interface EngramAccessOfflineSyncApplyResponse extends OfflineSyncApplyChangesetResult {
   namespace: string;
+}
+
+export interface EngramAccessOfflineSyncFinalizeConvergenceResponse {
+  namespaces: string[];
+  refreshed: true;
 }
 
 export type EngramAccessActionConfidenceRequest = ActionConfidenceInput;
@@ -5619,6 +5630,29 @@ export class EngramAccessService {
       }
       throw error;
     }
+  }
+
+  async offlineSyncFinalizeConvergence(
+    options: EngramAccessOfflineSyncFinalizeConvergenceRequest,
+  ): Promise<EngramAccessOfflineSyncFinalizeConvergenceResponse> {
+    if (options.sourceId !== "remnic-converge") {
+      throw new EngramAccessInputError("sourceId must be remnic-converge");
+    }
+    const requestedNamespaces = options.namespaces?.length
+      ? options.namespaces
+      : [undefined];
+    const resolvedNamespaces = Array.from(new Set(
+      requestedNamespaces.map((namespace) => this.writableNamespaceFor(
+        namespace,
+        undefined,
+        options.principal,
+      )),
+    ));
+    await this.orchestrator.refreshNamespacesAfterConvergence(resolvedNamespaces);
+    return {
+      namespaces: resolvedNamespaces,
+      refreshed: true,
+    };
   }
 
   async offlineSyncApply(

--- a/packages/remnic-core/src/access-surface-catalog.ts
+++ b/packages/remnic-core/src/access-surface-catalog.ts
@@ -183,6 +183,11 @@ export const HTTP_ROUTES: readonly HttpRouteEntry[] = [
   { method: "POST", pathname: "/engram/v1/offline-sync/files", operation: "offline_sync_files" },
   { method: "POST", pathname: "/engram/v1/offline-sync/file-content", operation: "offline_sync_file_content" },
   { method: "POST", pathname: "/engram/v1/offline-sync/apply-file-content", operation: "offline_sync_apply_file_content" },
+  {
+    method: "POST",
+    pathname: "/engram/v1/offline-sync/convergence-complete",
+    operation: "offline_sync_apply_file_content",
+  },
   { method: "POST", pathname: "/engram/v1/offline-sync/apply", operation: "offline_sync_apply" },
   { method: "POST", pathname: "/engram/v1/recall/explain", operation: "recall_explain" },
   { method: "POST", pathname: "/engram/v1/action-confidence", operation: "action_confidence" },

--- a/packages/remnic-core/src/convergence-refresh.ts
+++ b/packages/remnic-core/src/convergence-refresh.ts
@@ -1,8 +1,8 @@
 import {
   type RebuildMemoryProjectionOptions,
   rebuildMemoryProjection,
-} from "../maintenance/rebuild-memory-projection.js";
-import type { NamespaceSearchRouter } from "../namespaces/search.js";
+} from "./maintenance/rebuild-memory-projection.js";
+import type { NamespaceSearchRouter } from "./namespaces/search.js";
 
 type ConvergenceStorage = NonNullable<RebuildMemoryProjectionOptions["storage"]>;
 
@@ -14,12 +14,7 @@ export async function refreshConvergedNamespaces(
   const targetNamespaces = Array.from(new Set(namespaces.map((namespace) => namespace.trim()).filter(Boolean)));
   if (targetNamespaces.length === 0) return;
 
-  const update = await namespaceSearchRouter.updateNamespacesDetailed(targetNamespaces, undefined, { strict: true });
-  const eligible = new Set(update.eligibleNamespaces);
-  const missing = targetNamespaces.filter((namespace) => !eligible.has(namespace));
-  if (update.backendCount <= 0 || missing.length > 0) {
-    throw new Error(`QMD backend ineligible for convergence namespaces (${missing.length})`);
-  }
+  await namespaceSearchRouter.updateNamespacesDetailed(targetNamespaces, undefined, { strict: true });
 
   for (const namespace of targetNamespaces) {
     const storage = await getStorage(namespace);

--- a/packages/remnic-core/src/orchestration/convergence-refresh.ts
+++ b/packages/remnic-core/src/orchestration/convergence-refresh.ts
@@ -1,0 +1,33 @@
+import {
+  type RebuildMemoryProjectionOptions,
+  rebuildMemoryProjection,
+} from "../maintenance/rebuild-memory-projection.js";
+import type { NamespaceSearchRouter } from "../namespaces/search.js";
+
+type ConvergenceStorage = NonNullable<RebuildMemoryProjectionOptions["storage"]>;
+
+export async function refreshConvergedNamespaces(
+  namespaces: readonly string[],
+  namespaceSearchRouter: Pick<NamespaceSearchRouter, "updateNamespacesDetailed">,
+  getStorage: (namespace: string) => Promise<ConvergenceStorage>
+): Promise<void> {
+  const targetNamespaces = Array.from(new Set(namespaces.map((namespace) => namespace.trim()).filter(Boolean)));
+  if (targetNamespaces.length === 0) return;
+
+  const update = await namespaceSearchRouter.updateNamespacesDetailed(targetNamespaces, undefined, { strict: true });
+  const eligible = new Set(update.eligibleNamespaces);
+  const missing = targetNamespaces.filter((namespace) => !eligible.has(namespace));
+  if (update.backendCount <= 0 || missing.length > 0) {
+    throw new Error(`QMD backend ineligible for convergence namespaces (${missing.length})`);
+  }
+
+  for (const namespace of targetNamespaces) {
+    const storage = await getStorage(namespace);
+    await rebuildMemoryProjection({
+      memoryDir: storage.dir,
+      storage,
+      defaultNamespace: namespace,
+      dryRun: false,
+    });
+  }
+}

--- a/packages/remnic-core/src/orchestrator-convergence-refresh.test.ts
+++ b/packages/remnic-core/src/orchestrator-convergence-refresh.test.ts
@@ -76,35 +76,39 @@ test("refreshNamespacesAfterConvergence runs one strict QMD batch and rebuilds e
   }
 });
 
-test("refreshNamespacesAfterConvergence fails before projection when QMD cannot index every namespace", async () => {
-  let storageRequested = false;
-  const orchestrator = Object.create(Orchestrator.prototype) as Orchestrator;
-  const internals = orchestrator as unknown as {
-    namespaceSearchRouter: {
-      updateNamespacesDetailed(
-        namespaces: string[],
-        execution?: unknown,
-        options?: { strict?: boolean }
-      ): Promise<{ backendCount: number; eligibleNamespaces: string[] }>;
+test("refreshNamespacesAfterConvergence rebuilds projection when search is disabled", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-convergence-no-search-"));
+  try {
+    const storage = new StorageManager(memoryDir);
+    const memory = await storage.writeMemory("fact", "A received fact without search enabled.", {
+      source: "test",
+    });
+    const orchestrator = Object.create(Orchestrator.prototype) as Orchestrator;
+    const internals = orchestrator as unknown as {
+      namespaceSearchRouter: {
+        updateNamespacesDetailed(
+          namespaces: string[],
+          execution?: unknown,
+          options?: { strict?: boolean }
+        ): Promise<{ backendCount: number; eligibleNamespaces: string[] }>;
+      };
+      getStorage(namespace: string): Promise<StorageManager>;
     };
-    getStorage(namespace: string): Promise<StorageManager>;
-  };
-  internals.namespaceSearchRouter = {
-    async updateNamespacesDetailed() {
-      return { backendCount: 1, eligibleNamespaces: ["team"] };
-    },
-  };
-  internals.getStorage = async () => {
-    storageRequested = true;
-    throw new Error("projection should not run");
-  };
-  const refreshSurface = orchestrator as unknown as {
-    refreshNamespacesAfterConvergence(namespaces: readonly string[]): Promise<void>;
-  };
+    internals.namespaceSearchRouter = {
+      async updateNamespacesDetailed() {
+        return { backendCount: 0, eligibleNamespaces: [] };
+      },
+    };
+    internals.getStorage = async () => storage;
+    const refreshSurface = orchestrator as unknown as {
+      refreshNamespacesAfterConvergence(namespaces: readonly string[]): Promise<void>;
+    };
 
-  await assert.rejects(
-    () => refreshSurface.refreshNamespacesAfterConvergence(["team", "shared"]),
-    /QMD backend ineligible for convergence namespaces \(1\)/
-  );
-  assert.equal(storageRequested, false);
+    await refreshSurface.refreshNamespacesAfterConvergence(["default"]);
+
+    const projection = readProjectedMemoryBrowse(memoryDir, { limit: 10, offset: 0 });
+    assert.equal(projection?.memories[0]?.id, memory.id);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-core/src/orchestrator-convergence-refresh.test.ts
+++ b/packages/remnic-core/src/orchestrator-convergence-refresh.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { readProjectedMemoryBrowse } from "./memory-projection-store.js";
+import { Orchestrator } from "./orchestrator.js";
+import { StorageManager } from "./storage.js";
+
+test("refreshNamespacesAfterConvergence runs one strict QMD batch and rebuilds each namespace projection once", async () => {
+  const teamDir = await mkdtemp(path.join(os.tmpdir(), "remnic-convergence-team-"));
+  const sharedDir = await mkdtemp(path.join(os.tmpdir(), "remnic-convergence-shared-"));
+  try {
+    const teamStorage = new StorageManager(teamDir);
+    const sharedStorage = new StorageManager(sharedDir);
+    const teamMemory = await teamStorage.writeMemory("fact", "A received team fact.", {
+      source: "test",
+    });
+    const sharedMemory = await sharedStorage.writeMemory("fact", "A received shared fact.", {
+      source: "test",
+    });
+    const qmdCalls: Array<{
+      namespaces: string[];
+      options: { strict?: boolean } | undefined;
+    }> = [];
+    const storageCalls: string[] = [];
+    const orchestrator = Object.create(Orchestrator.prototype) as Orchestrator;
+    const internals = orchestrator as unknown as {
+      config: { defaultNamespace: string };
+      namespaceSearchRouter: {
+        updateNamespacesDetailed(
+          namespaces: string[],
+          execution?: unknown,
+          options?: { strict?: boolean }
+        ): Promise<{ backendCount: number; eligibleNamespaces: string[] }>;
+      };
+      getStorage(namespace: string): Promise<StorageManager>;
+    };
+    internals.config = { defaultNamespace: "default" };
+    internals.namespaceSearchRouter = {
+      async updateNamespacesDetailed(namespaces, _execution, options) {
+        qmdCalls.push({ namespaces, options });
+        return { backendCount: 1, eligibleNamespaces: namespaces };
+      },
+    };
+    const storageByNamespace = new Map([
+      ["team", teamStorage],
+      ["shared", sharedStorage],
+    ]);
+    internals.getStorage = async (namespace) => {
+      storageCalls.push(namespace);
+      const storage = storageByNamespace.get(namespace);
+      assert.ok(storage);
+      return storage;
+    };
+    const refreshSurface = orchestrator as unknown as {
+      refreshNamespacesAfterConvergence(namespaces: readonly string[]): Promise<void>;
+    };
+
+    await refreshSurface.refreshNamespacesAfterConvergence(["team", "shared", "team"]);
+
+    assert.deepEqual(qmdCalls, [
+      {
+        namespaces: ["team", "shared"],
+        options: { strict: true },
+      },
+    ]);
+    assert.deepEqual(storageCalls, ["team", "shared"]);
+    const teamProjection = readProjectedMemoryBrowse(teamDir, { limit: 10, offset: 0 });
+    const sharedProjection = readProjectedMemoryBrowse(sharedDir, { limit: 10, offset: 0 });
+    assert.equal(teamProjection?.memories[0]?.id, teamMemory.id);
+    assert.equal(sharedProjection?.memories[0]?.id, sharedMemory.id);
+  } finally {
+    await Promise.all([rm(teamDir, { recursive: true, force: true }), rm(sharedDir, { recursive: true, force: true })]);
+  }
+});
+
+test("refreshNamespacesAfterConvergence fails before projection when QMD cannot index every namespace", async () => {
+  let storageRequested = false;
+  const orchestrator = Object.create(Orchestrator.prototype) as Orchestrator;
+  const internals = orchestrator as unknown as {
+    namespaceSearchRouter: {
+      updateNamespacesDetailed(
+        namespaces: string[],
+        execution?: unknown,
+        options?: { strict?: boolean }
+      ): Promise<{ backendCount: number; eligibleNamespaces: string[] }>;
+    };
+    getStorage(namespace: string): Promise<StorageManager>;
+  };
+  internals.namespaceSearchRouter = {
+    async updateNamespacesDetailed() {
+      return { backendCount: 1, eligibleNamespaces: ["team"] };
+    },
+  };
+  internals.getStorage = async () => {
+    storageRequested = true;
+    throw new Error("projection should not run");
+  };
+  const refreshSurface = orchestrator as unknown as {
+    refreshNamespacesAfterConvergence(namespaces: readonly string[]): Promise<void>;
+  };
+
+  await assert.rejects(
+    () => refreshSurface.refreshNamespacesAfterConvergence(["team", "shared"]),
+    /QMD backend ineligible for convergence namespaces \(1\)/
+  );
+  assert.equal(storageRequested, false);
+});

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -218,7 +218,7 @@ import {
   runPatternReinforcement,
   type PatternReinforcementResult,
 } from "./maintenance/pattern-reinforcement.js";
-import { refreshConvergedNamespaces } from "./orchestration/convergence-refresh.js";
+import { refreshConvergedNamespaces } from "./convergence-refresh.js";
 import { ModelRegistry } from "./model-registry.js";
 import { applyRuntimeRetrievalPolicy, expandQuery } from "./retrieval.js";
 import {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -218,6 +218,7 @@ import {
   runPatternReinforcement,
   type PatternReinforcementResult,
 } from "./maintenance/pattern-reinforcement.js";
+import { refreshConvergedNamespaces } from "./orchestration/convergence-refresh.js";
 import { ModelRegistry } from "./model-registry.js";
 import { applyRuntimeRetrievalPolicy, expandQuery } from "./retrieval.js";
 import {
@@ -1278,10 +1279,10 @@ export class Orchestrator {
     return await this.namespaceSearchRouter.healthForNamespace(namespace, execution);
   }
 
-  private isSearchAvailableForNamespaceRouting(): boolean {
-    if (resolveNamespaceCapabilities(this.config).namespaces) return true;
-    return this.qmd.isAvailable();
+  async refreshNamespacesAfterConvergence(namespaces: readonly string[]): Promise<void> {
+    return refreshConvergedNamespaces(namespaces, this.namespaceSearchRouter, this.getStorage.bind(this));
   }
+
 
   invalidateLiveContentHashIndex(): void {
     this.contentHashIndex = null;
@@ -1530,7 +1531,7 @@ export class Orchestrator {
     });
     this.contradictionLinkingCoordinator = new ContradictionLinkingCoordinator({
       getConfig: () => this.config,
-      isSearchAvailable: () => this.isSearchAvailableForNamespaceRouting(),
+      isSearchAvailable: () => resolveNamespaceCapabilities(this.config).namespaces || this.qmd.isAvailable(),
       searchAcrossNamespaces: (options) => this.searchAcrossNamespaces(options),
       extractMemoryIdsFromResults: (results) => this.extractMemoryIdsFromResults(results),
       namespaceFromPath: (p) => this.namespaceFromPath(p),


### PR DESCRIPTION
Part of #2150.

A finished converge batch now tells the receiver which namespaces changed.

The receiver updates search once. It then rebuilds each changed memory view once.

The new route shares the same access right as the file writes. A failed refresh blocks success and the cursor update.

A partial run still refreshes each namespace whose writes finished.

Follow-up #2234 tracks retry state across runs. Follow-up #2235 tracks peer version checks. Follow-up #2240 tracks local pull refresh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches offline-sync write/finalize paths and orchestrator search plus projection rebuild; a failed or mis-scoped finalize intentionally blocks cursor advancement, which is correct but operationally sensitive.
> 
> **Overview**
> Adds a **post-batch convergence finalize** step so the peer that received file writes can refresh search and memory projections for the namespaces that actually changed.
> 
> **`remnic converge apply`** now POSTs to `offline-sync/convergence-complete` (remnic/engram aliases) with sorted `namespace` query params and `x-remnic-source-id: remnic-converge` after pushes that **applied** content—not when every write was skipped or the batch still has transfer failures. A **503 or invalid finalize response** counts as a failure, so the run is not converged and the **cursor is not advanced**. Peer push handling distinguishes **applied vs skipped** (including treating a successful fallback-route skip after a lost response as applied for finalize eligibility).
> 
> On the **receiver**, a new authenticated HTTP route shares the **offline sync apply-file-content** operation, write rate limit, and namespace token checks. **`offlineSyncFinalizeConvergence`** accepts only `sourceId === remnic-converge`, resolves writable namespaces for the principal, then **`refreshNamespacesAfterConvergence`**: one strict **`updateNamespacesDetailed`** batch plus **`rebuildMemoryProjection`** per namespace (new `convergence-refresh.ts`). HTTP query helpers move to **`access-http-query.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783d6391bd5c3d110f74dde40c83aed071775df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added convergence finalization to refresh search data and rebuild memory views for changed namespaces.
  - Added a protected endpoint for completing convergence and triggering namespace refreshes.
  - Added validation for optional, non-empty, and positive-integer query parameters.

- **Bug Fixes**
  - Improved route fallback handling and accurate reporting of applied versus skipped changes.
  - Ensured only successfully completed namespaces are finalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->