### PR TITLE
fix(converge): remove duplicate fetchPeerSnapshot from merge artifact

### DIFF
--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -152,22 +152,6 @@ async function readLocalTombstones(rootDir: string): Promise<Set<string>> {
   return shaSet;
 }
 
-async function fetchPeerSnapshot(
-  peerUrl: string,
-  namespace: string,
-  token?: string,
-  fetchImpl: typeof fetch = globalThis.fetch
-): Promise<{ files: ReconcileFileState[]; tombstones: Set<string> }> {
-  let base = peerUrl;
-  while (base.endsWith("/")) {
-    base = base.slice(0, -1);
-  }
-  const routes = [
-    `/remnic/v1/offline-sync/snapshot?namespace=${encodeURIComponent(namespace)}&content=false`,
-    `/engram/v1/offline-sync/snapshot?namespace=${encodeURIComponent(namespace)}&content=false`,
-  ];
-  const headers: Record<string, string> = token ? { authorization: `Bearer ${token}` } : {};
-  let lastFailure = "no snapshot route responded";
 interface TombstoneEvidence {
   contentHashes: Set<string>;
   fileSha256: Set<string>;


### PR DESCRIPTION
Hotfix: a conflict-resolution artifact left a broken duplicate fetchPeerSnapshot in converge.ts, failing check-types on main. Removes the incomplete first definition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only cleanup of dead duplicate code; peer snapshot behavior remains on the shared transport module.
> 
> **Overview**
> Removes an **incomplete duplicate** `fetchPeerSnapshot` in `converge.ts` that was left behind after conflict resolution. That stub only set up peer URL, snapshot routes, and auth headers and never finished the function body, which broke **`check-types` on main**.
> 
> Converge already imports **`fetchPeerSnapshot`** from `converge-peer-transport.js`; this change drops the stray local definition so there is a single implementation again. No intended runtime behavior change beyond restoring a compilable module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c61cac79bb50a76bf730c9bdd112d4512970e65f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization of deleted files by tracking deletion timestamps.
  - Correctly matches deletion records to their corresponding files.
  - Reads deletion records from all supported locations.
  - Validates deletion data, including file paths, timestamps, and duplicate entries.
  - Preserves relevant filesystem errors when reading deletion records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->