### PR TITLE
feat(entity): alias/symlink validation, control-char rejection, body-preserving migration (#2207 PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Extraction health no longer treats local filter skips as successful runs. Live empty runs record health only when later steps succeed.
 - Stats now add extraction counts from active namespaces. Scoped health keeps the backlog counts behind its status. Invalid calendar dates now fail metadata checks.
+- Entity migration now rejects symlinked alias configs and control characters in IDs. Reference rewrites preserve the original memory body bytes.
 
 ## [v9.45.1] — 2026-07-30
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -47,6 +47,8 @@ import {
 import { EntityCanonicalIdMigrationRunner } from "./storage/entity-canonical-id-migration-runner.js";
 import { rememberRawFrontmatter } from "./storage/memory-frontmatter-metadata.js";
 import { createMemoryEntityRefSerializer } from "./storage/memory-migration-serialization.js";
+import { readEntityAliasConfigSync } from "./storage/entity-alias-config.js";
+import { assertSafeEntityId } from "./storage/entity-id-safety.js";
 export { normalizeEntityName } from "./entity-id-normalization.js";
 import { isErrnoCode } from "./utils/errno.js";
 import { getCategoryDir, categoryDirName } from "./utils/category-dir.js";
@@ -639,7 +641,7 @@ function parseReinforcementCountField(raw: string | undefined): number | undefin
 }
 
 export function parseFrontmatter(raw: string): { frontmatter: MemoryFrontmatter; content: string } | null {
-  const match = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)([\s\S]*)$/);
   if (!match) return null;
 
   const fmBlock = match[1];
@@ -3748,27 +3750,28 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
 
   private loadAliasesSync(): void {
     const aliasPath = path.join(this.baseDir, "config", "aliases.json");
-    // Re-derive from the file on every call: a reload after the file was
-    // fixed, emptied, or removed must never leave a previous table active.
     this.userAliases = {};
+    const raw = readEntityAliasConfigSync(this.baseDir);
+    if (raw === undefined) return;
+    let parsed: unknown;
     try {
-      const raw = readFileSync(aliasPath, "utf-8");
-      const parsed = JSON.parse(raw);
-      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
-        const cleaned: Record<string, string> = {};
-        for (const [key, value] of Object.entries(parsed)) {
-          if (typeof value === "string" && value.trim().length > 0) {
-            cleaned[key] = value;
-          }
-        }
-        this.userAliases = cleaned;
-        log.debug(`loaded ${Object.keys(cleaned).length} entity aliases from ${aliasPath}`);
-      } else {
-        log.warn(`ignoring ${aliasPath}: payload must be a JSON object mapping variant → canonical strings`);
-      }
+      parsed = JSON.parse(raw);
     } catch {
-      // No aliases file — that's fine, use built-in only
-      log.debug("no config/aliases.json found — using built-in aliases only");
+      log.debug("invalid config/aliases.json — using built-in aliases only");
+      return;
+    }
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      const cleaned: Record<string, string> = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (typeof value === "string" && value.trim().length > 0) {
+          assertSafeEntityId(value);
+          cleaned[key] = value;
+        }
+      }
+      this.userAliases = cleaned;
+      log.debug(`loaded ${Object.keys(cleaned).length} entity aliases from ${aliasPath}`);
+    } else {
+      log.warn(`ignoring ${aliasPath}: payload must be a JSON object mapping variant → canonical strings`);
     }
   }
   private async runLegacyEntityCanonicalIdMigration(): Promise<string | undefined> {

--- a/packages/remnic-core/src/storage/entity-alias-config.ts
+++ b/packages/remnic-core/src/storage/entity-alias-config.ts
@@ -1,0 +1,97 @@
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+} from "node:fs";
+import path from "node:path";
+
+import { isErrnoCode } from "../utils/errno.js";
+import { assertPathInsideRoot } from "../utils/path-containment.js";
+
+function resolveSafeAliasRoots(baseDir: string, configDir: string): string | undefined {
+  let baseStat;
+  try {
+    baseStat = lstatSync(baseDir);
+  } catch (error) {
+    if (isErrnoCode(error, "ENOENT")) return undefined;
+    throw error;
+  }
+  if (baseStat.isSymbolicLink() || !baseStat.isDirectory()) {
+    throw new Error(`Refusing unsafe entity alias memory root: ${baseDir}.`);
+  }
+
+  let configStat;
+  try {
+    configStat = lstatSync(configDir);
+  } catch (error) {
+    if (isErrnoCode(error, "ENOENT")) return undefined;
+    throw error;
+  }
+  if (configStat.isSymbolicLink() || !configStat.isDirectory()) {
+    throw new Error(`Refusing unsafe entity alias config root: ${configDir}.`);
+  }
+
+  const memoryRoot = realpathSync(baseDir);
+  assertPathInsideRoot(memoryRoot, realpathSync(configDir), configDir);
+  return memoryRoot;
+}
+
+export function readEntityAliasConfigSync(baseDir: string): string | undefined {
+  const configDir = path.join(baseDir, "config");
+  const aliasPath = path.join(configDir, "aliases.json");
+  let memoryRoot = resolveSafeAliasRoots(baseDir, configDir);
+  if (memoryRoot === undefined) return undefined;
+
+  let aliasPreflight;
+  try {
+    aliasPreflight = lstatSync(aliasPath);
+  } catch (error) {
+    if (isErrnoCode(error, "ENOENT")) return undefined;
+    throw error;
+  }
+  if (aliasPreflight.isSymbolicLink() || !aliasPreflight.isFile()) {
+    throw new Error(`Refusing unsafe entity alias config file: ${aliasPath}.`);
+  }
+
+  let fd: number;
+  try {
+    fd = openSync(
+      aliasPath,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0) | (constants.O_NONBLOCK ?? 0),
+    );
+  } catch (error) {
+    if (isErrnoCode(error, "ENOENT")) {
+      resolveSafeAliasRoots(baseDir, configDir);
+      return undefined;
+    }
+    if (isErrnoCode(error, "ELOOP")) {
+      throw new Error(`Refusing unsafe entity alias config file: ${aliasPath}.`);
+    }
+    throw error;
+  }
+  try {
+    const opened = fstatSync(fd);
+    memoryRoot = resolveSafeAliasRoots(baseDir, configDir);
+    if (memoryRoot === undefined) {
+      throw new Error(`Refusing unsafe entity alias config root: ${configDir}.`);
+    }
+    const aliasStat = lstatSync(aliasPath);
+    if (
+      !opened.isFile() ||
+      aliasStat.isSymbolicLink() ||
+      !aliasStat.isFile() ||
+      aliasStat.dev !== opened.dev ||
+      aliasStat.ino !== opened.ino
+    ) {
+      throw new Error(`Refusing unsafe entity alias config file: ${aliasPath}.`);
+    }
+    assertPathInsideRoot(memoryRoot, realpathSync(aliasPath), aliasPath);
+    return readFileSync(fd, "utf-8");
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -21,6 +21,7 @@ import { withHeldFileLock } from "../utils/serialize-mutations.js";
 import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
 import { assertPathInsideRoot } from "../utils/path-containment.js";
 import { withEntityCanonicalMutationLock } from "./entity-canonical-id-lock.js";
+import { assertSafeEntityId } from "./entity-id-safety.js";
 
 import {
   ENTITY_CANONICAL_ID_MIGRATION_FILE,
@@ -238,6 +239,12 @@ async function readState(
   }
   const result = EntityCanonicalIdMigrationStateSchema.safeParse(parsed);
   if (!result.success) throw new Error("Invalid entity canonical-id migration state.");
+  for (const mappings of [result.data.mappings, result.data.blocked ?? {}]) {
+    for (const [legacyId, canonicalId] of Object.entries(mappings)) {
+      assertSafeEntityId(legacyId);
+      assertSafeEntityId(canonicalId);
+    }
+  }
   return result.data;
 }
 
@@ -289,12 +296,6 @@ async function sameFileIdentity(leftPath: string, rightPath: string): Promise<bo
   } catch (error) {
     if (isErrnoCode(error, "ENOENT")) return false;
     throw error;
-  }
-}
-
-function assertSafeEntityId(entityId: string): void {
-  if (/[\/\\\0]/.test(entityId)) {
-    throw new Error(`Refusing entity canonical-id migration through unsafe entity id: ${entityId}.`);
   }
 }
 

--- a/packages/remnic-core/src/storage/entity-canonical-id-references.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-references.ts
@@ -32,6 +32,7 @@ import { log } from "../logger.js";
 import { isErrnoCode } from "../utils/errno.js";
 import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
 import { withEntityCanonicalMutationLock } from "./entity-canonical-id-lock.js";
+import { assertSafeEntityId } from "./entity-id-safety.js";
 import { normalizeSupersessionKey } from "../temporal-supersession.js";
 
 export const ENTITY_CANONICAL_ID_MIGRATION_FILE = "entity-canonical-id-migration-v1.json";
@@ -51,6 +52,8 @@ function parseJournalMappings(raw: string): Readonly<Record<string, string>> {
   const cleaned: Record<string, string> = Object.create(null) as Record<string, string>;
   for (const [legacyId, canonicalId] of Object.entries(mappings)) {
     if (legacyId.length > 0 && typeof canonicalId === "string" && canonicalId.length > 0) {
+      assertSafeEntityId(legacyId);
+      assertSafeEntityId(canonicalId);
       cleaned[legacyId] = canonicalId;
     }
   }

--- a/packages/remnic-core/src/storage/entity-id-safety.ts
+++ b/packages/remnic-core/src/storage/entity-id-safety.ts
@@ -1,0 +1,7 @@
+const UNSAFE_ENTITY_ID_PATTERN = /[\/\\\p{Cc}\p{Zl}\p{Zp}]/u;
+
+export function assertSafeEntityId(entityId: string): void {
+  if (UNSAFE_ENTITY_ID_PATTERN.test(entityId)) {
+    throw new Error("Refusing unsafe entity id containing a path separator or control character.");
+  }
+}

--- a/packages/remnic-core/src/storage/memory-frontmatter-metadata.ts
+++ b/packages/remnic-core/src/storage/memory-frontmatter-metadata.ts
@@ -1,17 +1,12 @@
 export type RawFrontmatterOwner = object;
 
-const rawFrontmatterByMemory = new WeakMap<RawFrontmatterOwner, string>();
-
-export function extractRawFrontmatter(raw: string): string | null {
-  return raw.match(/^---\n([\s\S]*?)\n---\n?/)?.[1] ?? null;
-}
+const rawDocumentByMemory = new WeakMap<RawFrontmatterOwner, string>();
 
 export function rememberRawFrontmatter<T extends RawFrontmatterOwner>(owner: T, raw: string): T {
-  const frontmatter = extractRawFrontmatter(raw);
-  if (frontmatter !== null) rawFrontmatterByMemory.set(owner, frontmatter);
+  if (/^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/.test(raw)) rawDocumentByMemory.set(owner, raw);
   return owner;
 }
 
-export function readRawFrontmatter(owner: RawFrontmatterOwner): string | undefined {
-  return rawFrontmatterByMemory.get(owner);
+export function readRawMemoryDocument(owner: RawFrontmatterOwner): string | undefined {
+  return rawDocumentByMemory.get(owner);
 }

--- a/packages/remnic-core/src/storage/memory-migration-serialization.ts
+++ b/packages/remnic-core/src/storage/memory-migration-serialization.ts
@@ -1,5 +1,6 @@
 import type { MemoryFile, MemoryFrontmatter } from "../types.js";
-import { readRawFrontmatter } from "./memory-frontmatter-metadata.js";
+import { readRawMemoryDocument } from "./memory-frontmatter-metadata.js";
+import { canonicalizeEntityRefFrontmatter } from "./entity-canonical-id-references.js";
 
 export type MemoryEntityRefSerializer = (memory: MemoryFile, entityRef: string) => string;
 
@@ -8,20 +9,14 @@ export function serializeMemoryWithEntityRef(
   entityRef: string,
   fallback: MemoryEntityRefSerializer,
 ): string {
-  const rawFrontmatter = readRawFrontmatter(memory);
-  if (rawFrontmatter === undefined) return fallback(memory, entityRef);
-  const lines = rawFrontmatter.split("\n");
-  let entityRefLine = -1;
-  for (let index = 0; index < lines.length; index += 1) {
-    if (/^\s*entityRef\s*:/.test(lines[index] ?? "")) entityRefLine = index;
-  }
-  if (entityRefLine >= 0) {
-    const indent = lines[entityRefLine]!.match(/^\s*/)?.[0] ?? "";
-    lines[entityRefLine] = `${indent}entityRef: ${entityRef}`;
-  } else {
-    lines.push(`entityRef: ${entityRef}`);
-  }
-  return `---\n${lines.join("\n")}\n---\n\n${memory.content}\n`;
+  const rawDocument = readRawMemoryDocument(memory);
+  if (rawDocument === undefined) return fallback(memory, entityRef);
+  const currentEntityRef = memory.frontmatter.entityRef;
+  if (currentEntityRef === undefined) return fallback(memory, entityRef);
+  if (currentEntityRef === entityRef) return rawDocument;
+  const rewritten = canonicalizeEntityRefFrontmatter(rawDocument, { [currentEntityRef]: entityRef });
+  if (rewritten !== rawDocument) return rewritten;
+  return fallback(memory, entityRef);
 }
 
 export function createMemoryEntityRefSerializer(

--- a/tests/entity-synthesis-storage.test.ts
+++ b/tests/entity-synthesis-storage.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 import { link, lstat, mkdir, mkdtemp, open, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
 import {
   StorageManager,
   compareEntityTimestamps,
@@ -354,6 +355,111 @@ test("ensureDirectories migrates legacy Unicode entity ids and memory references
       [{ target: canonical, label: "depends on" }],
     );
     assert.deepEqual((await upgraded.readEntities()).sort(), [relatedCanonical, canonical].sort());
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("entity reference migration preserves the raw memory body byte-for-byte", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-migration-raw-body-"));
+  try {
+    const name = "月光";
+    const type = "project";
+    const canonical = normalizeEntityName(name, type);
+    const legacy = normalizeLegacyEntityName(name, type);
+    const seed = new StorageManager(dir);
+    await seed.ensureDirectories();
+    await seed.writeEntity(name, type, ["Synthetic entity fact."]);
+    await rename(path.join(dir, "entities", `${canonical}.md`), path.join(dir, "entities", `${legacy}.md`));
+    const day = new Date().toISOString().slice(0, 10);
+    const memoryPath = path.join(dir, "facts", day, "raw-body.md");
+    const rawBody = "\n    indented code block\n\nTrailing spaces stay.  \n\n";
+    const original =
+      [
+        "---",
+        "id: raw-body",
+        "category: fact",
+        "created: 2026-07-25T00:00:00.000Z",
+        `entityRef: ${legacy}`,
+        "---",
+      ].join("\n") + rawBody;
+    await writeFile(memoryPath, original, "utf-8");
+    await rm(path.join(dir, "state", "entity-canonical-id-migration-v1.json"), { force: true });
+
+    await new StorageManager(dir).ensureDirectories();
+
+    const migrated = await readFile(memoryPath, "utf-8");
+    assert.equal(migrated, original.replace(`entityRef: ${legacy}`, `entityRef: ${canonical}`));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("entity reference migration preserves CRLF memory documents byte-for-byte", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-migration-crlf-body-"));
+  try {
+    const name = "月光";
+    const type = "project";
+    const canonical = normalizeEntityName(name, type);
+    const legacy = normalizeLegacyEntityName(name, type);
+    const seed = new StorageManager(dir);
+    await seed.ensureDirectories();
+    await seed.writeEntity(name, type, ["Synthetic entity fact."]);
+    await rename(path.join(dir, "entities", `${canonical}.md`), path.join(dir, "entities", `${legacy}.md`));
+    const day = new Date().toISOString().slice(0, 10);
+    const memoryPath = path.join(dir, "facts", day, "raw-body-crlf.md");
+    const original = [
+      "---",
+      "id: raw-body-crlf",
+      "category: fact",
+      "created: 2026-07-25T00:00:00.000Z",
+      `entityRef: ${legacy}`,
+      "---",
+      "",
+      "    indented code block",
+      "",
+      "Trailing spaces stay.  ",
+      "",
+    ].join("\r\n");
+    await writeFile(memoryPath, original, "utf-8");
+    await rm(path.join(dir, "state", "entity-canonical-id-migration-v1.json"), { force: true });
+
+    await new StorageManager(dir).ensureDirectories();
+
+    const migrated = await readFile(memoryPath, "utf-8");
+    assert.equal(migrated, original.replace(`entityRef: ${legacy}`, `entityRef: ${canonical}`));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("entity reference migration leaves non-standalone frontmatter delimiters untouched", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-migration-malformed-delimiter-"));
+  try {
+    const name = "月光";
+    const type = "project";
+    const canonical = normalizeEntityName(name, type);
+    const legacy = normalizeLegacyEntityName(name, type);
+    const seed = new StorageManager(dir);
+    await seed.ensureDirectories();
+    await seed.writeEntity(name, type, ["Synthetic entity fact."]);
+    await rename(path.join(dir, "entities", `${canonical}.md`), path.join(dir, "entities", `${legacy}.md`));
+    const day = new Date().toISOString().slice(0, 10);
+    const memoryPath = path.join(dir, "facts", day, "malformed-delimiter.md");
+    const original = [
+      "---",
+      "id: malformed-delimiter",
+      "category: fact",
+      "created: 2026-07-25T00:00:00.000Z",
+      `entityRef: ${legacy}`,
+      "---body starts on the delimiter line",
+    ].join("\n");
+    await writeFile(memoryPath, original, "utf-8");
+    await rm(path.join(dir, "state", "entity-canonical-id-migration-v1.json"), { force: true });
+
+    await new StorageManager(dir).ensureDirectories();
+
+    assert.equal(await readFile(memoryPath, "utf-8"), original);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -1159,6 +1265,49 @@ test("ensureDirectories reruns migration when aliases change and ignores reversa
   }
 });
 
+test("StorageManager rejects symlinked entity alias roots and files before loading them", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-alias-root-symlink-"));
+  const fileDir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-alias-file-symlink-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-alias-outside-"));
+  try {
+    await new StorageManager(rootDir).ensureDirectories();
+    await new StorageManager(fileDir).ensureDirectories();
+    await rm(path.join(rootDir, "config"), { recursive: true, force: true });
+    await symlink(outsideDir, path.join(rootDir, "config"));
+    assert.throws(() => new StorageManager(rootDir), /unsafe entity alias config|symlink/i);
+
+    const outsideAliases = path.join(outsideDir, "aliases.json");
+    await writeFile(outsideAliases, JSON.stringify({ café: "coffee" }), "utf-8");
+    await symlink(outsideAliases, path.join(fileDir, "config", "aliases.json"));
+    assert.throws(() => new StorageManager(fileDir), /unsafe entity alias config|symlink/i);
+  } finally {
+    await Promise.all([
+      rm(rootDir, { recursive: true, force: true }),
+      rm(fileDir, { recursive: true, force: true }),
+      rm(outsideDir, { recursive: true, force: true }),
+    ]);
+  }
+});
+
+test(
+  "StorageManager rejects a non-regular alias entry without opening it",
+  {
+    skip: process.platform === "win32",
+  },
+  async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-alias-fifo-"));
+    try {
+      await new StorageManager(dir).ensureDirectories();
+      const aliasPath = path.join(dir, "config", "aliases.json");
+      execFileSync("mkfifo", [aliasPath]);
+
+      assert.throws(() => new StorageManager(dir), /unsafe entity alias config|regular file/i);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+);
+
 test("ensureDirectories rejects a symlinked migration journal", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-migration-journal-symlink-"));
   const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-migration-journal-outside-"));
@@ -1189,7 +1338,31 @@ test("ensureDirectories rejects a symlinked migration journal", async () => {
   }
 });
 
-test("ensureDirectories rejects path separators in alias migration targets", async () => {
+test("ensureDirectories rejects unsafe ids retained in a completed migration journal", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-migration-unsafe-journal-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    await writeFile(
+      path.join(dir, "state", "entity-canonical-id-migration-v1.json"),
+      JSON.stringify({
+        version: 1,
+        complete: true,
+        mappings: { "project-cafe": "project-foo\nbar" },
+      }),
+      "utf-8"
+    );
+
+    await assert.rejects(
+      () => new StorageManager(dir).ensureDirectories(),
+      /unsafe entity id|invalid entity canonical-id migration state/i
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadAliases rejects path separators before they can affect entity writes", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-migration-alias-path-"));
   try {
     const storage = new StorageManager(dir);
@@ -1199,21 +1372,30 @@ test("ensureDirectories rejects path separators in alias migration targets", asy
     const canonical = storage.normalizeEntityName(name, type);
     await storage.writeEntity(name, type, ["Canonical entity fact."]);
     const legacy = normalizeLegacyEntityName(name, type);
-    await rename(
-      path.join(dir, "entities", `${canonical}.md`),
-      path.join(dir, "entities", `${legacy}.md`),
-    );
-    await writeFile(
-      path.join(dir, "config", "aliases.json"),
-      JSON.stringify({ "café": "foo/bar" }),
-      "utf-8",
-    );
-    await storage.loadAliases();
+    await rename(path.join(dir, "entities", `${canonical}.md`), path.join(dir, "entities", `${legacy}.md`));
+    await writeFile(path.join(dir, "config", "aliases.json"), JSON.stringify({ café: "foo/bar" }), "utf-8");
+    await assert.rejects(() => storage.loadAliases(), /unsafe entity id|path separator/i);
+    assert.equal(storage.normalizeEntityName(name, type), canonical);
+    assert.match(await readFile(path.join(dir, "entities", `${legacy}.md`), "utf-8"), /# Café/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
 
-    await assert.rejects(
-      () => storage.ensureDirectories(),
-      /unsafe entity id|path separator/i,
-    );
+test("loadAliases rejects control characters before they can affect entity writes", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-migration-alias-control-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const name = "Café";
+    const type = "project";
+    const canonical = storage.normalizeEntityName(name, type);
+    const legacy = normalizeLegacyEntityName(name, type);
+    await storage.writeEntity(name, type, ["Canonical entity fact."]);
+    await rename(path.join(dir, "entities", `${canonical}.md`), path.join(dir, "entities", `${legacy}.md`));
+    await writeFile(path.join(dir, "config", "aliases.json"), JSON.stringify({ café: "foo\nbar" }), "utf-8");
+    await assert.rejects(() => storage.loadAliases(), /unsafe entity id|control character/i);
+    assert.equal(storage.normalizeEntityName(name, type), canonical);
     assert.match(await readFile(path.join(dir, "entities", `${legacy}.md`), "utf-8"), /# Café/);
   } finally {
     await rm(dir, { recursive: true, force: true });
@@ -1259,10 +1441,7 @@ test("ensureDirectories rejects a symlinked memory root", async () => {
   const linkedRoot = path.join(parent, "linked-root");
   try {
     await symlink(target, linkedRoot);
-    await assert.rejects(
-      () => new StorageManager(linkedRoot).ensureDirectories(),
-      /unsafe memory root|symlink/i,
-    );
+    assert.throws(() => new StorageManager(linkedRoot), /unsafe .*memory root|symlink/i);
   } finally {
     await rm(linkedRoot, { force: true });
     await Promise.all([


### PR DESCRIPTION
Part of #2207. Implements: symlinked/missing-target alias config rejection (O_NOFOLLOW); control-char rejection in alias targets and migration mappings; byte-preserving LF/CRLF entityRef migration; standalone frontmatter delimiter enforcement. Focused entity regression: 4/4 pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem safety around config reads and on-disk entity migration rewrites; mistakes could block startup or corrupt memory files, but behavior is heavily regression-tested and scoped to entity alias/migration paths.
> 
> **Overview**
> **Entity alias loading** now goes through `readEntityAliasConfigSync`, which refuses symlinked memory/config roots or `aliases.json`, opens the file with `O_NOFOLLOW`, and checks inode identity before read. Alias canonical targets and migration journal mappings are validated with shared **`assertSafeEntityId`** (path separators plus Unicode control/separator characters).
> 
> **Canonical-ID reference rewrites** no longer rebuild frontmatter from parsed fields: the full raw document is cached when parsing, and `serializeMemoryWithEntityRef` uses **`canonicalizeEntityRefFrontmatter`** so only `entityRef` changes while the body stays byte-identical (including CRLF and trailing spaces). **`parseFrontmatter`** accepts `\r\n` delimiters but still requires a standalone closing `---` line so malformed delimiters are not treated as valid frontmatter.
> 
> Regression tests cover symlink/FIFO alias rejection, unsafe journal IDs, alias load failures before writes, and migration byte preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e91dcf4109a12cfe17363ca4d0351e043402b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger validation for entity IDs, rejecting path separators and control characters.
  * Added safer alias configuration handling, including protection against symlinks and invalid paths.
  * Entity-reference migrations now preserve memory content exactly, including LF and CRLF line endings.

* **Bug Fixes**
  * Improved handling of malformed frontmatter and invalid migration data.
  * Prevented unsafe memory-root and alias configurations from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->