### PR TITLE
Stop duplicate facts during peer sync

### DIFF
--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -605,3 +605,60 @@ test("remnic converge plan builds semantic manifests from local and peer memory 
     await fs.rm(cursorDir, { recursive: true, force: true });
   }
 });
+
+test("remnic converge plan reuses unchanged shared peer semantics to collapse cross-path duplicates", async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-shared-manifest-"));
+  try {
+    const body = "same active fact at a shared path";
+    const semanticHash = ContentHashIndex.computeHash(body);
+    const memory = (id: string): string => [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      "created: 2026-01-01T00:00:00.000Z",
+      "updated: 2026-01-01T00:00:00.000Z",
+      `contentHash: ${semanticHash}`,
+      "status: active",
+      "---",
+      body,
+    ].join("\n");
+    const canonicalContent = memory("a");
+    const sharedContent = memory("z");
+    const sharedSha = createHash("sha256").update(sharedContent).digest("hex");
+    await fs.mkdir(path.join(rootDir, "facts"), { recursive: true });
+    await fs.writeFile(path.join(rootDir, "facts/a.md"), canonicalContent);
+    await fs.writeFile(path.join(rootDir, "facts/z.md"), sharedContent);
+    let peerContentRequests = 0;
+
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/offline-sync/snapshot")) {
+        return Response.json({
+          files:
+            url.searchParams.get("namespace") === "default"
+              ? [{ path: "facts/z.md", sha256: sharedSha, bytes: sharedContent.length, mtimeMs: 2000 }]
+              : [],
+          tombstones: [],
+        });
+      }
+      if (url.pathname.endsWith("/offline-sync/file-content")) {
+        peerContentRequests += 1;
+      }
+      return new Response(null, { status: 404 });
+    };
+
+    const plan = await computeConvergePlan({
+      config: parseConfig({ memoryDir: rootDir }),
+      peerUrl: "https://peer.example.test",
+      fetchImpl,
+    });
+
+    assert.equal(peerContentRequests, 0);
+    assert.equal(plan.converged, true, JSON.stringify(plan));
+    assert.deepEqual(plan.entries.map((entry) => [entry.path, entry.action, entry.reason]), [
+      ["facts/a.md", "identical", "semantic_duplicate"],
+    ]);
+  } finally {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { test } from "node:test";
-import { OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES, parseConfig } from "@remnic/core";
+import { ContentHashIndex, OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES, parseConfig } from "@remnic/core";
 import type { ReconcileFileState } from "@remnic/core/reconcile/plan.js";
 import {
   defaultConvergeCursorPath,
@@ -527,4 +527,81 @@ test("remnic converge apply: local-wins guards against the planned peer revision
   assert.equal(result.transfers.conflictsResolved, 1);
   assert.equal(result.transfers.failed, 0);
   assert.equal(baseHeader, peerSha256);
+});
+
+test("remnic converge plan builds semantic manifests from local and peer memory bytes", async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-manifest-"));
+  const cursorDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-cursor-"));
+  try {
+    const body = "same active fact";
+    const semanticHash = ContentHashIndex.computeHash(body);
+    const localContent = [
+      "---",
+      "id: local-id",
+      "category: fact",
+      "created: 2026-01-01T00:00:00.000Z",
+      "updated: 2026-01-01T00:00:00.000Z",
+      `contentHash: ${semanticHash}`,
+      "status: active",
+      "---",
+      body,
+    ].join("\n");
+    const peerContent = localContent;
+    const localSha = createHash("sha256").update(localContent).digest("hex");
+    const peerSha = createHash("sha256").update(peerContent).digest("hex");
+    await fs.mkdir(path.join(rootDir, "facts"), { recursive: true });
+    await fs.writeFile(path.join(rootDir, "facts/local-id.md"), localContent);
+
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/offline-sync/snapshot")) {
+        return Response.json({
+          files:
+            url.searchParams.get("namespace") === "default"
+              ? [{ path: "facts/peer-id.md", sha256: peerSha, bytes: peerContent.length, mtimeMs: 2000 }]
+              : [],
+          tombstones: [],
+        });
+      }
+      if (url.pathname.endsWith("/offline-sync/file-content")) {
+        return new Response(peerContent, {
+          headers: {
+            "x-remnic-file-path": encodeURIComponent("facts/peer-id.md"),
+            "x-remnic-file-sha256": peerSha,
+            "x-remnic-file-bytes": String(peerContent.length),
+            "x-remnic-file-mtime-ms": "2000",
+            "x-remnic-chunk-offset": "0",
+            "x-remnic-chunk-bytes": String(peerContent.length),
+          },
+        });
+      }
+      return new Response(null, { status: 404 });
+    };
+
+    const peerUrl = "https://peer.example.test";
+    const options = {
+      config: parseConfig({ memoryDir: rootDir }),
+      cursorDir,
+      peerUrl,
+      fetchImpl,
+    };
+    const plan = await computeConvergePlan(options);
+
+    assert.equal(localSha, peerSha);
+    assert.equal(plan.converged, true, JSON.stringify(plan));
+    assert.equal(plan.entries.length, 1);
+    assert.equal(plan.entries[0]?.action, "identical");
+    assert.equal(plan.entries[0]?.reason, "semantic_duplicate");
+    assert.equal(plan.entries[0]?.path, "facts/local-id.md");
+
+    const result = await executeConvergeApply(options);
+    assert.equal(result.converged, true);
+    const cursor = await readConvergeCursor(defaultConvergeCursorPath(cursorDir, peerUrl, "default"));
+    assert.deepEqual(cursor?.baseFiles, []);
+    const rerun = await computeConvergePlan(options);
+    assert.equal(rerun.converged, true, JSON.stringify(rerun));
+  } finally {
+    await fs.rm(rootDir, { recursive: true, force: true });
+    await fs.rm(cursorDir, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -461,11 +461,11 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
       const peerData = await fetchPeerSnapshot(peerUrl, ns, resolvedToken, fetchFn);
       peerMap.set(ns, peerData.files);
       peerTombstones.set(ns, peerData.tombstones);
-      const localPaths = new Set((localMap.get(ns) ?? []).map((file) => file.path));
       peerManifests.set(
         ns,
         await buildReconcileManifest({
-          files: peerData.files.filter((file) => !localPaths.has(file.path)),
+          files: peerData.files,
+          cachedFiles: localManifests.get(ns)?.files,
           readFile: async (file) => {
             const remote = await fetchPeerFileContent(peerUrl, ns, file.path, resolvedToken, fetchFn);
             if (!remote || remote.sha256 !== file.sha256) {

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -25,6 +25,11 @@ import {
   writeConvergeCursor,
   type ConvergeCursorState,
 } from "@remnic/core/reconcile/cursor.js";
+import {
+  buildReconcileManifest,
+  collapseActiveFactDuplicates,
+  type ReconcileManifest,
+} from "@remnic/core/reconcile/manifest.js";
 import { createOfflineStorageIo } from "./offline-storage-io.js";
 import { resolveAgentAccessAuthToken } from "@remnic/core/resolve-auth-token.js";
 export interface ConvergePlanOptions {
@@ -349,6 +354,8 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
   const localTombstones = new Map<string, Set<string>>();
   const peerMap = new Map<string, ReconcileFileState[]>();
   const peerTombstones = new Map<string, Set<string>>();
+  const localManifests = new Map<string, ReconcileManifest>();
+  const peerManifests = new Map<string, ReconcileManifest>();
 
   if (options.baseFilesByNamespace) {
     for (const [ns, files] of options.baseFilesByNamespace) {
@@ -409,6 +416,22 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
           bytes: record.bytes,
         }));
         localMap.set(ns, files);
+        const io = await createOfflineStorageIo(rootInfo.rootDir);
+        localManifests.set(
+          ns,
+          await buildReconcileManifest({
+            files,
+            readFile: async (file) => {
+              const readFile = io.readFile;
+              if (!readFile) throw new Error("offline storage cannot read reconciliation manifest files");
+              return await readFile({
+                root: rootInfo.rootDir,
+                path: file.path,
+                filePath: path.join(rootInfo.rootDir, file.path),
+              });
+            },
+          }),
+        );
         const tombstones = await readLocalTombstones(rootInfo.rootDir);
         localTombstones.set(ns, tombstones);
       } catch {
@@ -417,7 +440,8 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
     }
   }
 
-  if (!options.peerFilesByNamespace && options.peerUrl) {
+  const peerUrl = options.peerUrl;
+  if (!options.peerFilesByNamespace && peerUrl) {
     let resolvedToken: string | undefined;
     if (options.peerToken) {
       try {
@@ -430,9 +454,22 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
     }
     const fetchFn = options.fetchImpl ?? globalThis.fetch;
     for (const ns of namespacesToPlan) {
-      const peerData = await fetchPeerSnapshot(options.peerUrl, ns, resolvedToken, fetchFn);
+      const peerData = await fetchPeerSnapshot(peerUrl, ns, resolvedToken, fetchFn);
       peerMap.set(ns, peerData.files);
       peerTombstones.set(ns, peerData.tombstones);
+      peerManifests.set(
+        ns,
+        await buildReconcileManifest({
+          files: peerData.files,
+          readFile: async (file) => {
+            const remote = await fetchPeerFileContent(peerUrl, ns, file.path, resolvedToken, fetchFn);
+            if (!remote || remote.sha256 !== file.sha256) {
+              throw new Error(`failed to read peer reconciliation manifest file: ${file.path}`);
+            }
+            return remote.content;
+          },
+        }),
+      );
     }
   }
 
@@ -459,7 +496,8 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
     });
   }
 
-  return planReconciliation(inputs, { conflictPolicy: options.conflictPolicy });
+  const plan = planReconciliation(inputs, { conflictPolicy: options.conflictPolicy });
+  return collapseActiveFactDuplicates(plan, localManifests, peerManifests);
 }
 
 export async function executeConvergeApply(
@@ -766,11 +804,12 @@ async function updateCursorsForPlan(
   const namespaces = new Set(plan.byNamespace.map((n) => n.namespace));
   for (const ns of namespaces) {
     const cursorPath = defaultConvergeCursorPath(memoryDir, peerUrl, ns);
-    const nsEntries = plan.entries.filter((e) => e.namespace === ns);
-    const baseFiles = nsEntries.map((e) => ({
-      path: e.path,
-      sha256: e.localSha256 ?? e.peerSha256 ?? "unknown",
-    }));
+    const baseFiles = plan.entries
+      .filter((entry) => entry.namespace === ns && entry.reason !== "semantic_duplicate")
+      .map((entry) => ({
+        path: entry.path,
+        sha256: entry.localSha256 ?? entry.peerSha256 ?? "unknown",
+      }));
 
     const cursorState: ConvergeCursorState = {
       version: 1,

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -416,22 +416,26 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
           bytes: record.bytes,
         }));
         localMap.set(ns, files);
-        const io = await createOfflineStorageIo(rootInfo.rootDir);
-        localManifests.set(
-          ns,
-          await buildReconcileManifest({
-            files,
-            readFile: async (file) => {
-              const readFile = io.readFile;
-              if (!readFile) throw new Error("offline storage cannot read reconciliation manifest files");
-              return await readFile({
-                root: rootInfo.rootDir,
-                path: file.path,
-                filePath: path.join(rootInfo.rootDir, file.path),
-              });
-            },
-          }),
-        );
+        try {
+          const io = await createOfflineStorageIo(rootInfo.rootDir);
+          localManifests.set(
+            ns,
+            await buildReconcileManifest({
+              files,
+              readFile: async (file) => {
+                const readFile = io.readFile;
+                if (!readFile) throw new Error("offline storage cannot read reconciliation manifest files");
+                return await readFile({
+                  root: rootInfo.rootDir,
+                  path: file.path,
+                  filePath: path.join(rootInfo.rootDir, file.path),
+                });
+              },
+            }),
+          );
+        } catch {
+          localManifests.delete(ns);
+        }
         const tombstones = await readLocalTombstones(rootInfo.rootDir);
         localTombstones.set(ns, tombstones);
       } catch {
@@ -457,10 +461,11 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
       const peerData = await fetchPeerSnapshot(peerUrl, ns, resolvedToken, fetchFn);
       peerMap.set(ns, peerData.files);
       peerTombstones.set(ns, peerData.tombstones);
+      const localPaths = new Set((localMap.get(ns) ?? []).map((file) => file.path));
       peerManifests.set(
         ns,
         await buildReconcileManifest({
-          files: peerData.files,
+          files: peerData.files.filter((file) => !localPaths.has(file.path)),
           readFile: async (file) => {
             const remote = await fetchPeerFileContent(peerUrl, ns, file.path, resolvedToken, fetchFn);
             if (!remote || remote.sha256 !== file.sha256) {

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -166,6 +166,16 @@
       "remnic-source": "./src/reconcile/plan.ts",
       "import": "./dist/reconcile/plan.js"
     },
+    "./reconcile/manifest": {
+      "types": "./dist/reconcile/manifest.d.ts",
+      "remnic-source": "./src/reconcile/manifest.ts",
+      "import": "./dist/reconcile/manifest.js"
+    },
+    "./reconcile/manifest.js": {
+      "types": "./dist/reconcile/manifest.d.ts",
+      "remnic-source": "./src/reconcile/manifest.ts",
+      "import": "./dist/reconcile/manifest.js"
+    },
     "./reconcile/cursor": {
       "types": "./dist/reconcile/cursor.d.ts",
       "remnic-source": "./src/reconcile/cursor.ts",

--- a/packages/remnic-core/src/reconcile/manifest.test.ts
+++ b/packages/remnic-core/src/reconcile/manifest.test.ts
@@ -1,0 +1,193 @@
+import * as assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { test } from "node:test";
+import { ContentHashIndex } from "../storage/content-hash-index.js";
+import { type ReconcileManifest, buildReconcileManifest, collapseActiveFactDuplicates } from "./manifest.js";
+import { planReconciliation } from "./plan.js";
+
+const fileHash = (content: string): string => createHash("sha256").update(content).digest("hex");
+
+function memoryFile(options: {
+  id: string;
+  content: string;
+  contentHash?: string;
+  status?: string;
+}): string {
+  return [
+    "---",
+    `id: ${options.id}`,
+    "category: fact",
+    "created: 2026-01-01T00:00:00.000Z",
+    "updated: 2026-01-01T00:00:00.000Z",
+    ...(options.contentHash ? [`contentHash: ${options.contentHash}`] : []),
+    ...(options.status ? [`status: ${options.status}`] : []),
+    "---",
+    options.content,
+  ].join("\n");
+}
+
+test("reconcile manifest keeps file identity separate from canonical semantic identity", async () => {
+  const content = "The deployment uses a durable queue with an enrichment suffix.";
+  const semanticHash = ContentHashIndex.computeHash("The deployment uses a durable queue.");
+  const serialized = memoryFile({ id: "fact-a", content, contentHash: semanticHash, status: "active" });
+  const serializedHash = fileHash(serialized);
+
+  const manifest = await buildReconcileManifest({
+    files: [{ path: "facts/fact-a.md", sha256: serializedHash, bytes: Buffer.byteLength(serialized) }],
+    readFile: async () => Buffer.from(serialized),
+  });
+
+  assert.equal(manifest.format, "remnic-reconcile-manifest");
+  assert.equal(manifest.schemaVersion, 1);
+  assert.equal(manifest.files[0]?.sha256, serializedHash);
+  assert.notEqual(serializedHash, semanticHash);
+  assert.deepEqual(manifest.files[0]?.memory, {
+    id: "fact-a",
+    category: "fact",
+    contentHash: semanticHash,
+    status: "active",
+  });
+});
+
+test("reconcile manifest hashes parsed legacy content and uses effective lifecycle status", async () => {
+  const active = memoryFile({ id: "legacy", content: "Legacy fact body" });
+  const archived = memoryFile({ id: "archived", content: "Archived fact body", status: "active" });
+  const rawByPath = new Map([
+    ["facts/legacy.md", Buffer.from(active)],
+    ["archive/facts/archived.md", Buffer.from(archived)],
+  ]);
+
+  const manifest = await buildReconcileManifest({
+    files: [...rawByPath].map(([path, raw]) => ({ path, sha256: fileHash(raw.toString()) })),
+    readFile: async (file) => rawByPath.get(file.path) ?? null,
+  });
+
+  assert.equal(manifest.files[0]?.memory?.contentHash, ContentHashIndex.computeHash("Archived fact body"));
+  assert.equal(manifest.files[0]?.memory?.status, "archived");
+  assert.equal(manifest.files[1]?.memory?.contentHash, ContentHashIndex.computeHash("Legacy fact body"));
+  assert.equal(manifest.files[1]?.memory?.status, "active");
+});
+
+test("reconcile manifest keeps file identity when memory bytes cannot be trusted", async () => {
+  const readable = memoryFile({ id: "readable", content: "Readable fact" });
+  const changed = memoryFile({ id: "changed", content: "Changed after census" });
+  const files = [
+    { path: "facts/readable.md", sha256: fileHash(readable) },
+    { path: "facts/locked.md", sha256: "f".repeat(64) },
+    { path: "facts/changed.md", sha256: fileHash("bytes from census") },
+  ];
+
+  const manifest = await buildReconcileManifest({
+    files,
+    readFile: async (file) => {
+      if (file.path === "facts/locked.md") throw new Error("locked");
+      return file.path === "facts/changed.md" ? changed : readable;
+    },
+  });
+
+  assert.equal(manifest.files.length, 3);
+  assert.equal(manifest.files.find((file) => file.path === "facts/readable.md")?.memory?.id, "readable");
+  assert.equal(manifest.files.find((file) => file.path === "facts/locked.md")?.memory, undefined);
+  assert.equal(manifest.files.find((file) => file.path === "facts/changed.md")?.memory, undefined);
+});
+
+test("ContentHashIndex resolves a semantic hash to a stable canonical path without changing membership", () => {
+  const semanticHash = ContentHashIndex.computeHash("same fact");
+  const entries = [
+    { path: "facts/z.md", contentHash: semanticHash },
+    { path: "facts/a.md", contentHash: semanticHash },
+    { path: "facts/other.md", contentHash: ContentHashIndex.computeHash("other fact") },
+  ];
+  const index = new ContentHashIndex("unused");
+
+  assert.equal(ContentHashIndex.resolvePathByHash(semanticHash, entries), "facts/a.md");
+  assert.equal(ContentHashIndex.resolvePathByHash("f".repeat(64), entries), undefined);
+  assert.equal(index.has("same fact"), false);
+});
+
+test("semantic collapse prevents different active fact paths from transferring both directions", () => {
+  const semanticHash = ContentHashIndex.computeHash("same active fact");
+  const localFile = { path: "facts/local-id.md", sha256: "a".repeat(64) };
+  const peerFile = { path: "facts/peer-id.md", sha256: "b".repeat(64) };
+  const plan = planReconciliation([{ namespace: "default", local: [localFile], peer: [peerFile] }]);
+  const local: ReconcileManifest = {
+    format: "remnic-reconcile-manifest",
+    schemaVersion: 1,
+    files: [
+      { ...localFile, memory: { id: "local-id", category: "fact", contentHash: semanticHash, status: "active" } },
+    ],
+  };
+  const peer: ReconcileManifest = {
+    format: "remnic-reconcile-manifest",
+    schemaVersion: 1,
+    files: [{ ...peerFile, memory: { id: "peer-id", category: "fact", contentHash: semanticHash, status: "active" } }],
+  };
+
+  const collapsed = collapseActiveFactDuplicates(plan, new Map([["default", local]]), new Map([["default", peer]]));
+
+  assert.equal(collapsed.converged, true);
+  assert.deepEqual(collapsed.entries, [
+    {
+      path: "facts/local-id.md",
+      namespace: "default",
+      action: "identical",
+      reason: "semantic_duplicate",
+      localSha256: localFile.sha256,
+      peerSha256: peerFile.sha256,
+    },
+  ]);
+  assert.equal(collapsed.byNamespace[0]?.identical, 1);
+  assert.equal(collapsed.byNamespace[0]?.pull, 0);
+  assert.equal(collapsed.byNamespace[0]?.push, 0);
+});
+
+test("semantic collapse does not fold non-active facts or unrelated path conflicts", () => {
+  const semanticHash = ContentHashIndex.computeHash("same inactive fact");
+  const localFile = { path: "facts/local.md", sha256: "a".repeat(64) };
+  const peerFile = { path: "facts/peer.md", sha256: "b".repeat(64) };
+  const plan = planReconciliation([{ namespace: "default", local: [localFile], peer: [peerFile] }]);
+  const manifest = (file: typeof localFile, id: string, status: "active" | "archived"): ReconcileManifest => ({
+    format: "remnic-reconcile-manifest",
+    schemaVersion: 1,
+    files: [{ ...file, memory: { id, category: "fact", contentHash: semanticHash, status } }],
+  });
+
+  const collapsed = collapseActiveFactDuplicates(
+    plan,
+    new Map([["default", manifest(localFile, "local", "active")]]),
+    new Map([["default", manifest(peerFile, "peer", "archived")]])
+  );
+
+  assert.deepEqual(collapsed, plan);
+});
+
+test("semantic collapse leaves tombstone suppression authoritative", () => {
+  const semanticHash = ContentHashIndex.computeHash("retracted fact");
+  const localFile = { path: "facts/local.md", sha256: "a".repeat(64) };
+  const peerFile = { path: "facts/peer.md", sha256: "b".repeat(64) };
+  const plan = planReconciliation([
+    {
+      namespace: "default",
+      local: [localFile],
+      peer: [peerFile],
+      tombstonedFileSha256: [localFile.sha256],
+    },
+  ]);
+  const manifest = (file: typeof localFile, id: string): ReconcileManifest => ({
+    format: "remnic-reconcile-manifest",
+    schemaVersion: 1,
+    files: [{ ...file, memory: { id, category: "fact", contentHash: semanticHash, status: "active" } }],
+  });
+
+  const collapsed = collapseActiveFactDuplicates(
+    plan,
+    new Map([["default", manifest(localFile, "local")]]),
+    new Map([["default", manifest(peerFile, "peer")]])
+  );
+
+  assert.deepEqual(collapsed, plan);
+  assert.equal(
+    collapsed.entries.some((entry) => entry.action === "suppress"),
+    true
+  );
+});

--- a/packages/remnic-core/src/reconcile/manifest.test.ts
+++ b/packages/remnic-core/src/reconcile/manifest.test.ts
@@ -191,3 +191,26 @@ test("semantic collapse leaves tombstone suppression authoritative", () => {
     true
   );
 });
+
+test("semantic collapse preserves same-path metadata updates", () => {
+  const path = "facts/shared.md";
+  const localFile = { path, sha256: "a".repeat(64) };
+  const peerFile = { path, sha256: "b".repeat(64) };
+  const baseFile = { path, sha256: peerFile.sha256 };
+  const semanticHash = ContentHashIndex.computeHash("same raw fact");
+  const plan = planReconciliation([{ namespace: "default", local: [localFile], peer: [peerFile], base: [baseFile] }]);
+  const manifest = (file: typeof localFile, id: string): ReconcileManifest => ({
+    format: "remnic-reconcile-manifest",
+    schemaVersion: 1,
+    files: [{ ...file, memory: { id, category: "fact", contentHash: semanticHash, status: "active" } }],
+  });
+
+  const collapsed = collapseActiveFactDuplicates(
+    plan,
+    new Map([["default", manifest(localFile, "local")]]),
+    new Map([["default", manifest(peerFile, "peer")]])
+  );
+
+  assert.deepEqual(collapsed, plan);
+  assert.equal(collapsed.entries[0]?.action, "push");
+});

--- a/packages/remnic-core/src/reconcile/manifest.test.ts
+++ b/packages/remnic-core/src/reconcile/manifest.test.ts
@@ -214,3 +214,48 @@ test("semantic collapse preserves same-path metadata updates", () => {
   assert.deepEqual(collapsed, plan);
   assert.equal(collapsed.entries[0]?.action, "push");
 });
+
+test("semantic collapse remains converged after transferring the canonical one-sided duplicate", () => {
+  const semanticHash = ContentHashIndex.computeHash("same one-sided fact");
+  const canonical = { path: "facts/a.md", sha256: "a".repeat(64) };
+  const duplicate = { path: "facts/b.md", sha256: "b".repeat(64) };
+  const manifest = (files: Array<{ path: string; sha256: string }>): ReconcileManifest => ({
+    format: "remnic-reconcile-manifest",
+    schemaVersion: 1,
+    files: files.map((file) => ({
+      ...file,
+      memory: {
+        id: file.path,
+        category: "fact",
+        contentHash: semanticHash,
+        status: "active",
+      },
+    })),
+  });
+  const localManifest = manifest([canonical, duplicate]);
+  const firstPlan = planReconciliation([{ namespace: "default", local: [canonical, duplicate], peer: [] }]);
+
+  const firstCollapsed = collapseActiveFactDuplicates(
+    firstPlan,
+    new Map([["default", localManifest]]),
+    new Map([["default", manifest([])]])
+  );
+
+  assert.deepEqual(
+    firstCollapsed.entries.map((entry) => [entry.path, entry.action]),
+    [[canonical.path, "push"]]
+  );
+
+  const rerunPlan = planReconciliation([{ namespace: "default", local: [canonical, duplicate], peer: [canonical] }]);
+  const rerunCollapsed = collapseActiveFactDuplicates(
+    rerunPlan,
+    new Map([["default", localManifest]]),
+    new Map([["default", manifest([canonical])]])
+  );
+
+  assert.equal(rerunCollapsed.converged, true, JSON.stringify(rerunCollapsed));
+  assert.deepEqual(
+    rerunCollapsed.entries.map((entry) => [entry.path, entry.action]),
+    [[canonical.path, "identical"]]
+  );
+});

--- a/packages/remnic-core/src/reconcile/manifest.ts
+++ b/packages/remnic-core/src/reconcile/manifest.ts
@@ -35,6 +35,7 @@ export interface ReconcileManifest {
 export interface BuildReconcileManifestOptions {
   files: Iterable<ReconcileFileState>;
   readFile: (file: ReconcileFileState) => Promise<Buffer | string | null>;
+  cachedFiles?: Iterable<ReconcileManifestFile>;
 }
 
 const SHA256_PATTERN = /^[a-f0-9]{64}$/i;
@@ -94,8 +95,19 @@ function parsedMemoryIdentity(filePath: string, raw: Buffer | string): Reconcile
 }
 
 export async function buildReconcileManifest(options: BuildReconcileManifestOptions): Promise<ReconcileManifest> {
+  const cachedByPath = new Map<string, ReconcileManifestFile>();
+  for (const cached of options.cachedFiles ?? []) {
+    cachedByPath.set(cached.path, cached);
+  }
+
   const files: ReconcileManifestFile[] = [];
   for (const file of options.files) {
+    const cached = cachedByPath.get(file.path);
+    if (cached?.sha256.toLowerCase() === file.sha256.toLowerCase()) {
+      files.push({ ...file, ...(cached.memory ? { memory: cached.memory } : {}) });
+      continue;
+    }
+
     let raw: Buffer | string | null = null;
     if (isMemoryPath(file.path)) {
       try {
@@ -236,7 +248,10 @@ export function collapseActiveFactDuplicates(
         return false;
       });
       const canonicalPath = localPath ?? peerPath;
-      if (!canonicalPath || sameSideEntries.length < 2) continue;
+      const hasSharedCanonical = localPath !== undefined && localPath === peerPath;
+      if (!canonicalPath || sameSideEntries.length === 0 || (!hasSharedCanonical && sameSideEntries.length < 2)) {
+        continue;
+      }
       for (const entry of sameSideEntries) {
         if (entry.path !== canonicalPath) {
           removed.add(entry);

--- a/packages/remnic-core/src/reconcile/manifest.ts
+++ b/packages/remnic-core/src/reconcile/manifest.ts
@@ -1,0 +1,263 @@
+import { createHash } from "node:crypto";
+import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
+import { ContentHashIndex, type ContentHashPathEntry } from "../storage/content-hash-index.js";
+import type { MemoryFrontmatter, MemoryStatus } from "../types.js";
+import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
+import {
+  type ReconcileFileState,
+  type ReconcilePlan,
+  type ReconcilePlanEntry,
+  summarizeReconcilePlan,
+} from "./plan.js";
+
+export const RECONCILE_MANIFEST_FORMAT = "remnic-reconcile-manifest";
+export const RECONCILE_MANIFEST_SCHEMA_VERSION = 1;
+
+export interface ReconcileMemoryIdentity {
+  id: string;
+  category: string;
+  contentHash: string;
+  status: MemoryStatus;
+}
+
+export interface ReconcileManifestFile extends ReconcileFileState {
+  memory?: ReconcileMemoryIdentity;
+}
+
+type ActiveFactManifestFile = ReconcileManifestFile & { memory: ReconcileMemoryIdentity };
+
+export interface ReconcileManifest {
+  format: typeof RECONCILE_MANIFEST_FORMAT;
+  schemaVersion: typeof RECONCILE_MANIFEST_SCHEMA_VERSION;
+  files: ReconcileManifestFile[];
+}
+
+export interface BuildReconcileManifestOptions {
+  files: Iterable<ReconcileFileState>;
+  readFile: (file: ReconcileFileState) => Promise<Buffer | string | null>;
+}
+
+const SHA256_PATTERN = /^[a-f0-9]{64}$/i;
+const MEMORY_DIRS = new Set(RECALL_FALLBACK_DIRS);
+
+function isMemoryPath(filePath: string): boolean {
+  if (!filePath.endsWith(".md")) return false;
+  const segments = filePath.split("/");
+  let index = 0;
+  if (segments[index] === "cold" || segments[index] === "archive") index += 1;
+  return MEMORY_DIRS.has(segments[index] ?? "");
+}
+
+function parseScalar(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      return typeof parsed === "string" ? parsed : trimmed;
+    } catch {
+      return trimmed.slice(1, -1).replace(/\\"/g, '"');
+    }
+  }
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1).replace(/''/g, "'");
+  }
+  return trimmed;
+}
+
+function parsedMemoryIdentity(filePath: string, raw: Buffer | string): ReconcileMemoryIdentity | undefined {
+  if (!isMemoryPath(filePath)) return undefined;
+  const match = (Buffer.isBuffer(raw) ? raw.toString("utf8") : raw).match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) return undefined;
+  const fields = new Map<string, string>();
+  for (const line of match[1].split("\n")) {
+    const separator = line.indexOf(":");
+    if (separator > 0) fields.set(line.slice(0, separator).trim(), line.slice(separator + 1).trim());
+  }
+  const id = parseScalar(fields.get("id"));
+  if (!id) return undefined;
+  const category = parseScalar(fields.get("category")) ?? "fact";
+  const storedHash = parseScalar(fields.get("contentHash"));
+  const contentHash =
+    storedHash && SHA256_PATTERN.test(storedHash)
+      ? storedHash.toLowerCase()
+      : ContentHashIndex.computeHash(match[2].trim());
+  const status = inferMemoryStatus(
+    {
+      status: parseScalar(fields.get("status")) as MemoryStatus | undefined,
+      archivedAt: parseScalar(fields.get("archivedAt")),
+    } as MemoryFrontmatter,
+    filePath
+  );
+  return { id, category, contentHash, status };
+}
+
+export async function buildReconcileManifest(options: BuildReconcileManifestOptions): Promise<ReconcileManifest> {
+  const files: ReconcileManifestFile[] = [];
+  for (const file of options.files) {
+    let raw: Buffer | string | null = null;
+    if (isMemoryPath(file.path)) {
+      try {
+        raw = await options.readFile(file);
+      } catch {
+        raw = null;
+      }
+    }
+    if (raw !== null && createHash("sha256").update(raw).digest("hex") !== file.sha256.toLowerCase()) {
+      raw = null;
+    }
+    const memory = raw === null ? undefined : parsedMemoryIdentity(file.path, raw);
+    files.push({ ...file, ...(memory ? { memory } : {}) });
+  }
+  files.sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+  return {
+    format: RECONCILE_MANIFEST_FORMAT,
+    schemaVersion: RECONCILE_MANIFEST_SCHEMA_VERSION,
+    files,
+  };
+}
+
+function activeFactByPath(manifest: ReconcileManifest | undefined): Map<string, ActiveFactManifestFile> {
+  const result = new Map<string, ActiveFactManifestFile>();
+  for (const file of manifest?.files ?? []) {
+    if (file.memory?.category === "fact" && file.memory.status === "active") {
+      result.set(file.path, file as ActiveFactManifestFile);
+    }
+  }
+  return result;
+}
+
+function contentHashRows(files: Iterable<ActiveFactManifestFile>): ContentHashPathEntry[] {
+  const rows: ContentHashPathEntry[] = [];
+  for (const file of files) {
+    rows.push({ path: file.path, contentHash: file.memory.contentHash });
+  }
+  return rows;
+}
+
+function comparePlanEntries(left: ReconcilePlanEntry, right: ReconcilePlanEntry): number {
+  if (left.namespace !== right.namespace) return left.namespace < right.namespace ? -1 : 1;
+  return left.path < right.path ? -1 : left.path > right.path ? 1 : 0;
+}
+
+export function collapseActiveFactDuplicates(
+  plan: ReconcilePlan,
+  localManifests: ReadonlyMap<string, ReconcileManifest>,
+  peerManifests: ReadonlyMap<string, ReconcileManifest>
+): ReconcilePlan {
+  const entriesByNamespace = new Map<string, ReconcilePlanEntry[]>();
+  for (const entry of plan.entries) {
+    const entries = entriesByNamespace.get(entry.namespace) ?? [];
+    entries.push({ ...entry });
+    entriesByNamespace.set(entry.namespace, entries);
+  }
+
+  let changed = false;
+  for (const namespace of new Set([...localManifests.keys(), ...peerManifests.keys()])) {
+    const entries = entriesByNamespace.get(namespace) ?? [];
+    const localManifest = localManifests.get(namespace);
+    const peerManifest = peerManifests.get(namespace);
+    const localByPath = activeFactByPath(localManifest);
+    const peerByPath = activeFactByPath(peerManifest);
+    const localFilesByPath = new Map((localManifest?.files ?? []).map((file) => [file.path, file]));
+    const peerFilesByPath = new Map((peerManifest?.files ?? []).map((file) => [file.path, file]));
+    const localByHash = new Map<string, ActiveFactManifestFile[]>();
+    const peerByHash = new Map<string, ActiveFactManifestFile[]>();
+
+    for (const file of localByPath.values()) {
+      const hash = file.memory.contentHash;
+      const bucket = localByHash.get(hash) ?? [];
+      bucket.push(file);
+      localByHash.set(hash, bucket);
+    }
+    for (const file of peerByPath.values()) {
+      const hash = file.memory.contentHash;
+      const bucket = peerByHash.get(hash) ?? [];
+      bucket.push(file);
+      peerByHash.set(hash, bucket);
+    }
+
+    const removed = new Set<ReconcilePlanEntry>();
+    const replacements: ReconcilePlanEntry[] = [];
+    for (const hash of new Set([...localByHash.keys(), ...peerByHash.keys()])) {
+      const localCandidates = (localByHash.get(hash) ?? []).filter((file) => {
+        const opposite = peerFilesByPath.get(file.path);
+        const activeOpposite = peerByPath.get(file.path);
+        return opposite === undefined || activeOpposite?.memory.contentHash === hash;
+      });
+      const peerCandidates = (peerByHash.get(hash) ?? []).filter((file) => {
+        const opposite = localFilesByPath.get(file.path);
+        const activeOpposite = localByPath.get(file.path);
+        return opposite === undefined || activeOpposite?.memory.contentHash === hash;
+      });
+      const localPath = ContentHashIndex.resolvePathByHash(hash, contentHashRows(localCandidates));
+      const peerPath = ContentHashIndex.resolvePathByHash(hash, contentHashRows(peerCandidates));
+
+      if (localPath && peerPath) {
+        const localFile = localByPath.get(localPath);
+        const peerFile = peerByPath.get(peerPath);
+        if (!localFile || !peerFile) continue;
+        const duplicatePaths = new Set([
+          ...localCandidates.map((file) => file.path),
+          ...peerCandidates.map((file) => file.path),
+        ]);
+        const unsafeEntry = entries.some(
+          (entry) => duplicatePaths.has(entry.path) && (entry.action === "suppress" || entry.action === "conflict")
+        );
+        if (unsafeEntry) continue;
+        for (const entry of entries) {
+          if (
+            duplicatePaths.has(entry.path) &&
+            (entry.action === "pull" || entry.action === "push" || entry.action === "identical")
+          ) {
+            removed.add(entry);
+          }
+        }
+        replacements.push({
+          path: localPath < peerPath ? localPath : peerPath,
+          namespace,
+          action: "identical",
+          reason: "semantic_duplicate",
+          localSha256: localFile.sha256,
+          peerSha256: peerFile.sha256,
+        });
+        changed = true;
+        continue;
+      }
+
+      const sameSideEntries = entries.filter((entry) => {
+        if (localPath && entry.reason === "local_only") {
+          return localCandidates.some((file) => file.path === entry.path);
+        }
+        if (peerPath && entry.reason === "peer_only") {
+          return peerCandidates.some((file) => file.path === entry.path);
+        }
+        return false;
+      });
+      const canonicalPath = localPath ?? peerPath;
+      if (!canonicalPath || sameSideEntries.length < 2) continue;
+      for (const entry of sameSideEntries) {
+        if (entry.path !== canonicalPath) {
+          removed.add(entry);
+          changed = true;
+        }
+      }
+    }
+
+    if (removed.size > 0 || replacements.length > 0) {
+      entriesByNamespace.set(
+        namespace,
+        [...entries.filter((entry) => !removed.has(entry)), ...replacements].sort(comparePlanEntries)
+      );
+    }
+  }
+
+  if (!changed) return plan;
+  const entries = [...entriesByNamespace.values()].flat().sort(comparePlanEntries);
+  return {
+    entries,
+    byNamespace: summarizeReconcilePlan(entries),
+    converged: entries.every((entry) => entry.action === "identical"),
+  };
+}

--- a/packages/remnic-core/src/reconcile/manifest.ts
+++ b/packages/remnic-core/src/reconcile/manifest.ts
@@ -194,7 +194,7 @@ export function collapseActiveFactDuplicates(
       const localPath = ContentHashIndex.resolvePathByHash(hash, contentHashRows(localCandidates));
       const peerPath = ContentHashIndex.resolvePathByHash(hash, contentHashRows(peerCandidates));
 
-      if (localPath && peerPath) {
+      if (localPath && peerPath && localPath !== peerPath) {
         const localFile = localByPath.get(localPath);
         const peerFile = peerByPath.get(peerPath);
         if (!localFile || !peerFile) continue;

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -79,6 +79,7 @@ export type ReconcileReason =
   | "peer_changed"
   | "local_changed"
   | "same_content"
+  | "semantic_duplicate"
   | "both_modified"
   | "peer_deleted"
   | "local_deleted"

--- a/packages/remnic-core/src/storage/content-hash-index.ts
+++ b/packages/remnic-core/src/storage/content-hash-index.ts
@@ -84,6 +84,11 @@ type DiskFingerprint = {
   ctimeMs: number;
   birthtimeMs: number;
 };
+export interface ContentHashPathEntry {
+  readonly path: string;
+  readonly contentHash: string;
+}
+
 /**
  * Content-hash dedup index for facts.
  * Normalizes content (lowercase, strip punctuation, collapse whitespace),
@@ -667,6 +672,27 @@ export class ContentHashIndex {
     this.hashes.add(hash);
     this.added.add(hash);
     this.dirty = true;
+  }
+
+  /**
+   * Resolve a pre-computed semantic hash to one deterministic corpus path.
+   *
+   * This lookup is separate from durable hash membership: `this.hashes` stays
+   * one hash per line and `has(content)` keeps its existing raw-content contract.
+   * Reconciliation supplies short-lived manifest rows where hash and path coexist.
+   */
+  static resolvePathByHash(
+    hash: string,
+    entries: Iterable<ContentHashPathEntry>,
+  ): string | undefined {
+    const canonicalHash = hash.toLowerCase();
+    if (!/^[a-f0-9]{64}$/.test(canonicalHash)) return undefined;
+    let canonicalPath: string | undefined;
+    for (const entry of entries) {
+      if (entry.contentHash.toLowerCase() !== canonicalHash || entry.path.length === 0) continue;
+      if (canonicalPath === undefined || entry.path < canonicalPath) canonicalPath = entry.path;
+    }
+    return canonicalPath;
   }
 
   /** Normalize content (delegates to content-hash.ts for a single source of truth). */


### PR DESCRIPTION
Part of #2150.

## Summary

This adds a sync manifest with file and memory identity. It hashes the parsed memory body, not the full file. Peer sync can now spot the same active fact under two paths before it sends either copy.

Tombstones and path conflicts still win. An unreadable file stays in the file list and falls back to the normal sync plan. The content-hash index keeps its current file format and membership rules.

## Checks

The type check, focused tests, build, review-pattern check, and source ratchet check pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offline peer reconciliation and transfer decisions; safeguards preserve tombstones and conflicts, with broad test coverage.
> 
> **Overview**
> Peer **converge** planning now builds **reconcile manifests** that attach parsed memory identity (semantic `contentHash`, lifecycle status) to census files, then **collapses** active facts that match semantically but differ by path or file SHA-256.
> 
> After the normal reconcile plan, `collapseActiveFactDuplicates` can replace pull/push pairs with **`identical` / `semantic_duplicate`**, so the same fact under two paths does not sync both ways. Local manifest bytes are reused when building the peer manifest when SHA-256 matches, avoiding extra peer fetches when semantics are already known locally.
> 
> **Tombstones**, **conflicts**, and **suppress** entries are left alone; unreadable or hash-mismatched memory files keep the byte-level plan. Converge **cursors** no longer record paths whose only plan entry is `semantic_duplicate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a937d1fe17522d32f7f94d8d5c4b8bad26c139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved synchronization now detects semantically identical memories even when file bytes and SHA-256 differ.
  - Added reconcile-manifest support for building manifests and collapsing duplicate active facts using a stable canonical path.
- **Bug Fixes**
  - Improved reconciliation status handling for legacy/archived representations and for unreadable memory files.
  - Enhanced safety so suppression/conflict decisions are preserved during duplicate consolidation.
- **Tests**
  - Added coverage for semantic matching, duplicate consolidation, suppression precedence, and repeat convergence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->