### PR TITLE
fix(recall): partition tool-scoped memories by connector

### DIFF
--- a/packages/remnic-core/src/access-admin-ops-surface.ts
+++ b/packages/remnic-core/src/access-admin-ops-surface.ts
@@ -850,6 +850,7 @@ export class AccessAdminOpsSurface {
           lineage: memory.lineage,
           sourceMemoryId: memory.sourceMemoryId,
           actor: memory.actor,
+          ...(memory.toolScoped ? { toolScoped: true as const } : {}),
         });
         // #1645: a tombstone-blocked promotion lands pending_review (no active
         // copy in the target). Report it as a failed promotion so the admin

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -6,7 +6,7 @@ import test from "node:test";
 import { gzipSync } from "node:zlib";
 
 import { EngramAccessHttpServer, type RemnicAdminControls, type RemnicAdminDashboardStatus } from "./access-http.js";
-import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
+import { EngramAccessInputError, type EngramAccessRecallRequest, type EngramAccessService } from "./access-service.js";
 import { tokenCapabilityStore, type TokenCapabilities } from "./access-token-capabilities.js";
 import { parseConfig } from "./config.js";
 import { readPair, writePair } from "./contradiction/contradiction-review.js";
@@ -3080,6 +3080,42 @@ test("HTTP chat/message gates the NEW session's namespace — scoped token canno
     }
   } finally {
     await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("HTTP recall forwards the connector from the authorized token entry", async () => {
+  let captured: EngramAccessRecallRequest | undefined;
+  const service = {
+    recall: (request: EngramAccessRecallRequest) => {
+      captured = request;
+      return Promise.resolve({ context: "", count: 0, memoryIds: [], results: [] });
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authTokenEntriesGetter: () => [
+      { token: "connector-token", connector: "chatgpt" },
+    ],
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/recall`,
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer connector-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ query: "shared namespace query" }),
+      },
+    );
+    assert.equal(response.status, 200);
+    assert.equal(captured?.sourceConnector, "chatgpt");
+  } finally {
+    await server.stop();
   }
 });
 

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1059,6 +1059,7 @@ export class EngramAccessHttpServer {
         query: body.query ?? "",
         sessionKey: body.sessionKey,
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
+        sourceConnector: this.resolveConnector(req),
         idempotencyKey: body.idempotencyKey,
         namespace: this.resolveNamespace(req, body.namespace),
         topK: body.topK,
@@ -1540,6 +1541,7 @@ export class EngramAccessHttpServer {
           namespace,
           budget,
           authenticatedPrincipal: this.resolveRequestPrincipal(req),
+          sourceConnector: this.resolveConnector(req),
           ...(disclosure !== undefined ? { disclosure } : {}),
         });
       } catch (err) {

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -2740,6 +2740,7 @@ export class EngramMcpServer {
       const result = (await op.run(envelope, {
         service: this.service,
         authenticatedPrincipal: effectivePrincipal,
+        ...(sourceConnector ? { sourceConnector } : {}),
         ...(abortSignal ? { abortSignal } : {}),
       })) as { result: unknown };
       throwMcpAbort(abortSignal, "MCP recall aborted before postprocessing");

--- a/packages/remnic-core/src/access-operations-batch.ts
+++ b/packages/remnic-core/src/access-operations-batch.ts
@@ -88,7 +88,7 @@ defineOperation({ name: "recall", description: "Semantic recall.", schema: stric
     if (input.tags !== undefined) { if (!Array.isArray(input.tags) || !input.tags.every((t) => typeof t === "string")) throw new EngramAccessInputError("tags must be an array of strings"); tags = input.tags; }
     let tagMatch: "any" | "all" | undefined;
     if (input.tagMatch !== undefined) { if (input.tagMatch !== "any" && input.tagMatch !== "all") throw new EngramAccessInputError("tagMatch must be one of: any, all"); tagMatch = input.tagMatch; }
-    const result = await ctx.service.recall({ query: typeof input.query === "string" ? input.query : "", sessionKey: optStr(input.sessionKey), authenticatedPrincipal: ctx.authenticatedPrincipal, namespace: optStr(input.namespace), topK: optNum(input.topK), mode: optStr(input.mode) as RecallPlanMode | "auto" | undefined, includeDebug: input.includeDebug === true, disclosure, cwd: optStr(input.cwd), projectTag: optStr(input.projectTag), asOf: optStr(input.asOf), ...(tags ? { tags } : {}), ...(tagMatch ? { tagMatch } : {}), ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}) });
+    const result = await ctx.service.recall({ query: typeof input.query === "string" ? input.query : "", sessionKey: optStr(input.sessionKey), authenticatedPrincipal: ctx.authenticatedPrincipal, sourceConnector: ctx.sourceConnector, namespace: optStr(input.namespace), topK: optNum(input.topK), mode: optStr(input.mode) as RecallPlanMode | "auto" | undefined, includeDebug: input.includeDebug === true, disclosure, cwd: optStr(input.cwd), projectTag: optStr(input.projectTag), asOf: optStr(input.asOf), ...(tags ? { tags } : {}), ...(tagMatch ? { tagMatch } : {}), ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}) });
     return { result };
   },
 });
@@ -115,7 +115,7 @@ defineOperation({ name: "recall_xray", description: "X-ray recall.", schema: str
     let budget: number | undefined;
     if (input.budget !== undefined) { const p = typeof input.budget === "number" ? input.budget : typeof input.budget === "string" ? Number(input.budget) : undefined; if (p === undefined || !Number.isFinite(p) || p <= 0 || !Number.isInteger(p)) throw new EngramAccessInputError("recall_xray: budget expects a positive integer"); budget = p; }
     const dr = optStr(input.disclosure);
-    return { result: await ctx.service.recallXray({ query: defStr(input.query, ""), sessionKey: optStr(input.sessionKey), namespace: optStr(input.namespace), budget, authenticatedPrincipal: ctx.authenticatedPrincipal, ...(dr && dr !== "" ? { disclosure: dr as RecallDisclosure } : {}), ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}) }) };
+    return { result: await ctx.service.recallXray({ query: defStr(input.query, ""), sessionKey: optStr(input.sessionKey), namespace: optStr(input.namespace), budget, authenticatedPrincipal: ctx.authenticatedPrincipal, sourceConnector: ctx.sourceConnector, ...(dr && dr !== "" ? { disclosure: dr as RecallDisclosure } : {}), ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}) }) };
   },
 });
 defineOperation({ name: "namespace_writable", description: "Read-only preflight: is a namespace writable for the caller's principal?", allowedByOps: ["namespace_writable", "observe", "memory_store"], schema: strictSchema({ namespace: S.str, sessionKey: S.str, op: S.str, cwd: S.str, projectTag: S.str }), handler: async (input, ctx) => {
@@ -163,7 +163,7 @@ defineOperation({ name: "chatgpt_memory_inspector", description: "Memory inspect
     if (input.currentContextScopes !== undefined) ii.currentContextScopes = input.currentContextScopes as string[];
     if (input.allowUnverifiedPreview !== undefined) ii.allowUnverifiedPreview = input.allowUnverifiedPreview as boolean;
     const rsk = ii.sessionKey ?? (ctx.authenticatedPrincipal ? "remnic:chatgpt-memory-inspector:" + randomUUID() : undefined);
-    const xr = await ctx.service.recallXray({ query: ii.query, sessionKey: rsk, namespace: ii.namespace, currentContextScopes: ii.currentContextScopes, authenticatedPrincipal: ctx.authenticatedPrincipal, mode: "full", disclosure: "chunk", includeRecall: true, ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}) });
+    const xr = await ctx.service.recallXray({ query: ii.query, sessionKey: rsk, namespace: ii.namespace, currentContextScopes: ii.currentContextScopes, authenticatedPrincipal: ctx.authenticatedPrincipal, sourceConnector: ctx.sourceConnector, mode: "full", disclosure: "chunk", includeRecall: true, ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}) });
     const x = xr.snapshotFound === true ? (xr.snapshot ?? null) : null;
     const r = xr.recall ?? { query: ii.query, namespace: ii.namespace ?? x?.namespace ?? "global", context: "", count: 0, memoryIds: [], results: [], fallbackUsed: false, sourcesUsed: [], disclosure: "chunk" as const };
     const ac = await ctx.service.actionConfidence(buildChatGptMemoryInspectorActionRequest(ii, r, x));

--- a/packages/remnic-core/src/access-recall-surface.ts
+++ b/packages/remnic-core/src/access-recall-surface.ts
@@ -862,6 +862,7 @@ export class AccessRecallSurface {
         contextComposition = composition;
       },
       ...(authenticatedPrincipal ? { principalOverride: authenticatedPrincipal } : {}),
+      ...(request.sourceConnector ? { sourceConnector: request.sourceConnector } : {}),
       ...(asOf !== undefined ? { asOf } : {}),
       ...(request.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
       ...(request.abortSignal ? { abortSignal: request.abortSignal } : {}),
@@ -943,6 +944,7 @@ export class AccessRecallSurface {
     namespace?: string;
     budget?: number;
     authenticatedPrincipal?: string;
+    sourceConnector?: string;
     /**
      * Disclosure depth used to shape per-result payload (issue #677
      * PR 3/4).  When set, each X-ray result is decorated with the
@@ -1095,6 +1097,7 @@ export class AccessRecallSurface {
           ...(authenticatedPrincipal
             ? { principalOverride: authenticatedPrincipal }
             : {}),
+          ...(request.sourceConnector ? { sourceConnector: request.sourceConnector } : {}),
           ...(request.currentContextScopes !== undefined
             ? { currentContextScopes: request.currentContextScopes }
             : {}),

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -377,6 +377,8 @@ export interface EngramAccessRecallRequest {
   sessionKey?: string;
   namespace?: string;
   authenticatedPrincipal?: string;
+  /** Trusted connector identity resolved at the transport boundary. */
+  sourceConnector?: string;
   idempotencyKey?: string;
   topK?: number;
   mode?: RecallPlanMode | "auto";
@@ -2865,6 +2867,7 @@ export class EngramAccessService {
     namespace?: string;
     budget?: number;
     authenticatedPrincipal?: string;
+    sourceConnector?: string;
     /**
      * Disclosure depth used to shape per-result payload (issue #677
      * PR 3/4).  When set, each X-ray result is decorated with the

--- a/packages/remnic-core/src/admin/admin-surfaces.ts
+++ b/packages/remnic-core/src/admin/admin-surfaces.ts
@@ -783,6 +783,7 @@ export interface PromotionStorageProvider {
        */
       lineage: string[];
       sourceConnector?: string;
+      toolScoped?: true;
     }
   ): Promise<string>;
 }
@@ -920,6 +921,7 @@ export async function promoteMemory(options: PromoteMemoryOptions): Promise<Memo
         validAt: sourceMemory.frontmatter.valid_at,
         lineage: [options.sourceMemoryId],
         ...(sourceMemory.frontmatter.sourceConnector ? { sourceConnector: sourceMemory.frontmatter.sourceConnector } : {}),
+        ...(sourceMemory.frontmatter.toolScoped ? { toolScoped: true as const } : {}),
       });
       target.promoted = true;
       target.promotedMemoryId = promotedId;

--- a/packages/remnic-core/src/connector-provenance.test.ts
+++ b/packages/remnic-core/src/connector-provenance.test.ts
@@ -16,9 +16,11 @@ import path from "node:path";
 import test from "node:test";
 
 import { EngramMcpServer } from "./access-mcp.js";
+import { getOperation } from "./access-boundary.js";
 import { memoryStoreOperation } from "./access-operations.js";
 import type {
   EngramAccessMemoryStoreRequest,
+  EngramAccessRecallRequest,
   EngramAccessService,
   EngramAccessWriteResponse,
 } from "./access-service.js";
@@ -117,6 +119,26 @@ test("memory_store via MCP with no sourceConnector (operator) → service receiv
   );
 });
 
+test("recall operation forwards only the server-resolved connector", async () => {
+  const captured: EngramAccessRecallRequest[] = [];
+  const service = {
+    recall: (request: EngramAccessRecallRequest) => {
+      captured.push(request);
+      return Promise.resolve({});
+    },
+  } as unknown as EngramAccessService;
+  const recallOperation = getOperation("recall");
+  assert.ok(recallOperation);
+
+  await recallOperation.run(
+    { query: "shared namespace query", sourceConnector: "spoofed-client" },
+    { service, sourceConnector: "chatgpt" },
+  );
+
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0]?.sourceConnector, "chatgpt");
+});
+
 // ---------------------------------------------------------------------------
 // Test 4: client-supplied sourceConnector in args is IGNORED
 // ---------------------------------------------------------------------------
@@ -212,6 +234,65 @@ test("StorageManager.writeMemory without sourceConnector → frontmatter omits i
       undefined,
       "frontmatter should omit sourceConnector when not provided",
     );
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(baseDir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager classifies connector-attributed tool memories at write time", async () => {
+  StorageManager.clearAllStaticCaches();
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "prov-tool-scope-"));
+  try {
+    const storage = new StorageManager(baseDir);
+    await storage.ensureDirectories();
+
+    const { id } = await storage.writeMemory(
+      "fact",
+      "Use the search tool with a path argument.",
+      { sourceConnector: "chatgpt" },
+    );
+
+    assert.equal((await storage.getMemoryById(id))?.frontmatter.toolScoped, true);
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(baseDir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager leaves unattributed tool-like memories unpartitioned", async () => {
+  StorageManager.clearAllStaticCaches();
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "prov-tool-scope-"));
+  try {
+    const storage = new StorageManager(baseDir);
+    await storage.ensureDirectories();
+
+    const { id } = await storage.writeMemory(
+      "fact",
+      "Use the search tool with a path argument.",
+    );
+
+    assert.equal((await storage.getMemoryById(id))?.frontmatter.toolScoped, undefined);
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(baseDir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager preserves an explicit structured tool classification", async () => {
+  StorageManager.clearAllStaticCaches();
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "prov-tool-scope-"));
+  try {
+    const storage = new StorageManager(baseDir);
+    await storage.ensureDirectories();
+
+    const { id } = await storage.writeMemory(
+      "procedure",
+      "Workflow for locating an implementation",
+      { sourceConnector: "chatgpt", toolScoped: true },
+    );
+
+    assert.equal((await storage.getMemoryById(id))?.frontmatter.toolScoped, true);
   } finally {
     StorageManager.clearAllStaticCaches();
     await rm(baseDir, { recursive: true, force: true });

--- a/packages/remnic-core/src/connector-provenance.test.ts
+++ b/packages/remnic-core/src/connector-provenance.test.ts
@@ -298,3 +298,23 @@ test("StorageManager preserves an explicit structured tool classification", asyn
     await rm(baseDir, { recursive: true, force: true });
   }
 });
+test("StorageManager preserves connector partition metadata on artifacts", async () => {
+  StorageManager.clearAllStaticCaches();
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "prov-artifact-tool-scope-"));
+  try {
+    const storage = new StorageManager(baseDir);
+    await storage.ensureDirectories();
+    const id = await storage.writeArtifact("Use the search tool with a path argument.", {
+      sourceConnector: "chatgpt",
+      toolScoped: true,
+    });
+    const artifact = (await storage.searchArtifacts("search tool", 10)).find(
+      (candidate) => candidate.frontmatter.id === id,
+    );
+    assert.equal(artifact?.frontmatter.sourceConnector, "chatgpt");
+    assert.equal(artifact?.frontmatter.toolScoped, true);
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(baseDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/correction/correction-access-wiring.ts
+++ b/packages/remnic-core/src/correction/correction-access-wiring.ts
@@ -568,6 +568,7 @@ async function rescopeMemoryFn(
       ...(fm.entityRef ? { entityRef: fm.entityRef } : {}),
       ...(fm.structuredAttributes ? { structuredAttributes: fm.structuredAttributes } : {}),
       ...(fm.valid_at ? { validAt: fm.valid_at } : {}),
+      ...(fm.sourceConnector ? { sourceConnector: fm.sourceConnector } : {}),
     },
     { source: `correction:rescope:${namespace}` },
     { salvage: true },
@@ -581,6 +582,7 @@ async function rescopeMemoryFn(
     ...(fm.memoryKind ? { memoryKind: fm.memoryKind } : {}),
     ...(Array.isArray(fm.links) ? { links: fm.links } : {}),
     ...(fm.intentGoal ? { intentGoal: fm.intentGoal } : {}),
+    ...(fm.toolScoped ? { toolScoped: true as const } : {}),
   });
   if (destBlocked) {
     // #1645: destination tombstone-blocked the rescope (pending_review). Don't

--- a/packages/remnic-core/src/orchestration/extraction-persist.ts
+++ b/packages/remnic-core/src/orchestration/extraction-persist.ts
@@ -419,6 +419,7 @@ export class ExtractionPersistCoordinator {
       source: string;
       sources?: ProvenanceSource[];
       provenance?: "verified" | "unverified" | "none";
+      toolScoped?: true;
     }): Promise<void> => {
       if (
         !scopeProfileWritePlan ||
@@ -536,6 +537,7 @@ export class ExtractionPersistCoordinator {
             contentHashSource: options.category === "fact" ? dedupContent : rawContent,
             ...(options.sources && options.sources.length > 0 ? { sources: options.sources } : {}),
             ...(options.provenance ? { provenance: options.provenance } : {}),
+            ...(options.toolScoped ? { toolScoped: true as const } : {}),
           });
           const promotedId = targetPromotion.id;
           // #1645: if the TARGET namespace's own tombstone blocked this promotion,
@@ -615,8 +617,12 @@ export class ExtractionPersistCoordinator {
       sources?: ProvenanceSource[];
       provenance?: "verified" | "unverified" | "none";
     }): Promise<void> => {
-      await promoteMemoryToProfileTargets(options);
-      if (lifecycleCaps.extractionScopeClassification && withholdToolScopedFromSharedNamespace(options)) return;
+      const toolScoped = withholdToolScopedFromSharedNamespace(options);
+      await promoteMemoryToProfileTargets({
+        ...options,
+        ...(toolScoped ? { toolScoped: true as const } : {}),
+      });
+      if (lifecycleCaps.extractionScopeClassification && toolScoped) return;
       if (
         !shouldPromoteToShared(
           this.deps.config,
@@ -939,6 +945,7 @@ export class ExtractionPersistCoordinator {
           // Claim-level provenance spans (issue #1575 PR 2).
           ...(options.sources && options.sources.length > 0 ? { sources: options.sources } : {}),
           ...(options.provenance ? { provenance: options.provenance } : {}),
+          ...(toolScoped ? { toolScoped: true as const } : {}),
         });
         const promotedId = sharedPromotion.id;
         // #1645: if the shared namespace's own tombstone blocked this promotion,
@@ -2019,6 +2026,11 @@ export class ExtractionPersistCoordinator {
           ? "extraction-proactive"
           : "extraction";
       const extractionSourceConnector = sourceContext?.sourceConnector;
+      const factToolScoped = withholdToolScopedFromSharedNamespace({
+        content: fact.content,
+        sourceConnector: extractionSourceConnector,
+        procedureSteps: fact.procedureSteps,
+      });
 
       // Check for contradictions before writing (Phase 2B).
       // NOTE: This block was moved above the chunking branch so that the
@@ -2227,6 +2239,7 @@ export class ExtractionPersistCoordinator {
             // PR #2016: never defer here — fallible chunk/artifact writes follow this
             // durable parent .md; flush the hash now so a throw can't strand it (dup).
             deferHashIndexSave: false,
+            ...(factToolScoped ? { toolScoped: true as const } : {}),
           });
           const parentId = parentWrite.id;
           // #1645: surface the tombstone block and gate active post-write paths
@@ -2310,6 +2323,7 @@ export class ExtractionPersistCoordinator {
                   ...(fact.sources && fact.sources.length > 0 ? { sources: fact.sources } : {}),
                   ...(fact.provenance ? { provenance: fact.provenance } : {}),
                   ...(extractionSourceConnector ? { sourceConnector: extractionSourceConnector } : {}),
+                  ...(factToolScoped ? { toolScoped: true as const } : {}),
                 },
               );
             }
@@ -2598,6 +2612,7 @@ export class ExtractionPersistCoordinator {
         // #1909: defer the per-fact index flush to the batch save only when
         // fact dedup is on (the batch saver is a no-op otherwise).
         deferHashIndexSave: factDedupEnabled,
+        ...(factToolScoped ? { toolScoped: true as const } : {}),
       });
       const memoryId = factWrite.id;
       // #1645: surface the tombstone block; gate active post-write paths like #1576

--- a/packages/remnic-core/src/orchestration/extraction-persist.ts
+++ b/packages/remnic-core/src/orchestration/extraction-persist.ts
@@ -2471,6 +2471,7 @@ export class ExtractionPersistCoordinator {
                 intentActionType: inferredIntent?.actionType,
                 intentEntityTypes: inferredIntent?.entityTypes,
                 ...(extractionSourceConnector ? { sourceConnector: extractionSourceConnector } : {}),
+                ...(factToolScoped ? { toolScoped: true as const } : {}),
               });
             }
             // v8.2: graph edge building for chunked memories. #1576: skip pending_review.
@@ -2777,6 +2778,7 @@ export class ExtractionPersistCoordinator {
             intentActionType: inferredIntent?.actionType,
             intentEntityTypes: inferredIntent?.entityTypes,
             ...(extractionSourceConnector ? { sourceConnector: extractionSourceConnector } : {}),
+            ...(factToolScoped ? { toolScoped: true as const } : {}),
           });
         }
         // Register in the target storage content-hash index after successful

--- a/packages/remnic-core/src/orchestration/orchestrator-helpers.ts
+++ b/packages/remnic-core/src/orchestration/orchestrator-helpers.ts
@@ -197,6 +197,8 @@ export interface RecallInvocationOptions {
   topK?: number;
   mode?: RecallPlanMode;
   abortSignal?: AbortSignal;
+  /** Server-resolved identity of the connector performing this recall. */
+  sourceConnector?: string;
   /**
    * Capture a `RecallXraySnapshot` for this recall (issue #570).  When
    * `true`, the orchestrator builds a snapshot from the data it has

--- a/packages/remnic-core/src/orchestration/recall-internal-deps.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal-deps.ts
@@ -64,6 +64,7 @@ export interface RecallInternalDeps {
     onDegradation?: (degradation: SearchDegradation) => void;
     /** Issue #680 — historical recall point in ms-since-epoch. */
     asOfMs?: number;
+    requestingConnector?: string;
     /**
      * Optional out-parameter that receives the pre-MMR / pre-truncation
      * pool size captured inside the pipeline (issue #570 PR 1).  The
@@ -126,6 +127,7 @@ export interface RecallInternalDeps {
        * string at the input boundary (CLI / HTTP / MCP).
        */
       asOfMs?: number;
+      requestingConnector?: string;
     },
   ): Promise<QmdSearchResult[]>;
   boxBuilderFor(storage: StorageManager): BoxBuilder;
@@ -234,6 +236,7 @@ export interface RecallInternalDeps {
       abortSignal?: AbortSignal;
       dropUnresolved?: boolean;
       recallNamespaces?: readonly string[];
+      requestingConnector?: string;
     },
   ): Promise<{ results: QmdSearchResult[]; memoryByPath: Map<string, MemoryFile> }>;
   formatCausalTrajectoryResults(

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -39,6 +39,7 @@ import { collectNativeKnowledgeChunks, formatNativeKnowledgeSection, searchNativ
 import { objectiveStateStoreOverrideForNamespace, searchObjectiveStateSnapshots } from "../objective-state.js";
 import { type GraphRecallRankedResult, type GraphRecallShadowComparison, mergeGraphExpandedResults } from "./graph-recall-coordinator.js";
 import { buildProcedureRecallSection } from "../procedural/procedure-recall.js";
+import { canRecallToolScopedMemory } from "../tool-scoped-memory.js";
 import { buildQmdRecallCacheKey, getCachedQmdRecall, setCachedQmdRecall } from "../qmd-recall-cache.js";
 import { MEMORY_ID_PATTERN } from "../recall-handles.js";
 import {
@@ -1296,7 +1297,11 @@ export class RecallInternalCoordinator {
         source: "fresh",
         success: true,
       });
-      return results;
+      return caps.extractionScopeClassification
+        ? results.filter((artifact) =>
+            canRecallToolScopedMemory(artifact.frontmatter, options.sourceConnector),
+          )
+        : results;
     })();
 
     const objectiveStatePromise = (async (): Promise<string | null> => {
@@ -2794,6 +2799,10 @@ export class RecallInternalCoordinator {
           profileStorage,
           retrievalQuery,
           this.deps.config,
+          {
+            partitionToolScoped: caps.extractionScopeClassification,
+            requestingConnector: options.sourceConnector,
+          },
         );
       } catch (err) {
         log.debug(

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -3959,6 +3959,7 @@ export class RecallInternalCoordinator {
           abortSignal: options.abortSignal,
           dropUnresolved: true,
           recallNamespaces,
+          requestingConnector: options.sourceConnector,
         },
       );
 
@@ -3971,7 +3972,7 @@ export class RecallInternalCoordinator {
             recallNamespaces,
             retrievalQuery,
             qmdBoostInput.memoryByPath,
-            { asOfMs },
+            { asOfMs, requestingConnector: options.sourceConnector },
           ),
         qmdBoostInput.results,
       );
@@ -4199,7 +4200,7 @@ export class RecallInternalCoordinator {
               recallNamespaces,
               retrievalQuery,
               undefined,
-              { asOfMs },
+              { asOfMs, requestingConnector: options.sourceConnector },
             );
             // MMR runs on the pre-truncation pool so diverse candidates just
             // below the cutoff can be promoted into the injected set.
@@ -4294,6 +4295,7 @@ export class RecallInternalCoordinator {
             trustByPathSink,
             deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
             asOfMs,
+            requestingConnector: options.sourceConnector,
             ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
           });
           // Issue #1577 — read the cold pipeline's trust map back so cold
@@ -4394,7 +4396,7 @@ export class RecallInternalCoordinator {
               recallNamespaces,
               retrievalQuery,
               undefined,
-              { asOfMs },
+              { asOfMs, requestingConnector: options.sourceConnector },
             );
             // MMR runs on the pre-truncation pool so diverse candidates just
             // below the cutoff can be promoted into the injected set.
@@ -4554,6 +4556,7 @@ export class RecallInternalCoordinator {
               trustByPathSink,
               deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
               asOfMs,
+              requestingConnector: options.sourceConnector,
               ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
             });
             // Issue #1577 — read the cold pipeline's trust map back (rule 41).
@@ -4608,7 +4611,7 @@ export class RecallInternalCoordinator {
                     recallNamespaces,
                     retrievalQuery,
                     preloadedMap,
-                    { asOfMs },
+                    { asOfMs, requestingConnector: options.sourceConnector },
                   )
                 ).sort((a, b) => b.score - a.score);
                 // MMR runs on the pre-truncation pool so diverse candidates just
@@ -4707,6 +4710,7 @@ export class RecallInternalCoordinator {
                 trustByPathSink,
                 deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
                 asOfMs,
+                requestingConnector: options.sourceConnector,
                 ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
               });
               // Issue #1577 — read the cold pipeline's trust map back (rule 41).
@@ -4758,6 +4762,7 @@ export class RecallInternalCoordinator {
             trustByPathSink,
             deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
             asOfMs,
+            requestingConnector: options.sourceConnector,
             ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
           });
           // Issue #1577 — read the cold pipeline's trust map back (rule 41).

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -1297,7 +1297,7 @@ export class RecallInternalCoordinator {
         source: "fresh",
         success: true,
       });
-      return caps.extractionScopeClassification
+      return lifecycleCaps.extractionScopeClassification
         ? results.filter((artifact) =>
             canRecallToolScopedMemory(artifact.frontmatter, options.sourceConnector),
           )
@@ -2800,7 +2800,7 @@ export class RecallInternalCoordinator {
           retrievalQuery,
           this.deps.config,
           {
-            partitionToolScoped: caps.extractionScopeClassification,
+            partitionToolScoped: lifecycleCaps.extractionScopeClassification,
             requestingConnector: options.sourceConnector,
           },
         );

--- a/packages/remnic-core/src/orchestration/recall-search-pipeline.test.ts
+++ b/packages/remnic-core/src/orchestration/recall-search-pipeline.test.ts
@@ -28,12 +28,16 @@ function memory(path: string, status: string): MemoryFile {
   };
 }
 
-async function makeCoordinator(memoryDir: string): Promise<RecallSearchPipelineCoordinator> {
+async function makeCoordinator(
+  memoryDir: string,
+  extractionScopeClassificationEnabled = true,
+): Promise<RecallSearchPipelineCoordinator> {
   const config = parseConfig({
     openaiApiKey: "sk-test",
     memoryDir,
     workspaceDir: path.join(memoryDir, "workspace"),
     namespaces: true,
+    extractionScopeClassificationEnabled,
   });
   const deps = {
     config,
@@ -99,6 +103,76 @@ test("recall safety derives sourceConnector exclusively from the hydrated memory
     assert.equal(byPath.get("facts/none.md"), undefined, "an untrusted value is cleared when the memory is connectorless");
     // The shared/cached input objects are never mutated.
     assert.equal(has.sourceConnector, "untrusted", "the input result object is not mutated (copy semantics, no cross-recall leak)");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("recall safety partitions tool-scoped memories by requesting connector", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-connector-partition-"));
+  try {
+    const coordinator = await makeCoordinator(memoryDir);
+    const memories = [
+      {
+        path: "facts/same-tool.md",
+        content: "Use the search tool with a path.",
+        frontmatter: { status: "active", sourceConnector: "chatgpt", toolScoped: true },
+      },
+      {
+        path: "facts/other-tool.md",
+        content: "Use the search tool with a path.",
+        frontmatter: { status: "active", sourceConnector: "pi", toolScoped: true },
+      },
+      {
+        path: "facts/portable.md",
+        content: "Prefer focused searches.",
+        frontmatter: { status: "active", sourceConnector: "pi" },
+      },
+      {
+        path: "facts/legacy.md",
+        content: "Use the search tool with a path.",
+        frontmatter: { status: "active", sourceConnector: "pi" },
+      },
+      {
+        path: "facts/unattributed-tool.md",
+        content: "Use the search tool with a path.",
+        frontmatter: { status: "active", toolScoped: true },
+      },
+    ] as unknown as MemoryFile[];
+    const results = memories.map((candidate, index) => ({
+      ...result("default", candidate.path),
+      ...(index === 1 ? { sourceConnector: "chatgpt" } : {}),
+    }));
+    const memoryByPath = new Map(
+      memories.map((candidate) => [`default\0${candidate.path}`, candidate]),
+    );
+
+    const safe = coordinator.filterSearchResultsByRecallSafety(results, memoryByPath, {
+      requestingConnector: "chatgpt",
+    });
+
+    assert.deepEqual(
+      safe.map((candidate) => candidate.path),
+      [
+        "facts/same-tool.md",
+        "facts/portable.md",
+        "facts/legacy.md",
+        "facts/unattributed-tool.md",
+      ],
+    );
+    assert.equal(safe[0]?.sourceConnector, "chatgpt");
+    assert.equal(results[1]?.sourceConnector, "chatgpt");
+    assert.equal(
+      coordinator.filterSearchResultsByRecallSafety(results, memoryByPath).length,
+      results.length,
+    );
+    const gateDisabled = await makeCoordinator(memoryDir, false);
+    assert.equal(
+      gateDisabled.filterSearchResultsByRecallSafety(results, memoryByPath, {
+        requestingConnector: "chatgpt",
+      }).length,
+      results.length,
+    );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
+++ b/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
@@ -90,6 +90,7 @@ export interface RecallSearchPipelineDeps {
        * string at the input boundary (CLI / HTTP / MCP).
        */
       asOfMs?: number;
+      requestingConnector?: string;
     },
   ): Promise<QmdSearchResult[]>;
   buildConfiguredQmdSearchOptions(
@@ -152,6 +153,7 @@ export interface RecallSearchPipelineDeps {
       allowDedicatedSurface?: boolean;
       asOfMs?: number;
       blockedPaths?: Set<string>;
+      requestingConnector?: string;
     },
   ): QmdSearchResult[];
   filterSearchResultsForRecall(
@@ -165,6 +167,7 @@ export interface RecallSearchPipelineDeps {
       abortSignal?: AbortSignal;
       dropUnresolved?: boolean;
       recallNamespaces?: readonly string[];
+      requestingConnector?: string;
     },
   ): Promise<{ results: QmdSearchResult[]; memoryByPath: Map<string, MemoryFile> }>;
   loadSearchResultMemoryMap(
@@ -719,6 +722,7 @@ export class RecallSearchPipelineCoordinator {
     onDegradation?: (degradation: SearchDegradation) => void;
     /** Issue #680 — historical recall point in ms-since-epoch. */
     asOfMs?: number;
+    requestingConnector?: string;
     /**
      * Optional out-parameter that receives the pre-MMR / pre-truncation
      * pool size captured inside the pipeline (issue #570 PR 1).  The
@@ -983,6 +987,7 @@ export class RecallSearchPipelineCoordinator {
         abortSignal: options.abortSignal,
         dropUnresolved: true,
         recallNamespaces: options.recallNamespaces,
+        requestingConnector: options.requestingConnector,
       },
     );
     results = boostInput.results;
@@ -1000,7 +1005,11 @@ export class RecallSearchPipelineCoordinator {
                 options.recallNamespaces,
                 options.prompt,
                 boostInput.memoryByPath,
-                { allowLifecycleFiltered: true, asOfMs: options.asOfMs },
+                {
+                  allowLifecycleFiltered: true,
+                  asOfMs: options.asOfMs,
+                  requestingConnector: options.requestingConnector,
+                },
               ),
               new Promise<{ status: "timed_out" }>((resolve) => {
                 timeoutHandle = setTimeout(
@@ -1014,7 +1023,11 @@ export class RecallSearchPipelineCoordinator {
               options.recallNamespaces,
               options.prompt,
               boostInput.memoryByPath,
-              { allowLifecycleFiltered: true, asOfMs: options.asOfMs },
+              {
+                allowLifecycleFiltered: true,
+                asOfMs: options.asOfMs,
+                requestingConnector: options.requestingConnector,
+              },
             ));
         if (
           typeof boosted === "object" &&
@@ -1225,6 +1238,7 @@ export class RecallSearchPipelineCoordinator {
       allowDedicatedSurface?: boolean;
       asOfMs?: number;
       blockedPaths?: Set<string>;
+      requestingConnector?: string;
     },
   ): QmdSearchResult[] {
     const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.deps.config);
@@ -1234,6 +1248,7 @@ export class RecallSearchPipelineCoordinator {
     let dedicatedSurfaceFilteredCount = 0;
     let forgottenFilteredCount = 0;
     let blockedPathFilteredCount = 0;
+    let connectorPartitionFilteredCount = 0;
     const filtered: QmdSearchResult[] = [];
     for (const r of results) {
       if (options?.blockedPaths && resultHasKey(options.blockedPaths, r)) {
@@ -1242,6 +1257,18 @@ export class RecallSearchPipelineCoordinator {
       }
       const memory = memoryForResult(memoryByPath, r);
       if (memory) {
+        const memoryConnector = memory.frontmatter.sourceConnector?.trim();
+        const requestingConnector = options?.requestingConnector?.trim();
+        if (
+          lifecycleCaps.extractionScopeClassification &&
+          memory.frontmatter.toolScoped === true &&
+          memoryConnector &&
+          requestingConnector &&
+          memoryConnector !== requestingConnector
+        ) {
+          connectorPartitionFilteredCount += 1;
+          continue;
+        }
         // Review-lifecycle statuses never enter active recall injection
         // (forgotten, pending_review, rejected, quarantined). Superseded and
         // archived have dedicated filters below. #1576: the faithfulness gate
@@ -1349,6 +1376,11 @@ export class RecallSearchPipelineCoordinator {
         sourceConnector: memory ? memory.frontmatter.sourceConnector : undefined,
       });
     }
+    if (connectorPartitionFilteredCount > 0) {
+      log.debug(
+        `connector partition filter removed ${connectorPartitionFilteredCount} tool-scoped candidates from recall`,
+      );
+    }
     if (lifecycleFilteredCount > 0) {
       log.debug(
         `lifecycle retrieval filter removed ${lifecycleFilteredCount} stale/archived candidates`,
@@ -1393,6 +1425,7 @@ export class RecallSearchPipelineCoordinator {
       abortSignal?: AbortSignal;
       dropUnresolved?: boolean;
       recallNamespaces?: readonly string[];
+      requestingConnector?: string;
     },
   ): Promise<{ results: QmdSearchResult[]; memoryByPath: Map<string, MemoryFile> }> {
     if (results.length === 0) {
@@ -1455,6 +1488,7 @@ export class RecallSearchPipelineCoordinator {
        * string at the input boundary (CLI / HTTP / MCP).
        */
       asOfMs?: number;
+      requestingConnector?: string;
     },
   ): Promise<QmdSearchResult[]> {
     const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.deps.config);

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3640,6 +3640,7 @@ export class Orchestrator {
     onDegradation?: (degradation: SearchDegradation) => void;
     /** Issue #680 — historical recall point in ms-since-epoch. */
     asOfMs?: number;
+    requestingConnector?: string;
     /**
      * Optional out-parameter that receives the pre-MMR / pre-truncation
      * pool size captured inside the pipeline (issue #570 PR 1).  The
@@ -3719,6 +3720,7 @@ export class Orchestrator {
       allowDedicatedSurface?: boolean;
       asOfMs?: number;
       blockedPaths?: Set<string>;
+      requestingConnector?: string;
     },
   ): QmdSearchResult[] {
     return this.recallSearchPipelineCoordinator.filterSearchResultsByRecallSafety(
@@ -3739,6 +3741,7 @@ export class Orchestrator {
       abortSignal?: AbortSignal;
       dropUnresolved?: boolean;
       recallNamespaces?: readonly string[];
+      requestingConnector?: string;
     },
   ): Promise<{ results: QmdSearchResult[]; memoryByPath: Map<string, MemoryFile> }> {
     return this.recallSearchPipelineCoordinator.filterSearchResultsForRecall(
@@ -3764,6 +3767,7 @@ export class Orchestrator {
        * string at the input boundary (CLI / HTTP / MCP).
        */
       asOfMs?: number;
+      requestingConnector?: string;
     },
   ): Promise<QmdSearchResult[]> {
     return this.recallSearchPipelineCoordinator.boostSearchResults(

--- a/packages/remnic-core/src/procedural/procedure-recall.ts
+++ b/packages/remnic-core/src/procedural/procedure-recall.ts
@@ -6,6 +6,7 @@ import type { MemoryFile, PluginConfig } from "../types.js";
 import type { StorageManager } from "../storage.js";
 import { inferIntentFromText, intentCompatibilityScore, isTaskInitiationIntent } from "../intent.js";
 import { isActiveMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
+import { canRecallToolScopedMemory } from "../tool-scoped-memory.js";
 
 function tokenOverlapScore(prompt: string, memoryText: string): number {
   const norm = (s: string) =>
@@ -44,6 +45,7 @@ export async function buildProcedureRecallSection(
   storage: StorageManager,
   prompt: string,
   config: PluginConfig,
+  options?: { partitionToolScoped?: boolean; requestingConnector?: string },
 ): Promise<string | null> {
   if (config.procedural?.enabled !== true) return null;
   const trimmed = typeof prompt === "string" ? prompt.trim() : "";
@@ -72,7 +74,9 @@ export async function buildProcedureRecallSection(
     .filter(
       (m) =>
         m.frontmatter.category === "procedure" &&
-        isActiveMemoryStatus(m.frontmatter.status),
+        isActiveMemoryStatus(m.frontmatter.status) &&
+        (options?.partitionToolScoped !== true ||
+          canRecallToolScopedMemory(m.frontmatter, options.requestingConnector)),
     )
     .map((m) => ({ m, score: scoreProcedureForPrompt(m, trimmed, queryIntent) }))
     .filter((x) => x.score > 0.04)

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -75,6 +75,7 @@ import {
 } from "./in-flight-reads.js";
 import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
+import { withholdToolScopedFromSharedNamespace } from "./tool-scoped-memory.js";
 import {
   serializeProvenanceFields,
   parseProvenanceSources,
@@ -373,6 +374,7 @@ function serializeFrontmatter(fm: MemoryFrontmatter): string {
     const safe = /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(fm.sourceConnector);
     lines.push(`sourceConnector: ${safe ? fm.sourceConnector : JSON.stringify(fm.sourceConnector)}`);
   }
+  if (fm.toolScoped === true) lines.push("toolScoped: true");
   if (fm.supersedes) lines.push(`supersedes: ${fm.supersedes}`);
   if (fm.expiresAt) lines.push(`expiresAt: ${fm.expiresAt}`);
   if (fm.lineage && fm.lineage.length > 0) {
@@ -897,6 +899,7 @@ export function parseFrontmatter(raw: string): { frontmatter: MemoryFrontmatter;
       tags,
       entityRef: fm.entityRef || undefined,
       sourceConnector: fm.sourceConnector ? decodeYamlScalar(fm.sourceConnector) || undefined : undefined,
+      toolScoped: fm.toolScoped === "true" ? true : undefined,
       supersedes: fm.supersedes || undefined,
       expiresAt: fm.expiresAt || undefined,
       lineage: lineage && lineage.length > 0 ? lineage : undefined,
@@ -1750,6 +1753,7 @@ export interface WriteMemoryOptions {
   sources?: ProvenanceSource[];
   provenance?: "verified" | "unverified" | "none";
   sourceConnector?: string;
+  toolScoped?: true;
 }
 
 /**
@@ -3952,6 +3956,15 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     const sanitized = assemblePersistedBody(content, options.structuredAttributes);
     if (!sanitized.clean) {
       log.warn(`memory content sanitized for ${id}; violations=${sanitized.violations.join(", ")}`);
+    }
+    if (
+      options.toolScoped ||
+      withholdToolScopedFromSharedNamespace({
+        content: sanitized.text,
+        sourceConnector: options.sourceConnector,
+      })
+    ) {
+      fm.toolScoped = true;
     }
 
     // Persist the raw-content dedup hash on the frontmatter so archive and
@@ -6851,6 +6864,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       observedAt?: string;
       eventTimeSource?: "extracted" | "assumed";
       sourceConnector?: string;
+      toolScoped?: true;
     } = {}
   ): Promise<string> {
     await this.ensureDirectories();
@@ -6865,6 +6879,10 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     const validAt = normalizeMemoryWriteTimestamp("validAt", options.validAt);
     const chunkInvalidAt = normalizeMemoryWriteTimestamp("invalidAt", options.invalidAt);
     const chunkObservedAt = normalizeMemoryWriteTimestamp("observedAt", options.observedAt);
+    const sanitized = sanitizeMemoryContent(content);
+    if (!sanitized.clean) {
+      log.warn(`chunk content sanitized for ${id}; violations=${sanitized.violations.join(", ")}`);
+    }
 
     const fm: MemoryFrontmatter = {
       id,
@@ -6894,12 +6912,15 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       ...(options.sources ? { sources: options.sources } : {}),
       ...(options.provenance ? { provenance: options.provenance } : {}),
       ...(options.sourceConnector ? { sourceConnector: options.sourceConnector } : {}),
+      ...(options.toolScoped ||
+      withholdToolScopedFromSharedNamespace({
+        content: sanitized.text,
+        sourceConnector: options.sourceConnector,
+      })
+        ? { toolScoped: true as const }
+        : {}),
     };
 
-    const sanitized = sanitizeMemoryContent(content);
-    if (!sanitized.clean) {
-      log.warn(`chunk content sanitized for ${id}; violations=${sanitized.violations.join(", ")}`);
-    }
     const filePath = await this.resolveCategoryWritePath(category, id, today);
     const fileContent = `${serializeFrontmatter(fm)}\n\n${sanitized.text}\n`;
     // A retried chunk write lands on the SAME deterministic path, so the

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -4349,6 +4349,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       intentActionType?: string;
       intentEntityTypes?: string[];
       sourceConnector?: string;
+      toolScoped?: true;
     } = {}
   ): Promise<string> {
     await this.ensureDirectories();
@@ -4374,6 +4375,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       intentActionType: options.intentActionType,
       intentEntityTypes: options.intentEntityTypes,
       ...(options.sourceConnector ? { sourceConnector: options.sourceConnector } : {}),
+      ...(options.toolScoped ? { toolScoped: true as const } : {}),
     };
 
     const sanitized = sanitizeMemoryContent(quote);

--- a/packages/remnic-core/src/tool-scoped-memory.ts
+++ b/packages/remnic-core/src/tool-scoped-memory.ts
@@ -173,6 +173,16 @@ export function withholdToolScopedFromSharedNamespace({
   return false;
 }
 
+export function canRecallToolScopedMemory(
+  frontmatter: { sourceConnector?: string; toolScoped?: true },
+  requestingConnector?: string,
+): boolean {
+  if (frontmatter.toolScoped !== true) return true;
+  const sourceConnector = frontmatter.sourceConnector?.trim();
+  const requester = requestingConnector?.trim();
+  return !sourceConnector || !requester || sourceConnector === requester;
+}
+
 export interface GlobalFactPromotionInputs {
   scope: string | null | undefined;
   content: string;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -2788,6 +2788,8 @@ export interface ImportanceScore {
 }
 
 export interface MemoryFrontmatter extends SourceConnectorProvenance {
+  /** True when write-time classification ties this memory to its source connector's tools or commands. */
+  toolScoped?: true;
   id: string;
   category: MemoryCategory;
   created: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1956,7 +1956,8 @@ const pluginDefinition = {
     });
     const activeRecallEngine = createActiveRecallEngine(
       {
-        recall: async (query, sessionKey) => orchestrator.recall(query, sessionKey),
+        recall: async (query, sessionKey) =>
+          orchestrator.recall(query, sessionKey, { sourceConnector: "openclaw" }),
         getLastRecallSnapshot: (sessionKey) => orchestrator.getLastRecall(sessionKey),
         explainLastRecall:
           cfg.activeRecallAttachRecallExplain === true
@@ -3093,6 +3094,7 @@ const pluginDefinition = {
         ).catch(() => []);
         let recallComposition: RecallContextComposition | undefined;
         const context = await orchestrator.recall(prompt, sessionKey, {
+          sourceConnector: "openclaw",
           onContextComposition: (composition) => {
             recallComposition = composition;
           },

--- a/tests/procedure-recall.test.ts
+++ b/tests/procedure-recall.test.ts
@@ -44,6 +44,42 @@ test("buildProcedureRecallSection returns ranked procedures on task-initiation p
   }
 });
 
+test("buildProcedureRecallSection partitions tool-scoped procedures by connector", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-procedure-connector-partition-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const body = buildProcedureMarkdownBody([{ order: 1, intent: "Run deploy checks for production gateway" }]);
+    const matching = await storage.writeMemory("procedure", `When you deploy the gateway with connector A\n\n${body}`, {
+      source: "test",
+      sourceConnector: "connector-a",
+      toolScoped: true,
+    });
+    const foreign = await storage.writeMemory("procedure", `When you deploy the gateway with connector B\n\n${body}`, {
+      source: "test",
+      sourceConnector: "connector-b",
+      toolScoped: true,
+    });
+    const portable = await storage.writeMemory("procedure", `When you deploy the gateway\n\n${body}`, { source: "test" });
+    const config = parseConfig({
+      memoryDir: dir,
+      workspaceDir: path.join(dir, "ws"),
+      openaiApiKey: "test-key",
+      procedural: { enabled: true, recallMaxProcedures: 5 },
+    });
+    const section = await buildProcedureRecallSection(storage, "Let's deploy the gateway to production today", config, {
+      partitionToolScoped: true,
+      requestingConnector: "connector-a",
+    });
+    assert.ok(section);
+    assert.match(section, new RegExp(matching.id));
+    assert.match(section, new RegExp(portable.id));
+    assert.doesNotMatch(section, new RegExp(foreign.id));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("buildProcedureRecallSection returns null when procedural.enabled is false", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-procedure-recall-off-"));
   try {

--- a/tests/tool-scoped-promotion-guard.test.ts
+++ b/tests/tool-scoped-promotion-guard.test.ts
@@ -161,6 +161,13 @@ test("promotion guard: global tool-scoped fact with sourceConnector stays in ses
       defaultMems.some((m) => m.content?.includes(TOOL_FACT.slice(0, 20))),
       "tool-scoped global fact must remain in the session (default) namespace",
     );
+    assert.equal(
+      defaultMems.find((memory) =>
+        memory.content?.includes(TOOL_FACT.slice(0, 20)),
+      )?.frontmatter.toolScoped,
+      true,
+      "tool-scoped classification must survive in frontmatter for recall partitioning",
+    );
   } finally {
     StorageManager.clearAllStaticCaches();
     await rm(memoryDir, { recursive: true, force: true });
@@ -416,6 +423,12 @@ test("auto-promote: chunked path also withholds a tool-scoped fact with sourceCo
       defaultMems.some((m) => m.content?.includes("search")),
       "chunked fact must actually be persisted in the session namespace (non-vacuous)",
     );
+    const childChunks = defaultMems.filter((memory) => memory.frontmatter.parentId);
+    assert.ok(childChunks.length > 0, "chunking fixture must persist child chunks");
+    assert.ok(
+      childChunks.every((memory) => memory.frontmatter.toolScoped === true),
+      "every persisted child chunk must inherit the parent's tool-scoped classification",
+    );
     assert.equal(
       sharedMems.some((m) => m.content?.includes("search tool")),
       false,
@@ -459,6 +472,13 @@ test("scope-routing: global procedure with portable title + tool-bearing steps +
     assert.ok(
       defaultMems.some((m) => m.content?.includes("locating an implementation")),
       "global procedure must actually be persisted in the session namespace (non-vacuous)",
+    );
+    assert.equal(
+      defaultMems.find((memory) =>
+        memory.content?.includes("locating an implementation"),
+      )?.frontmatter.toolScoped,
+      true,
+      "structured procedure classification must survive even when its title is portable",
     );
     assert.equal(
       sharedMems.some((m) => m.content?.includes("locating an implementation")),


### PR DESCRIPTION
## Summary

This change keeps tool memories with the connector that made them. It stores the connector and tool marker on memories, chunks, artifacts, and moved copies. It carries the trusted connector through MCP, HTTP, batch, recall, and x-ray paths. Recall filters tool facts, procedures, and artifacts by connector. Portable and older memories stay shared.

## Validation

- `pnpm run check-types`
- `pnpm run build`
- focused connector, recall, procedure, promotion, MCP, and HTTP tests
- `bash scripts/check-review-patterns.sh`

Closes #2202

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-connector recall visibility and connector provenance on multiple entry points; mis-wiring could hide memories or leak tool facts across integrations, but behavior is gated and covered by focused tests.
> 
> **Overview**
> Introduces **`toolScoped`** frontmatter and write-time classification so connector-attributed, tool-like memories are marked and persisted on memories, chunks, artifacts, and copies moved via admin promotion or correction rescope.
> 
> **Trusted `sourceConnector`** is threaded from the transport boundary into recall: HTTP **`/recall`** and **`recall_xray`** set it from the authorized token; MCP and batch recall paths pass the server-resolved connector (client-supplied values are ignored). OpenClaw recall calls now stamp **`openclaw`**.
> 
> When **`extractionScopeClassification`** is enabled, recall filters **`toolScoped`** rows so only the matching connector sees them—main QMD safety filtering, artifact enrichment, and procedure recall—while portable and legacy memories stay visible to all callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adb61999ca6a99e21fdbe5320aaaffb096d46d89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->