### PR TITLE
fix(converge): preserve config compatibility

### DIFF
--- a/packages/remnic-cli/src/config-path.test.ts
+++ b/packages/remnic-cli/src/config-path.test.ts
@@ -4,13 +4,20 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { resolveConfigPath, resolveMemoryDir, resolveSyncSourceDir } from "./index.js";
+import {
+  loadConvergeCommandConfig,
+  resolveConfigPath,
+  resolveMemoryDir,
+  resolveSyncSourceDir,
+} from "./index.js";
 
 const ORIGINAL_ENV = {
   HOME: process.env.HOME,
   USERPROFILE: process.env.USERPROFILE,
   REMNIC_CONFIG_PATH: process.env.REMNIC_CONFIG_PATH,
   ENGRAM_CONFIG_PATH: process.env.ENGRAM_CONFIG_PATH,
+  OPENCLAW_CONFIG_PATH: process.env.OPENCLAW_CONFIG_PATH,
+  OPENCLAW_ENGRAM_CONFIG_PATH: process.env.OPENCLAW_ENGRAM_CONFIG_PATH,
   REMNIC_MEMORY_DIR: process.env.REMNIC_MEMORY_DIR,
   ENGRAM_MEMORY_DIR: process.env.ENGRAM_MEMORY_DIR,
 };
@@ -125,6 +132,100 @@ test("resolveConfigPath expands home-relative env config paths", async () => {
     process.env.ENGRAM_CONFIG_PATH = "${HOME}/engram.json";
 
     assert.equal(resolveConfigPath(), path.join(home, "engram.json"));
+  } finally {
+    restoreEnv();
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("converge prefers a plugin-scoped manual policy over standalone config", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-converge-openclaw-"));
+  const openclawConfigPath = path.join(home, "openclaw.json");
+  const standaloneConfigPath = path.join(home, "remnic.json");
+  try {
+    process.env.HOME = home;
+    process.env.REMNIC_CONFIG_PATH = standaloneConfigPath;
+    delete process.env.ENGRAM_CONFIG_PATH;
+    process.env.OPENCLAW_CONFIG_PATH = openclawConfigPath;
+    delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
+    await writeFile(
+      standaloneConfigPath,
+      JSON.stringify({ converge: { conflictPolicy: "newest-wins" } }),
+    );
+    await writeFile(
+      openclawConfigPath,
+      JSON.stringify({
+        plugins: {
+          slots: { memory: "openclaw-remnic" },
+          entries: {
+            "openclaw-remnic": {
+              config: { converge: { conflictPolicy: "manual" } },
+            },
+          },
+        },
+      }),
+    );
+
+    assert.equal(
+      loadConvergeCommandConfig().converge.conflictPolicy,
+      "manual",
+    );
+  } finally {
+    restoreEnv();
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("converge defaults a plugin entry with no config block", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-converge-openclaw-default-"));
+  const openclawConfigPath = path.join(home, "openclaw.json");
+  try {
+    process.env.HOME = home;
+    delete process.env.REMNIC_CONFIG_PATH;
+    delete process.env.ENGRAM_CONFIG_PATH;
+    process.env.OPENCLAW_CONFIG_PATH = openclawConfigPath;
+    delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
+    await writeFile(
+      openclawConfigPath,
+      JSON.stringify({
+        plugins: {
+          entries: {
+            "openclaw-remnic": { enabled: true },
+          },
+        },
+      }),
+    );
+
+    assert.equal(
+      loadConvergeCommandConfig().converge.conflictPolicy,
+      "newest-wins",
+    );
+  } finally {
+    restoreEnv();
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("converge falls back to standalone config when OpenClaw JSON is malformed", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-converge-openclaw-malformed-"));
+  const openclawConfigPath = path.join(home, "openclaw.json");
+  const standaloneConfigPath = path.join(home, "remnic.json");
+  try {
+    process.env.HOME = home;
+    process.env.REMNIC_CONFIG_PATH = standaloneConfigPath;
+    delete process.env.ENGRAM_CONFIG_PATH;
+    process.env.OPENCLAW_CONFIG_PATH = openclawConfigPath;
+    delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
+    await writeFile(openclawConfigPath, "{");
+    await writeFile(
+      standaloneConfigPath,
+      JSON.stringify({ converge: { conflictPolicy: "manual" } }),
+    );
+
+    assert.equal(
+      loadConvergeCommandConfig().converge.conflictPolicy,
+      "manual",
+    );
   } finally {
     restoreEnv();
     await rm(home, { recursive: true, force: true });

--- a/packages/remnic-cli/src/config-path.test.ts
+++ b/packages/remnic-cli/src/config-path.test.ts
@@ -292,3 +292,29 @@ test("converge rejects malformed OpenClaw JSON", async () => {
     await rm(home, { recursive: true, force: true });
   }
 });
+
+test("converge surfaces an invalid plugin conflictPolicy instead of silently defaulting", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-converge-invalid-policy-"));
+  const openclawConfigPath = path.join(home, "openclaw.json");
+  try {
+    process.env.HOME = home;
+    delete process.env.REMNIC_CONFIG_PATH;
+    delete process.env.ENGRAM_CONFIG_PATH;
+    process.env.OPENCLAW_CONFIG_PATH = openclawConfigPath;
+    delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
+    await writeFile(
+      openclawConfigPath,
+      JSON.stringify({
+        plugins: {
+          entries: {
+            "openclaw-remnic": { config: { converge: { conflictPolicy: "manul" } }, enabled: true },
+          },
+        },
+      }),
+    );
+    assert.throws(() => loadConvergeCommandConfig());
+  } finally {
+    restoreEnv();
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-cli/src/config-path.test.ts
+++ b/packages/remnic-cli/src/config-path.test.ts
@@ -176,15 +176,20 @@ test("converge prefers a plugin-scoped manual policy over standalone config", as
   }
 });
 
-test("converge defaults a plugin entry with no config block", async () => {
+test("converge falls back to standalone config when a plugin entry has no config", async () => {
   const home = await mkdtemp(path.join(os.tmpdir(), "remnic-converge-openclaw-default-"));
   const openclawConfigPath = path.join(home, "openclaw.json");
+  const standaloneConfigPath = path.join(home, "remnic.json");
   try {
     process.env.HOME = home;
-    delete process.env.REMNIC_CONFIG_PATH;
+    process.env.REMNIC_CONFIG_PATH = standaloneConfigPath;
     delete process.env.ENGRAM_CONFIG_PATH;
     process.env.OPENCLAW_CONFIG_PATH = openclawConfigPath;
     delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
+    await writeFile(
+      standaloneConfigPath,
+      JSON.stringify({ converge: { conflictPolicy: "manual" } }),
+    );
     await writeFile(
       openclawConfigPath,
       JSON.stringify({
@@ -198,7 +203,21 @@ test("converge defaults a plugin entry with no config block", async () => {
 
     assert.equal(
       loadConvergeCommandConfig().converge.conflictPolicy,
-      "newest-wins",
+      "manual",
+    );
+    await writeFile(
+      openclawConfigPath,
+      JSON.stringify({
+        plugins: {
+          entries: {
+            "openclaw-remnic": { config: null, enabled: true },
+          },
+        },
+      }),
+    );
+    assert.equal(
+      loadConvergeCommandConfig().converge.conflictPolicy,
+      "manual",
     );
   } finally {
     restoreEnv();

--- a/packages/remnic-cli/src/config-path.test.ts
+++ b/packages/remnic-cli/src/config-path.test.ts
@@ -252,20 +252,6 @@ test("converge falls back to standalone config when a plugin entry has no config
       loadConvergeCommandConfig().converge.conflictPolicy,
       "manual",
     );
-    await writeFile(
-      openclawConfigPath,
-      JSON.stringify({
-        plugins: {
-          entries: {
-            "openclaw-remnic": { config: { remnic: false }, enabled: true },
-          },
-        },
-      }),
-    );
-    assert.equal(
-      loadConvergeCommandConfig().converge.conflictPolicy,
-      "manual",
-    );
   } finally {
     restoreEnv();
     await rm(home, { recursive: true, force: true });

--- a/packages/remnic-cli/src/config-path.test.ts
+++ b/packages/remnic-cli/src/config-path.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -138,20 +138,15 @@ test("resolveConfigPath expands home-relative env config paths", async () => {
   }
 });
 
-test("converge prefers a plugin-scoped manual policy over standalone config", async () => {
+test("converge loads a plugin-scoped manual conflict policy", async () => {
   const home = await mkdtemp(path.join(os.tmpdir(), "remnic-converge-openclaw-"));
   const openclawConfigPath = path.join(home, "openclaw.json");
-  const standaloneConfigPath = path.join(home, "remnic.json");
   try {
     process.env.HOME = home;
-    process.env.REMNIC_CONFIG_PATH = standaloneConfigPath;
+    delete process.env.REMNIC_CONFIG_PATH;
     delete process.env.ENGRAM_CONFIG_PATH;
     process.env.OPENCLAW_CONFIG_PATH = openclawConfigPath;
     delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
-    await writeFile(
-      standaloneConfigPath,
-      JSON.stringify({ converge: { conflictPolicy: "newest-wins" } }),
-    );
     await writeFile(
       openclawConfigPath,
       JSON.stringify({
@@ -176,8 +171,8 @@ test("converge prefers a plugin-scoped manual policy over standalone config", as
   }
 });
 
-test("converge falls back to standalone config when a plugin entry has no config", async () => {
-  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-converge-openclaw-default-"));
+test("converge honors an explicit standalone config path", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-converge-standalone-"));
   const openclawConfigPath = path.join(home, "openclaw.json");
   const standaloneConfigPath = path.join(home, "remnic.json");
   try {
@@ -186,6 +181,44 @@ test("converge falls back to standalone config when a plugin entry has no config
     delete process.env.ENGRAM_CONFIG_PATH;
     process.env.OPENCLAW_CONFIG_PATH = openclawConfigPath;
     delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
+    await writeFile(
+      standaloneConfigPath,
+      JSON.stringify({ converge: { conflictPolicy: "newest-wins" } }),
+    );
+    await writeFile(
+      openclawConfigPath,
+      JSON.stringify({
+        plugins: {
+          entries: {
+            "openclaw-remnic": {
+              config: { converge: { conflictPolicy: "manual" } },
+            },
+          },
+        },
+      }),
+    );
+
+    assert.equal(
+      loadConvergeCommandConfig().converge.conflictPolicy,
+      "newest-wins",
+    );
+  } finally {
+    restoreEnv();
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("converge falls back to standalone config when a plugin entry has no config", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-converge-openclaw-default-"));
+  const openclawConfigPath = path.join(home, "openclaw.json");
+  const standaloneConfigPath = path.join(home, ".config", "remnic", "config.json");
+  try {
+    process.env.HOME = home;
+    delete process.env.REMNIC_CONFIG_PATH;
+    delete process.env.ENGRAM_CONFIG_PATH;
+    process.env.OPENCLAW_CONFIG_PATH = openclawConfigPath;
+    delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
+    await mkdir(path.dirname(standaloneConfigPath), { recursive: true });
     await writeFile(
       standaloneConfigPath,
       JSON.stringify({ converge: { conflictPolicy: "manual" } }),
@@ -219,31 +252,40 @@ test("converge falls back to standalone config when a plugin entry has no config
       loadConvergeCommandConfig().converge.conflictPolicy,
       "manual",
     );
+    await writeFile(
+      openclawConfigPath,
+      JSON.stringify({
+        plugins: {
+          entries: {
+            "openclaw-remnic": { config: { remnic: false }, enabled: true },
+          },
+        },
+      }),
+    );
+    assert.equal(
+      loadConvergeCommandConfig().converge.conflictPolicy,
+      "manual",
+    );
   } finally {
     restoreEnv();
     await rm(home, { recursive: true, force: true });
   }
 });
 
-test("converge falls back to standalone config when OpenClaw JSON is malformed", async () => {
+test("converge rejects malformed OpenClaw JSON", async () => {
   const home = await mkdtemp(path.join(os.tmpdir(), "remnic-converge-openclaw-malformed-"));
   const openclawConfigPath = path.join(home, "openclaw.json");
-  const standaloneConfigPath = path.join(home, "remnic.json");
   try {
     process.env.HOME = home;
-    process.env.REMNIC_CONFIG_PATH = standaloneConfigPath;
+    delete process.env.REMNIC_CONFIG_PATH;
     delete process.env.ENGRAM_CONFIG_PATH;
     process.env.OPENCLAW_CONFIG_PATH = openclawConfigPath;
     delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
     await writeFile(openclawConfigPath, "{");
-    await writeFile(
-      standaloneConfigPath,
-      JSON.stringify({ converge: { conflictPolicy: "manual" } }),
-    );
 
-    assert.equal(
-      loadConvergeCommandConfig().converge.conflictPolicy,
-      "manual",
+    assert.throws(
+      () => loadConvergeCommandConfig(),
+      /contains invalid JSON/,
     );
   } finally {
     restoreEnv();

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4056,15 +4056,10 @@ function loadStandaloneConvergeCommandConfig(): PluginConfig {
 function parseConvergePluginConfig(value: unknown): PluginConfig | undefined {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
   if (Object.keys(value as Record<string, unknown>).length === 0) return undefined;
-  try {
-    return parseConfig(resolveRemnicConfigRecord(value));
-  } catch (error) {
-    // A present `converge` block that fails to parse is an explicit invalid operator
-    // config — surface it rather than silently defaulting to newest-wins (which could
-    // auto-resolve conflicts). Non-converge parse issues fall back to standalone.
-    if ("converge" in (value as Record<string, unknown>)) throw error;
-    return undefined;
-  }
+  // Present and non-empty config is authoritative. Parse strictly — any invalid value
+  // (unknown key, bad policy, malformed/nested structure) MUST surface as an error,
+  // never silently default to newest-wins, which could auto-resolve conflicts.
+  return parseConfig(resolveRemnicConfigRecord(value));
 }
 
 export function loadConvergeCommandConfig(): PluginConfig {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4055,6 +4055,7 @@ function loadStandaloneConvergeCommandConfig(): PluginConfig {
 
 function parseConvergePluginConfig(value: unknown): PluginConfig | undefined {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  if (Object.keys(value as Record<string, unknown>).length === 0) return undefined;
   try {
     return parseConfig(resolveRemnicConfigRecord(value));
   } catch {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4058,10 +4058,7 @@ export function loadConvergeCommandConfig(): PluginConfig {
   const pluginEntry = resolveRemnicPluginEntry(openclawConfig);
   if (pluginEntry !== undefined) {
     const pluginConfig = pluginEntry["config"];
-    if (pluginConfig === undefined || pluginConfig === null) {
-      return parseConfig({});
-    }
-    if (typeof pluginConfig === "object" && !Array.isArray(pluginConfig)) {
+    if (pluginConfig !== null && typeof pluginConfig === "object" && !Array.isArray(pluginConfig)) {
       return parseConfig(resolveRemnicConfigRecord(pluginConfig));
     }
   }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -173,6 +173,7 @@ import {
   OPERATION_NAMES,
   validateCapabilitiesForMint,
 } from "@remnic/core";
+import { resolveRemnicPluginEntry } from "@remnic/core/plugin-id.js";
 import { runMeetingsBinaryCommand } from "./commands/meetings.js";
 // @remnic/export-weclone is an optional install surface (training:export
 // only uses it). Load lazily so the CLI works without it — see
@@ -4043,6 +4044,34 @@ async function writeBenchReproManifestForPackageRun(args: {
 }
 
 // ── Config helpers ───────────────────────────────────────────────────────────
+
+export function loadConvergeCommandConfig(): PluginConfig {
+  const openclawConfigPath = resolveOpenclawConfigPath();
+  let openclawConfig: unknown;
+  if (fs.existsSync(openclawConfigPath)) {
+    try {
+      openclawConfig = JSON.parse(fs.readFileSync(openclawConfigPath, "utf8"));
+    } catch {
+      openclawConfig = undefined;
+    }
+  }
+  const pluginEntry = resolveRemnicPluginEntry(openclawConfig);
+  if (pluginEntry !== undefined) {
+    const pluginConfig = pluginEntry["config"];
+    if (pluginConfig === undefined || pluginConfig === null) {
+      return parseConfig({});
+    }
+    if (typeof pluginConfig === "object" && !Array.isArray(pluginConfig)) {
+      return parseConfig(resolveRemnicConfigRecord(pluginConfig));
+    }
+  }
+
+  const configPath = resolveConfigPath();
+  const raw = fs.existsSync(configPath)
+    ? JSON.parse(fs.readFileSync(configPath, "utf8"))
+    : {};
+  return parseConfig(resolveRemnicConfigRecord(raw));
+}
 
 export function resolveConfigPath(cliPath?: string): string {
   if (cliPath) return path.resolve(expandTilde(cliPath));
@@ -12985,11 +13014,7 @@ Options:
         await cmdConverge(action, args, json);
         break;
       }
-      const configPath = resolveConfigPath();
-      const raw = fs.existsSync(configPath)
-        ? JSON.parse(fs.readFileSync(configPath, "utf8"))
-        : {};
-      const config = parseConfig(resolveRemnicConfigRecord(raw));
+      const config = loadConvergeCommandConfig();
       await cmdConverge(action, args, json, config);
       break;
     }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4058,7 +4058,11 @@ function parseConvergePluginConfig(value: unknown): PluginConfig | undefined {
   if (Object.keys(value as Record<string, unknown>).length === 0) return undefined;
   try {
     return parseConfig(resolveRemnicConfigRecord(value));
-  } catch {
+  } catch (error) {
+    // A present `converge` block that fails to parse is an explicit invalid operator
+    // config — surface it rather than silently defaulting to newest-wins (which could
+    // auto-resolve conflicts). Non-converge parse issues fall back to standalone.
+    if ("converge" in (value as Record<string, unknown>)) throw error;
     return undefined;
   }
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4045,29 +4045,33 @@ async function writeBenchReproManifestForPackageRun(args: {
 
 // ── Config helpers ───────────────────────────────────────────────────────────
 
-export function loadConvergeCommandConfig(): PluginConfig {
-  const openclawConfigPath = resolveOpenclawConfigPath();
-  let openclawConfig: unknown;
-  if (fs.existsSync(openclawConfigPath)) {
-    try {
-      openclawConfig = JSON.parse(fs.readFileSync(openclawConfigPath, "utf8"));
-    } catch {
-      openclawConfig = undefined;
-    }
-  }
-  const pluginEntry = resolveRemnicPluginEntry(openclawConfig);
-  if (pluginEntry !== undefined) {
-    const pluginConfig = pluginEntry["config"];
-    if (pluginConfig !== null && typeof pluginConfig === "object" && !Array.isArray(pluginConfig)) {
-      return parseConfig(resolveRemnicConfigRecord(pluginConfig));
-    }
-  }
-
+function loadStandaloneConvergeCommandConfig(): PluginConfig {
   const configPath = resolveConfigPath();
   const raw = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
   return parseConfig(resolveRemnicConfigRecord(raw));
+}
+
+function parseConvergePluginConfig(value: unknown): PluginConfig | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  try {
+    return parseConfig(resolveRemnicConfigRecord(value));
+  } catch {
+    return undefined;
+  }
+}
+
+export function loadConvergeCommandConfig(): PluginConfig {
+  if (readCompatEnv("REMNIC_CONFIG_PATH", "ENGRAM_CONFIG_PATH")) {
+    return loadStandaloneConvergeCommandConfig();
+  }
+
+  const openclawConfig = readOpenclawConfig(resolveOpenclawConfigPath());
+  const pluginEntry = resolveRemnicPluginEntry(openclawConfig);
+  const pluginConfig = parseConvergePluginConfig(pluginEntry?.["config"]);
+  if (pluginConfig) return pluginConfig;
+  return loadStandaloneConvergeCommandConfig();
 }
 
 export function resolveConfigPath(cliPath?: string): string {

--- a/packages/remnic-core/src/converge-conflict-policy-type.test.ts
+++ b/packages/remnic-core/src/converge-conflict-policy-type.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ReconcileConflictPolicy } from "./reconcile/plan.js";
+import type { ConvergeConflictPolicy } from "./types.js";
+
+type Equal<Left, Right> = (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+  ? true
+  : false;
+
+const conflictPolicyNamesAreEquivalent: Equal<ReconcileConflictPolicy, ConvergeConflictPolicy> = true;
+
+test("ReconcileConflictPolicy remains a type alias for ConvergeConflictPolicy", () => {
+  assert.equal(conflictPolicyNamesAreEquivalent, true);
+});

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_CONVERGE_CONFLICT_POLICY,
 } from "../converge-config.js";
 import type { ConvergeConflictPolicy } from "../types.js";
+export type ReconcileConflictPolicy = ConvergeConflictPolicy;
 
 /**
  * Bootstrap reconciliation planner for two peer daemons whose corpora have

--- a/scripts/config-contract/fixtures/hand-rolled.ts
+++ b/scripts/config-contract/fixtures/hand-rolled.ts
@@ -4,7 +4,7 @@
  */
 type Rec = Record<string, unknown>;
 function requireObject(value: unknown, _name: string): Rec {
-  if (!value || typeof value !== "object") throw new Error("bad");
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("bad");
   return value as Rec;
 }
 function coerceBool(value: unknown): boolean | undefined {

--- a/scripts/config-contract/fixtures/hand-rolled.ts
+++ b/scripts/config-contract/fixtures/hand-rolled.ts
@@ -20,9 +20,42 @@ export interface FixtureHandRolledConfig {
 
 export function parseFixtureHandRolledConfig(value: unknown): FixtureHandRolledConfig {
   const raw = requireObject(value, "fixture");
+  if (raw.enabled !== undefined && typeof raw.enabled !== "boolean") {
+    throw new Error("enabled must be a boolean");
+  }
+  if (
+    raw.intervalMinutes !== undefined &&
+    (typeof raw.intervalMinutes !== "number" ||
+      !Number.isFinite(raw.intervalMinutes) ||
+      raw.intervalMinutes <= 0)
+  ) {
+    throw new Error("intervalMinutes must be a positive number");
+  }
+  if (
+    raw.fusion !== undefined &&
+    (!raw.fusion || typeof raw.fusion !== "object" || Array.isArray(raw.fusion))
+  ) {
+    throw new Error("fusion must be an object");
+  }
+  if (raw.label !== undefined && typeof raw.label !== "string") {
+    throw new Error("label must be a string");
+  }
+
+  const fusionRaw = (raw.fusion as Rec | undefined) ?? {};
+  if (fusionRaw.enabled !== undefined && typeof fusionRaw.enabled !== "boolean") {
+    throw new Error("fusion.enabled must be a boolean");
+  }
+  if (
+    fusionRaw.gapMs !== undefined &&
+    (typeof fusionRaw.gapMs !== "number" ||
+      !Number.isFinite(fusionRaw.gapMs) ||
+      fusionRaw.gapMs < 0)
+  ) {
+    throw new Error("fusion.gapMs must be a non-negative number");
+  }
+
   const enabled = coerceBool(raw.enabled) ?? false;
   const intervalMinutes = typeof raw.intervalMinutes === "number" ? raw.intervalMinutes : 15;
-  const fusionRaw = raw.fusion && typeof raw.fusion === "object" ? (raw.fusion as Rec) : {};
   const fusion = {
     enabled: coerceBool(fusionRaw.enabled) ?? false,
     gapMs: typeof fusionRaw.gapMs === "number" ? fusionRaw.gapMs : 1000,

--- a/scripts/config-contract/fixtures/hand-rolled.ts
+++ b/scripts/config-contract/fixtures/hand-rolled.ts
@@ -27,7 +27,7 @@ export function parseFixtureHandRolledConfig(value: unknown): FixtureHandRolledC
     enabled: coerceBool(fusionRaw.enabled) ?? false,
     gapMs: typeof fusionRaw.gapMs === "number" ? fusionRaw.gapMs : 1000,
   };
-  const { label, ...unknown } = raw as { label?: string };
+  const { enabled: _enabled, intervalMinutes: _intervalMinutes, fusion: _fusion, label, ...unknown } = raw;
   if (Object.keys(unknown).length > 0) throw new Error("unknown");
   return { enabled, intervalMinutes, fusion, label: typeof label === "string" ? label.trim() : undefined };
 }

--- a/tests/config-contract-extractor.test.ts
+++ b/tests/config-contract-extractor.test.ts
@@ -6,6 +6,7 @@ import {
   extractParsedKeyPaths,
   extractRealConfigKeys,
 } from "../scripts/config-contract/extract-parsed-keys.ts";
+import { parseFixtureHandRolledConfig } from "../scripts/config-contract/fixtures/hand-rolled.ts";
 
 /**
  * check-config-contract v2 extractor (issue #1990 PR1).
@@ -47,6 +48,23 @@ test("hand-rolled fixture: aliases, coercion helpers, nested blocks, and destruc
   assert.ok(keys.includes("topLevelFlag"), "entry parser direct read");
   // Value properties never leak as config keys.
   assert.equal(keys.some((k) => k.endsWith(".trim") || k.endsWith(".length")), false);
+});
+
+test("hand-rolled fixture accepts every recognized runtime field", () => {
+  assert.deepEqual(
+    parseFixtureHandRolledConfig({
+      enabled: true,
+      intervalMinutes: 5,
+      fusion: { enabled: true, gapMs: 250 },
+      label: " fixture ",
+    }),
+    {
+      enabled: true,
+      intervalMinutes: 5,
+      fusion: { enabled: true, gapMs: 250 },
+      label: "fixture",
+    },
+  );
 });
 
 test("zod fixture: static z.object walk collects nested schema keys", () => {

--- a/tests/config-contract-extractor.test.ts
+++ b/tests/config-contract-extractor.test.ts
@@ -67,6 +67,20 @@ test("hand-rolled fixture accepts every recognized runtime field", () => {
   );
 });
 
+test("hand-rolled fixture rejects invalid recognized fields", () => {
+  assert.throws(() => parseFixtureHandRolledConfig({ enabled: "true" }), /enabled/);
+  assert.throws(() => parseFixtureHandRolledConfig({ intervalMinutes: 0 }), /intervalMinutes/);
+  assert.throws(() => parseFixtureHandRolledConfig({ fusion: [] }), /fusion/);
+  assert.throws(
+    () => parseFixtureHandRolledConfig({ fusion: { enabled: "true" } }),
+    /fusion.enabled/,
+  );
+  assert.throws(
+    () => parseFixtureHandRolledConfig({ fusion: { gapMs: -1 } }),
+    /fusion.gapMs/,
+  );
+});
+
 test("zod fixture: static z.object walk collects nested schema keys", () => {
   const { keys } = extractFixture();
   assert.ok(keys.includes("zodBlock.endpoint"), keys.filter((k) => k.startsWith("zodBlock")).join(","));


### PR DESCRIPTION
This fixes three config bugs.

The old conflict policy type name remains as an alias.

Converge first reads policy settings from the OpenClaw plugin entry. If that entry has no config, it uses the standalone Remnic file.

The hand-written test config now accepts all known fields.

Type checks and focused tests pass. The build, config check, review scan, and size check pass.

The full test run found three AMB preflight failures under shared load. All six AMB preflight tests pass when run alone.

Closes #2245
Closes #2249
Closes #2250

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Converge conflict resolution behavior now depends on OpenClaw plugin config and strict parsing; a bad or unexpected policy value errors instead of defaulting, which is safer but changes runtime behavior for plugin installs.
> 
> **Overview**
> **Converge** no longer reads only the standalone Remnic JSON file. New `loadConvergeCommandConfig()` chooses settings in order: if `REMNIC_CONFIG_PATH` / `ENGRAM_CONFIG_PATH` is set, standalone wins; otherwise it reads OpenClaw config, uses the Remnic plugin entry’s `config` when present and non-empty (strict `parseConfig`, including invalid `converge.conflictPolicy`), then falls back to the default standalone path. Malformed OpenClaw JSON fails with an explicit error instead of being ignored.
> 
> **Reconcile** exports `ReconcileConflictPolicy` as a type alias of `ConvergeConflictPolicy`, with a compile-time test so the names stay equivalent.
> 
> **Config-contract** hand-rolled fixture parsing now rejects arrays at the root object check, validates each known field’s type/range before applying defaults, trims `label`, and only then rejects unknown top-level keys; tests cover valid payloads and invalid fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f280c92e986152455c730937795ccb51b2a6fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `converge` command now prefers plugin-scoped configuration when available, with clearer fallback/override behavior to standalone settings.
  * Added a public conflict-policy type for reconciliation planning.

* **Bug Fixes**
  * Hand-rolled config parsing now performs stronger runtime validation (including rejecting array inputs) before coercing defaults, and better reports invalid values.
  * Malformed/invalid conflict-policy inputs now reliably throw instead of silently defaulting.
  * Configuration label normalization trims surrounding whitespace.

* **Tests**
  * Improved configuration-loading coverage, including environment isolation and additional fixture parser cases.
  * Added a type-level compatibility assertion for conflict policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->