### PR TITLE
fix(core): harden tombstone-blocked capture coordination

### DIFF
--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -132,6 +132,20 @@ export function isEncryptedFile(buf: Uint8Array): boolean {
   return b.subarray(0, MAGIC_BYTES.length).equals(MAGIC_BYTES);
 }
 
+type PositionedFileReader = {
+  read: (buffer: Buffer, offset: number, length: number, position: number) => Promise<{ bytesRead: number }>;
+};
+
+async function readPositionedPrefix(handle: PositionedFileReader, buffer: Buffer): Promise<number> {
+  let bytesRead = 0;
+  while (bytesRead < buffer.length) {
+    const result = await handle.read(buffer, bytesRead, buffer.length - bytesRead, bytesRead);
+    if (result.bytesRead === 0) break;
+    bytesRead += result.bytesRead;
+  }
+  return bytesRead;
+}
+
 /**
  * True when the REGULAR file at `probePath` is encrypted at rest (its first
  * bytes are the REMNIC-ENC magic header). ENOENT resolves to false — an absent
@@ -153,14 +167,14 @@ export async function probeEncryptedRegularFileHeader(probePath: string): Promis
   }
   if (!entryStat.isFile()) {
     throw new Error(
-      `refusing to probe non-regular state path ${probePath} `
-      + `(symlink/FIFO/device); opening it could block or escape containment (#2033)`,
+      `refusing to probe non-regular state path ${probePath} ` +
+        `(symlink/FIFO/device); opening it could block or escape containment (#2033)`
     );
   }
   const handle = await openFile(probePath, "r");
   try {
     const header = Buffer.alloc(MAGIC_HEADER_SIZE);
-    const { bytesRead } = await handle.read(header, 0, header.length, 0);
+    const bytesRead = await readPositionedPrefix(handle, header);
     return isEncryptedFile(header.subarray(0, bytesRead));
   } finally {
     await handle.close();
@@ -431,7 +445,7 @@ export async function* readMaybeEncryptedFileFromChunks(
   const headerSize = MAGIC_HEADER_SIZE + ENVELOPE_HEADER_SIZE;
   try {
     const prefix = Buffer.alloc(headerSize);
-    const { bytesRead: prefixBytes } = await handle.read(prefix, 0, prefix.length, 0);
+    const prefixBytes = await readPositionedPrefix(handle, prefix);
     const prefixView = prefix.subarray(0, prefixBytes);
     if (!isEncryptedFile(prefixView)) {
       if (prefixBytes > 0) yield Buffer.from(prefixView);
@@ -459,15 +473,9 @@ export async function* readMaybeEncryptedFileFromChunks(
     if (version !== ENVELOPE_VERSION) {
       throw new Error(`secure-store: unsupported envelope version ${version}`);
     }
-    const salt = envelope.subarray(
-      ENVELOPE_LAYOUT.salt,
-      ENVELOPE_LAYOUT.salt + ENVELOPE_SALT_LENGTH
-    );
+    const salt = envelope.subarray(ENVELOPE_LAYOUT.salt, ENVELOPE_LAYOUT.salt + ENVELOPE_SALT_LENGTH);
     const iv = envelope.subarray(ENVELOPE_LAYOUT.iv, ENVELOPE_LAYOUT.iv + IV_LENGTH);
-    const authTag = envelope.subarray(
-      ENVELOPE_LAYOUT.authTag,
-      ENVELOPE_LAYOUT.authTag + AUTH_TAG_LENGTH
-    );
+    const authTag = envelope.subarray(ENVELOPE_LAYOUT.authTag, ENVELOPE_LAYOUT.authTag + AUTH_TAG_LENGTH);
     const decipher = createDecipheriv("aes-256-gcm", key, iv, { authTagLength: AUTH_TAG_LENGTH });
     decipher.setAAD(Buffer.concat([buildHeaderAad(salt), filePathAad(filePath, memoryDir)]));
     decipher.setAuthTag(authTag);

--- a/packages/remnic-core/src/secure-store/secure-store.test.ts
+++ b/packages/remnic-core/src/secure-store/secure-store.test.ts
@@ -15,7 +15,7 @@
  */
 
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, open as openFile, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -77,6 +77,7 @@ import {
   migrateMemoryDirToEncrypted,
   probeEncryptedRegularFileHeader,
   readMaybeEncryptedFile,
+  readMaybeEncryptedFileFromChunks,
 } from "./secure-fs.js";
 
 /** Cheap scrypt params for tests — still hex-correct but ~milliseconds. */
@@ -965,6 +966,44 @@ test("secure-store migration encrypts memory category dirs but leaves the questi
   }
 });
 
+test("chunked encrypted reads fill the header across positioned short reads", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-chunked-header-"));
+  const filePath = path.join(dir, "encrypted.md");
+  const key = Buffer.alloc(32, 9);
+  const plaintext = Buffer.from("streamed encrypted content survives short header reads");
+  await writeFile(filePath, encryptFileBody(plaintext, key, filePathAad(filePath, dir)));
+
+  const probeHandle = await openFile(filePath, "r");
+  type PositionedRead = (
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number | null
+  ) => Promise<{ bytesRead: number; buffer: Buffer }>;
+  const handlePrototype = Object.getPrototypeOf(probeHandle) as { read: PositionedRead };
+  const originalRead = handlePrototype.read;
+  await probeHandle.close();
+  let shortReadsRemaining = 3;
+  handlePrototype.read = async function (buffer, offset, length, position) {
+    const boundedLength = shortReadsRemaining > 0 ? Math.min(length, 4) : length;
+    shortReadsRemaining -= 1;
+    return await originalRead.call(this, buffer, offset, boundedLength, position);
+  };
+
+  try {
+    assert.equal(await probeEncryptedRegularFileHeader(filePath), true);
+    shortReadsRemaining = 3;
+    const chunks: Buffer[] = [];
+    for await (const chunk of readMaybeEncryptedFileFromChunks(filePath, key, dir, 11)) {
+      chunks.push(chunk);
+    }
+    assert.deepEqual(Buffer.concat(chunks), plaintext);
+  } finally {
+    handlePrototype.read = originalRead;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("probeEncryptedRegularFileHeader detects encryption, treats absent as false, and refuses non-regular paths (#2033)", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "remnic-probe-header-"));
   try {
@@ -994,7 +1033,7 @@ test("probeEncryptedRegularFileHeader detects encryption, treats absent as false
         assert.match(message, /symlink\/FIFO\/device/);
         assert.ok(message.includes(linkPath));
         return true;
-      },
+      }
     );
 
     // A directory is likewise non-regular and refused.

--- a/packages/remnic-core/src/storage-fact-hash-index-defer.test.ts
+++ b/packages/remnic-core/src/storage-fact-hash-index-defer.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import assert from "node:assert/strict";
 import { mkdtemp, mkdir, readFile, readdir, rename, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -10,8 +11,12 @@ import {
   buildExplicitCaptureDedupKey,
   TombstoneBlockedCaptureIndex,
 } from "./storage/tombstone-blocked-capture-index.js";
-import { TombstoneBlockedCaptureWriteLock } from "./storage/tombstone-blocked-capture-mutation.js";
-import { isEncryptedFile } from "./secure-store/secure-fs.js";
+import {
+  buildCapturePathLockIdentity,
+  runTombstoneBlockedMutation,
+  TombstoneBlockedCaptureWriteLock,
+} from "./storage/tombstone-blocked-capture-mutation.js";
+import { isEncryptedFile, SECURE_STORE_ENVELOPE_OVERHEAD_BYTES } from "./secure-store/secure-fs.js";
 import type { MemoryFile } from "./types.js";
 
 // Issue #1909 (Part B): writeMemory("fact") used to rewrite the whole
@@ -52,6 +57,171 @@ test("capture write locks combine streamed hashes in canonical order", async () 
       ),
       /tombstone-blocked capture write lock remained busy/
     );
+  });
+});
+test("active mutations recheck queued-review replacements inside coordinated identity locks", async () => {
+  const pathname = "/memory/facts/active.md";
+  const active = {
+    path: pathname,
+    content: "active content",
+    frontmatter: { id: "active", category: "fact", status: "active" },
+  } as MemoryFile;
+  const queued = {
+    path: pathname,
+    content: "queued content",
+    frontmatter: {
+      id: "queued",
+      category: "fact",
+      status: "pending_review",
+      tags: ["queued-review"],
+      sourceConnector: "provider-a",
+    },
+  } as MemoryFile;
+  const activeIdentity = buildExplicitCaptureDedupKey(
+    active.content,
+    active.frontmatter.category,
+    active.frontmatter.sourceConnector
+  );
+  const queuedIdentity = buildExplicitCaptureDedupKey(
+    queued.content,
+    queued.frontmatter.category,
+    queued.frontmatter.sourceConnector
+  );
+  let current = active;
+  const lockIdentities: string[][] = [];
+  let writes = 0;
+
+  await runTombstoneBlockedMutation(
+    {
+      readCurrent: async () => current,
+      isBlocked: () => false,
+      isQueuedReview: (memory) => memory?.frontmatter.id === queued.frontmatter.id,
+      memoryIdentity: (memory) => (memory.frontmatter.id === active.frontmatter.id ? activeIdentity : queuedIdentity),
+      prepareWrite: async () => "marker",
+      commitWrite: async () => {},
+      discardWrite: async () => {},
+      markUntrusted: () => {},
+      writeStorageSecureFile: async () => {
+        assert.equal(lockIdentities.length, 2);
+        assert.ok(lockIdentities[1]?.includes(queuedIdentity));
+        writes += 1;
+      },
+      withCaptureWriteLock: async (task, identity) => {
+        const identities = Array.isArray(identity) ? [...identity] : [identity];
+        lockIdentities.push(identities);
+        if (lockIdentities.length === 1) current = queued;
+        await task();
+      },
+      logWarning: () => {},
+    },
+    {
+      blocked: false,
+      pathname,
+      fileContent: "replacement",
+      identity: [
+        buildCapturePathLockIdentity(pathname),
+        activeIdentity,
+        buildExplicitCaptureDedupKey("replacement", "fact", undefined),
+      ],
+      updateIndex: async () => {},
+    }
+  );
+
+  assert.equal(writes, 1);
+  assert.equal(lockIdentities.length, 2);
+  assert.ok(lockIdentities[0]?.includes(activeIdentity));
+  assert.ok(lockIdentities[0]?.includes(buildCapturePathLockIdentity(pathname)));
+});
+
+test("shared memory writes include their pathname in the capture lock union", async () => {
+  await withMemoryDir(async (dir) => {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const storageWithOverride = storage as unknown as {
+      withTombstoneBlockedCaptureWriteLock: (
+        task: () => Promise<unknown>,
+        identity?: string | readonly string[]
+      ) => Promise<unknown>;
+    };
+    const originalLock = storageWithOverride.withTombstoneBlockedCaptureWriteLock.bind(storage);
+    const captured: Array<string | readonly string[] | undefined> = [];
+    storageWithOverride.withTombstoneBlockedCaptureWriteLock = async (task, identity) => {
+      captured.push(identity);
+      return await originalLock(task, identity);
+    };
+    try {
+      const written = await storage.writeMemory("fact", "Every writer shares the deterministic pathname lock.", {
+        source: "test",
+      });
+      const memory = await storage.getMemoryById(written.id);
+      assert.ok(memory);
+      const pathIdentity = buildCapturePathLockIdentity(memory.path);
+      assert.ok(captured.some((identity) => (Array.isArray(identity) ? identity : [identity]).includes(pathIdentity)));
+    } finally {
+      storageWithOverride.withTombstoneBlockedCaptureWriteLock = originalLock;
+    }
+  });
+});
+
+test("offline sync reserves a marker when its locked snapshot became blocked with the same identity", async () => {
+  await withMemoryDir(async (dir) => {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const target = path.join(dir, "memory", "facts", "same-identity.md");
+    const active = {
+      path: target,
+      content: "Same identity, different review state.",
+      frontmatter: {
+        id: "same-identity",
+        category: "fact",
+        status: "active",
+        sourceConnector: "provider-a",
+      },
+    } as MemoryFile;
+    const blocked = {
+      ...active,
+      frontmatter: {
+        ...active.frontmatter,
+        status: "pending_review",
+        blockedBy: "same-identity-tombstone",
+      },
+    } as MemoryFile;
+    let readCount = 0;
+    let prepared = 0;
+    const fakeIndex = {
+      withCaptureWriteLock: async <T>(task: () => Promise<T>) => await task(),
+      prepareWrite: async () => {
+        prepared += 1;
+        return "same-identity-marker";
+      },
+      commitWrite: async () => {},
+      discardWrite: async () => {},
+      markUntrusted: () => {},
+    };
+    const storageWithOverrides = storage as unknown as {
+      readMemoryByPath: (pathname: string) => Promise<MemoryFile | null>;
+      getTombstoneBlockedCaptureIndex: () => typeof fakeIndex;
+      invalidateAfterOfflineSyncMutation: (pathname: string, marker?: string) => Promise<void>;
+      runTombstoneBlockedOfflineSyncMutation: (
+        pathname: string,
+        after: MemoryFile | null,
+        write: () => Promise<void>
+      ) => Promise<void>;
+    };
+    const originalRead = storageWithOverrides.readMemoryByPath.bind(storage);
+    const originalIndex = storageWithOverrides.getTombstoneBlockedCaptureIndex.bind(storage);
+    const originalInvalidate = storageWithOverrides.invalidateAfterOfflineSyncMutation.bind(storage);
+    storageWithOverrides.readMemoryByPath = async () => (readCount++ === 0 ? active : blocked);
+    storageWithOverrides.getTombstoneBlockedCaptureIndex = () => fakeIndex;
+    storageWithOverrides.invalidateAfterOfflineSyncMutation = async () => {};
+    try {
+      await storageWithOverrides.runTombstoneBlockedOfflineSyncMutation(target, active, async () => {});
+      assert.equal(prepared, 1);
+    } finally {
+      storageWithOverrides.readMemoryByPath = originalRead;
+      storageWithOverrides.getTombstoneBlockedCaptureIndex = originalIndex;
+      storageWithOverrides.invalidateAfterOfflineSyncMutation = originalInvalidate;
+    }
   });
 });
 
@@ -1662,6 +1832,45 @@ test("blocked chunk writes recheck identity after waiting on the capture lock", 
   });
 });
 
+test("chunk rewrites reacquire discovered identities in canonical lock order", async () => {
+  await withMemoryDir(async (dir) => {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    let queuedContent = "";
+    let blockedContent = "";
+    for (let index = 0; index < 100 && queuedContent.length === 0; index += 1) {
+      const queuedCandidate = `queued identity ${index}`;
+      const blockedCandidate = `blocked identity ${index}`;
+      const queuedHash = createHash("sha256")
+        .update(buildExplicitCaptureDedupKey(queuedCandidate, "fact", "provider-a"))
+        .digest("hex");
+      const blockedHash = createHash("sha256")
+        .update(buildExplicitCaptureDedupKey(blockedCandidate, "fact", "provider-a"))
+        .digest("hex");
+      if (queuedHash < blockedHash) {
+        queuedContent = queuedCandidate;
+        blockedContent = blockedCandidate;
+      }
+    }
+    assert.ok(queuedContent.length > 0);
+
+    await storage.writeChunk("nested-lock-order", 0, 1, "fact", queuedContent, {
+      source: "explicit-inline-review",
+      sourceConnector: "provider-a",
+      status: "pending_review",
+      tags: ["queued-review"],
+    });
+    const id = await storage.writeChunk("nested-lock-order", 0, 1, "fact", blockedContent, {
+      source: "offline-sync",
+      sourceConnector: "provider-a",
+      status: "pending_review",
+      blockedBy: "tombstone-lock-order",
+    });
+
+    assert.equal((await storage.getMemoryById(id))?.content, blockedContent);
+  });
+});
+
 test("offline sync rechecks blocked identity after waiting on the capture lock", async () => {
   await withMemoryDir(async (dir) => {
     const storage = new StorageManager(dir);
@@ -1725,6 +1934,84 @@ test("offline sync rechecks blocked identity after waiting on the capture lock",
     assert.equal(matches[0]?.frontmatter.id, captureResult.id);
   });
 });
+test("offline sync locks queued-review target identities before replacement", async () => {
+  await withMemoryDir(async (dir) => {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const queuedContent = "A queued review must not disappear during capture dedupe.";
+    const queuedResult = await storage.writeMemory("fact", queuedContent, {
+      source: "explicit-inline-review",
+      sourceConnector: "provider-a",
+      status: "pending_review",
+      tags: ["explicit-capture", "queued-review"],
+    });
+    const queuedMemory = await storage.getMemoryById(queuedResult.id);
+    assert.ok(queuedMemory);
+    const queuedIdentity = buildExplicitCaptureDedupKey(queuedContent, "fact", "provider-a");
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const held = storage.withTombstoneBlockedCaptureWriteLock(async () => {
+      entered.resolve();
+      await release.promise;
+    }, queuedIdentity);
+    await entered.promise;
+    const storageWithOverride = storage as unknown as {
+      withTombstoneBlockedCaptureWriteLock: (
+        task: () => Promise<unknown>,
+        identity?: string | readonly string[]
+      ) => Promise<unknown>;
+    };
+    const originalLock = storageWithOverride.withTombstoneBlockedCaptureWriteLock.bind(storage);
+    const coordinationAttempted = Promise.withResolvers<void>();
+    storageWithOverride.withTombstoneBlockedCaptureWriteLock = async (task, identity) => {
+      if ((Array.isArray(identity) ? identity : [identity]).includes(queuedIdentity)) {
+        coordinationAttempted.resolve();
+      }
+      return await originalLock(task, identity);
+    };
+
+    const replacementContent = "The reviewed replacement is now active.";
+    const replacementFile = [
+      "---",
+      "id: queued-review-replacement",
+      "category: fact",
+      "created: 2026-01-01T00:00:00.000Z",
+      "updated: 2026-01-01T00:00:00.000Z",
+      "source: offline-sync",
+      "confidence: 0.8",
+      "confidenceTier: implied",
+      "tags: []",
+      "status: active",
+      "---",
+      "",
+      replacementContent,
+      "",
+    ].join("\n");
+    let completed = false;
+    let replacement: Promise<void> | undefined;
+    try {
+      replacement = storage.writeOfflineSyncFile(queuedMemory.path, Buffer.from(replacementFile, "utf8")).then(() => {
+        completed = true;
+      });
+      const first = await Promise.race([
+        coordinationAttempted.promise.then(() => "coordinated" as const),
+        replacement.then(() => "completed" as const),
+      ]);
+      assert.equal(first, "coordinated");
+      assert.equal(completed, false, "offline sync must wait for the queued-review identity lock");
+      release.resolve();
+      await held;
+      await replacement;
+      assert.equal((await storage.getMemoryById("queued-review-replacement"))?.content, replacementContent);
+    } finally {
+      release.resolve();
+      storageWithOverride.withTombstoneBlockedCaptureWriteLock = originalLock;
+      await held.catch(() => undefined);
+      await replacement?.catch(() => undefined);
+    }
+  });
+});
+
 test("offline sync reacquires a rewritten blocked target identity", async () => {
   await withMemoryDir(async (dir) => {
     const storage = new StorageManager(dir);
@@ -1776,9 +2063,7 @@ test("offline sync reacquires a rewritten blocked target identity", async () => 
       contentA,
       "",
     ].join("\n");
-    const targetMemory = (await storage.readAllMemories()).find(
-      (memory) => memory.frontmatter.id === target.id
-    );
+    const targetMemory = (await storage.readAllMemories()).find((memory) => memory.frontmatter.id === target.id);
     assert.ok(targetMemory);
     const identityA = buildExplicitCaptureDedupKey(contentA, "fact", "provider-a");
     const identityB = buildExplicitCaptureDedupKey(contentB, "fact", "provider-a");
@@ -1786,7 +2071,7 @@ test("offline sync reacquires a rewritten blocked target identity", async () => 
     const storageWithOverride = storage as unknown as {
       withTombstoneBlockedCaptureWriteLock: (
         task: () => Promise<unknown>,
-        identity?: string | readonly string[],
+        identity?: string | readonly string[]
       ) => Promise<unknown>;
     };
     const originalLock = storageWithOverride.withTombstoneBlockedCaptureWriteLock.bind(storage);
@@ -1816,7 +2101,7 @@ test("offline sync reacquires a rewritten blocked target identity", async () => 
           await releaseMarker.promise;
         }
         return marker;
-      },
+      }
     );
 
     const sync = storage.writeOfflineSyncFile(targetMemory.path, Buffer.from(incomingFile, "utf8"));
@@ -1826,11 +2111,11 @@ test("offline sync reacquires a rewritten blocked target identity", async () => 
       const secondKeys = capturedIdentities[1];
       assert.ok(
         (Array.isArray(firstKeys) ? firstKeys : [firstKeys]).includes(identityB),
-        "sync must first observe the original target identity",
+        "sync must first observe the original target identity"
       );
       assert.ok(
         (Array.isArray(secondKeys) ? secondKeys : [secondKeys]).includes(identityC),
-        "sync must reacquire the rewritten target identity",
+        "sync must reacquire the rewritten target identity"
       );
       let recaptureCompleted = false;
       const recapture = peer
@@ -1852,7 +2137,7 @@ test("offline sync reacquires a rewritten blocked target identity", async () => 
       assert.equal(
         after.find((memory) => memory.path === targetMemory.path)?.content,
         contentA,
-        "offline sync must replace the target after holding its current identity lock",
+        "offline sync must replace the target after holding its current identity lock"
       );
       assert.equal(after.filter((memory) => memory.content === contentC).length, 1);
     } finally {
@@ -2309,6 +2594,52 @@ test("chunked offline sync scans oversized frontmatter before locking its identi
   });
 });
 
+test("chunked offline sync lowercases contextual Unicode across staged read boundaries", async () => {
+  await withMemoryDir(async (dir) => {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const header = (id: string) =>
+      [
+        "---",
+        `id: ${id}`,
+        "category: fact",
+        "created: 2026-01-01T00:00:00.000Z",
+        "updated: 2026-01-01T00:00:00.000Z",
+        "source: offline-sync",
+        "confidence: 0.8",
+        "confidenceTier: implied",
+        "tags: []",
+        "sourceConnector: provider-a",
+        "status: pending_review",
+        "blockedBy: tombstone-unicode-boundary",
+        "---",
+      ].join("\n");
+    const incomingHeader = header("unicode-boundary-incoming");
+    const firstReadBoundary = SECURE_STORE_ENVELOPE_OVERHEAD_BYTES + 64 * 1024;
+    const bodyOffset = Buffer.byteLength(`${incomingHeader}\n`);
+    const prefixLength = firstReadBoundary - bodyOffset - Buffer.byteLength("\nΟΣ", "utf8");
+    assert.ok(prefixLength > 0);
+    const content = `${"x".repeat(prefixLength)}ΟΣΑ${"z".repeat(1_050_000)}`;
+    assert.equal(Buffer.byteLength(`${incomingHeader}\n\n${"x".repeat(prefixLength)}ΟΣ`, "utf8"), firstReadBoundary);
+    const memoryFile = (id: string) => `${header(id)}\n\n${content}\n`;
+    const existingPath = path.join(dir, "facts", "2026-01-01", "unicode-boundary-existing.md");
+    await storage.writeOfflineSyncFile(existingPath, Buffer.from(memoryFile("unicode-boundary-existing"), "utf8"));
+
+    const incomingPath = path.join(dir, "facts", "2026-01-01", "unicode-boundary-incoming.md");
+    const incoming = Buffer.from(memoryFile("unicode-boundary-incoming"), "utf8");
+    const chunks = (async function* (): AsyncIterable<Buffer> {
+      for (let offset = 0; offset < incoming.length; offset += 32 * 1024) {
+        yield incoming.subarray(offset, offset + 32 * 1024);
+      }
+    })();
+    await storage.writeOfflineSyncFileChunks(incomingPath, chunks);
+
+    assert.equal(existsSync(incomingPath), false, "the normalized duplicate must not be published");
+    const matches = (await storage.readAllMemories()).filter((memory) => memory.content === content);
+    assert.equal(matches.length, 1);
+  });
+});
+
 test("chunked offline sync encrypts oversized staging files when secure storage is enabled", async () => {
   await withMemoryDir(async (dir) => {
     const storage = new StorageManager(dir);
@@ -2481,9 +2812,7 @@ test("chunked offline sync acquires a target identity discovered in a nested rec
     });
     assert.ok(targetTombstone);
     assert.equal(target.tombstoneBlocked, false);
-    const targetMemory = (await storage.readAllMemories()).find(
-      (memory) => memory.frontmatter.id === target.id
-    );
+    const targetMemory = (await storage.readAllMemories()).find((memory) => memory.frontmatter.id === target.id);
     assert.ok(targetMemory);
     const incomingFile = [
       "---",
@@ -2512,13 +2841,13 @@ test("chunked offline sync acquires a target identity discovered in a nested rec
     const storageWithOverrides = storage as unknown as {
       withTombstoneBlockedCaptureWriteLock: (
         task: () => Promise<unknown>,
-        identity?: string | readonly string[],
+        identity?: string | readonly string[]
       ) => Promise<unknown>;
       runTombstoneBlockedOfflineSyncMutation: (
         target: string,
         after: MemoryFile | null,
         write: () => Promise<void>,
-        coordinate?: boolean,
+        coordinate?: boolean
       ) => Promise<void>;
     };
     const originalLock = storageWithOverrides.withTombstoneBlockedCaptureWriteLock.bind(storage);
@@ -2532,17 +2861,10 @@ test("chunked offline sync acquires a target identity discovered in a nested rec
     let pauseNextPrepare = false;
     const markerEntered = Promise.withResolvers<void>();
     const releaseMarker = Promise.withResolvers<void>();
-    storageWithOverrides.runTombstoneBlockedOfflineSyncMutation = async (
-      syncTarget,
-      after,
-      write,
-      coordinate,
-    ) => {
+    storageWithOverrides.runTombstoneBlockedOfflineSyncMutation = async (syncTarget, after, write, coordinate) => {
       if (!rewroteTarget) {
         rewroteTarget = true;
-        const current = (await peer.readAllMemories()).find(
-          (memory) => memory.frontmatter.id === target.id
-        );
+        const current = (await peer.readAllMemories()).find((memory) => memory.frontmatter.id === target.id);
         assert.ok(current);
         await peer.writeMemoryFrontmatter(current, {
           status: "pending_review",
@@ -2564,17 +2886,15 @@ test("chunked offline sync acquires a target identity discovered in a nested rec
           await releaseMarker.promise;
         }
         return marker;
-      },
+      }
     );
 
     const sync = storage.writeOfflineSyncFileChunks(targetMemory.path, chunks);
     try {
       await markerEntered.promise;
       assert.ok(
-        capturedIdentities.some((identity) =>
-          (Array.isArray(identity) ? identity : [identity]).includes(identityC)
-        ),
-        "nested chunk sync must acquire the identity discovered after the outer recheck",
+        capturedIdentities.some((identity) => (Array.isArray(identity) ? identity : [identity]).includes(identityC)),
+        "nested chunk sync must acquire the identity discovered after the outer recheck"
       );
       let recaptureCompleted = false;
       const recapture = peer
@@ -2596,7 +2916,7 @@ test("chunked offline sync acquires a target identity discovered in a nested rec
       assert.equal(
         after.find((memory) => memory.path === targetMemory.path)?.content,
         incomingContent,
-        "chunk sync must replace the target only while holding its current identity lock",
+        "chunk sync must replace the target only while holding its current identity lock"
       );
       assert.equal(after.filter((memory) => memory.content === targetContent).length, 1);
     } finally {
@@ -2672,7 +2992,7 @@ test("large blocked offline sync streams through bounded staging and deduplicate
         largeContent,
         "",
       ].join("\n"),
-      "utf8",
+      "utf8"
     );
     assert.ok(incomingFile.byteLength > 1_048_576);
     const target = path.join(dir, "cold", "large-stream-incoming.md");
@@ -2689,10 +3009,9 @@ test("large blocked offline sync streams through bounded staging and deduplicate
 
     assert.equal(consumedBytes, incomingFile.byteLength);
     assert.equal(existsSync(target), false, "a streamed blocked duplicate must not publish a new row");
-    const matches = [
-      ...(await storage.readAllMemories()),
-      ...(await storage.readAllColdMemories()),
-    ].filter((memory) => memory.frontmatter.id === existing.id);
+    const matches = [...(await storage.readAllMemories()), ...(await storage.readAllColdMemories())].filter(
+      (memory) => memory.frontmatter.id === existing.id
+    );
     assert.equal(matches.length, 1, "the existing blocked row remains the sole durable duplicate");
   });
 });
@@ -2827,10 +3146,7 @@ test("frontmatter rewrites invalidate cold cache before blocked index sync", asy
     );
     assert.ok(coldMemory, "migrated blocked memory must be readable from cold tier");
 
-    assert.equal(
-      await storage.writeMemoryFrontmatter(coldMemory, { sourceConnector: "provider-b" }),
-      true
-    );
+    assert.equal(await storage.writeMemoryFrontmatter(coldMemory, { sourceConnector: "provider-b" }), true);
     assert.equal(
       await storage.hasTombstoneBlockedExplicitCapture(content, "fact", "provider-a"),
       false,
@@ -3207,7 +3523,7 @@ test("blocked invalidation reserves the index marker before deleting under the i
     const storageWithOverride = storage as unknown as {
       withTombstoneBlockedCaptureWriteLock: (
         task: () => Promise<boolean>,
-        identity?: string | readonly string[],
+        identity?: string | readonly string[]
       ) => Promise<boolean>;
     };
     let capturedIdentity: string | readonly string[] | undefined;
@@ -3229,7 +3545,7 @@ test("blocked invalidation reserves the index marker before deleting under the i
           await release.promise;
         }
         return marker;
-      },
+      }
     );
 
     const invalidation = storage.invalidateMemory(first.id);
@@ -3238,15 +3554,12 @@ test("blocked invalidation reserves the index marker before deleting under the i
         entered.promise.then(() => true),
         new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 100)),
       ]);
-      assert.equal(
-        enteredBeforeTimeout,
-        true,
-        "blocked invalidation must reserve its rebuild marker before unlinking",
-      );
-      assert.equal(capturedIdentity, identity);
+      assert.equal(enteredBeforeTimeout, true, "blocked invalidation must reserve its rebuild marker before unlinking");
+      assert.ok(Array.isArray(capturedIdentity) && capturedIdentity.includes(identity));
+      assert.ok(Array.isArray(capturedIdentity) && capturedIdentity.some((key) => key.startsWith("path ")));
       assert.ok(
         (await readdir(path.join(dir, "state", "tombstone-blocked-capture", "rebuild-required"))).length > 0,
-        "blocked invalidation must publish its rebuild marker before unlinking",
+        "blocked invalidation must publish its rebuild marker before unlinking"
       );
 
       let peerCompleted = false;
@@ -3266,10 +3579,7 @@ test("blocked invalidation reserves the index marker before deleting under the i
       const second = await recapture;
       assert.equal(second.tombstoneBlocked, true);
       assert.notEqual(second.id, first.id);
-      assert.equal(
-        (await peer.readAllMemories()).filter((memory) => memory.content === content).length,
-        1,
-      );
+      assert.equal((await peer.readAllMemories()).filter((memory) => memory.content === content).length, 1);
     } finally {
       release.resolve();
       prepareSpy.mock.restore();
@@ -3313,7 +3623,7 @@ test("blocked archive serializes capture scans with the archive transition", asy
     const storageWithOverride = storage as unknown as {
       withTombstoneBlockedCaptureWriteLock: (
         task: () => Promise<unknown>,
-        identity?: string | readonly string[],
+        identity?: string | readonly string[]
       ) => Promise<unknown>;
     };
     const originalLock = storageWithOverride.withTombstoneBlockedCaptureWriteLock.bind(storage);
@@ -3338,7 +3648,7 @@ test("blocked archive serializes capture scans with the archive transition", asy
           await releaseMarker.promise;
         }
         return marker;
-      },
+      }
     );
 
     const archive = storage.archiveMemory(firstMemory);
@@ -3348,7 +3658,8 @@ test("blocked archive serializes capture scans with the archive transition", asy
         new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 100)),
       ]);
       assert.equal(enteredBeforeTimeout, true, "archive must reserve its marker under the capture lock");
-      assert.equal(capturedIdentity, identity);
+      assert.ok(Array.isArray(capturedIdentity) && capturedIdentity.includes(identity));
+      assert.ok(Array.isArray(capturedIdentity) && capturedIdentity.some((key) => key.startsWith("path ")));
 
       let recaptureCompleted = false;
       const recapture = peer
@@ -3372,12 +3683,12 @@ test("blocked archive serializes capture scans with the archive transition", asy
       assert.equal(
         (await peer.readAllMemories()).filter((memory) => memory.content === content).length,
         1,
-        "recapture must recreate the review row after archive removes the old row",
+        "recapture must recreate the review row after archive removes the old row"
       );
       assert.equal(
         await peer.hasTombstoneBlockedExplicitCapture(content, "fact", "provider-a"),
         true,
-        "the recreated review row must remain indexed",
+        "the recreated review row must remain indexed"
       );
     } finally {
       releaseMarker.resolve();
@@ -3396,7 +3707,7 @@ test("blocked archive failures discard their uncommitted rebuild marker", async 
       protected override writeStorageSecureFile(
         filePath: string,
         content: string | Buffer,
-        forceEncrypt = false,
+        forceEncrypt = false
       ): Promise<void> {
         if (this.failArchiveWrites && filePath.includes(`${path.sep}archive${path.sep}`)) {
           return Promise.reject(new Error("simulated archive write failure"));
@@ -3476,7 +3787,7 @@ test("blocked invalidation reacquires the reloaded identity lock", async () => {
     const storageWithOverride = storage as unknown as {
       withTombstoneBlockedCaptureWriteLock: (
         task: () => Promise<unknown>,
-        identity?: string | readonly string[],
+        identity?: string | readonly string[]
       ) => Promise<unknown>;
     };
     const originalLock = storageWithOverride.withTombstoneBlockedCaptureWriteLock.bind(storage);
@@ -3506,13 +3817,23 @@ test("blocked invalidation reacquires the reloaded identity lock", async () => {
           await releaseMarker.promise;
         }
         return marker;
-      },
+      }
     );
 
     const invalidation = storage.invalidateMemory(first.id);
     try {
       await markerEntered.promise;
-      assert.deepEqual(capturedIdentities, [identityA, identityB]);
+      assert.deepEqual(
+        capturedIdentities.map((identity) =>
+          (Array.isArray(identity) ? identity : [identity]).filter((key) => key?.startsWith("category "))
+        ),
+        [[identityA], [identityA, identityB]]
+      );
+      assert.ok(
+        capturedIdentities.every((identity) =>
+          (Array.isArray(identity) ? identity : [identity]).some((key) => key?.startsWith("path "))
+        )
+      );
       let recaptureCompleted = false;
       const recapture = peer
         .writeMemory("fact", contentB, {
@@ -3530,10 +3851,7 @@ test("blocked invalidation reacquires the reloaded identity lock", async () => {
       const second = await recapture;
       assert.equal(second.tombstoneBlocked, true);
       assert.notEqual(second.id, first.id);
-      assert.equal(
-        (await peer.readAllMemories()).filter((memory) => memory.content === contentB).length,
-        1,
-      );
+      assert.equal((await peer.readAllMemories()).filter((memory) => memory.content === contentB).length, 1);
     } finally {
       releaseMarker.resolve();
       prepareSpy.mock.restore();
@@ -3570,7 +3888,7 @@ test("blocked rewrites reacquire a target identity changed before update", async
           createdBy: "user_correction",
           sourceMemoryId,
           rawContent,
-        }),
+        })
       );
     }
     const target = await storage.writeMemory("fact", contentA, {
@@ -3578,9 +3896,7 @@ test("blocked rewrites reacquire a target identity changed before update", async
       sourceConnector: "provider-a",
     });
     assert.equal(target.tombstoneBlocked, true);
-    const targetMemory = (await storage.readAllMemories()).find(
-      (memory) => memory.frontmatter.id === target.id
-    );
+    const targetMemory = (await storage.readAllMemories()).find((memory) => memory.frontmatter.id === target.id);
     assert.ok(targetMemory);
     const identityA = buildExplicitCaptureDedupKey(contentA, "fact", "provider-a");
     const identityB = buildExplicitCaptureDedupKey(contentB, "fact", "provider-a");
@@ -3588,7 +3904,7 @@ test("blocked rewrites reacquire a target identity changed before update", async
     const storageWithOverride = storage as unknown as {
       withTombstoneBlockedCaptureWriteLock: (
         task: () => Promise<unknown>,
-        identity?: string | readonly string[],
+        identity?: string | readonly string[]
       ) => Promise<unknown>;
     };
     const originalLock = storageWithOverride.withTombstoneBlockedCaptureWriteLock.bind(storage);
@@ -3618,7 +3934,7 @@ test("blocked rewrites reacquire a target identity changed before update", async
           await releaseMarker.promise;
         }
         return marker;
-      },
+      }
     );
 
     const update = storage.updateMemory(target.id, contentC, { sourceConnector: "provider-a" });
@@ -3629,11 +3945,11 @@ test("blocked rewrites reacquire a target identity changed before update", async
       const secondKeys = capturedIdentities[1];
       assert.ok(
         (Array.isArray(firstKeys) ? firstKeys : [firstKeys]).includes(identityA),
-        "update must first lock the identity read before the peer rewrite",
+        "update must first lock the identity read before the peer rewrite"
       );
       assert.ok(
         (Array.isArray(secondKeys) ? secondKeys : [secondKeys]).includes(identityB),
-        "update must reacquire the rewritten target identity",
+        "update must reacquire the rewritten target identity"
       );
       let recaptureCompleted = false;
       const recapture = peer
@@ -3655,7 +3971,7 @@ test("blocked rewrites reacquire a target identity changed before update", async
       assert.equal(
         after.find((memory) => memory.path === targetMemory.path)?.content,
         contentC,
-        "update must write only after holding the current target identity lock",
+        "update must write only after holding the current target identity lock"
       );
       assert.equal(after.filter((memory) => memory.content === contentB).length, 1);
     } finally {
@@ -3914,130 +4230,97 @@ test("queued-review dispositions coordinate with explicit capture dedupe", async
   });
 });
 
-test("active rewrites recheck a target that becomes blocked before the unlocked write", async () => {
+test("active rewrites serialize the target path across their read and write", async () => {
   await withMemoryDir(async (dir) => {
     const storage = new StorageManager(dir);
     const peer = new StorageManager(dir);
     await storage.ensureDirectories();
     await peer.ensureDirectories();
-    const tombstoneConfig = {
-      enabled: true,
-      semanticMatch: false,
-      semanticThreshold: 0.9,
-      namespace: "default",
-    };
-    storage.setTombstonesConfig(tombstoneConfig);
-    peer.setTombstonesConfig(tombstoneConfig);
-    const contentA = "An active target becomes blocked before an update writes.";
-    const contentB = "The rewritten blocked target identity must be locked.";
-    const contentC = "The stale update must publish only after locking identity B.";
-    const tombstoneId = await peer.appendTombstone({
-      reason: "correction",
-      createdBy: "user_correction",
-      sourceMemoryId: "active-rewrite-recheck",
-      rawContent: contentB,
-    });
-    assert.ok(tombstoneId);
+    const contentA = "An active target is read before a concurrent update.";
+    const contentB = "The concurrent update must run after the in-flight write.";
+    const contentC = "The in-flight update holds the path through persistence.";
     const target = await storage.writeMemory("fact", contentA, {
       source: "test",
       sourceConnector: "provider-a",
     });
     const targetMemory = await storage.getMemoryById(target.id);
     assert.ok(targetMemory);
-    assert.equal(targetMemory.frontmatter.status, "active");
-    const identityB = buildExplicitCaptureDedupKey(contentB, "fact", "provider-a");
-    await storage.hasTombstoneBlockedExplicitCapture(contentB, "fact", "provider-a");
 
+    const readPaused = Promise.withResolvers<void>();
+    const releaseRead = Promise.withResolvers<void>();
     const storageWithOverrides = storage as unknown as {
       readMemoryByPath: (filePath: string) => Promise<MemoryFile | null>;
       withTombstoneBlockedCaptureWriteLock: (
         task: () => Promise<unknown>,
-        identity?: string | readonly string[],
+        identity?: string | readonly string[]
       ) => Promise<unknown>;
     };
     const originalRead = storageWithOverrides.readMemoryByPath.bind(storage);
-    let rewriteOnRead = true;
+    let pauseRead = true;
     storageWithOverrides.readMemoryByPath = async (filePath) => {
       const current = await originalRead(filePath);
-      if (rewriteOnRead) {
-        rewriteOnRead = false;
-        assert.ok(current);
-        assert.equal(await peer.updateMemory(target.id, contentB, { sourceConnector: "provider-a" }), true);
-        const rewritten = await peer.getMemoryById(target.id);
-        assert.ok(rewritten);
-        assert.equal(
-          await peer.writeMemoryFrontmatter(rewritten, {
-            status: "pending_review",
-            blockedBy: tombstoneId,
-          }),
-          true,
-        );
-        pauseNextPrepare = true;
-        return await originalRead(filePath);
+      if (pauseRead && filePath === targetMemory.path) {
+        pauseRead = false;
+        readPaused.resolve();
+        await releaseRead.promise;
       }
       return current;
     };
-    const originalLock = storageWithOverrides.withTombstoneBlockedCaptureWriteLock.bind(storage);
-    const capturedIdentities: Array<string | readonly string[] | undefined> = [];
+    const originalStorageLock = storageWithOverrides.withTombstoneBlockedCaptureWriteLock.bind(storage);
+    const storageIdentities: Array<string | readonly string[] | undefined> = [];
     storageWithOverrides.withTombstoneBlockedCaptureWriteLock = async (task, identity) => {
-      capturedIdentities.push(identity);
-      return await originalLock(task, identity);
+      storageIdentities.push(identity);
+      return await originalStorageLock(task, identity);
     };
-    const releaseMarker = Promise.withResolvers<void>();
-    const markerEntered = Promise.withResolvers<void>();
-    let pauseNextPrepare = false;
-    const originalPrepare = TombstoneBlockedCaptureIndex.prototype.prepareWrite;
-    const prepareSpy = mock.method(
-      TombstoneBlockedCaptureIndex.prototype,
-      "prepareWrite",
-      async function (this: TombstoneBlockedCaptureIndex) {
-        const marker = await originalPrepare.call(this);
-        if (pauseNextPrepare) {
-          pauseNextPrepare = false;
-          markerEntered.resolve();
-          await releaseMarker.promise;
-        }
-        return marker;
-      }
-    );
+
+    const peerWithOverride = peer as unknown as {
+      withTombstoneBlockedCaptureWriteLock: (
+        task: () => Promise<unknown>,
+        identity?: string | readonly string[]
+      ) => Promise<unknown>;
+    };
+    const originalPeerLock = peerWithOverride.withTombstoneBlockedCaptureWriteLock.bind(peer);
+    const peerLockRequested = Promise.withResolvers<void>();
+    const peerIdentities: Array<string | readonly string[] | undefined> = [];
+    peerWithOverride.withTombstoneBlockedCaptureWriteLock = async (task, identity) => {
+      peerIdentities.push(identity);
+      peerLockRequested.resolve();
+      return await originalPeerLock(task, identity);
+    };
 
     const update = storage.updateMemory(target.id, contentC, { sourceConnector: "provider-a" });
+    let competingUpdate: Promise<boolean> | undefined;
+    let competingFinished = false;
     try {
-      await markerEntered.promise;
+      await readPaused.promise;
+      competingUpdate = peer.updateMemory(target.id, contentB, { sourceConnector: "provider-a" }).then((updated) => {
+        competingFinished = true;
+        return updated;
+      });
+      await peerLockRequested.promise;
+      const contentionWindow = Promise.withResolvers<void>();
+      setTimeout(contentionWindow.resolve, 50);
+      await contentionWindow.promise;
+      const pathIdentity = buildCapturePathLockIdentity(targetMemory.path);
       assert.ok(
-        capturedIdentities.some((identity) =>
-          (Array.isArray(identity) ? identity : [identity]).includes(identityB)
-        ),
-        "active rewrite must reacquire the current blocked target identity",
+        storageIdentities.some((identity) => (Array.isArray(identity) ? identity : [identity]).includes(pathIdentity))
       );
-      let recaptureCompleted = false;
-      const recapture = peer
-        .writeMemory("fact", contentB, {
-          source: "test",
-          sourceConnector: "provider-a",
-        })
-        .then((result) => {
-          recaptureCompleted = true;
-          return result;
-        });
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      assert.equal(recaptureCompleted, false, "recapture must wait for the current target identity lock");
-      releaseMarker.resolve();
+      assert.ok(
+        peerIdentities.some((identity) => (Array.isArray(identity) ? identity : [identity]).includes(pathIdentity))
+      );
+      assert.equal(competingFinished, false, "the peer must wait while the first writer holds the target path");
+
+      releaseRead.resolve();
       assert.equal(await update, true);
-      assert.equal((await recapture).tombstoneBlocked, true);
-      const after = await peer.readAllMemories();
-      assert.equal(
-        after.find((memory) => memory.path === targetMemory.path)?.content,
-        contentC,
-        "the stale update must write the requested content",
-      );
-      assert.equal(await peer.hasTombstoneBlockedExplicitCapture(contentB, "fact", "provider-a"), true);
+      assert.equal(await competingUpdate, true);
+      assert.equal((await peer.getMemoryById(target.id))?.content, contentB);
     } finally {
-      releaseMarker.resolve();
-      prepareSpy.mock.restore();
+      releaseRead.resolve();
       storageWithOverrides.readMemoryByPath = originalRead;
-      storageWithOverrides.withTombstoneBlockedCaptureWriteLock = originalLock;
+      storageWithOverrides.withTombstoneBlockedCaptureWriteLock = originalStorageLock;
+      peerWithOverride.withTombstoneBlockedCaptureWriteLock = originalPeerLock;
       await update.catch(() => false);
+      await competingUpdate?.catch(() => false);
     }
   });
 });

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -196,7 +196,11 @@ import {
   parseTombstoneBlockedOfflineSyncMemory,
   type TombstoneBlockedCaptureIndexOptions,
 } from "./storage/tombstone-blocked-capture-index.js";
-import { isQueuedReviewMemory, tombstoneBlocked } from "./storage/tombstone-blocked-capture-mutation.js";
+import {
+  buildCapturePathLockIdentity,
+  isQueuedReviewMemory,
+  tombstoneBlocked,
+} from "./storage/tombstone-blocked-capture-mutation.js";
 export { ContentHashIndex, FactHashIndexNotAuthoritativeError };
 export type { ContentHashIndexLockOptions };
 export {
@@ -4000,14 +4004,41 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       await this.writeTombstoneBlockedMemory(filePath, fileContent, fm, sanitized.text, async () => {
         this.invalidateAllMemoriesCache();
       });
+      if (refIds && typeof rawEntityRef === "string") {
+        const refBeforeRepair = fm.entityRef;
+        try {
+          await entityRefs.repairEntityRefAfterJournalMove({
+            stateDir: this.stateDir,
+            currentIds: () => this.currentHistoricalIds(),
+            idsAtResolve: refIds,
+            rawRef: rawEntityRef,
+            frontmatter: fm,
+            rewrite: async () => {
+              await applyTombstoneGate();
+              await this.writeTombstoneBlockedMemory(
+                filePath,
+                `${serializeFrontmatter(fm)}\n\n${sanitized.text}\n`,
+                fm,
+                sanitized.text,
+                async () => this.invalidateAllMemoriesCache()
+              );
+              this.invalidateAllMemoriesCache();
+            },
+          });
+        } catch (err) {
+          await unlink(filePath).catch(() => undefined);
+          this.invalidateAllMemoriesCache();
+          await this.rebuildTombstoneBlockedCaptureAfterInvalidationForPath(filePath);
+          throw err;
+        }
+        await this.entityRefRepair.syncProjection(id, refBeforeRepair, fm.entityRef);
+      }
       return null;
     };
-    const duplicateBlocked = tombstoneBlocked
-      ? await this.withTombstoneBlockedCaptureWriteLock(
-          persistFile,
-          buildExplicitCaptureDedupKey(sanitized.text, category, fm.sourceConnector)
-        )
-      : await persistFile();
+    const duplicateBlocked = await this.withTombstoneBlockedCaptureWriteLock(persistFile, [
+      buildCapturePathLockIdentity(filePath),
+      buildExplicitCaptureDedupKey(sanitized.text, category, fm.sourceConnector),
+    ]);
     if (duplicateBlocked) {
       return {
         id: duplicateBlocked.frontmatter.id,
@@ -4015,38 +4046,6 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         blockedBy: duplicateBlocked.frontmatter.blockedBy,
         duplicateOf: duplicateBlocked.frontmatter.id,
       };
-    }
-    if (refIds && typeof rawEntityRef === "string") {
-      const refBeforeRepair = fm.entityRef;
-      try {
-        await entityRefs.repairEntityRefAfterJournalMove({
-          stateDir: this.stateDir,
-          currentIds: () => this.currentHistoricalIds(),
-          idsAtResolve: refIds,
-          rawRef: rawEntityRef,
-          frontmatter: fm,
-          rewrite: async () => {
-            // Re-gate under the final ref, then rewrite THROUGH the blocked-
-            // capture surface so any verdict change keeps the index consistent.
-            await applyTombstoneGate();
-            await this.writeTombstoneBlockedMemory(
-              filePath,
-              `${serializeFrontmatter(fm)}\n\n${sanitized.text}\n`,
-              fm,
-              sanitized.text,
-              async () => this.invalidateAllMemoriesCache()
-            );
-            this.invalidateAllMemoriesCache();
-          },
-        });
-      } catch (err) {
-        // Remove the just-created file before propagating (§14): it would
-        // linger un-bumped/un-indexed and a retry would duplicate it.
-        await unlink(filePath).catch(() => undefined);
-        this.invalidateAllMemoriesCache();
-        throw err;
-      }
-      await this.entityRefRepair.syncProjection(id, refBeforeRepair, fm.entityRef);
     }
     await this.patchHotMemoriesCache({ addedPath: filePath }, "memory-create");
     this.notifyMemoryWrite(filePath);
@@ -6943,23 +6942,18 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       sanitized.text,
       () => this.findExistingTombstoneBlockedMemory(sanitized.text, category, fm.sourceConnector),
       async () => {
+        if (refIds && typeof rawEntityRef === "string") {
+          await this.entityRefRepair.repair(filePath, fm, rawEntityRef, refIds, sanitized.text, {
+            regateFact: true,
+            ...(priorChunk ? { onFailRestore: priorChunk } : { onFailRemove: filePath }),
+          });
+        }
         // Keep the version-keyed hot-memories cache coherent with the new chunk
         // file (issue #1902) — same single-file patch path writeMemory uses.
         await this.patchHotMemoriesCache({ addedPath: filePath }, "memory-create");
         log.debug(`wrote chunk ${id} (${chunkIndex + 1}/${chunkTotal}) to ${filePath}`);
       }
     );
-    // Repair only when THIS chunk persisted: a tombstone-dedupe result
-    // returns an existing id without writing filePath, and an unconditional
-    // repair rewrite would create a stray second chunk from scratch. The
-    // rewrite RE-GATES under the final ref (Bugbot): a journal move into
-    // tombstone-blocked identity space must not leave a fact chunk active.
-    if (written === id && refIds && typeof rawEntityRef === "string") {
-      await this.entityRefRepair.repair(filePath, fm, rawEntityRef, refIds, sanitized.text, {
-        regateFact: true,
-        ...(priorChunk ? { onFailRestore: priorChunk } : { onFailRemove: filePath }),
-      });
-    }
     return written;
   }
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -6920,20 +6920,6 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     }
     const filePath = await this.resolveCategoryWritePath(category, id, today);
     const fileContent = `${serializeFrontmatter(fm)}\n\n${sanitized.text}\n`;
-    // A retried chunk write lands on the SAME deterministic path, so the
-    // target can already hold a valid prior chunk: snapshot it, and a repair
-    // failure restores it — unlink only a file THIS invocation created
-    // (Codex P2, round 22).
-    let priorChunk: MemoryFile | null = null;
-    try {
-      const priorRaw = await readMaybeEncryptedFile(filePath, this._secureStoreKey, this.baseDir);
-      const parsedPrior = parseFrontmatter(priorRaw);
-      if (parsedPrior) {
-        priorChunk = { path: filePath, frontmatter: parsedPrior.frontmatter, content: parsedPrior.content };
-      }
-    } catch {
-      priorChunk = null;
-    }
 
     const written = await this.writeTombstoneBlockedChunk(
       filePath,
@@ -6941,7 +6927,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       fm,
       sanitized.text,
       () => this.findExistingTombstoneBlockedMemory(sanitized.text, category, fm.sourceConnector),
-      async () => {
+      async (priorChunk) => {
         if (refIds && typeof rawEntityRef === "string") {
           await this.entityRefRepair.repair(filePath, fm, rawEntityRef, refIds, sanitized.text, {
             regateFact: true,

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -194,6 +194,7 @@ import {
   parseTombstoneBlockedOfflineSyncMemory,
   type TombstoneBlockedCaptureIndexOptions,
 } from "./storage/tombstone-blocked-capture-index.js";
+import { isQueuedReviewMemory, tombstoneBlocked } from "./storage/tombstone-blocked-capture-mutation.js";
 export { ContentHashIndex, FactHashIndexNotAuthoritativeError };
 export type { ContentHashIndexLockOptions };
 export {
@@ -278,20 +279,24 @@ const DELETION_REVISION_LOCK_MAX_WAIT_MS = 120_000;
 
 function isValidDeletionRevisionPath(value: unknown): value is string {
   return (
-    typeof value === "string"
-    && value.length > 0
-    && !value.includes("\\")
-    && !value.includes("\0")
-    && !path.posix.isAbsolute(value)
-    && path.posix.normalize(value) === value
-    && value !== "."
-    && value !== ".."
-    && !value.startsWith("../")
+    typeof value === "string" &&
+    value.length > 0 &&
+    !value.includes("\\") &&
+    !value.includes("\0") &&
+    !path.posix.isAbsolute(value) &&
+    path.posix.normalize(value) === value &&
+    value !== "." &&
+    value !== ".." &&
+    !value.startsWith("../")
   );
 }
 
 function deletionRevisionPathIdentity(value: string): string {
-  return value.normalize("NFC").toUpperCase().toLowerCase().replace(/\u00df/g, "ss");
+  return value
+    .normalize("NFC")
+    .toUpperCase()
+    .toLowerCase()
+    .replace(/\u00df/g, "ss");
 }
 
 export interface ReextractJobRequest {
@@ -1053,7 +1058,6 @@ function inferCurrentStateStatus(
 ): MemoryStatus {
   return inferMemoryStatus(frontmatter, pathRel, fallbackStatus);
 }
-
 
 /**
  * Simple Levenshtein distance between two strings.
@@ -2035,9 +2039,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
   setSecureStoreKey(key: Buffer | null, encryptOnWrite = true): void {
     if (!this.applySecureStoreKey(key, encryptOnWrite) || key === null) return;
     void this.entityCanonicalIdMigration.triggerAfterUnlock().catch((error: unknown) => {
-      log.warn(
-        `secure-store unlock migration failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      log.warn(`secure-store unlock migration failed: ${error instanceof Error ? error.message : String(error)}`);
     });
   }
 
@@ -2346,10 +2348,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     return path.join(this.stateDir, `.${kind}-version.log`);
   }
 
-  private bumpSharedVersion(
-    kind: SharedVersionKind,
-    fallbackMap: Map<string, number>
-  ): number {
+  private bumpSharedVersion(kind: SharedVersionKind, fallbackMap: Map<string, number>): number {
     const filePath = this.versionFilePath(kind);
     try {
       mkdirSync(this.stateDir, { recursive: true });
@@ -2364,10 +2363,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     }
   }
 
-  private readSharedVersion(
-    kind: SharedVersionKind,
-    fallbackMap: Map<string, number>
-  ): number {
+  private readSharedVersion(kind: SharedVersionKind, fallbackMap: Map<string, number>): number {
     const filePath = this.versionFilePath(kind);
     try {
       return statSync(filePath).size;
@@ -2676,7 +2672,6 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     return resolved;
   }
 
-
   private parseDeletionRevisionMetadata(raw: string): Map<string, number> {
     let parsed: unknown;
     try {
@@ -2689,9 +2684,9 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     }
     const root = parsed as Record<string, unknown>;
     if (
-      Object.keys(root).sort().join(",") !== "deletions,version"
-      || root.version !== 1
-      || !Array.isArray(root.deletions)
+      Object.keys(root).sort().join(",") !== "deletions,version" ||
+      root.version !== 1 ||
+      !Array.isArray(root.deletions)
     ) {
       throw new Error("Deletion revision metadata is invalid.");
     }
@@ -2703,13 +2698,13 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       }
       const entry = rawEntry as Record<string, unknown>;
       if (
-        Object.keys(entry).sort().join(",") !== "mtimeMs,path"
-        || !isValidDeletionRevisionPath(entry.path)
-        || typeof entry.mtimeMs !== "number"
-        || !Number.isFinite(entry.mtimeMs)
-        || entry.mtimeMs < 0
-        || entry.mtimeMs > DELETION_REVISION_MAX_MTIME_MS
-        || revisions.has(entry.path)
+        Object.keys(entry).sort().join(",") !== "mtimeMs,path" ||
+        !isValidDeletionRevisionPath(entry.path) ||
+        typeof entry.mtimeMs !== "number" ||
+        !Number.isFinite(entry.mtimeMs) ||
+        entry.mtimeMs < 0 ||
+        entry.mtimeMs > DELETION_REVISION_MAX_MTIME_MS ||
+        revisions.has(entry.path)
       ) {
         throw new Error("Deletion revision metadata is invalid.");
       }
@@ -2720,9 +2715,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       pathByIdentity.set(identity, entry.path);
       revisions.set(entry.path, entry.mtimeMs);
     }
-    return new Map(
-      [...revisions.entries()].sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
-    );
+    return new Map([...revisions.entries()].sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0)));
   }
 
   private async readDeletionRevisionMetadata(): Promise<Map<string, number>> {
@@ -2741,11 +2734,10 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     lock: HeldFileLockController
   ): Promise<void> {
     const deletions = [...revisions.entries()]
-      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
       .map(([entryPath, mtimeMs]) => ({ path: entryPath, mtimeMs }));
     const metadata: DeletionRevisionMetadata = { version: 1, deletions };
-    const temporaryPath =
-      `${this.deletionRevisionMetadataPath}.${process.pid}.${randomUUID()}.tmp`;
+    const temporaryPath = `${this.deletionRevisionMetadataPath}.${process.pid}.${randomUUID()}.tmp`;
     let handle: FileHandle | null = null;
     try {
       handle = await open(temporaryPath, "wx", 0o600);
@@ -2765,9 +2757,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     }
   }
 
-  private async withDeletionRevisionLock<T>(
-    task: (lock: HeldFileLockController) => Promise<T>
-  ): Promise<T> {
+  private async withDeletionRevisionLock<T>(task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
     return withHeldFileLock(
       this.deletionRevisionLockPath,
       {
@@ -2786,15 +2776,12 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
   }
 
   async recordReplicatedDeletionRevision(filePath: string, mtimeMs: number): Promise<void> {
-    const target = this.assertManagedStoragePath(
-      filePath,
-      "storage.recordReplicatedDeletionRevision"
-    );
+    const target = this.assertManagedStoragePath(filePath, "storage.recordReplicatedDeletionRevision");
     if (
-      typeof mtimeMs !== "number"
-      || !Number.isFinite(mtimeMs)
-      || mtimeMs < 0
-      || mtimeMs > DELETION_REVISION_MAX_MTIME_MS
+      typeof mtimeMs !== "number" ||
+      !Number.isFinite(mtimeMs) ||
+      mtimeMs < 0 ||
+      mtimeMs > DELETION_REVISION_MAX_MTIME_MS
     ) {
       throw new Error("Deletion revision timestamp is invalid.");
     }
@@ -2812,8 +2799,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
           break;
         }
       }
-      const existingMtimeMs =
-        existingPath === undefined ? undefined : revisions.get(existingPath);
+      const existingMtimeMs = existingPath === undefined ? undefined : revisions.get(existingPath);
       if (existingMtimeMs !== undefined && existingMtimeMs >= mtimeMs) return;
 
       const updated = new Map(revisions);
@@ -2823,10 +2809,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     });
   }
 
-  protected async writeManagedStorageFile(
-    filePath: string,
-    write: () => Promise<void>
-  ): Promise<void> {
+  protected async writeManagedStorageFile(filePath: string, write: () => Promise<void>): Promise<void> {
     const target = this.assertManagedStoragePath(filePath, "storage.writeManagedStorageFile");
     const relativePath = path.relative(this.baseDir, target).split(path.sep).join("/");
     if (!isValidDeletionRevisionPath(relativePath)) {
@@ -2835,8 +2818,9 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     await this.withDeletionRevisionLock(async (lock) => {
       const before = await this.readDeletionRevisionMetadata();
       const identity = deletionRevisionPathIdentity(relativePath);
-      const existingPath = [...before.keys()]
-        .find((candidatePath) => deletionRevisionPathIdentity(candidatePath) === identity);
+      const existingPath = [...before.keys()].find(
+        (candidatePath) => deletionRevisionPathIdentity(candidatePath) === identity
+      );
       await write();
       if (existingPath === undefined) return;
       const updated = new Map(before);
@@ -2845,19 +2829,15 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     });
   }
 
-  protected async deleteManagedStorageFile(
-    filePath: string,
-    deletionMtimeMs?: number | null
-  ): Promise<boolean> {
+  protected async deleteManagedStorageFile(filePath: string, deletionMtimeMs?: number | null): Promise<boolean> {
     const target = this.assertManagedStoragePath(filePath, "storage.deleteManagedStorageFile");
     if (
-      deletionMtimeMs !== undefined && deletionMtimeMs !== null
-      && (
-        typeof deletionMtimeMs !== "number"
-        || !Number.isFinite(deletionMtimeMs)
-        || deletionMtimeMs < 0
-        || deletionMtimeMs > DELETION_REVISION_MAX_MTIME_MS
-      )
+      deletionMtimeMs !== undefined &&
+      deletionMtimeMs !== null &&
+      (typeof deletionMtimeMs !== "number" ||
+        !Number.isFinite(deletionMtimeMs) ||
+        deletionMtimeMs < 0 ||
+        deletionMtimeMs > DELETION_REVISION_MAX_MTIME_MS)
     ) {
       throw new Error("Deletion revision timestamp is invalid.");
     }
@@ -2872,7 +2852,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       if (!isValidDeletionRevisionPath(relativePath)) {
         throw new Error("Deletion revision path is invalid.");
       }
-      const revision = deletionMtimeMs === null ? undefined : deletionMtimeMs ?? Date.now();
+      const revision = deletionMtimeMs === null ? undefined : (deletionMtimeMs ?? Date.now());
       const before = await this.readDeletionRevisionMetadata();
       const identity = deletionRevisionPathIdentity(relativePath);
       let existingPath: string | undefined;
@@ -2884,8 +2864,8 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       }
       const existing = existingPath === undefined ? undefined : before.get(existingPath);
       const changed =
-        (existingPath !== undefined && existingPath !== relativePath)
-        || (revision === undefined ? existing !== undefined : existing !== revision);
+        (existingPath !== undefined && existingPath !== relativePath) ||
+        (revision === undefined ? existing !== undefined : existing !== revision);
       if (changed) {
         const updated = new Map(before);
         if (existingPath !== undefined) updated.delete(existingPath);
@@ -3325,7 +3305,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         () => this.currentHistoricalIds(),
         (identity) => store.appendTombstone({ ...input, rawContent: strippedRawContent, ...identity }),
         (tombstoneId) => store.revoke(tombstoneId, input.createdBy),
-        input.sourceMemoryId,
+        input.sourceMemoryId
       );
     } catch (err) {
       log.warn(`tombstone append failed (memory=${input.sourceMemoryId}): ${err}`);
@@ -3718,12 +3698,12 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
   private readonly entityCanonicalIdMigration = new EntityCanonicalIdMigrationRunner(
     () => !(this._secureStoreRequired && !this.isSecureStoreUnlocked()),
     () => this.runLegacyEntityCanonicalIdMigration(),
-    () => entityMigration.getFingerprint(this.baseDir, this.entitiesDir, () => String(this.getEntityMutationVersion())),
+    () => entityMigration.getFingerprint(this.baseDir, this.entitiesDir, () => String(this.getEntityMutationVersion()))
   );
   normalizeEntityName(raw: string, type: string): string {
     return entityRefs.resolveHistoricalEntityCanonicalId(
       this.entityStore.normalizeEntityName(raw, type),
-      this.currentHistoricalIds(),
+      this.currentHistoricalIds()
     );
   }
 
@@ -3776,7 +3756,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       this as unknown as EntityCanonicalIdMigrationHost,
       (content) => parseEntityFile(content, this.entitySchemas),
       (entity) => serializeEntityFile(entity, this.entitySchemas),
-      createMemoryEntityRefSerializer(serializeFrontmatter),
+      createMemoryEntityRefSerializer(serializeFrontmatter)
     );
     return completionFingerprint;
   }
@@ -4051,7 +4031,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
               `${serializeFrontmatter(fm)}\n\n${sanitized.text}\n`,
               fm,
               sanitized.text,
-              async () => this.invalidateAllMemoriesCache(),
+              async () => this.invalidateAllMemoriesCache()
             );
             this.invalidateAllMemoriesCache();
           },
@@ -4490,16 +4470,10 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     if (newBullets.length === 0) return;
 
     if (!existing) {
-      const content = [
-        "# Behavioral Profile",
-        "",
-        ...newBullets.map((b) => `- ${b}`),
-        "",
-      ].join("\n");
+      const content = ["# Behavioral Profile", "", ...newBullets.map((b) => `- ${b}`), ""].join("\n");
       await this.writeProfile(content);
     } else {
-      const withBullets =
-        existing.trimEnd() + "\n" + newBullets.map((b) => `- ${b}`).join("\n") + "\n";
+      const withBullets = existing.trimEnd() + "\n" + newBullets.map((b) => `- ${b}`).join("\n") + "\n";
       await this.writeProfile(withBullets);
     }
   }
@@ -4864,15 +4838,18 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
             const raw = await readMaybeEncryptedFile(fullPath, this._secureStoreKey, this.baseDir);
             const parsed = parseFrontmatter(raw);
             if (!parsed) return null;
-            return rememberRawFrontmatter({
-              path: fullPath,
-              frontmatter: normalizeFrontmatterForPath(
-                parsed.frontmatter,
-                toMemoryPathRel(this.baseDir, fullPath),
-                parsed.content
-              ),
-              content: parsed.content,
-            } satisfies MemoryFile, raw);
+            return rememberRawFrontmatter(
+              {
+                path: fullPath,
+                frontmatter: normalizeFrontmatterForPath(
+                  parsed.frontmatter,
+                  toMemoryPathRel(this.baseDir, fullPath),
+                  parsed.content
+                ),
+                content: parsed.content,
+              } satisfies MemoryFile,
+              raw
+            );
           } catch (err) {
             // Re-throw store-locked errors so a locked encrypted store fails
             // loudly rather than appearing as an empty memory corpus (Cursor
@@ -5023,15 +5000,20 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
               const raw = await readMaybeEncryptedFile(fullPath, this._secureStoreKey, this.baseDir);
               const parsed = parseFrontmatter(raw);
               if (parsed) {
-                memories.push(rememberRawFrontmatter({
-                  path: fullPath,
-                  frontmatter: normalizeFrontmatterForPath(
-                    parsed.frontmatter,
-                    toMemoryPathRel(this.baseDir, fullPath),
-                    parsed.content
-                  ),
-                  content: parsed.content,
-                }, raw));
+                memories.push(
+                  rememberRawFrontmatter(
+                    {
+                      path: fullPath,
+                      frontmatter: normalizeFrontmatterForPath(
+                        parsed.frontmatter,
+                        toMemoryPathRel(this.baseDir, fullPath),
+                        parsed.content
+                      ),
+                      content: parsed.content,
+                    },
+                    raw
+                  )
+                );
               }
             } catch (err) {
               // Re-throw store-locked errors — a locked encrypted store
@@ -5101,7 +5083,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         `${serializeFrontmatter(frontmatter)}\n\n${memory.content}\n`,
         this.resolveWriteKey(),
         {},
-        this.baseDir,
+        this.baseDir
       );
     // Snapshot pre-write destination bytes (raw — encryption-agnostic) so a
     // repair failure restores them or removes a fresh copy (§14): a retained
@@ -5140,17 +5122,51 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     this.notifyCatalogWrite();
   }
   async moveMemoryToPath(memory: MemoryFile, targetPath: string): Promise<void> {
-    await this.writeMemoryFileAtomic(targetPath, memory);
-    const sourcePath = path.resolve(memory.path);
-    const destPath = path.resolve(targetPath);
-    if (sourcePath !== destPath) {
-      await this.deleteManagedStorageFile(memory.path);
-      // Re-invalidate after the unlink — writeMemoryFileAtomic already
-      // invalidated, but a concurrent readAllMemories() may have re-populated
-      // the cache between the write and the unlink.
-      this.invalidateAllMemoriesCache();
-      updateProjectedMemoryPath(this.baseDir, memory.frontmatter.id, toMemoryPathRel(this.baseDir, targetPath));
-    }
+    await this.withTombstoneBlockedMemoryPathLock(
+      memory.path,
+      async (current) => {
+        if (current?.frontmatter.id !== memory.frontmatter.id) {
+          throw new Error(`memory ${memory.frontmatter.id} changed before its tier move`);
+        }
+        const destination = await this.readMemoryByPath(targetPath);
+        const coordinate =
+          tombstoneBlocked(current.frontmatter) ||
+          isQueuedReviewMemory(current) ||
+          (destination !== null && tombstoneBlocked(destination.frontmatter)) ||
+          isQueuedReviewMemory(destination);
+        const index = this.getTombstoneBlockedCaptureIndex();
+        const marker = coordinate ? await index.prepareWrite() : undefined;
+        let durable = false;
+        try {
+          if (destination?.frontmatter.id === current.frontmatter.id) {
+            await this.deleteManagedStorageFile(current.path);
+            durable = true;
+            this.invalidateAllMemoriesCache();
+            updateProjectedMemoryPath(this.baseDir, current.frontmatter.id, toMemoryPathRel(this.baseDir, targetPath));
+          } else {
+            await this.writeMemoryFileAtomic(targetPath, current);
+            durable = true;
+            const sourcePath = path.resolve(current.path);
+            const destPath = path.resolve(targetPath);
+            if (sourcePath !== destPath) {
+              await this.deleteManagedStorageFile(current.path);
+              this.invalidateAllMemoriesCache();
+              updateProjectedMemoryPath(
+                this.baseDir,
+                current.frontmatter.id,
+                toMemoryPathRel(this.baseDir, targetPath)
+              );
+            }
+          }
+          if (marker !== undefined) await this.rebuildTombstoneBlockedCaptureAfterInvalidation(marker);
+        } catch (error) {
+          if (marker !== undefined && !durable) await index.discardWrite(marker).catch(() => index.markUntrusted());
+          if (marker !== undefined && durable) index.markUntrusted();
+          throw error;
+        }
+      },
+      [targetPath]
+    );
   }
 
   async migrateMemoryToTier(
@@ -5161,14 +5177,6 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     const sourcePath = path.resolve(memory.path);
     const destPath = path.resolve(targetPath);
     if (sourcePath === destPath) {
-      return { changed: false, targetPath };
-    }
-
-    const existing = await this.readMemoryByPath(targetPath);
-    if (existing?.frontmatter.id === memory.frontmatter.id) {
-      await this.deleteManagedStorageFile(memory.path);
-      updateProjectedMemoryPath(this.baseDir, memory.frontmatter.id, toMemoryPathRel(this.baseDir, targetPath));
-      this.bumpMemoryStatusVersion();
       return { changed: false, targetPath };
     }
 
@@ -5208,7 +5216,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
             archivedAt: now.toISOString(),
             updated: now.toISOString(),
           },
-          refIdsAtWrite,
+          refIdsAtWrite
         );
         const fileContent = `${serializeFrontmatter(updatedFm)}\n\n${current.content}\n`;
         const destPath = path.join(destDir, path.basename(current.path));
@@ -5219,7 +5227,11 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         if (typeof current.frontmatter.entityRef === "string") {
           try {
             await this.entityRefRepair.repair(
-              destPath, updatedFm, current.frontmatter.entityRef, refIdsAtWrite, current.content,
+              destPath,
+              updatedFm,
+              current.frontmatter.entityRef,
+              refIdsAtWrite,
+              current.content
             );
           } catch (err) {
             // Restore/remove the destination before reporting failure (§14):
@@ -5325,25 +5337,21 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     return null;
   }
 
-
   async invalidateMemory(id: string): Promise<boolean> {
     const memories = await this.readAllMemories();
     const memory = memories.find((candidate) => candidate.frontmatter.id === id);
     if (!memory) return false;
 
-    return await this.runTombstoneBlockedInvalidation(
-      memory,
-      async (current, rebuildMarker, markDurable) => {
-        if (!(await this.deleteManagedStorageFile(current.path))) return false;
-        markDurable();
-        markProjectedMemoryPathInvalid(this.baseDir, id);
-        this.invalidateAllMemoriesCache();
-        await this.rebuildTombstoneBlockedCaptureAfterInvalidation(rebuildMarker);
-        this.bumpMemoryStatusVersion();
-        log.debug(`invalidated memory ${id}`);
-        return true;
-      }
-    );
+    return await this.runTombstoneBlockedInvalidation(memory, async (current, rebuildMarker, markDurable) => {
+      if (!(await this.deleteManagedStorageFile(current.path))) return false;
+      markDurable();
+      markProjectedMemoryPathInvalid(this.baseDir, id);
+      this.invalidateAllMemoriesCache();
+      await this.rebuildTombstoneBlockedCaptureAfterInvalidation(rebuildMarker);
+      this.bumpMemoryStatusVersion();
+      log.debug(`invalidated memory ${id}`);
+      return true;
+    });
   }
 
   async updateMemory(
@@ -5371,7 +5379,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
           ? { sourceConnector: options.sourceConnector }
           : {}),
       },
-      refIdsAtWrite,
+      refIdsAtWrite
     );
     const sanitized = sanitizeMemoryContent(newContent);
     if (!sanitized.clean) {
@@ -5383,8 +5391,12 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     });
     if (typeof memory.frontmatter.entityRef === "string") {
       await this.entityRefRepair.repair(
-        memory.path, updated, memory.frontmatter.entityRef, refIdsAtWrite, sanitized.text,
-        { onFailRestore: memory },
+        memory.path,
+        updated,
+        memory.frontmatter.entityRef,
+        refIdsAtWrite,
+        sanitized.text,
+        { onFailRestore: memory }
       );
     }
     await this.patchHotMemoriesCache({ addedPath: memory.path });
@@ -5419,7 +5431,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     const resolveIds = this.currentHistoricalIds();
     const updated: MemoryFrontmatter = entityRefs.canonicalizeEntityRefOption(
       { ...memory.frontmatter, ...patch },
-      resolveIds,
+      resolveIds
     );
     const refIds = typeof updated.entityRef === "string" ? resolveIds : null;
     const afterStatus = updated.status ?? "active";
@@ -5434,10 +5446,9 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     });
     const rawMergedRef = typeof patch.entityRef === "string" ? patch.entityRef : memory.frontmatter.entityRef;
     if (refIds && typeof rawMergedRef === "string") {
-      await this.entityRefRepair.repair(
-        memory.path, updated, rawMergedRef, refIds, memory.content,
-        { onFailRestore: memory },
-      );
+      await this.entityRefRepair.repair(memory.path, updated, rawMergedRef, refIds, memory.content, {
+        onFailRestore: memory,
+      });
     }
     await this.patchHotMemoriesCache({ addedPath: memory.path });
     if (memory.path.includes(`${path.sep}cold${path.sep}`)) {
@@ -6585,26 +6596,31 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         : memoryMap.get(entry.memoryId);
       if (!memory) continue;
 
-      const rowIds = this.currentHistoricalIds();
-      const newFm: MemoryFrontmatter = entityRefs.canonicalizeEntityRefOption(
-        { ...memory.frontmatter, accessCount: entry.newCount, lastAccessed: entry.lastAccessed },
-        rowIds,
-      );
-
       try {
-        const fileContent = `${serializeFrontmatter(newFm)}\n\n${memory.content}\n`;
-        await this.writeStorageSecureFile(memory.path, fileContent);
-        if (typeof memory.frontmatter.entityRef === "string") {
-          // onFailRestore (§14): the count patch was never reported applied.
-          await this.entityRefRepair.repair(
-            memory.path, newFm, memory.frontmatter.entityRef, rowIds, memory.content,
-            { onFailRestore: memory },
+        const applied = await this.withTombstoneBlockedMemoryPathLock(memory.path, async (current) => {
+          if (current?.frontmatter.id !== entry.memoryId) return null;
+          const rowIds = this.currentHistoricalIds();
+          const newFm: MemoryFrontmatter = entityRefs.canonicalizeEntityRefOption(
+            { ...current.frontmatter, accessCount: entry.newCount, lastAccessed: entry.lastAccessed },
+            rowIds
           );
-        }
-        // Patch the hot corpus cache entry in place (#1902); the shared
-        // sentinel is bumped once after the loop for cross-process coherence.
+          const fileContent = `${serializeFrontmatter(newFm)}\n\n${current.content}\n`;
+          await this.writeTombstoneBlockedFrontmatter(current, fileContent, newFm);
+          if (typeof current.frontmatter.entityRef === "string") {
+            await this.entityRefRepair.repair(
+              current.path,
+              newFm,
+              current.frontmatter.entityRef,
+              rowIds,
+              current.content,
+              { onFailRestore: current }
+            );
+          }
+          return { current, newFm };
+        });
+        if (applied === null) continue;
         if (warm) {
-          updateCacheOnWrite(this.baseDir, { ...memory, frontmatter: newFm }, keyId);
+          updateCacheOnWrite(this.baseDir, { ...applied.current, frontmatter: applied.newFm }, keyId);
         }
         appliedPatches.set(path.resolve(memory.path), {
           accessCount: entry.newCount,
@@ -6969,25 +6985,33 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     if (!oldMemory) return false;
 
     const now = new Date().toISOString();
-    // Whole-record rewrite — inherited-entityRef rule (issue #2213).
-    const refIdsAtWrite = this.currentHistoricalIds();
-    const updatedFm: MemoryFrontmatter = entityRefs.canonicalizeEntityRefOption(
-      { ...oldMemory.frontmatter, status: "superseded", supersededBy: newMemoryId, supersededAt: now, updated: now },
-      refIdsAtWrite,
-    );
-
-    const fileContent = `${serializeFrontmatter(updatedFm)}\n\n${oldMemory.content}\n`;
+    let currentBefore = oldMemory;
+    let updatedFm = oldMemory.frontmatter;
 
     try {
-      await this.writeStorageSecureFile(oldMemory.path, fileContent);
-      if (typeof oldMemory.frontmatter.entityRef === "string") {
-        // onFailRestore (§14): a record left superseded on disk would skip
-        // its non-resurrection tombstone while caches expose the old state.
-        await this.entityRefRepair.repair(
-          oldMemory.path, updatedFm, oldMemory.frontmatter.entityRef, refIdsAtWrite, oldMemory.content,
-          { onFailRestore: oldMemory },
+      const written = await this.withTombstoneBlockedMemoryPathLock(oldMemory.path, async (current) => {
+        if (current?.frontmatter.id !== oldMemoryId) return false;
+        currentBefore = current;
+        const refIdsAtWrite = this.currentHistoricalIds();
+        updatedFm = entityRefs.canonicalizeEntityRefOption(
+          { ...current.frontmatter, status: "superseded", supersededBy: newMemoryId, supersededAt: now, updated: now },
+          refIdsAtWrite
         );
-      }
+        const fileContent = `${serializeFrontmatter(updatedFm)}\n\n${current.content}\n`;
+        await this.writeTombstoneBlockedFrontmatter(current, fileContent, updatedFm);
+        if (typeof current.frontmatter.entityRef === "string") {
+          await this.entityRefRepair.repair(
+            current.path,
+            updatedFm,
+            current.frontmatter.entityRef,
+            refIdsAtWrite,
+            current.content,
+            { onFailRestore: current }
+          );
+        }
+        return true;
+      });
+      if (!written) return false;
       // Advance the corpus sentinel immediately after the on-disk write, BEFORE
       // the awaited lifecycle append (Cursor Medium, #1902). Otherwise a warm
       // hot-memories cache keeps serving the pre-supersede snapshot during the
@@ -7000,8 +7024,8 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         timestamp: now,
         actor: "storage.supersedeMemory",
         reasonCode: reason,
-        before: this.summarizeLifecycleState(oldMemory.frontmatter, oldMemory.path),
-        after: this.summarizeLifecycleState(updatedFm, oldMemory.path),
+        before: this.summarizeLifecycleState(currentBefore.frontmatter, currentBefore.path),
+        after: this.summarizeLifecycleState(updatedFm, currentBefore.path),
         relatedMemoryIds: [newMemoryId],
       });
       this.bumpMemoryStatusVersion();
@@ -7011,14 +7035,14 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       // so emitting covers each exactly once (rule 22); facts only. One
       // tombstone PER derived supersession key (thread Oci-Y) so a
       // paraphrased re-write is caught on the keyed tier.
-      if (oldMemory.frontmatter.category === "fact") {
+      if (currentBefore.frontmatter.category === "fact") {
         for (const input of buildRetiredFactTombstoneInputs(
           {
             id: oldMemoryId,
-            content: stripCitationForTemplate(oldMemory.content, this.citationTemplate),
-            contentHash: oldMemory.frontmatter.contentHash,
+            content: stripCitationForTemplate(currentBefore.content, this.citationTemplate),
+            contentHash: currentBefore.frontmatter.contentHash,
             entityRef: updatedFm.entityRef,
-            structuredAttributes: oldMemory.frontmatter.structuredAttributes,
+            structuredAttributes: currentBefore.frontmatter.structuredAttributes,
           },
           {
             reason: "contradiction_resolution",
@@ -7032,7 +7056,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       }
 
       // Audit-trail correction — sealed even INSIDE the engine (#2022 review).
-      const auditBody = `Superseded: ${oldMemory.content}\n\nReason: ${reason}`;
+      const auditBody = `Superseded: ${currentBefore.content}\n\nReason: ${reason}`;
       const auditInput = {
         content: auditBody,
         category: "correction" as const,
@@ -7103,22 +7127,33 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       if (!memory) continue;
 
       const now = new Date().toISOString();
-      const rowIds = this.currentHistoricalIds();
-      const updatedFm: MemoryFrontmatter = entityRefs.canonicalizeEntityRefOption(
-        { ...memory.frontmatter, status: "archived", archivedAt: now, updated: now },
-        rowIds,
-      );
+      let currentBefore = memory;
+      let updatedFm = memory.frontmatter;
 
       try {
-        const fileContent = `${serializeFrontmatter(updatedFm)}\n\n${memory.content}\n`;
-        await this.writeStorageSecureFile(memory.path, fileContent);
-        if (typeof memory.frontmatter.entityRef === "string") {
-          // onFailRestore (§14): the method reports the row NOT archived.
-          await this.entityRefRepair.repair(
-            memory.path, updatedFm, memory.frontmatter.entityRef, rowIds, memory.content,
-            { onFailRestore: memory },
+        const written = await this.withTombstoneBlockedMemoryPathLock(memory.path, async (current) => {
+          if (current?.frontmatter.id !== id) return false;
+          currentBefore = current;
+          const rowIds = this.currentHistoricalIds();
+          updatedFm = entityRefs.canonicalizeEntityRefOption(
+            { ...current.frontmatter, status: "archived", archivedAt: now, updated: now },
+            rowIds
           );
-        }
+          const fileContent = `${serializeFrontmatter(updatedFm)}\n\n${current.content}\n`;
+          await this.writeTombstoneBlockedFrontmatter(current, fileContent, updatedFm);
+          if (typeof current.frontmatter.entityRef === "string") {
+            await this.entityRefRepair.repair(
+              current.path,
+              updatedFm,
+              current.frontmatter.entityRef,
+              rowIds,
+              current.content,
+              { onFailRestore: current }
+            );
+          }
+          return true;
+        });
+        if (!written) continue;
         // Per-file corpus bump BEFORE the awaited lifecycle append (#1902):
         // the end-of-loop status bump fires only after the whole batch.
         this.bumpMemoryCorpusVersion();
@@ -7128,8 +7163,8 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
           timestamp: updatedFm.archivedAt ?? updatedFm.updated,
           actor: "storage.archiveMemories",
           reasonCode: `summary:${summaryId}`,
-          before: this.summarizeLifecycleState(memory.frontmatter, memory.path),
-          after: this.summarizeLifecycleState(updatedFm, memory.path),
+          before: this.summarizeLifecycleState(currentBefore.frontmatter, currentBefore.path),
+          after: this.summarizeLifecycleState(updatedFm, currentBefore.path),
           relatedMemoryIds: [summaryId],
         });
         archived++;

--- a/packages/remnic-core/src/storage/tombstone-blocked-capture-mutation.ts
+++ b/packages/remnic-core/src/storage/tombstone-blocked-capture-mutation.ts
@@ -30,9 +30,15 @@ export function buildExplicitCaptureDedupKey(
   ].join(" ");
 }
 
+export function buildCapturePathLockIdentity(pathname: string): string {
+  return `path ${pathname.length} ${pathname}`;
+}
+
 export function captureIdentityHash(memory: MemoryFile): string {
   return createHash("sha256")
-    .update(buildExplicitCaptureDedupKey(memory.content, memory.frontmatter.category, memory.frontmatter.sourceConnector))
+    .update(
+      buildExplicitCaptureDedupKey(memory.content, memory.frontmatter.category, memory.frontmatter.sourceConnector)
+    )
     .digest("hex");
 }
 
@@ -48,9 +54,7 @@ export class TombstoneBlockedCaptureWriteLock {
 
   private captureWriteLockPathForHash(identityHash: string): string {
     const filename =
-      identityHash.length === 0
-        ? "explicit-capture-write.lock"
-        : `explicit-capture-write-${identityHash}.lock`;
+      identityHash.length === 0 ? "explicit-capture-write.lock" : `explicit-capture-write-${identityHash}.lock`;
     return path.join(this.options.stateDir, "tombstone-blocked-capture", filename);
   }
 
@@ -87,7 +91,7 @@ export class TombstoneBlockedCaptureWriteLock {
     task: () => Promise<T>,
     identityHashes: readonly string[]
   ): Promise<T> {
-    const lockPaths = [...new Set(identityHashes.map((hash) => this.captureWriteLockPathForHash(hash)))].sort();
+    const lockPaths = [...new Set(identityHashes.map((hash) => this.captureWriteLockPathForHash(hash)))];
     const acquire = async (index: number): Promise<T> => {
       if (index === lockPaths.length) return await task();
       return await this.withSingleCaptureWriteLock(lockPaths[index], () => acquire(index + 1));
@@ -95,20 +99,13 @@ export class TombstoneBlockedCaptureWriteLock {
     return await acquire(0);
   }
 
-
-  async withCaptureWriteLock<T>(
-    task: () => Promise<T>,
-    identity?: string | readonly string[]
-  ): Promise<T> {
+  async withCaptureWriteLock<T>(task: () => Promise<T>, identity?: string | readonly string[]): Promise<T> {
     const identities =
       Array.isArray(identity) && identity.length > 0 ? identity : [typeof identity === "string" ? identity : ""];
     return await this.withCaptureWriteLocks(task, identities, []);
   }
 
-  async withCaptureWriteLockHashes<T>(
-    task: () => Promise<T>,
-    identityHashes: readonly string[]
-  ): Promise<T> {
+  async withCaptureWriteLockHashes<T>(task: () => Promise<T>, identityHashes: readonly string[]): Promise<T> {
     return await this.withCaptureWriteLocks(task, [], identityHashes);
   }
 
@@ -134,17 +131,44 @@ export class TombstoneBlockedCaptureWriteLock {
       key.length === 0 ? "" : createHash("sha256").update(key).digest("hex");
     const identityKeys = [...new Set(identities)];
     const hashes = [...new Set(identityHashes)];
-    const missingIdentityHashes = identityKeys
-      .filter((key) => !current || (!current.has(key) && !current.has(hashToken(key))))
-      .map(identityHash);
-    const missingHashes = hashes.filter((hash) => !current || !current.has(`\u0000${hash}`));
-    const physicalMissing = [...new Set([...missingIdentityHashes, ...missingHashes])];
-    if (current && physicalMissing.length > 0) {
-      const heldLockPaths = [...current]
+    const requested = [
+      ...identityKeys
+        .filter((key) => !current || (!current.has(key) && !current.has(hashToken(key))))
+        .map((key) => ({ hash: identityHash(key), pathLock: key.startsWith("path ") })),
+      ...hashes.filter((hash) => !current || !current.has(`\u0000${hash}`)).map((hash) => ({ hash, pathLock: false })),
+    ]
+      .filter((entry, index, entries) => entries.findIndex((candidate) => candidate.hash === entry.hash) === index)
+      .sort(
+        (left, right) =>
+          Number(left.pathLock) - Number(right.pathLock) ||
+          this.captureWriteLockPathForHash(left.hash).localeCompare(this.captureWriteLockPathForHash(right.hash))
+      );
+    const physicalMissing = requested.map((entry) => entry.hash);
+    if (current && requested.length > 0) {
+      const held = [...current]
         .filter((token) => token.startsWith("\u0000"))
-        .map((token) => this.captureWriteLockPathForHash(token.slice(1)));
-      const requestedLockPaths = physicalMissing.map((hash) => this.captureWriteLockPathForHash(hash));
-      if (heldLockPaths.some((held) => requestedLockPaths.some((requested) => requested < held))) {
+        .map((token) => {
+          const hash = token.slice(1);
+          const pathLock = [...current].some(
+            (key) => !key.startsWith("\u0000") && key.startsWith("path ") && hashToken(key) === token
+          );
+          return { hash, pathLock };
+        });
+      const requestedFirst = requested[0];
+      const heldLast = held
+        .sort(
+          (left, right) =>
+            Number(left.pathLock) - Number(right.pathLock) ||
+            this.captureWriteLockPathForHash(left.hash).localeCompare(this.captureWriteLockPathForHash(right.hash))
+        )
+        .at(-1);
+      if (
+        heldLast &&
+        requestedFirst &&
+        (Number(requestedFirst.pathLock) < Number(heldLast.pathLock) ||
+          (requestedFirst.pathLock === heldLast.pathLock &&
+            this.captureWriteLockPathForHash(requestedFirst.hash) < this.captureWriteLockPathForHash(heldLast.hash)))
+      ) {
         throw new Error(CAPTURE_WRITE_LOCK_BUSY_MESSAGE);
       }
     }
@@ -159,7 +183,6 @@ export class TombstoneBlockedCaptureWriteLock {
     return await this.withPhysicalCaptureWriteLocks(run, physicalMissing);
   }
 }
-
 
 export type TombstoneBlockedMutationHost = {
   readCurrent: () => Promise<MemoryFile | null>;
@@ -187,17 +210,16 @@ export type TombstoneBlockedMutation = {
 
 export async function runTombstoneBlockedMutation(
   host: TombstoneBlockedMutationHost,
-  mutation: TombstoneBlockedMutation,
+  mutation: TombstoneBlockedMutation
 ): Promise<void> {
   let lockIdentity: string | readonly string[] = mutation.identity;
-  let mustLock = mutation.blocked || mutation.coordinate === true;
   for (;;) {
     let retryIdentity: string | undefined;
     const mutate = async (): Promise<void> => {
       const current = await host.readCurrent();
       const currentBlocked = host.isBlocked(current);
       const currentQueuedReview = host.isQueuedReview(current);
-      if (current !== null && (currentBlocked || currentQueuedReview)) {
+      if (current !== null && (mutation.coordinate === true || currentBlocked || currentQueuedReview)) {
         const currentIdentity = host.memoryIdentity(current);
         const heldIdentities = Array.isArray(lockIdentity) ? lockIdentity : [lockIdentity];
         if (!heldIdentities.includes(currentIdentity)) {
@@ -230,17 +252,10 @@ export async function runTombstoneBlockedMutation(
       if (rebuildMarker) await mutation.beforeIndexUpdate?.();
       await mutation.updateIndex(rebuildMarker, currentBlocked && current !== null ? current : undefined);
     };
-    if (mustLock) {
-      await host.withCaptureWriteLock(mutate, lockIdentity);
-    } else {
-      await mutate();
-    }
+    await host.withCaptureWriteLock(mutate, lockIdentity);
     if (retryIdentity === undefined) return;
-    const identities = Array.isArray(lockIdentity)
-      ? [...lockIdentity, retryIdentity]
-      : [lockIdentity, retryIdentity];
+    const identities = Array.isArray(lockIdentity) ? [...lockIdentity, retryIdentity] : [lockIdentity, retryIdentity];
     lockIdentity = [...new Set(identities)];
-    mustLock = true;
   }
 }
 
@@ -254,31 +269,4 @@ export function isQueuedReviewFrontmatter(frontmatter: MemoryFrontmatter): boole
 
 export function isQueuedReviewMemory(memory: MemoryFile | null): memory is MemoryFile {
   return memory !== null && isQueuedReviewFrontmatter(memory.frontmatter);
-}
-
-export type TombstoneBlockedChunkMutation = {
-  blocked: boolean;
-  id: string;
-  identity: string;
-  findDuplicate: () => Promise<MemoryFile | null>;
-  persistMemory: () => Promise<void>;
-  afterWrite: () => Promise<void>;
-  withCaptureWriteLock: (task: () => Promise<string>, identity: string) => Promise<string>;
-};
-
-export async function runTombstoneBlockedChunkMutation(
-  mutation: TombstoneBlockedChunkMutation,
-): Promise<string> {
-  const persist = async (): Promise<string> => {
-    if (mutation.blocked) {
-      const duplicate = await mutation.findDuplicate();
-      if (duplicate) return duplicate.frontmatter.id;
-    }
-    await mutation.persistMemory();
-    await mutation.afterWrite();
-    return mutation.id;
-  };
-  return mutation.blocked
-    ? await mutation.withCaptureWriteLock(persist, mutation.identity)
-    : await persist();
 }

--- a/packages/remnic-core/src/storage/tombstone-blocked-capture-sync.ts
+++ b/packages/remnic-core/src/storage/tombstone-blocked-capture-sync.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHash, randomUUID, type Hash } from "node:crypto";
 import { unlink } from "node:fs/promises";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
@@ -7,21 +7,14 @@ import type { MemoryFile, MemoryFrontmatter } from "../types.js";
 import { markProjectedMemoryPathInvalid } from "../memory-projection-store.js";
 import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
 import { isErrnoCode } from "../utils/errno.js";
-import {
-  pathMayCarryEntityRefs,
-  requestEntityCanonicalIdReconcile,
-} from "./entity-canonical-id-references.js";
-import {
-  readMaybeEncryptedFileFromChunks,
-  writeMaybeEncryptedFileFromChunks,
-} from "../secure-store/secure-fs.js";
+import { pathMayCarryEntityRefs, requestEntityCanonicalIdReconcile } from "./entity-canonical-id-references.js";
+import { readMaybeEncryptedFileFromChunks, writeMaybeEncryptedFileFromChunks } from "../secure-store/secure-fs.js";
 import {
   buildExplicitCaptureDedupKey,
+  buildCapturePathLockIdentity,
   captureIdentityHash,
   tombstoneBlocked,
-  isQueuedReviewFrontmatter,
   isQueuedReviewMemory,
-  runTombstoneBlockedChunkMutation,
   runTombstoneBlockedMutation,
   type TombstoneBlockedMutationHost,
 } from "./tombstone-blocked-capture-mutation.js";
@@ -31,6 +24,9 @@ import type { TombstoneBlockedCaptureIndexOptions } from "./tombstone-blocked-ca
 const OFFLINE_SYNC_BUFFER_LIMIT_BYTES = 1_048_576;
 const OFFLINE_SYNC_STAGE_READ_BYTES = 64 * 1024;
 const OFFLINE_SYNC_FRONTMATTER_DELIMITER = Buffer.from("\n---\n", "utf8");
+
+const CASED_CHARACTER = /\p{Cased}/u;
+const CASE_IGNORABLE_CHARACTER = /\p{Case_Ignorable}/u;
 
 type StreamedOfflineSyncIdentity = {
   identityHash: string;
@@ -43,36 +39,75 @@ type PreparedOfflineSyncChunks = {
   streamedIdentity?: StreamedOfflineSyncIdentity;
 };
 
-function createExplicitContentNormalizer(onChunk: (chunk: string) => void): {
+type ExplicitContentNormalizerSink = {
+  write: (chunk: string) => void;
+  beginConditionalSigma: () => void;
+  resolveConditionalSigma: (useFinalSigma: boolean) => void;
+};
+
+function createExplicitContentNormalizer(sink: ExplicitContentNormalizerSink): {
   push: (text: string) => void;
   finish: () => void;
 } {
   let started = false;
   let pendingSpace = false;
   let output = "";
+  let precededByCased = false;
+  let pendingSigma = false;
   const flush = () => {
     if (output.length > 0) {
-      onChunk(output);
+      sink.write(output);
       output = "";
     }
   };
-  return {
-    push(text) {
-      for (const character of text.toLowerCase()) {
-        if (/\s/u.test(character)) {
-          if (started) pendingSpace = true;
+  const emit = (text: string) => {
+    for (const character of text) {
+      if (/\s/u.test(character)) {
+        if (started) pendingSpace = true;
+        continue;
+      }
+      if (pendingSpace) {
+        output += " ";
+        pendingSpace = false;
+      }
+      output += character;
+      started = true;
+      if (output.length >= OFFLINE_SYNC_STAGE_READ_BYTES) flush();
+    }
+  };
+  const resolveSigma = (followedByCased: boolean) => {
+    flush();
+    sink.resolveConditionalSigma(!followedByCased);
+    pendingSigma = false;
+  };
+  const push = (text: string) => {
+    for (const character of text) {
+      const caseIgnorable = CASE_IGNORABLE_CHARACTER.test(character);
+      const cased = CASED_CHARACTER.test(character);
+      if (pendingSigma) {
+        if (caseIgnorable) {
+          emit(character.toLowerCase());
           continue;
         }
-        if (pendingSpace) {
-          output += " ";
-          pendingSpace = false;
-        }
-        output += character;
-        started = true;
-        if (output.length >= OFFLINE_SYNC_STAGE_READ_BYTES) flush();
+        resolveSigma(cased);
       }
+      if (character === "Σ" && precededByCased) {
+        flush();
+        sink.beginConditionalSigma();
+        pendingSigma = true;
+        precededByCased = true;
+        continue;
+      }
+      emit(character.toLowerCase());
+      if (!caseIgnorable) precededByCased = cased;
+    }
+  };
+  return {
+    push,
+    finish() {
+      if (pendingSigma) resolveSigma(false);
+      flush();
     },
-    finish: flush,
   };
 }
 
@@ -86,10 +121,7 @@ async function forEachStagedTextChunk(
   const decoder = new TextDecoder("utf-8");
   let remaining = offset;
   for await (const chunk of readMaybeEncryptedFileFromChunks(stagePath, key, memoryDir)) {
-    const textChunk =
-      remaining >= chunk.length
-        ? null
-        : chunk.subarray(remaining);
+    const textChunk = remaining >= chunk.length ? null : chunk.subarray(remaining);
     remaining = Math.max(0, remaining - chunk.length);
     if (textChunk === null || textChunk.length === 0) continue;
     const text = decoder.decode(textChunk, { stream: true });
@@ -99,11 +131,7 @@ async function forEachStagedTextChunk(
   if (finalText.length > 0) onText(finalText);
 }
 
-async function findStagedBodyOffset(
-  stagePath: string,
-  key: Buffer | null,
-  memoryDir: string
-): Promise<number | null> {
+async function findStagedBodyOffset(stagePath: string, key: Buffer | null, memoryDir: string): Promise<number | null> {
   let scannedBytes = 0;
   let tail = Buffer.alloc(0);
   for await (const chunk of readMaybeEncryptedFileFromChunks(stagePath, key, memoryDir)) {
@@ -178,14 +206,8 @@ export abstract class TombstoneBlockedCaptureIndexHost {
   protected abstract bumpMemoryStatusVersion(): void;
   protected abstract bumpMemoryCorpusVersion(): void;
   protected abstract markFactHashIndexNotAuthoritative(): void;
-  protected abstract deleteManagedStorageFile(
-    filePath: string,
-    deletionMtimeMs?: number | null
-  ): Promise<boolean>;
-  protected abstract writeManagedStorageFile(
-    filePath: string,
-    write: () => Promise<void>
-  ): Promise<void>;
+  protected abstract deleteManagedStorageFile(filePath: string, deletionMtimeMs?: number | null): Promise<boolean>;
+  protected abstract writeManagedStorageFile(filePath: string, write: () => Promise<void>): Promise<void>;
 
   private async writeStorageSecureFileChunks(filePath: string, chunks: AsyncIterable<Buffer>): Promise<void> {
     const options = this.tombstoneBlockedCaptureIndexOptions();
@@ -239,8 +261,7 @@ export abstract class TombstoneBlockedCaptureIndexHost {
       discardWrite: (marker) => this.getTombstoneBlockedCaptureIndex().discardWrite(marker),
       markUntrusted: () => this.getTombstoneBlockedCaptureIndex().markUntrusted(),
       writeStorageSecureFile: (target, content) => this.writeStorageSecureFile(target, content),
-      withCaptureWriteLock: (task, lockIdentity) =>
-        this.withTombstoneBlockedCaptureWriteLock(task, lockIdentity),
+      withCaptureWriteLock: (task, lockIdentity) => this.withTombstoneBlockedCaptureWriteLock(task, lockIdentity),
       logWarning: (message) => log.warn(message),
     };
     await runTombstoneBlockedMutation(host, {
@@ -265,11 +286,42 @@ export abstract class TombstoneBlockedCaptureIndexHost {
       tombstoneBlocked(frontmatter),
       pathname,
       fileContent,
-      buildExplicitCaptureDedupKey(content, frontmatter.category, frontmatter.sourceConnector),
+      [
+        buildCapturePathLockIdentity(pathname),
+        buildExplicitCaptureDedupKey(content, frontmatter.category, frontmatter.sourceConnector),
+      ],
       (rebuildMarker) =>
         this.getTombstoneBlockedCaptureIndex().addWrittenMemory(pathname, frontmatter, content, rebuildMarker),
       beforeIndexUpdate
     );
+  }
+
+  protected async withTombstoneBlockedMemoryPathLock<T>(
+    pathname: string,
+    task: (current: MemoryFile | null) => Promise<T>,
+    additionalPathnames: readonly string[] = []
+  ): Promise<T> {
+    let lockIdentities = [pathname, ...additionalPathnames].map(buildCapturePathLockIdentity);
+    for (;;) {
+      let retryIdentity: string | undefined;
+      let result: T | undefined;
+      await this.withTombstoneBlockedCaptureWriteLock(async () => {
+        const current = await this.readMemoryByPath(pathname);
+        if (current !== null) {
+          const currentIdentity = this.offlineSyncMemoryIdentity(current);
+          if (!lockIdentities.includes(currentIdentity)) {
+            retryIdentity = currentIdentity;
+            return;
+          }
+        }
+        result = await task(current);
+      }, lockIdentities);
+      if (retryIdentity !== undefined) {
+        lockIdentities = [...new Set([...lockIdentities, retryIdentity])];
+        continue;
+      }
+      return result!;
+    }
   }
 
   protected async writeTombstoneBlockedChunk(
@@ -280,15 +332,33 @@ export abstract class TombstoneBlockedCaptureIndexHost {
     findDuplicate: () => Promise<MemoryFile | null>,
     afterWrite: () => Promise<void>
   ): Promise<string> {
-    return await runTombstoneBlockedChunkMutation({
-      blocked: tombstoneBlocked(frontmatter),
-      id: frontmatter.id,
-      identity: buildExplicitCaptureDedupKey(content, frontmatter.category, frontmatter.sourceConnector),
-      findDuplicate,
-      persistMemory: () => this.writeTombstoneBlockedMemory(pathname, fileContent, frontmatter, content),
-      afterWrite,
-      withCaptureWriteLock: (task, identity) => this.withTombstoneBlockedCaptureWriteLock(task, identity),
-    });
+    const incomingIdentity = buildExplicitCaptureDedupKey(content, frontmatter.category, frontmatter.sourceConnector);
+    let lockIdentities = [buildCapturePathLockIdentity(pathname), incomingIdentity];
+    for (;;) {
+      let retryIdentity: string | undefined;
+      let result = frontmatter.id;
+      await this.withTombstoneBlockedCaptureWriteLock(async () => {
+        const current = await this.readMemoryByPath(pathname);
+        if (current !== null) {
+          const currentIdentity = this.offlineSyncMemoryIdentity(current);
+          if (!lockIdentities.includes(currentIdentity)) {
+            retryIdentity = currentIdentity;
+            return;
+          }
+        }
+        if (tombstoneBlocked(frontmatter)) {
+          const duplicate = await findDuplicate();
+          if (duplicate) {
+            result = duplicate.frontmatter.id;
+            return;
+          }
+        }
+        await this.writeTombstoneBlockedMemory(pathname, fileContent, frontmatter, content);
+        await afterWrite();
+      }, lockIdentities);
+      if (retryIdentity === undefined) return result;
+      lockIdentities = [...new Set([...lockIdentities, retryIdentity])];
+    }
   }
 
   protected async writeTombstoneBlockedUpdate(
@@ -303,30 +373,9 @@ export abstract class TombstoneBlockedCaptureIndexHost {
       before.path,
       fileContent,
       [
-        ...(tombstoneBlocked(before.frontmatter)
-          ? [
-              buildExplicitCaptureDedupKey(
-                before.content,
-                before.frontmatter.category,
-                before.frontmatter.sourceConnector
-              ),
-            ]
-          : []),
-        ...(tombstoneBlocked(frontmatter)
-          ? [buildExplicitCaptureDedupKey(content, frontmatter.category, frontmatter.sourceConnector)]
-          : []),
-        ...(isQueuedReviewMemory(before)
-          ? [
-              buildExplicitCaptureDedupKey(
-                before.content,
-                before.frontmatter.category,
-                before.frontmatter.sourceConnector
-              ),
-            ]
-          : []),
-        ...(isQueuedReviewFrontmatter(frontmatter)
-          ? [buildExplicitCaptureDedupKey(content, frontmatter.category, frontmatter.sourceConnector)]
-          : []),
+        buildCapturePathLockIdentity(before.path),
+        this.offlineSyncMemoryIdentity(before),
+        buildExplicitCaptureDedupKey(content, frontmatter.category, frontmatter.sourceConnector),
       ],
       (rebuildMarker, current) =>
         this.getTombstoneBlockedCaptureIndex().syncUpdatedMemory(
@@ -336,7 +385,7 @@ export abstract class TombstoneBlockedCaptureIndexHost {
           rebuildMarker
         ),
       beforeIndexUpdate,
-      isQueuedReviewMemory(before) || isQueuedReviewFrontmatter(frontmatter)
+      true
     );
   }
 
@@ -351,39 +400,14 @@ export abstract class TombstoneBlockedCaptureIndexHost {
       before.path,
       fileContent,
       [
-        ...(tombstoneBlocked(before.frontmatter)
-          ? [
-              buildExplicitCaptureDedupKey(
-                before.content,
-                before.frontmatter.category,
-                before.frontmatter.sourceConnector
-              ),
-            ]
-          : []),
-        ...(tombstoneBlocked(frontmatter)
-          ? [buildExplicitCaptureDedupKey(before.content, frontmatter.category, frontmatter.sourceConnector)]
-          : []),
-        ...(isQueuedReviewMemory(before)
-          ? [
-              buildExplicitCaptureDedupKey(
-                before.content,
-                before.frontmatter.category,
-                before.frontmatter.sourceConnector
-              ),
-            ]
-          : []),
-        ...(isQueuedReviewFrontmatter(frontmatter)
-          ? [buildExplicitCaptureDedupKey(before.content, frontmatter.category, frontmatter.sourceConnector)]
-          : []),
+        buildCapturePathLockIdentity(before.path),
+        this.offlineSyncMemoryIdentity(before),
+        buildExplicitCaptureDedupKey(before.content, frontmatter.category, frontmatter.sourceConnector),
       ],
       (rebuildMarker, current) =>
-        this.getTombstoneBlockedCaptureIndex().syncUpdatedFrontmatter(
-          current ?? before,
-          frontmatter,
-          rebuildMarker
-        ),
+        this.getTombstoneBlockedCaptureIndex().syncUpdatedFrontmatter(current ?? before, frontmatter, rebuildMarker),
       beforeIndexUpdate,
-      isQueuedReviewMemory(before) || isQueuedReviewFrontmatter(frontmatter)
+      true
     );
   }
 
@@ -448,45 +472,41 @@ export abstract class TombstoneBlockedCaptureIndexHost {
     memory: MemoryFile,
     task: (current: MemoryFile, markDurable: () => void) => Promise<string | null>
   ): Promise<string | null> {
-    if (!this.isTombstoneBlockedMemory(memory) && !isQueuedReviewMemory(memory)) {
-      return await task(memory, () => {});
-    }
     let archivedPath: string | null = null;
-    const archived = await this.runTombstoneBlockedInvalidation(
-      memory,
-      async (current, rebuildMarker, markDurable) => {
-        let archiveDurable = false;
-        const markArchiveDurable = () => {
-          archiveDurable = true;
-          markDurable();
-        };
-        archivedPath = await task(current, markArchiveDurable);
-        if (rebuildMarker !== undefined && (archivedPath !== null || archiveDurable)) {
-          await this.rebuildTombstoneBlockedCaptureAfterInvalidation(rebuildMarker);
-        } else if (rebuildMarker !== undefined) {
-          const index = this.getTombstoneBlockedCaptureIndex();
-          try { await index.discardWrite(rebuildMarker); } catch { index.markUntrusted(); }
+    const archived = await this.runTombstoneBlockedInvalidation(memory, async (current, rebuildMarker, markDurable) => {
+      let archiveDurable = false;
+      const markArchiveDurable = () => {
+        archiveDurable = true;
+        markDurable();
+      };
+      archivedPath = await task(current, markArchiveDurable);
+      if (rebuildMarker !== undefined && (archivedPath !== null || archiveDurable)) {
+        await this.rebuildTombstoneBlockedCaptureAfterInvalidation(rebuildMarker);
+      } else if (rebuildMarker !== undefined) {
+        const index = this.getTombstoneBlockedCaptureIndex();
+        try {
+          await index.discardWrite(rebuildMarker);
+        } catch {
+          index.markUntrusted();
         }
-        return archivedPath !== null;
       }
-    );
+      return archivedPath !== null;
+    });
     return archived ? archivedPath : null;
   }
 
   protected async runTombstoneBlockedInvalidation(
     memory: MemoryFile,
-    task: (
-      current: MemoryFile,
-      rebuildMarker: string | undefined,
-      markDurable: () => void
-    ) => Promise<boolean>,
+    task: (current: MemoryFile, rebuildMarker: string | undefined, markDurable: () => void) => Promise<boolean>,
     propagateErrors = false,
     coordinate = false
   ): Promise<boolean> {
-    let lockIdentity =
-      coordinate || this.isTombstoneBlockedMemory(memory) || isQueuedReviewMemory(memory)
-        ? this.offlineSyncMemoryIdentity(memory)
-        : undefined;
+    let lockIdentities = [
+      buildCapturePathLockIdentity(memory.path),
+      ...(coordinate || this.isTombstoneBlockedMemory(memory) || isQueuedReviewMemory(memory)
+        ? [this.offlineSyncMemoryIdentity(memory)]
+        : []),
+    ];
     for (;;) {
       const attempt = async () => {
         const options = this.tombstoneBlockedCaptureIndexOptions();
@@ -499,7 +519,7 @@ export abstract class TombstoneBlockedCaptureIndexHost {
         const queuedReview = isQueuedReviewMemory(current);
         if (blocked || queuedReview) {
           const currentIdentity = this.offlineSyncMemoryIdentity(current);
-          if (lockIdentity !== currentIdentity) return { retryIdentity: currentIdentity };
+          if (!lockIdentities.includes(currentIdentity)) return { retryIdentity: currentIdentity };
         }
         const blockedIndex = blocked ? this.getTombstoneBlockedCaptureIndex() : null;
         let rebuildMarker: string | undefined;
@@ -529,12 +549,9 @@ export abstract class TombstoneBlockedCaptureIndexHost {
           return { result: false };
         }
       };
-      const result =
-        lockIdentity === undefined
-          ? await attempt()
-          : await this.withTombstoneBlockedCaptureWriteLock(attempt, lockIdentity);
+      const result = await this.withTombstoneBlockedCaptureWriteLock(attempt, lockIdentities);
       if (result.retryIdentity !== undefined) {
-        lockIdentity = result.retryIdentity;
+        lockIdentities = [...new Set([...lockIdentities, result.retryIdentity])];
         continue;
       }
       return result.result;
@@ -578,22 +595,19 @@ export abstract class TombstoneBlockedCaptureIndexHost {
   ): Promise<void> {
     for (;;) {
       const before = await this.readMemoryByPath(target);
-      const targetIdentity = this.isTombstoneBlockedMemory(before)
-        ? this.offlineSyncMemoryIdentity(before)
-        : undefined;
-      const blocked = coordinate || targetIdentity !== undefined || this.isTombstoneBlockedMemory(after);
+      const targetIdentity = before === null ? undefined : this.offlineSyncMemoryIdentity(before);
+      const afterIdentity = after === null || streamedIdentity ? undefined : this.offlineSyncMemoryIdentity(after);
+      const mustCoordinate =
+        coordinate || targetIdentity !== undefined || afterIdentity !== undefined || streamedIdentity !== undefined;
       const identities = [
+        ...(mustCoordinate ? [buildCapturePathLockIdentity(target)] : []),
         ...(targetIdentity === undefined ? [] : [targetIdentity]),
-        ...(!streamedIdentity && this.isTombstoneBlockedMemory(after)
-          ? [this.offlineSyncMemoryIdentity(after)]
-          : []),
-        ...(coordinate ? [target] : []),
-        ...(coordinate && after === null && streamedIdentity === undefined ? [""] : []),
+        ...(afterIdentity === undefined ? [] : [afterIdentity]),
       ];
       let retryIdentity: string | undefined;
       const mutate = async (): Promise<void> => {
         const current = await this.readMemoryByPath(target);
-        if (this.isTombstoneBlockedMemory(current)) {
+        if (current !== null) {
           const currentIdentity = this.offlineSyncMemoryIdentity(current);
           if (currentIdentity !== targetIdentity) {
             retryIdentity = currentIdentity;
@@ -606,7 +620,9 @@ export abstract class TombstoneBlockedCaptureIndexHost {
         ) {
           return;
         }
-        const marker = blocked ? await this.getTombstoneBlockedCaptureIndex().prepareWrite() : undefined;
+        const affectsBlockedIndex =
+          coordinate || this.isTombstoneBlockedMemory(current) || this.isTombstoneBlockedMemory(after);
+        const marker = affectsBlockedIndex ? await this.getTombstoneBlockedCaptureIndex().prepareWrite() : undefined;
         let durable = false;
         try {
           await write();
@@ -632,18 +648,12 @@ export abstract class TombstoneBlockedCaptureIndexHost {
           throw err;
         }
       };
-      if (!blocked) {
+      if (!mustCoordinate) {
         await mutate();
+      } else if (streamedIdentity) {
+        await this.withTombstoneBlockedCaptureWriteLockAndHashes(mutate, identities, [streamedIdentity.identityHash]);
       } else {
-        if (streamedIdentity) {
-          await this.withTombstoneBlockedCaptureWriteLockAndHashes(
-            mutate,
-            identities,
-            [streamedIdentity.identityHash]
-          );
-        } else {
-          await this.withTombstoneBlockedCaptureWriteLock(mutate, identities);
-        }
+        await this.withTombstoneBlockedCaptureWriteLock(mutate, identities);
       }
       if (retryIdentity !== undefined) continue;
       return;
@@ -654,10 +664,7 @@ export abstract class TombstoneBlockedCaptureIndexHost {
     await this.runTombstoneBlockedOfflineSyncMutation(
       target,
       this.tombstoneBlockedCaptureIndexOptions().parseMemory?.(target, content) ?? null,
-      () => this.writeManagedStorageFile(
-        target,
-        () => this.writeStorageSecureFile(target, content)
-      )
+      () => this.writeManagedStorageFile(target, () => this.writeStorageSecureFile(target, content))
     );
   }
 
@@ -763,28 +770,48 @@ export abstract class TombstoneBlockedCaptureIndexHost {
     after: MemoryFile
   ): Promise<StreamedOfflineSyncIdentity> {
     let normalizedLength = 0;
-    const countNormalizer = createExplicitContentNormalizer((chunk) => {
-      normalizedLength += chunk.length;
+    const countNormalizer = createExplicitContentNormalizer({
+      write: (chunk) => {
+        normalizedLength += chunk.length;
+      },
+      beginConditionalSigma: () => {
+        normalizedLength += 1;
+      },
+      resolveConditionalSigma: () => {},
     });
     const options = this.tombstoneBlockedCaptureIndexOptions();
     const key = options.secureStoreKeyProvider();
-    await forEachStagedTextChunk(
-      stagePath,
-      bodyOffset,
-      (text) => countNormalizer.push(text),
-      key,
-      options.memoryDir
-    );
+    await forEachStagedTextChunk(stagePath, bodyOffset, (text) => countNormalizer.push(text), key, options.memoryDir);
     countNormalizer.finish();
 
     const category = after.frontmatter.category;
     const connector = after.frontmatter.sourceConnector?.trim() ?? "";
     const encode = (label: string, value: string): string => `${label} ${value.length} ${value}`;
-    const identityPrefix =
-      [encode("category", category), encode("connector", connector), `content ${normalizedLength} `].join(" ");
-    const identityHash = createHash("sha256");
+    const identityPrefix = [
+      encode("category", category),
+      encode("connector", connector),
+      `content ${normalizedLength} `,
+    ].join(" ");
+    let identityHash = createHash("sha256");
+    let normalSigmaIdentityHash: Hash | undefined;
     identityHash.update(identityPrefix);
-    const identityNormalizer = createExplicitContentNormalizer((chunk) => identityHash.update(chunk));
+    const identityNormalizer = createExplicitContentNormalizer({
+      write: (chunk) => {
+        identityHash.update(chunk);
+        normalSigmaIdentityHash?.update(chunk);
+      },
+      beginConditionalSigma: () => {
+        normalSigmaIdentityHash = identityHash.copy().update("σ");
+        identityHash.update("ς");
+      },
+      resolveConditionalSigma: (useFinalSigma) => {
+        if (!useFinalSigma) {
+          if (normalSigmaIdentityHash === undefined) throw new Error("conditional sigma hash state is missing");
+          identityHash = normalSigmaIdentityHash;
+        }
+        normalSigmaIdentityHash = undefined;
+      },
+    });
     await forEachStagedTextChunk(
       stagePath,
       bodyOffset,
@@ -823,10 +850,7 @@ export abstract class TombstoneBlockedCaptureIndexHost {
         await this.runTombstoneBlockedOfflineSyncMutation(
           target,
           prepared.after,
-          () => this.writeManagedStorageFile(
-            target,
-            () => this.writeStorageSecureFileChunks(target, prepared.chunks)
-          ),
+          () => this.writeManagedStorageFile(target, () => this.writeStorageSecureFileChunks(target, prepared.chunks)),
           coordinate,
           streamedIdentity
         );
@@ -861,10 +885,7 @@ export abstract class TombstoneBlockedCaptureIndexHost {
     await requestEntityCanonicalIdReconcile(stateDir);
   }
 
-  async deleteOfflineSyncFile(
-    filePath: string,
-    deletionMtimeMs?: number | null
-  ): Promise<void> {
+  async deleteOfflineSyncFile(filePath: string, deletionMtimeMs?: number | null): Promise<void> {
     const target = this.assertManagedStoragePath(filePath, "storage.deleteOfflineSyncFile");
     await this.deleteTombstoneBlockedOfflineSyncFile(target, deletionMtimeMs);
   }

--- a/packages/remnic-core/src/storage/tombstone-blocked-capture-sync.ts
+++ b/packages/remnic-core/src/storage/tombstone-blocked-capture-sync.ts
@@ -330,7 +330,7 @@ export abstract class TombstoneBlockedCaptureIndexHost {
     frontmatter: MemoryFrontmatter,
     content: string,
     findDuplicate: () => Promise<MemoryFile | null>,
-    afterWrite: () => Promise<void>
+    afterWrite: (current: MemoryFile | null) => Promise<void>
   ): Promise<string> {
     const incomingIdentity = buildExplicitCaptureDedupKey(content, frontmatter.category, frontmatter.sourceConnector);
     let lockIdentities = [buildCapturePathLockIdentity(pathname), incomingIdentity];
@@ -354,7 +354,7 @@ export abstract class TombstoneBlockedCaptureIndexHost {
           }
         }
         await this.writeTombstoneBlockedMemory(pathname, fileContent, frontmatter, content);
-        await afterWrite();
+        await afterWrite(current);
       }, lockIdentities);
       if (retryIdentity === undefined) return result;
       lockIdentities = [...new Set([...lockIdentities, retryIdentity])];


### PR DESCRIPTION
## Summary
- preserve contextual Unicode lowercasing across streamed chunk boundaries
- fill encrypted headers across positioned short reads
- coordinate path, identity, repair, tier-move, and frontmatter mutations under canonical locks
- rebuild blocked-capture indexes from locked durable state

## Validation
- pnpm run check-types (remnic-core)
- pnpm exec tsx --test src/storage-fact-hash-index-defer.test.ts (83/83)
- pnpm exec tsx --test src/secure-store/secure-store.test.ts (65/65)
- pnpm run build
- bash scripts/check-review-patterns.sh
- node scripts/check-ratchets.mjs

Closes #2205

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core storage concurrency, tombstone dedupe, and offline sync identity hashing; regressions could cause duplicate captures, deadlocks, or missed blocked duplicates.
> 
> **Overview**
> Hardens **tombstone-blocked capture** so concurrent writers cannot race on the same memory file or dedupe identity.
> 
> **Path locks** join explicit-capture dedupe keys on writes, updates, chunks, offline sync, tier moves, invalidation, and related mutations. The write-lock layer acquires identities in **canonical order** (path locks before category locks) and **retries** when the on-disk row’s identity changes mid-mutation (e.g. queued-review → blocked). `writeMemory` keeps entity-ref repair **inside** the coordinated lock; tier moves use a dedicated path-lock helper with blocked-index markers when needed.
> 
> **Secure-store reads** loop until the full magic/envelope prefix is read, fixing mis-detection when positioned reads return short buffers.
> 
> **Chunked offline sync** normalizes explicit-capture content for hashing with **contextual Unicode** (including final vs. medial sigma) across staged read boundaries so streamed duplicates match non-streamed dedup.
> 
> Tests cover short header reads, lock unions, offline sync at Unicode boundaries, and path serialization for competing updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38839665223f586c4988da61bdecc203da30a40a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->