### PR TITLE
fix: preserve reconciliation cursor identity

### DIFF
--- a/.changeset/converge-semantic-followups.md
+++ b/.changeset/converge-semantic-followups.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+"@remnic/cli": patch
+---
+
+Keep shared-path changes when semantic duplicates collapse. Store each side's real path and digest in the cursor. Save the digest chosen by the action that ran.

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -645,8 +645,48 @@ test("remnic converge apply: peer-wins guards against the planned local revision
     assert.equal(result.transfers.conflictsResolved, 1);
     assert.equal(result.transfers.failed, 0);
     assert.equal(await fs.readFile(path.join(rootDir, "facts/shared.md"), "utf8"), "peer content");
+    const cursor = await readConvergeCursor(defaultConvergeCursorPath(
+      rootDir,
+      "https://peer.example.test",
+      "default"
+    ));
+    assert.equal(cursor?.baseFiles[0]?.sha256, peerSha256);
   } finally {
     await fs.rm(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("remnic converge apply: pull advances the cursor to the peer digest", async () => {
+  const cursorDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-pull-cursor-test-"));
+  try {
+    const filePath = "facts/shared.md";
+    const localContent = Buffer.from("local content");
+    const peerContent = Buffer.from("peer content");
+    const localSha256 = createHash("sha256").update(localContent).digest("hex");
+    const peerSha256 = createHash("sha256").update(peerContent).digest("hex");
+    const peerUrl = "https://peer.example.test";
+
+    const result = await executeConvergeApply({
+      cursorDir,
+      peerUrl,
+      baseFilesByNamespace: new Map([
+        ["default", [{ path: filePath, sha256: localSha256 }]],
+      ]),
+      localFilesByNamespace: new Map([
+        ["default", [{ path: filePath, sha256: localSha256 }]],
+      ]),
+      peerFilesByNamespace: new Map([
+        ["default", [{ path: filePath, sha256: peerSha256 }]],
+      ]),
+      localFileBuffers: new Map([["default", new Map([[filePath, localContent]])]]),
+      peerFileBuffers: new Map([["default", new Map([[filePath, peerContent]])]]),
+    });
+
+    assert.equal(result.transfers.pulled, 1);
+    const cursor = await readConvergeCursor(defaultConvergeCursorPath(cursorDir, peerUrl, "default"));
+    assert.equal(cursor?.baseFiles[0]?.sha256, peerSha256);
+  } finally {
+    await fs.rm(cursorDir, { recursive: true, force: true });
   }
 });
 
@@ -726,24 +766,25 @@ test("remnic converge CLI rejects removed and unknown conflict-policy overrides"
   }
 });
 
-test("remnic converge plan builds semantic manifests from local and peer memory bytes", async () => {
+test("remnic converge retains per-side semantic state across a later metadata edit", async () => {
   const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-manifest-"));
   const cursorDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-cursor-"));
   try {
     const body = "same active fact";
     const semanticHash = ContentHashIndex.computeHash(body);
-    const localContent = [
+    const memory = (id: string, updated: string): string => [
       "---",
-      "id: local-id",
+      `id: ${id}`,
       "category: fact",
       "created: 2026-01-01T00:00:00.000Z",
-      "updated: 2026-01-01T00:00:00.000Z",
+      `updated: ${updated}`,
       `contentHash: ${semanticHash}`,
       "status: active",
       "---",
       body,
     ].join("\n");
-    const peerContent = localContent;
+    let localContent = memory("local-id", "2026-01-01T00:00:00.000Z");
+    const peerContent = memory("peer-id", "2026-01-02T00:00:00.000Z");
     const localSha = createHash("sha256").update(localContent).digest("hex");
     const peerSha = createHash("sha256").update(peerContent).digest("hex");
     await fs.mkdir(path.join(rootDir, "facts"), { recursive: true });
@@ -784,19 +825,63 @@ test("remnic converge plan builds semantic manifests from local and peer memory 
     };
     const plan = await computeConvergePlan(options);
 
-    assert.equal(localSha, peerSha);
+    assert.notEqual(localSha, peerSha);
     assert.equal(plan.converged, true, JSON.stringify(plan));
-    assert.equal(plan.entries.length, 1);
-    assert.equal(plan.entries[0]?.action, "identical");
-    assert.equal(plan.entries[0]?.reason, "semantic_duplicate");
-    assert.equal(plan.entries[0]?.path, "facts/local-id.md");
+    assert.deepEqual(plan.entries[0]?.semanticAgreement, {
+      local: { path: "facts/local-id.md", sha256: localSha },
+      peer: { path: "facts/peer-id.md", sha256: peerSha },
+    });
+    assert.equal(plan.entries[0]?.semanticChange, "unchanged");
 
     const result = await executeConvergeApply(options);
     assert.equal(result.converged, true);
-    const cursor = await readConvergeCursor(defaultConvergeCursorPath(cursorDir, peerUrl, "default"));
+    const cursorPath = defaultConvergeCursorPath(cursorDir, peerUrl, "default");
+    const cursor = await readConvergeCursor(cursorPath);
     assert.deepEqual(cursor?.baseFiles, []);
-    const rerun = await computeConvergePlan(options);
-    assert.equal(rerun.converged, true, JSON.stringify(rerun));
+    assert.deepEqual(cursor?.semanticAgreements, [{
+      local: { path: "facts/local-id.md", sha256: localSha },
+      peer: { path: "facts/peer-id.md", sha256: peerSha },
+    }]);
+
+    localContent = memory("local-id", "2026-01-03T00:00:00.000Z");
+    const editedLocalSha = createHash("sha256").update(localContent).digest("hex");
+    await fs.writeFile(path.join(rootDir, "facts/local-id.md"), localContent);
+    const explicitPlan = await computeConvergePlan({
+      ...options,
+      semanticAgreementsByNamespace: new Map([["default", [{
+        local: { path: "facts/local-id.md", sha256: editedLocalSha },
+        peer: { path: "facts/peer-id.md", sha256: peerSha },
+      }]]]),
+    });
+    assert.equal(explicitPlan.entries[0]?.semanticChange, "unchanged");
+
+    const changedPlan = await computeConvergePlan(options);
+    assert.equal(changedPlan.converged, true, JSON.stringify(changedPlan));
+    assert.equal(changedPlan.entries[0]?.action, "identical");
+    assert.equal(changedPlan.entries[0]?.semanticChange, "local_changed");
+    assert.deepEqual(changedPlan.entries[0]?.semanticAgreement, {
+      local: { path: "facts/local-id.md", sha256: editedLocalSha },
+      peer: { path: "facts/peer-id.md", sha256: peerSha },
+    });
+    assert.equal(changedPlan.entries[0]?.localSha256, undefined);
+    assert.equal(changedPlan.entries[0]?.peerSha256, undefined);
+
+    const changedResult = await executeConvergeApply(options);
+    assert.deepEqual(changedResult.transfers, {
+      pulled: 0,
+      pushed: 0,
+      conflictsResolved: 0,
+      suppressed: 0,
+      failed: 0,
+    });
+    const changedCursor = await readConvergeCursor(cursorPath);
+    assert.deepEqual(changedCursor?.semanticAgreements, [{
+      local: { path: "facts/local-id.md", sha256: editedLocalSha },
+      peer: { path: "facts/peer-id.md", sha256: peerSha },
+    }]);
+
+    const unchangedPlan = await computeConvergePlan(options);
+    assert.equal(unchangedPlan.entries[0]?.semanticChange, "unchanged");
   } finally {
     await fs.rm(rootDir, { recursive: true, force: true });
     await fs.rm(cursorDir, { recursive: true, force: true });

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -21,9 +21,11 @@ import {
   type ReconcileFileState,
   type ReconcileNamespaceInput,
   type ReconcilePlan,
+  type ReconcileSemanticAgreement,
 } from "@remnic/core/reconcile/plan.js";
 import {
   defaultConvergeCursorPath,
+  deriveConvergeCursorBase,
   readConvergeCursor,
   writeConvergeCursor,
   type ConvergeCursorState,
@@ -44,6 +46,7 @@ export interface ConvergePlanOptions {
   fetchImpl?: typeof fetch;
   resolveSecretRef?: ResolveSecretRefFn;
   baseFilesByNamespace?: Map<string, ReconcileFileState[]>;
+  semanticAgreementsByNamespace?: Map<string, ReconcileSemanticAgreement[]>;
   localFilesByNamespace?: Map<string, ReconcileFileState[]>;
   localTombstonesByNamespace?: Map<string, Iterable<string>>;
   localDeletionMtimeMsByNamespace?: Map<string, ReadonlyMap<string, number>>;
@@ -460,6 +463,7 @@ async function postPeerFileDeletion(
 
 export async function computeConvergePlan(options: ConvergePlanOptions = {}): Promise<ReconcilePlan> {
   const baseMap = new Map<string, ReconcileFileState[]>();
+  const semanticAgreementMap = new Map<string, ReconcileSemanticAgreement[]>();
   const namespacesToPlan = new Set<string>();
   const localMap = new Map<string, ReconcileFileState[]>();
   const localTombstones = new Map<string, Set<string>>();
@@ -474,6 +478,12 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
     for (const [ns, files] of options.baseFilesByNamespace) {
       namespacesToPlan.add(ns);
       baseMap.set(ns, files);
+    }
+  }
+  if (options.semanticAgreementsByNamespace) {
+    for (const [ns, agreements] of options.semanticAgreementsByNamespace) {
+      namespacesToPlan.add(ns);
+      semanticAgreementMap.set(ns, agreements);
     }
   }
   if (options.localFilesByNamespace) {
@@ -604,12 +614,23 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
   }
 
   const memoryDir = options.cursorDir ?? config?.memoryDir;
-  if (!options.baseFilesByNamespace && memoryDir && options.peerUrl) {
+  if (
+    memoryDir
+    && options.peerUrl
+    && (!options.baseFilesByNamespace || !options.semanticAgreementsByNamespace)
+  ) {
     for (const ns of namespacesToPlan) {
       const cursorPath = defaultConvergeCursorPath(memoryDir, options.peerUrl, ns);
       const cursor = await readConvergeCursor(cursorPath);
-      if (cursor?.baseFiles && cursor.baseFiles.length > 0) {
+      if (!options.baseFilesByNamespace && cursor?.baseFiles && cursor.baseFiles.length > 0) {
         baseMap.set(ns, cursor.baseFiles);
+      }
+      if (
+        !options.semanticAgreementsByNamespace
+        && cursor?.semanticAgreements
+        && cursor.semanticAgreements.length > 0
+      ) {
+        semanticAgreementMap.set(ns, cursor.semanticAgreements);
       }
     }
   }
@@ -637,7 +658,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
     ?? config?.converge.conflictPolicy
     ?? DEFAULT_CONVERGE_CONFLICT_POLICY;
   const plan = planReconciliation(inputs, { conflictPolicy });
-  return collapseActiveFactDuplicates(plan, localManifests, peerManifests);
+  return collapseActiveFactDuplicates(plan, localManifests, peerManifests, semanticAgreementMap);
 }
 
 export async function executeConvergeApply(
@@ -1015,17 +1036,14 @@ async function updateCursorsForPlan(
   const namespaces = new Set(plan.byNamespace.map((n) => n.namespace));
   for (const ns of namespaces) {
     const cursorPath = defaultConvergeCursorPath(memoryDir, peerUrl, ns);
-    const baseFiles = plan.entries
-      .filter((entry) => (
-        entry.namespace === ns
-        && entry.reason !== "semantic_duplicate"
-        && !(entry.reason === "local_modified_peer_deleted" && entry.resolution === "peer-wins")
-        && !(entry.reason === "local_deleted_peer_modified" && entry.resolution === "local-wins")
-      ))
-      .map((entry) => ({
-        path: entry.path,
-        sha256: entry.localSha256 ?? entry.peerSha256 ?? "unknown",
-      }));
+    const priorSemanticAgreements = options.semanticAgreementsByNamespace?.get(ns)
+      ?? (await readConvergeCursor(cursorPath))?.semanticAgreements
+      ?? [];
+    const { baseFiles, semanticAgreements } = deriveConvergeCursorBase(
+      plan.entries,
+      ns,
+      priorSemanticAgreements,
+    );
 
     const cursorState: ConvergeCursorState = {
       version: 1,
@@ -1033,6 +1051,7 @@ async function updateCursorsForPlan(
       namespace: ns,
       lastConvergedAt: new Date().toISOString(),
       baseFiles,
+      semanticAgreements,
     };
     try {
       await writeConvergeCursor(cursorPath, cursorState);

--- a/packages/remnic-core/src/reconcile/cursor.test.ts
+++ b/packages/remnic-core/src/reconcile/cursor.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { test } from "node:test";
 import {
   defaultConvergeCursorPath,
+  deriveConvergeCursorBase,
   hashPeerNamespace,
   normalizeConvergeCursor,
   readConvergeCursor,
@@ -13,6 +14,7 @@ import {
 } from "./cursor.js";
 
 const shaA = "a".repeat(64);
+const shaB = "b".repeat(64);
 
 test("hashPeerNamespace: deterministic key normalization", () => {
   const k1 = hashPeerNamespace("http://peer.example.com/", "default");
@@ -46,6 +48,18 @@ test("defaultConvergeCursorPath: constructs path under memoryDir state", () => {
   assert.ok(p.endsWith(".json"));
 });
 
+test("deriveConvergeCursorBase retains a deferred semantic agreement", () => {
+  const semanticAgreement = {
+    local: { path: "facts/local.md", sha256: shaA },
+    peer: { path: "facts/peer.md", sha256: shaB },
+  };
+
+  assert.deepEqual(
+    deriveConvergeCursorBase([], "default", [semanticAgreement]).semanticAgreements,
+    [semanticAgreement]
+  );
+});
+
 test("normalizeConvergeCursor: validates envelope shape", () => {
   assert.throws(() => normalizeConvergeCursor(null), /must be an object/);
   assert.throws(() => normalizeConvergeCursor({ version: 2 }), /version must be 1/);
@@ -63,11 +77,19 @@ test("normalizeConvergeCursor: validates envelope shape", () => {
     peerUrl: "http://peer",
     namespace: "default",
     baseFiles: [{ path: "a.md", sha256: shaA }],
+    semanticAgreements: [{
+      local: { path: "facts/local.md", sha256: shaA },
+      peer: { path: "facts/peer.md", sha256: shaB },
+    }],
   });
   assert.equal(valid.peerUrl, "http://peer");
   assert.equal(valid.namespace, "default");
   assert.equal(valid.baseFiles.length, 1);
   assert.equal(valid.baseFiles[0]?.path, "a.md");
+  assert.deepEqual(valid.semanticAgreements, [{
+    local: { path: "facts/local.md", sha256: shaA },
+    peer: { path: "facts/peer.md", sha256: shaB },
+  }]);
 });
 
 test("readConvergeCursor: returns null when file is missing or invalid", async () => {
@@ -96,6 +118,10 @@ test("writeConvergeCursor & readConvergeCursor: atomic write roundtrip", async (
       lastConvergedAt: new Date().toISOString(),
       baseFiles: [{ path: "facts/a.md", sha256: shaA, bytes: 120, mtimeMs: 1000 }],
       completedPaths: ["facts/a.md"],
+      semanticAgreements: [{
+        local: { path: "facts/local.md", sha256: shaA },
+        peer: { path: "facts/peer.md", sha256: shaB },
+      }],
     };
 
     await writeConvergeCursor(cursorPath, cursor);
@@ -106,6 +132,10 @@ test("writeConvergeCursor & readConvergeCursor: atomic write roundtrip", async (
     assert.equal(read.baseFiles.length, 1);
     assert.equal(read.baseFiles[0]?.sha256, shaA);
     assert.deepEqual(read.completedPaths, ["facts/a.md"]);
+    assert.deepEqual(read.semanticAgreements, [{
+      local: { path: "facts/local.md", sha256: shaA },
+      peer: { path: "facts/peer.md", sha256: shaB },
+    }]);
 
     // Update existing cursor atomically
     const updated: ConvergeCursorState = {

--- a/packages/remnic-core/src/reconcile/cursor.ts
+++ b/packages/remnic-core/src/reconcile/cursor.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import type { ReconcilePlanEntry, ReconcileSemanticAgreement } from "./plan.js";
 
 export interface ConvergeCursorFileState {
   path: string;
@@ -15,6 +16,7 @@ export interface ConvergeCursorState {
   namespace: string;
   lastConvergedAt?: string;
   baseFiles: ConvergeCursorFileState[];
+  semanticAgreements?: ReconcileSemanticAgreement[];
   completedPaths?: string[];
 }
 
@@ -48,6 +50,56 @@ export function defaultConvergeCursorPath(
   return path.join(path.resolve(memoryDir), ".remnic", "state", "converge-cursors", `${key}.json`);
 }
 
+function normalizeSemanticFileState(input: unknown): { path: string; sha256: string } | undefined {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return undefined;
+  const file = input as Record<string, unknown>;
+  if (typeof file.path !== "string" || typeof file.sha256 !== "string") return undefined;
+  return { path: file.path, sha256: file.sha256 };
+}
+
+function digestAfterReconcile(entry: ReconcilePlanEntry): string | undefined {
+  if (entry.action === "push") return entry.localSha256;
+  if (entry.action === "pull") return entry.peerSha256;
+  if (entry.action === "conflict") {
+    if (entry.resolution === "local-wins") return entry.localSha256;
+    if (entry.resolution === "peer-wins") return entry.peerSha256;
+    return undefined;
+  }
+  if (entry.action !== "identical") return undefined;
+  if (entry.localSha256 && entry.peerSha256 && entry.localSha256 !== entry.peerSha256) return undefined;
+  return entry.localSha256 ?? entry.peerSha256;
+}
+
+function semanticAgreementKey(agreement: ReconcileSemanticAgreement): string {
+  return `${agreement.local.path}\0${agreement.peer.path}`;
+}
+
+export function deriveConvergeCursorBase(
+  entries: readonly ReconcilePlanEntry[],
+  namespace: string,
+  priorSemanticAgreements: readonly ReconcileSemanticAgreement[] = [],
+): Pick<ConvergeCursorState, "baseFiles" | "semanticAgreements"> {
+  const baseFiles: ConvergeCursorFileState[] = [];
+  const semanticAgreementsByPathPair = new Map(
+    priorSemanticAgreements.map((agreement) => [semanticAgreementKey(agreement), agreement])
+  );
+  for (const entry of entries) {
+    if (entry.namespace !== namespace) continue;
+    if (entry.semanticAgreement) {
+      semanticAgreementsByPathPair.set(semanticAgreementKey(entry.semanticAgreement), entry.semanticAgreement);
+      continue;
+    }
+    const sha256 = digestAfterReconcile(entry);
+    if (sha256) baseFiles.push({ path: entry.path, sha256 });
+  }
+  baseFiles.sort((left, right) => left.path.localeCompare(right.path));
+  const semanticAgreements = [...semanticAgreementsByPathPair.values()];
+  semanticAgreements.sort((left, right) =>
+    left.local.path.localeCompare(right.local.path) || left.peer.path.localeCompare(right.peer.path)
+  );
+  return { baseFiles, semanticAgreements };
+}
+
 export function normalizeConvergeCursor(input: unknown): ConvergeCursorState {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new Error("converge cursor must be an object");
@@ -78,6 +130,16 @@ export function normalizeConvergeCursor(input: unknown): ConvergeCursorState {
       }
     }
   }
+  const semanticAgreements: ReconcileSemanticAgreement[] = [];
+  if (Array.isArray(obj.semanticAgreements)) {
+    for (const item of obj.semanticAgreements) {
+      if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+      const agreement = item as Record<string, unknown>;
+      const local = normalizeSemanticFileState(agreement.local);
+      const peer = normalizeSemanticFileState(agreement.peer);
+      if (local && peer) semanticAgreements.push({ local, peer });
+    }
+  }
   const completedPaths: string[] = [];
   if (Array.isArray(obj.completedPaths)) {
     for (const item of obj.completedPaths) {
@@ -92,6 +154,7 @@ export function normalizeConvergeCursor(input: unknown): ConvergeCursorState {
     namespace: obj.namespace.trim(),
     lastConvergedAt: typeof obj.lastConvergedAt === "string" ? obj.lastConvergedAt : undefined,
     baseFiles,
+    semanticAgreements,
     completedPaths,
   };
 }

--- a/packages/remnic-core/src/reconcile/manifest.test.ts
+++ b/packages/remnic-core/src/reconcile/manifest.test.ts
@@ -132,13 +132,61 @@ test("semantic collapse prevents different active fact paths from transferring b
       namespace: "default",
       action: "identical",
       reason: "semantic_duplicate",
-      localSha256: localFile.sha256,
-      peerSha256: peerFile.sha256,
+      semanticAgreement: {
+        local: localFile,
+        peer: peerFile,
+      },
+      semanticChange: "unchanged",
     },
   ]);
   assert.equal(collapsed.byNamespace[0]?.identical, 1);
   assert.equal(collapsed.byNamespace[0]?.pull, 0);
   assert.equal(collapsed.byNamespace[0]?.push, 0);
+});
+
+test("semantic collapse classifies a later one-sided metadata edit from its per-side base", () => {
+  const semanticHash = ContentHashIndex.computeHash("same active fact");
+  const priorLocal = { path: "facts/local-id.md", sha256: "a".repeat(64) };
+  const currentLocal = { ...priorLocal, sha256: "c".repeat(64) };
+  const peerFile = { path: "facts/peer-id.md", sha256: "b".repeat(64) };
+  const manifest = (file: typeof currentLocal): ReconcileManifest => ({
+    format: "remnic-reconcile-manifest",
+    schemaVersion: 1,
+    files: [{
+      ...file,
+      memory: {
+        id: file.path,
+        category: "fact",
+        contentHash: semanticHash,
+        status: "active",
+      },
+    }],
+  });
+  const plan = planReconciliation([{
+    namespace: "default",
+    local: [currentLocal],
+    peer: [peerFile],
+  }]);
+
+  const collapsed = collapseActiveFactDuplicates(
+    plan,
+    new Map([["default", manifest(currentLocal)]]),
+    new Map([["default", manifest(peerFile)]]),
+    new Map([["default", [{ local: priorLocal, peer: peerFile }]]])
+  );
+
+  assert.deepEqual(collapsed.entries, [{
+    path: currentLocal.path,
+    namespace: "default",
+    action: "identical",
+    reason: "semantic_duplicate",
+    semanticAgreement: {
+      local: currentLocal,
+      peer: peerFile,
+    },
+    semanticChange: "local_changed",
+  }]);
+  assert.equal(collapsed.converged, true);
 });
 
 test("semantic collapse does not fold non-active facts or unrelated path conflicts", () => {
@@ -213,6 +261,49 @@ test("semantic collapse preserves same-path metadata updates", () => {
 
   assert.deepEqual(collapsed, plan);
   assert.equal(collapsed.entries[0]?.action, "push");
+});
+
+test("semantic collapse preserves a shared-path metadata update when peer canonical path differs", () => {
+  const semanticHash = ContentHashIndex.computeHash("same raw fact");
+  const sharedLocal = { path: "facts/b.md", sha256: "a".repeat(64) };
+  const sharedPeer = { path: "facts/b.md", sha256: "b".repeat(64) };
+  const peerDuplicate = { path: "facts/a.md", sha256: "c".repeat(64) };
+  const plan = planReconciliation([{
+    namespace: "default",
+    local: [sharedLocal],
+    peer: [peerDuplicate, sharedPeer],
+    base: [{ path: sharedPeer.path, sha256: sharedPeer.sha256 }],
+  }]);
+  const manifest = (files: Array<{ path: string; sha256: string }>): ReconcileManifest => ({
+    format: "remnic-reconcile-manifest",
+    schemaVersion: 1,
+    files: files.map((file) => ({
+      ...file,
+      memory: {
+        id: file.path,
+        category: "fact",
+        contentHash: semanticHash,
+        status: "active",
+      },
+    })),
+  });
+
+  const collapsed = collapseActiveFactDuplicates(
+    plan,
+    new Map([["default", manifest([sharedLocal])]]),
+    new Map([["default", manifest([peerDuplicate, sharedPeer])]])
+  );
+
+  assert.deepEqual(collapsed.entries, [{
+    path: sharedLocal.path,
+    namespace: "default",
+    action: "push",
+    reason: "local_changed",
+    localSha256: sharedLocal.sha256,
+    peerSha256: sharedPeer.sha256,
+    baseSha256: sharedPeer.sha256,
+  }]);
+  assert.equal(collapsed.converged, false);
 });
 
 test("semantic collapse remains converged after transferring the canonical one-sided duplicate", () => {

--- a/packages/remnic-core/src/reconcile/manifest.ts
+++ b/packages/remnic-core/src/reconcile/manifest.ts
@@ -7,6 +7,8 @@ import {
   type ReconcileFileState,
   type ReconcilePlan,
   type ReconcilePlanEntry,
+  type ReconcileSemanticAgreement,
+  type ReconcileSemanticChange,
   summarizeReconcilePlan,
 } from "./plan.js";
 
@@ -153,10 +155,28 @@ function comparePlanEntries(left: ReconcilePlanEntry, right: ReconcilePlanEntry)
   return left.path < right.path ? -1 : left.path > right.path ? 1 : 0;
 }
 
+function semanticAgreementKey(agreement: ReconcileSemanticAgreement): string {
+  return `${agreement.local.path}\0${agreement.peer.path}`;
+}
+
+function classifySemanticChange(
+  current: ReconcileSemanticAgreement,
+  prior: ReconcileSemanticAgreement | undefined
+): ReconcileSemanticChange {
+  if (!prior) return "unchanged";
+  const localChanged = current.local.sha256 !== prior.local.sha256;
+  const peerChanged = current.peer.sha256 !== prior.peer.sha256;
+  if (localChanged && peerChanged) return "both_modified";
+  if (localChanged) return "local_changed";
+  if (peerChanged) return "peer_changed";
+  return "unchanged";
+}
+
 export function collapseActiveFactDuplicates(
   plan: ReconcilePlan,
   localManifests: ReadonlyMap<string, ReconcileManifest>,
-  peerManifests: ReadonlyMap<string, ReconcileManifest>
+  peerManifests: ReadonlyMap<string, ReconcileManifest>,
+  priorSemanticAgreements?: ReadonlyMap<string, readonly ReconcileSemanticAgreement[]>,
 ): ReconcilePlan {
   const entriesByNamespace = new Map<string, ReconcilePlanEntry[]>();
   for (const entry of plan.entries) {
@@ -174,6 +194,12 @@ export function collapseActiveFactDuplicates(
     const peerByPath = activeFactByPath(peerManifest);
     const localFilesByPath = new Map((localManifest?.files ?? []).map((file) => [file.path, file]));
     const peerFilesByPath = new Map((peerManifest?.files ?? []).map((file) => [file.path, file]));
+    const priorSemanticByPathPair = new Map(
+      (priorSemanticAgreements?.get(namespace) ?? []).map((agreement) => [
+        semanticAgreementKey(agreement),
+        agreement,
+      ])
+    );
     const localByHash = new Map<string, ActiveFactManifestFile[]>();
     const peerByHash = new Map<string, ActiveFactManifestFile[]>();
 
@@ -214,6 +240,26 @@ export function collapseActiveFactDuplicates(
           ...localCandidates.map((file) => file.path),
           ...peerCandidates.map((file) => file.path),
         ]);
+        const authoritativeSamePathEntries = new Set(entries.filter(
+          (entry) =>
+            duplicatePaths.has(entry.path)
+            && localFilesByPath.has(entry.path)
+            && peerFilesByPath.has(entry.path)
+            && entry.action !== "identical"
+        ));
+        if (authoritativeSamePathEntries.size > 0) {
+          for (const entry of entries) {
+            if (
+              duplicatePaths.has(entry.path)
+              && !authoritativeSamePathEntries.has(entry)
+              && (entry.action === "pull" || entry.action === "push" || entry.action === "identical")
+            ) {
+              removed.add(entry);
+              changed = true;
+            }
+          }
+          continue;
+        }
         const unsafeEntry = entries.some(
           (entry) => duplicatePaths.has(entry.path) && (entry.action === "suppress" || entry.action === "conflict")
         );
@@ -226,13 +272,20 @@ export function collapseActiveFactDuplicates(
             removed.add(entry);
           }
         }
+        const semanticAgreement: ReconcileSemanticAgreement = {
+          local: { path: localPath, sha256: localFile.sha256 },
+          peer: { path: peerPath, sha256: peerFile.sha256 },
+        };
         replacements.push({
           path: localPath < peerPath ? localPath : peerPath,
           namespace,
           action: "identical",
           reason: "semantic_duplicate",
-          localSha256: localFile.sha256,
-          peerSha256: peerFile.sha256,
+          semanticAgreement,
+          semanticChange: classifySemanticChange(
+            semanticAgreement,
+            priorSemanticByPathPair.get(semanticAgreementKey(semanticAgreement))
+          ),
         });
         changed = true;
         continue;

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -37,6 +37,18 @@ export type ReconcileAction = "pull" | "push" | "identical" | "conflict" | "supp
  */
 export type ReconcileResolution = "local-wins" | "peer-wins" | "supersede-link" | "unresolved";
 
+export interface ReconcileSemanticFileState {
+  path: string;
+  sha256: string;
+}
+
+export interface ReconcileSemanticAgreement {
+  local: ReconcileSemanticFileState;
+  peer: ReconcileSemanticFileState;
+}
+
+export type ReconcileSemanticChange = "unchanged" | "local_changed" | "peer_changed" | "both_modified";
+
 export interface ReconcilePlanEntry {
   path: string;
   namespace: string;
@@ -56,6 +68,13 @@ export interface ReconcilePlanEntry {
    * delete the live copy instead of the retracted one.
    */
   suppressSide?: "local" | "peer" | "both";
+  /**
+   * Real per-side identities for a cross-path semantic agreement. Synthetic
+   * rows omit the top-level side digests because `path` cannot name both files.
+   */
+  semanticAgreement?: ReconcileSemanticAgreement;
+  /** Each side's current digest compared with its own prior semantic digest. */
+  semanticChange?: ReconcileSemanticChange;
 }
 
 export type ReconcileReason =


### PR DESCRIPTION
## Summary

This keeps shared-path work when matching facts collapse. The cursor now stores each side's real path and hash. It also saves the hash chosen by the action that ran.

## Checks

The type check, focused tests, build, lint, review check, and source ratchet check pass.

Closes #2246, #2247, #2251

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core offline converge cursor format and duplicate-collapse logic; incorrect cursor state could mis-plan pulls/pushes on subsequent runs, though behavior is heavily covered by new tests.
> 
> **Overview**
> Fixes converge **cursor** and **semantic duplicate** handling so reconciliation state stays correct when the same fact lives at different paths on local vs peer, or when only metadata changes after a prior agreement.
> 
> **Semantic agreements in the cursor:** Cross-path `semantic_duplicate` rows now carry `semanticAgreement` (local path + digest, peer path + digest) instead of a single synthetic path/digest. The converge cursor persists `semanticAgreements` alongside `baseFiles`, loads them on the next plan, and uses `deriveConvergeCursorBase` so applied pull/push/conflict actions record the **winning side’s digest** in `baseFiles` while agreements are updated or retained.
> 
> **Planning behavior:** `collapseActiveFactDuplicates` takes prior agreements, emits `semanticChange` (`unchanged`, `local_changed`, etc.) by comparing each side to its stored base, and **does not collapse** when both sides share a path but the planner still has a real push/pull (e.g. shared-path metadata update with an extra peer duplicate at another path).
> 
> **CLI:** `computeConvergePlan` / apply hydrate and write semantic agreements from the cursor; tests cover pull/peer-wins cursor advancement and metadata edits across runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da8c3f6f7bb90c8ffb33efdb0601498ca5fe5e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved convergence for semantically duplicate files and shared paths.
  * Plans now distinguish unchanged, local-only, peer-only, and simultaneous metadata changes.
  * Metadata-only updates are tracked without unnecessary file transfers.
  * Convergence state now preserves file identity and semantic agreement information across subsequent runs.

* **Bug Fixes**
  * Corrected cursor advancement and persisted digests after pulls and peer-wins operations.
  * Improved handling of differing canonical paths during shared-path updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->