### PR TITLE
feat(converge): configure conflict policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `converge.conflictPolicy` configures `newest-wins`, `manual`, or `keep-both` conflict handling. The default remains `newest-wins`, and `--conflict-policy` overrides it for one command (#2150 increment 5).
+- `converge.conflictPolicy` configures `newest-wins` or `manual` conflict handling. The default remains `newest-wins`, including timestamped delete-versus-modify conflicts, and `--conflict-policy` overrides it for one command (#2150 increment 5).
 
 ## [v9.42.0] — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `converge.conflictPolicy` configures `newest-wins`, `manual`, or `keep-both` conflict handling. The default remains `newest-wins`, and `--conflict-policy` overrides it for one command (#2150 increment 5).
+
 ## [v9.42.0] — 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `converge.conflictPolicy` configures `newest-wins` or `manual` conflict handling. The default remains `newest-wins`, including timestamped delete-versus-modify conflicts, and `--conflict-policy` overrides it for one command (#2150 increment 5).
+- `converge.conflictPolicy` configures `newest-wins` or `manual` conflict handling. This release changes the default to `newest-wins`; conflicts without comparable timestamps still stop before mutation. `--conflict-policy` overrides the config for one command (#2150 increment 5).
 
 ## [v9.44.0] — 2026-07-30
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1188,7 +1188,7 @@ Polling never runs inline on the health request path: a probe reads the last com
 
 Policy values:
 
-- `newest-wins` selects the revision with the newest timestamp. For a delete-versus-modify conflict, the timestamped surviving revision wins. If two revisions tie or either timestamp is unavailable, apply stops because Remnic cannot yet preserve both revisions at distinct durable identities. This is the backward-compatible default.
+- `newest-wins` selects the newer revision when both sides carry comparable timestamps. Delete-versus-modify conflicts require a durable per-path deletion timestamp; without one, apply stops before mutation. If two revisions tie or either timestamp is unavailable, apply also stops because Remnic cannot yet preserve both revisions at distinct durable identities.
 - `manual` reports unresolved conflicts and stops before mutation.
 
 The CLI `--conflict-policy <policy>` flag overrides `converge.conflictPolicy` for that invocation.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1188,9 +1188,8 @@ Polling never runs inline on the health request path: a probe reads the last com
 
 Policy values:
 
-- `newest-wins` selects the revision with the newest timestamp. If either timestamp is unavailable or they tie, it preserves both with a supersede link. This is the backward-compatible default.
+- `newest-wins` selects the revision with the newest timestamp. For a delete-versus-modify conflict, the timestamped surviving revision wins. If two revisions tie or either timestamp is unavailable, apply stops because Remnic cannot yet preserve both revisions at distinct durable identities. This is the backward-compatible default.
 - `manual` reports unresolved conflicts and stops before mutation.
-- `keep-both` preserves both revisions and uses the planner's supersede links to retain their relationship.
 
 The CLI `--conflict-policy <policy>` flag overrides `converge.conflictPolicy` for that invocation.
 If neither is set, Remnic uses `newest-wins`.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1180,6 +1180,21 @@ A daemon configured with peer URLs polls each peer's authenticated `/health` cor
 
 Polling never runs inline on the health request path: a probe reads the last completed poll (with its timestamp) and a stale entry triggers a bounded background refresh (the corpus-watermark stale-while-revalidate idiom). The `replica` block on `/health` is filtered to the presenting token's namespace capabilities, so a namespace-restricted token never learns about namespaces it cannot see.
 
+## Replica convergence conflict policy (issue #2150)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `converge.conflictPolicy` | `newest-wins` | Selects how `remnic converge` resolves revisions that conflict. |
+
+Policy values:
+
+- `newest-wins` selects the revision with the newest timestamp. If either timestamp is unavailable or they tie, it preserves both with a supersede link. This is the backward-compatible default.
+- `manual` reports unresolved conflicts and stops before mutation.
+- `keep-both` preserves both revisions and uses the planner's supersede links to retain their relationship.
+
+The CLI `--conflict-policy <policy>` flag overrides `converge.conflictPolicy` for that invocation.
+If neither is set, Remnic uses `newest-wins`.
+
 ## Pattern reinforcement (issue #687)
 
 Cross-session pattern detection: clusters memories by normalized content, reinforces recurring primitives with `reinforcement_count` + `last_reinforced_at`, and optionally boosts their recall score. Narrative overview: [pattern-reinforcement.md](pattern-reinforcement.md).
@@ -1236,6 +1251,7 @@ in recall responses. See [Threat model](security/memory-extraction-threat-model.
 | `recallAuditAnomalyRapidFireLimit` | `30` | Max queries in window before rapid-fire flag |
 | `memoryExtensionsRoot` | `""` | Override memory extensions root directory |
 | `offlineSyncExcludes` | `[]` | Extra offline-sync push-side exclude globs, additive to the built-in node-local state excludes (issue #1786) |
+| `converge.conflictPolicy` | `newest-wins` | Default conflict policy for `remnic converge`; `--conflict-policy` overrides it per command |
 
 
 ## Schema-Complete Default and Recommended Settings
@@ -1788,6 +1804,7 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `memoryExtensionsEnabled` | `true` | `true` |
 | `memoryExtensionsRoot` | `""` | `""` |
 | `offlineSyncExcludes` | `[]` | `[]` |
+| `converge.conflictPolicy` | `"newest-wins"` | `"newest-wins"` |
 | `activity.enabled` | `false` | `false` until a trusted local activity source is configured |
 | `activity.extractionMode` | `"off"` | `"off"`; set `"smart"` only to create trust-gated first-person memory candidates |
 | `activity.timezone` | `"UTC"` | Machine-local IANA timezone |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -295,15 +295,15 @@ Conflict policy precedence is:
 2. `converge.conflictPolicy` from the loaded config.
 3. `newest-wins`, the backward-compatible default.
 
-Choose a policy based on how much operator review and history retention the corpus needs:
+Choose a policy based on how much operator review the corpus needs:
 
-- `newest-wins` selects the revision with the newest timestamp. If timestamps tie or either is
-  missing, it uses the `keep-both` behavior. Use it for automatic reconciliation and behavior
-  compatible with releases that predate configurable policies.
+- `newest-wins` selects the revision with the newest timestamp. For delete-versus-modify
+  conflicts, the timestamped surviving revision wins. If two revisions tie or either timestamp is
+  missing, apply stops because transport cannot yet preserve both at distinct durable identities.
+  Use it for automatic reconciliation and behavior compatible with releases that predate
+  configurable policies.
 - `manual` leaves conflicts unresolved. A plan can report them, but apply stops before any
   mutation while conflicts remain. Use it when an operator must review every conflict.
-- `keep-both` preserves both revisions and uses the planner's supersede links to retain their
-  relationship. Use it when preserving competing history matters more than selecting one winner.
 
 For the safest workflow, run `plan`, inspect its conflicts and actions, then run `apply --dry-run`
 with the same peer, token, and policy. Run `apply` without `--dry-run` only after that output is

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -83,8 +83,8 @@ openclaw engram migrate normalize-frontmatter  # Canonical frontmatter rewrite (
 openclaw engram migrate rescore-importance     # Recompute local importance scores
 openclaw engram migrate rechunk                # Rebuild chunk files from current chunking heuristics
 openclaw engram migrate reextract --model gpt-5-mini  # Queue bounded re-extraction requests
-remnic converge plan --peer <url>    # Build a non-mutating convergence plan
-remnic converge apply --peer <url>   # Apply a convergence plan
+remnic converge plan --peer https://peer.example.com    # Build a non-mutating convergence plan
+remnic converge apply --peer https://peer.example.com   # Apply a convergence plan
 ```
 
 Compatibility diagnostics:
@@ -278,9 +278,9 @@ that plan only when requested.
 
 ### Replica reconciliation (issue #2150)
 
-Preview a plan before applying it:
+Command syntax (replace the bracketed placeholders before running):
 
-```bash
+```text
 remnic converge plan --peer <url> [--token <token>] [--conflict-policy <policy>] [--json]
 remnic converge apply --peer <url> [--token <token>] [--conflict-policy <policy>] [--dry-run] [--json]
 ```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -293,15 +293,14 @@ Conflict policy precedence is:
 
 1. `--conflict-policy <policy>` for the current command.
 2. `converge.conflictPolicy` from the loaded config.
-3. `newest-wins`, the backward-compatible default.
+3. `newest-wins`, the current default.
 
 Choose a policy based on how much operator review the corpus needs:
 
-- `newest-wins` selects the revision with the newest timestamp. For delete-versus-modify
-  conflicts, the timestamped surviving revision wins. If two revisions tie or either timestamp is
-  missing, apply stops because transport cannot yet preserve both at distinct durable identities.
-  Use it for automatic reconciliation and behavior compatible with releases that predate
-  configurable policies.
+- `newest-wins` selects the newer revision when both sides carry comparable timestamps.
+  Delete-versus-modify conflicts require a durable per-path deletion timestamp; without one,
+  apply stops before mutation. Tied or missing timestamps also stop because transport cannot yet
+  preserve both revisions at distinct durable identities.
 - `manual` leaves conflicts unresolved. A plan can report them, but apply stops before any
   mutation while conflicts remain. Use it when an operator must review every conflict.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -83,6 +83,8 @@ openclaw engram migrate normalize-frontmatter  # Canonical frontmatter rewrite (
 openclaw engram migrate rescore-importance     # Recompute local importance scores
 openclaw engram migrate rechunk                # Rebuild chunk files from current chunking heuristics
 openclaw engram migrate reextract --model gpt-5-mini  # Queue bounded re-extraction requests
+remnic converge plan --peer <url>    # Build a non-mutating convergence plan
+remnic converge apply --peer <url>   # Apply a convergence plan
 ```
 
 Compatibility diagnostics:
@@ -270,10 +272,43 @@ per resolver for the process lifetime, so a rotated peer secret is picked up on 
 they are never logged or included in any payload, and a peer is
 identified only by its redacted `host:port`.
 
-**Detection is deliberately separate from reconciliation.** This surface only reports drift;
-making a diverged pair converge is tracked in issue #2150. Polling is stale-while-revalidate:
-a probe reads the last completed poll with its timestamp and never blocks on peer I/O, so a
-health check stays cheap.
+Detection and reconciliation remain separate. Detection reports drift without mutating either
+replica. The convergence commands fetch peer revisions, build a deterministic plan, and apply
+that plan only when requested.
+
+### Replica reconciliation (issue #2150)
+
+Preview a plan before applying it:
+
+```bash
+remnic converge plan --peer <url> [--token <token>] [--conflict-policy <policy>] [--json]
+remnic converge apply --peer <url> [--token <token>] [--conflict-policy <policy>] [--dry-run] [--json]
+```
+
+`plan` never mutates either replica. `apply` executes the planned actions; pass `--dry-run` to
+exercise the apply path without mutation. The `transport` and `sync` subcommands are aliases for
+`apply`.
+
+Conflict policy precedence is:
+
+1. `--conflict-policy <policy>` for the current command.
+2. `converge.conflictPolicy` from the loaded config.
+3. `newest-wins`, the backward-compatible default.
+
+Choose a policy based on how much operator review and history retention the corpus needs:
+
+- `newest-wins` selects the revision with the newest timestamp. If timestamps tie or either is
+  missing, it uses the `keep-both` behavior. Use it for automatic reconciliation and behavior
+  compatible with releases that predate configurable policies.
+- `manual` leaves conflicts unresolved. A plan can report them, but apply stops before any
+  mutation while conflicts remain. Use it when an operator must review every conflict.
+- `keep-both` preserves both revisions and uses the planner's supersede links to retain their
+  relationship. Use it when preserving competing history matters more than selecting one winner.
+
+For the safest workflow, run `plan`, inspect its conflicts and actions, then run `apply --dry-run`
+with the same peer, token, and policy. Run `apply` without `--dry-run` only after that output is
+acceptable. `manual` adds a fail-closed guard: unresolved conflicts prevent all mutation even
+without `--dry-run`.
 
 ## Compression Guideline Optimizer Tool
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1403,7 +1403,7 @@
               "manual"
             ],
             "default": "newest-wins",
-            "description": "Default conflict policy for convergence. newest-wins selects the newer timestamped revision, including delete-versus-modify conflicts, and manual stops before mutation when conflicts remain."
+            "description": "Default conflict policy for convergence. newest-wins selects the newer revision when both sides carry comparable timestamps; manual stops before mutation when conflicts remain."
           }
         }
       },
@@ -6752,7 +6752,7 @@
     "converge.conflictPolicy": {
       "label": "Converge Conflict Policy",
       "advanced": true,
-      "help": "newest-wins selects the newer timestamped revision, including delete-versus-modify conflicts; manual stops before mutation when conflicts remain. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
+      "help": "newest-wins selects the newer revision when both sides carry comparable timestamps; manual stops before mutation when conflicts remain. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
     },
     "temporalSupersessionEnabled": {
       "label": "Temporal Supersession",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1389,6 +1389,25 @@
         "default": 0.7,
         "description": "QMD similarity threshold to trigger contradiction check"
       },
+      "converge": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {
+          "conflictPolicy": "newest-wins"
+        },
+        "properties": {
+          "conflictPolicy": {
+            "type": "string",
+            "enum": [
+              "newest-wins",
+              "manual",
+              "keep-both"
+            ],
+            "default": "newest-wins",
+            "description": "Default conflict policy for convergence. newest-wins selects the newer revision, manual stops before mutation when conflicts remain, and keep-both preserves both revisions with supersede links."
+          }
+        }
+      },
       "conversationIndexBackend": {
         "type": "string",
         "enum": [
@@ -6730,6 +6749,11 @@
     "contradictionScan": {
       "label": "Contradiction Scan",
       "help": "Nightly cron that pairs similar memories and flags contradictions for review (issue #520)"
+    },
+    "converge.conflictPolicy": {
+      "label": "Converge Conflict Policy",
+      "advanced": true,
+      "help": "newest-wins selects the newer revision; manual stops before mutation when conflicts remain; keep-both preserves both revisions with supersede links. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
     },
     "temporalSupersessionEnabled": {
       "label": "Temporal Supersession",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1400,11 +1400,10 @@
             "type": "string",
             "enum": [
               "newest-wins",
-              "manual",
-              "keep-both"
+              "manual"
             ],
             "default": "newest-wins",
-            "description": "Default conflict policy for convergence. newest-wins selects the newer revision, manual stops before mutation when conflicts remain, and keep-both preserves both revisions with supersede links."
+            "description": "Default conflict policy for convergence. newest-wins selects the newer timestamped revision, including delete-versus-modify conflicts, and manual stops before mutation when conflicts remain."
           }
         }
       },
@@ -6753,7 +6752,7 @@
     "converge.conflictPolicy": {
       "label": "Converge Conflict Policy",
       "advanced": true,
-      "help": "newest-wins selects the newer revision; manual stops before mutation when conflicts remain; keep-both preserves both revisions with supersede links. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
+      "help": "newest-wins selects the newer timestamped revision, including delete-versus-modify conflicts; manual stops before mutation when conflicts remain. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
     },
     "temporalSupersessionEnabled": {
       "label": "Temporal Supersession",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1403,7 +1403,7 @@
               "manual"
             ],
             "default": "newest-wins",
-            "description": "Default conflict policy for convergence. newest-wins selects the newer timestamped revision, including delete-versus-modify conflicts, and manual stops before mutation when conflicts remain."
+            "description": "Default conflict policy for convergence. newest-wins selects the newer revision when both sides carry comparable timestamps; manual stops before mutation when conflicts remain."
           }
         }
       },
@@ -6752,7 +6752,7 @@
     "converge.conflictPolicy": {
       "label": "Converge Conflict Policy",
       "advanced": true,
-      "help": "newest-wins selects the newer timestamped revision, including delete-versus-modify conflicts; manual stops before mutation when conflicts remain. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
+      "help": "newest-wins selects the newer revision when both sides carry comparable timestamps; manual stops before mutation when conflicts remain. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
     },
     "temporalSupersessionEnabled": {
       "label": "Temporal Supersession",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1389,6 +1389,25 @@
         "default": 0.7,
         "description": "QMD similarity threshold to trigger contradiction check"
       },
+      "converge": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {
+          "conflictPolicy": "newest-wins"
+        },
+        "properties": {
+          "conflictPolicy": {
+            "type": "string",
+            "enum": [
+              "newest-wins",
+              "manual",
+              "keep-both"
+            ],
+            "default": "newest-wins",
+            "description": "Default conflict policy for convergence. newest-wins selects the newer revision, manual stops before mutation when conflicts remain, and keep-both preserves both revisions with supersede links."
+          }
+        }
+      },
       "conversationIndexBackend": {
         "type": "string",
         "enum": [
@@ -6730,6 +6749,11 @@
     "contradictionScan": {
       "label": "Contradiction Scan",
       "help": "Nightly cron that pairs similar memories and flags contradictions for review (issue #520)"
+    },
+    "converge.conflictPolicy": {
+      "label": "Converge Conflict Policy",
+      "advanced": true,
+      "help": "newest-wins selects the newer revision; manual stops before mutation when conflicts remain; keep-both preserves both revisions with supersede links. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
     },
     "temporalSupersessionEnabled": {
       "label": "Temporal Supersession",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1400,11 +1400,10 @@
             "type": "string",
             "enum": [
               "newest-wins",
-              "manual",
-              "keep-both"
+              "manual"
             ],
             "default": "newest-wins",
-            "description": "Default conflict policy for convergence. newest-wins selects the newer revision, manual stops before mutation when conflicts remain, and keep-both preserves both revisions with supersede links."
+            "description": "Default conflict policy for convergence. newest-wins selects the newer timestamped revision, including delete-versus-modify conflicts, and manual stops before mutation when conflicts remain."
           }
         }
       },
@@ -6753,7 +6752,7 @@
     "converge.conflictPolicy": {
       "label": "Converge Conflict Policy",
       "advanced": true,
-      "help": "newest-wins selects the newer revision; manual stops before mutation when conflicts remain; keep-both preserves both revisions with supersede links. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
+      "help": "newest-wins selects the newer timestamped revision, including delete-versus-modify conflicts; manual stops before mutation when conflicts remain. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
     },
     "temporalSupersessionEnabled": {
       "label": "Temporal Supersession",

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -266,47 +266,82 @@ test("remnic converge apply: newest-wins stops when timestamps cannot resolve a 
   assert.equal(result.cursorUpdated, false);
 });
 
-test("remnic converge apply: configured newest-wins resolves delete-versus-modify in both directions", async () => {
-  const localModifiedPath = "facts/local-modified.md";
-  const peerModifiedPath = "facts/peer-modified.md";
+test("remnic converge apply: configured newest-wins compares deletion and modification times", async () => {
+  const localModificationWins = "facts/local-modification-wins.md";
+  const peerDeletionWins = "facts/peer-deletion-wins.md";
+  const peerModificationWins = "facts/peer-modification-wins.md";
+  const localDeletionWins = "facts/local-deletion-wins.md";
   const localModified = Buffer.from("local v2");
   const peerModified = Buffer.from("peer v2");
   const localSha = createHash("sha256").update(localModified).digest("hex");
   const peerSha = createHash("sha256").update(peerModified).digest("hex");
   const baseSha = "c".repeat(64);
   const localMap = new Map<string, ReconcileFileState[]>([
-    ["default", [{ path: localModifiedPath, sha256: localSha, mtimeMs: 2000 }]],
+    ["default", [
+      { path: localModificationWins, sha256: localSha, mtimeMs: 4000 },
+      { path: peerDeletionWins, sha256: localSha, mtimeMs: 2000 },
+    ]],
   ]);
   const peerMap = new Map<string, ReconcileFileState[]>([
-    ["default", [{ path: peerModifiedPath, sha256: peerSha, mtimeMs: 3000 }]],
+    ["default", [
+      { path: peerModificationWins, sha256: peerSha, mtimeMs: 4000 },
+      { path: localDeletionWins, sha256: peerSha, mtimeMs: 2000 },
+    ]],
   ]);
   const baseMap = new Map<string, ReconcileFileState[]>([
     ["default", [
-      { path: localModifiedPath, sha256: baseSha, mtimeMs: 1000 },
-      { path: peerModifiedPath, sha256: baseSha, mtimeMs: 1000 },
+      { path: localModificationWins, sha256: baseSha, mtimeMs: 1000 },
+      { path: peerDeletionWins, sha256: baseSha, mtimeMs: 1000 },
+      { path: peerModificationWins, sha256: baseSha, mtimeMs: 1000 },
+      { path: localDeletionWins, sha256: baseSha, mtimeMs: 1000 },
     ]],
   ]);
   const localBuffers = new Map<string, Map<string, Buffer>>([
-    ["default", new Map([[localModifiedPath, localModified]])],
+    ["default", new Map([
+      [localModificationWins, localModified],
+      [peerDeletionWins, localModified],
+    ])],
   ]);
   const peerBuffers = new Map<string, Map<string, Buffer>>([
-    ["default", new Map([[peerModifiedPath, peerModified]])],
+    ["default", new Map([
+      [peerModificationWins, peerModified],
+      [localDeletionWins, peerModified],
+    ])],
   ]);
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-delete-"));
 
   const result = await executeConvergeApply({
     config: parseConfig({ converge: { conflictPolicy: "newest-wins" } }),
     baseFilesByNamespace: baseMap,
     localFilesByNamespace: localMap,
     peerFilesByNamespace: peerMap,
+    localDeletionMtimeMsByNamespace: new Map([["default", new Map([
+      [peerModificationWins, 3000],
+      [localDeletionWins, 3000],
+    ])]]),
+    peerDeletionMtimeMsByNamespace: new Map([["default", new Map([
+      [localModificationWins, 3000],
+      [peerDeletionWins, 3000],
+    ])]]),
     localFileBuffers: localBuffers,
     peerFileBuffers: peerBuffers,
+    cursorDir: tmpDir,
+    peerUrl: "buffer://peer",
   });
 
   assert.equal(result.status, "applied");
-  assert.equal(result.transfers.conflictsResolved, 2);
+  assert.equal(result.transfers.conflictsResolved, 4);
   assert.equal(result.transfers.failed, 0);
-  assert.equal(peerBuffers.get("default")?.get(localModifiedPath), localModified);
-  assert.equal(localBuffers.get("default")?.get(peerModifiedPath), peerModified);
+  assert.equal(peerBuffers.get("default")?.get(localModificationWins), localModified);
+  assert.equal(localBuffers.get("default")?.has(peerDeletionWins), false);
+  assert.equal(localBuffers.get("default")?.get(peerModificationWins), peerModified);
+  assert.equal(peerBuffers.get("default")?.has(localDeletionWins), false);
+  const cursor = await readConvergeCursor(defaultConvergeCursorPath(tmpDir, "buffer://peer", "default"));
+  assert.deepEqual(
+    cursor?.baseFiles.map((file) => file.path).sort(),
+    [localModificationWins, peerModificationWins].sort(),
+  );
+  await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
 test("remnic converge apply: dry-run mode simulates transfers without disk writes", async () => {
@@ -431,6 +466,55 @@ test("remnic converge apply: uses chunked offline-sync HTTP contracts for pull a
   assert.match(pushRequest.url, /offline-sync\/apply-file-content\?namespace=default$/);
   assert.equal(new Headers(pushRequest.init?.headers).get("x-remnic-file-sha256"), localSha);
   assert.equal(new Headers(pushRequest.init?.headers).get("x-remnic-file-bytes"), String(localContent.length));
+});
+
+test("remnic converge apply: a newer local deletion uses the guarded remote delete contract", async () => {
+  const filePath = "facts/deleted-locally.md";
+  const peerContent = Buffer.from("peer v2");
+  const peerSha = createHash("sha256").update(peerContent).digest("hex");
+  const baseSha = "d".repeat(64);
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    requests.push({ url: String(input), init });
+    return Response.json({
+      appliedUpserts: 0,
+      appliedDeletes: 1,
+      skipped: 0,
+      conflicts: [],
+      currentFiles: [],
+    });
+  };
+
+  const result = await executeConvergeApply({
+    config: parseConfig({ converge: { conflictPolicy: "newest-wins" } }),
+    peerUrl: "https://peer.example.test",
+    fetchImpl,
+    baseFilesByNamespace: new Map([["default", [{ path: filePath, sha256: baseSha }]]]),
+    localFilesByNamespace: new Map([["default", []]]),
+    peerFilesByNamespace: new Map([
+      ["default", [{ path: filePath, sha256: peerSha, bytes: peerContent.length, mtimeMs: 2000 }]],
+    ]),
+    localDeletionMtimeMsByNamespace: new Map([
+      ["default", new Map([[filePath, 3000]])],
+    ]),
+  });
+
+  assert.equal(result.transfers.conflictsResolved, 1);
+  assert.equal(result.transfers.failed, 0);
+  const request = requests.find(({ url }) => url.endsWith("/remnic/v1/offline-sync/apply"));
+  assert.ok(request);
+  const body = JSON.parse(String(request.init?.body)) as {
+    namespace: string;
+    changeset: {
+      format: string;
+      changes: Array<{ type: string; path: string; baseSha256: string }>;
+    };
+  };
+  assert.equal(body.namespace, "default");
+  assert.equal(body.changeset.format, "remnic.offline-sync.changeset.v1");
+  assert.deepEqual(body.changeset.changes, [
+    { type: "delete", path: filePath, baseSha256: peerSha },
+  ]);
 });
 
 test("remnic converge plan: fails closed when the peer census cannot be fetched", async () => {

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -528,3 +528,41 @@ test("remnic converge apply: local-wins guards against the planned peer revision
   assert.equal(result.transfers.failed, 0);
   assert.equal(baseHeader, peerSha256);
 });
+
+test("remnic converge plan: config selects the policy and a CLI option overrides it", async () => {
+  const localFilesByNamespace = new Map<string, ReconcileFileState[]>([
+    ["default", [{ path: "facts/shared.md", sha256: shaA, mtimeMs: 1000 }]],
+  ]);
+  const peerFilesByNamespace = new Map<string, ReconcileFileState[]>([
+    ["default", [{ path: "facts/shared.md", sha256: shaB, mtimeMs: 2000 }]],
+  ]);
+  const config = parseConfig({ converge: { conflictPolicy: "keep-both" } });
+
+  const configured = await computeConvergePlan({
+    config,
+    localFilesByNamespace,
+    peerFilesByNamespace,
+  });
+  assert.equal(configured.entries[0]?.resolution, "supersede-link");
+
+  const overridden = await computeConvergePlan({
+    config,
+    conflictPolicy: "manual",
+    localFilesByNamespace,
+    peerFilesByNamespace,
+  });
+  assert.equal(overridden.entries[0]?.resolution, "unresolved");
+});
+
+test("remnic converge CLI rejects an invalid conflict-policy override", async () => {
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    await assert.rejects(
+      () => cmdConverge("plan", ["--conflict-policy", "invalid"], true, parseConfig({})),
+      /--conflict-policy must be one of newest-wins, manual, keep-both/,
+    );
+  } finally {
+    console.log = originalLog;
+  }
+});

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -247,6 +247,25 @@ test("remnic converge apply: manual conflict policy stops mutation on unresolved
   assert.equal(result.transfers.conflictsResolved, 0);
 });
 
+test("remnic converge apply: newest-wins stops when timestamps cannot resolve a conflict", async () => {
+  const localMap = new Map<string, ReconcileFileState[]>([
+    ["default", [{ path: "facts/shared.md", sha256: shaA, mtimeMs: 1000 }]],
+  ]);
+  const peerMap = new Map<string, ReconcileFileState[]>([
+    ["default", [{ path: "facts/shared.md", sha256: shaB, mtimeMs: 1000 }]],
+  ]);
+
+  const result = await executeConvergeApply({
+    localFilesByNamespace: localMap,
+    peerFilesByNamespace: peerMap,
+    conflictPolicy: "newest-wins",
+  });
+
+  assert.equal(result.converged, false);
+  assert.equal(result.status, "stopped_unresolved_conflicts");
+  assert.equal(result.cursorUpdated, false);
+});
+
 test("remnic converge apply: dry-run mode simulates transfers without disk writes", async () => {
   const peerFile: ReconcileFileState = { path: "facts/remote.md", sha256: shaA };
   const localMap = new Map<string, ReconcileFileState[]>([["default", []]]);

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -266,6 +266,49 @@ test("remnic converge apply: newest-wins stops when timestamps cannot resolve a 
   assert.equal(result.cursorUpdated, false);
 });
 
+test("remnic converge apply: configured newest-wins resolves delete-versus-modify in both directions", async () => {
+  const localModifiedPath = "facts/local-modified.md";
+  const peerModifiedPath = "facts/peer-modified.md";
+  const localModified = Buffer.from("local v2");
+  const peerModified = Buffer.from("peer v2");
+  const localSha = createHash("sha256").update(localModified).digest("hex");
+  const peerSha = createHash("sha256").update(peerModified).digest("hex");
+  const baseSha = "c".repeat(64);
+  const localMap = new Map<string, ReconcileFileState[]>([
+    ["default", [{ path: localModifiedPath, sha256: localSha, mtimeMs: 2000 }]],
+  ]);
+  const peerMap = new Map<string, ReconcileFileState[]>([
+    ["default", [{ path: peerModifiedPath, sha256: peerSha, mtimeMs: 3000 }]],
+  ]);
+  const baseMap = new Map<string, ReconcileFileState[]>([
+    ["default", [
+      { path: localModifiedPath, sha256: baseSha, mtimeMs: 1000 },
+      { path: peerModifiedPath, sha256: baseSha, mtimeMs: 1000 },
+    ]],
+  ]);
+  const localBuffers = new Map<string, Map<string, Buffer>>([
+    ["default", new Map([[localModifiedPath, localModified]])],
+  ]);
+  const peerBuffers = new Map<string, Map<string, Buffer>>([
+    ["default", new Map([[peerModifiedPath, peerModified]])],
+  ]);
+
+  const result = await executeConvergeApply({
+    config: parseConfig({ converge: { conflictPolicy: "newest-wins" } }),
+    baseFilesByNamespace: baseMap,
+    localFilesByNamespace: localMap,
+    peerFilesByNamespace: peerMap,
+    localFileBuffers: localBuffers,
+    peerFileBuffers: peerBuffers,
+  });
+
+  assert.equal(result.status, "applied");
+  assert.equal(result.transfers.conflictsResolved, 2);
+  assert.equal(result.transfers.failed, 0);
+  assert.equal(peerBuffers.get("default")?.get(localModifiedPath), localModified);
+  assert.equal(localBuffers.get("default")?.get(peerModifiedPath), peerModified);
+});
+
 test("remnic converge apply: dry-run mode simulates transfers without disk writes", async () => {
   const peerFile: ReconcileFileState = { path: "facts/remote.md", sha256: shaA };
   const localMap = new Map<string, ReconcileFileState[]>([["default", []]]);
@@ -555,32 +598,34 @@ test("remnic converge plan: config selects the policy and a CLI option overrides
   const peerFilesByNamespace = new Map<string, ReconcileFileState[]>([
     ["default", [{ path: "facts/shared.md", sha256: shaB, mtimeMs: 2000 }]],
   ]);
-  const config = parseConfig({ converge: { conflictPolicy: "keep-both" } });
+  const config = parseConfig({ converge: { conflictPolicy: "manual" } });
 
   const configured = await computeConvergePlan({
     config,
     localFilesByNamespace,
     peerFilesByNamespace,
   });
-  assert.equal(configured.entries[0]?.resolution, "supersede-link");
+  assert.equal(configured.entries[0]?.resolution, "unresolved");
 
   const overridden = await computeConvergePlan({
     config,
-    conflictPolicy: "manual",
+    conflictPolicy: "newest-wins",
     localFilesByNamespace,
     peerFilesByNamespace,
   });
-  assert.equal(overridden.entries[0]?.resolution, "unresolved");
+  assert.equal(overridden.entries[0]?.resolution, "peer-wins");
 });
 
-test("remnic converge CLI rejects an invalid conflict-policy override", async () => {
+test("remnic converge CLI rejects removed and unknown conflict-policy overrides", async () => {
   const originalLog = console.log;
   console.log = () => {};
   try {
-    await assert.rejects(
-      () => cmdConverge("plan", ["--conflict-policy", "invalid"], true, parseConfig({})),
-      /--conflict-policy must be one of newest-wins, manual, keep-both/,
-    );
+    for (const conflictPolicy of ["keep-both", "invalid"]) {
+      await assert.rejects(
+        () => cmdConverge("plan", ["--conflict-policy", conflictPolicy], true, parseConfig({})),
+        /--conflict-policy must be one of newest-wins, manual/,
+      );
+    }
   } finally {
     console.log = originalLog;
   }

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -3,6 +3,8 @@ import { createHash } from "node:crypto";
 import * as path from "node:path";
 import {
   type PluginConfig,
+  CONVERGE_CONFLICT_POLICIES,
+  DEFAULT_CONVERGE_CONFLICT_POLICY,
   parseConfig,
   type ResolveSecretRefFn,
   buildOfflineSyncSnapshotFromBase,
@@ -10,11 +12,11 @@ import {
   OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
   applyOfflineSyncFileContentChunk,
 } from "@remnic/core";
+import type { ConvergeConflictPolicy } from "@remnic/core/types.js";
 import { resolveCorpusNamespaceRoots } from "@remnic/core/corpus-watermark.js";
 import { listNamespaces } from "@remnic/core/namespaces/migrate.js";
 import {
   planReconciliation,
-  type ReconcileConflictPolicy,
   type ReconcileFileState,
   type ReconcileNamespaceInput,
   type ReconcilePlan,
@@ -32,7 +34,7 @@ export interface ConvergePlanOptions {
   peerUrl?: string;
   peerToken?: string;
   cursorDir?: string;
-  conflictPolicy?: ReconcileConflictPolicy;
+  conflictPolicy?: ConvergeConflictPolicy;
   fetchImpl?: typeof fetch;
   resolveSecretRef?: ResolveSecretRefFn;
   baseFilesByNamespace?: Map<string, ReconcileFileState[]>;
@@ -459,13 +461,18 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
     });
   }
 
-  return planReconciliation(inputs, { conflictPolicy: options.conflictPolicy });
+  const conflictPolicy = options.conflictPolicy
+    ?? config?.converge.conflictPolicy
+    ?? DEFAULT_CONVERGE_CONFLICT_POLICY;
+  return planReconciliation(inputs, { conflictPolicy });
 }
 
 export async function executeConvergeApply(
   options: ConvergeApplyOptions = {},
 ): Promise<ConvergeApplyResult> {
-  const conflictPolicy = options.conflictPolicy ?? "manual";
+  const conflictPolicy = options.conflictPolicy
+    ?? options.config?.converge.conflictPolicy
+    ?? DEFAULT_CONVERGE_CONFLICT_POLICY;
   const plan = await computeConvergePlan({ ...options, conflictPolicy });
 
   if (plan.converged && !options.dryRun) {
@@ -481,7 +488,7 @@ export async function executeConvergeApply(
 
   const unresolvedCount = plan.byNamespace.reduce((acc, report) => acc + report.unresolved, 0);
   if (unresolvedCount > 0 && conflictPolicy === "manual") {
-    // DEFAULT: unresolved conflicts STOP mutation (never auto-resolve a conflict).
+    // Manual policy stops before any unresolved conflict can mutate a peer.
     return {
       converged: false,
       status: "stopped_unresolved_conflicts",
@@ -824,7 +831,12 @@ export function formatConvergeApplyReport(result: ConvergeApplyResult): string {
   return lines.join("\n");
 }
 
-export async function cmdConverge(action: string, rest: string[], json: boolean): Promise<void> {
+export async function cmdConverge(
+  action: string,
+  rest: string[],
+  json: boolean,
+  config: PluginConfig = parseConfig({}),
+): Promise<void> {
   if (action === "help" || action === "--help" || action === "-h" || rest.includes("--help") || rest.includes("-h")) {
     console.log(`Usage: remnic converge <plan|apply> [options]
 
@@ -836,7 +848,8 @@ Options:
   --peer <url>      Peer server URL (or --remote-url / --remote)
   --token <token>   Bearer token or SecretRef for peer authentication
   --conflict-policy <policy>
-                    Conflict resolution policy (manual|newest-wins|keep-both)
+                    Policy override (newest-wins|manual|keep-both)
+                    Default: converge.conflictPolicy (newest-wins)
   --dry-run         Simulate transfers without mutating disk or remote peer
   --json            Output detailed JSON plan report
 `);
@@ -852,7 +865,7 @@ Options:
   let peerUrl: string | undefined;
   let peerToken: string | undefined;
   let dryRun = false;
-  let conflictPolicy: ReconcileConflictPolicy | undefined;
+  let conflictPolicy: ConvergeConflictPolicy | undefined;
 
   for (let i = 0; i < rest.length; i += 1) {
     const arg = rest[i];
@@ -864,17 +877,23 @@ Options:
       i += 1;
     } else if (arg === "--dry-run") {
       dryRun = true;
-    } else if (arg === "--conflict-policy" && rest[i + 1]) {
-      const pol = rest[i + 1];
-      if (pol === "manual" || pol === "newest-wins" || pol === "keep-both") {
-        conflictPolicy = pol;
+    } else if (arg === "--conflict-policy") {
+      const policy = rest[i + 1];
+      if (
+        typeof policy !== "string"
+        || !CONVERGE_CONFLICT_POLICIES.includes(policy as ConvergeConflictPolicy)
+      ) {
+        throw new Error(
+          `converge: --conflict-policy must be one of ${CONVERGE_CONFLICT_POLICIES.join(", ")}`,
+        );
       }
+      conflictPolicy = policy as ConvergeConflictPolicy;
       i += 1;
     }
   }
 
   if (action === "plan") {
-    const plan = await computeConvergePlan({ peerUrl, peerToken, conflictPolicy });
+    const plan = await computeConvergePlan({ config, peerUrl, peerToken, conflictPolicy });
     if (json) {
       console.log(JSON.stringify(plan, null, 2));
     } else {
@@ -888,6 +907,7 @@ Options:
     peerToken,
     dryRun,
     conflictPolicy,
+    config,
   });
 
   if (json) {

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -579,9 +579,6 @@ export async function executeConvergeApply(
         transferType = "pull";
       } else if (entry.resolution === "local-wins") {
         transferType = "push";
-      } else if (entry.resolution === "supersede-link") {
-        if (entry.newerSide === "peer") transferType = "pull";
-        else if (entry.newerSide === "local") transferType = "push";
       }
     }
 
@@ -848,7 +845,7 @@ Options:
   --peer <url>      Peer server URL (or --remote-url / --remote)
   --token <token>   Bearer token or SecretRef for peer authentication
   --conflict-policy <policy>
-                    Policy override (newest-wins|manual|keep-both)
+                    Policy override (newest-wins|manual)
                     Default: converge.conflictPolicy (newest-wins)
   --dry-run         Simulate transfers without mutating disk or remote peer
   --json            Output detailed JSON plan report

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -9,6 +9,7 @@ import {
   type ResolveSecretRefFn,
   buildOfflineSyncSnapshotFromBase,
   OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+  OFFLINE_SYNC_CHANGESET_FORMAT,
   OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
   applyOfflineSyncFileContentChunk,
 } from "@remnic/core";
@@ -40,8 +41,10 @@ export interface ConvergePlanOptions {
   baseFilesByNamespace?: Map<string, ReconcileFileState[]>;
   localFilesByNamespace?: Map<string, ReconcileFileState[]>;
   localTombstonesByNamespace?: Map<string, Iterable<string>>;
+  localDeletionMtimeMsByNamespace?: Map<string, ReadonlyMap<string, number>>;
   peerFilesByNamespace?: Map<string, ReconcileFileState[]>;
   peerTombstonesByNamespace?: Map<string, Iterable<string>>;
+  peerDeletionMtimeMsByNamespace?: Map<string, ReadonlyMap<string, number>>;
 }
 
 export interface ConvergeApplyOptions extends ConvergePlanOptions {
@@ -101,7 +104,7 @@ async function fetchPeerSnapshot(
   namespace: string,
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
-): Promise<{ files: ReconcileFileState[]; tombstones: Set<string> }> {
+): Promise<{ files: ReconcileFileState[]; tombstones: Set<string>; capturedAtMs?: number }> {
   let base = peerUrl;
   while (base.endsWith("/")) {
     base = base.slice(0, -1);
@@ -166,7 +169,14 @@ async function fetchPeerSnapshot(
       }
       tombstones.add(tombstone.toLowerCase());
     }
-    return { files, tombstones };
+    let capturedAtMs: number | undefined;
+    if ("createdAt" in data) {
+      if (typeof data.createdAt !== "string" || !Number.isFinite(Date.parse(data.createdAt))) {
+        throw new Error(`invalid peer snapshot for namespace ${namespace}: createdAt must be an ISO timestamp`);
+      }
+      capturedAtMs = Date.parse(data.createdAt);
+    }
+    return { files, tombstones, capturedAtMs };
   }
 
   throw new Error(`failed to fetch peer snapshot for namespace ${namespace}: ${lastFailure}`);
@@ -344,6 +354,59 @@ async function postPeerFileContent(
   return false;
 }
 
+async function postPeerFileDeletion(
+  peerUrl: string,
+  namespace: string,
+  filePath: string,
+  baseSha256: string,
+  token?: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<boolean> {
+  const base = peerUrl.replace(/\/+$/, "");
+  const routes = ["/remnic/v1/offline-sync/apply", "/engram/v1/offline-sync/apply"];
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+  for (const route of routes) {
+    try {
+      const response = await fetchImpl(`${base}${route}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          namespace,
+          changeset: {
+            format: OFFLINE_SYNC_CHANGESET_FORMAT,
+            schemaVersion: 1,
+            createdAt: new Date().toISOString(),
+            sourceId: "remnic-converge",
+            includeTranscripts: false,
+            changes: [{ type: "delete", path: filePath, baseSha256 }],
+          },
+        }),
+      });
+      if (!response.ok) throw new Error(`offline apply request failed: ${response.status}`);
+      const result: unknown = await response.json().catch(() => null);
+      if (
+        !result
+        || typeof result !== "object"
+        || !("appliedDeletes" in result)
+        || typeof result.appliedDeletes !== "number"
+        || !("skipped" in result)
+        || typeof result.skipped !== "number"
+        || !("conflicts" in result)
+        || !Array.isArray(result.conflicts)
+      ) {
+        return false;
+      }
+      return result.conflicts.length === 0 && (result.appliedDeletes === 1 || result.skipped === 1);
+    } catch {
+      // try next route
+    }
+  }
+  return false;
+}
+
 export async function computeConvergePlan(options: ConvergePlanOptions = {}): Promise<ReconcilePlan> {
   const baseMap = new Map<string, ReconcileFileState[]>();
   const namespacesToPlan = new Set<string>();
@@ -351,6 +414,10 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
   const localTombstones = new Map<string, Set<string>>();
   const peerMap = new Map<string, ReconcileFileState[]>();
   const peerTombstones = new Map<string, Set<string>>();
+  const localDeletionMtimeMs = new Map<string, ReadonlyMap<string, number>>();
+  const peerDeletionMtimeMs = new Map<string, ReadonlyMap<string, number>>();
+  const localSnapshotMtimeMs = new Map<string, number>();
+  const peerSnapshotMtimeMs = new Map<string, number>();
 
   if (options.baseFilesByNamespace) {
     for (const [ns, files] of options.baseFilesByNamespace) {
@@ -369,6 +436,12 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
       localTombstones.set(ns, new Set(tombstones));
     }
   }
+  if (options.localDeletionMtimeMsByNamespace) {
+    for (const [ns, mtimes] of options.localDeletionMtimeMsByNamespace) {
+      namespacesToPlan.add(ns);
+      localDeletionMtimeMs.set(ns, mtimes);
+    }
+  }
   if (options.peerFilesByNamespace) {
     for (const [ns, files] of options.peerFilesByNamespace) {
       namespacesToPlan.add(ns);
@@ -378,6 +451,12 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
   if (options.peerTombstonesByNamespace) {
     for (const [ns, tombstones] of options.peerTombstonesByNamespace) {
       peerTombstones.set(ns, new Set(tombstones));
+    }
+  }
+  if (options.peerDeletionMtimeMsByNamespace) {
+    for (const [ns, mtimes] of options.peerDeletionMtimeMsByNamespace) {
+      namespacesToPlan.add(ns);
+      peerDeletionMtimeMs.set(ns, mtimes);
     }
   }
   let config = options.config;
@@ -411,6 +490,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
           bytes: record.bytes,
         }));
         localMap.set(ns, files);
+        localSnapshotMtimeMs.set(ns, Date.parse(snapshot.createdAt));
         const tombstones = await readLocalTombstones(rootInfo.rootDir);
         localTombstones.set(ns, tombstones);
       } catch {
@@ -435,6 +515,9 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
       const peerData = await fetchPeerSnapshot(options.peerUrl, ns, resolvedToken, fetchFn);
       peerMap.set(ns, peerData.files);
       peerTombstones.set(ns, peerData.tombstones);
+      if (peerData.capturedAtMs !== undefined) {
+        peerSnapshotMtimeMs.set(ns, peerData.capturedAtMs);
+      }
     }
   }
 
@@ -451,11 +534,32 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
 
   const inputs: ReconcileNamespaceInput[] = [];
   for (const ns of [...namespacesToPlan].sort()) {
+    const baseFiles = baseMap.get(ns);
+    const localFiles = localMap.get(ns) ?? [];
+    const peerFiles = peerMap.get(ns) ?? [];
+    const localDeletions = new Map(localDeletionMtimeMs.get(ns) ?? []);
+    const peerDeletions = new Map(peerDeletionMtimeMs.get(ns) ?? []);
+    if (baseFiles) {
+      const localPaths = new Set(localFiles.map((file) => file.path));
+      const peerPaths = new Set(peerFiles.map((file) => file.path));
+      for (const baseFile of baseFiles) {
+        const localCapturedAtMs = localSnapshotMtimeMs.get(ns);
+        if (!localPaths.has(baseFile.path) && !localDeletions.has(baseFile.path) && localCapturedAtMs !== undefined) {
+          localDeletions.set(baseFile.path, localCapturedAtMs);
+        }
+        const peerCapturedAtMs = peerSnapshotMtimeMs.get(ns);
+        if (!peerPaths.has(baseFile.path) && !peerDeletions.has(baseFile.path) && peerCapturedAtMs !== undefined) {
+          peerDeletions.set(baseFile.path, peerCapturedAtMs);
+        }
+      }
+    }
     inputs.push({
       namespace: ns,
-      local: localMap.get(ns) ?? [],
-      peer: peerMap.get(ns) ?? [],
-      base: baseMap.get(ns),
+      local: localFiles,
+      peer: peerFiles,
+      base: baseFiles,
+      localDeletionMtimeMs: localDeletions,
+      peerDeletionMtimeMs: peerDeletions,
       tombstonedFileSha256: localTombstones.get(ns) ?? [],
       peerTombstonedFileSha256: peerTombstones.get(ns) ?? [],
     });
@@ -567,7 +671,7 @@ export async function executeConvergeApply(
   for (const entry of plan.entries) {
     if (entry.action === "identical") continue;
 
-    let transferType: "pull" | "push" | "suppress" | "none" = "none";
+    let transferType: "pull" | "push" | "delete-local" | "delete-peer" | "suppress" | "none" = "none";
     if (entry.action === "pull") {
       transferType = "pull";
     } else if (entry.action === "push") {
@@ -576,9 +680,9 @@ export async function executeConvergeApply(
       transferType = "suppress";
     } else if (entry.action === "conflict") {
       if (entry.resolution === "peer-wins") {
-        transferType = "pull";
+        transferType = entry.peerSha256 ? "pull" : "delete-local";
       } else if (entry.resolution === "local-wins") {
-        transferType = "push";
+        transferType = entry.localSha256 ? "push" : "delete-peer";
       }
     }
 
@@ -734,6 +838,62 @@ export async function executeConvergeApply(
       } else {
         actualTransfers.failed += 1;
       }
+    } else if (transferType === "delete-local") {
+      let deleted = false;
+      const bufferedFiles = options.localFileBuffers?.get(entry.namespace);
+      if (options.localFileBuffers) {
+        const current = bufferedFiles?.get(entry.path);
+        if (
+          current
+          && entry.localSha256
+          && createHash("sha256").update(current).digest("hex") === entry.localSha256
+        ) {
+          bufferedFiles!.delete(entry.path);
+          deleted = true;
+        }
+      } else {
+        const rootDir = rootMap.get(entry.namespace);
+        if (rootDir && entry.localSha256) {
+          try {
+            const io = await createOfflineStorageIo(rootDir);
+            const filePath = path.join(rootDir, entry.path);
+            const current = await io.readFileDigest({ root: rootDir, path: entry.path, filePath });
+            if (current.sha256 === entry.localSha256) {
+              await io.deleteFile({ root: rootDir, path: entry.path, filePath });
+              deleted = true;
+            }
+          } catch {
+            deleted = false;
+          }
+        }
+      }
+      if (deleted) actualTransfers.conflictsResolved += 1;
+      else actualTransfers.failed += 1;
+    } else if (transferType === "delete-peer") {
+      let deleted = false;
+      const bufferedFiles = options.peerFileBuffers?.get(entry.namespace);
+      if (options.peerFileBuffers) {
+        const current = bufferedFiles?.get(entry.path);
+        if (
+          current
+          && entry.peerSha256
+          && createHash("sha256").update(current).digest("hex") === entry.peerSha256
+        ) {
+          bufferedFiles!.delete(entry.path);
+          deleted = true;
+        }
+      } else if (options.peerUrl && entry.peerSha256) {
+        deleted = await postPeerFileDeletion(
+          options.peerUrl,
+          entry.namespace,
+          entry.path,
+          entry.peerSha256,
+          resolvedToken,
+          fetchFn,
+        );
+      }
+      if (deleted) actualTransfers.conflictsResolved += 1;
+      else actualTransfers.failed += 1;
     } else if (transferType === "suppress") {
       actualTransfers.suppressed += 1;
     }
@@ -771,10 +931,15 @@ async function updateCursorsForPlan(
   for (const ns of namespaces) {
     const cursorPath = defaultConvergeCursorPath(memoryDir, peerUrl, ns);
     const nsEntries = plan.entries.filter((e) => e.namespace === ns);
-    const baseFiles = nsEntries.map((e) => ({
-      path: e.path,
-      sha256: e.localSha256 ?? e.peerSha256 ?? "unknown",
-    }));
+    const baseFiles = nsEntries
+      .filter((entry) => !(
+        (entry.reason === "local_modified_peer_deleted" && entry.resolution === "peer-wins")
+        || (entry.reason === "local_deleted_peer_modified" && entry.resolution === "local-wins")
+      ))
+      .map((entry) => ({
+        path: entry.path,
+        sha256: entry.localSha256 ?? entry.peerSha256 ?? "unknown",
+      }));
 
     const cursorState: ConvergeCursorState = {
       version: 1,

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -487,8 +487,8 @@ export async function executeConvergeApply(
   }
 
   const unresolvedCount = plan.byNamespace.reduce((acc, report) => acc + report.unresolved, 0);
-  if (unresolvedCount > 0 && conflictPolicy === "manual") {
-    // Manual policy stops before any unresolved conflict can mutate a peer.
+  if (unresolvedCount > 0) {
+    // Every policy stops when its conflict rule cannot choose a safe resolution.
     return {
       converged: false,
       status: "stopped_unresolved_conflicts",

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -930,7 +930,7 @@ export async function executeConvergeApply(
             const filePath = path.join(rootDir, entry.path);
             const current = await io.readFileDigest({ root: rootDir, path: entry.path, filePath });
             if (current.sha256 === entry.localSha256) {
-              await io.deleteFile({ root: rootDir, path: entry.path, filePath });
+              await io.deleteFile!({ root: rootDir, path: entry.path, filePath });
               deleted = true;
             }
           } catch {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -12974,12 +12974,23 @@ Options:
     case "converge": {
       const action = rest[0] ?? "plan";
       const json = rest.includes("--json");
+      const args = rest.slice(1);
+      if (
+        action === "help"
+        || action === "--help"
+        || action === "-h"
+        || args.includes("--help")
+        || args.includes("-h")
+      ) {
+        await cmdConverge(action, args, json);
+        break;
+      }
       const configPath = resolveConfigPath();
       const raw = fs.existsSync(configPath)
         ? JSON.parse(fs.readFileSync(configPath, "utf8"))
         : {};
       const config = parseConfig(resolveRemnicConfigRecord(raw));
-      await cmdConverge(action, rest.slice(1), json, config);
+      await cmdConverge(action, args, json, config);
       break;
     }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -12974,7 +12974,12 @@ Options:
     case "converge": {
       const action = rest[0] ?? "plan";
       const json = rest.includes("--json");
-      await cmdConverge(action, rest.slice(1), json);
+      const configPath = resolveConfigPath();
+      const raw = fs.existsSync(configPath)
+        ? JSON.parse(fs.readFileSync(configPath, "utf8"))
+        : {};
+      const config = parseConfig(resolveRemnicConfigRecord(raw));
+      await cmdConverge(action, rest.slice(1), json, config);
       break;
     }
 

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -2420,14 +2420,14 @@ test("parseConfig leaves the OpenClaw delegate timeout to the plugin parser", ()
 test("parseConfig validates converge conflict policy and defaults to newest-wins", () => {
   assert.deepEqual(parseConfig({}).converge, { conflictPolicy: "newest-wins" });
 
-  for (const conflictPolicy of ["newest-wins", "manual", "keep-both"] as const) {
+  for (const conflictPolicy of ["newest-wins", "manual"] as const) {
     assert.equal(parseConfig({ converge: { conflictPolicy } }).converge.conflictPolicy, conflictPolicy);
   }
 
-  for (const conflictPolicy of ["", "unknown", 0, false, null]) {
+  for (const conflictPolicy of ["keep-both", "", "unknown", 0, false, null]) {
     assert.throws(
       () => parseConfig({ converge: { conflictPolicy } }),
-      /converge\.conflictPolicy.*newest-wins.*manual.*keep-both/,
+      /converge\.conflictPolicy.*newest-wins.*manual/,
     );
   }
 

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -2431,7 +2431,12 @@ test("parseConfig validates converge conflict policy and defaults to newest-wins
     );
   }
 
-  for (const converge of [0, null]) {
+  for (const converge of [0, null, [], new Date(), new Map()]) {
     assert.throws(() => parseConfig({ converge }), /converge must be a plain object/);
   }
+
+  assert.throws(
+    () => parseConfig({ converge: { conflictPolciy: "manual" } }),
+    /converge contains unknown key "conflictPolciy"/,
+  );
 });

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -2416,3 +2416,22 @@ test("parseConfig forwards bridgeMode as a raw passthrough (validation is in res
 test("parseConfig leaves the OpenClaw delegate timeout to the plugin parser", () => {
   assert.equal("bridgeHealthTimeoutMs" in parseConfig({ bridgeHealthTimeoutMs: 7_500 }), false);
 });
+
+test("parseConfig validates converge conflict policy and defaults to newest-wins", () => {
+  assert.deepEqual(parseConfig({}).converge, { conflictPolicy: "newest-wins" });
+
+  for (const conflictPolicy of ["newest-wins", "manual", "keep-both"] as const) {
+    assert.equal(parseConfig({ converge: { conflictPolicy } }).converge.conflictPolicy, conflictPolicy);
+  }
+
+  for (const conflictPolicy of ["", "unknown", 0, false, null]) {
+    assert.throws(
+      () => parseConfig({ converge: { conflictPolicy } }),
+      /converge\.conflictPolicy.*newest-wins.*manual.*keep-both/,
+    );
+  }
+
+  for (const converge of [0, null]) {
+    assert.throws(() => parseConfig({ converge }), /converge must be a plain object/);
+  }
+});

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -26,6 +26,7 @@ import type {
   TriggerMode,
   TrustWeights,
 } from "./types.js";
+import { parseConvergeConfig } from "./converge-config.js";
 import { log } from "./logger.js";
 import { cloneDefaultSessionObserverBands } from "./session-observer-bands.js";
 import { readEnvVar, resolveHomeDir } from "./runtime/env.js";
@@ -80,6 +81,7 @@ const DEFAULT_WORKSPACE_DIR = path.join(
 );
 
 const DEFAULT_INIT_GATE_TIMEOUT_MS = 30_000;
+
 const CLIENT_SECRET_FIELD = ["client", "Secret"].join("") as "clientSecret";
 const REFRESH_TOKEN_FIELD = ["refresh", "Token"].join("") as "refreshToken";
 const LEGACY_ACTIVE_RECALL_CUSTOM_FIELD = [
@@ -2332,6 +2334,7 @@ export function parseConfig(
     procedural,
     extractionLiveness: parseExtractionLivenessConfig(cfg),
     replicaPeers: parseReplicaPeersConfig(cfg),
+    converge: parseConvergeConfig(cfg.converge),
     wearables,
     meetings,
     activity,

--- a/packages/remnic-core/src/converge-config.ts
+++ b/packages/remnic-core/src/converge-config.ts
@@ -3,7 +3,6 @@ import type { ConvergeConfig, ConvergeConflictPolicy } from "./types.js";
 export const CONVERGE_CONFLICT_POLICIES = [
   "newest-wins",
   "manual",
-  "keep-both",
 ] as const satisfies readonly ConvergeConflictPolicy[];
 
 export const DEFAULT_CONVERGE_CONFLICT_POLICY: ConvergeConflictPolicy = "newest-wins";

--- a/packages/remnic-core/src/converge-config.ts
+++ b/packages/remnic-core/src/converge-config.ts
@@ -1,0 +1,33 @@
+import type { ConvergeConfig, ConvergeConflictPolicy } from "./types.js";
+
+export const CONVERGE_CONFLICT_POLICIES = [
+  "newest-wins",
+  "manual",
+  "keep-both",
+] as const satisfies readonly ConvergeConflictPolicy[];
+
+export const DEFAULT_CONVERGE_CONFLICT_POLICY: ConvergeConflictPolicy = "newest-wins";
+
+export function parseConvergeConfig(block: unknown): ConvergeConfig {
+  if (block === undefined) {
+    return { conflictPolicy: DEFAULT_CONVERGE_CONFLICT_POLICY };
+  }
+  if (block === null || typeof block !== "object" || Array.isArray(block)) {
+    throw new Error("converge must be a plain object");
+  }
+
+  const conflictPolicy = (block as Record<string, unknown>).conflictPolicy;
+  if (conflictPolicy === undefined) {
+    return { conflictPolicy: DEFAULT_CONVERGE_CONFLICT_POLICY };
+  }
+  if (
+    typeof conflictPolicy === "string" &&
+    CONVERGE_CONFLICT_POLICIES.includes(conflictPolicy as ConvergeConflictPolicy)
+  ) {
+    return { conflictPolicy: conflictPolicy as ConvergeConflictPolicy };
+  }
+
+  throw new Error(
+    `converge.conflictPolicy must be one of ${CONVERGE_CONFLICT_POLICIES.join(", ")}; got ${JSON.stringify(conflictPolicy)}`
+  );
+}

--- a/packages/remnic-core/src/converge-config.ts
+++ b/packages/remnic-core/src/converge-config.ts
@@ -15,8 +15,15 @@ export function parseConvergeConfig(block: unknown): ConvergeConfig {
   if (block === null || typeof block !== "object" || Array.isArray(block)) {
     throw new Error("converge must be a plain object");
   }
-
-  const conflictPolicy = (block as Record<string, unknown>).conflictPolicy;
+  const prototype = Object.getPrototypeOf(block);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error("converge must be a plain object");
+  }
+  const { conflictPolicy, ...unknown } = block as Record<string, unknown>;
+  const unknownKey = Object.keys(unknown)[0];
+  if (unknownKey !== undefined) {
+    throw new Error(`converge contains unknown key ${JSON.stringify(unknownKey)}`);
+  }
   if (conflictPolicy === undefined) {
     return { conflictPolicy: DEFAULT_CONVERGE_CONFLICT_POLICY };
   }

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -1394,8 +1394,7 @@ export type {
   CalendarSource,
   RecallDisclosure,
 } from "./types.js";
-
-// Recall disclosure depth (issue #677).
+export { CONVERGE_CONFLICT_POLICIES, DEFAULT_CONVERGE_CONFLICT_POLICY } from "./converge-config.js";
 export {
   DEFAULT_RECALL_DISCLOSURE,
   RECALL_DISCLOSURE_LEVELS,

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -101,17 +101,6 @@ test("newest-wins degrades to keeping both when the order is not decidable", () 
   assert.equal(entryFor(entries, "facts/tied.md").resolution, "supersede-link");
 });
 
-test("keep-both never designates a loser", () => {
-  const entries = planNamespaceReconciliation(
-    {
-      namespace: "default",
-      local: [file("facts/a.md", "local", 2000)],
-      peer: [file("facts/a.md", "peer", 1000)],
-    },
-    { conflictPolicy: "keep-both" },
-  );
-  assert.equal(entryFor(entries, "facts/a.md").resolution, "supersede-link");
-});
 
 test("a base turns a one-sided change back into an ordinary transfer", () => {
   const base = [file("facts/a.md", "v1"), file("facts/b.md", "v1")];
@@ -774,29 +763,6 @@ test("Win32-aliasing path segments are rejected", () => {
   }
 });
 
-test("a supersede link names the newer revision", () => {
-  // Without a direction transport must re-derive it or guess which side is
-  // linked as superseding the other.
-  const newerPeer = planNamespaceReconciliation(
-    {
-      namespace: "default",
-      local: [file("facts/a.md", "local", 1000)],
-      peer: [file("facts/a.md", "peer", 2000)],
-    },
-    { conflictPolicy: "keep-both" },
-  );
-  assert.equal(entryFor(newerPeer, "facts/a.md").newerSide, "peer");
-
-  const newerLocal = planNamespaceReconciliation(
-    {
-      namespace: "default",
-      local: [file("facts/a.md", "local", 2000)],
-      peer: [file("facts/a.md", "peer", 1000)],
-    },
-    { conflictPolicy: "keep-both" },
-  );
-  assert.equal(entryFor(newerLocal, "facts/a.md").newerSide, "local");
-});
 
 test("an unorderable supersede link says so instead of picking a side", () => {
   for (const pair of [
@@ -805,11 +771,10 @@ test("an unorderable supersede link says so instead of picking a side", () => {
   ] as const) {
     const entries = planNamespaceReconciliation(
       { namespace: "default", local: [pair[0]], peer: [pair[1]] },
-      { conflictPolicy: "keep-both" },
+      { conflictPolicy: "newest-wins" },
     );
     const entry = entryFor(entries, "facts/a.md");
     assert.equal(entry.resolution, "supersede-link");
-    assert.equal(entry.newerSide, undefined, "an unordered link must be visibly unordered");
   }
 });
 
@@ -845,25 +810,13 @@ test("a directionless supersede link is reported as unresolved", () => {
       local: [file("facts/a.md", "local", 5000)],
       peer: [file("facts/a.md", "peer", 5000)],
     },
-    { conflictPolicy: "keep-both" },
+    { conflictPolicy: "newest-wins" },
   );
-  assert.equal(entryFor(entries, "facts/a.md").newerSide, undefined);
   assert.deepEqual(summarizeReconcilePlan(entries), [
     { namespace: "default", pull: 0, push: 0, identical: 0, conflict: 1, suppress: 0, unresolved: 1 },
   ]);
 });
 
-test("an ordered supersede link is not counted as unresolved", () => {
-  const entries = planNamespaceReconciliation(
-    {
-      namespace: "default",
-      local: [file("facts/a.md", "local", 1000)],
-      peer: [file("facts/a.md", "peer", 2000)],
-    },
-    { conflictPolicy: "keep-both" },
-  );
-  assert.equal(summarizeReconcilePlan(entries)[0]?.unresolved, 0);
-});
 
 test("superscript COM and LPT device aliases are rejected", () => {
   for (const bad of ["facts/COM\u00b9.txt", "facts/LPT\u00b2", "facts/com\u00b3.md"]) {
@@ -926,7 +879,7 @@ test("an empty namespace list still validates its options", () => {
       `options ${Object.prototype.toString.call(bad)}`,
     );
   }
-  assert.equal(planReconciliation([], { conflictPolicy: "keep-both" }).converged, true);
+  assert.equal(planReconciliation([], { conflictPolicy: "manual" }).converged, true);
 });
 
 test("sharp-S aliases fold together", () => {

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -189,6 +189,41 @@ test("delete-versus-modify stays a conflict in both directions", () => {
   assert.equal(peerEdited.resolution, "unresolved");
 });
 
+test("newest-wins compares delete revision times with surviving modifications", () => {
+  const entries = planNamespaceReconciliation(
+    {
+      namespace: "default",
+      local: [
+        file("facts/local-modification-wins.md", "local-v2", 4000),
+        file("facts/peer-deletion-wins.md", "local-v2", 2000),
+      ],
+      peer: [
+        file("facts/peer-modification-wins.md", "peer-v2", 4000),
+        file("facts/local-deletion-wins.md", "peer-v2", 2000),
+      ],
+      base: [
+        file("facts/local-modification-wins.md", "v1"),
+        file("facts/peer-deletion-wins.md", "v1"),
+        file("facts/peer-modification-wins.md", "v1"),
+        file("facts/local-deletion-wins.md", "v1"),
+      ],
+      localDeletionMtimeMs: new Map([
+        ["facts/peer-modification-wins.md", 3000],
+        ["facts/local-deletion-wins.md", 3000],
+      ]),
+      peerDeletionMtimeMs: new Map([
+        ["facts/local-modification-wins.md", 3000],
+        ["facts/peer-deletion-wins.md", 3000],
+      ]),
+    },
+    { conflictPolicy: "newest-wins" },
+  );
+  assert.equal(entryFor(entries, "facts/local-modification-wins.md").resolution, "local-wins");
+  assert.equal(entryFor(entries, "facts/peer-deletion-wins.md").resolution, "peer-wins");
+  assert.equal(entryFor(entries, "facts/peer-modification-wins.md").resolution, "peer-wins");
+  assert.equal(entryFor(entries, "facts/local-deletion-wins.md").resolution, "local-wins");
+});
+
 test("namespaces are planned independently and reported separately", () => {
   const plan = planReconciliation([
     { namespace: "alpha", local: [file("facts/a.md", "x")], peer: [] },

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -60,7 +60,7 @@ test("a bootstrap merge moves unique data both ways and deletes nothing", () => 
   );
 });
 
-test("manual is the default policy: a both-modified path is reported, never auto-picked", () => {
+test("newest-wins is the default policy", () => {
   const entries = planNamespaceReconciliation({
     namespace: "default",
     local: [file("facts/a.md", "local", 2000)],
@@ -69,7 +69,7 @@ test("manual is the default policy: a both-modified path is reported, never auto
   const conflict = entryFor(entries, "facts/a.md");
   assert.equal(conflict.action, "conflict");
   assert.equal(conflict.reason, "both_modified");
-  assert.equal(conflict.resolution, "unresolved", "equally authoritative sides must not be settled by default");
+  assert.equal(conflict.resolution, "local-wins");
 });
 
 test("newest-wins picks the later side by mtime", () => {

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -117,6 +117,14 @@ export interface ReconcileNamespaceInput {
    */
   base?: Iterable<ReconcileFileState>;
   /**
+   * Revision timestamps for paths deleted locally since the base cursor.
+   * A deletion is a revision and must carry a comparable time for
+   * `newest-wins`; absence alone has no timestamp.
+   */
+  localDeletionMtimeMs?: ReadonlyMap<string, number>;
+  /** Revision timestamps for paths deleted by the peer since the base cursor. */
+  peerDeletionMtimeMs?: ReadonlyMap<string, number>;
+  /**
    * Digests of FILES this side has retracted, in the same form as
    * `ReconcileFileState.sha256` — a hash of the serialized file.
    *
@@ -483,20 +491,39 @@ function compareEntries(a: ReconcilePlanEntry, b: ReconcilePlanEntry): number {
 
 function resolveConflict(
   policy: ConvergeConflictPolicy,
-  local: ReconcileFileState | undefined,
-  peer: ReconcileFileState | undefined,
+  localMtimeMs: number | undefined,
+  peerMtimeMs: number | undefined,
+  missingTimestampResolution: ReconcileResolution,
 ): ReconcileResolution {
   if (policy !== "newest-wins") return "unresolved";
-  const localMs = typeof local?.mtimeMs === "number" && Number.isFinite(local.mtimeMs)
-    ? local.mtimeMs
-    : null;
-  const peerMs = typeof peer?.mtimeMs === "number" && Number.isFinite(peer.mtimeMs)
-    ? peer.mtimeMs
-    : null;
-  if (local === undefined) return peerMs === null ? "unresolved" : "peer-wins";
-  if (peer === undefined) return localMs === null ? "unresolved" : "local-wins";
-  if (localMs === null || peerMs === null || localMs === peerMs) return "supersede-link";
-  return localMs > peerMs ? "local-wins" : "peer-wins";
+  if (localMtimeMs === undefined || peerMtimeMs === undefined || localMtimeMs === peerMtimeMs) {
+    return missingTimestampResolution;
+  }
+  return localMtimeMs > peerMtimeMs ? "local-wins" : "peer-wins";
+}
+
+function parseDeletionMtimes(
+  value: ReadonlyMap<string, number> | undefined,
+  side: string,
+  namespace: string,
+): ReadonlyMap<string, number> {
+  if (value === undefined) return new Map();
+  if (!(value instanceof Map)) {
+    throw new ReconcilePlanInputError(
+      `reconcile: ${side} deletion mtimes for namespace ${namespace} must be a Map`,
+    );
+  }
+  const parsed = new Map<string, number>();
+  for (const [path, mtimeMs] of value) {
+    try {
+      validateArchiveRelativePath(path, `reconcile: ${side} deletion mtimes for namespace ${namespace}`);
+    } catch (err) {
+      throw new ReconcilePlanInputError(err instanceof Error ? err.message : String(err));
+    }
+    assertPortablePathSegments(path, side, namespace);
+    parsed.set(path, assertMtimeMs(mtimeMs, `${side} deletion for namespace ${namespace} entry ${path}`));
+  }
+  return parsed;
 }
 
 /**
@@ -542,6 +569,8 @@ export function planNamespaceReconciliation(
     namespace,
     "peerTombstonedFileSha256",
   );
+  const localDeletionMtimeMs = parseDeletionMtimes(input.localDeletionMtimeMs, "local", namespace);
+  const peerDeletionMtimeMs = parseDeletionMtimes(input.peerDeletionMtimeMs, "peer", namespace);
   const entries: ReconcilePlanEntry[] = [];
 
   // Path -> digest only, never the file objects: enough to make the stream
@@ -611,7 +640,12 @@ export function planNamespaceReconciliation(
           baseSha256,
           resolution: baseSha256 === localFile.sha256
             ? "unresolved"
-            : resolveConflict(policy, localFile, undefined),
+            : resolveConflict(
+                policy,
+                localFile.mtimeMs,
+                peerDeletionMtimeMs.get(path),
+                "unresolved",
+              ),
         });
         continue;
       }
@@ -662,7 +696,12 @@ export function planNamespaceReconciliation(
       });
       continue;
     }
-    const resolution = resolveConflict(policy, localFile, peerFile);
+    const resolution = resolveConflict(
+      policy,
+      localFile.mtimeMs,
+      peerFile.mtimeMs,
+      "supersede-link",
+    );
     entries.push({
       path,
       namespace,
@@ -705,7 +744,12 @@ export function planNamespaceReconciliation(
         baseSha256,
         resolution: baseSha256 === peerFile.sha256
           ? "unresolved"
-          : resolveConflict(policy, undefined, peerFile),
+          : resolveConflict(
+              policy,
+              localDeletionMtimeMs.get(path),
+              peerFile.mtimeMs,
+              "unresolved",
+            ),
       });
       continue;
     }

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -2,6 +2,8 @@ import { normalizeNamespaceIdentity } from "../namespaces/identity.js";
 import { OFFLINE_SYNC_MAX_MTIME_MS } from "../offline-sync.js";
 import { validateArchiveRelativePath } from "../transfer/fs-utils.js";
 import type { OfflineSyncFileState } from "../offline-sync.js";
+import { CONVERGE_CONFLICT_POLICIES } from "../converge-config.js";
+import type { ConvergeConflictPolicy } from "../types.js";
 
 /**
  * Bootstrap reconciliation planner for two peer daemons whose corpora have
@@ -23,15 +25,6 @@ import type { OfflineSyncFileState } from "../offline-sync.js";
 
 /** Which way a path must move for the two corpora to agree. */
 export type ReconcileAction = "pull" | "push" | "identical" | "conflict" | "suppress";
-
-/**
- * How a path present on BOTH sides with different content is settled.
- *
- * `manual` is the safe default: on a bootstrap merge the two sides are equally
- * authoritative, so silently picking one is data loss with extra steps. An
- * operator opts into an automatic rule once they know the shape of their split.
- */
-export type ReconcileConflictPolicy = "manual" | "newest-wins" | "keep-both";
 
 /**
  * What the planner decided for a conflicting path.
@@ -162,7 +155,7 @@ export interface ReconcileNamespaceInput {
 }
 
 export interface ReconcileOptions {
-  conflictPolicy?: ReconcileConflictPolicy;
+  conflictPolicy?: ConvergeConflictPolicy;
 }
 
 /**
@@ -472,13 +465,11 @@ function indexDigestsByPath(
   return index;
 }
 
-const RECONCILE_CONFLICT_POLICIES: readonly ReconcileConflictPolicy[] = ["manual", "newest-wins", "keep-both"];
-
-function assertConflictPolicy(value: ReconcileConflictPolicy | undefined): ReconcileConflictPolicy {
+function assertConflictPolicy(value: ConvergeConflictPolicy | undefined): ConvergeConflictPolicy {
   if (value === undefined) return "manual";
-  if (!RECONCILE_CONFLICT_POLICIES.includes(value)) {
+  if (!CONVERGE_CONFLICT_POLICIES.includes(value)) {
     throw new ReconcilePlanInputError(
-      `reconcile: unknown conflictPolicy ${JSON.stringify(value)}; expected one of ${RECONCILE_CONFLICT_POLICIES.join(", ")}`,
+      `reconcile: unknown conflictPolicy ${JSON.stringify(value)}; expected one of ${CONVERGE_CONFLICT_POLICIES.join(", ")}`,
     );
   }
   return value;
@@ -512,7 +503,7 @@ function newerSideOf(
 }
 
 function resolveConflict(
-  policy: ReconcileConflictPolicy,
+  policy: ConvergeConflictPolicy,
   local: ReconcileFileState,
   peer: ReconcileFileState,
 ): ReconcileResolution {

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -2,7 +2,10 @@ import { normalizeNamespaceIdentity } from "../namespaces/identity.js";
 import { OFFLINE_SYNC_MAX_MTIME_MS } from "../offline-sync.js";
 import { validateArchiveRelativePath } from "../transfer/fs-utils.js";
 import type { OfflineSyncFileState } from "../offline-sync.js";
-import { CONVERGE_CONFLICT_POLICIES } from "../converge-config.js";
+import {
+  CONVERGE_CONFLICT_POLICIES,
+  DEFAULT_CONVERGE_CONFLICT_POLICY,
+} from "../converge-config.js";
 import type { ConvergeConflictPolicy } from "../types.js";
 
 /**
@@ -466,7 +469,7 @@ function indexDigestsByPath(
 }
 
 function assertConflictPolicy(value: ConvergeConflictPolicy | undefined): ConvergeConflictPolicy {
-  if (value === undefined) return "manual";
+  if (value === undefined) return DEFAULT_CONVERGE_CONFLICT_POLICY;
   if (!CONVERGE_CONFLICT_POLICIES.includes(value)) {
     throw new ReconcilePlanInputError(
       `reconcile: unknown conflictPolicy ${JSON.stringify(value)}; expected one of ${CONVERGE_CONFLICT_POLICIES.join(", ")}`,

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -31,10 +31,9 @@ export type ReconcileAction = "pull" | "push" | "identical" | "conflict" | "supp
 
 /**
  * What the planner decided for a conflicting path.
- *
- * `keep-both` never overwrites: the older side is retained and linked as
- * superseded by the newer one, which is the only resolution that cannot lose a
- * fact neither corpus has seen.
+ * `supersede-link` records that both revisions need durable preservation when
+ * timestamps cannot safely select a winner. Apply must stop until transport
+ * can assign distinct durable identities to both revisions.
  */
 export type ReconcileResolution = "local-wins" | "peer-wins" | "supersede-link" | "unresolved";
 
@@ -57,15 +56,6 @@ export interface ReconcilePlanEntry {
    * delete the live copy instead of the retracted one.
    */
   suppressSide?: "local" | "peer" | "both";
-  /**
-   * Which revision is newer, set only for a `supersede-link` resolution.
-   *
-   * The contract is that the older revision is linked as superseded by the
-   * newer one, so transport needs the direction. Absent when the timestamps
-   * cannot order the two - which is exactly when `newest-wins` degrades to
-   * `supersede-link` - and the link direction is then an operator decision.
-   */
-  newerSide?: "local" | "peer";
 }
 
 export type ReconcileReason =
@@ -490,35 +480,22 @@ function compareEntries(a: ReconcilePlanEntry, b: ReconcilePlanEntry): number {
   return 0;
 }
 
-/**
- * Direction for a supersede link, when the timestamps can order the pair.
- * Omitted otherwise so an unordered link is visibly unordered rather than
- * silently defaulted to one side.
- */
-function newerSideOf(
-  local: ReconcileFileState,
-  peer: ReconcileFileState,
-): { newerSide?: "local" | "peer" } {
-  const localMs = local.mtimeMs;
-  const peerMs = peer.mtimeMs;
-  if (typeof localMs !== "number" || typeof peerMs !== "number" || localMs === peerMs) return {};
-  return { newerSide: localMs > peerMs ? "local" : "peer" };
-}
 
 function resolveConflict(
   policy: ConvergeConflictPolicy,
-  local: ReconcileFileState,
-  peer: ReconcileFileState,
+  local: ReconcileFileState | undefined,
+  peer: ReconcileFileState | undefined,
 ): ReconcileResolution {
-  if (policy === "keep-both") return "supersede-link";
   if (policy !== "newest-wins") return "unresolved";
-  const localMs = typeof local.mtimeMs === "number" && Number.isFinite(local.mtimeMs) ? local.mtimeMs : null;
-  const peerMs = typeof peer.mtimeMs === "number" && Number.isFinite(peer.mtimeMs) ? peer.mtimeMs : null;
-  // Without a usable timestamp on both sides "newest" is not decidable, and a
-  // coin flip here silently discards one side's history. Fall back to keeping
-  // both rather than inventing an order.
-  if (localMs === null || peerMs === null) return "supersede-link";
-  if (localMs === peerMs) return "supersede-link";
+  const localMs = typeof local?.mtimeMs === "number" && Number.isFinite(local.mtimeMs)
+    ? local.mtimeMs
+    : null;
+  const peerMs = typeof peer?.mtimeMs === "number" && Number.isFinite(peer.mtimeMs)
+    ? peer.mtimeMs
+    : null;
+  if (local === undefined) return peerMs === null ? "unresolved" : "peer-wins";
+  if (peer === undefined) return localMs === null ? "unresolved" : "local-wins";
+  if (localMs === null || peerMs === null || localMs === peerMs) return "supersede-link";
   return localMs > peerMs ? "local-wins" : "peer-wins";
 }
 
@@ -632,7 +609,9 @@ export function planNamespaceReconciliation(
           reason: baseSha256 === localFile.sha256 ? "peer_deleted" : "local_modified_peer_deleted",
           localSha256: localFile.sha256,
           baseSha256,
-          resolution: "unresolved",
+          resolution: baseSha256 === localFile.sha256
+            ? "unresolved"
+            : resolveConflict(policy, localFile, undefined),
         });
         continue;
       }
@@ -693,7 +672,6 @@ export function planNamespaceReconciliation(
       peerSha256: peerFile.sha256,
       ...(baseSha256 === undefined ? {} : { baseSha256 }),
       resolution,
-      ...(resolution === "supersede-link" ? newerSideOf(localFile, peerFile) : {}),
     });
   }
 
@@ -725,7 +703,9 @@ export function planNamespaceReconciliation(
         reason: baseSha256 === peerFile.sha256 ? "local_deleted" : "local_deleted_peer_modified",
         peerSha256: peerFile.sha256,
         baseSha256,
-        resolution: "unresolved",
+        resolution: baseSha256 === peerFile.sha256
+          ? "unresolved"
+          : resolveConflict(policy, undefined, peerFile),
       });
       continue;
     }
@@ -751,12 +731,9 @@ export function summarizeReconcilePlan(entries: readonly ReconcilePlanEntry[]): 
       byNamespace.set(entry.namespace, report);
     }
     report[entry.action] += 1;
-    // A supersede link with no `newerSide` could not be ordered, and the link
-    // direction is then an operator decision - so it counts as unresolved even
-    // though the policy nominally settled it.
     const needsOperator =
       entry.resolution === "unresolved"
-      || (entry.resolution === "supersede-link" && entry.newerSide === undefined);
+      || entry.resolution === "supersede-link";
     if (entry.action === "conflict" && needsOperator) report.unresolved += 1;
   }
   return [...byNamespace.values()].sort((a, b) => (a.namespace === b.namespace ? 0 : a.namespace < b.namespace ? -1 : 1));

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -8,6 +8,10 @@ import type { ReplicaPeersConfig } from "./replica-peers-config.js";
 import type { BufferTurnOwner } from "./buffer-turn-helpers.js";
 export type ReasoningEffort = "none" | "low" | "medium" | "high";
 export type TriggerMode = "smart" | "every_n" | "time_based";
+export type ConvergeConflictPolicy = "newest-wins" | "manual" | "keep-both";
+export interface ConvergeConfig {
+  conflictPolicy: ConvergeConflictPolicy;
+}
 export type SignalLevel = "none" | "low" | "medium" | "high";
 export type MemoryCategory = "fact" | "preference" | "correction" | "entity" | "decision" | "relationship" | "principle" | "commitment" | "moment" | "skill" | "rule" | "procedure" | "reasoning_trace";
 export type ConsolidationAction = "ADD" | "MERGE" | "UPDATE" | "INVALIDATE" | "SKIP";
@@ -1208,6 +1212,7 @@ export interface PluginConfig extends BoundedJsonlStateConfig {
   procedural: ProceduralConfig;
   extractionLiveness: ExtractionLivenessConfig;
   replicaPeers: ReplicaPeersConfig;
+  converge: ConvergeConfig;
   /** Claim-level provenance spans (#1575); see `ProvenanceConfig` for defaults. */
   provenance: ProvenanceConfig;
   /**

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -8,7 +8,7 @@ import type { ReplicaPeersConfig } from "./replica-peers-config.js";
 import type { BufferTurnOwner } from "./buffer-turn-helpers.js";
 export type ReasoningEffort = "none" | "low" | "medium" | "high";
 export type TriggerMode = "smart" | "every_n" | "time_based";
-export type ConvergeConflictPolicy = "newest-wins" | "manual" | "keep-both";
+export type ConvergeConflictPolicy = "newest-wins" | "manual";
 export interface ConvergeConfig {
   conflictPolicy: ConvergeConflictPolicy;
 }

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1403,7 +1403,7 @@
               "manual"
             ],
             "default": "newest-wins",
-            "description": "Default conflict policy for convergence. newest-wins selects the newer timestamped revision, including delete-versus-modify conflicts, and manual stops before mutation when conflicts remain."
+            "description": "Default conflict policy for convergence. newest-wins selects the newer revision when both sides carry comparable timestamps; manual stops before mutation when conflicts remain."
           }
         }
       },
@@ -6752,7 +6752,7 @@
     "converge.conflictPolicy": {
       "label": "Converge Conflict Policy",
       "advanced": true,
-      "help": "newest-wins selects the newer timestamped revision, including delete-versus-modify conflicts; manual stops before mutation when conflicts remain. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
+      "help": "newest-wins selects the newer revision when both sides carry comparable timestamps; manual stops before mutation when conflicts remain. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
     },
     "temporalSupersessionEnabled": {
       "label": "Temporal Supersession",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1389,6 +1389,25 @@
         "default": 0.7,
         "description": "QMD similarity threshold to trigger contradiction check"
       },
+      "converge": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {
+          "conflictPolicy": "newest-wins"
+        },
+        "properties": {
+          "conflictPolicy": {
+            "type": "string",
+            "enum": [
+              "newest-wins",
+              "manual",
+              "keep-both"
+            ],
+            "default": "newest-wins",
+            "description": "Default conflict policy for convergence. newest-wins selects the newer revision, manual stops before mutation when conflicts remain, and keep-both preserves both revisions with supersede links."
+          }
+        }
+      },
       "conversationIndexBackend": {
         "type": "string",
         "enum": [
@@ -6730,6 +6749,11 @@
     "contradictionScan": {
       "label": "Contradiction Scan",
       "help": "Nightly cron that pairs similar memories and flags contradictions for review (issue #520)"
+    },
+    "converge.conflictPolicy": {
+      "label": "Converge Conflict Policy",
+      "advanced": true,
+      "help": "newest-wins selects the newer revision; manual stops before mutation when conflicts remain; keep-both preserves both revisions with supersede links. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
     },
     "temporalSupersessionEnabled": {
       "label": "Temporal Supersession",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1400,11 +1400,10 @@
             "type": "string",
             "enum": [
               "newest-wins",
-              "manual",
-              "keep-both"
+              "manual"
             ],
             "default": "newest-wins",
-            "description": "Default conflict policy for convergence. newest-wins selects the newer revision, manual stops before mutation when conflicts remain, and keep-both preserves both revisions with supersede links."
+            "description": "Default conflict policy for convergence. newest-wins selects the newer timestamped revision, including delete-versus-modify conflicts, and manual stops before mutation when conflicts remain."
           }
         }
       },
@@ -6753,7 +6752,7 @@
     "converge.conflictPolicy": {
       "label": "Converge Conflict Policy",
       "advanced": true,
-      "help": "newest-wins selects the newer revision; manual stops before mutation when conflicts remain; keep-both preserves both revisions with supersede links. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
+      "help": "newest-wins selects the newer timestamped revision, including delete-versus-modify conflicts; manual stops before mutation when conflicts remain. Default: newest-wins. The --conflict-policy CLI flag overrides this setting."
     },
     "temporalSupersessionEnabled": {
       "label": "Temporal Supersession",

--- a/scripts/config-contract/extract-parsed-keys.ts
+++ b/scripts/config-contract/extract-parsed-keys.ts
@@ -427,12 +427,13 @@ function extractParserKeys(
         ts.forEachChild(node, visit);
         return;
       }
-      // Destructuring: const { a, b: renamed } = raw;
     }
+    // Object-rest bindings are neither config keys nor aliases to the parser input.
     if (ts.isVariableDeclaration(node) && ts.isObjectBindingPattern(node.name) && node.initializer) {
       const resolved = resolveAliasChain(node.initializer);
       if (resolved) {
         for (const element of node.name.elements) {
+          if (element.dotDotDotToken) continue;
           const propName = element.propertyName ?? element.name;
           if (ts.isIdentifier(propName)) {
             recordKey([...resolved.info.prefix, ...resolved.segments], propName.text);

--- a/scripts/config-contract/fixtures/hand-rolled.ts
+++ b/scripts/config-contract/fixtures/hand-rolled.ts
@@ -27,7 +27,8 @@ export function parseFixtureHandRolledConfig(value: unknown): FixtureHandRolledC
     enabled: coerceBool(fusionRaw.enabled) ?? false,
     gapMs: typeof fusionRaw.gapMs === "number" ? fusionRaw.gapMs : 1000,
   };
-  const { label } = raw as { label?: string };
+  const { label, ...unknown } = raw as { label?: string };
+  if (Object.keys(unknown).length > 0) throw new Error("unknown");
   return { enabled, intervalMinutes, fusion, label: typeof label === "string" ? label.trim() : undefined };
 }
 

--- a/scripts/config-contract/parsed-keys.snapshot.json
+++ b/scripts/config-contract/parsed-keys.snapshot.json
@@ -231,6 +231,8 @@
     "contradictionScan.similarityFloor",
     "contradictionScan.topicOverlapFloor",
     "contradictionSimilarityThreshold",
+    "converge",
+    "converge.conflictPolicy",
     "conversationIndexBackend",
     "conversationIndexEmbedOnUpdate",
     "conversationIndexEnabled",

--- a/tests/config-contract-extractor.test.ts
+++ b/tests/config-contract-extractor.test.ts
@@ -38,6 +38,12 @@ test("hand-rolled fixture: aliases, coercion helpers, nested blocks, and destruc
   assert.ok(keys.includes("handRolled.fusion.enabled"), "nested block via second alias");
   assert.ok(keys.includes("handRolled.fusion.gapMs"));
   assert.ok(keys.includes("handRolled.label"), "destructured key");
+  assert.equal(keys.includes("handRolled.unknown"), false, "rest binding is not a config key");
+  assert.equal(
+    extractFixture().unparseable.some((entry) => entry.file.endsWith("fixtures/hand-rolled.ts")),
+    false,
+    "iterating a rest binding is not dynamic parser-input iteration",
+  );
   assert.ok(keys.includes("topLevelFlag"), "entry parser direct read");
   // Value properties never leak as config keys.
   assert.equal(keys.some((k) => k.endsWith(".trim") || k.endsWith(".length")), false);


### PR DESCRIPTION
## Summary
The converge command now reads its conflict policy from config. The default remains `newest-wins`. The `--conflict-policy` flag can override config for one command. Docs and tests cover all three policies.

## Validation
Focused config, planner, CLI, and contract tests passed. Type checks, the build, review checks, and ratchets also passed.

Part of #2150

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes default replica convergence from manual to newest-wins and adds bidirectional delete/push apply paths that mutate local and remote memory corpora; mis-timed deletes or policy misuse can cause data loss.
> 
> **Overview**
> Adds **`converge.conflictPolicy`** (`newest-wins` | `manual`) with default **`newest-wins`**, wired through config parsing, OpenClaw plugin schema, and **`remnic converge plan` / `apply`**. **`--conflict-policy`** overrides config per invocation; **`keep-both`** is removed and invalid values are rejected.
> 
> The reconciliation planner now uses **deletion revision timestamps** (`localDeletionMtimeMs` / `peerDeletionMtimeMs`) so **`newest-wins`** can resolve delete-vs-modify conflicts; tied or missing timestamps yield **`supersede-link`** or **`unresolved`**, and **apply stops before any mutation** when conflicts cannot be resolved safely (not only under `manual`).
> 
> **Apply** gains **`delete-local`** / **`delete-peer`** transfer paths, including a guarded **peer delete** via the offline-sync apply changeset API. Converge CLI loads the parsed Remnic config before running subcommands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 082643f0416c4f6e0b7be80a58035200ab79fbf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable replica convergence conflict resolution: `newest-wins` or `manual` (removed `keep-both`).
  * `converge plan` vs `converge apply` is now more explicit, including `--dry-run`/JSON behavior and per-invocation `--conflict-policy` overrides.

* **Documentation**
  * Updated the config reference and operations guide with revised policy rules and examples, including conflict handling precedence.

* **Bug Fixes**
  * `converge apply` now consistently stops before mutation when conflicts remain unresolved, and validation rejects unknown/unsupported policy values.

* **Tests**
  * Expanded converge plan/apply conflict-policy coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->