### PR TITLE
fix(core): make extraction diagnostics truthful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Extraction health no longer counts local filter skips as successful runs. Live empty runs now record health only after later steps finish.
+- Extraction health no longer treats local filter skips as successful runs. Live empty runs record health only when later steps succeed.
 - Stats now add extraction counts from active namespaces. Scoped health keeps the backlog counts behind its status. Invalid calendar dates now fail metadata checks.
 
 ## [v9.45.1] — 2026-07-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Extraction health no longer counts local filter skips as successful runs. Live empty runs now record health only after later steps finish.
+- Stats now add extraction counts from active namespaces. Scoped health keeps the backlog counts behind its status. Invalid calendar dates now fail metadata checks.
+
 ## [v9.45.1] — 2026-07-30
 
 ### Added

--- a/packages/remnic-core/src/access-service-health.test.ts
+++ b/packages/remnic-core/src/access-service-health.test.ts
@@ -474,10 +474,12 @@ test("health keeps namespace QMD failures scoped to the namespace", async () => 
   }
 });
 
-test("health surfaces extraction liveness as degraded when the buffer is non-empty and the watermark is stale", async () => {
+test("health surfaces extraction liveness as degraded when the buffer is non-empty and the watermark is stale", async (t) => {
+  const nowMs = Date.parse("2026-07-30T12:00:00.000Z");
+  t.mock.timers.enable({ apis: ["Date"], now: nowMs });
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-liveness-"));
   try {
-    const oldTs = new Date(Date.now() - 10_000).toISOString();
+    const oldTs = new Date(nowMs - 10_000).toISOString();
     const config = parseConfig({ memoryDir, qmdEnabled: false, extractionLiveness: { staleWindowMs: 1000 } });
     const service = new EngramAccessService({
       config,
@@ -506,11 +508,7 @@ test("health surfaces extraction liveness as degraded when the buffer is non-emp
     assert.equal(health.extraction.bufferedSessionCount, 3);
     assert.equal(health.extraction.pendingTurnCount, 12);
     assert.equal(health.extraction.lastExtractionAt, oldTs);
-    const oldestAge = health.extraction.oldestBufferedTurnAgeMs ?? -1;
-    assert.ok(
-      oldestAge >= 10_000 && oldestAge < 60_000,
-      `oldest buffered turn age reflects the ~10s offset, not merely non-negative (got ${oldestAge}ms)`,
-    );
+    assert.equal(health.extraction.oldestBufferedTurnAgeMs, 10_000);
     assert.ok(
       health.extraction.degradedReason !== null && health.extraction.degradedReason.length > 0,
       "degraded reason is populated",
@@ -523,13 +521,12 @@ test("health surfaces extraction liveness as degraded when the buffer is non-emp
     assert.equal(scopedHealth.extraction.degraded, true);
     assert.equal(scopedHealth.extraction.bufferedSessionCount, 3);
     assert.equal(scopedHealth.extraction.pendingTurnCount, 12);
-    assert.ok(
-      scopedHealth.extraction.oldestBufferedTurnAgeMs !== null &&
-        Math.abs(scopedHealth.extraction.oldestBufferedTurnAgeMs - oldestAge) < 100,
-    );
+    assert.equal(scopedHealth.extraction.oldestBufferedTurnAgeMs, 10_000);
     assert.match(scopedHealth.extraction.degradedReason ?? "", /3 buffered session/);
+    assert.match(scopedHealth.extraction.degradedReason ?? "", /12 turn\(s\) pending extraction/);
     assert.doesNotMatch(scopedHealth.extraction.degradedReason ?? "", /last succeeded|unreadable/);
   } finally {
+    t.mock.timers.reset();
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
@@ -686,6 +683,13 @@ test("health reports extraction liveness degraded when the buffer read fails (§
     assert.equal(health.extraction.degraded, true, "an unreadable buffer must not report a healthy pipeline");
     assert.match(health.extraction.degradedReason ?? "", /unreadable/);
     assert.match(health.extraction.degradedReason ?? "", /buffer file corrupt/);
+    const scopedHealth = await tokenCapabilityStore.run(
+      { version: TOKEN_CAPABILITIES_VERSION, namespaces: ["default"] },
+      () => service.health(),
+    );
+    assert.equal(scopedHealth.extraction.lastExtractionAt, null);
+    assert.match(scopedHealth.extraction.degradedReason ?? "", /extraction buffer unreadable/);
+    assert.doesNotMatch(scopedHealth.extraction.degradedReason ?? "", /buffer file corrupt/);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
@@ -716,6 +720,13 @@ test("health reports extraction liveness degraded when the watermark (meta) read
     assert.equal(health.extraction.degraded, true, "an unreadable watermark must not report a healthy pipeline");
     assert.match(health.extraction.degradedReason ?? "", /watermark unreadable/);
     assert.match(health.extraction.degradedReason ?? "", /meta\.json unreadable/);
+    const scopedHealth = await tokenCapabilityStore.run(
+      { version: TOKEN_CAPABILITIES_VERSION, namespaces: ["default"] },
+      () => service.health(),
+    );
+    assert.equal(scopedHealth.extraction.lastExtractionAt, null);
+    assert.match(scopedHealth.extraction.degradedReason ?? "", /extraction watermark unreadable/);
+    assert.doesNotMatch(scopedHealth.extraction.degradedReason ?? "", /meta\.json unreadable/);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/access-service-health.test.ts
+++ b/packages/remnic-core/src/access-service-health.test.ts
@@ -515,6 +515,20 @@ test("health surfaces extraction liveness as degraded when the buffer is non-emp
       health.extraction.degradedReason !== null && health.extraction.degradedReason.length > 0,
       "degraded reason is populated",
     );
+    const scopedHealth = await tokenCapabilityStore.run(
+      { version: TOKEN_CAPABILITIES_VERSION, namespaces: ["default"] },
+      () => service.health(),
+    );
+    assert.equal(scopedHealth.extraction.lastExtractionAt, null);
+    assert.equal(scopedHealth.extraction.degraded, true);
+    assert.equal(scopedHealth.extraction.bufferedSessionCount, 3);
+    assert.equal(scopedHealth.extraction.pendingTurnCount, 12);
+    assert.ok(
+      scopedHealth.extraction.oldestBufferedTurnAgeMs !== null &&
+        Math.abs(scopedHealth.extraction.oldestBufferedTurnAgeMs - oldestAge) < 100,
+    );
+    assert.match(scopedHealth.extraction.degradedReason ?? "", /3 buffered session/);
+    assert.doesNotMatch(scopedHealth.extraction.degradedReason ?? "", /last succeeded|unreadable/);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2393,14 +2393,24 @@ export class EngramAccessService {
       extractionWatermark,
       caps?.namespaces !== undefined ? undefined : this.extractionLivenessWarn,
     );
+    let scopedDegradedReason: string | null = null;
+    if (extraction.degraded) {
+      if (extraction.degradedReason?.includes("watermark unreadable")) {
+        scopedDegradedReason = "daemon extraction pipeline degraded; extraction watermark unreadable";
+      } else if (extraction.degradedReason?.includes("buffer unreadable")) {
+        scopedDegradedReason = "daemon extraction pipeline degraded; extraction buffer unreadable";
+      } else {
+        scopedDegradedReason =
+          `daemon extraction pipeline degraded; ${extraction.bufferedSessionCount} buffered session(s), ` +
+          `${extraction.pendingTurnCount} turn(s) pending extraction`;
+      }
+    }
     const visibleExtraction =
       caps?.namespaces !== undefined
         ? {
             ...extraction,
             lastExtractionAt: null,
-            degradedReason: extraction.degraded
-              ? `daemon extraction pipeline degraded; ${extraction.bufferedSessionCount} buffered session(s), ${extraction.pendingTurnCount} turn(s) pending extraction`
-              : null,
+            degradedReason: scopedDegradedReason,
           }
         : extraction;
     // ONE call: the corpus array and the flag describing it must not come from

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2400,9 +2400,7 @@ export class EngramAccessService {
       } else if (extraction.degradedReason?.includes("buffer unreadable")) {
         scopedDegradedReason = "daemon extraction pipeline degraded; extraction buffer unreadable";
       } else {
-        scopedDegradedReason =
-          `daemon extraction pipeline degraded; ${extraction.bufferedSessionCount} buffered session(s), ` +
-          `${extraction.pendingTurnCount} turn(s) pending extraction`;
+        scopedDegradedReason = "daemon extraction pipeline degraded; backlog pending extraction";
       }
     }
     const visibleExtraction =
@@ -2410,6 +2408,9 @@ export class EngramAccessService {
         ? {
             ...extraction,
             lastExtractionAt: null,
+            bufferedSessionCount: 0,
+            pendingTurnCount: 0,
+            oldestBufferedTurnAgeMs: null,
             degradedReason: scopedDegradedReason,
           }
         : extraction;

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2398,10 +2398,9 @@ export class EngramAccessService {
         ? {
             ...extraction,
             lastExtractionAt: null,
-            bufferedSessionCount: 0,
-            pendingTurnCount: 0,
-            oldestBufferedTurnAgeMs: null,
-            degradedReason: extraction.degraded ? "daemon extraction pipeline degraded" : null,
+            degradedReason: extraction.degraded
+              ? `daemon extraction pipeline degraded; ${extraction.bufferedSessionCount} buffered session(s), ${extraction.pendingTurnCount} turn(s) pending extraction`
+              : null,
           }
         : extraction;
     // ONE call: the corpus array and the flag describing it must not come from

--- a/packages/remnic-core/src/extraction-scope-source-agent.test.ts
+++ b/packages/remnic-core/src/extraction-scope-source-agent.test.ts
@@ -311,6 +311,27 @@ test("telemetry prefilter runs on turn content, not the Source agent header", as
   assert.equal(withoutConnector.result.facts.length, 0, "untagged transcript filtered identically");
 });
 
+test("prefilter results identify why provider extraction was skipped", async () => {
+  const workLayerOnly = await extractViaGateway([
+    {
+      role: "assistant",
+      content: "[WORK_LAYER_CONTEXT link_to_memory=false]\ninternal scratch\n[/WORK_LAYER_CONTEXT]",
+      timestamp: TS,
+    },
+  ]);
+  assert.equal(workLayerOnly.result.extractionSkippedReason, "conversation_only_non_memory");
+
+  const mechanicalTurns: BufferTurn[] = [];
+  for (let i = 1; i <= 9; i += 1) {
+    mechanicalTurns.push({ role: "user", content: `[action ${i}]: moved left`, timestamp: TS });
+  }
+  for (let i = 0; i < 11; i += 1) {
+    mechanicalTurns.push({ role: "assistant", content: "ok", timestamp: TS });
+  }
+  const mechanical = await extractViaGateway(mechanicalTurns);
+  assert.equal(mechanical.result.extractionSkippedReason, "mechanical_telemetry");
+});
+
 // FIX 3: connector is validated before interpolation; injection yields no header.
 test("resolveSourceConnector reuses the registry validator (accepts . and _) and blocks injection", () => {
   const t = (connector: string): BufferTurn => ({ role: "user", content: "Use the search tool.", timestamp: TS, sourceConnector: connector });

--- a/packages/remnic-core/src/extraction-timeout.test.ts
+++ b/packages/remnic-core/src/extraction-timeout.test.ts
@@ -205,6 +205,7 @@ test("extraction skips mechanical action telemetry without durable memory cues",
     profileUpdates: [],
     entities: [],
     questions: [],
+    extractionSkippedReason: "mechanical_telemetry",
   });
 });
 

--- a/packages/remnic-core/src/extraction-watermark.test.ts
+++ b/packages/remnic-core/src/extraction-watermark.test.ts
@@ -266,11 +266,11 @@ test("valid ISO timestamp variants remain eligible for aggregate watermark selec
           async () =>
             namespace === "team-a"
               ? "2026-07-20t12:00:00z"
-              : "2026-07-20T08:00:00-05:00",
+              : "2026-07-20T08:00:00-0500",
         ),
     });
 
-    assert.equal(result.lastExtractionAt, "2026-07-20T08:00:00-05:00");
+    assert.equal(result.lastExtractionAt, "2026-07-20T08:00:00-0500");
     assert.equal(result.readFailed, false);
   } finally {
     await rm(fixture.memoryDir, { recursive: true, force: true });

--- a/packages/remnic-core/src/extraction-watermark.test.ts
+++ b/packages/remnic-core/src/extraction-watermark.test.ts
@@ -254,6 +254,64 @@ test("overflowed calendar timestamp in namespace store fails the aggregate read"
   }
 });
 
+test("valid ISO timestamp variants remain eligible for aggregate watermark selection", async () => {
+  const fixture = await namespacedFixture();
+  try {
+    const result = await readAggregateExtractionWatermark({
+      config: fixture.config,
+      rootStorage: storage(fixture.memoryDir, async () => "2026-07-20T12:00:00Z"),
+      storageForNamespace: async (namespace) =>
+        storage(
+          fixture.namespaceDirs[namespace],
+          async () =>
+            namespace === "team-a"
+              ? "2026-07-20T14:00:00+02:00"
+              : "2026-07-20T08:00:00-05:00",
+        ),
+    });
+
+    assert.equal(result.lastExtractionAt, "2026-07-20T08:00:00-05:00");
+    assert.equal(result.readFailed, false);
+  } finally {
+    await rm(fixture.memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("overflowed consolidation timestamp in namespace store fails the aggregate read", async () => {
+  const fixture = await namespacedFixture();
+  try {
+    const result = await readAggregateExtractionWatermark({
+      config: fixture.config,
+      rootStorage: {
+        dir: fixture.memoryDir,
+        loadMeta: async () => ({
+          lastExtractionAt: "2026-07-20T12:00:00.000Z",
+          extractionCount: 2,
+          lastConsolidationAt: "2026-07-20T13:00:00.000Z",
+        }),
+      },
+      storageForNamespace: async (namespace) => ({
+        dir: fixture.namespaceDirs[namespace],
+        loadMeta: async () => ({
+          lastExtractionAt: "2026-07-21T12:00:00.000Z",
+          extractionCount: 3,
+          lastConsolidationAt:
+            namespace === "team-a"
+              ? "2026-02-30T13:00:00.000Z"
+              : "2026-07-21T13:00:00.000Z",
+        }),
+      }),
+    });
+
+    assert.equal(result.lastExtractionAt, null);
+    assert.equal(result.readFailed, true);
+    assert.equal(result.rootStats, undefined);
+    assert.match(result.readError ?? "", /consolidation timestamp invalid/);
+  } finally {
+    await rm(fixture.memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("namespace discovery I/O failure is an explicit incomplete read", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-extraction-watermark-enumeration-"));
   try {

--- a/packages/remnic-core/src/extraction-watermark.test.ts
+++ b/packages/remnic-core/src/extraction-watermark.test.ts
@@ -259,13 +259,13 @@ test("valid ISO timestamp variants remain eligible for aggregate watermark selec
   try {
     const result = await readAggregateExtractionWatermark({
       config: fixture.config,
-      rootStorage: storage(fixture.memoryDir, async () => "2026-07-19T24:00:00Z"),
+      rootStorage: storage(fixture.memoryDir, async () => "2026-07-19t24:00:00z"),
       storageForNamespace: async (namespace) =>
         storage(
           fixture.namespaceDirs[namespace],
           async () =>
             namespace === "team-a"
-              ? "2026-07-20T14:00:00+02:00"
+              ? "2026-07-20t12:00:00z"
               : "2026-07-20T08:00:00-05:00",
         ),
     });

--- a/packages/remnic-core/src/extraction-watermark.test.ts
+++ b/packages/remnic-core/src/extraction-watermark.test.ts
@@ -64,6 +64,49 @@ test("aggregate watermark selects the most recent extraction across distinct nam
   }
 });
 
+test("aggregate stats sum extraction counts and select the newest consolidation", async () => {
+  const fixture = await namespacedFixture();
+  try {
+    const result = await readAggregateExtractionWatermark({
+      config: fixture.config,
+      rootStorage: {
+        dir: fixture.memoryDir,
+        loadMeta: async () => ({
+          lastExtractionAt: "2026-07-20T12:00:00.000Z",
+          extractionCount: 2,
+          lastConsolidationAt: "2026-07-20T13:00:00.000Z",
+        }),
+      },
+      storageForNamespace: async (namespace, rootDir) => ({
+        dir: rootDir,
+        loadMeta: async () => ({
+          lastExtractionAt:
+            namespace === "team-a"
+              ? "2026-07-21T12:00:00.000Z"
+              : "2026-07-22T12:00:00.000Z",
+          extractionCount:
+            namespace === "team-a"
+              ? 3
+              : namespace === fixture.config.sharedNamespace
+                ? 7
+                : 5,
+          lastConsolidationAt:
+            namespace === "team-a"
+              ? "2026-07-23T13:00:00.000Z"
+              : "2026-07-21T13:00:00.000Z",
+        }),
+      }),
+    });
+
+    assert.deepEqual(result.rootStats, {
+      extractionCount: 17,
+      lastConsolidationAt: "2026-07-23T13:00:00.000Z",
+    });
+  } finally {
+    await rm(fixture.memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("a namespace-isolated extraction advances the daemon aggregate watermark", async () => {
   const fixture = await namespacedFixture();
   try {
@@ -89,7 +132,14 @@ test("a partial namespace read returns readFailed instead of a survivor's fresh 
   try {
     const result = await readAggregateExtractionWatermark({
       config: fixture.config,
-      rootStorage: storage(fixture.memoryDir, async () => "2026-07-23T12:00:00.000Z"),
+      rootStorage: {
+        dir: fixture.memoryDir,
+        loadMeta: async () => ({
+          lastExtractionAt: "2026-07-23T12:00:00.000Z",
+          extractionCount: 2,
+          lastConsolidationAt: null,
+        }),
+      },
       storageForNamespace: async (namespace) =>
         storage(fixture.namespaceDirs[namespace], async () => {
           if (namespace === "team-b") throw new Error("meta store unavailable");
@@ -101,6 +151,7 @@ test("a partial namespace read returns readFailed instead of a survivor's fresh 
     assert.equal(result.readFailed, true);
     assert.match(result.readError ?? "", /namespace watermark unreadable/);
     assert.match(result.readError ?? "", /meta store unavailable/);
+    assert.equal(result.rootStats, undefined, "partial aggregate counters must not be reported");
   } finally {
     await rm(fixture.memoryDir, { recursive: true, force: true });
   }
@@ -136,17 +187,27 @@ test("default root capability check uses normalized aliases for migrated storage
       rootStorage: storage(fixture.memoryDir, async () => {
         throw new Error("inactive legacy root is unreadable");
       }),
-      storageForNamespace: async (_namespace, rootDir) =>
-        storage(rootDir, async () =>
-          path.resolve(rootDir) === path.resolve(migratedDefaultDir)
-            ? "2026-07-26T12:00:00.000Z"
-            : "2026-07-24T12:00:00.000Z",
-        ),
+      storageForNamespace: async (_namespace, rootDir) => ({
+        dir: rootDir,
+        loadMeta: async () => ({
+          lastExtractionAt:
+            path.resolve(rootDir) === path.resolve(migratedDefaultDir)
+              ? "2026-07-26T12:00:00.000Z"
+              : "2026-07-24T12:00:00.000Z",
+          extractionCount:
+            path.resolve(rootDir) === path.resolve(migratedDefaultDir) ? 7 : 11,
+          lastConsolidationAt: null,
+        }),
+      }),
       caps: { version: TOKEN_CAPABILITIES_VERSION, namespaces: ["default"] },
     });
 
     assert.equal(result.lastExtractionAt, "2026-07-26T12:00:00.000Z");
     assert.equal(result.readFailed, false);
+    assert.deepEqual(result.rootStats, {
+      extractionCount: 7,
+      lastConsolidationAt: null,
+    });
   } finally {
     await rm(fixture.memoryDir, { recursive: true, force: true });
   }
@@ -159,6 +220,30 @@ test("unparsable non-null timestamp in namespace store fails the aggregate read"
       rootStorage: storage(fixture.memoryDir, async () => "2026-07-20T12:00:00.000Z"),
       storageForNamespace: async (namespace) =>
         storage(fixture.namespaceDirs[namespace], async () => (namespace === "team-a" ? "invalid-date-string" : "2026-07-25T12:00:00.000Z")),
+    });
+
+    assert.equal(result.lastExtractionAt, null);
+    assert.equal(result.readFailed, true);
+    assert.match(result.readError ?? "", /watermark timestamp invalid/);
+  } finally {
+    await rm(fixture.memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("overflowed calendar timestamp in namespace store fails the aggregate read", async () => {
+  const fixture = await namespacedFixture();
+  try {
+    const result = await readAggregateExtractionWatermark({
+      config: fixture.config,
+      rootStorage: storage(fixture.memoryDir, async () => "2026-07-20T12:00:00.000Z"),
+      storageForNamespace: async (namespace) =>
+        storage(
+          fixture.namespaceDirs[namespace],
+          async () =>
+            namespace === "team-a"
+              ? "2026-02-30T12:00:00.000Z"
+              : "2026-07-25T12:00:00.000Z",
+        ),
     });
 
     assert.equal(result.lastExtractionAt, null);

--- a/packages/remnic-core/src/extraction-watermark.test.ts
+++ b/packages/remnic-core/src/extraction-watermark.test.ts
@@ -259,7 +259,7 @@ test("valid ISO timestamp variants remain eligible for aggregate watermark selec
   try {
     const result = await readAggregateExtractionWatermark({
       config: fixture.config,
-      rootStorage: storage(fixture.memoryDir, async () => "2026-07-20T12:00:00Z"),
+      rootStorage: storage(fixture.memoryDir, async () => "2026-07-19T24:00:00Z"),
       storageForNamespace: async (namespace) =>
         storage(
           fixture.namespaceDirs[namespace],

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -1161,7 +1161,13 @@ export class ExtractionEngine {
     };
     if (renderedConversation.trim().length === 0) {
       log.debug("extraction skipped — conversation only contained non-memory work-layer context");
-      return { facts: [], profileUpdates: [], entities: [], questions: [] };
+      return {
+        facts: [],
+        profileUpdates: [],
+        entities: [],
+        questions: [],
+        extractionSkippedReason: "conversation_only_non_memory",
+      };
     }
     if (
       lifecycleCaps.extractionTelemetryPrefilter &&
@@ -1173,6 +1179,7 @@ export class ExtractionEngine {
         profileUpdates: [],
         entities: [],
         questions: [],
+        extractionSkippedReason: "mechanical_telemetry",
       };
     }
 

--- a/packages/remnic-core/src/orchestration/extraction-run-helpers.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run-helpers.ts
@@ -309,11 +309,11 @@ export async function runExtractionPostPersist(
 }
 
 /**
- * Advance the extraction liveness watermark for a successfully parsed empty
- * extraction (#2223) and record its processed fingerprint when applicable.
- * Fingerprinted/import runs treat the metadata save as load-bearing (dedupe
- * state) and propagate failures; normal live runs treat the stamp as
- * diagnostic liveness and fail open. Deadline errors always propagate.
+ * Record a processed fingerprint when applicable and advance the extraction
+ * liveness watermark only for a provider-backed empty success. Fingerprinted
+ * imports treat the metadata save as load-bearing dedupe state; normal live
+ * runs treat the stamp as diagnostic and fail open. Deadline errors always
+ * propagate.
  */
 export async function commitEmptySuccessExtraction(args: {
   storage: StorageManager;
@@ -321,6 +321,7 @@ export async function commitEmptySuccessExtraction(args: {
   extractionFingerprint: string | null;
   shouldPersistProcessedFingerprint: boolean;
   hasExtractionFailure: boolean;
+  extractionSkippedReason: ExtractionResult["extractionSkippedReason"];
   recordProcessedExtractionFingerprint: (storage: StorageManager, fingerprint: string, meta: MetaState) => Promise<unknown>;
   runDeadlineAware: <T>(operation: () => Promise<T>, phase: string, clearTimerOnError?: boolean) => Promise<T>;
   isDeadlineError: (error: unknown) => boolean;
@@ -331,26 +332,43 @@ export async function commitEmptySuccessExtraction(args: {
     extractionFingerprint,
     shouldPersistProcessedFingerprint,
     hasExtractionFailure,
+    extractionSkippedReason,
     recordProcessedExtractionFingerprint,
     runDeadlineAware,
     isDeadlineError,
   } = args;
-  let meta = existingMeta;
-  if (extractionFingerprint && shouldPersistProcessedFingerprint && !hasExtractionFailure) {
-    meta ??= await storage.loadMeta();
-    await recordProcessedExtractionFingerprint(storage, extractionFingerprint, meta);
-  }
-  if (!hasExtractionFailure) {
-    const livenessStampFatal = shouldPersistProcessedFingerprint;
-    try {
-      meta ??= await runDeadlineAware(() => storage.loadMeta(), "during_empty_success_liveness_load", false);
+  const shouldRecordFingerprint =
+    extractionFingerprint !== null &&
+    shouldPersistProcessedFingerprint &&
+    !hasExtractionFailure;
+  const shouldStampLiveness =
+    !hasExtractionFailure && extractionSkippedReason === undefined;
+  if (!shouldRecordFingerprint && !shouldStampLiveness) return;
+
+  const metadataFailureIsFatal = shouldRecordFingerprint;
+  try {
+    const meta =
+      existingMeta ??
+      await runDeadlineAware(
+        () => storage.loadMeta(),
+        "during_empty_success_liveness_load",
+        false,
+      );
+    if (shouldRecordFingerprint) {
+      await recordProcessedExtractionFingerprint(storage, extractionFingerprint, meta);
+    }
+    if (shouldStampLiveness) {
       meta.extractionCount += 1;
       meta.lastExtractionAt = new Date().toISOString();
-      await runDeadlineAware(() => storage.saveMeta(meta!), "during_empty_success_liveness_save", false);
-    } catch (err) {
-      if (isDeadlineError(err)) throw err;
-      if (livenessStampFatal) throw err;
-      log.warn("runExtraction: failed to stamp empty-success liveness watermark (non-fatal)", err);
     }
+    await runDeadlineAware(
+      () => storage.saveMeta(meta),
+      "during_empty_success_liveness_save",
+      false,
+    );
+  } catch (err) {
+    if (isDeadlineError(err)) throw err;
+    if (metadataFailureIsFatal) throw err;
+    log.warn("runExtraction: failed to stamp empty-success liveness watermark (non-fatal)", err);
   }
 }

--- a/packages/remnic-core/src/orchestration/extraction-run.test.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.test.ts
@@ -701,6 +701,32 @@ test("circuit breaker: a forced flush still calls extract() while the breaker is
   }
 });
 
+test("circuit breaker: a forced local prefilter skip does not heal an open breaker", async () => {
+  const h = await makeHarness({
+    extractionRetryScheduleMs: [3_600_000],
+    extractionBreakerFailureThreshold: 1,
+    extractionBreakerCooldownMs: 3_600_000,
+  });
+  try {
+    const coord = h.newCoordinator();
+    h.setRespond(() => failureResult("provider_retryable"));
+    await h.run(coord, "fp-1");
+    assert.equal(coord.getExtractionResilienceStatus().breaker.state, "open");
+
+    h.setRespond(() => ({
+      ...emptySuccessResult(),
+      extractionSkippedReason: "mechanical_telemetry",
+    }));
+    const result = await h.run(coord, "fp-2", { force: true });
+
+    assert.equal(result.reason, "empty_extraction_result");
+    assert.equal(coord.getExtractionResilienceStatus().breaker.state, "open");
+    assert.equal(coord.getExtractionResilienceStatus().breaker.consecutiveFailures, 1);
+  } finally {
+    await h.cleanup();
+  }
+});
+
 test("circuit breaker: auth_config failure opens the breaker immediately (no hot loop)", async () => {
   const h = await makeHarness({
     extractionRetryScheduleMs: [3_600_000],

--- a/packages/remnic-core/src/orchestration/extraction-run.test.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.test.ts
@@ -93,7 +93,11 @@ interface Harness {
   setRespond: (fn: (turns: BufferTurn[]) => ExtractionResult | Promise<ExtractionResult>) => void;
   setPassiveCapture: (fn: () => void | Promise<void>) => void;
   setMemoryBox: (fn: () => void | Promise<void>) => void;
+  setBufferClear: (fn: () => void | Promise<void>) => void;
   setPersist: (fn: () => void | Promise<void>) => void;
+  setFingerprintRecorder: (
+    fn: ExtractionRunCoordinatorDeps["recordProcessedExtractionFingerprint"],
+  ) => void;
   recordedProcessedCount: () => number;
   run: (
     coord: ExtractionRunCoordinator,
@@ -140,6 +144,9 @@ async function makeHarness(overrides: Record<string, unknown> = {}): Promise<Har
   let persistHandler: () => void | Promise<void> = async () => {};
   let memoryBoxHandler: () => void | Promise<void> = async () => {};
   let recordedProcessedCount = 0;
+  let fingerprintRecorder:
+    ExtractionRunCoordinatorDeps["recordProcessedExtractionFingerprint"] =
+      async () => {};
 
   let threadingBlocked = false;
   let persistCalls = 0;
@@ -184,8 +191,9 @@ async function makeHarness(overrides: Record<string, unknown> = {}): Promise<Har
     requestQmdMaintenance: () => {},
     runTierMigrationCycle: async () => migrationSummary,
     getLastPersistExtractionDeferredCount: () => 0,
-    recordProcessedExtractionFingerprint: async () => {
+    recordProcessedExtractionFingerprint: async (storage, fingerprint, meta) => {
       recordedProcessedCount += 1;
+      await fingerprintRecorder(storage, fingerprint, meta);
     },
   });
 
@@ -209,6 +217,14 @@ async function makeHarness(overrides: Record<string, unknown> = {}): Promise<Har
     },
     setMemoryBox: (fn) => {
       memoryBoxHandler = fn;
+    },
+    setBufferClear: (fn) => {
+      buffer.clearAfterExtraction = async () => {
+        await fn();
+      };
+    },
+    setFingerprintRecorder: (fn) => {
+      fingerprintRecorder = fn;
     },
     setPersist: (fn) => {
       persistHandler = fn;
@@ -1013,7 +1029,7 @@ test("extraction liveness (#2223): a normal live empty success advances lastExtr
     const result = await coord.runExtraction(liveTurns("nothing-durable-here"), {
       skipCharThreshold: true,
       skipUserTurnThreshold: true,
-      clearBufferAfterExtraction: false,
+      clearBufferAfterExtraction: true,
       bufferKey: "nothing-durable-here",
     });
 
@@ -1025,6 +1041,133 @@ test("extraction liveness (#2223): a normal live empty success advances lastExtr
     assert.equal(after.extractionCount, baselineCount + 1, "empty success increments extractionCount");
     assert.ok(after.lastExtractionAt, "empty success stamps lastExtractionAt");
     assert.equal(h.recordedProcessedCount(), 0, "normal live turns never record a processed fingerprint");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("extraction liveness (#2227): prefilter skips do not advance the watermark", async () => {
+  for (const extractionSkippedReason of [
+    "conversation_only_non_memory",
+    "mechanical_telemetry",
+  ] as const) {
+    const h = await makeHarness();
+    try {
+      h.setRespond(() => ({ ...emptySuccessResult(), extractionSkippedReason }));
+      const storage = await h.storageForNs("default");
+      const before = await storage.loadMeta();
+
+      const result = await h.newCoordinator().runExtraction(liveTurns(extractionSkippedReason), {
+        skipCharThreshold: true,
+        skipUserTurnThreshold: true,
+        clearBufferAfterExtraction: true,
+        bufferKey: extractionSkippedReason,
+      });
+
+      assert.equal(result.reason, "empty_extraction_result");
+      const after = await storage.loadMeta();
+      assert.equal(after.extractionCount, before.extractionCount);
+      assert.equal(after.lastExtractionAt, before.lastExtractionAt);
+    } finally {
+      await h.cleanup();
+    }
+  }
+});
+
+test("extraction liveness (#2227): passive-correction failure prevents a live empty-success stamp", async () => {
+  const h = await makeHarness();
+  try {
+    h.setRespond(() => emptySuccessResult());
+    h.setPassiveCapture(() => {
+      throw new Error("passive capture failed");
+    });
+    const storage = await h.storageForNs("default");
+    const before = await storage.loadMeta();
+
+    await assert.rejects(
+      h.newCoordinator().runExtraction(liveTurns("passive-capture-failure"), {
+        skipCharThreshold: true,
+        skipUserTurnThreshold: true,
+        clearBufferAfterExtraction: true,
+        bufferKey: "passive-capture-failure",
+      }),
+      /passive capture failed/,
+    );
+
+    const after = await storage.loadMeta();
+    assert.equal(after.extractionCount, before.extractionCount);
+    assert.equal(after.lastExtractionAt, before.lastExtractionAt);
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("extraction liveness (#2227): buffer-clear failure prevents a live empty-success stamp", async () => {
+  const h = await makeHarness();
+  try {
+    h.setRespond(() => emptySuccessResult());
+    h.setBufferClear(() => {
+      throw new Error("buffer clear failed");
+    });
+    const storage = await h.storageForNs("default");
+    const before = await storage.loadMeta();
+
+    await assert.rejects(
+      h.newCoordinator().runExtraction(liveTurns("buffer-clear-failure"), {
+        skipCharThreshold: true,
+        skipUserTurnThreshold: true,
+        clearBufferAfterExtraction: true,
+        bufferKey: "buffer-clear-failure",
+      }),
+      /buffer clear failed/,
+    );
+
+    const after = await storage.loadMeta();
+    assert.equal(after.extractionCount, before.extractionCount);
+    assert.equal(after.lastExtractionAt, before.lastExtractionAt);
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("extraction liveness (#2227): a fingerprinted prefilter skip persists dedupe state without stamping liveness", async () => {
+  const h = await makeHarness();
+  try {
+    h.setRespond(() => ({
+      ...emptySuccessResult(),
+      extractionSkippedReason: "mechanical_telemetry",
+    }));
+    h.setFingerprintRecorder(async (_storage, fingerprint, meta) => {
+      assert.ok(meta, "empty-success commit supplies preloaded metadata");
+      meta.processedExtractionFingerprints = [
+        ...(meta.processedExtractionFingerprints ?? []),
+        { fingerprint, observedAt: new Date().toISOString() },
+      ];
+    });
+    const storage = await h.storageForNs("default");
+    const before = await storage.loadMeta();
+    const baselineFingerprintCount =
+      before.processedExtractionFingerprints?.length ?? 0;
+
+    const result = await h.newCoordinator().runExtraction(
+      makeTurns("fingerprinted-prefilter"),
+      {
+        skipCharThreshold: true,
+        skipUserTurnThreshold: true,
+        clearBufferAfterExtraction: true,
+        bufferKey: "fingerprinted-prefilter",
+      },
+    );
+
+    assert.equal(result.reason, "empty_extraction_result");
+    const after = await storage.loadMeta();
+    assert.equal(after.extractionCount, before.extractionCount);
+    assert.equal(after.lastExtractionAt, before.lastExtractionAt);
+    assert.equal(
+      after.processedExtractionFingerprints?.length,
+      baselineFingerprintCount + 1,
+    );
+    assert.equal(h.recordedProcessedCount(), 1);
   } finally {
     await h.cleanup();
   }

--- a/packages/remnic-core/src/orchestration/extraction-run.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.ts
@@ -979,7 +979,7 @@ export class ExtractionRunCoordinator {
           // pre-#1908 clear-buffer behavior applies below.
           log.warn("runExtraction: failed to load meta for retry bookkeeping (non-fatal)", err);
         }
-      } else {
+      } else if (result.extractionSkippedReason === undefined) {
         // Provider responded without failure → breaker heals; clear any
         // parked backoff for this fingerprint so it proceeds normally.
         this.resetProviderBreakerOnSuccess();

--- a/packages/remnic-core/src/orchestration/extraction-run.ts
+++ b/packages/remnic-core/src/orchestration/extraction-run.ts
@@ -1016,19 +1016,20 @@ export class ExtractionRunCoordinator {
           { extractionFailure }
         );
       }
-      await commitEmptySuccessExtraction({
+      const emptySuccessCommit = {
         storage,
         meta,
         extractionFingerprint,
         shouldPersistProcessedFingerprint,
         hasExtractionFailure: Boolean(extractionFailure),
+        extractionSkippedReason: result.extractionSkippedReason,
         recordProcessedExtractionFingerprint: this.deps.recordProcessedExtractionFingerprint,
         runDeadlineAware,
-        isDeadlineError: (error) => error instanceof ExtractionDeadlineError,
-      });
-      // Correction-only turns that meet char/user-turn thresholds but yield
-      // zero facts still need passive capture (review: "empty extraction skips
-      // capture"). selfNamespace/principal already resolved above.
+        isDeadlineError: (error: unknown) => error instanceof ExtractionDeadlineError,
+      };
+      if (shouldPersistProcessedFingerprint) {
+        await commitEmptySuccessExtraction(emptySuccessCommit);
+      }
       await runPassiveCapture(normalizedTurns as BufferTurn[], {
         sessionKey,
         principal,
@@ -1037,15 +1038,12 @@ export class ExtractionRunCoordinator {
         isLiveSession: clearBufferAfterExtraction,
       });
       if (recordedRetryFailure) {
-        // Retain the failed turns so the backoff gate can re-attempt them after
-        // nextEligibleAt. Clearing here would lose the data the retry state
-        // points at (cursor high + codex P1). Trigger/forced paths already
-        // retain via clearBufferAfterExtraction=false; this covers the normal
-        // live-session path. Overflow is bounded by MAX_BUFFER_ENTRY_COUNT
-        // with a loud eviction log.
         log.debug("runExtraction: retaining buffer for backoff retry after failure");
       } else {
         await clearBuffer();
+      }
+      if (!shouldPersistProcessedFingerprint) {
+        await commitEmptySuccessExtraction(emptySuccessCommit);
       }
       return { status: "skipped", reason: "empty_extraction_result", persistedCount: 0, durableOutputCount: 0 };
     }

--- a/packages/remnic-core/src/orchestration/extraction-watermark.ts
+++ b/packages/remnic-core/src/orchestration/extraction-watermark.ts
@@ -48,10 +48,38 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function canonicalTimestampMs(value: string): number | null {
+const ISO_TIMESTAMP_PATTERN =
+  /^([+-]?\d{4,6})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/;
+
+function validatedTimestampMs(value: string): number | null {
+  const match = ISO_TIMESTAMP_PATTERN.exec(value);
   const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed)) return null;
-  return new Date(parsed).toISOString() === value ? parsed : null;
+  if (!match || !Number.isFinite(parsed)) return null;
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, fraction, zone] = match;
+  const zoneSign = zone === "Z" || zone[0] === "+" ? 1 : -1;
+  const offsetMinutes =
+    zone === "Z" ? 0 : zoneSign * (Number(zone.slice(1, 3)) * 60 + Number(zone.slice(4, 6)));
+  const representedCalendar = new Date(parsed + offsetMinutes * 60_000);
+  const millisecond = Number((fraction ?? "").padEnd(3, "0").slice(0, 3));
+  const expected = [
+    Number(yearText),
+    Number(monthText),
+    Number(dayText),
+    Number(hourText),
+    Number(minuteText),
+    Number(secondText),
+    millisecond,
+  ];
+  const actual = [
+    representedCalendar.getUTCFullYear(),
+    representedCalendar.getUTCMonth() + 1,
+    representedCalendar.getUTCDate(),
+    representedCalendar.getUTCHours(),
+    representedCalendar.getUTCMinutes(),
+    representedCalendar.getUTCSeconds(),
+    representedCalendar.getUTCMilliseconds(),
+  ];
+  return actual.every((part, index) => part === expected[index]) ? parsed : null;
 }
 
 function mergeRootStats(
@@ -83,10 +111,19 @@ function mergeRootStats(
 }
 
 function watermarkFromMeta(meta: ExtractionWatermarkMeta, name: string): ExtractionWatermarkRead {
-  if (meta.lastExtractionAt !== null && meta.lastExtractionAt !== undefined) {
-    if (canonicalTimestampMs(meta.lastExtractionAt) === null) {
-      return readFailure(`${name} watermark timestamp invalid`);
-    }
+  if (
+    meta.lastExtractionAt !== null &&
+    meta.lastExtractionAt !== undefined &&
+    validatedTimestampMs(meta.lastExtractionAt) === null
+  ) {
+    return readFailure(`${name} watermark timestamp invalid`);
+  }
+  if (
+    meta.lastConsolidationAt !== null &&
+    meta.lastConsolidationAt !== undefined &&
+    validatedTimestampMs(meta.lastConsolidationAt) === null
+  ) {
+    return readFailure(`${name} consolidation timestamp invalid`);
   }
   const hasRootStats = meta.extractionCount !== undefined || meta.lastConsolidationAt !== undefined;
   return {
@@ -139,10 +176,10 @@ function isReadFailure(value: CorpusNamespaceRoot[] | ExtractionWatermarkRead): 
 
 function newerWatermark(current: string | null, candidate: string | null): string | null {
   if (candidate === null) return current;
-  const candidateMs = canonicalTimestampMs(candidate);
+  const candidateMs = validatedTimestampMs(candidate);
   if (candidateMs === null) return current;
   if (current === null) return candidate;
-  const currentMs = canonicalTimestampMs(current);
+  const currentMs = validatedTimestampMs(current);
   return currentMs === null || candidateMs > currentMs ? candidate : current;
 }
 

--- a/packages/remnic-core/src/orchestration/extraction-watermark.ts
+++ b/packages/remnic-core/src/orchestration/extraction-watermark.ts
@@ -49,13 +49,14 @@ function errorMessage(error: unknown): string {
 }
 
 const ISO_TIMESTAMP_PATTERN =
-  /^([+-]?\d{4,6})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/;
+  /^([+-]?\d{4,6})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/i;
 
 function validatedTimestampMs(value: string): number | null {
   const match = ISO_TIMESTAMP_PATTERN.exec(value);
   const parsed = Date.parse(value);
   if (!match || !Number.isFinite(parsed)) return null;
   const [, yearText, monthText, dayText, hourText, minuteText, secondText, fraction, zone] = match;
+  const normalizedZone = zone.toUpperCase();
   const year = Number(yearText);
   const month = Number(monthText);
   const day = Number(dayText);
@@ -69,9 +70,11 @@ function validatedTimestampMs(value: string): number | null {
     const isEndOfDay = minute === 0 && second === 0 && /^0*$/.test(fraction ?? "");
     return isEndOfDay ? parsed : null;
   }
-  const zoneSign = zone === "Z" || zone[0] === "+" ? 1 : -1;
+  const zoneSign = normalizedZone === "Z" || normalizedZone[0] === "+" ? 1 : -1;
   const offsetMinutes =
-    zone === "Z" ? 0 : zoneSign * (Number(zone.slice(1, 3)) * 60 + Number(zone.slice(4, 6)));
+    normalizedZone === "Z"
+      ? 0
+      : zoneSign * (Number(normalizedZone.slice(1, 3)) * 60 + Number(normalizedZone.slice(4, 6)));
   const representedCalendar = new Date(parsed + offsetMinutes * 60_000);
   const millisecond = Number((fraction ?? "").padEnd(3, "0").slice(0, 3));
   const expected = [

--- a/packages/remnic-core/src/orchestration/extraction-watermark.ts
+++ b/packages/remnic-core/src/orchestration/extraction-watermark.ts
@@ -49,7 +49,7 @@ function errorMessage(error: unknown): string {
 }
 
 const ISO_TIMESTAMP_PATTERN =
-  /^([+-]?\d{4,6})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/i;
+  /^([+-]?\d{4,6})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:?\d{2})$/i;
 
 function validatedTimestampMs(value: string): number | null {
   const match = ISO_TIMESTAMP_PATTERN.exec(value);
@@ -57,6 +57,9 @@ function validatedTimestampMs(value: string): number | null {
   if (!match || !Number.isFinite(parsed)) return null;
   const [, yearText, monthText, dayText, hourText, minuteText, secondText, fraction, zone] = match;
   const normalizedZone = zone.toUpperCase();
+  const offsetMinuteText = normalizedZone.includes(":")
+    ? normalizedZone.slice(4, 6)
+    : normalizedZone.slice(3, 5);
   const year = Number(yearText);
   const month = Number(monthText);
   const day = Number(dayText);
@@ -74,7 +77,7 @@ function validatedTimestampMs(value: string): number | null {
   const offsetMinutes =
     normalizedZone === "Z"
       ? 0
-      : zoneSign * (Number(normalizedZone.slice(1, 3)) * 60 + Number(normalizedZone.slice(4, 6)));
+      : zoneSign * (Number(normalizedZone.slice(1, 3)) * 60 + Number(offsetMinuteText));
   const representedCalendar = new Date(parsed + offsetMinutes * 60_000);
   const millisecond = Number((fraction ?? "").padEnd(3, "0").slice(0, 3));
   const expected = [

--- a/packages/remnic-core/src/orchestration/extraction-watermark.ts
+++ b/packages/remnic-core/src/orchestration/extraction-watermark.ts
@@ -56,18 +56,31 @@ function validatedTimestampMs(value: string): number | null {
   const parsed = Date.parse(value);
   if (!match || !Number.isFinite(parsed)) return null;
   const [, yearText, monthText, dayText, hourText, minuteText, secondText, fraction, zone] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (month < 1 || month > 12 || day < 1 || day > daysInMonth[month - 1]!) return null;
+  if (hour === 24) {
+    const isEndOfDay = minute === 0 && second === 0 && /^0*$/.test(fraction ?? "");
+    return isEndOfDay ? parsed : null;
+  }
   const zoneSign = zone === "Z" || zone[0] === "+" ? 1 : -1;
   const offsetMinutes =
     zone === "Z" ? 0 : zoneSign * (Number(zone.slice(1, 3)) * 60 + Number(zone.slice(4, 6)));
   const representedCalendar = new Date(parsed + offsetMinutes * 60_000);
   const millisecond = Number((fraction ?? "").padEnd(3, "0").slice(0, 3));
   const expected = [
-    Number(yearText),
-    Number(monthText),
-    Number(dayText),
-    Number(hourText),
-    Number(minuteText),
-    Number(secondText),
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
     millisecond,
   ];
   const actual = [

--- a/packages/remnic-core/src/orchestration/extraction-watermark.ts
+++ b/packages/remnic-core/src/orchestration/extraction-watermark.ts
@@ -36,12 +36,11 @@ export interface AggregateExtractionWatermarkOptions {
   caps?: TokenCapabilities;
 }
 
-function readFailure(reason: string, rootStats?: ExtractionRootStats): ExtractionWatermarkRead {
+function readFailure(reason: string): ExtractionWatermarkRead {
   return {
     lastExtractionAt: null,
     readFailed: true,
     readError: reason,
-    ...(rootStats ? { rootStats } : {}),
   };
 }
 
@@ -49,10 +48,43 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function canonicalTimestampMs(value: string): number | null {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString() === value ? parsed : null;
+}
+
+function mergeRootStats(
+  current: ExtractionRootStats | undefined,
+  candidate: ExtractionRootStats | undefined,
+): ExtractionRootStats | undefined {
+  if (!current && !candidate) return undefined;
+  const currentCount = current?.extractionCount;
+  const candidateCount = candidate?.extractionCount;
+  const extractionCount =
+    currentCount === undefined && candidateCount === undefined
+      ? undefined
+      : (currentCount ?? 0) + (candidateCount ?? 0);
+  const currentConsolidation = current?.lastConsolidationAt;
+  const candidateConsolidation = candidate?.lastConsolidationAt;
+  const hasConsolidation =
+    currentConsolidation !== undefined || candidateConsolidation !== undefined;
+  return {
+    ...(extractionCount === undefined ? {} : { extractionCount }),
+    ...(hasConsolidation
+      ? {
+          lastConsolidationAt: newerWatermark(
+            currentConsolidation ?? null,
+            candidateConsolidation ?? null,
+          ),
+        }
+      : {}),
+  };
+}
+
 function watermarkFromMeta(meta: ExtractionWatermarkMeta, name: string): ExtractionWatermarkRead {
   if (meta.lastExtractionAt !== null && meta.lastExtractionAt !== undefined) {
-    const parsed = Date.parse(meta.lastExtractionAt);
-    if (!Number.isFinite(parsed)) {
+    if (canonicalTimestampMs(meta.lastExtractionAt) === null) {
       return readFailure(`${name} watermark timestamp invalid`);
     }
   }
@@ -107,11 +139,11 @@ function isReadFailure(value: CorpusNamespaceRoot[] | ExtractionWatermarkRead): 
 
 function newerWatermark(current: string | null, candidate: string | null): string | null {
   if (candidate === null) return current;
-  const candidateMs = Date.parse(candidate);
-  if (!Number.isFinite(candidateMs)) return current;
+  const candidateMs = canonicalTimestampMs(candidate);
+  if (candidateMs === null) return current;
   if (current === null) return candidate;
-  const currentMs = Date.parse(current);
-  return !Number.isFinite(currentMs) || candidateMs > currentMs ? candidate : current;
+  const currentMs = canonicalTimestampMs(current);
+  return currentMs === null || candidateMs > currentMs ? candidate : current;
 }
 
 export async function readAggregateExtractionWatermark(
@@ -155,10 +187,13 @@ export async function readAggregateExtractionWatermark(
     (!options.caps || capabilityAllowsNamespace(options.caps, defaultNamespace));
   let rootRead: ExtractionWatermarkRead = { lastExtractionAt: null, readFailed: false };
   if (canAccessRoot) {
-    rootRead = await readWatermark(options.rootStorage, "root store");
+    rootRead = options.rootMeta
+      ? watermarkFromMeta(options.rootMeta, "root store")
+      : await readWatermark(options.rootStorage, "root store");
     if (rootRead.readFailed) return rootRead;
   }
   let lastExtractionAt = rootRead.lastExtractionAt;
+  let rootStats = rootRead.rootStats;
 
   const reads = await Promise.all(
     targets.map(async (target) => {
@@ -173,16 +208,14 @@ export async function readAggregateExtractionWatermark(
 
   for (const read of reads) {
     if (read.readFailed) {
-      return readFailure(
-        read.readError ?? "namespace watermark unreadable",
-        rootRead.rootStats
-      );
+      return readFailure(read.readError ?? "namespace watermark unreadable");
     }
     lastExtractionAt = newerWatermark(lastExtractionAt, read.lastExtractionAt);
+    rootStats = mergeRootStats(rootStats, read.rootStats);
   }
   return {
     lastExtractionAt,
     readFailed: false,
-    ...(rootRead.rootStats ? { rootStats: rootRead.rootStats } : {}),
+    ...(rootStats ? { rootStats } : {}),
   };
 }

--- a/packages/remnic-core/src/orchestration/extraction-watermark.ts
+++ b/packages/remnic-core/src/orchestration/extraction-watermark.ts
@@ -49,7 +49,7 @@ function errorMessage(error: unknown): string {
 }
 
 const ISO_TIMESTAMP_PATTERN =
-  /^([+-]?\d{4,6})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:?\d{2})$/i;
+  /^([+-]?\d{4,6})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?(?:\.(\d+))?(Z|[+-]\d{2}:?\d{2})$/i;
 
 function validatedTimestampMs(value: string): number | null {
   const match = ISO_TIMESTAMP_PATTERN.exec(value);
@@ -65,7 +65,7 @@ function validatedTimestampMs(value: string): number | null {
   const day = Number(dayText);
   const hour = Number(hourText);
   const minute = Number(minuteText);
-  const second = Number(secondText);
+  const second = secondText !== undefined ? Number(secondText) : 0;
   const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
   const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
   if (month < 1 || month > 12 || day < 1 || day > daysInMonth[month - 1]!) return null;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -3329,6 +3329,8 @@ export interface ExtractionResult {
   extractionFailure?: string;
   /** Coarse class used by the retry/backoff + circuit-breaker layer (extraction hot loop). */
   extractionFailureClass?: ExtractionFailureClass;
+  /** Local prefilter reason; no provider extraction was attempted. */
+  extractionSkippedReason?: "conversation_only_non_memory" | "mechanical_telemetry";
   /** Trusted source connector resolved over boundedTurns; persisted verbatim by the orchestrator so it is not recomputed (#2183). */
   sourceConnector?: string;
 }

--- a/tests/work-extraction-boundary.test.ts
+++ b/tests/work-extraction-boundary.test.ts
@@ -149,7 +149,13 @@ test("extraction skips work-only conversation before calling fallback parser", a
     },
   ]);
 
-  assert.deepEqual(result, { facts: [], profileUpdates: [], entities: [], questions: [] });
+  assert.deepEqual(result, {
+    facts: [],
+    profileUpdates: [],
+    entities: [],
+    questions: [],
+    extractionSkippedReason: "conversation_only_non_memory",
+  });
   assert.equal(tracker.called, false);
 });
 


### PR DESCRIPTION
## What changed

Local filter skips no longer count as provider runs.
Live health updates only after later work succeeds.
Stats now include every active namespace.
Scoped health keeps its backlog counts while hiding the exact run time.
Bad calendar dates now fail metadata checks.

## Checks

- `pnpm run check-types`
- `pnpm --filter @remnic/core test`
- `pnpm run build`
- `bash scripts/check-review-patterns.sh`
- `node scripts/check-ratchets.mjs`

Closes #2227
Closes #2230

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches extraction orchestration, circuit-breaker healing, and health/watermark aggregation used for ops alerts; behavior changes could affect degradation signals and retry semantics, but changes are well covered by new tests.
> 
> **Overview**
> Makes **extraction health and stats** reflect what actually ran, not local prefilter skips or incomplete pipeline steps.
> 
> **Liveness and resilience:** Empty extractions now carry `extractionSkippedReason` (`conversation_only_non_memory`, `mechanical_telemetry`) when the provider is never called. `commitEmptySuccessExtraction` only bumps `extractionCount` / `lastExtractionAt` when there is no skip reason, and for live runs that stamp runs **after** passive capture and buffer clear so failures there do not look like success. Prefilter skips no longer reset the provider circuit breaker.
> 
> **Aggregate watermark / stats:** `readAggregateExtractionWatermark` merges `extractionCount` and newest `lastConsolidationAt` across root and namespace meta, drops partial-read survivor stats, and rejects invalid calendar ISO timestamps (including consolidation fields).
> 
> **Scoped `/health`:** Token-scoped callers still hide daemon `lastExtractionAt` but get clearer `degradedReason` text (watermark vs buffer vs backlog) instead of a generic pipeline message; tests also expect backlog session/turn metrics to remain visible for scoped health.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db155121f0e5fccc9d7fdd241aa773d22e95c316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Extraction results that are intentionally skipped now include `extractionSkippedReason` (`conversation_only_non_memory` or `mechanical_telemetry`) for clearer diagnostics.

- **Bug Fixes**
  - Improved extraction health reporting with more specific scoped degradation reasons and corrected buffered/pending metrics.
  - Prevented liveness/watermark advancement for local skip and incomplete outcomes; refined timestamp validation and aggregate `rootStats` merging.

- **Tests**
  - Added/expanded deterministic timing, scoped health assertions, skipped-reason checks, stricter watermark/aggregation validation (including `rootStats`), and regression coverage for circuit-breaker behavior not being healed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->