### PR TITLE
fix(extraction): complete source-grounding P2 hardening (#2204)

### DIFF
--- a/.changeset/grounding-lexical-hardening.md
+++ b/.changeset/grounding-lexical-hardening.md
@@ -2,4 +2,4 @@
 "@remnic/core": patch
 ---
 
-Harden source grounding for verb inflections, proper identifiers, and coordinated clauses.
+Harden source grounding for verb inflections, proper identifiers, predicate positions, disjunctions, and object wh-questions.

--- a/packages/remnic-core/src/extraction-source-grounding-helpers.ts
+++ b/packages/remnic-core/src/extraction-source-grounding-helpers.ts
@@ -10,7 +10,7 @@ export function isInterrogativeSourceSentence(sentence: string): boolean {
     || hasEmbeddedQuestion
     || (
       !normalized.includes(":")
-      && /^(?:suppose|assuming|assume|maybe|perhaps|hypothetically|if|whether|imagine|imagining|presume|presuming|supposing|is|are|am|was|were|do|does|did|can|could|will|would|should|has|have|had|what|which|when|where|why|how|who)\b/iu.test(
+      && /^(?:suppose|assuming|assume|maybe|perhaps|hypothetically|if|whether|imagine|imagining|presume|presuming|supposing|is|are|am|was|were|do|does|did|can|could|will|would|should|has|have|had|what|which|when|where|why|how|who|whom)\b/iu.test(
         normalized,
       )
     );
@@ -171,6 +171,7 @@ export const GROUNDING_STOPWORDS: Record<string, true> = {
   where: true,
   which: true,
   who: true,
+  whom: true,
   will: true,
   with: true,
   would: true,
@@ -342,26 +343,56 @@ export function groundingLexemes(text: string): GroundingLexeme[] {
     const previousToken = tokens[index - 1];
     const followsAuxiliary = previousToken !== undefined
       && GROUNDING_AUXILIARY_TOKENS.has(previousToken);
-    const capitalized = /^\p{Lu}/u.test(rawTokens[index] ?? "");
-    return followsAuxiliary || (
-      !capitalized
+    let previousMeaningfulIndex = index - 1;
+    while (
+      previousMeaningfulIndex >= 0
+      && !GROUNDING_COPULAR_FORMS.has(tokens[previousMeaningfulIndex] ?? "")
       && (
-        GROUNDING_COMMON_VERB_FORMS[token] === true
-        || token.endsWith("ed")
-        || token.endsWith("ing")
+        GROUNDING_STOPWORDS[tokens[previousMeaningfulIndex] ?? ""] === true
+        || (tokens[previousMeaningfulIndex] ?? "").endsWith("ly")
       )
+    ) {
+      previousMeaningfulIndex -= 1;
+    }
+    const followsCopularAuxiliary = GROUNDING_COPULAR_FORMS.has(
+      tokens[previousMeaningfulIndex] ?? "",
     );
+    const capitalized = /^\p{Lu}/u.test(rawTokens[index] ?? "");
+    const terminalSInflection = index > 0
+      && token.endsWith("s")
+      && !token.endsWith("ss")
+      && !GROUNDING_AUXILIARY_TOKENS.has(token);
+    const capitalizedSubjectHasLaterPredicate = index === 0
+      && tokens.some((laterToken, laterIndex) =>
+        laterIndex > 0
+        && !/^\p{Lu}/u.test(rawTokens[laterIndex] ?? "")
+        && (
+          GROUNDING_AUXILIARY_TOKENS.has(laterToken)
+          || GROUNDING_COMMON_VERB_FORMS[laterToken] === true
+          || laterToken.endsWith("ed")
+          || laterToken.endsWith("ing")
+        ));
+    if (capitalized && (index !== 0 || capitalizedSubjectHasLaterPredicate)) return false;
+    if (followsCopularAuxiliary && terminalSInflection) return false;
+    return GROUNDING_COMMON_VERB_FORMS[token] === true
+      || token.endsWith("ed")
+      || token.endsWith("ing")
+      || (followsAuxiliary && !followsCopularAuxiliary)
+      || terminalSInflection;
   });
   if (predicateIndex === -1) {
-    predicateIndex = tokens.findIndex((token, index) =>
-      index > 0
-      && !/^\p{Lu}/u.test(rawTokens[index] ?? "")
-      && token.endsWith("s")
-      && !token.endsWith("ss"));
-  }
-  if (predicateIndex === -1) {
     const leadingSubjectLength = rawTokens.findIndex((rawToken) => !/^\p{Lu}/u.test(rawToken));
-    if (leadingSubjectLength > 0) predicateIndex = leadingSubjectLength;
+    if (leadingSubjectLength > 0) {
+      predicateIndex = tokens.findIndex((token, index) =>
+        index >= leadingSubjectLength
+        && (
+          GROUNDING_AUXILIARY_TOKENS.has(token)
+          || (
+            GROUNDING_STOPWORDS[token] !== true
+            && !/^\p{Lu}/u.test(rawTokens[index] ?? "")
+          )
+        ));
+    }
   }
   return rawTokens.map((rawToken, index) => {
     const token = tokens[index]!;

--- a/packages/remnic-core/src/extraction-source-grounding-rules.ts
+++ b/packages/remnic-core/src/extraction-source-grounding-rules.ts
@@ -211,6 +211,18 @@ function hasAlignedSubjectPredicateOverlap(candidate: string, source: string): b
   return false;
 }
 
+function omitsSourceDisjunction(candidate: string, source: string): boolean {
+  if (!/\bor\b/iu.test(source) || /\bor\b/iu.test(candidate)) return false;
+  const candidateTokens = normalizedGroundingTokenSequence(candidate);
+  return splitGroundingClauses([source], true).some((sourceSpan) => {
+    const sourceSpanTokens = normalizedGroundingTokenSequence(sourceSpan);
+    return candidateTokens.length === sourceSpanTokens.length
+      && candidateTokens.every(
+        (token, index) => areGroundingTokensCompatible(token, sourceSpanTokens[index]!),
+      );
+  });
+}
+
 function groundedTokenScore(
   candidate: string,
   source: string,
@@ -242,7 +254,8 @@ function groundedTokenScore(
 }
 
 function candidateClauses(candidate: string): string[] {
-  return splitGroundingClauses(sourceSentences(candidate));
+  return sourceSentences(candidate).flatMap((sentence) =>
+    /\bor\b/iu.test(sentence) ? [sentence] : splitGroundingClauses([sentence]));
 }
 
 function isSourceGroundedClause(
@@ -264,6 +277,7 @@ function isSourceGroundedClause(
       if (
         precedingSentence !== undefined
         && isInterrogativeSourceSentence(precedingSentence)
+        && !omitsSourceDisjunction(candidate, precedingSentence)
         && groundedTokenScore(candidate, precedingSentence) === 1
         && (
           (answerToken === "yes" && !contradictoryPolarity)
@@ -280,6 +294,7 @@ function isSourceGroundedClause(
     if (!includeInterrogativeSource && isInterrogativeSourceSentence(sentence) && !isExplanatoryLabel) {
       continue;
     }
+    if (omitsSourceDisjunction(candidate, sentence)) continue;
     const sourceSpans = /\b(?:rather\s+than|instead\s+of)\b/iu.test(candidate)
       ? [sentence]
       : splitGroundingClauses([sentence], true);
@@ -319,6 +334,7 @@ function isSourceGrounded(
     const isExplanatoryLabel = sentenceText.startsWith(`${candidateText}:`)
       && !sentence.trim().endsWith("?");
     if (!includeInterrogativeSource && isInterrogativeSourceSentence(sentence) && !isExplanatoryLabel) return false;
+    if (omitsSourceDisjunction(candidateText, sentenceText)) return false;
     return containsExactTokenSequence(candidateText, sentenceText)
       && !hasContradictoryPolarity(candidateText, sentenceText);
   });
@@ -394,6 +410,7 @@ function hasGroundingAnchor(
 ): boolean {
   return sourceSentences(assertionSource).some((sentence) => {
     if (!includeInterrogativeSource && isInterrogativeSourceSentence(sentence)) return false;
+    if (omitsSourceDisjunction(candidate, sentence)) return false;
     const sourceSpans = /\b(?:rather\s+than|instead\s+of)\b/iu.test(candidate)
       ? [sentence]
       : splitGroundingClauses([sentence], true);
@@ -431,6 +448,7 @@ function hasAnswerSupport(
     if (
       precedingSentence === undefined
       || !isInterrogativeSourceSentence(precedingSentence)
+      || omitsSourceDisjunction(candidate, precedingSentence)
       || groundedTokenScore(candidate, precedingSentence) !== 1
     ) {
       return false;
@@ -920,18 +938,34 @@ function isYesNoAnswer(sentence: string): boolean {
     .test(sentence.trim());
 }
 
+const GROUNDING_WH_OBJECT_QUESTION_PATTERN = new RegExp(
+  "^(?:(?:what|which)(?:\\s+.+?)?|who|whom)\\s+"
+    + "(?:is|are|was|were|do|does|did|can|could|will|would|should|has|have|had)\\s+"
+    + "(.+?)\\??$",
+  "iu",
+);
+
 function hasWhAnswerRoleAlignment(question: string, sentence: string): boolean {
   const normalizedQuestion = question.trim();
-  const objectQuestionMatch = /^(?:what|which)\s+.+?\s+(?:is|are|was|were|do|does|did|can|could|will|would|should|has|have|had)\s+(.+?)\s+([^\s?]+)\??$/iu
-    .exec(normalizedQuestion);
+  const objectQuestionMatch = GROUNDING_WH_OBJECT_QUESTION_PATTERN.exec(normalizedQuestion);
   const sourceTokens = normalizedGroundingTokenSequence(sentence);
   if (objectQuestionMatch !== null) {
-    const subjectTokens = groundingTokenSequence(objectQuestionMatch[1] ?? "");
-    const predicateTokens = groundingTokenSequence(objectQuestionMatch[2] ?? "");
-    if (subjectTokens.length === 0 || predicateTokens.length === 0) return true;
+    const questionBodyLexemes = groundingLexemes(objectQuestionMatch[1] ?? "");
+    const predicateIndex = questionBodyLexemes.findIndex(({ isPredicate }) => isPredicate);
+    if (predicateIndex < 1) return false;
+    const subjectTokens = groundingTokenSequence(
+      questionBodyLexemes.slice(0, predicateIndex).map(({ surface }) => surface).join(" "),
+    );
+    const predicateTokens = groundingTokenSequence(
+      questionBodyLexemes.slice(predicateIndex).map(({ surface }) => surface).join(" "),
+    );
+    if (subjectTokens.length === 0 || predicateTokens.length === 0) return false;
     let sourceIndex = 0;
     for (const token of [...subjectTokens, ...predicateTokens]) {
-      const matchedIndex = sourceTokens.indexOf(token, sourceIndex);
+      const matchedIndex = sourceTokens.findIndex(
+        (sourceToken, index) =>
+          index >= sourceIndex && areGroundingTokensCompatible(token, sourceToken),
+      );
       if (matchedIndex === -1) return false;
       sourceIndex = matchedIndex + 1;
     }
@@ -943,11 +977,15 @@ function hasWhAnswerRoleAlignment(question: string, sentence: string): boolean {
   const predicateTokens = groundingTokenSequence(subjectQuestionMatch[1] ?? "");
   const objectTokens = groundingTokenSequence(subjectQuestionMatch[2] ?? "");
   if (predicateTokens.length === 0 || objectTokens.length === 0) return true;
-  const predicateStart = sourceTokens.indexOf(predicateTokens[0]!);
+  const predicateStart = sourceTokens.findIndex((sourceToken) =>
+    areGroundingTokensCompatible(predicateTokens[0]!, sourceToken));
   if (predicateStart === -1) return false;
   let sourceIndex = predicateStart + predicateTokens.length;
   for (const objectToken of objectTokens) {
-    const objectIndex = sourceTokens.indexOf(objectToken, sourceIndex);
+    const objectIndex = sourceTokens.findIndex(
+      (sourceToken, index) =>
+        index >= sourceIndex && areGroundingTokensCompatible(objectToken, sourceToken),
+    );
     if (objectIndex === -1) return false;
     sourceIndex = objectIndex + 1;
   }

--- a/packages/remnic-core/src/extraction-source-grounding.test.ts
+++ b/packages/remnic-core/src/extraction-source-grounding.test.ts
@@ -2112,39 +2112,6 @@ test("grounding scopes nested entity facts to the enclosing entity", () => {
   }]);
 });
 
-test("grounding preserves punctuation in technology identifiers", () => {
-  const cppResult = filterExtractionResultBySource(
-    {
-      facts: [{
-        category: "fact",
-        content: "Alice uses C++.",
-        confidence: 0.9,
-        tags: [],
-      }],
-      profileUpdates: [],
-      entities: [],
-      questions: [],
-    },
-    "Alice uses C.",
-  );
-  const plainCResult = filterExtractionResultBySource(
-    {
-      facts: [{
-        category: "fact",
-        content: "Alice uses C.",
-        confidence: 0.9,
-        tags: [],
-      }],
-      profileUpdates: [],
-      entities: [],
-      questions: [],
-    },
-    "Alice uses C++.",
-  );
-
-  assert.deepEqual(cppResult.facts, []);
-  assert.deepEqual(plainCResult.facts, []);
-});
 
 test("grounding requires unresolved questions on the asserted target turn", () => {
   const result = filterExtractionResultBySource(
@@ -2465,23 +2432,25 @@ test("grounding uses the main source when a role source is omitted", () => {
   assert.deepEqual(result.profileUpdates, ["User prefers tea."]);
 });
 
-test("grounding preserves hash-suffixed technology identifiers", () => {
-  for (const [source, content] of [
-    ["Alice uses C.", "Alice uses C#."],
-    ["Alice uses C#.", "Alice uses C."],
-    ["Alice uses C++.", "Alice uses C#."],
-    ["Alice uses C#.", "Alice uses C++."],
-  ]) {
-    const result = filterExtractionResultBySource(
-      {
-        facts: [{ category: "fact", content, confidence: 0.9, tags: [] }],
-        profileUpdates: [],
-        entities: [],
-        questions: [],
-      },
-      source,
-    );
-    assert.deepEqual(result.facts, []);
+test("grounding keeps C, C++, and C# identifiers pairwise distinct", () => {
+  const identifiers = ["C", "C++", "C#"];
+  for (const sourceIdentifier of identifiers) {
+    for (const candidateIdentifier of identifiers) {
+      const content = `Alice uses ${candidateIdentifier}.`;
+      const result = filterExtractionResultBySource(
+        {
+          facts: [{ category: "fact", content, confidence: 0.9, tags: [] }],
+          profileUpdates: [],
+          entities: [],
+          questions: [],
+        },
+        `Alice uses ${sourceIdentifier}.`,
+      );
+      assert.deepEqual(
+        result.facts.map((fact) => fact.content),
+        sourceIdentifier === candidateIdentifier ? [content] : [],
+      );
+    }
   }
 });
 
@@ -2540,4 +2509,159 @@ test("grounding requires causal evidence before removing why questions", () => {
     "Why did Alice deploy Acme?\nAlice deployed Acme because customers requested it.",
   );
   assert.deepEqual(answered.questions, []);
+});
+
+test("grounding rejects partial assertions from source disjunctions", () => {
+  for (const source of [
+    "Alice uses Redis or PostgreSQL.",
+    "Does Alice use Redis or PostgreSQL?\nYes.",
+  ]) {
+    for (const content of ["Alice uses Redis.", "Alice uses PostgreSQL."]) {
+      const result = filterExtractionResultBySource(
+        {
+          facts: [{ category: "fact", content, confidence: 0.9, tags: [] }],
+          profileUpdates: [],
+          entities: [],
+          questions: [],
+        },
+        source,
+      );
+      assert.deepEqual(result.facts, []);
+    }
+  }
+
+  for (const source of [
+    "Alice uses Redis or PostgreSQL.",
+    "Does Alice use Redis or PostgreSQL?\nYes.",
+  ]) {
+    const content = "Alice uses Redis or PostgreSQL.";
+    const result = filterExtractionResultBySource(
+      {
+        facts: [{ category: "fact", content, confidence: 0.9, tags: [] }],
+        profileUpdates: [],
+        entities: [],
+        questions: [],
+      },
+      source,
+    );
+    assert.deepEqual(result.facts.map((fact) => fact.content), [content]);
+  }
+
+  const commonPrefix = filterExtractionResultBySource(
+    {
+      facts: [{
+        category: "fact",
+        content: "Alice uses Redis.",
+        confidence: 0.9,
+        tags: [],
+      }],
+      profileUpdates: [],
+      entities: [],
+      questions: [],
+    },
+    "Alice uses Redis for cache hits or misses.",
+  );
+  assert.deepEqual(
+    commonPrefix.facts.map((fact) => fact.content),
+    ["Alice uses Redis."],
+  );
+});
+
+test("grounding aligns object wh-question answers by subject and predicate", () => {
+  for (const [questionText, answer, roleReversedAnswer] of [
+    [
+      "What database does Alice use?",
+      "Alice uses PostgreSQL as the database.",
+      "PostgreSQL uses Alice as the database.",
+    ],
+    ["Who does Alice employ?", "Alice employs Bob.", "Bob employs Alice."],
+    ["Whom does Alice employ?", "Alice employs Bob.", "Bob employs Alice."],
+    ["Who does Alice work with?", "Alice works with Bob.", "Bob works with Alice."],
+    ["Whom does Alice connect to?", "Alice connects to Bob.", "Bob connects to Alice."],
+  ]) {
+    const question = { question: questionText, context: "", priority: 0.5 };
+    const answered = filterExtractionResultBySource(
+      { facts: [], profileUpdates: [], entities: [], questions: [question] },
+      `${questionText}\n${answer}`,
+    );
+    assert.deepEqual(answered.questions, []);
+
+    const roleReversed = filterExtractionResultBySource(
+      { facts: [], profileUpdates: [], entities: [], questions: [question] },
+      `${questionText}\n${roleReversedAnswer}`,
+    );
+    assert.deepEqual(roleReversed.questions, [question]);
+  }
+});
+
+test("grounding does not stem verb-like object plurals", () => {
+  const result = filterExtractionResultBySource(
+    {
+      facts: [{
+        category: "fact",
+        content: "Alice sells the plan.",
+        confidence: 0.9,
+        tags: [],
+      }],
+      profileUpdates: [],
+      entities: [],
+      questions: [],
+    },
+    "Alice sells plans.",
+  );
+
+  assert.deepEqual(result.facts, []);
+});
+
+test("grounding recognizes capitalized predicates in subjectless role fragments", () => {
+  const result = filterExtractionResultBySource(
+    {
+      facts: [],
+      profileUpdates: ["User uses Redis."],
+      entities: [],
+      questions: [],
+    },
+    "Uses Redis.",
+    undefined,
+    { profile: "Uses Redis.", identity: "" },
+  );
+
+  assert.deepEqual(result.profileUpdates, ["User uses Redis."]);
+});
+
+test("grounding keeps sentence-initial plural subjects distinct", () => {
+  const result = filterExtractionResultBySource(
+    {
+      facts: [{
+        category: "fact",
+        content: "Plan is active.",
+        confidence: 0.9,
+        tags: [],
+      }],
+      profileUpdates: [],
+      entities: [],
+      questions: [],
+    },
+    "Plans are active.",
+  );
+
+  assert.deepEqual(result.facts, []);
+});
+
+test("grounding preserves plural identifiers after a proper-name copular subject", () => {
+  for (const [source, content] of [
+    ["Alice is atlas.", "Alice is atla."],
+    ["Alice is the atlas.", "Alice is the atla."],
+  ]) {
+    const result = filterExtractionResultBySource(
+      {
+        facts: [{ category: "fact", content, confidence: 0.9, tags: [] }],
+        profileUpdates: [],
+        entities: [],
+        questions: [],
+      },
+      source,
+    );
+    assert.deepEqual(result.facts, []);
+  }
 });


### PR DESCRIPTION
Closes #2204. Remaining deferred findings: question evidence, predicate-position logic, sentence-initial verbs, or-disjunction partial assertions, stopword handling, C/C# identifier tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which extracted facts, profile updates, and questions survive filtering; behavior is heavily tested but mis-grounding could drop valid memories or accept wrong paraphrases.
> 
> **Overview**
> Hardens **extraction source grounding** so model outputs are only kept when they truly match the source text, closing gaps around verb forms, identifiers, `or` disjunctions, and object **wh-**questions.
> 
> **Predicate and inflection logic** (`groundingLexemes`): predicate detection now skips intervening stopwords/adverbs before copulas, avoids treating plural **-s** after **is/was** as verbs (e.g. `atlas` vs `atla`), and improves sentence-initial proper-name subjects and subjectless fragments like `Uses Redis.`
> 
> **Disjunctions**: new `omitsSourceDisjunction` blocks grounding a single branch when the source says `A or B` (including yes/no follow-ups); candidates containing `or` are not clause-split the same way.
> 
> **Wh-questions**: `whom` is treated as interrogative; object questions (`what/which/who/whom` + auxiliary) parse subject/predicate via lexemes and require **compatible token alignment** so role-reversed answers do not clear questions.
> 
> Tests add pairwise **C / C++ / C#** checks and cases for disjunctions, wh-QA, verb-like plurals, and copular plural identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc73ce5e520a3efd41f8af2bdb82aa2f34a13496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source grounding for verb inflections, plural terms, and distinct identifiers such as `C`, `C++`, and `C#`.
  * Improved handling of `what`, `which`, `who`, and `whom` questions, including object-question answers.
  * Prevented incomplete matches from disjunctions using “or.”
  * Improved recognition of predicates and subject–predicate relationships in varied sentence structures.

* **Tests**
  * Expanded coverage for identifiers, disjunctions, interrogative forms, and predicate alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->