### PR TITLE
fix(converge): harden transport, manifest route, internal-state exclusion (#2232, #2233, #2236)

### DIFF
--- a/packages/remnic-cli/src/converge-peer-manifest.test.ts
+++ b/packages/remnic-cli/src/converge-peer-manifest.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parsePeerManifestStream } from "./converge-peer-manifest.js";
+import { fetchPeerManifestStream } from "./converge-peer-transport.js";
+
+function streamedResponse(lines: string[], splitAt: number): Response {
+  const encoded = new TextEncoder().encode(`${lines.join("\n")}\n`);
+  return new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoded.slice(0, splitAt));
+      controller.enqueue(encoded.slice(splitAt));
+      controller.close();
+    },
+  }), { headers: { "content-type": "application/x-ndjson" } });
+}
+
+test("peer manifest parser preserves separate file and content hashes across streamed chunks", async () => {
+  const fileSha = "a".repeat(64);
+  const contentHash = "b".repeat(64);
+  const response = streamedResponse([
+    JSON.stringify({
+      type: "manifest",
+      namespace: "team",
+      format: "remnic-reconcile-manifest",
+      schemaVersion: 1,
+    }),
+    JSON.stringify({
+      type: "file",
+      file: {
+        path: "facts/a.md",
+        sha256: fileSha,
+        bytes: 123,
+        mtimeMs: 456,
+        memory: {
+          id: "fact-a",
+          category: "fact",
+          status: "active",
+          contentHash,
+        },
+      },
+    }),
+    JSON.stringify({
+      type: "file",
+      file: {
+        path: ".remnic\\state\\converge-cursors\\private.json",
+        sha256: "c".repeat(64),
+      },
+    }),
+  ], 37);
+
+  const manifest = await parsePeerManifestStream(response, "team");
+
+  assert.equal(manifest.files[0]?.sha256, fileSha);
+  assert.equal(manifest.files.length, 1);
+  assert.equal(manifest.files[0]?.memory?.contentHash, contentHash);
+  assert.notEqual(manifest.files[0]?.sha256, manifest.files[0]?.memory?.contentHash);
+  assert.equal(JSON.stringify(manifest).includes("memory body"), false);
+});
+
+test("peer manifest parser rejects malformed headers and raw body fields", async () => {
+  await assert.rejects(
+    parsePeerManifestStream(streamedResponse([
+      JSON.stringify({ type: "manifest", namespace: "other", format: "remnic-reconcile-manifest", schemaVersion: 1 }),
+    ], 10), "team"),
+    /malformed header/,
+  );
+  await assert.rejects(
+    parsePeerManifestStream(streamedResponse([
+      JSON.stringify({ type: "manifest", namespace: "team", format: "remnic-reconcile-manifest", schemaVersion: 1 }),
+      JSON.stringify({
+        type: "file",
+        file: { path: "facts/a.md", sha256: "a".repeat(64), content: "memory body" },
+      }),
+    ], 10), "team"),
+    /raw body/,
+  );
+});
+
+test("peer manifest transport falls back only when both route aliases are unsupported", async () => {
+  let calls = 0;
+  const unsupported: typeof fetch = async () => {
+    calls += 1;
+    return new Response(null, { status: calls === 1 ? 404 : 405 });
+  };
+  assert.equal(
+    await fetchPeerManifestStream("https://peer.example.test", "team", undefined, unsupported),
+    null,
+  );
+  assert.equal(calls, 2);
+
+  for (const status of [401, 500]) {
+    let attempts = 0;
+    await assert.rejects(
+      fetchPeerManifestStream(
+        "https://peer.example.test",
+        "team",
+        undefined,
+        async () => {
+          attempts += 1;
+          return new Response(null, { status });
+        },
+      ),
+      /peer manifest/,
+    );
+    assert.equal(attempts, 1);
+  }
+
+  let malformedAttempts = 0;
+  await assert.rejects(
+    fetchPeerManifestStream(
+      "https://peer.example.test",
+      "team",
+      undefined,
+      async () => {
+        malformedAttempts += 1;
+        return new Response("not json\n");
+      },
+    ),
+    /row was not JSON/,
+  );
+  assert.equal(malformedAttempts, 1);
+
+  let timeoutAttempts = 0;
+  await assert.rejects(
+    fetchPeerManifestStream(
+      "https://peer.example.test",
+      "team",
+      undefined,
+      async () => {
+        timeoutAttempts += 1;
+        throw new Error("request timed out");
+      },
+    ),
+    /request timed out/,
+  );
+  assert.equal(timeoutAttempts, 1);
+});

--- a/packages/remnic-cli/src/converge-peer-manifest.ts
+++ b/packages/remnic-cli/src/converge-peer-manifest.ts
@@ -1,0 +1,149 @@
+import { isInternalRemnicStatePath } from "@remnic/core";
+import {
+  RECONCILE_MANIFEST_FORMAT,
+  RECONCILE_MANIFEST_SCHEMA_VERSION,
+  type ReconcileManifest,
+  type ReconcileManifestFile,
+  type ReconcileMemoryIdentity,
+} from "@remnic/core/reconcile/manifest.js";
+import type { MemoryStatus } from "@remnic/core/types.js";
+
+const SHA256_PATTERN = /^[a-f0-9]{64}$/i;
+const MEMORY_STATUSES = new Set<MemoryStatus>([
+  "active",
+  "pending_review",
+  "rejected",
+  "quarantined",
+  "superseded",
+  "archived",
+  "forgotten",
+]);
+const BODY_FIELDS = ["body", "content", "contentBase64", "rawContent"] as const;
+
+function record(value: unknown, message: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(message);
+  return value as Record<string, unknown>;
+}
+
+function assertBodyFree(value: Record<string, unknown>, message: string): void {
+  if (BODY_FIELDS.some((field) => field in value)) throw new Error(message);
+}
+
+function optionalNonNegativeNumber(value: unknown, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`peer manifest file had invalid ${name}`);
+  }
+  return value;
+}
+
+function parseMemory(value: unknown): ReconcileMemoryIdentity | undefined {
+  if (value === undefined) return undefined;
+  const memory = record(value, "peer manifest file had malformed memory metadata");
+  assertBodyFree(memory, "peer manifest memory metadata contained a raw body");
+  if (typeof memory.id !== "string" || memory.id.length === 0) {
+    throw new Error("peer manifest memory metadata had invalid id");
+  }
+  if (typeof memory.category !== "string" || memory.category.length === 0) {
+    throw new Error("peer manifest memory metadata had invalid category");
+  }
+  if (typeof memory.contentHash !== "string" || !SHA256_PATTERN.test(memory.contentHash)) {
+    throw new Error("peer manifest memory metadata had invalid contentHash");
+  }
+  if (typeof memory.status !== "string" || !MEMORY_STATUSES.has(memory.status as MemoryStatus)) {
+    throw new Error("peer manifest memory metadata had invalid status");
+  }
+  return {
+    id: memory.id,
+    category: memory.category,
+    contentHash: memory.contentHash.toLowerCase(),
+    status: memory.status as MemoryStatus,
+  };
+}
+
+function parseFile(value: unknown): ReconcileManifestFile | undefined {
+  const file = record(value, "peer manifest row had malformed file metadata");
+  assertBodyFree(file, "peer manifest file row contained a raw body");
+  if (typeof file.path !== "string" || file.path.length === 0) {
+    throw new Error("peer manifest file had invalid path");
+  }
+  if (isInternalRemnicStatePath(file.path)) return undefined;
+  if (typeof file.sha256 !== "string" || !SHA256_PATTERN.test(file.sha256)) {
+    throw new Error("peer manifest file had invalid sha256");
+  }
+  const bytes = optionalNonNegativeNumber(file.bytes, "bytes");
+  const mtimeMs = optionalNonNegativeNumber(file.mtimeMs, "mtimeMs");
+  const memory = parseMemory(file.memory);
+  return {
+    path: file.path,
+    sha256: file.sha256.toLowerCase(),
+    ...(bytes === undefined ? {} : { bytes }),
+    ...(mtimeMs === undefined ? {} : { mtimeMs }),
+    ...(memory === undefined ? {} : { memory }),
+  };
+}
+
+async function* responseLines(response: Response): AsyncIterable<string> {
+  if (!response.body) throw new Error("peer manifest response had no body");
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let pending = "";
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      pending += decoder.decode(value, { stream: !done });
+      let newline = pending.indexOf("\n");
+      while (newline >= 0) {
+        const line = pending.slice(0, newline).replace(/\r$/, "");
+        pending = pending.slice(newline + 1);
+        if (line.trim().length > 0) yield line;
+        newline = pending.indexOf("\n");
+      }
+      if (done) break;
+    }
+    if (pending.trim().length > 0) yield pending.replace(/\r$/, "");
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export async function parsePeerManifestStream(
+  response: Response,
+  expectedNamespace: string,
+): Promise<ReconcileManifest> {
+  let headerSeen = false;
+  const files: ReconcileManifestFile[] = [];
+  for await (const line of responseLines(response)) {
+    let value: unknown;
+    try {
+      value = JSON.parse(line);
+    } catch {
+      throw new Error(`invalid peer manifest for namespace ${expectedNamespace}: row was not JSON`);
+    }
+    const row = record(value, `invalid peer manifest for namespace ${expectedNamespace}: row was not an object`);
+    assertBodyFree(row, `invalid peer manifest for namespace ${expectedNamespace}: row contained a raw body`);
+    if (!headerSeen) {
+      if (
+        row.type !== "manifest"
+        || row.namespace !== expectedNamespace
+        || row.format !== RECONCILE_MANIFEST_FORMAT
+        || row.schemaVersion !== RECONCILE_MANIFEST_SCHEMA_VERSION
+      ) {
+        throw new Error(`invalid peer manifest for namespace ${expectedNamespace}: malformed header`);
+      }
+      headerSeen = true;
+      continue;
+    }
+    if (row.type !== "file") {
+      throw new Error(`invalid peer manifest for namespace ${expectedNamespace}: malformed row type`);
+    }
+    const file = parseFile(row.file);
+    if (file) files.push(file);
+  }
+  if (!headerSeen) throw new Error(`invalid peer manifest for namespace ${expectedNamespace}: missing header`);
+  return {
+    format: RECONCILE_MANIFEST_FORMAT,
+    schemaVersion: RECONCILE_MANIFEST_SCHEMA_VERSION,
+    files,
+  };
+}

--- a/packages/remnic-cli/src/converge-peer-transport.test.ts
+++ b/packages/remnic-cli/src/converge-peer-transport.test.ts
@@ -1,0 +1,182 @@
+import * as assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { test } from "node:test";
+import { MessageChannel } from "node:worker_threads";
+import { OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES } from "@remnic/core";
+import {
+  fetchPeerSnapshot,
+  postPeerFileContent,
+  postPeerFileDeletion,
+  streamPeerFileContent,
+} from "./converge-peer-transport.js";
+
+test("peer transport canonicalizes request URLs without credentials or request-only parts", async () => {
+  let requestedUrl = "";
+  let requestSignal: AbortSignal | null | undefined;
+  await fetchPeerSnapshot(
+    " HTTPS://user:secret@PEER.EXAMPLE.COM:443/Memory/?token=abc#fragment ",
+    "default",
+    undefined,
+    async (input, init) => {
+      requestedUrl = String(input);
+      requestSignal = init?.signal;
+      return Response.json({ files: [], tombstones: [] });
+    },
+    50,
+  );
+
+  assert.equal(
+    requestedUrl,
+    "https://peer.example.com/Memory/remnic/v1/offline-sync/snapshot?namespace=default&content=false",
+  );
+  assert.ok(requestSignal instanceof AbortSignal);
+});
+
+test("peer file pull resumes the staged stream on the alias route without buffering the file", async () => {
+  const content = Buffer.from("abcdefgh");
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  const observedOffsets: number[] = [];
+  const delivered: Buffer[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = new URL(String(input));
+    const request = JSON.parse(String(init?.body)) as { offset: number };
+    observedOffsets.push(request.offset);
+    if (url.pathname.includes("/remnic/") && request.offset === 4) {
+      throw new Error("first route interrupted");
+    }
+    const chunk = content.subarray(request.offset, request.offset + 4);
+    return new Response(chunk, {
+      headers: {
+        "x-remnic-chunk-offset": String(request.offset),
+        "x-remnic-chunk-bytes": String(chunk.length),
+        "x-remnic-file-bytes": String(content.length),
+        "x-remnic-file-mtime-ms": "1234",
+        "x-remnic-file-path": encodeURIComponent("facts/a.md"),
+        "x-remnic-file-sha256": sha256,
+      },
+    });
+  };
+
+  const result = await streamPeerFileContent(
+    "http://peer",
+    "default",
+    "facts/a.md",
+    async (chunk) => {
+      delivered.push(chunk.content);
+    },
+    undefined,
+    fetchImpl,
+  );
+
+  assert.deepEqual(observedOffsets, [0, 4, 4]);
+  assert.equal(Buffer.concat(delivered).toString(), content.toString());
+  assert.deepEqual(result, { sha256, bytes: content.length, mtimeMs: 1234 });
+});
+
+test("peer file upload reads bounded chunks and resumes from the last acknowledged offset", async () => {
+  const content = Buffer.alloc(OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES + 3, 7);
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  const readOffsets: number[] = [];
+  const postedOffsets: number[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = new URL(String(input));
+    const offset = Number(new Headers(init?.headers).get("x-remnic-chunk-offset"));
+    postedOffsets.push(offset);
+    if (url.pathname.includes("/remnic/") && offset > 0) {
+      throw new Error("first route interrupted");
+    }
+    const body = Buffer.from(await new Response(init?.body).arrayBuffer());
+    return Response.json({
+      done: offset + body.length === content.length,
+      applied: offset + body.length === content.length,
+      skipped: false,
+    });
+  };
+
+  const result = await postPeerFileContent(
+    "http://peer",
+    "default",
+    "facts/a.bin",
+    {
+      sha256,
+      bytes: content.length,
+      mtimeMs: 1234,
+      readChunk: async (offset, length) => {
+        readOffsets.push(offset);
+        assert.ok(length <= OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES);
+        assert.ok(length < content.length);
+        return content.subarray(offset, offset + length);
+      },
+    },
+    undefined,
+    fetchImpl,
+  );
+
+  assert.equal(result, "applied");
+  assert.deepEqual(postedOffsets, [
+    0,
+    OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
+    OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
+  ]);
+  assert.deepEqual(readOffsets, postedOffsets);
+});
+
+test("peer transport rejects internal state paths before issuing a request", async () => {
+  let requests = 0;
+  let reads = 0;
+  const internalPath = ".remnic/state/cursor.json";
+  const fetchImpl: typeof fetch = async () => {
+    requests += 1;
+    throw new Error("must not fetch");
+  };
+
+  await assert.rejects(
+    streamPeerFileContent("http://peer", "default", internalPath, async () => {}, undefined, fetchImpl),
+    /internal Remnic state path/,
+  );
+  await assert.rejects(
+    postPeerFileContent(
+      "http://peer",
+      "default",
+      internalPath,
+      {
+        sha256: "a".repeat(64),
+        bytes: 1,
+        mtimeMs: 1,
+        readChunk: async () => {
+          reads += 1;
+          return Buffer.from("x");
+        },
+      },
+      undefined,
+      fetchImpl,
+    ),
+    /internal Remnic state path/,
+  );
+  await assert.rejects(
+    postPeerFileDeletion("http://peer", "default", internalPath, "a".repeat(64), undefined, fetchImpl),
+    /internal Remnic state path/,
+  );
+  assert.equal(requests, 0);
+  assert.equal(reads, 0);
+});
+
+test("peer transport aborts a stalled request at the configured timeout", async () => {
+  const fetchImpl: typeof fetch = async (_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+    });
+  const keepAlive = new MessageChannel();
+  keepAlive.port1.ref();
+  keepAlive.port2.ref();
+
+  try {
+    await assert.rejects(
+      fetchPeerSnapshot("http://peer", "default", undefined, fetchImpl, 1),
+      /timeout|abort/i,
+    );
+  } finally {
+    keepAlive.port1.close();
+    keepAlive.port2.close();
+  }
+});

--- a/packages/remnic-cli/src/converge-peer-transport.ts
+++ b/packages/remnic-cli/src/converge-peer-transport.ts
@@ -1,0 +1,536 @@
+import { createHash } from "node:crypto";
+import {
+  isInternalRemnicStatePath,
+  OFFLINE_SYNC_CHANGESET_FORMAT,
+  OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+  OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
+} from "@remnic/core";
+import { normalizeConvergePeerUrl } from "@remnic/core/reconcile/cursor.js";
+import type { ReconcileFileState } from "@remnic/core/reconcile/plan.js";
+import type { ReconcileManifest } from "@remnic/core/reconcile/manifest.js";
+import { parsePeerManifestStream } from "./converge-peer-manifest.js";
+
+export const DEFAULT_PEER_REQUEST_TIMEOUT_MS = 30_000;
+
+function normalizePeerBaseUrl(peerUrl: string): string {
+  const normalized = normalizeConvergePeerUrl(peerUrl);
+  const url = new URL(normalized);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`unsupported peer URL protocol: ${url.protocol}`);
+  }
+  return normalized;
+}
+
+function assertTransferablePeerPath(filePath: string): void {
+  if (isInternalRemnicStatePath(filePath)) {
+    throw new Error(`peer transport rejects internal Remnic state path: ${filePath}`);
+  }
+}
+
+async function fetchPeerRequest(
+  fetchImpl: typeof fetch,
+  input: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = init.signal
+    ? AbortSignal.any([init.signal, timeoutSignal])
+    : timeoutSignal;
+  return fetchImpl(input, { ...init, signal });
+}
+
+export interface PeerSyncCapabilities {
+  convergenceFinalization: boolean;
+  manifestStream: boolean;
+}
+
+export async function fetchPeerSyncCapabilities(
+  peerUrl: string,
+  token: string | undefined,
+  fetchImpl: typeof fetch,
+  timeoutMs: number,
+): Promise<PeerSyncCapabilities | null> {
+  const base = normalizePeerBaseUrl(peerUrl);
+  const headers: Record<string, string> = token ? { authorization: `Bearer ${token}` } : {};
+  const routes = [
+    "/remnic/v1/offline-sync/capabilities",
+    "/engram/v1/offline-sync/capabilities",
+  ];
+  for (const route of routes) {
+    const response = await fetchPeerRequest(fetchImpl, `${base}${route}`, { headers }, timeoutMs);
+    if (response.status === 404 || response.status === 405) continue;
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(`peer capability authentication failed: HTTP ${response.status}`);
+    }
+    if (!response.ok) {
+      throw new Error(`peer capability request failed: HTTP ${response.status}`);
+    }
+    const payload: unknown = await response.json().catch(() => null);
+    if (
+      !payload
+      || typeof payload !== "object"
+      || !("convergenceFinalization" in payload)
+      || typeof payload.convergenceFinalization !== "boolean"
+      || !("manifestStream" in payload)
+      || typeof payload.manifestStream !== "boolean"
+    ) {
+      throw new Error("peer capability response was malformed");
+    }
+    return {
+      convergenceFinalization: payload.convergenceFinalization,
+      manifestStream: payload.manifestStream,
+    };
+  }
+  return null;
+}
+export async function fetchPeerManifestStream(
+  peerUrl: string,
+  namespace: string,
+  token?: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+): Promise<ReconcileManifest | null> {
+  const base = normalizePeerBaseUrl(peerUrl);
+  const headers: Record<string, string> = token ? { authorization: `Bearer ${token}` } : {};
+  const routes = [
+    `/remnic/v1/offline-sync/manifest-stream?namespace=${encodeURIComponent(namespace)}&include_transcripts=false`,
+    `/engram/v1/offline-sync/manifest-stream?namespace=${encodeURIComponent(namespace)}&include_transcripts=false`,
+  ];
+  for (const route of routes) {
+    const response = await fetchPeerRequest(fetchImpl, `${base}${route}`, { headers }, timeoutMs);
+    if (response.status === 404 || response.status === 405) continue;
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(`peer manifest authentication failed: HTTP ${response.status}`);
+    }
+    if (!response.ok) throw new Error(`peer manifest request failed: HTTP ${response.status}`);
+    return parsePeerManifestStream(response, namespace);
+  }
+  return null;
+}
+
+
+export async function fetchPeerSnapshot(
+  peerUrl: string,
+  namespace: string,
+  token?: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+): Promise<{
+  files: ReconcileFileState[];
+  tombstones: Set<string>;
+}> {
+  const base = normalizePeerBaseUrl(peerUrl);
+  const routes = [
+    `/remnic/v1/offline-sync/snapshot?namespace=${encodeURIComponent(namespace)}&content=false`,
+    `/engram/v1/offline-sync/snapshot?namespace=${encodeURIComponent(namespace)}&content=false`,
+  ];
+  const headers: Record<string, string> = token ? { authorization: `Bearer ${token}` } : {};
+  let lastFailure = "no snapshot route responded";
+
+  for (const route of routes) {
+    let response: Response;
+    try {
+      response = await fetchPeerRequest(fetchImpl, `${base}${route}`, { headers }, timeoutMs);
+    } catch (error) {
+      lastFailure = error instanceof Error ? error.message : String(error);
+      continue;
+    }
+    if (!response.ok) {
+      lastFailure = `HTTP ${response.status}`;
+      continue;
+    }
+
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      throw new Error(`invalid peer snapshot for namespace ${namespace}: response was not JSON`);
+    }
+    if (!data || typeof data !== "object" || !("files" in data) || !Array.isArray(data.files)) {
+      throw new Error(`invalid peer snapshot for namespace ${namespace}: files must be an array`);
+    }
+
+    const files: ReconcileFileState[] = data.files.map((item, index) => {
+      if (
+        !item
+        || typeof item !== "object"
+        || !("path" in item)
+        || typeof item.path !== "string"
+        || !("sha256" in item)
+        || typeof item.sha256 !== "string"
+      ) {
+        throw new Error(`invalid peer snapshot for namespace ${namespace}: malformed file at index ${index}`);
+      }
+      return {
+        path: item.path,
+        sha256: item.sha256,
+        mtimeMs: "mtimeMs" in item && typeof item.mtimeMs === "number" ? item.mtimeMs : undefined,
+        bytes: "bytes" in item && typeof item.bytes === "number" ? item.bytes : undefined,
+      };
+    }).filter((file) => !isInternalRemnicStatePath(file.path));
+
+    const rawTombstones = "tombstones" in data ? data.tombstones : undefined;
+    if (rawTombstones !== undefined && !Array.isArray(rawTombstones)) {
+      throw new Error(`invalid peer snapshot for namespace ${namespace}: tombstones must be an array`);
+    }
+    const tombstones = new Set<string>();
+    for (const tombstone of rawTombstones ?? []) {
+      if (typeof tombstone !== "string" || !/^[0-9a-f]{64}$/i.test(tombstone)) {
+        throw new Error(`invalid peer snapshot for namespace ${namespace}: malformed tombstone`);
+      }
+      tombstones.add(tombstone.toLowerCase());
+    }
+    return { files, tombstones };
+  }
+
+  throw new Error(`failed to fetch peer snapshot for namespace ${namespace}: ${lastFailure}`);
+}
+
+
+export interface PeerFileContent {
+  content: Buffer;
+  sha256: string;
+  bytes: number;
+  mtimeMs: number;
+}
+
+function requiredResponseNumber(response: Response, name: string): number {
+  const raw = response.headers.get(name);
+  const value = raw === null ? Number.NaN : Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`offline file content response had invalid ${name}`);
+  }
+  return value;
+}
+
+export interface PeerFileChunk {
+  content: Buffer;
+  offset: number;
+  sha256: string;
+  bytes: number;
+  mtimeMs: number;
+}
+
+export async function streamPeerFileContent(
+  peerUrl: string,
+  namespace: string,
+  filePath: string,
+  onChunk: (chunk: PeerFileChunk) => Promise<void>,
+  token?: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+): Promise<Omit<PeerFileContent, "content"> | null> {
+  assertTransferablePeerPath(filePath);
+  const base = normalizePeerBaseUrl(peerUrl);
+  const routes = [
+    "/remnic/v1/offline-sync/file-content",
+    "/engram/v1/offline-sync/file-content",
+  ];
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+  const hash = createHash("sha256");
+  let offset = 0;
+  let expectedBytes: number | undefined;
+  let expectedSha256: string | undefined;
+  let mtimeMs: number | undefined;
+
+  for (const route of routes) {
+    let routeFailed = false;
+    do {
+      let response: Response;
+      try {
+        response = await fetchPeerRequest(fetchImpl, `${base}${route}`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            namespace,
+            includeTranscripts: false,
+            path: filePath,
+            offset,
+            length: OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+          }),
+        }, timeoutMs);
+        if (!response.ok) throw new Error(`offline file content request failed: ${response.status}`);
+      } catch {
+        routeFailed = true;
+        break;
+      }
+
+      let content: Buffer;
+      let totalBytes: number;
+      let responseMtimeMs: number;
+      let sha256: string | null;
+      try {
+        content = Buffer.from(await response.arrayBuffer());
+        const chunkOffset = requiredResponseNumber(response, "x-remnic-chunk-offset");
+        const chunkBytes = requiredResponseNumber(response, "x-remnic-chunk-bytes");
+        totalBytes = requiredResponseNumber(response, "x-remnic-file-bytes");
+        responseMtimeMs = requiredResponseNumber(response, "x-remnic-file-mtime-ms");
+        sha256 = response.headers.get("x-remnic-file-sha256");
+        const encodedPath = response.headers.get("x-remnic-file-path");
+        if (
+          !sha256
+          || chunkOffset !== offset
+          || chunkBytes !== content.length
+          || (encodedPath !== null && decodeURIComponent(encodedPath) !== filePath)
+          || (expectedBytes !== undefined && expectedBytes !== totalBytes)
+          || (expectedSha256 !== undefined && expectedSha256 !== sha256)
+          || (content.length === 0 && offset < totalBytes)
+        ) {
+          throw new Error(`offline file content response changed during transfer: ${filePath}`);
+        }
+      } catch {
+        routeFailed = true;
+        break;
+      }
+
+      expectedBytes = totalBytes;
+      expectedSha256 = sha256;
+      mtimeMs = responseMtimeMs;
+      await onChunk({
+        content,
+        offset,
+        sha256,
+        bytes: totalBytes,
+        mtimeMs: responseMtimeMs,
+      });
+      hash.update(content);
+      offset += content.length;
+    } while (expectedBytes === undefined || offset < expectedBytes);
+
+    if (!routeFailed && expectedBytes !== undefined && offset === expectedBytes) break;
+  }
+
+  if (
+    expectedBytes === undefined
+    || expectedSha256 === undefined
+    || mtimeMs === undefined
+    || offset !== expectedBytes
+    || hash.digest("hex") !== expectedSha256
+  ) {
+    return null;
+  }
+  return { sha256: expectedSha256, bytes: expectedBytes, mtimeMs };
+}
+
+export async function fetchPeerFileContent(
+  peerUrl: string,
+  namespace: string,
+  filePath: string,
+  token?: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+): Promise<PeerFileContent | null> {
+  const chunks: Buffer[] = [];
+  const metadata = await streamPeerFileContent(
+    peerUrl,
+    namespace,
+    filePath,
+    async (chunk) => {
+      chunks.push(chunk.content);
+    },
+    token,
+    fetchImpl,
+    timeoutMs,
+  );
+  if (!metadata) return null;
+  return {
+    ...metadata,
+    content: Buffer.concat(chunks, metadata.bytes),
+  };
+}
+
+
+export interface PeerFileSource {
+  sha256: string;
+  bytes: number;
+  mtimeMs: number;
+  baseSha256?: string;
+  readChunk(offset: number, length: number): Promise<Buffer>;
+}
+
+export async function postPeerFileContent(
+  peerUrl: string,
+  namespace: string,
+  filePath: string,
+  source: PeerFileSource,
+  token?: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+): Promise<"applied" | "skipped" | false> {
+  assertTransferablePeerPath(filePath);
+  const base = normalizePeerBaseUrl(peerUrl);
+  const routes = [
+    `/remnic/v1/offline-sync/apply-file-content?namespace=${encodeURIComponent(namespace)}`,
+    `/engram/v1/offline-sync/apply-file-content?namespace=${encodeURIComponent(namespace)}`,
+  ];
+  let offset = 0;
+  let previousAttemptFailed = false;
+  for (const route of routes) {
+    let restartedRoute = false;
+    while (offset < source.bytes || (source.bytes === 0 && offset === 0)) {
+      const length = Math.min(OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES, source.bytes - offset);
+      let chunk: Buffer;
+      try {
+        chunk = await source.readChunk(offset, length);
+      } catch {
+        return false;
+      }
+      if (chunk.length !== length) return false;
+      const headers: Record<string, string> = {
+        "content-type": "application/octet-stream",
+        "x-remnic-include-transcripts": "false",
+        "x-remnic-source-id": encodeURIComponent("remnic-converge"),
+        "x-remnic-file-path": encodeURIComponent(filePath),
+        "x-remnic-file-sha256": source.sha256,
+        "x-remnic-file-bytes": String(source.bytes),
+        "x-remnic-file-mtime-ms": String(source.mtimeMs),
+        "x-remnic-chunk-offset": String(offset),
+        ...(source.baseSha256 ? { "x-remnic-base-sha256": source.baseSha256 } : {}),
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      };
+      let response: Response;
+      try {
+        response = await fetchPeerRequest(fetchImpl, `${base}${route}`, {
+          method: "POST",
+          headers,
+          body: new Uint8Array(chunk),
+        }, timeoutMs);
+        if (!response.ok) throw new Error(`offline apply-file-content request failed: ${response.status}`);
+      } catch {
+        if (previousAttemptFailed && offset > 0 && !restartedRoute) {
+          offset = 0;
+          restartedRoute = true;
+          continue;
+        }
+        previousAttemptFailed = true;
+        break;
+      }
+      const result: unknown = await response.json().catch(() => null);
+      if (
+        !result
+        || typeof result !== "object"
+        || !("done" in result)
+        || typeof result.done !== "boolean"
+        || !("applied" in result)
+        || typeof result.applied !== "boolean"
+        || !("skipped" in result)
+        || typeof result.skipped !== "boolean"
+        || ("conflict" in result && result.conflict)
+      ) {
+        return false;
+      }
+      if (result.done) {
+        if (result.skipped) return previousAttemptFailed ? "applied" : "skipped";
+        return result.applied && offset + chunk.length === source.bytes ? "applied" : false;
+      }
+      if (result.applied || result.skipped || chunk.length === 0) return false;
+      offset += chunk.length;
+    }
+  }
+  return false;
+}
+
+export async function postPeerConvergenceComplete(
+  peerUrl: string,
+  namespaces: readonly string[],
+  token?: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+): Promise<boolean> {
+  const base = normalizePeerBaseUrl(peerUrl);
+  const query = namespaces
+    .map((namespace) => `namespace=${encodeURIComponent(namespace)}`)
+    .join("&");
+  const routes = [
+    "/remnic/v1/offline-sync/convergence-complete",
+    "/engram/v1/offline-sync/convergence-complete",
+  ];
+  for (const route of routes) {
+    const response = await fetchPeerRequest(fetchImpl, `${base}${route}?${query}`, {
+      method: "POST",
+      headers: {
+        "x-remnic-source-id": encodeURIComponent("remnic-converge"),
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+    }, timeoutMs).catch(() => null);
+    if (!response?.ok) continue;
+    const result: unknown = await response.json().catch(() => null);
+    if (
+      result
+      && typeof result === "object"
+      && "namespaces" in result
+      && Array.isArray(result.namespaces)
+      && result.namespaces.length === namespaces.length
+      && result.namespaces.every((namespace, index) => namespace === namespaces[index])
+      && "refreshed" in result
+      && result.refreshed === true
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function postPeerFileDeletion(
+  peerUrl: string,
+  namespace: string,
+  filePath: string,
+  baseSha256: string,
+  token?: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+): Promise<"applied" | "skipped" | false> {
+  assertTransferablePeerPath(filePath);
+  const base = normalizePeerBaseUrl(peerUrl);
+  const routes = ["/remnic/v1/offline-sync/apply", "/engram/v1/offline-sync/apply"];
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+  let previousAttemptFailed = false;
+  for (const route of routes) {
+    try {
+      const response = await fetchPeerRequest(fetchImpl, `${base}${route}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          namespace,
+          changeset: {
+            format: OFFLINE_SYNC_CHANGESET_FORMAT,
+            schemaVersion: 1,
+            createdAt: new Date().toISOString(),
+            sourceId: "remnic-converge",
+            includeTranscripts: false,
+            changes: [{ type: "delete", path: filePath, baseSha256 }],
+          },
+        }),
+      }, timeoutMs);
+      if (!response.ok) throw new Error(`offline apply request failed: ${response.status}`);
+      const result: unknown = await response.json().catch(() => null);
+      if (
+        !result
+        || typeof result !== "object"
+        || !("appliedDeletes" in result)
+        || typeof result.appliedDeletes !== "number"
+        || !("skipped" in result)
+        || typeof result.skipped !== "number"
+        || !("conflicts" in result)
+        || !Array.isArray(result.conflicts)
+        || result.conflicts.length > 0
+      ) {
+        return false;
+      }
+      if (result.appliedDeletes === 1) return "applied";
+      if (result.skipped === 1) return previousAttemptFailed ? "applied" : "skipped";
+      return false;
+    } catch {
+      previousAttemptFailed = true;
+    }
+  }
+  return false;
+}
+

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -172,6 +172,101 @@ test("remnic converge plan: validates a namespace present only in provided base 
   );
 });
 
+test("remnic converge plan: enumerates durable cursor-only namespaces before peer census", async () => {
+  const cursorDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-cursor-only-"));
+  const peerUrl = "https://peer.example.com/Memory";
+  try {
+    await writeConvergeCursor(defaultConvergeCursorPath(cursorDir, peerUrl, "archived"), {
+      version: 1,
+      peerUrl,
+      namespace: "archived",
+      baseFiles: [],
+    });
+    const requestedNamespaces: string[] = [];
+    await computeConvergePlan({
+      cursorDir,
+      peerUrl,
+      localFilesByNamespace: new Map([["default", []]]),
+      fetchImpl: async (input) => {
+        const url = new URL(String(input));
+        if (url.pathname.endsWith("/offline-sync/capabilities")) {
+          return new Response(null, { status: 404 });
+        }
+        requestedNamespaces.push(url.searchParams.get("namespace") ?? "");
+        return Response.json({ files: [], tombstones: [] });
+      },
+    });
+    assert.deepEqual(requestedNamespaces.sort(), ["archived", "default"]);
+  } finally {
+    await fs.rm(cursorDir, { recursive: true, force: true });
+  }
+});
+
+test("remnic converge plan: fails closed on malformed durable cursor state", async () => {
+  const cursorDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-bad-cursor-"));
+  try {
+    const directory = path.join(cursorDir, ".remnic", "state", "converge-cursors");
+    await fs.mkdir(directory, { recursive: true });
+    await fs.writeFile(path.join(directory, "broken.json"), "{not-json");
+    await assert.rejects(
+      computeConvergePlan({
+        cursorDir,
+        peerUrl: "http://peer",
+        localFilesByNamespace: new Map([["default", []]]),
+        fetchImpl: async () => Response.json({ files: [], tombstones: [] }),
+      }),
+      /invalid converge cursor/,
+    );
+  } finally {
+    await fs.rm(cursorDir, { recursive: true, force: true });
+  }
+});
+
+test("remnic converge plan: maps peer tombstone content hashes through the manifest file identity", async () => {
+  const contentHash = "c".repeat(64);
+  const memoryContent = Buffer.from(
+    `---\nid: mem-1\ncategory: fact\ncontentHash: ${contentHash}\nstatus: active\n---\nRetired fact\n`,
+  );
+  const memorySha = createHash("sha256").update(memoryContent).digest("hex");
+  const tombstoneContent = Buffer.from(`${JSON.stringify({ contentHash })}\n`);
+  const tombstoneSha = createHash("sha256").update(tombstoneContent).digest("hex");
+  const files = [
+    { path: "facts/retracted.md", sha256: memorySha, bytes: memoryContent.length, mtimeMs: 1 },
+    { path: "state/tombstones.jsonl", sha256: tombstoneSha, bytes: tombstoneContent.length, mtimeMs: 1 },
+  ];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname.endsWith("/offline-sync/capabilities")) {
+      return new Response(null, { status: 404 });
+    }
+    if (url.pathname.endsWith("/offline-sync/snapshot")) {
+      return Response.json({ files, tombstones: [] });
+    }
+    const request = JSON.parse(String(init?.body)) as { path: string; offset: number };
+    const content = request.path === "state/tombstones.jsonl" ? tombstoneContent : memoryContent;
+    const sha256 = request.path === "state/tombstones.jsonl" ? tombstoneSha : memorySha;
+    return new Response(content.subarray(request.offset), {
+      headers: {
+        "x-remnic-chunk-offset": String(request.offset),
+        "x-remnic-chunk-bytes": String(content.length - request.offset),
+        "x-remnic-file-bytes": String(content.length),
+        "x-remnic-file-mtime-ms": "1",
+        "x-remnic-file-path": encodeURIComponent(request.path),
+        "x-remnic-file-sha256": sha256,
+      },
+    });
+  };
+
+  const plan = await computeConvergePlan({
+    peerUrl: "http://peer",
+    localFilesByNamespace: new Map([["default", [files[0]!]]]),
+    fetchImpl,
+  });
+  const suppression = plan.entries.find((entry) => entry.path === "facts/retracted.md");
+  assert.equal(suppression?.action, "suppress");
+  assert.equal(suppression?.suppressSide, "both");
+});
+
 test("remnic converge apply: converged state returns immediate no-op and updates cursor", async () => {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-apply-test-"));
   try {
@@ -220,11 +315,33 @@ test("remnic converge apply: converged dry-run does not write cursor", async () 
     });
 
     assert.equal(result.status, "dry_run");
+    assert.equal(result.converged, true);
     assert.equal(result.cursorUpdated, false);
     assert.equal(await readConvergeCursor(cursorPath), null);
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }
+});
+
+test("remnic converge apply: tombstone suppression deletes the retracted revision on both sides", async () => {
+  const filePath = "facts/retracted.md";
+  const content = Buffer.from("retracted");
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  const localBuffers = new Map([["default", new Map([[filePath, content]])]]);
+  const peerBuffers = new Map([["default", new Map([[filePath, content]])]]);
+
+  const result = await executeConvergeApply({
+    localFilesByNamespace: new Map([["default", [{ path: filePath, sha256 }]]]),
+    peerFilesByNamespace: new Map([["default", [{ path: filePath, sha256 }]]]),
+    localTombstonesByNamespace: new Map([["default", [sha256]]]),
+    localFileBuffers: localBuffers,
+    peerFileBuffers: peerBuffers,
+  });
+
+  assert.equal(result.transfers.suppressed, 1);
+  assert.equal(result.transfers.failed, 0);
+  assert.equal(localBuffers.get("default")?.has(filePath), false);
+  assert.equal(peerBuffers.get("default")?.has(filePath), false);
 });
 
 test("remnic converge apply: manual conflict policy stops mutation on unresolved conflicts", async () => {
@@ -526,7 +643,10 @@ test("remnic converge apply: a newer local deletion uses the guarded remote dele
 });
 
 test("remnic converge plan: fails closed when the peer census cannot be fetched", async () => {
-  const fetchImpl: typeof fetch = async () => new Response(null, { status: 503 });
+  const fetchImpl: typeof fetch = async (input) =>
+    String(input).includes("/offline-sync/capabilities")
+      ? new Response(null, { status: 404 })
+      : new Response(null, { status: 503 });
 
   await assert.rejects(
     computeConvergePlan({
@@ -539,8 +659,10 @@ test("remnic converge plan: fails closed when the peer census cannot be fetched"
 });
 
 test("remnic converge plan: rejects malformed peer census records", async () => {
-  const fetchImpl: typeof fetch = async () =>
-    Response.json({ files: [{ path: "facts/incomplete.md" }], tombstones: [] });
+  const fetchImpl: typeof fetch = async (input) =>
+    String(input).includes("/offline-sync/capabilities")
+      ? new Response(null, { status: 404 })
+      : Response.json({ files: [{ path: "facts/incomplete.md" }], tombstones: [] });
 
   await assert.rejects(
     computeConvergePlan({
@@ -887,6 +1009,177 @@ test("remnic converge retains per-side semantic state across a later metadata ed
     await fs.rm(cursorDir, { recursive: true, force: true });
   }
 });
+test("remnic converge consumes peer manifests without per-fact content requests", async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-stream-manifest-"));
+  try {
+    const body = "same streamed fact";
+    const semanticHash = ContentHashIndex.computeHash(body);
+    const memory = (id: string): string => [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      `contentHash: ${semanticHash}`,
+      "status: active",
+      "---",
+      body,
+    ].join("\n");
+    const localContent = memory("local-id");
+    const peerContent = memory("peer-id");
+    const peerSha = createHash("sha256").update(peerContent).digest("hex");
+    await fs.mkdir(path.join(rootDir, "facts"), { recursive: true });
+    await fs.writeFile(path.join(rootDir, "facts/local-id.md"), localContent);
+    let peerContentRequests = 0;
+    let manifestRequests = 0;
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/offline-sync/capabilities")) {
+        return Response.json({ version: 1, convergenceFinalization: true, manifestStream: true });
+      }
+      if (url.pathname.endsWith("/offline-sync/snapshot")) {
+        const files = url.searchParams.get("namespace") === "default"
+          ? [{ path: "facts/peer-id.md", sha256: peerSha, bytes: peerContent.length, mtimeMs: 2000 }]
+          : [];
+        return Response.json({ files, tombstones: [] });
+      }
+      if (url.pathname.endsWith("/offline-sync/manifest-stream")) {
+        manifestRequests += 1;
+        const namespace = url.searchParams.get("namespace");
+        const rows = [JSON.stringify({
+          type: "manifest",
+          namespace,
+          format: "remnic-reconcile-manifest",
+          schemaVersion: 1,
+        })];
+        if (namespace === "default") {
+          rows.push(JSON.stringify({
+            type: "file",
+            file: {
+              path: "facts/peer-id.md",
+              sha256: peerSha,
+              bytes: peerContent.length,
+              mtimeMs: 2000,
+              memory: {
+                id: "peer-id",
+                category: "fact",
+                contentHash: semanticHash,
+                status: "active",
+              },
+            },
+          }));
+        }
+        return new Response([...rows, ""].join("\n"));
+      }
+      if (url.pathname.endsWith("/offline-sync/file-content")) peerContentRequests += 1;
+      return new Response(null, { status: 404 });
+    };
+
+    const plan = await computeConvergePlan({
+      config: parseConfig({ memoryDir: rootDir }),
+      peerUrl: "https://peer.example.test",
+      fetchImpl,
+    });
+
+    assert.equal(manifestRequests, 2);
+    assert.equal(peerContentRequests, 0);
+    assert.equal(plan.converged, true, JSON.stringify(plan));
+    assert.equal(plan.entries[0]?.reason, "semantic_duplicate");
+  } finally {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("remnic converge falls back to per-fact content only for an older peer", async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-legacy-manifest-"));
+  try {
+    const body = "same legacy peer fact";
+    const semanticHash = ContentHashIndex.computeHash(body);
+    const memory = (id: string): string => [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      `contentHash: ${semanticHash}`,
+      "status: active",
+      "---",
+      body,
+    ].join("\n");
+    const localContent = memory("local-id");
+    const peerContent = memory("peer-id");
+    const peerSha = createHash("sha256").update(peerContent).digest("hex");
+    await fs.mkdir(path.join(rootDir, "facts"), { recursive: true });
+    await fs.writeFile(path.join(rootDir, "facts/local-id.md"), localContent);
+    let peerContentRequests = 0;
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/offline-sync/capabilities")) {
+        return new Response(null, { status: 404 });
+      }
+      if (url.pathname.endsWith("/offline-sync/snapshot")) {
+        const files = url.searchParams.get("namespace") === "default"
+          ? [{ path: "facts/peer-id.md", sha256: peerSha, bytes: peerContent.length, mtimeMs: 2000 }]
+          : [];
+        return Response.json({ files, tombstones: [] });
+      }
+      if (url.pathname.endsWith("/offline-sync/file-content")) {
+        peerContentRequests += 1;
+        return new Response(peerContent, {
+          headers: {
+            "x-remnic-file-path": encodeURIComponent("facts/peer-id.md"),
+            "x-remnic-file-sha256": peerSha,
+            "x-remnic-file-bytes": String(peerContent.length),
+            "x-remnic-file-mtime-ms": "2000",
+            "x-remnic-chunk-offset": "0",
+            "x-remnic-chunk-bytes": String(peerContent.length),
+          },
+        });
+      }
+      return new Response(null, { status: 404 });
+    };
+
+    const plan = await computeConvergePlan({
+      config: parseConfig({ memoryDir: rootDir }),
+      peerUrl: "https://older-peer.example.test",
+      fetchImpl,
+    });
+
+    assert.equal(peerContentRequests, 1);
+    assert.equal(plan.converged, true, JSON.stringify(plan));
+    assert.equal(plan.entries[0]?.reason, "semantic_duplicate");
+  } finally {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("remnic converge does not hide legacy manifest content failures", async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-legacy-failure-"));
+  try {
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/offline-sync/capabilities")) {
+        return new Response(null, { status: 404 });
+      }
+      if (url.pathname.endsWith("/offline-sync/snapshot")) {
+        return Response.json({
+          files: [{ path: "facts/peer-id.md", sha256: "a".repeat(64), bytes: 10, mtimeMs: 2000 }],
+          tombstones: [],
+        });
+      }
+      if (url.pathname.endsWith("/offline-sync/file-content")) throw new Error("request timed out");
+      return new Response(null, { status: 404 });
+    };
+
+    await assert.rejects(
+      computeConvergePlan({
+        config: parseConfig({ memoryDir: rootDir }),
+        peerUrl: "https://older-peer.example.test",
+        fetchImpl,
+      }),
+      /failed to read peer reconciliation manifest file: facts\/peer-id\.md/,
+    );
+  } finally {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  }
+});
+
 
 test("remnic converge plan reuses unchanged shared peer semantics to collapse cross-path duplicates", async () => {
   const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-shared-manifest-"));
@@ -1199,4 +1492,51 @@ test("remnic converge apply: a failed peer refresh prevents convergence and curs
   assert.equal(result.converged, false);
   assert.equal(result.cursorUpdated, false);
   assert.equal(finalizeCalls, 2);
+});
+
+test("remnic converge apply: durable cursor state is excluded and a clean second run performs no file transport", async () => {
+  const memoryDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-clean-rerun-"));
+  const peerUrl = "http://peer";
+  const filePath = "assets/a.bin";
+  const content = Buffer.from("stable");
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  try {
+    await fs.mkdir(path.join(memoryDir, "assets"), { recursive: true });
+    await fs.writeFile(path.join(memoryDir, filePath), content);
+    await executeConvergeApply({
+      cursorDir: memoryDir,
+      peerUrl,
+      localFilesByNamespace: new Map([["default", [{ path: filePath, sha256 }]]]),
+      peerFilesByNamespace: new Map([["default", [{ path: filePath, sha256 }]]]),
+    });
+
+    let fileTransportCalls = 0;
+    const result = await executeConvergeApply({
+      config: parseConfig({ memoryDir }),
+      peerUrl,
+      fetchImpl: async (input) => {
+        const url = new URL(String(input));
+        if (url.pathname.endsWith("/offline-sync/capabilities")) {
+          return new Response(null, { status: 404 });
+        }
+        if (url.pathname.endsWith("/offline-sync/snapshot")) {
+          const files = url.searchParams.get("namespace") === "default"
+            ? [
+                { path: filePath, sha256, bytes: content.length, mtimeMs: 1 },
+                { path: ".remnic/state/converge-cursors/host.json", sha256: shaA, bytes: 1, mtimeMs: 1 },
+              ]
+            : [];
+          return Response.json({ files, tombstones: [] });
+        }
+        fileTransportCalls += 1;
+        throw new Error(`unexpected file transport: ${url.pathname}`);
+      },
+    });
+
+    assert.equal(result.converged, true);
+    assert.equal(fileTransportCalls, 0);
+    assert.equal(result.plan.entries.some((entry) => entry.path.startsWith(".remnic/")), false);
+  } finally {
+    await fs.rm(memoryDir, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -8,11 +8,11 @@ import {
   parseConfig,
   type ResolveSecretRefFn,
   buildOfflineSyncSnapshotFromBase,
-  OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
-  OFFLINE_SYNC_CHANGESET_FORMAT,
-  OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
   applyOfflineSyncFileContentChunk,
+  isInternalRemnicStatePath,
+  OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
 } from "@remnic/core";
+import { parseFrontmatter } from "@remnic/core/storage.js";
 import type { ConvergeConflictPolicy } from "@remnic/core/types.js";
 import { resolveCorpusNamespaceRoots } from "@remnic/core/corpus-watermark.js";
 import { listNamespaces } from "@remnic/core/namespaces/migrate.js";
@@ -29,6 +29,7 @@ import {
   readConvergeCursor,
   writeConvergeCursor,
   type ConvergeCursorState,
+  normalizeConvergePeerUrl,
 } from "@remnic/core/reconcile/cursor.js";
 import {
   buildReconcileManifest,
@@ -37,6 +38,20 @@ import {
 } from "@remnic/core/reconcile/manifest.js";
 import { createOfflineStorageIo } from "./offline-storage-io.js";
 import { resolveAgentAccessAuthToken } from "@remnic/core/resolve-auth-token.js";
+import {
+  DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+  fetchPeerFileContent,
+  fetchPeerManifestStream,
+  fetchPeerSyncCapabilities,
+  fetchPeerSnapshot,
+  postPeerConvergenceComplete,
+  postPeerFileContent,
+  postPeerFileDeletion,
+  streamPeerFileContent,
+  type PeerFileContent,
+  type PeerFileChunk,
+  type PeerFileSource,
+} from "./converge-peer-transport.js";
 export interface ConvergePlanOptions {
   config?: PluginConfig;
   peerUrl?: string;
@@ -44,6 +59,7 @@ export interface ConvergePlanOptions {
   cursorDir?: string;
   conflictPolicy?: ConvergeConflictPolicy;
   fetchImpl?: typeof fetch;
+  peerRequestTimeoutMs?: number;
   resolveSecretRef?: ResolveSecretRefFn;
   baseFilesByNamespace?: Map<string, ReconcileFileState[]>;
   semanticAgreementsByNamespace?: Map<string, ReconcileSemanticAgreement[]>;
@@ -76,390 +92,84 @@ export interface ConvergeApplyResult {
   cursorUpdated: boolean;
 }
 
-async function readLocalTombstones(rootDir: string): Promise<Set<string>> {
-  const shaSet = new Set<string>();
-  const candidates = [
-    path.join(rootDir, "state", "tombstones.jsonl"),
-    path.join(rootDir, "tombstones.jsonl"),
-  ];
-  for (const tombPath of candidates) {
-    try {
-      const content = await fs.promises.readFile(tombPath, "utf-8");
-      for (const line of content.split("\n")) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-        try {
-          const record = JSON.parse(trimmed) as { contentHash?: unknown; fileSha256?: unknown };
-          if (typeof record.contentHash === "string" && /^[0-9a-f]{64}$/i.test(record.contentHash)) {
-            shaSet.add(record.contentHash.toLowerCase());
-          }
-          if (typeof record.fileSha256 === "string" && /^[0-9a-f]{64}$/i.test(record.fileSha256)) {
-            shaSet.add(record.fileSha256.toLowerCase());
-          }
-        } catch {
-          // ignore unparseable line
-        }
-      }
-    } catch {
-      // file does not exist
-    }
-  }
-  return shaSet;
+interface TombstoneEvidence {
+  contentHashes: Set<string>;
+  fileSha256: Set<string>;
 }
 
-async function fetchPeerSnapshot(
-  peerUrl: string,
-  namespace: string,
-  token?: string,
-  fetchImpl: typeof fetch = globalThis.fetch,
-): Promise<{ files: ReconcileFileState[]; tombstones: Set<string> }> {
-  let base = peerUrl;
-  while (base.endsWith("/")) {
-    base = base.slice(0, -1);
-  }
-  const routes = [
-    `/remnic/v1/offline-sync/snapshot?namespace=${encodeURIComponent(namespace)}&content=false`,
-    `/engram/v1/offline-sync/snapshot?namespace=${encodeURIComponent(namespace)}&content=false`,
-  ];
-  const headers: Record<string, string> = token ? { authorization: `Bearer ${token}` } : {};
-  let lastFailure = "no snapshot route responded";
+const TOMBSTONE_PATHS = ["state/tombstones.jsonl", "tombstones.jsonl"] as const;
 
-  for (const route of routes) {
-    let response: Response;
+function parseTombstoneEvidence(content: string): TombstoneEvidence {
+  const contentHashes = new Set<string>();
+  const fileSha256 = new Set<string>();
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
     try {
-      response = await fetchImpl(`${base}${route}`, { headers });
+      const record = JSON.parse(trimmed) as { contentHash?: unknown; fileSha256?: unknown };
+      if (typeof record.contentHash === "string" && /^[0-9a-f]{64}$/i.test(record.contentHash)) {
+        contentHashes.add(record.contentHash.toLowerCase());
+      }
+      if (typeof record.fileSha256 === "string" && /^[0-9a-f]{64}$/i.test(record.fileSha256)) {
+        fileSha256.add(record.fileSha256.toLowerCase());
+      }
+    } catch {
+      continue;
+    }
+  }
+  return { contentHashes, fileSha256 };
+}
+
+function tombstonedFileDigests(
+  evidence: TombstoneEvidence,
+  manifest: ReconcileManifest | undefined,
+): Set<string> {
+  const result = new Set(evidence.fileSha256);
+  for (const file of manifest?.files ?? []) {
+    if (file.memory && evidence.contentHashes.has(file.memory.contentHash.toLowerCase())) {
+      result.add(file.sha256.toLowerCase());
+    }
+  }
+  return result;
+}
+
+async function readLocalTombstoneEvidence(rootDir: string): Promise<TombstoneEvidence> {
+  const merged: TombstoneEvidence = { contentHashes: new Set(), fileSha256: new Set() };
+  for (const relativePath of TOMBSTONE_PATHS) {
+    let content: string;
+    try {
+      content = await fs.promises.readFile(path.join(rootDir, relativePath), "utf-8");
     } catch (error) {
-      lastFailure = error instanceof Error ? error.message : String(error);
-      continue;
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw error;
     }
-    if (!response.ok) {
-      lastFailure = `HTTP ${response.status}`;
-      continue;
-    }
-
-    let data: unknown;
-    try {
-      data = await response.json();
-    } catch {
-      throw new Error(`invalid peer snapshot for namespace ${namespace}: response was not JSON`);
-    }
-    if (!data || typeof data !== "object" || !("files" in data) || !Array.isArray(data.files)) {
-      throw new Error(`invalid peer snapshot for namespace ${namespace}: files must be an array`);
-    }
-
-    const files: ReconcileFileState[] = data.files.map((item, index) => {
-      if (
-        !item
-        || typeof item !== "object"
-        || !("path" in item)
-        || typeof item.path !== "string"
-        || !("sha256" in item)
-        || typeof item.sha256 !== "string"
-      ) {
-        throw new Error(`invalid peer snapshot for namespace ${namespace}: malformed file at index ${index}`);
-      }
-      return {
-        path: item.path,
-        sha256: item.sha256,
-        mtimeMs: "mtimeMs" in item && typeof item.mtimeMs === "number" ? item.mtimeMs : undefined,
-        bytes: "bytes" in item && typeof item.bytes === "number" ? item.bytes : undefined,
-      };
-    });
-
-    const rawTombstones = "tombstones" in data ? data.tombstones : undefined;
-    if (rawTombstones !== undefined && !Array.isArray(rawTombstones)) {
-      throw new Error(`invalid peer snapshot for namespace ${namespace}: tombstones must be an array`);
-    }
-    const tombstones = new Set<string>();
-    for (const tombstone of rawTombstones ?? []) {
-      if (typeof tombstone !== "string" || !/^[0-9a-f]{64}$/i.test(tombstone)) {
-        throw new Error(`invalid peer snapshot for namespace ${namespace}: malformed tombstone`);
-      }
-      tombstones.add(tombstone.toLowerCase());
-    }
-    return { files, tombstones };
+    const parsed = parseTombstoneEvidence(content);
+    for (const value of parsed.contentHashes) merged.contentHashes.add(value);
+    for (const value of parsed.fileSha256) merged.fileSha256.add(value);
   }
-
-  throw new Error(`failed to fetch peer snapshot for namespace ${namespace}: ${lastFailure}`);
+  return merged;
 }
 
-interface PeerFileContent {
-  content: Buffer;
-  sha256: string;
-  bytes: number;
-  mtimeMs: number;
-}
-
-function requiredResponseNumber(response: Response, name: string): number {
-  const raw = response.headers.get(name);
-  const value = raw === null ? Number.NaN : Number(raw);
-  if (!Number.isFinite(value) || value < 0) {
-    throw new Error(`offline file content response had invalid ${name}`);
+async function discoverCursorNamespaces(memoryDir: string, peerUrl: string): Promise<string[]> {
+  const cursorDir = path.join(path.resolve(memoryDir), ".remnic", "state", "converge-cursors");
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(cursorDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
   }
-  return value;
-}
-
-async function fetchPeerFileContent(
-  peerUrl: string,
-  namespace: string,
-  filePath: string,
-  token?: string,
-  fetchImpl: typeof fetch = globalThis.fetch,
-): Promise<PeerFileContent | null> {
-  const base = peerUrl.replace(/\/+$/, "");
-  const routes = [
-    "/remnic/v1/offline-sync/file-content",
-    "/engram/v1/offline-sync/file-content",
-  ];
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-    ...(token ? { authorization: `Bearer ${token}` } : {}),
-  };
-  for (const route of routes) {
-    try {
-      const chunks: Buffer[] = [];
-      const hash = createHash("sha256");
-      let offset = 0;
-      let expectedBytes: number | undefined;
-      let expectedSha256: string | undefined;
-      let mtimeMs: number | undefined;
-      do {
-        const response = await fetchImpl(`${base}${route}`, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            namespace,
-            includeTranscripts: false,
-            path: filePath,
-            offset,
-            length: OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
-          }),
-        });
-        if (!response.ok) throw new Error(`offline file content request failed: ${response.status}`);
-        const content = Buffer.from(await response.arrayBuffer());
-        const chunkOffset = requiredResponseNumber(response, "x-remnic-chunk-offset");
-        const chunkBytes = requiredResponseNumber(response, "x-remnic-chunk-bytes");
-        const totalBytes = requiredResponseNumber(response, "x-remnic-file-bytes");
-        const responseMtimeMs = requiredResponseNumber(response, "x-remnic-file-mtime-ms");
-        const sha256 = response.headers.get("x-remnic-file-sha256");
-        const encodedPath = response.headers.get("x-remnic-file-path");
-        if (
-          !sha256
-          || chunkOffset !== offset
-          || chunkBytes !== content.length
-          || (encodedPath !== null && decodeURIComponent(encodedPath) !== filePath)
-          || (expectedBytes !== undefined && expectedBytes !== totalBytes)
-          || (expectedSha256 !== undefined && expectedSha256 !== sha256)
-        ) {
-          throw new Error(`offline file content response changed during transfer: ${filePath}`);
-        }
-        if (content.length === 0 && offset < totalBytes) {
-          throw new Error(`offline file content chunk was empty before EOF: ${filePath}`);
-        }
-        expectedBytes = totalBytes;
-        expectedSha256 = sha256;
-        mtimeMs = responseMtimeMs;
-        chunks.push(content);
-        hash.update(content);
-        offset += content.length;
-      } while (expectedBytes === undefined || offset < expectedBytes);
-      if (
-        expectedBytes === undefined
-        || expectedSha256 === undefined
-        || mtimeMs === undefined
-        || offset !== expectedBytes
-        || hash.digest("hex") !== expectedSha256
-      ) {
-        throw new Error(`offline file content checksum mismatch: ${filePath}`);
-      }
-      return {
-        content: Buffer.concat(chunks, expectedBytes),
-        sha256: expectedSha256,
-        bytes: expectedBytes,
-        mtimeMs,
-      };
-    } catch {
-      // try next route
-    }
+  const namespaces = new Set<string>();
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const cursor = await readConvergeCursor(path.join(cursorDir, entry.name));
+    if (!cursor) throw new Error(`invalid converge cursor: ${entry.name}`);
+    if (path.basename(defaultConvergeCursorPath(memoryDir, peerUrl, cursor.namespace)) !== entry.name) continue;
+    namespaces.add(cursor.namespace);
   }
-  return null;
+  return [...namespaces].sort();
 }
 
-function withoutTrailingSlashes(value: string): string {
-  let end = value.length;
-  while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
-  return value.slice(0, end);
-}
-
-async function postPeerFileContent(
-  peerUrl: string,
-  namespace: string,
-  filePath: string,
-  content: Buffer,
-  metadata: { sha256: string; mtimeMs: number; baseSha256?: string },
-  token?: string,
-  fetchImpl: typeof fetch = globalThis.fetch,
-): Promise<"applied" | "skipped" | false> {
-  const base = withoutTrailingSlashes(peerUrl);
-  const routes = [
-    `/remnic/v1/offline-sync/apply-file-content?namespace=${encodeURIComponent(namespace)}`,
-    `/engram/v1/offline-sync/apply-file-content?namespace=${encodeURIComponent(namespace)}`,
-  ];
-  let previousAttemptFailed = false;
-  for (const route of routes) {
-    try {
-      let offset = 0;
-      do {
-        const chunk = content.subarray(
-          offset,
-          Math.min(content.length, offset + OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES),
-        );
-        const headers: Record<string, string> = {
-          "content-type": "application/octet-stream",
-          "x-remnic-include-transcripts": "false",
-          "x-remnic-source-id": encodeURIComponent("remnic-converge"),
-          "x-remnic-file-path": encodeURIComponent(filePath),
-          "x-remnic-file-sha256": metadata.sha256,
-          "x-remnic-file-bytes": String(content.length),
-          "x-remnic-file-mtime-ms": String(metadata.mtimeMs),
-          "x-remnic-chunk-offset": String(offset),
-          ...(metadata.baseSha256 ? { "x-remnic-base-sha256": metadata.baseSha256 } : {}),
-          ...(token ? { authorization: `Bearer ${token}` } : {}),
-        };
-        const response = await fetchImpl(`${base}${route}`, {
-          method: "POST",
-          headers,
-          body: new Uint8Array(chunk),
-        });
-        if (!response.ok) throw new Error(`offline apply-file-content request failed: ${response.status}`);
-        const result: unknown = await response.json().catch(() => null);
-        if (
-          !result
-          || typeof result !== "object"
-          || !("done" in result)
-          || typeof result.done !== "boolean"
-          || !("applied" in result)
-          || typeof result.applied !== "boolean"
-          || !("skipped" in result)
-          || typeof result.skipped !== "boolean"
-          || ("conflict" in result && result.conflict)
-        ) {
-          return false;
-        }
-        if (result.done) {
-          if (result.skipped) return previousAttemptFailed ? "applied" : "skipped";
-          if (result.applied && offset + chunk.length === content.length) return "applied";
-          return false;
-        }
-        if (result.applied || result.skipped || chunk.length === 0) {
-          return false;
-        }
-        offset += chunk.length;
-      } while (offset < content.length);
-      return false;
-    } catch {
-      previousAttemptFailed = true;
-    }
-  }
-  return false;
-}
-
-async function postPeerConvergenceComplete(
-  peerUrl: string,
-  namespaces: readonly string[],
-  token?: string,
-  fetchImpl: typeof fetch = globalThis.fetch,
-): Promise<boolean> {
-  const base = withoutTrailingSlashes(peerUrl);
-  const query = namespaces
-    .map((namespace) => `namespace=${encodeURIComponent(namespace)}`)
-    .join("&");
-  const routes = [
-    "/remnic/v1/offline-sync/convergence-complete",
-    "/engram/v1/offline-sync/convergence-complete",
-  ];
-  for (const route of routes) {
-    const response = await fetchImpl(`${base}${route}?${query}`, {
-      method: "POST",
-      headers: {
-        "x-remnic-source-id": encodeURIComponent("remnic-converge"),
-        ...(token ? { authorization: `Bearer ${token}` } : {}),
-      },
-    }).catch(() => null);
-    if (!response?.ok) continue;
-    const result: unknown = await response.json().catch(() => null);
-    if (
-      result
-      && typeof result === "object"
-      && "namespaces" in result
-      && Array.isArray(result.namespaces)
-      && result.namespaces.length === namespaces.length
-      && result.namespaces.every((namespace, index) => namespace === namespaces[index])
-      && "refreshed" in result
-      && result.refreshed === true
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-async function postPeerFileDeletion(
-  peerUrl: string,
-  namespace: string,
-  filePath: string,
-  baseSha256: string,
-  token?: string,
-  fetchImpl: typeof fetch = globalThis.fetch,
-): Promise<"applied" | "skipped" | false> {
-  const base = withoutTrailingSlashes(peerUrl);
-  const routes = ["/remnic/v1/offline-sync/apply", "/engram/v1/offline-sync/apply"];
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-    ...(token ? { authorization: `Bearer ${token}` } : {}),
-  };
-  let previousAttemptFailed = false;
-  for (const route of routes) {
-    try {
-      const response = await fetchImpl(`${base}${route}`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          namespace,
-          changeset: {
-            format: OFFLINE_SYNC_CHANGESET_FORMAT,
-            schemaVersion: 1,
-            createdAt: new Date().toISOString(),
-            sourceId: "remnic-converge",
-            includeTranscripts: false,
-            changes: [{ type: "delete", path: filePath, baseSha256 }],
-          },
-        }),
-      });
-      if (!response.ok) throw new Error(`offline apply request failed: ${response.status}`);
-      const result: unknown = await response.json().catch(() => null);
-      if (
-        !result
-        || typeof result !== "object"
-        || !("appliedDeletes" in result)
-        || typeof result.appliedDeletes !== "number"
-        || !("skipped" in result)
-        || typeof result.skipped !== "number"
-        || !("conflicts" in result)
-        || !Array.isArray(result.conflicts)
-        || result.conflicts.length > 0
-      ) {
-        return false;
-      }
-      if (result.appliedDeletes === 1) return "applied";
-      if (result.skipped === 1) return previousAttemptFailed ? "applied" : "skipped";
-      return false;
-    } catch {
-      previousAttemptFailed = true;
-    }
-  }
-  return false;
-}
 
 export async function computeConvergePlan(options: ConvergePlanOptions = {}): Promise<ReconcilePlan> {
   const baseMap = new Map<string, ReconcileFileState[]>();
@@ -477,7 +187,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
   if (options.baseFilesByNamespace) {
     for (const [ns, files] of options.baseFilesByNamespace) {
       namespacesToPlan.add(ns);
-      baseMap.set(ns, files);
+      baseMap.set(ns, files.filter((file) => !isInternalRemnicStatePath(file.path)));
     }
   }
   if (options.semanticAgreementsByNamespace) {
@@ -489,7 +199,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
   if (options.localFilesByNamespace) {
     for (const [ns, files] of options.localFilesByNamespace) {
       namespacesToPlan.add(ns);
-      localMap.set(ns, files);
+      localMap.set(ns, files.filter((file) => !isInternalRemnicStatePath(file.path)));
     }
   }
   if (options.localTombstonesByNamespace) {
@@ -506,7 +216,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
   if (options.peerFilesByNamespace) {
     for (const [ns, files] of options.peerFilesByNamespace) {
       namespacesToPlan.add(ns);
-      peerMap.set(ns, files);
+      peerMap.set(ns, files.filter((file) => !isInternalRemnicStatePath(file.path)));
     }
   }
   if (options.peerTombstonesByNamespace) {
@@ -528,6 +238,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
       // ignore missing/invalid config in fallback mode
     }
   }
+  const memoryDir = options.cursorDir ?? config?.memoryDir;
 
   if (!options.localFilesByNamespace && config) {
     const roots = await resolveCorpusNamespaceRoots({ config });
@@ -538,48 +249,58 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
     for (const rootInfo of roots) {
       const ns = rootInfo.namespace;
       namespacesToPlan.add(ns);
-      try {
         const snapshot = await buildOfflineSyncSnapshotFromBase({
           root: rootInfo.rootDir,
           sourceId: "local",
           includeContent: false,
         });
-        const files: ReconcileFileState[] = snapshot.files.map((record) => ({
-          path: record.path,
-          sha256: record.sha256,
-          mtimeMs: record.mtimeMs,
-          bytes: record.bytes,
-        }));
+        const files: ReconcileFileState[] = snapshot.files
+          .filter((record) => !isInternalRemnicStatePath(record.path))
+          .map((record) => ({
+            path: record.path,
+            sha256: record.sha256,
+            mtimeMs: record.mtimeMs,
+            bytes: record.bytes,
+          }));
         localMap.set(ns, files);
-        try {
-          const io = await createOfflineStorageIo(rootInfo.rootDir);
-          localManifests.set(
-            ns,
-            await buildReconcileManifest({
-              files,
-              readFile: async (file) => {
-                const readFile = io.readFile;
-                if (!readFile) throw new Error("offline storage cannot read reconciliation manifest files");
-                return await readFile({
-                  root: rootInfo.rootDir,
-                  path: file.path,
-                  filePath: path.join(rootInfo.rootDir, file.path),
-                });
-              },
-            }),
-          );
-        } catch {
-          localManifests.delete(ns);
+        const evidence = await readLocalTombstoneEvidence(rootInfo.rootDir);
+        const io = await createOfflineStorageIo(rootInfo.rootDir);
+        let manifestReadFailed = false;
+        const manifest = await buildReconcileManifest({
+          files,
+          parseMemory: parseFrontmatter,
+          readFile: async (file) => {
+            const readFile = io.readFile;
+            if (!readFile) {
+              manifestReadFailed = true;
+              throw new Error("offline storage cannot read reconciliation manifest files");
+            }
+            try {
+              return await readFile({
+                root: rootInfo.rootDir,
+                path: file.path,
+                filePath: path.join(rootInfo.rootDir, file.path),
+              });
+            } catch (error) {
+              manifestReadFailed = true;
+              throw error;
+            }
+          },
+        });
+        if (manifestReadFailed) {
+          throw new Error(`failed to build local reconciliation manifest for namespace ${ns}`);
         }
-        const tombstones = await readLocalTombstones(rootInfo.rootDir);
-        localTombstones.set(ns, tombstones);
-      } catch {
-        localMap.set(ns, []);
-      }
+        localManifests.set(ns, manifest);
+        localTombstones.set(ns, tombstonedFileDigests(evidence, manifest));
     }
   }
 
   const peerUrl = options.peerUrl;
+  if (memoryDir && peerUrl) {
+    for (const namespace of await discoverCursorNamespaces(memoryDir, peerUrl)) {
+      namespacesToPlan.add(namespace);
+    }
+  }
   if (!options.peerFilesByNamespace && peerUrl) {
     let resolvedToken: string | undefined;
     if (options.peerToken) {
@@ -592,28 +313,70 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
       }
     }
     const fetchFn = options.fetchImpl ?? globalThis.fetch;
+    const timeoutMs = options.peerRequestTimeoutMs ?? DEFAULT_PEER_REQUEST_TIMEOUT_MS;
+    const capabilities = await fetchPeerSyncCapabilities(
+      peerUrl,
+      resolvedToken,
+      fetchFn,
+      timeoutMs,
+    );
     for (const ns of namespacesToPlan) {
-      const peerData = await fetchPeerSnapshot(peerUrl, ns, resolvedToken, fetchFn);
-      peerMap.set(ns, peerData.files);
-      peerTombstones.set(ns, peerData.tombstones);
-      peerManifests.set(
-        ns,
-        await buildReconcileManifest({
-          files: peerData.files,
+      const peerData = await fetchPeerSnapshot(peerUrl, ns, resolvedToken, fetchFn, timeoutMs);
+      const streamedManifest = capabilities?.manifestStream
+        ? await fetchPeerManifestStream(peerUrl, ns, resolvedToken, fetchFn, timeoutMs)
+        : null;
+      const peerFiles = streamedManifest?.files ?? peerData.files;
+      peerMap.set(ns, peerFiles);
+      let peerManifest = streamedManifest;
+      if (!peerManifest) {
+        let readFailure: Error | undefined;
+        peerManifest = await buildReconcileManifest({
+          files: peerFiles,
+          parseMemory: parseFrontmatter,
           cachedFiles: localManifests.get(ns)?.files,
           readFile: async (file) => {
-            const remote = await fetchPeerFileContent(peerUrl, ns, file.path, resolvedToken, fetchFn);
+            let remote: PeerFileContent | null;
+            try {
+              remote = await fetchPeerFileContent(peerUrl, ns, file.path, resolvedToken, fetchFn, timeoutMs);
+            } catch (error) {
+              readFailure = error instanceof Error ? error : new Error(String(error));
+              throw readFailure;
+            }
             if (!remote || remote.sha256 !== file.sha256) {
-              throw new Error(`failed to read peer reconciliation manifest file: ${file.path}`);
+              readFailure = new Error(`failed to read peer reconciliation manifest file: ${file.path}`);
+              throw readFailure;
             }
             return remote.content;
           },
-        }),
-      );
+        });
+        if (readFailure) throw readFailure;
+      }
+      peerManifests.set(ns, peerManifest);
+      const evidence: TombstoneEvidence = { contentHashes: new Set(), fileSha256: new Set() };
+      for (const tombstonePath of TOMBSTONE_PATHS) {
+        const state = peerFiles.find((file) => file.path === tombstonePath);
+        if (!state) continue;
+        const remote = await fetchPeerFileContent(
+          peerUrl,
+          ns,
+          tombstonePath,
+          resolvedToken,
+          fetchFn,
+          timeoutMs,
+        );
+        if (!remote || remote.sha256.toLowerCase() !== state.sha256.toLowerCase()) {
+          throw new Error(`failed to read peer tombstone evidence: ${tombstonePath}`);
+        }
+        const parsed = parseTombstoneEvidence(remote.content.toString("utf8"));
+        for (const value of parsed.contentHashes) evidence.contentHashes.add(value);
+        for (const value of parsed.fileSha256) evidence.fileSha256.add(value);
+      }
+      const mapped = tombstonedFileDigests(evidence, peerManifests.get(ns));
+      for (const digest of peerData.tombstones) mapped.add(digest);
+      peerTombstones.set(ns, mapped);
     }
   }
 
-  const memoryDir = options.cursorDir ?? config?.memoryDir;
   if (
     memoryDir
     && options.peerUrl
@@ -623,14 +386,24 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
       const cursorPath = defaultConvergeCursorPath(memoryDir, options.peerUrl, ns);
       const cursor = await readConvergeCursor(cursorPath);
       if (!options.baseFilesByNamespace && cursor?.baseFiles && cursor.baseFiles.length > 0) {
-        baseMap.set(ns, cursor.baseFiles);
+        baseMap.set(
+          ns,
+          cursor.baseFiles.filter((file) => !isInternalRemnicStatePath(file.path)),
+        );
       }
       if (
         !options.semanticAgreementsByNamespace
         && cursor?.semanticAgreements
         && cursor.semanticAgreements.length > 0
       ) {
-        semanticAgreementMap.set(ns, cursor.semanticAgreements);
+        semanticAgreementMap.set(
+          ns,
+          cursor.semanticAgreements.filter(
+            (agreement) =>
+              !isInternalRemnicStatePath(agreement.local.path)
+              && !isInternalRemnicStatePath(agreement.peer.path),
+          ),
+        );
       }
     }
   }
@@ -709,7 +482,7 @@ export async function executeConvergeApply(
 
   if (options.dryRun) {
     return {
-      converged: false,
+      converged: plan.converged,
       status: "dry_run",
       plan,
       transfers: plannedTransfers,
@@ -737,6 +510,7 @@ export async function executeConvergeApply(
     }
   }
   const fetchFn = options.fetchImpl ?? globalThis.fetch;
+  const timeoutMs = options.peerRequestTimeoutMs ?? DEFAULT_PEER_REQUEST_TIMEOUT_MS;
 
   let config = options.config;
   if (!config) {
@@ -776,146 +550,218 @@ export async function executeConvergeApply(
         transferType = entry.localSha256 ? "push" : "delete-peer";
       }
     }
+    const localPath = entry.semanticAgreement?.local.path ?? entry.path;
+    const peerPath = entry.semanticAgreement?.peer.path ?? entry.path;
 
     if (transferType === "pull") {
-      let remoteFile: PeerFileContent | null = null;
-      const buffered = options.peerFileBuffers?.get(entry.namespace)?.get(entry.path);
+      const buffered = options.peerFileBuffers?.get(entry.namespace)?.get(peerPath);
+      if (options.localFileBuffers) {
+        let remoteFile: PeerFileContent | null = null;
+        if (buffered) {
+          const state = options.peerFilesByNamespace
+            ?.get(entry.namespace)
+            ?.find((file) => file.path === peerPath);
+          remoteFile = {
+            content: buffered,
+            sha256: state?.sha256 ?? entry.peerSha256 ?? createHash("sha256").update(buffered).digest("hex"),
+            bytes: buffered.length,
+            mtimeMs: state?.mtimeMs ?? 0,
+          };
+        } else if (options.peerUrl) {
+          remoteFile = await fetchPeerFileContent(
+            options.peerUrl,
+            entry.namespace,
+            peerPath,
+            resolvedToken,
+            fetchFn,
+            timeoutMs,
+          );
+        }
+        if (!remoteFile || (entry.peerSha256 && remoteFile.sha256 !== entry.peerSha256)) {
+          actualTransfers.failed += 1;
+          continue;
+        }
+        let namespaceFiles = options.localFileBuffers.get(entry.namespace);
+        if (!namespaceFiles) {
+          namespaceFiles = new Map();
+          options.localFileBuffers.set(entry.namespace, namespaceFiles);
+        }
+        namespaceFiles.set(localPath, remoteFile.content);
+        if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
+        else actualTransfers.pulled += 1;
+        continue;
+      }
+
+      const rootDir = rootMap.get(entry.namespace);
+      if (!rootDir) {
+        actualTransfers.failed += 1;
+        continue;
+      }
+      const io = await createOfflineStorageIo(rootDir);
+      const expectedLocalSha256 = entry.action === "conflict" ? entry.localSha256 : entry.baseSha256;
+      let transferComplete = false;
+      let transferRejected = false;
+      const applyChunk = async (chunk: PeerFileChunk): Promise<void> => {
+        if (transferRejected) return;
+        if (entry.peerSha256 && chunk.sha256 !== entry.peerSha256) {
+          transferRejected = true;
+          return;
+        }
+        const chunkResult = await applyOfflineSyncFileContentChunk({
+          root: rootDir,
+          sourceId: "remnic-converge",
+          path: localPath,
+          sha256: chunk.sha256,
+          bytes: chunk.bytes,
+          mtimeMs: chunk.mtimeMs,
+          offset: chunk.offset,
+          content: chunk.content,
+          ...(expectedLocalSha256 ? { baseSha256: expectedLocalSha256 } : {}),
+          readFile: io.readFile,
+          readFileDigest: io.readFileDigest,
+          writeFile: io.writeFile,
+          writeStagingFile: io.writeStagingFile,
+          writeFileChunks: io.writeFileChunks,
+        });
+        if (chunkResult.conflict) {
+          transferRejected = true;
+        } else if (chunkResult.done) {
+          transferComplete = chunkResult.applied || chunkResult.skipped;
+        } else if (chunkResult.applied || chunkResult.skipped || chunk.content.length === 0) {
+          transferRejected = true;
+        }
+      };
+
+      let metadata: Omit<PeerFileContent, "content"> | null = null;
       if (buffered) {
         const state = options.peerFilesByNamespace
           ?.get(entry.namespace)
-          ?.find((file) => file.path === entry.path);
-        remoteFile = {
-          content: buffered,
-          sha256: state?.sha256 ?? entry.peerSha256 ?? createHash("sha256").update(buffered).digest("hex"),
-          bytes: buffered.length,
-          mtimeMs: state?.mtimeMs ?? 0,
-        };
+          ?.find((file) => file.path === peerPath);
+        const sha256 = state?.sha256 ?? entry.peerSha256 ?? createHash("sha256").update(buffered).digest("hex");
+        const bytes = buffered.length;
+        const mtimeMs = state?.mtimeMs ?? 0;
+        let offset = 0;
+        do {
+          const content = buffered.subarray(
+            offset,
+            Math.min(bytes, offset + OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES),
+          );
+          await applyChunk({ content, offset, sha256, bytes, mtimeMs });
+          offset += content.length;
+        } while (!transferRejected && !transferComplete && offset < bytes);
+        metadata = { sha256, bytes, mtimeMs };
       } else if (options.peerUrl) {
-        remoteFile = await fetchPeerFileContent(
+        metadata = await streamPeerFileContent(
           options.peerUrl,
           entry.namespace,
-          entry.path,
+          peerPath,
+          applyChunk,
           resolvedToken,
           fetchFn,
+          timeoutMs,
         );
       }
-
-      if (remoteFile !== null && (!entry.peerSha256 || remoteFile.sha256 === entry.peerSha256)) {
-        if (options.localFileBuffers) {
-          let nsMap = options.localFileBuffers.get(entry.namespace);
-          if (!nsMap) {
-            nsMap = new Map();
-            options.localFileBuffers.set(entry.namespace, nsMap);
-          }
-          nsMap.set(entry.path, remoteFile.content);
-          if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
-          else actualTransfers.pulled += 1;
-        } else {
-          const rootDir = rootMap.get(entry.namespace);
-          if (rootDir) {
-            const io = await createOfflineStorageIo(rootDir);
-            const expectedLocalSha256 = entry.action === "conflict"
-              ? entry.localSha256
-              : entry.baseSha256;
-            let offset = 0;
-            let transferComplete = false;
-            do {
-              const chunk = remoteFile.content.subarray(
-                offset,
-                Math.min(
-                  remoteFile.content.length,
-                  offset + OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
-                ),
-              );
-              const chunkResult = await applyOfflineSyncFileContentChunk({
-                root: rootDir,
-                sourceId: "remnic-converge",
-                path: entry.path,
-                sha256: remoteFile.sha256,
-                bytes: remoteFile.bytes,
-                mtimeMs: remoteFile.mtimeMs,
-                offset,
-                content: chunk,
-                ...(expectedLocalSha256 ? { baseSha256: expectedLocalSha256 } : {}),
-                readFile: io.readFile,
-                readFileDigest: io.readFileDigest,
-                writeFile: io.writeFile,
-                writeStagingFile: io.writeStagingFile,
-                writeFileChunks: io.writeFileChunks,
-              });
-              if (chunkResult.conflict) {
-                break;
-              }
-              if (chunkResult.done) {
-                transferComplete = chunkResult.applied || chunkResult.skipped;
-                break;
-              }
-              if (chunkResult.applied || chunkResult.skipped || chunk.length === 0) {
-                break;
-              }
-              offset += chunk.length;
-            } while (offset < remoteFile.content.length);
-            if (transferComplete) {
-              if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
-              else actualTransfers.pulled += 1;
-            } else {
-              actualTransfers.failed += 1;
-            }
-          } else {
-            actualTransfers.failed += 1;
-          }
-        }
+      if (
+        metadata
+        && transferComplete
+        && !transferRejected
+        && (!entry.peerSha256 || metadata.sha256 === entry.peerSha256)
+      ) {
+        if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
+        else actualTransfers.pulled += 1;
       } else {
         actualTransfers.failed += 1;
       }
     } else if (transferType === "push") {
-      let content: Buffer | null = null;
-      let mtimeMs = options.localFilesByNamespace
-        ?.get(entry.namespace)
-        ?.find((file) => file.path === entry.path)
-        ?.mtimeMs;
-      if (options.localFileBuffers?.get(entry.namespace)?.has(entry.path)) {
-        content = options.localFileBuffers.get(entry.namespace)!.get(entry.path)!;
-      } else {
+      const localBuffer = options.localFileBuffers?.get(entry.namespace)?.get(localPath);
+      let source: PeerFileSource | null = null;
+      let closeSource: (() => Promise<void>) | undefined;
+      const expectedPeerSha256 = entry.action === "conflict" ? entry.peerSha256 : entry.baseSha256;
+      if (localBuffer && entry.localSha256) {
+        source = {
+          sha256: entry.localSha256,
+          bytes: localBuffer.length,
+          mtimeMs: options.localFilesByNamespace
+            ?.get(entry.namespace)
+            ?.find((file) => file.path === localPath)
+            ?.mtimeMs ?? 0,
+          ...(expectedPeerSha256 ? { baseSha256: expectedPeerSha256 } : {}),
+          readChunk: async (offset, length) => localBuffer.subarray(offset, offset + length),
+        };
+      } else if (entry.localSha256) {
         const rootDir = rootMap.get(entry.namespace);
         if (rootDir) {
-          const filePath = path.join(rootDir, entry.path);
           try {
+            const filePath = path.join(rootDir, localPath);
             const io = await createOfflineStorageIo(rootDir);
-            content = await io.readFile!({ root: rootDir, path: entry.path, filePath });
-            mtimeMs ??= (await fs.promises.stat(filePath)).mtimeMs;
+            const current = await io.readFileDigest({ root: rootDir, path: localPath, filePath });
+            if (current.sha256 !== entry.localSha256) {
+              throw new Error(`local file changed during push: ${localPath}`);
+            }
+            const stat = await fs.promises.stat(filePath);
+            let chunks: AsyncIterator<Buffer> | undefined;
+            let chunkOffset = 0;
+            const resetChunks = async (): Promise<void> => {
+              await chunks?.return?.();
+              chunks = io.readFileChunks({
+                root: rootDir,
+                path: localPath,
+                filePath,
+                chunkSize: OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
+              })[Symbol.asyncIterator]();
+              chunkOffset = 0;
+            };
+            closeSource = async () => {
+              await chunks?.return?.();
+            };
+            source = {
+              sha256: entry.localSha256,
+              bytes: current.bytes,
+              mtimeMs: stat.mtimeMs,
+              ...(expectedPeerSha256 ? { baseSha256: expectedPeerSha256 } : {}),
+              readChunk: async (offset, length) => {
+                if (!chunks || offset < chunkOffset) await resetChunks();
+                while (chunkOffset < offset) {
+                  const skipped = await chunks!.next();
+                  if (skipped.done || chunkOffset + skipped.value.length > offset) {
+                    throw new Error(`cannot resume local file upload at offset ${offset}: ${localPath}`);
+                  }
+                  chunkOffset += skipped.value.length;
+                }
+                const next = await chunks!.next();
+                if (next.done) return Buffer.alloc(0);
+                if (next.value.length > length) {
+                  throw new Error(`local file chunk exceeds requested length: ${localPath}`);
+                }
+                chunkOffset += next.value.length;
+                return next.value;
+              },
+            };
           } catch {
-            content = null;
+            source = null;
           }
         }
       }
 
-      if (content !== null) {
-        if (options.peerFileBuffers) {
-          let nsMap = options.peerFileBuffers.get(entry.namespace);
-          if (!nsMap) {
-            nsMap = new Map();
-            options.peerFileBuffers.set(entry.namespace, nsMap);
+      try {
+        if (options.peerFileBuffers && localBuffer) {
+          let namespaceFiles = options.peerFileBuffers.get(entry.namespace);
+          if (!namespaceFiles) {
+            namespaceFiles = new Map();
+            options.peerFileBuffers.set(entry.namespace, namespaceFiles);
           }
-          nsMap.set(entry.path, content);
+          namespaceFiles.set(peerPath, localBuffer);
           if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
           else actualTransfers.pushed += 1;
-        } else if (options.peerUrl && entry.localSha256) {
-          const expectedPeerSha256 = entry.action === "conflict"
-            ? entry.peerSha256
-            : entry.baseSha256;
+        } else if (options.peerUrl && source) {
           const applied = await postPeerFileContent(
             options.peerUrl,
             entry.namespace,
-            entry.path,
-            content,
-            {
-              sha256: entry.localSha256,
-              mtimeMs: mtimeMs ?? 0,
-              ...(expectedPeerSha256 ? { baseSha256: expectedPeerSha256 } : {}),
-            },
+            peerPath,
+            source,
             resolvedToken,
             fetchFn,
+            timeoutMs,
           );
           if (applied) {
             if (applied === "applied") peerMutatedNamespaces.add(entry.namespace);
@@ -927,20 +773,20 @@ export async function executeConvergeApply(
         } else {
           actualTransfers.failed += 1;
         }
-      } else {
-        actualTransfers.failed += 1;
+      } finally {
+        await closeSource?.();
       }
     } else if (transferType === "delete-local") {
       let deleted = false;
       const bufferedFiles = options.localFileBuffers?.get(entry.namespace);
       if (options.localFileBuffers) {
-        const current = bufferedFiles?.get(entry.path);
+        const current = bufferedFiles?.get(localPath);
         if (
           current
           && entry.localSha256
           && createHash("sha256").update(current).digest("hex") === entry.localSha256
         ) {
-          bufferedFiles!.delete(entry.path);
+          bufferedFiles!.delete(localPath);
           deleted = true;
         }
       } else {
@@ -948,10 +794,10 @@ export async function executeConvergeApply(
         if (rootDir && entry.localSha256) {
           try {
             const io = await createOfflineStorageIo(rootDir);
-            const filePath = path.join(rootDir, entry.path);
-            const current = await io.readFileDigest({ root: rootDir, path: entry.path, filePath });
+            const filePath = path.join(rootDir, localPath);
+            const current = await io.readFileDigest({ root: rootDir, path: localPath, filePath });
             if (current.sha256 === entry.localSha256) {
-              await io.deleteFile!({ root: rootDir, path: entry.path, filePath });
+              await io.deleteFile!({ root: rootDir, path: localPath, filePath });
               deleted = true;
             }
           } catch {
@@ -965,23 +811,24 @@ export async function executeConvergeApply(
       let deleted = false;
       const bufferedFiles = options.peerFileBuffers?.get(entry.namespace);
       if (options.peerFileBuffers) {
-        const current = bufferedFiles?.get(entry.path);
+        const current = bufferedFiles?.get(peerPath);
         if (
           current
           && entry.peerSha256
           && createHash("sha256").update(current).digest("hex") === entry.peerSha256
         ) {
-          bufferedFiles!.delete(entry.path);
+          bufferedFiles!.delete(peerPath);
           deleted = true;
         }
       } else if (options.peerUrl && entry.peerSha256) {
         const deletionResult = await postPeerFileDeletion(
           options.peerUrl,
           entry.namespace,
-          entry.path,
+          peerPath,
           entry.peerSha256,
           resolvedToken,
           fetchFn,
+          timeoutMs,
         );
         deleted = Boolean(deletionResult);
         if (deletionResult === "applied") peerMutatedNamespaces.add(entry.namespace);
@@ -989,7 +836,60 @@ export async function executeConvergeApply(
       if (deleted) actualTransfers.conflictsResolved += 1;
       else actualTransfers.failed += 1;
     } else if (transferType === "suppress") {
-      actualTransfers.suppressed += 1;
+      let suppressed = entry.suppressSide !== undefined;
+      if (entry.suppressSide === "local" || entry.suppressSide === "both") {
+        let deletedLocal = false;
+        if (entry.localSha256 && options.localFileBuffers) {
+          const files = options.localFileBuffers.get(entry.namespace);
+          const current = files?.get(localPath);
+          if (current && createHash("sha256").update(current).digest("hex") === entry.localSha256) {
+            files!.delete(localPath);
+            deletedLocal = true;
+          }
+        } else if (entry.localSha256) {
+          const rootDir = rootMap.get(entry.namespace);
+          if (rootDir) {
+            try {
+              const io = await createOfflineStorageIo(rootDir);
+              const filePath = path.join(rootDir, localPath);
+              const current = await io.readFileDigest({ root: rootDir, path: localPath, filePath });
+              if (current.sha256 === entry.localSha256) {
+                await io.deleteFile!({ root: rootDir, path: localPath, filePath });
+                deletedLocal = true;
+              }
+            } catch {
+              deletedLocal = false;
+            }
+          }
+        }
+        suppressed &&= deletedLocal;
+      }
+      if (entry.suppressSide === "peer" || entry.suppressSide === "both") {
+        let deletedPeer = false;
+        if (entry.peerSha256 && options.peerFileBuffers) {
+          const files = options.peerFileBuffers.get(entry.namespace);
+          const current = files?.get(peerPath);
+          if (current && createHash("sha256").update(current).digest("hex") === entry.peerSha256) {
+            files!.delete(peerPath);
+            deletedPeer = true;
+          }
+        } else if (entry.peerSha256 && options.peerUrl) {
+          const result = await postPeerFileDeletion(
+            options.peerUrl,
+            entry.namespace,
+            peerPath,
+            entry.peerSha256,
+            resolvedToken,
+            fetchFn,
+            timeoutMs,
+          );
+          deletedPeer = Boolean(result);
+          if (result === "applied") peerMutatedNamespaces.add(entry.namespace);
+        }
+        suppressed &&= deletedPeer;
+      }
+      if (suppressed) actualTransfers.suppressed += 1;
+      else actualTransfers.failed += 1;
     }
   }
 
@@ -1000,6 +900,7 @@ export async function executeConvergeApply(
       namespaces,
       resolvedToken,
       fetchFn,
+      timeoutMs,
     )) {
       actualTransfers.failed += 1;
     }
@@ -1024,7 +925,7 @@ async function updateCursorsForPlan(
   plan: ReconcilePlan,
   options: ConvergeApplyOptions,
 ): Promise<void> {
-  const peerUrl = options.peerUrl ?? "local";
+  const peerUrl = normalizeConvergePeerUrl(options.peerUrl ?? "local");
   let memoryDir: string | undefined;
   if (options.cursorDir) {
     memoryDir = options.cursorDir;

--- a/packages/remnic-core/src/access-http-offline-stream.ts
+++ b/packages/remnic-core/src/access-http-offline-stream.ts
@@ -1,0 +1,79 @@
+import type { ServerResponse } from "node:http";
+import type { OfflineSyncManifestStreamResponse } from "./access-offline-manifest.js";
+import type { EngramAccessOfflineSyncSnapshotStreamResponse } from "./access-service.js";
+
+async function respondOfflineNdjsonStream(
+  response: ServerResponse,
+  header: unknown,
+  files: AsyncIterable<unknown>,
+  requestId?: string,
+): Promise<void> {
+  response.statusCode = 200;
+  response.setHeader("content-type", "application/x-ndjson; charset=utf-8");
+  response.setHeader("cache-control", "no-store");
+  if (requestId) response.setHeader("x-request-id", requestId);
+  const waitForDrainOrClose = async (): Promise<boolean> => {
+    const { promise, resolve, reject } = Promise.withResolvers<boolean>();
+    const cleanup = () => {
+      response.off("drain", onDrain);
+      response.off("close", onClose);
+      response.off("error", onError);
+    };
+    const onDrain = () => {
+      cleanup();
+      resolve(true);
+    };
+    const onClose = () => {
+      cleanup();
+      resolve(false);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    response.once("drain", onDrain);
+    response.once("close", onClose);
+    response.once("error", onError);
+    return promise;
+  };
+  const writeLine = async (payload: unknown): Promise<boolean> => {
+    if (response.destroyed || response.writableEnded) return false;
+    if (response.write(`${JSON.stringify(payload)}\n`)) return true;
+    if (response.destroyed || response.writableEnded) return false;
+    return waitForDrainOrClose();
+  };
+  if (!await writeLine(header)) return;
+  for await (const file of files) {
+    if (!await writeLine({ type: "file", file })) return;
+  }
+  if (!response.destroyed && !response.writableEnded) response.end();
+}
+
+export async function respondOfflineSnapshotStream(
+  response: ServerResponse,
+  snapshot: EngramAccessOfflineSyncSnapshotStreamResponse,
+  requestId?: string,
+): Promise<void> {
+  await respondOfflineNdjsonStream(response, {
+    type: "snapshot",
+    namespace: snapshot.namespace,
+    format: snapshot.format,
+    schemaVersion: snapshot.schemaVersion,
+    createdAt: snapshot.createdAt,
+    sourceId: snapshot.sourceId,
+    includeTranscripts: snapshot.includeTranscripts,
+  }, snapshot.files, requestId);
+}
+
+export async function respondOfflineManifestStream(
+  response: ServerResponse,
+  manifest: OfflineSyncManifestStreamResponse,
+  requestId?: string,
+): Promise<void> {
+  await respondOfflineNdjsonStream(response, {
+    type: "manifest",
+    namespace: manifest.namespace,
+    format: manifest.format,
+    schemaVersion: manifest.schemaVersion,
+  }, manifest.files, requestId);
+}

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -1062,6 +1062,120 @@ test("HTTP offline snapshot stream emits metadata records as NDJSON", async () =
     await server.stop();
   }
 });
+test("HTTP offline manifest stream preserves snapshot-stream auth and emits body-free rows", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const service = {
+    offlineSyncManifestStream: async (options: Record<string, unknown>) => {
+      calls.push(options);
+      return {
+        namespace: options.namespace ?? "default",
+        format: "remnic-reconcile-manifest",
+        schemaVersion: 1,
+        files: (async function* () {
+          yield {
+            path: "facts/a.md",
+            sha256: "a".repeat(64),
+            bytes: 12,
+            mtimeMs: 1234,
+            memory: {
+              id: "fact-a",
+              status: "active",
+              category: "fact",
+              contentHash: "b".repeat(64),
+            },
+          };
+        })(),
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    principal: "reader",
+    authTokenEntriesGetter: () => [
+      { token: "wrong-op", capabilities: { version: 1, ops: ["offline_sync_snapshot"] } },
+      {
+        token: "wrong-namespace",
+        capabilities: { version: 1, ops: ["offline_sync_snapshot_stream"], namespaces: ["other"] },
+      },
+      {
+        token: "reader",
+        capabilities: { version: 1, ops: ["offline_sync_snapshot_stream"], namespaces: ["team"] },
+      },
+    ],
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+  const request = (token: string, query = "namespace=team&include_transcripts=false") =>
+    fetch(`http://127.0.0.1:${status.port}/remnic/v1/offline-sync/manifest-stream?${query}`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+  try {
+    assert.equal((await request("wrong-op")).status, 403);
+    assert.equal((await request("wrong-namespace")).status, 403);
+    assert.equal(calls.length, 0);
+    assert.equal((await request("reader", "namespace=team&include_transcripts=invalid")).status, 400);
+    assert.equal((await request("reader", "namespace=team&content=true")).status, 400);
+    assert.equal(calls.length, 0);
+
+    const response = await request("reader");
+    const text = await response.text();
+    const lines = text.trim().split("\n").map((line) => JSON.parse(line) as Record<string, unknown>);
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "application/x-ndjson; charset=utf-8");
+    assert.equal(lines[0]?.type, "manifest");
+    assert.equal(lines[1]?.type, "file");
+    assert.deepEqual(lines[1]?.file, {
+      path: "facts/a.md",
+      sha256: "a".repeat(64),
+      bytes: 12,
+      mtimeMs: 1234,
+      memory: {
+        id: "fact-a",
+        status: "active",
+        category: "fact",
+        contentHash: "b".repeat(64),
+      },
+    });
+    assert.doesNotMatch(text, /contentBase64|rawContent|memory body/);
+    assert.deepEqual({
+      namespace: calls[0]?.namespace,
+      principal: calls[0]?.principal,
+      includeTranscripts: calls[0]?.includeTranscripts,
+    }, {
+      namespace: "team",
+      principal: "reader",
+      includeTranscripts: false,
+    });
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP offline sync capabilities advertise manifest streaming", async () => {
+  const server = new EngramAccessHttpServer({
+    service: {} as EngramAccessService,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/offline-sync/capabilities`,
+      { headers: { authorization: "Bearer test-token" } },
+    );
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      version: 1,
+      convergenceFinalization: true,
+      manifestStream: true,
+    });
+  } finally {
+    await server.stop();
+  }
+});
+
 
 test("HTTP offline files forwards namespace and requested paths", async () => {
   const calls: Array<{

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -18,6 +18,10 @@ import {
   type EngramAccessWriteResponse,
 } from "./access-service.js";
 import { maybeHandleLifecycleFlush, type LifecycleFlushHttpDeps } from "./access-http-lifecycle-flush.js";
+import {
+  respondOfflineManifestStream,
+  respondOfflineSnapshotStream,
+} from "./access-http-offline-stream.js";
 import { nonEmptyQueryParam, optionalQueryString, positiveIntQueryParam } from "./access-http-query.js";
 import { CorrectionContractError } from "./correction/correction-contract.js";
 import { WearablesInputError } from "./wearables/errors.js"; import { respondMeetingsList, respondMeetingsGet, respondMeetingsBuild } from "./meetings/http-glue.js";
@@ -1144,6 +1148,20 @@ export class EngramAccessHttpServer {
 
     if (
       req.method === "GET" &&
+      (pathname === "/engram/v1/offline-sync/capabilities" ||
+        pathname === "/remnic/v1/offline-sync/capabilities")
+    ) {
+      this.enforceTokenOp("offline_sync_snapshot");
+      this.respondJson(res, 200, {
+        version: 1,
+        convergenceFinalization: true,
+        manifestStream: true,
+      });
+      return;
+    }
+
+    if (
+      req.method === "GET" &&
       (pathname === "/engram/v1/offline-sync/snapshot" || pathname === "/remnic/v1/offline-sync/snapshot")
     ) {
       this.enforceTokenOp("offline_sync_snapshot"); // boundary dispatch (issue #1525)
@@ -1215,9 +1233,43 @@ export class EngramAccessHttpServer {
         includeContent: false,
         signal: this.createRequestAbortSignal(req, res),
       });
-      await this.respondOfflineSnapshotStream(res, result);
+      await respondOfflineSnapshotStream(res, result, correlationIdStore.getStore());
       return;
     }
+    if (
+      req.method === "GET" &&
+      (pathname === "/engram/v1/offline-sync/manifest-stream" ||
+        pathname === "/remnic/v1/offline-sync/manifest-stream")
+    ) {
+      this.enforceTokenOp("offline_sync_snapshot_stream");
+      const includeTranscriptsRaw = parsed.searchParams.get("include_transcripts");
+      const includeContentRaw = parsed.searchParams.get("content");
+      if (
+        includeTranscriptsRaw !== null &&
+        includeTranscriptsRaw !== "true" &&
+        includeTranscriptsRaw !== "false"
+      ) {
+        throw new EngramAccessInputError(
+          `include_transcripts must be one of: true, false (got: ${includeTranscriptsRaw})`,
+        );
+      }
+      if (includeContentRaw !== null && includeContentRaw !== "false") {
+        throw new EngramAccessInputError("manifest-stream content must be false");
+      }
+      const namespaceParam = parsed.searchParams.get("namespace");
+      const result = await this.service.offlineSyncManifestStream({
+        namespace: this.resolveNamespace(
+          req,
+          namespaceParam && namespaceParam.length > 0 ? namespaceParam : undefined,
+        ),
+        principal: this.resolveRequestPrincipal(req),
+        includeTranscripts: includeTranscriptsRaw !== "false",
+        signal: this.createRequestAbortSignal(req, res),
+      });
+      await respondOfflineManifestStream(res, result, correlationIdStore.getStore());
+      return;
+    }
+
 
     if (
       req.method === "POST" &&
@@ -3370,61 +3422,6 @@ export class EngramAccessHttpServer {
     res.end(body);
   }
 
-  private async respondOfflineSnapshotStream(
-    res: ServerResponse,
-    snapshot: Awaited<ReturnType<EngramAccessService["offlineSyncSnapshotStream"]>>,
-  ): Promise<void> {
-    res.statusCode = 200;
-    res.setHeader("content-type", "application/x-ndjson; charset=utf-8");
-    res.setHeader("cache-control", "no-store");
-    const cid = correlationIdStore.getStore();
-    if (cid) {
-      res.setHeader("x-request-id", cid);
-    }
-    const waitForDrainOrClose = async (): Promise<boolean> => new Promise((resolve, reject) => {
-      const cleanup = () => {
-        res.off("drain", onDrain);
-        res.off("close", onClose);
-        res.off("error", onError);
-      };
-      const onDrain = () => {
-        cleanup();
-        resolve(true);
-      };
-      const onClose = () => {
-        cleanup();
-        resolve(false);
-      };
-      const onError = (error: Error) => {
-        cleanup();
-        reject(error);
-      };
-      res.once("drain", onDrain);
-      res.once("close", onClose);
-      res.once("error", onError);
-    });
-    const writeLine = async (payload: unknown): Promise<boolean> => {
-      if (res.destroyed || res.writableEnded) return false;
-      if (res.write(`${JSON.stringify(payload)}\n`)) return true;
-      if (res.destroyed || res.writableEnded) return false;
-      return waitForDrainOrClose();
-    };
-    if (!await writeLine({
-      type: "snapshot",
-      namespace: snapshot.namespace,
-      format: snapshot.format,
-      schemaVersion: snapshot.schemaVersion,
-      createdAt: snapshot.createdAt,
-      sourceId: snapshot.sourceId,
-      includeTranscripts: snapshot.includeTranscripts,
-    })) return;
-    for await (const file of snapshot.files) {
-      if (!await writeLine({ type: "file", file })) return;
-    }
-    if (!res.destroyed && !res.writableEnded) {
-      res.end();
-    }
-  }
 
   private respondBinary(
     res: ServerResponse,

--- a/packages/remnic-core/src/access-offline-manifest.ts
+++ b/packages/remnic-core/src/access-offline-manifest.ts
@@ -1,0 +1,54 @@
+import * as nodePath from "node:path";
+import type { Orchestrator } from "./orchestrator.js";
+import { iterateOfflineSyncSnapshotFileRecords } from "./offline-sync.js";
+import { offlineSyncStorageForSnapshot } from "./offline-sync-impression-drain.js";
+import {
+  buildReconcileManifestFile,
+  RECONCILE_MANIFEST_FORMAT,
+  RECONCILE_MANIFEST_SCHEMA_VERSION,
+  type ReconcileManifest,
+  type ReconcileManifestFile,
+  type ReconcileMemoryParser,
+} from "./reconcile/manifest.js";
+
+export interface OfflineSyncManifestRequest {
+  includeTranscripts?: boolean;
+  signal?: AbortSignal;
+}
+
+export interface OfflineSyncManifestStreamResponse extends Omit<ReconcileManifest, "files"> {
+  namespace: string;
+  files: AsyncIterable<ReconcileManifestFile>;
+}
+
+export async function createOfflineSyncManifestStream(
+  orchestrator: Orchestrator,
+  namespace: string,
+  userExcludeRegexps: RegExp[],
+  options: OfflineSyncManifestRequest,
+  parseMemory: ReconcileMemoryParser,
+): Promise<OfflineSyncManifestStreamResponse> {
+  const storage = await offlineSyncStorageForSnapshot(orchestrator, namespace);
+  const snapshotFiles = iterateOfflineSyncSnapshotFileRecords({
+    root: storage.dir,
+    includeContent: false,
+    includeTranscripts: options.includeTranscripts !== false,
+    readFileDigest: async ({ filePath }) => storage.digestOfflineSyncFile(filePath),
+    signal: options.signal,
+    userExcludeRegexps,
+  });
+  return {
+    namespace,
+    format: RECONCILE_MANIFEST_FORMAT,
+    schemaVersion: RECONCILE_MANIFEST_SCHEMA_VERSION,
+    files: (async function* () {
+      for await (const file of snapshotFiles) {
+        yield await buildReconcileManifestFile(
+          file,
+          async ({ path }) => storage.readOfflineSyncFile(nodePath.join(storage.dir, path)),
+          parseMemory,
+        );
+      }
+    })(),
+  };
+}

--- a/packages/remnic-core/src/access-service-offline-file-content.test.ts
+++ b/packages/remnic-core/src/access-service-offline-file-content.test.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import { EngramAccessInputError, EngramAccessService } from "./access-service.js";
-import { OFFLINE_SYNC_MAX_MTIME_MS } from "./offline-sync.js";
+import { OFFLINE_SYNC_CHANGESET_FORMAT, OFFLINE_SYNC_MAX_MTIME_MS } from "./offline-sync.js";
+import { isEncryptedFile } from "./secure-store/index.js";
+import { ContentHashIndex } from "./storage/content-hash-index.js";
+import { StorageManager } from "./storage.js";
 
 function createOfflineService(): EngramAccessService {
   return new EngramAccessService({
@@ -17,6 +23,241 @@ function createOfflineService(): EngramAccessService {
     }),
   } as any);
 }
+
+function memoryFile(options: {
+  id: string;
+  body: string;
+  status?: string;
+  contentHash?: string;
+}): string {
+  return [
+    "---",
+    `id: ${options.id}`,
+    "category: fact",
+    ...(options.status ? [`status: ${options.status}`] : []),
+    ...(options.contentHash ? [`contentHash: ${options.contentHash}`] : []),
+    "---",
+    options.body,
+  ].join("\n");
+}
+
+function createManifestService(options: {
+  root: string;
+  storage: StorageManager;
+  namespacesEnabled?: boolean;
+}): { service: EngramAccessService; getStorageCalls: string[] } {
+  const getStorageCalls: string[] = [];
+  const service = new EngramAccessService({
+    config: {
+      memoryDir: options.root,
+      namespacesEnabled: options.namespacesEnabled === true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      namespacePolicies: options.namespacesEnabled
+        ? [{ name: "team", readPrincipals: ["reader"], writePrincipals: [] }]
+        : [],
+      offlineSyncExcludes: [],
+    },
+    namespaceCatalog: {
+      async listNamespaces() {
+        return [];
+      },
+    },
+    async drainPendingRecallImpressions() {
+      return { folded: false, pendingDeferred: false };
+    },
+    async getStorage(namespace: string) {
+      getStorageCalls.push(namespace);
+      return options.storage;
+    },
+  } as unknown as ConstructorParameters<typeof EngramAccessService>[0]);
+  return { service, getStorageCalls };
+}
+
+test("offline manifest streams body-free active, archived, old, bad, and encrypted memory rows lazily", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-access-manifest-"));
+  try {
+    const activeBody = "active body must never leave the service";
+    const archivedBody = "archived body must never leave the service";
+    const oldBody = "legacy body must never leave the service";
+    const encryptedBody = "encrypted body must never leave the service";
+    const activeContentHash = ContentHashIndex.computeHash(activeBody);
+    const files = new Map<string, string>([
+      [
+        "facts/active.md",
+        memoryFile({
+          id: "active-memory",
+          body: activeBody,
+          status: "active",
+          contentHash: activeContentHash,
+        }),
+      ],
+      [
+        "archive/facts/archived.md",
+        memoryFile({ id: "archived-memory", body: archivedBody, status: "active" }),
+      ],
+      ["facts/old.md", memoryFile({ id: "old-memory", body: oldBody })],
+      ["facts/bad.md", `not valid memory frontmatter\n${activeBody}`],
+    ]);
+    for (const [relativePath, content] of files) {
+      const filePath = path.join(root, relativePath);
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, content);
+    }
+    const storage = new StorageManager(root);
+    await storage.ensureDirectories();
+    storage.setSecureStoreKey(Buffer.alloc(32, 11));
+    storage.setSecureStoreRequired(true);
+    const encryptedRelativePath = "facts/encrypted.md";
+    await storage.writeOfflineSyncFile(
+      path.join(root, encryptedRelativePath),
+      Buffer.from(memoryFile({ id: "encrypted-memory", body: encryptedBody, status: "active" })),
+    );
+    assert.equal(isEncryptedFile(await readFile(path.join(root, encryptedRelativePath))), true);
+
+    let digestReads = 0;
+    let bodyReads = 0;
+    const digestOfflineSyncFile = storage.digestOfflineSyncFile.bind(storage);
+    const readOfflineSyncFile = storage.readOfflineSyncFile.bind(storage);
+    storage.digestOfflineSyncFile = async (filePath: string) => {
+      digestReads += 1;
+      return digestOfflineSyncFile(filePath);
+    };
+    storage.readOfflineSyncFile = async (filePath: string) => {
+      bodyReads += 1;
+      return readOfflineSyncFile(filePath);
+    };
+    const { service } = createManifestService({ root, storage });
+
+    const manifest = await service.offlineSyncManifestStream();
+    assert.equal(manifest.format, "remnic-reconcile-manifest");
+    assert.equal(manifest.schemaVersion, 1);
+    assert.equal(Array.isArray(manifest.files), false);
+    assert.equal(digestReads, 0);
+    assert.equal(bodyReads, 0);
+
+    const iterator = manifest.files[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    assert.equal(first.done, false);
+    assert.equal(first.value?.path, "archive/facts/archived.md");
+    assert.equal(digestReads, 1);
+    assert.equal(bodyReads, 1);
+
+    const rows = first.value ? [first.value] : [];
+    for await (const row of { [Symbol.asyncIterator]: () => iterator }) rows.push(row);
+    const rowsByPath = new Map(rows.map((row) => [row.path, row]));
+    assert.deepEqual(rowsByPath.get("facts/active.md")?.memory, {
+      id: "active-memory",
+      category: "fact",
+      contentHash: activeContentHash,
+      status: "active",
+    });
+    assert.notEqual(rowsByPath.get("facts/active.md")?.sha256, activeContentHash);
+    assert.equal(rowsByPath.get("archive/facts/archived.md")?.memory?.status, "archived");
+    assert.equal(
+      rowsByPath.get("facts/old.md")?.memory?.contentHash,
+      ContentHashIndex.computeHash(oldBody),
+    );
+    assert.equal(rowsByPath.get("facts/old.md")?.memory?.status, "active");
+    assert.equal(rowsByPath.get("facts/bad.md")?.memory, undefined);
+    assert.equal(rowsByPath.get(encryptedRelativePath)?.memory?.id, "encrypted-memory");
+    for (const row of rows) {
+      assert.equal("content" in row, false);
+      assert.equal("contentBase64" in row, false);
+      assert.doesNotMatch(JSON.stringify(row), /body must never leave the service/);
+      assert.equal(typeof row.sha256, "string");
+      assert.equal(typeof row.bytes, "number");
+      assert.equal(typeof row.mtimeMs, "number");
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline manifest uses snapshot namespace authorization and storage routing", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-access-manifest-namespace-"));
+  try {
+    const storage = new StorageManager(path.join(root, "namespaces", "team"));
+    await storage.ensureDirectories();
+    const { service, getStorageCalls } = createManifestService({
+      root,
+      storage,
+      namespacesEnabled: true,
+    });
+    await assert.rejects(
+      () => service.offlineSyncManifestStream({ namespace: "team", principal: "outsider" }),
+      /namespace is not readable: team/,
+    );
+    const manifest = await service.offlineSyncManifestStream({
+      namespace: "team",
+      principal: "reader",
+      includeTranscripts: false,
+    });
+    assert.equal(manifest.namespace, "team");
+    assert.deepEqual(getStorageCalls, ["team"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline file-transfer endpoints reject internal Remnic state paths", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-access-internal-state-"));
+  try {
+    const storage = new StorageManager(root);
+    await storage.ensureDirectories();
+    const { service } = createManifestService({ root, storage });
+    const internalPath = ".remnic/state/converge-cursors/peer.json";
+    const internalFilePath = path.join(root, internalPath);
+    await mkdir(path.dirname(internalFilePath), { recursive: true });
+    await writeFile(internalFilePath, "cursor");
+
+    await assert.rejects(
+      () => service.offlineSyncFiles({ paths: [internalPath] }),
+      (error) =>
+        error instanceof EngramAccessInputError
+        && /offline sync snapshot path is excluded/.test(error.message),
+    );
+    await assert.rejects(
+      () => service.offlineSyncFileContent({ path: internalPath, offset: 0, length: 1 }),
+      (error) =>
+        error instanceof EngramAccessInputError
+        && /offline sync file content path is excluded/.test(error.message),
+    );
+    await assert.rejects(
+      () => service.offlineSyncApplyFileContent({
+        sourceId: "peer",
+        path: internalPath,
+        sha256: "a".repeat(64),
+        bytes: 0,
+        mtimeMs: 0,
+        offset: 0,
+        content: Buffer.alloc(0),
+      }),
+      (error) =>
+        error instanceof EngramAccessInputError
+        && /offline sync file content path is excluded/.test(error.message),
+    );
+    const applyResult = await service.offlineSyncApply({
+      changeset: {
+        format: OFFLINE_SYNC_CHANGESET_FORMAT,
+        schemaVersion: 1,
+        createdAt: new Date().toISOString(),
+        sourceId: "peer",
+        includeTranscripts: true,
+        changes: [{
+          type: "delete",
+          path: internalPath,
+          baseSha256: "b".repeat(64),
+        }],
+      },
+    });
+    assert.equal(applyResult.appliedDeletes, 0);
+    assert.equal(await readFile(internalFilePath, "utf8"), "cursor");
+
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
 
 test("offline apply-file-content reports invalid metadata as input errors", async () => {
   const service = createOfflineService();

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -180,7 +180,7 @@ import type {
   Orchestrator,
   RecallInvocationOptions,
 } from "./orchestrator.js";
-import { parseEntityFile, StorageManager } from "./storage.js";
+import { parseEntityFile, parseFrontmatter, StorageManager } from "./storage.js";
 import {
   buildGraphSnapshot,
   type GraphSnapshotRequest,
@@ -293,6 +293,10 @@ import {
   type OfflineSyncSnapshot,
 } from "./offline-sync.js";
 import { offlineSyncStorageForSnapshot } from "./offline-sync-impression-drain.js";
+import {
+  createOfflineSyncManifestStream,
+  type OfflineSyncManifestStreamResponse,
+} from "./access-offline-manifest.js";
 import {
   evaluateActionConfidence,
   type ActionConfidenceInput,
@@ -779,6 +783,12 @@ export interface EngramAccessOfflineSyncSnapshotRequest {
   includeContent?: boolean;
   baseCapturedAt?: Date;
   baseFiles?: OfflineSyncFileState[];
+}
+
+export interface EngramAccessOfflineSyncManifestRequest {
+  namespace?: string;
+  principal?: string;
+  includeTranscripts?: boolean;
 }
 
 export interface EngramAccessOfflineSyncFilesRequest {
@@ -5513,6 +5523,19 @@ export class EngramAccessService {
       }),
     };
   }
+  async offlineSyncManifestStream(
+    options: EngramAccessOfflineSyncManifestRequest & { signal?: AbortSignal } = {},
+  ): Promise<OfflineSyncManifestStreamResponse> {
+    const namespace = this.resolveReadableNamespace(options.namespace, options.principal);
+    return createOfflineSyncManifestStream(
+      this.orchestrator,
+      namespace,
+      this.offlineSyncUserExcludes,
+      options,
+      parseFrontmatter,
+    );
+  }
+
 
   async offlineSyncFiles(
     options: EngramAccessOfflineSyncFilesRequest,

--- a/packages/remnic-core/src/access-surface-catalog.ts
+++ b/packages/remnic-core/src/access-surface-catalog.ts
@@ -179,6 +179,7 @@ export const HTTP_ROUTES: readonly HttpRouteEntry[] = [
   { method: "POST", pathname: "/engram/v1/capsules/export", operation: "capsule_export" },
   { method: "POST", pathname: "/engram/v1/capsules/import", operation: "capsule_import" },
   { method: "GET", pathname: "/engram/v1/offline-sync/snapshot", operation: "offline_sync_snapshot" },
+  { method: "GET", pathname: "/engram/v1/offline-sync/capabilities", operation: "offline_sync_snapshot" },
     { method: "POST", pathname: "/engram/v1/offline-sync/snapshot", operation: "offline_sync_snapshot" },
   { method: "POST", pathname: "/engram/v1/offline-sync/files", operation: "offline_sync_files" },
   { method: "POST", pathname: "/engram/v1/offline-sync/file-content", operation: "offline_sync_file_content" },
@@ -252,6 +253,7 @@ export const HTTP_ROUTES: readonly HttpRouteEntry[] = [
   // The operation registration makes them visible to the boundary; the
   // streaming lifecycle is owned by the HTTP transport (handleGraphEventsSSE).
   { method: "GET", pathname: "/engram/v1/offline-sync/snapshot-stream", operation: "offline_sync_snapshot_stream" },
+  { method: "GET", pathname: "/engram/v1/offline-sync/manifest-stream", operation: "offline_sync_snapshot_stream" },
   { method: "GET", pathname: "/engram/v1/graph/events", operation: "graph_events" },
   { method: "POST", pathname: "/engram/v1/chat/message", operation: "chat_message" },
   { method: "GET", pathname: "/engram/v1/chat/events/:id", operation: "chat_events" },

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -852,6 +852,7 @@ export {
   fileStatesFromSnapshot,
   globToRegExp,
   iterateOfflineSyncSnapshotFileRecords,
+  isInternalRemnicStatePath,
   normalizeOfflineSyncChangeset,
   normalizeOfflineSyncSnapshot,
   offlineSyncStateFromSnapshot,

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -16,7 +16,9 @@ import {
   buildOfflineSyncSnapshotForPaths,
   compileOfflineSyncExcludeGlobs,
   globToRegExp,
+  isInternalRemnicStatePath,
   OFFLINE_SYNC_MAX_MTIME_MS,
+  OFFLINE_SYNC_SNAPSHOT_FORMAT,
   readOfflineSyncFileContentChunk,
   shouldPreferIncomingOfflineRuntimeFile,
   summarizeOfflineSyncPendingChanges,
@@ -102,6 +104,98 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
         "state/last_recall.json",
       ],
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline sync excludes the internal Remnic tree from snapshots and file transfer", async () => {
+  const root = await tempDir("remnic-offline-internal-state");
+  const internalPaths = [
+    ".remnic/state/converge-cursors/peer.json",
+    ".remnic/state/converge.lock",
+    ".remnic/state/converge.tmp-123",
+    ".remnic/state/conflicts/fact.remote",
+  ];
+  const corpusPath = "Facts/.remnic-notes/MixedCase.md";
+  try {
+    for (const relPath of internalPaths) await write(root, relPath, relPath);
+    await write(root, corpusPath, "corpus");
+
+    assert.equal(isInternalRemnicStatePath(".remnic"), true);
+    assert.equal(isInternalRemnicStatePath(internalPaths[0]!), true);
+    assert.equal(isInternalRemnicStatePath(".Remnic/state/cursor.json"), false);
+    assert.equal(isInternalRemnicStatePath("facts/.remnic/note.md"), true);
+    assert.equal(isInternalRemnicStatePath("facts\\.remnic\\note.md"), true);
+
+    const snapshot = await buildOfflineSyncSnapshot({
+      root,
+      sourceId: "local",
+      includeContent: false,
+    });
+    assert.deepEqual(snapshot.files.map((file) => file.path), [corpusPath]);
+
+    await assert.rejects(
+      () => buildOfflineSyncSnapshotForPaths({
+        root,
+        sourceId: "local",
+        paths: [internalPaths[0]!],
+      }),
+      /offline sync snapshot path is excluded/,
+    );
+    await assert.rejects(
+      () => readOfflineSyncFileContentChunk({
+        root,
+        path: internalPaths[0]!,
+      }),
+      /offline sync file content path is excluded/,
+    );
+
+    const cursorContent = Buffer.from(internalPaths[0]!);
+    await assert.rejects(
+      () => applyOfflineSyncFileContentChunk({
+        root,
+        sourceId: "peer",
+        path: internalPaths[0]!,
+        sha256: createHash("sha256").update(cursorContent).digest("hex"),
+        bytes: cursorContent.length,
+        mtimeMs: Date.now(),
+        offset: 0,
+        content: cursorContent,
+      }),
+      /offline sync file content path is excluded/,
+    );
+    const writes: string[] = [];
+    const applyResult = await applyOfflineSyncSnapshot({
+      root,
+      snapshot: {
+        format: OFFLINE_SYNC_SNAPSHOT_FORMAT,
+        schemaVersion: 1,
+        createdAt: new Date().toISOString(),
+        sourceId: "peer",
+        includeTranscripts: true,
+        files: [{
+          path: internalPaths[0]!,
+          sha256: createHash("sha256").update(cursorContent).digest("hex"),
+          bytes: cursorContent.length,
+          mtimeMs: Date.now(),
+          contentBase64: cursorContent.toString("base64"),
+        }],
+      },
+      baseFiles: [],
+      currentFiles: [],
+      writeFile: async ({ path: relPath }) => {
+        writes.push(relPath);
+      },
+      deleteFile: async ({ path: relPath }) => {
+        writes.push(relPath);
+      },
+    });
+    assert.deepEqual(writes, []);
+    assert.equal(applyResult.upserted, 0);
+    assert.equal(applyResult.deleted, 0);
+
+    assert.equal(await readUtf8(root, internalPaths[0]!), internalPaths[0]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -515,7 +515,16 @@ function assertUniquePaths(entries: readonly { path: string }[], context: string
   }
 }
 
+export function isInternalRemnicStatePath(relPosix: string): boolean {
+  const normalized = relPosix.includes("\\") ? relPosix.replaceAll("\\", "/") : relPosix;
+  return normalized === ".remnic"
+    || normalized.startsWith(".remnic/")
+    || normalized.endsWith("/.remnic")
+    || normalized.includes("/.remnic/");
+}
+
 function shouldExcludeRelPath(relPosix: string, includeTranscripts: boolean): boolean {
+  if (isInternalRemnicStatePath(relPosix)) return true;
   const parts = relPosix.split("/");
   if (parts.some((part) => DEFAULT_TRANSFER_EXCLUDE_DIRS.has(part))) return true;
   if (parts.some((part) => part === SYNC_INTERNAL_DIR)) return true;
@@ -615,6 +624,7 @@ export function parseOfflineSyncExcludes(raw: unknown): string[] {
 }
 
 function shouldIgnoreIncomingRuntimePath(relPosix: string): boolean {
+  if (isInternalRemnicStatePath(relPosix)) return true;
   const parts = relPosix.split("/");
   const basename = parts[parts.length - 1] ?? "";
   return isCanonicalRuntimeStatePath(parts) && basename.includes(".tmp-");

--- a/packages/remnic-core/src/reconcile/cursor.test.ts
+++ b/packages/remnic-core/src/reconcile/cursor.test.ts
@@ -8,6 +8,7 @@ import {
   deriveConvergeCursorBase,
   hashPeerNamespace,
   normalizeConvergeCursor,
+  normalizeConvergePeerUrl,
   readConvergeCursor,
   writeConvergeCursor,
   type ConvergeCursorState,
@@ -39,6 +40,21 @@ test("hashPeerNamespace: preserves path case while normalizing URL authority and
   assert.equal(
     lowercasePath,
     hashPeerNamespace("HTTP://PEER.EXAMPLE.COM/memory/", "default"),
+  );
+});
+
+test("normalizeConvergePeerUrl: strips credentials and request-only URL parts without folding path case", () => {
+  assert.equal(
+    normalizeConvergePeerUrl(" HTTPS://user:secret@PEER.EXAMPLE.COM:443/Memory/?token=abc#fragment "),
+    "https://peer.example.com/Memory",
+  );
+  assert.equal(
+    hashPeerNamespace("https://user:secret@peer.example.com/Memory?token=abc#fragment", "default"),
+    hashPeerNamespace("https://peer.example.com/Memory/", "DEFAULT "),
+  );
+  assert.notEqual(
+    hashPeerNamespace("https://peer.example.com/Memory", "default"),
+    hashPeerNamespace("https://peer.example.com/memory", "default"),
   );
 });
 

--- a/packages/remnic-core/src/reconcile/cursor.ts
+++ b/packages/remnic-core/src/reconcile/cursor.ts
@@ -20,20 +20,23 @@ export interface ConvergeCursorState {
   completedPaths?: string[];
 }
 
-export function hashPeerNamespace(peerUrl: string, namespace: string): string {
-  let normalizedUrl: string;
+export function normalizeConvergePeerUrl(peerUrl: string): string {
+  const trimmed = peerUrl.trim();
   try {
-    const url = new URL(peerUrl);
-    const credentials =
-      url.username || url.password
-        ? `${url.username}${url.password ? `:${url.password}` : ""}@`
-        : "";
-    normalizedUrl =
-      `${url.protocol.toLowerCase()}//${credentials}${url.hostname.toLowerCase()}` +
-      `${url.port ? `:${url.port}` : ""}${url.pathname.replace(/\/+$/, "")}${url.search}${url.hash}`;
+    const url = new URL(trimmed);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    return url.toString().replace(/\/$/, "");
   } catch {
-    normalizedUrl = peerUrl.trim().replace(/\/+$/, "").toLowerCase();
+    return trimmed.replace(/\/+$/, "");
   }
+}
+
+export function hashPeerNamespace(peerUrl: string, namespace: string): string {
+  const normalizedUrl = normalizeConvergePeerUrl(peerUrl);
   const normalizedNs = namespace.trim().toLowerCase();
   return createHash("sha256")
     .update(`${normalizedUrl}\0${normalizedNs}`)

--- a/packages/remnic-core/src/reconcile/manifest.test.ts
+++ b/packages/remnic-core/src/reconcile/manifest.test.ts
@@ -2,6 +2,7 @@ import * as assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { test } from "node:test";
 import { ContentHashIndex } from "../storage/content-hash-index.js";
+import { parseFrontmatter } from "../storage.js";
 import { type ReconcileManifest, buildReconcileManifest, collapseActiveFactDuplicates } from "./manifest.js";
 import { planReconciliation } from "./plan.js";
 
@@ -34,6 +35,7 @@ test("reconcile manifest keeps file identity separate from canonical semantic id
 
   const manifest = await buildReconcileManifest({
     files: [{ path: "facts/fact-a.md", sha256: serializedHash, bytes: Buffer.byteLength(serialized) }],
+    parseMemory: parseFrontmatter,
     readFile: async () => Buffer.from(serialized),
   });
 
@@ -59,6 +61,7 @@ test("reconcile manifest hashes parsed legacy content and uses effective lifecyc
 
   const manifest = await buildReconcileManifest({
     files: [...rawByPath].map(([path, raw]) => ({ path, sha256: fileHash(raw.toString()) })),
+    parseMemory: parseFrontmatter,
     readFile: async (file) => rawByPath.get(file.path) ?? null,
   });
 
@@ -79,6 +82,7 @@ test("reconcile manifest keeps file identity when memory bytes cannot be trusted
 
   const manifest = await buildReconcileManifest({
     files,
+    parseMemory: parseFrontmatter,
     readFile: async (file) => {
       if (file.path === "facts/locked.md") throw new Error("locked");
       return file.path === "facts/changed.md" ? changed : readable;

--- a/packages/remnic-core/src/reconcile/manifest.ts
+++ b/packages/remnic-core/src/reconcile/manifest.ts
@@ -34,9 +34,14 @@ export interface ReconcileManifest {
   files: ReconcileManifestFile[];
 }
 
+export type ReconcileMemoryParser = (
+  raw: string,
+) => { frontmatter: MemoryFrontmatter; content: string } | null;
+
 export interface BuildReconcileManifestOptions {
   files: Iterable<ReconcileFileState>;
   readFile: (file: ReconcileFileState) => Promise<Buffer | string | null>;
+  parseMemory: ReconcileMemoryParser;
   cachedFiles?: Iterable<ReconcileManifestFile>;
 }
 
@@ -51,49 +56,46 @@ function isMemoryPath(filePath: string): boolean {
   return MEMORY_DIRS.has(segments[index] ?? "");
 }
 
-function parseScalar(value: string | undefined): string | undefined {
-  if (value === undefined) return undefined;
-  const trimmed = value.trim();
-  if (trimmed.length === 0) return undefined;
-  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
-    try {
-      const parsed = JSON.parse(trimmed) as unknown;
-      return typeof parsed === "string" ? parsed : trimmed;
-    } catch {
-      return trimmed.slice(1, -1).replace(/\\"/g, '"');
-    }
-  }
-  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
-    return trimmed.slice(1, -1).replace(/''/g, "'");
-  }
-  return trimmed;
-}
 
-function parsedMemoryIdentity(filePath: string, raw: Buffer | string): ReconcileMemoryIdentity | undefined {
+function parsedMemoryIdentity(
+  filePath: string,
+  raw: Buffer | string,
+  parseMemory: ReconcileMemoryParser,
+): ReconcileMemoryIdentity | undefined {
   if (!isMemoryPath(filePath)) return undefined;
-  const match = (Buffer.isBuffer(raw) ? raw.toString("utf8") : raw).match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
-  if (!match) return undefined;
-  const fields = new Map<string, string>();
-  for (const line of match[1].split("\n")) {
-    const separator = line.indexOf(":");
-    if (separator > 0) fields.set(line.slice(0, separator).trim(), line.slice(separator + 1).trim());
-  }
-  const id = parseScalar(fields.get("id"));
-  if (!id) return undefined;
-  const category = parseScalar(fields.get("category")) ?? "fact";
-  const storedHash = parseScalar(fields.get("contentHash"));
+  const parsed = parseMemory(Buffer.isBuffer(raw) ? raw.toString("utf8") : raw);
+  if (!parsed?.frontmatter.id) return undefined;
+  const storedHash = parsed.frontmatter.contentHash;
   const contentHash =
     storedHash && SHA256_PATTERN.test(storedHash)
       ? storedHash.toLowerCase()
-      : ContentHashIndex.computeHash(match[2].trim());
-  const status = inferMemoryStatus(
-    {
-      status: parseScalar(fields.get("status")) as MemoryStatus | undefined,
-      archivedAt: parseScalar(fields.get("archivedAt")),
-    } as MemoryFrontmatter,
-    filePath
-  );
-  return { id, category, contentHash, status };
+      : ContentHashIndex.computeHash(parsed.content);
+  return {
+    id: parsed.frontmatter.id,
+    category: parsed.frontmatter.category,
+    contentHash,
+    status: inferMemoryStatus(parsed.frontmatter, filePath),
+  };
+}
+
+export async function buildReconcileManifestFile(
+  file: ReconcileFileState,
+  readFile: (file: ReconcileFileState) => Promise<Buffer | string | null>,
+  parseMemory: ReconcileMemoryParser,
+): Promise<ReconcileManifestFile> {
+  let raw: Buffer | string | null = null;
+  if (isMemoryPath(file.path)) {
+    try {
+      raw = await readFile(file);
+    } catch {
+      raw = null;
+    }
+  }
+  if (raw !== null && createHash("sha256").update(raw).digest("hex") !== file.sha256.toLowerCase()) {
+    raw = null;
+  }
+  const memory = raw === null ? undefined : parsedMemoryIdentity(file.path, raw, parseMemory);
+  return { ...file, ...(memory ? { memory } : {}) };
 }
 
 export async function buildReconcileManifest(options: BuildReconcileManifestOptions): Promise<ReconcileManifest> {
@@ -110,19 +112,7 @@ export async function buildReconcileManifest(options: BuildReconcileManifestOpti
       continue;
     }
 
-    let raw: Buffer | string | null = null;
-    if (isMemoryPath(file.path)) {
-      try {
-        raw = await options.readFile(file);
-      } catch {
-        raw = null;
-      }
-    }
-    if (raw !== null && createHash("sha256").update(raw).digest("hex") !== file.sha256.toLowerCase()) {
-      raw = null;
-    }
-    const memory = raw === null ? undefined : parsedMemoryIdentity(file.path, raw);
-    files.push({ ...file, ...(memory ? { memory } : {}) });
+    files.push(await buildReconcileManifestFile(file, options.readFile, options.parseMemory));
   }
   files.sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
   return {


### PR DESCRIPTION
## Summary
Hardens converge transport (#2232), adds a body-free sync-manifest route (#2233), and excludes internal state from corpus snapshots (#2236).

## Closes
#2232, #2233, #2236

## Validation
- Focused integrated suite: 211 passed
- check-types, build, review-patterns, ratchets passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to peer reconciliation, file transfer, and tombstone/suppress apply paths can affect data convergence correctness; credential stripping and internal-path guards reduce leakage but behavior shifts are broad.
> 
> **Overview**
> **Converge** peer I/O moves into dedicated transport/manifest modules with request timeouts, URL canonicalization (credentials/query/hash stripped), `/remnic` vs `/engram` route fallback, and **chunked** pull/push that can resume after partial failure. Planning uses a new **capabilities** probe and, when `manifestStream` is supported, an NDJSON **manifest-stream** so semantic reconciliation avoids per-fact file downloads; legacy peers still fetch file bodies and errors surface instead of being swallowed.
> 
> **Server-side**, offline sync adds **GET manifest-stream** and **capabilities** (advertising `manifestStream`), shared NDJSON streaming helpers, and lazy body-free manifest rows with memory metadata only. **`isInternalRemnicStatePath`** excludes `.remnic` trees from snapshots, transfers, converge cursors/plans, and peer manifest parsing.
> 
> Converge planning/apply also **discovers cursor-only namespaces**, fails on bad cursor JSON, maps tombstone **content hashes** to file digests via manifests, and **suppress** actions now perform real deletes on local/peer/both. Dry-run reports `converged` from the plan; peer URL normalization for cursor keys no longer lowercases path case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 975f49a41b8242905943bfacfd73a95c6633e948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peer-to-peer offline synchronization with streamed manifests and chunked file transfers.
  * Added capability detection, route fallback, convergence completion, and file deletion support.
  * Added manifest streaming for offline-sync endpoints, including transcript filtering and namespace authorization.
* **Bug Fixes**
  * Improved transfer integrity checks, retries, timeouts, and error handling.
  * Excluded internal `.remnic` state files from snapshots, manifests, and file operations.
  * Improved tombstone handling and durable cursor behavior.
* **Refactor**
  * Standardized peer URL normalization and manifest memory metadata parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->