### PR TITLE
fix(extraction): harden lexical source grounding

### DIFF
--- a/.changeset/grounding-lexical-hardening.md
+++ b/.changeset/grounding-lexical-hardening.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Harden source grounding for verb inflections, proper identifiers, and coordinated clauses.

--- a/packages/remnic-core/src/extraction-source-grounding-helpers.ts
+++ b/packages/remnic-core/src/extraction-source-grounding-helpers.ts
@@ -31,12 +31,16 @@ export function hasExplicitRoleSubjectToken(
   sourceTokensBySentence: ReadonlyArray<ReadonlyArray<string>>,
 ): boolean {
   return candidateRole !== undefined
-    && sourceTokensBySentence.some((tokens) => tokens.includes(candidateRole));
+    && sourceTokensBySentence.some((tokens) =>
+      tokens.some((token) => token.replace(/^[\u0000\u0001]/u, "") === candidateRole));
 }
 
-export function splitGroundingClauses(sentences: ReadonlyArray<string>): string[] {
-  return sentences.flatMap((sentence) =>
-    sentence
+export function splitGroundingClauses(
+  sentences: ReadonlyArray<string>,
+  inheritCoordinatedSubjects = false,
+): string[] {
+  return sentences.flatMap((sentence) => {
+    const clauses = sentence
       .split(/,\s+(?=[\p{L}][\p{L}\p{N}'’-]*\s+\S)/gu)
       .flatMap((commaClause) =>
         commaClause
@@ -47,8 +51,49 @@ export function splitGroundingClauses(sentences: ReadonlyArray<string>): string[
               .map((clause) => clause.trim())
               .filter((clause) => clause.length > 0),
           ),
-      ),
-  );
+      );
+    if (!inheritCoordinatedSubjects || clauses.length < 2) return clauses;
+
+    const firstLexemes = groundingLexemes(clauses[0]!)
+      .filter(({ token }) => GROUNDING_STOPWORDS[token] !== true);
+    const firstPredicateIndex = firstLexemes.findIndex(({ isPredicate }) => isPredicate);
+    let subjectLexemes = firstLexemes
+      .slice(0, firstPredicateIndex < 1 ? 1 : firstPredicateIndex)
+      .filter(({ token }) => !token.endsWith("ly"));
+    let subject = subjectLexemes.map(({ surface }) => surface).join(" ");
+    let predicate = firstLexemes[firstPredicateIndex < 1 ? 1 : firstPredicateIndex]?.surface;
+    if (subject.length === 0 || predicate === undefined) return clauses;
+
+    const sourceSpans = [clauses[0]!];
+    for (const clause of clauses.slice(1)) {
+      const clauseLexemes = groundingLexemes(clause)
+        .filter(({ token }) => GROUNDING_STOPWORDS[token] !== true);
+      const clausePredicateIndex = clauseLexemes.findIndex(({ isPredicate }) => isPredicate);
+      const clauseSubjectLexemes = clausePredicateIndex > 0
+        ? clauseLexemes
+          .slice(0, clausePredicateIndex)
+          .filter(({ token }) => !token.endsWith("ly"))
+        : [];
+      const repeatsSubject = clauseSubjectLexemes.length === subjectLexemes.length
+        && subjectLexemes.every(
+          ({ token }, index) => clauseSubjectLexemes[index]?.token === token,
+        );
+      if (repeatsSubject) {
+        sourceSpans.push(clause);
+        continue;
+      }
+      if (clauseSubjectLexemes.length > 0) {
+        subjectLexemes = clauseSubjectLexemes;
+        subject = subjectLexemes.map(({ surface }) => surface).join(" ");
+        predicate = clauseLexemes[clausePredicateIndex]?.surface;
+        sourceSpans.push(clause);
+        continue;
+      }
+      const prefix = clausePredicateIndex === -1 ? `${subject} ${predicate}` : subject;
+      sourceSpans.push(clause, `${prefix} ${clause}`);
+    }
+    return sourceSpans;
+  });
 }
 
 export const GROUNDING_STOPWORDS: Record<string, true> = {
@@ -215,44 +260,122 @@ export const GROUNDING_ENTITY_TYPE_PREFIXES = new Set([
   "other",
 ]);
 
-export const GROUNDING_COMMON_VERB_FORMS = new Set([
-  "contains",
-  "employs",
-  "gives",
-  "has",
-  "hosts",
-  "likes",
-  "makes",
-  "needs",
-  "owns",
-  "prefers",
-  "requires",
-  "runs",
-  "shares",
-  "supports",
-  "takes",
-  "uses",
-  "wants",
-  "works",
-]);
+export const GROUNDING_COMMON_VERB_FORMS: Record<string, true> = {
+  add: true,
+  adds: true,
+  call: true,
+  calls: true,
+  contain: true,
+  contains: true,
+  employ: true,
+  deploy: true,
+  deploys: true,
+  design: true,
+  designs: true,
+  employs: true,
+  fill: true,
+  fills: true,
+  go: true,
+  goes: true,
+  gone: true,
+  went: true,
+  give: true,
+  gives: true,
+  has: true,
+  host: true,
+  hosts: true,
+  like: true,
+  likes: true,
+  manage: true,
+  manages: true,
+  make: true,
+  makes: true,
+  need: true,
+  needs: true,
+  own: true,
+  owns: true,
+  plan: true,
+  plans: true,
+  prefer: true,
+  prefers: true,
+  require: true,
+  requires: true,
+  run: true,
+  runs: true,
+  sleep: true,
+  sleeps: true,
+  stop: true,
+  stops: true,
+  swim: true,
+  swims: true,
+  share: true,
+  shares: true,
+  support: true,
+  supports: true,
+  take: true,
+  takes: true,
+  try: true,
+  tries: true,
+  use: true,
+  uses: true,
+  want: true,
+  wants: true,
+  work: true,
+  works: true,
+};
+
 
 export interface GroundingLexeme {
   token: string;
+  surface: string;
+  isPredicate: boolean;
   preserveTerminalS: boolean;
 }
 
 export function groundingLexemes(text: string): GroundingLexeme[] {
-  return text.normalize("NFKC").match(
+  const rawTokens = text.normalize("NFKC").match(
     /[\p{L}\p{N}]+(?:['’][\p{L}\p{N}]+)?(?:\+\+[\p{L}\p{N}]*|#[\p{L}\p{N}]*)?/gu,
-  )
-    ?.map((rawToken) => {
-      const token = rawToken.replaceAll("’", "'").toLocaleLowerCase();
-      return {
-        token,
-        preserveTerminalS: /^\p{Lu}/u.test(rawToken) && !GROUNDING_COMMON_VERB_FORMS.has(token),
-      };
-    })
-    ?? [];
+  ) ?? [];
+  const tokens = rawTokens.map((rawToken) =>
+    rawToken.replaceAll("’", "'").toLocaleLowerCase());
+  let predicateIndex = tokens.findIndex((token, index) => {
+    const previousToken = tokens[index - 1];
+    const followsAuxiliary = previousToken !== undefined
+      && GROUNDING_AUXILIARY_TOKENS.has(previousToken);
+    const capitalized = /^\p{Lu}/u.test(rawTokens[index] ?? "");
+    return followsAuxiliary || (
+      !capitalized
+      && (
+        GROUNDING_COMMON_VERB_FORMS[token] === true
+        || token.endsWith("ed")
+        || token.endsWith("ing")
+      )
+    );
+  });
+  if (predicateIndex === -1) {
+    predicateIndex = tokens.findIndex((token, index) =>
+      index > 0
+      && !/^\p{Lu}/u.test(rawTokens[index] ?? "")
+      && token.endsWith("s")
+      && !token.endsWith("ss"));
+  }
+  if (predicateIndex === -1) {
+    const leadingSubjectLength = rawTokens.findIndex((rawToken) => !/^\p{Lu}/u.test(rawToken));
+    if (leadingSubjectLength > 0) predicateIndex = leadingSubjectLength;
+  }
+  return rawTokens.map((rawToken, index) => {
+    const token = tokens[index]!;
+    const isPredicate = index === predicateIndex;
+    return {
+      token,
+      surface: rawToken,
+      preserveTerminalS: !isPredicate && (
+        /^\p{Lu}/u.test(rawToken)
+        || token.endsWith("s")
+      ),
+      isPredicate,
+    };
+  });
 }
 
 export function tokenSequence(text: string): string[] {
@@ -302,22 +425,37 @@ export function isNegatedAt(tokens: ReadonlyArray<string>, index: number): boole
 export const GROUNDING_MIN_SHARED_TOKENS = 2;
 export const GROUNDING_MIN_COVERAGE = 0.5;
 
-export function stemToken(token: string, preserveTerminalS = false): string {
+const STRICT_GROUNDING_TOKEN_PREFIX = "\u0000";
+const INFLECTED_GROUNDING_TOKEN_PREFIX = "\u0001";
+
+export function stemToken(
+  token: string,
+  preserveTerminalS = false,
+  markExact = false,
+): string {
   if (token.endsWith("'s")) return token.slice(0, -2);
-  if (preserveTerminalS) return token;
+  if (preserveTerminalS) {
+    if (!markExact) return token;
+    return `${STRICT_GROUNDING_TOKEN_PREFIX}${token}`;
+  }
   if (token.length > 5 && token.endsWith("ing")) {
     const stem = token.slice(0, -3);
-    return /(.)\1$/u.test(stem) ? stem.slice(0, -1) : stem;
+    const inflectionDoubled = /(.)\1$/u.test(stem) && stem.length > 3 && !/[lsz]$/u.test(stem);
+    const normalized = inflectionDoubled ? stem.slice(0, -1) : stem;
+    return markExact ? `${INFLECTED_GROUNDING_TOKEN_PREFIX}${normalized}` : normalized;
   }
-  if (token.length > 4 && token.endsWith("ed")) return token.slice(0, -2);
-  if (
-    !preserveTerminalS
-    && token.length > 3
-    && token.endsWith("s")
-    && !token.endsWith("ss")
-    && GROUNDING_COMMON_VERB_FORMS.has(token)
-  ) {
-    return token.slice(0, -1);
+  if (token.length > 4 && token.endsWith("ied")) {
+    const normalized = `${token.slice(0, -3)}y`;
+    return markExact ? `${INFLECTED_GROUNDING_TOKEN_PREFIX}${normalized}` : normalized;
+  }
+  if (token.length > 4 && token.endsWith("ed")) {
+    const stem = token.slice(0, -2);
+    const inflectionDoubled = /(.)\1$/u.test(stem) && stem.length > 3 && !/[lsz]$/u.test(stem);
+    const normalized = inflectionDoubled ? stem.slice(0, -1) : stem;
+    return markExact ? `${INFLECTED_GROUNDING_TOKEN_PREFIX}${normalized}` : normalized;
+  }
+  if (token.length > 3 && token.endsWith("s") && !token.endsWith("ss")) {
+    return token.endsWith("ies") ? `${token.slice(0, -3)}y` : token.slice(0, -1);
   }
   return token;
 }
@@ -326,7 +464,7 @@ export function stemToken(token: string, preserveTerminalS = false): string {
 export function tokenize(text: string): Set<string> {
   const tokens = new Set<string>();
   for (const { token, preserveTerminalS } of groundingLexemes(text)) {
-    if (GROUNDING_STOPWORDS[token] !== true) tokens.add(stemToken(token, preserveTerminalS));
+    if (GROUNDING_STOPWORDS[token] !== true) tokens.add(stemToken(token, preserveTerminalS, true));
   }
   return tokens;
 }
@@ -371,7 +509,7 @@ export function groundingTokenSequence(text: string): string[] {
   }
   return lexemes
     .filter(({ token }) => GROUNDING_STOPWORDS[token] !== true)
-    .map(({ token, preserveTerminalS }) => stemToken(token, preserveTerminalS));
+    .map(({ token, preserveTerminalS }) => stemToken(token, preserveTerminalS, true));
 }
 export function normalizedGroundingAlignmentTokenSequence(text: string): string[] {
   const normalized = normalizedGroundingTokenSequence(text);
@@ -379,7 +517,7 @@ export function normalizedGroundingAlignmentTokenSequence(text: string): string[
   if (firstLexeme === undefined || !GROUNDING_SUBJECT_PRONOUNS.has(firstLexeme.token)) {
     return normalized;
   }
-  return [stemToken(firstLexeme.token, firstLexeme.preserveTerminalS), ...normalized];
+  return [stemToken(firstLexeme.token, firstLexeme.preserveTerminalS, true), ...normalized];
 }
 
 
@@ -388,7 +526,28 @@ export function normalizedGroundingTokenSequence(text: string): string[] {
 }
 
 export function areGroundingTokensCompatible(left: string, right: string): boolean {
-  return left === right || `${left}e` === right || left === `${right}e`;
+  const leftPrefix = left[0];
+  const rightPrefix = right[0];
+  const leftMarked = leftPrefix === STRICT_GROUNDING_TOKEN_PREFIX
+    || leftPrefix === INFLECTED_GROUNDING_TOKEN_PREFIX;
+  const rightMarked = rightPrefix === STRICT_GROUNDING_TOKEN_PREFIX
+    || rightPrefix === INFLECTED_GROUNDING_TOKEN_PREFIX;
+  const leftToken = leftMarked ? left.slice(1) : left;
+  const rightToken = rightMarked ? right.slice(1) : right;
+  if (leftToken === rightToken) {
+    const strictToInflected = (
+      leftPrefix === STRICT_GROUNDING_TOKEN_PREFIX
+      && rightPrefix === INFLECTED_GROUNDING_TOKEN_PREFIX
+    ) || (
+      rightPrefix === STRICT_GROUNDING_TOKEN_PREFIX
+      && leftPrefix === INFLECTED_GROUNDING_TOKEN_PREFIX
+    );
+    return !strictToInflected;
+  }
+  if (leftPrefix === STRICT_GROUNDING_TOKEN_PREFIX || rightPrefix === STRICT_GROUNDING_TOKEN_PREFIX) {
+    return false;
+  }
+  return `${leftToken}e` === rightToken || leftToken === `${rightToken}e`;
 }
 const GROUNDING_DENIAL_REPORTING_VERBS = new Set([
   "deny",

--- a/packages/remnic-core/src/extraction-source-grounding-rules.ts
+++ b/packages/remnic-core/src/extraction-source-grounding-rules.ts
@@ -94,8 +94,8 @@ function groundingCopularClaim(text: string): GroundingCopularClaim | undefined 
   if (subjectLexeme === undefined || predicateLexeme === undefined) return undefined;
 
   return {
-    subject: stemToken(subjectLexeme.token, subjectLexeme.preserveTerminalS),
-    predicate: stemToken(predicateLexeme.token, predicateLexeme.preserveTerminalS),
+    subject: stemToken(subjectLexeme.token, subjectLexeme.preserveTerminalS, true),
+    predicate: stemToken(predicateLexeme.token, predicateLexeme.preserveTerminalS, true),
   };
 }
 
@@ -137,18 +137,44 @@ function isGroundingAlignmentModifier(token: string): boolean {
   return GROUNDING_ALIGNMENT_MODIFIERS.has(token);
 }
 
+function groundingSubjectTokenSequence(text: string): string[] {
+  const lexemes = groundingLexemes(text)
+    .filter(({ token }) => GROUNDING_STOPWORDS[token] !== true);
+  const predicateIndex = lexemes.findIndex(({ isPredicate }) => isPredicate);
+  if (predicateIndex < 1) return [];
+  return lexemes
+    .slice(0, predicateIndex)
+    .filter(({ token }) => !isGroundingAlignmentModifier(token) && !token.endsWith("ly"))
+    .map(({ token, preserveTerminalS }) => stemToken(token, preserveTerminalS, true));
+}
+
 
 function hasAlignedSubjectPredicateOverlap(candidate: string, source: string): boolean {
   const candidateTokens = normalizedGroundingAlignmentTokenSequence(candidate);
   const sourceTokens = normalizedGroundingAlignmentTokenSequence(source);
+  const candidateSubjectTokens = groundingSubjectTokenSequence(candidate);
+  const sourceSubjectTokens = groundingSubjectTokenSequence(source);
+  const hasCorrectionReordering = /\b(?:rather\s+than|instead\s+of)\b/iu.test(candidate)
+    && /\b(?:not|rather\s+than|instead\s+of)\b/iu.test(source);
+  if (
+    candidateSubjectTokens.length > 0
+    && sourceSubjectTokens.length > 0
+    && !hasCorrectionReordering
+    && (
+      candidateSubjectTokens.length !== sourceSubjectTokens.length
+      || candidateSubjectTokens.some(
+        (token, index) => !areGroundingTokensCompatible(token, sourceSubjectTokens[index]!),
+      )
+    )
+  ) {
+    return false;
+  }
   if (candidateTokens.length < 3 || sourceTokens.length < 3) {
     return hasCopularPredicateEvidence(candidate, source);
   }
 
   const candidateSubject = candidateTokens[0];
   if (candidateSubject === undefined) return false;
-  const hasCorrectionReordering = /\b(?:rather\s+than|instead\s+of)\b/iu.test(candidate)
-    && /\b(?:not|rather\s+than|instead\s+of)\b/iu.test(source);
   for (let sourceSubjectIndex = 0; sourceSubjectIndex < sourceTokens.length; sourceSubjectIndex += 1) {
     if (!areGroundingTokensCompatible(candidateSubject, sourceTokens[sourceSubjectIndex]!)) continue;
     let sourceCursor = sourceSubjectIndex + 1;
@@ -256,7 +282,7 @@ function isSourceGroundedClause(
     }
     const sourceSpans = /\b(?:rather\s+than|instead\s+of)\b/iu.test(candidate)
       ? [sentence]
-      : splitGroundingClauses([sentence]);
+      : splitGroundingClauses([sentence], true);
     for (const sourceSpan of sourceSpans) {
       const sourceSpanText = normalizeForExactMatch(sourceSpan);
       if (containsExactTokenSequence(candidate, sourceSpanText)) {
@@ -298,12 +324,12 @@ function isSourceGrounded(
   });
   if (hasSupportedExactMatch) return true;
 
-  const clauses = candidateClauses(candidateText);
+  const clauses = candidateClauses(candidate);
   if (clauses.length > 1) {
     return clauses.every((clause) =>
       isSourceGroundedClause(clause, sourceText, includeInterrogativeSource));
   }
-  return isSourceGroundedClause(candidateText, sourceText, includeInterrogativeSource);
+  return isSourceGroundedClause(candidate, sourceText, includeInterrogativeSource);
 }
 
 function normalizedEntityIdentifierTokens(name: string): string[] {
@@ -341,17 +367,22 @@ function buildEntitySupportSource(name: string, source: string): string {
 function hasGroundedPredicateAnchor(candidate: string, sentence: string): boolean {
   const candidateTokens = normalizedGroundingTokenSequence(candidate);
   const sourceTokens = normalizedGroundingTokenSequence(sentence);
-  const comparableCandidateTokens = GROUNDING_ROLE_SUBJECT_TOKENS.has(candidateTokens[0] ?? "")
+  const comparableCandidateTokens = GROUNDING_ROLE_SUBJECT_TOKENS.has(
+    (candidateTokens[0] ?? "").replace(/^[\u0000\u0001]/u, ""),
+  )
     ? candidateTokens.slice(1)
     : candidateTokens;
   if (comparableCandidateTokens.length < 2) return false;
   const subjectToken = comparableCandidateTokens[0];
-  if (subjectToken === undefined || !sourceTokens.includes(subjectToken)) {
+  if (
+    subjectToken === undefined
+    || !sourceTokens.some((sourceToken) => areGroundingTokensCompatible(subjectToken, sourceToken))
+  ) {
     return false;
   }
   const candidatePredicateTokens = comparableCandidateTokens.slice(1);
-  const sourceTokenSet = new Set(sourceTokens);
-  const sharedPredicateTokens = candidatePredicateTokens.filter((token) => sourceTokenSet.has(token));
+  const sharedPredicateTokens = candidatePredicateTokens.filter((token) =>
+    sourceTokens.some((sourceToken) => areGroundingTokensCompatible(token, sourceToken)));
   const requiredSharedTokens = Math.min(2, candidatePredicateTokens.length);
   return sharedPredicateTokens.length >= requiredSharedTokens;
 }
@@ -365,7 +396,7 @@ function hasGroundingAnchor(
     if (!includeInterrogativeSource && isInterrogativeSourceSentence(sentence)) return false;
     const sourceSpans = /\b(?:rather\s+than|instead\s+of)\b/iu.test(candidate)
       ? [sentence]
-      : splitGroundingClauses([sentence]);
+      : splitGroundingClauses([sentence], true);
     return sourceSpans.some((sourceSpan) => {
       const exactMatch = containsExactTokenSequence(candidate, sourceSpan)
         && !hasContradictoryPolarity(candidate, sourceSpan);
@@ -413,7 +444,9 @@ const GROUNDING_ROLE_SUBJECT_TOKENS = new Set(["assistant", "user"]);
 
 function hasRoleNormalizedGrounding(candidate: string, source: string): boolean {
   const candidateTokens = groundingTokenSequence(candidate);
-  if (!GROUNDING_ROLE_SUBJECT_TOKENS.has(candidateTokens[0] ?? "")) return false;
+  if (!GROUNDING_ROLE_SUBJECT_TOKENS.has(
+    (candidateTokens[0] ?? "").replace(/^[\u0000\u0001]/u, ""),
+  )) return false;
   const claimTokens = candidateTokens.slice(1);
   if (claimTokens.length === 0) return false;
 
@@ -424,7 +457,10 @@ function hasRoleNormalizedGrounding(candidate: string, source: string): boolean 
     let sourceIndex = 0;
     let sharedTokens = 0;
     for (const claimToken of claimTokens) {
-      const matchingIndex = sourceTokens.indexOf(claimToken, sourceIndex);
+      const matchingIndex = sourceTokens.findIndex(
+        (sourceToken, index) =>
+          index >= sourceIndex && areGroundingTokensCompatible(claimToken, sourceToken),
+      );
       if (matchingIndex === -1) continue;
       sharedTokens += 1;
       sourceIndex = matchingIndex + 1;
@@ -448,8 +484,9 @@ function resolveGroundingContext(
   assertionSource: string | undefined,
   roleAssertionSources: ExtractionGroundingRoleSources | undefined,
 ): GroundingContext {
-  const candidateRole = groundingTokenSequence(candidate)[0];
-  if (!GROUNDING_ROLE_SUBJECT_TOKENS.has(candidateRole ?? "")) {
+  const candidateRole = (groundingTokenSequence(candidate)[0] ?? "")
+    .replace(/^[\u0000\u0001]/u, "");
+  if (!GROUNDING_ROLE_SUBJECT_TOKENS.has(candidateRole)) {
     return { source, assertionSource, allowRoleNormalization: false };
   }
   if (roleAssertionSources === undefined) {
@@ -458,9 +495,12 @@ function resolveGroundingContext(
   const roleSource = candidateRole === "user"
     ? roleAssertionSources.profile
     : roleAssertionSources.identity;
+  if (roleSource === undefined) {
+    return { source, assertionSource, allowRoleNormalization: true };
+  }
   return {
-    source: roleSource ?? "",
-    assertionSource: roleSource ?? "",
+    source: roleSource,
+    assertionSource: roleSource,
     allowRoleNormalization: true,
     fallbackSource: source,
     fallbackAssertionSource: assertionSource,
@@ -480,7 +520,7 @@ function selectGroundingContext(candidate: string, context: GroundingContext): G
   if (
     context.fallbackSource === undefined
     || !hasExplicitRoleSubjectToken(
-      groundingTokenSequence(candidate)[0],
+      (groundingTokenSequence(candidate)[0] ?? "").replace(/^[\u0000\u0001]/u, ""),
       sourceSentences(context.fallbackSource).map((sentence) => groundingTokenSequence(sentence)),
     )
   ) return context;
@@ -516,7 +556,9 @@ function isGroundedCandidate(
   const roleGrounded = allowRoleNormalization && hasRoleNormalizedGrounding(candidate, source);
   const candidateTokens = groundingTokenSequence(candidate);
   const roleNormalizedCandidate = allowRoleNormalization
-    && GROUNDING_ROLE_SUBJECT_TOKENS.has(candidateTokens[0] ?? "");
+    && GROUNDING_ROLE_SUBJECT_TOKENS.has(
+      (candidateTokens[0] ?? "").replace(/^[\u0000\u0001]/u, ""),
+    );
   if (roleNormalizedCandidate && !roleGrounded) return false;
   if (!sourceGrounded && !roleGrounded) return false;
   if (assertionSource === undefined) return true;
@@ -961,6 +1003,25 @@ function groundQuestion(
   return question;
 }
 
+function isRoleGroundedCandidate(
+  candidate: string,
+  source: string,
+  assertionSource: string | undefined,
+  roleAssertionSources: ExtractionGroundingRoleSources | undefined,
+): boolean {
+  const context = selectGroundingContext(
+    candidate,
+    resolveGroundingContext(candidate, source, assertionSource, roleAssertionSources),
+  );
+  return isGroundedCandidate(
+    candidate,
+    context.source,
+    context.assertionSource,
+    false,
+    context.allowRoleNormalization,
+  );
+}
+
 export function filterExtractionResultBySource(
   result: ExtractionResult,
   source: string,
@@ -990,10 +1051,8 @@ export function filterExtractionResultBySource(
     );
     return grounded === undefined ? [] : [grounded];
   });
-  const profileGroundingSource = roleAssertionSources?.profile ?? source;
-  const profileAssertionSource = roleAssertionSources?.profile ?? assertionSource;
   const profileUpdates = result.profileUpdates.filter((update) =>
-    isGroundedCandidate(update, profileGroundingSource, profileAssertionSource, false, true),
+    isRoleGroundedCandidate(update, source, assertionSource, roleAssertionSources),
   );
   const entities = result.entities.flatMap((entity) => {
     const grounded = filterGroundedEntity(entity, source, assertionSource);
@@ -1006,15 +1065,12 @@ export function filterExtractionResultBySource(
   const relationships = result.relationships?.filter((relationship) =>
     isGroundedRelationship(relationship, source, assertionSource),
   );
-  const identityGroundingSource = roleAssertionSources?.identity ?? source;
-  const identityAssertionSource = roleAssertionSources?.identity ?? assertionSource;
   const identityReflection = result.identityReflection
-    && isGroundedCandidate(
+    && isRoleGroundedCandidate(
       result.identityReflection,
-      identityGroundingSource,
-      identityAssertionSource,
-      false,
-      true,
+      source,
+      assertionSource,
+      roleAssertionSources,
     )
     ? result.identityReflection
     : undefined;

--- a/packages/remnic-core/src/extraction-source-grounding.test.ts
+++ b/packages/remnic-core/src/extraction-source-grounding.test.ts
@@ -2321,6 +2321,212 @@ test("grounding aligns predicates after medial source modifiers", () => {
   }
 });
 
+test("grounding normalizes regular third-person verb inflections", () => {
+  for (const [source, content] of [
+    ["Alice deploys Acme.", "Alice deployed Acme."],
+    ["Alice designs Atlas.", "Alice designed Atlas."],
+    ["Alice manages Beacon.", "Alice managed Beacon."],
+    ["Alice plans Atlas.", "Alice planned Atlas."],
+    ["Alice stops Beacon.", "Alice stopped Beacon."],
+    ["Alice tries again.", "Alice tried again."],
+    ["They add tags.", "They added tags."],
+    ["They call Alice.", "They called Alice."],
+    ["They fill forms.", "They filled forms."],
+    ["Alice Smith plans Atlas.", "Alice Smith planned Atlas."],
+    ["Alice King works at Acme.", "Alice King worked at Acme."],
+  ]) {
+    const result = filterExtractionResultBySource(
+      {
+        facts: [{ category: "fact", content, confidence: 0.9, tags: [] }],
+        profileUpdates: [],
+        entities: [],
+        questions: [],
+      },
+      source,
+    );
+    assert.deepEqual(result.facts.map((fact) => fact.content), [content]);
+  }
+});
+
+test("grounding keeps silent-e compatibility out of proper identifiers", () => {
+  for (const [source, content] of [
+    ["Alice works at Strip.", "Alice works at Stripe."],
+    ["Alice met Kat.", "Alice met Kate."],
+    ["Alice owns Plan.", "Alice planned."],
+  ]) {
+    const result = filterExtractionResultBySource(
+      {
+        facts: [{ category: "fact", content, confidence: 0.9, tags: [] }],
+        profileUpdates: [],
+        entities: [],
+        questions: [],
+      },
+      source,
+    );
+    assert.deepEqual(result.facts, []);
+  }
+});
+
+test("grounding preserves lowercase identifier tokens ending in s", () => {
+  const result = filterExtractionResultBySource(
+    {
+      facts: [{ category: "fact", content: "alice deployed atla.", confidence: 0.9, tags: [] }],
+      profileUpdates: [],
+      entities: [],
+      questions: [],
+    },
+    "alice deployed atlas.",
+  );
+
+  assert.deepEqual(result.facts, []);
+});
+
+test("grounding role normalization matches exact-marked identifiers case-insensitively", () => {
+  const result = filterExtractionResultBySource(
+    {
+      facts: [],
+      profileUpdates: ["User works at Stripe."],
+      entities: [],
+      questions: [],
+    },
+    "I work at stripe.",
+    undefined,
+    { profile: "I work at stripe.", identity: "" },
+  );
+
+  assert.deepEqual(result.profileUpdates, ["User works at Stripe."]);
+});
+
+test("grounding does not stem role-source identifiers ending in s", () => {
+  for (const content of ["User uses Redi.", "User uses Redis."]) {
+    const result = filterExtractionResultBySource(
+      {
+        facts: [],
+        profileUpdates: [content],
+        entities: [],
+        questions: [],
+      },
+      "I use redis.",
+      undefined,
+      { profile: "I use redis.", identity: "" },
+    );
+    assert.deepEqual(
+      result.profileUpdates,
+      content.endsWith("Redis.") ? [content] : [],
+    );
+  }
+});
+
+test("grounding does not treat role-source object plurals as predicates", () => {
+  const result = filterExtractionResultBySource(
+    {
+      facts: [],
+      profileUpdates: ["User planned."],
+      entities: [],
+      questions: [],
+    },
+    "I own plans.",
+    undefined,
+    { profile: "I own plans.", identity: "" },
+  );
+
+  assert.deepEqual(result.profileUpdates, []);
+});
+
+test("grounding falls back to explicitly role-labeled source sentences", () => {
+  const result = filterExtractionResultBySource(
+    {
+      facts: [],
+      profileUpdates: ["User prefers tea."],
+      entities: [],
+      questions: [],
+    },
+    "User prefers tea.",
+    undefined,
+    { profile: "", identity: "" },
+  );
+
+  assert.deepEqual(result.profileUpdates, ["User prefers tea."]);
+});
+
+test("grounding uses the main source when a role source is omitted", () => {
+  const result = filterExtractionResultBySource(
+    {
+      facts: [],
+      profileUpdates: ["User prefers tea."],
+      entities: [],
+      questions: [],
+    },
+    "I prefer tea.",
+    undefined,
+    { identity: "" },
+  );
+
+  assert.deepEqual(result.profileUpdates, ["User prefers tea."]);
+});
+
+test("grounding preserves hash-suffixed technology identifiers", () => {
+  for (const [source, content] of [
+    ["Alice uses C.", "Alice uses C#."],
+    ["Alice uses C#.", "Alice uses C."],
+    ["Alice uses C++.", "Alice uses C#."],
+    ["Alice uses C#.", "Alice uses C++."],
+  ]) {
+    const result = filterExtractionResultBySource(
+      {
+        facts: [{ category: "fact", content, confidence: 0.9, tags: [] }],
+        profileUpdates: [],
+        entities: [],
+        questions: [],
+      },
+      source,
+    );
+    assert.deepEqual(result.facts, []);
+  }
+});
+
+
+test("grounding inherits coordinated subjects and predicates", () => {
+  for (const [source, content] of [
+    ["Alice works at Acme and owns Mars.", "Alice owns Mars."],
+    ["Alice uses PostgreSQL, Redis, and Kafka.", "Alice uses Kafka."],
+  ]) {
+    const result = filterExtractionResultBySource(
+      {
+        facts: [{ category: "fact", content, confidence: 0.9, tags: [] }],
+        profileUpdates: [],
+        entities: [],
+        questions: [],
+      },
+      source,
+    );
+    assert.deepEqual(result.facts.map((fact) => fact.content), [content]);
+  }
+});
+
+test("grounding does not inherit across explicit coordinated subjects", () => {
+  for (const [source, content] of [
+    ["Alice works at Acme and Bob owns Mars.", "Alice owns Mars."],
+    ["Alice works at Acme and Bob sleeps.", "Alice sleeps."],
+    ["Alice works at Acme, Bob called Alice, and designed Mars.", "Alice designed Mars."],
+    ["Alice works at Acme and Bob can swim.", "Alice can swim."],
+    ["Acme works with Alice, Acme Labs called Bob, and designed Mars.", "Acme designed Mars."],
+    ["Alice works at Acme and Bob went home.", "Alice went home."],
+    ["Alice works at Acme and Bob ate lunch.", "Alice ate lunch."],
+  ]) {
+    const result = filterExtractionResultBySource(
+      {
+        facts: [{ category: "fact", content, confidence: 0.9, tags: [] }],
+        profileUpdates: [],
+        entities: [],
+        questions: [],
+      },
+      source,
+    );
+    assert.deepEqual(result.facts, []);
+  }
+});
+
 test("grounding requires causal evidence before removing why questions", () => {
   const question = { question: "Why did Alice deploy Acme?", context: "", priority: 0.5 };
   const unanswered = filterExtractionResultBySource(


### PR DESCRIPTION
## Summary
- normalize regular, silent-e, doubled-consonant, and irregular predicate forms without stemming identifiers
- preserve C/C++/C# and exact proper identifiers across role-normalized evidence
- inherit coordinated subject/predicate spans while resetting on explicit subjects
- compare exact-marked role and predicate tokens through the shared compatibility contract

## Validation
- `pnpm --filter @remnic/core exec tsx --test src/extraction-source-grounding.test.ts`
- `pnpm --filter @remnic/core check-types`
- `pnpm run check-types`
- `bash scripts/check-review-patterns.sh`

Part of #2204

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core grounding heuristics that decide which extracted facts and profile updates are kept; regressions could drop valid memories or admit hallucinations, though behavior is heavily covered by new unit tests.
> 
> **Overview**
> Tightens **extraction source grounding** so paraphrased facts stay tied to evidence without over-matching names or coordinated sentences.
> 
> **Lexical matching** adds predicate detection in `groundingLexemes`, expands common verb forms, and routes tokens through `stemToken` with strict vs inflected markers so regular **-ed/-ing/-s** paraphrases align while **proper names**, **C/C++/C#**, and silent-e pairs like Stripe/Strip do not spuriously match. `areGroundingTokensCompatible` enforces that contract across alignment, copular claims, and role-normalized paths.
> 
> **Coordinated clauses**: `splitGroundingClauses(..., inheritCoordinatedSubjects)` synthesizes source spans that reuse the first clause’s subject for trailing **and**/list fragments, with explicit new subjects resetting inheritance.
> 
> **Role-aware filtering** centralizes profile/identity checks in `isRoleGroundedCandidate`, falls back to the main source when a role assertion source is missing, and strips grounding prefix bytes when resolving User/assistant tokens and explicit role labels in source text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d12c93c39c9497e0e9bba436a17d2d13b899443b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->