### PR TITLE
fix(entity): complete entity migration/retrieval P2 hardening (#2207)

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@remnic/core";
 import type { RecallXraySnapshot } from "@remnic/core";
 import { LcmEngine } from "@remnic/core/lcm";
+import { withEntityCanonicalMutationLock } from "../../../remnic-core/src/storage/entity-canonical-id-lock.js";
 
 import {
   buildBenchAdapterConfig,
@@ -1737,6 +1738,145 @@ test("direct adapter session reset clears caller-owned entity timeline state", a
   } finally {
     await adapter.destroy();
     await rm(memoryDir, { recursive: true, force: true, ...BENCH_TEST_RM_RETRY_OPTIONS });
+  }
+});
+
+test("direct adapter session entity cleanup waits for the canonical mutation lock", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-reset-entity-lock-"));
+  const resetSession = "owned-entity-lock-reset-session";
+  const controlMemoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-reset-entity-control-"));
+  const controlSession = "owned-entity-lock-control-session";
+  const otherSession = "owned-entity-lock-other-session";
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    configOverrides: {
+      entityRetrievalEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+  const controlAdapter = await createRemnicAdapter({
+    memoryDir: controlMemoryDir,
+    configOverrides: {
+      entityRetrievalEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+  const storage = new StorageManager(memoryDir);
+  const sharedEntityName = await storage.writeEntity(
+    "Shared Lock Entity",
+    "project",
+    ["Remember the locked reset code is marigold-31."],
+    { source: "extraction", sessionKey: resetSession },
+  );
+  await storage.writeEntity(
+    "Shared Lock Entity",
+    "project",
+    ["Remember the preserved lock code is willow-42."],
+    { source: "extraction", sessionKey: otherSession },
+  );
+  const resetOnlyEntityName = await storage.writeEntity(
+    "Reset Only Lock Entity",
+    "project",
+    ["Remember the locked delete code is spruce-53."],
+    { source: "extraction", sessionKey: resetSession },
+  );
+  const sharedEntityPath = path.join(memoryDir, "entities", `${sharedEntityName}.md`);
+  const resetOnlyEntityPath = path.join(memoryDir, "entities", `${resetOnlyEntityName}.md`);
+  const sharedEntityBeforeReset = await readFile(sharedEntityPath, "utf8");
+  const resetOnlyEntityBeforeReset = await readFile(resetOnlyEntityPath, "utf8");
+  const cleanupReady = createDeferredForTest();
+  const cleanupCanContinue = createDeferredForTest();
+  let sharedEntityWriteEntered = false;
+  let resetPromise: Promise<void> | undefined;
+
+  type EntityCleanupProbeStorage = StorageManager & {
+    writeStorageSecureFile(
+      filePath: string,
+      content: string | Buffer,
+      forceEncrypt?: boolean,
+    ): Promise<void>;
+  };
+  const storagePrototype = StorageManager.prototype as EntityCleanupProbeStorage;
+  const originalReadAllColdMemories = storagePrototype.readAllColdMemories;
+  const originalListEntityNames = storagePrototype.listEntityNames;
+  const originalReadEntity = storagePrototype.readEntity;
+  const originalWriteStorageSecureFile = storagePrototype.writeStorageSecureFile;
+  let prototypesRestored = false;
+  const restoreStoragePrototype = (): void => {
+    if (prototypesRestored) return;
+    prototypesRestored = true;
+    storagePrototype.readAllColdMemories = originalReadAllColdMemories;
+    storagePrototype.listEntityNames = originalListEntityNames;
+    storagePrototype.readEntity = originalReadEntity;
+    storagePrototype.writeStorageSecureFile = originalWriteStorageSecureFile;
+  };
+
+  storagePrototype.readAllColdMemories = async function patchedReadAllColdMemories() {
+    if (this.dir !== memoryDir) {
+      return originalReadAllColdMemories.call(this);
+    }
+    cleanupReady.resolve();
+    await cleanupCanContinue.promise;
+    return [];
+  };
+  storagePrototype.listEntityNames = async function patchedListEntityNames() {
+    if (this.dir !== memoryDir) {
+      return originalListEntityNames.call(this);
+    }
+    return [sharedEntityName, resetOnlyEntityName];
+  };
+  storagePrototype.readEntity = async function patchedReadEntity(entityName: string) {
+    if (this.dir !== memoryDir) {
+      return originalReadEntity.call(this, entityName);
+    }
+    if (entityName === sharedEntityName) return sharedEntityBeforeReset;
+    if (entityName === resetOnlyEntityName) return resetOnlyEntityBeforeReset;
+    return originalReadEntity.call(this, entityName);
+  };
+  storagePrototype.writeStorageSecureFile = function patchedWriteStorageSecureFile(
+    filePath: string,
+    content: string | Buffer,
+    forceEncrypt = false,
+  ): Promise<void> {
+    if (this.dir === memoryDir && filePath === sharedEntityPath) {
+      sharedEntityWriteEntered = true;
+    }
+    return originalWriteStorageSecureFile.call(this, filePath, content, forceEncrypt);
+  };
+
+  try {
+    resetPromise = adapter.reset?.(resetSession);
+    assert.ok(resetPromise);
+    await cleanupReady.promise;
+
+    await withEntityCanonicalMutationLock(path.join(memoryDir, "state"), async () => {
+      cleanupCanContinue.resolve();
+      const controlReset = controlAdapter.reset?.(controlSession);
+      assert.ok(controlReset);
+      await controlReset;
+      assert.equal(
+        sharedEntityWriteEntered,
+        false,
+        "session cleanup must not enter its entity rewrite while the canonical lock is held",
+      );
+      assert.equal(await readFile(sharedEntityPath, "utf8"), sharedEntityBeforeReset);
+      assert.equal(await readFile(resetOnlyEntityPath, "utf8"), resetOnlyEntityBeforeReset);
+    });
+
+    await resetPromise;
+    restoreStoragePrototype();
+    const sharedEntityAfterReset = await storage.readEntity(sharedEntityName);
+    assert.doesNotMatch(sharedEntityAfterReset, /marigold-31/);
+    assert.match(sharedEntityAfterReset, /willow-42/);
+    await assertPathMissingForTest(resetOnlyEntityPath);
+  } finally {
+    cleanupCanContinue.resolve();
+    await resetPromise?.catch(() => undefined);
+    restoreStoragePrototype();
+    await adapter.destroy();
+    await controlAdapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true, ...BENCH_TEST_RM_RETRY_OPTIONS });
+    await rm(controlMemoryDir, { recursive: true, force: true, ...BENCH_TEST_RM_RETRY_OPTIONS });
   }
 });
 

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -34,6 +34,7 @@ import {
   parseEntityFile,
   serializeEntityFile,
   StorageManager,
+  withRawEntityPageMutation,
 } from "@remnic/core";
 import { withBenchCoreMemorySource } from "./with-bench-core-memory-source.js";
 
@@ -1489,6 +1490,18 @@ function pruneBenchEntityStructuredFacts(
 }
 
 async function clearBenchCoreEntitiesForSession(
+  orchestrator: Orchestrator,
+  sessionId: string,
+): Promise<void> {
+  const baseDir = orchestrator.storage.dir;
+  await withRawEntityPageMutation(
+    baseDir,
+    path.join(baseDir, "entities", ".bench-session-cleanup.md"),
+    async () => clearBenchCoreEntitiesForSessionUnlocked(orchestrator, sessionId),
+  );
+}
+
+async function clearBenchCoreEntitiesForSessionUnlocked(
   orchestrator: Orchestrator,
   sessionId: string,
 ): Promise<void> {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -10450,7 +10450,7 @@ async function cmdSpace(action: string, rest: string[], json: boolean): Promise<
       console.error("Usage: remnic space push <source> <target>");
       process.exit(1);
     }
-    const result = pushToSpace(sourceId, targetId, { force: rest.includes("--force") });
+    const result = await pushToSpace(sourceId, targetId, { force: rest.includes("--force") });
     if (json) {
       console.log(JSON.stringify(result, null, 2));
     } else {
@@ -10465,7 +10465,7 @@ async function cmdSpace(action: string, rest: string[], json: boolean): Promise<
       console.error("Usage: remnic space pull <source> <target>");
       process.exit(1);
     }
-    const result = pullFromSpace(sourceId, targetId, { force: rest.includes("--force") });
+    const result = await pullFromSpace(sourceId, targetId, { force: rest.includes("--force") });
     if (json) {
       console.log(JSON.stringify(result, null, 2));
     } else {
@@ -10489,7 +10489,7 @@ async function cmdSpace(action: string, rest: string[], json: boolean): Promise<
       console.error("Usage: remnic space promote <source> <target>");
       process.exit(1);
     }
-    const result = promoteSpace(sourceId, targetId, {
+    const result = await promoteSpace(sourceId, targetId, {
       force: rest.includes("--force"),
       forceOverwrite: rest.includes("--force-overwrite"),
     });

--- a/packages/remnic-core/src/access-service-offline-file-content.test.ts
+++ b/packages/remnic-core/src/access-service-offline-file-content.test.ts
@@ -9,6 +9,50 @@ import { OFFLINE_SYNC_CHANGESET_FORMAT, OFFLINE_SYNC_MAX_MTIME_MS } from "./offl
 import { isEncryptedFile } from "./secure-store/index.js";
 import { ContentHashIndex } from "./storage/content-hash-index.js";
 import { StorageManager } from "./storage.js";
+import { withEntityCanonicalMutationLock } from "./storage/entity-canonical-id-lock.js";
+
+class RawEntityMutationProbeStorage extends StorageManager {
+  readonly probeEntitiesDir: string;
+  writeEntered = false;
+  deleteEntered = false;
+
+  constructor(memoryDir: string) {
+    super(memoryDir);
+    this.probeEntitiesDir = path.join(memoryDir, "entities");
+  }
+
+  override async readMemoryByPath(filePath: string) {
+    if (path.dirname(filePath) === this.probeEntitiesDir) return null;
+    return super.readMemoryByPath(filePath);
+  }
+
+  protected override tombstoneBlockedCaptureIndexOptions() {
+    const options = super.tombstoneBlockedCaptureIndexOptions();
+    return {
+      ...options,
+      parseMemory: (filePath: string, content: Buffer) =>
+        path.dirname(filePath) === this.probeEntitiesDir
+          ? null
+          : options.parseMemory?.(filePath, content) ?? null,
+    };
+  }
+
+  protected override async writeManagedStorageFile(
+    filePath: string,
+    write: () => Promise<void>,
+  ): Promise<void> {
+    this.writeEntered = true;
+    await super.writeManagedStorageFile(filePath, write);
+  }
+
+  protected override async deleteManagedStorageFile(
+    filePath: string,
+    deletionMtimeMs?: number | null,
+  ): Promise<boolean> {
+    this.deleteEntered = true;
+    return super.deleteManagedStorageFile(filePath, deletionMtimeMs);
+  }
+}
 
 function createOfflineService(): EngramAccessService {
   return new EngramAccessService({
@@ -332,4 +376,63 @@ test("offline convergence completion refreshes authorized namespaces as one batc
 
   assert.deepEqual(result, { namespaces: ["global"], refreshed: true });
   assert.deepEqual(refreshed, [["global"]]);
+});
+
+test("offline raw entity writes wait for the canonical mutation lock", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-offline-entity-write-lock-"));
+  let writePromise: Promise<void> | undefined;
+  try {
+    await new StorageManager(root).ensureDirectories();
+    const storage = new RawEntityMutationProbeStorage(root);
+    const target = path.join(root, "entities", "project-replicated.md");
+    const content = Buffer.from(
+      "---\nid: project-replicated\n---\n\n# Replicated\n\n**Type:** project\n\nReplicated bytes.\n",
+      "utf8",
+    );
+
+    await withEntityCanonicalMutationLock(path.join(root, "state"), async () => {
+      writePromise = storage.writeOfflineSyncFile(target, content);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(
+        storage.writeEntered,
+        false,
+        "the raw entity write must not enter its managed-file mutation while the canonical lock is held",
+      );
+    });
+
+    assert.ok(writePromise);
+    await writePromise;
+    assert.deepEqual(await readFile(target), content);
+  } finally {
+    await writePromise?.catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline raw entity deletes wait for the canonical mutation lock", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-offline-entity-delete-lock-"));
+  let deletePromise: Promise<void> | undefined;
+  try {
+    await new StorageManager(root).ensureDirectories();
+    const target = path.join(root, "entities", "project-replicated.md");
+    await writeFile(target, "# Replicated\n", "utf8");
+    const storage = new RawEntityMutationProbeStorage(root);
+
+    await withEntityCanonicalMutationLock(path.join(root, "state"), async () => {
+      deletePromise = storage.deleteOfflineSyncFile(target, null);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(
+        storage.deleteEntered,
+        false,
+        "the raw entity delete must not enter its managed-file mutation while the canonical lock is held",
+      );
+    });
+
+    assert.ok(deletePromise);
+    await deletePromise;
+    await assert.rejects(() => readFile(target));
+  } finally {
+    await deletePromise?.catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
@@ -7,8 +7,9 @@ import test from "node:test";
 
 import { runBinaryLifecyclePipeline } from "./pipeline.js";
 import { manifestPath, writeManifest } from "./manifest.js";
-import type { BinaryLifecycleConfig } from "./types.js";
+import type { BinaryLifecycleConfig, PipelineResult } from "./types.js";
 import type { BinaryStorageBackend } from "./backend.js";
+import { withEntityCanonicalMutationLock } from "../storage/entity-canonical-id-lock.js";
 
 const baseConfig: BinaryLifecycleConfig = {
   enabled: true,
@@ -663,6 +664,110 @@ test("binary lifecycle fails closed without overwriting an invalid manifest", as
     assert.equal(await readFile(mPath, "utf8"), '{"version":1,"assets":[');
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("binary lifecycle entity redirects wait for the canonical mutation lock", async () => {
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-entity-lock-"));
+  const controlDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-control-"));
+  const entityPath = path.join(targetDir, "entities", "binary-lock-target.md");
+  const originalEntity = "entity before redirect\n\n![img](../image.png)\n";
+  const redirectedEntity = "entity before redirect\n\n![img](remote/image.png)\n";
+  let targetPromise: Promise<PipelineResult> | undefined;
+
+  try {
+    await Promise.all([
+      mkdir(path.dirname(entityPath), { recursive: true }),
+      mkdir(path.join(targetDir, "state"), { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(path.join(targetDir, "image.png"), "image", "utf8"),
+      writeFile(entityPath, originalEntity, "utf8"),
+      writeFile(path.join(controlDir, "image.png"), "image", "utf8"),
+      writeFile(path.join(controlDir, "note.md"), "![img](image.png)\n", "utf8"),
+    ]);
+    const manifest = {
+      version: 1 as const,
+      assets: [
+        {
+          originalPath: "image.png",
+          mirroredPath: "remote/image.png",
+          contentHash: sha256("image"),
+          sizeBytes: "image".length,
+          mimeType: "image/png",
+          mirroredAt: "2026-01-01T00:00:00.000Z",
+          status: "mirrored" as const,
+        },
+      ],
+    };
+    await Promise.all([
+      writeManifest(targetDir, manifest),
+      writeManifest(controlDir, manifest),
+    ]);
+
+    const redirectPrepared = Promise.withResolvers<void>();
+    const continueRedirect = Promise.withResolvers<void>();
+    let targetFinished = false;
+
+    await withEntityCanonicalMutationLock(path.join(targetDir, "state"), async () => {
+      targetPromise = runBinaryLifecyclePipeline(
+        targetDir,
+        baseConfig,
+        nestedRemoteBackend,
+        noopLogger,
+        {
+          readMarkdownFile: async (filePath) => {
+            const content = await readFile(filePath, "utf8");
+            if (filePath === entityPath) {
+              redirectPrepared.resolve();
+              await continueRedirect.promise;
+            }
+            return content;
+          },
+        },
+      );
+      void targetPromise.then(
+        () => {
+          targetFinished = true;
+        },
+        () => undefined,
+      );
+
+      await redirectPrepared.promise;
+      continueRedirect.resolve();
+      const controlResult = await runBinaryLifecyclePipeline(
+        controlDir,
+        baseConfig,
+        nestedRemoteBackend,
+        noopLogger,
+      );
+      assert.equal(controlResult.redirected, 1);
+      assert.equal(
+        await readFile(path.join(controlDir, "note.md"), "utf8"),
+        "![img](remote/image.png)\n",
+      );
+      assert.equal(
+        targetFinished,
+        false,
+        "the target redirect must not finish while its entity mutation lock is held",
+      );
+      assert.equal(
+        await readFile(entityPath, "utf8"),
+        originalEntity,
+        "the entity redirect write must not enter while the canonical mutation lock is held",
+      );
+    });
+
+    assert.ok(targetPromise);
+    const targetResult = await targetPromise;
+    assert.equal(targetResult.redirected, 1);
+    assert.equal(await readFile(entityPath, "utf8"), redirectedEntity);
+  } finally {
+    await targetPromise?.catch(() => undefined);
+    await Promise.all([
+      rm(targetDir, { recursive: true, force: true }),
+      rm(controlDir, { recursive: true, force: true }),
+    ]);
   }
 });
 

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.ts
@@ -27,6 +27,7 @@ import {
   repairContentAfterJournalMove,
   requestEntityCanonicalIdReconcile,
 } from "../storage/entity-canonical-id-references.js";
+import { withRawEntityPageMutation } from "../storage/entity-canonical-id-lock.js";
 
 // Write-boundary journal cache for redirect rewrites (issue #2213).
 const historicalIdCache = new HistoricalEntityCanonicalIdCache();
@@ -338,6 +339,7 @@ async function stageRedirect(
         // keep their bytes (plus the redirect) untouched, and entities/ pages
         // get the bounded reconcile marker instead — their migrated surface
         // is relationship targets, not an entityRef frontmatter field.
+        await withRawEntityPageMutation(memoryDir, update.mdPath, async () => {
         const stateDir = path.join(memoryDir, "state");
         const kind = classifyEntityRefWritePath(memoryDir, update.mdPath);
         if (kind === "memory") {
@@ -371,6 +373,7 @@ async function stageRedirect(
             await requestEntityCanonicalIdReconcile(stateDir);
           }
         }
+        });
         // The redirect rewrote an on-disk memory file out-of-band (not through a
         // StorageManager mutation). Bump the corpus sentinel per write so a warm
         // hot-memories cache rescans — mid-batch too, never serving pre-redirect

--- a/packages/remnic-core/src/consolidation-undo.ts
+++ b/packages/remnic-core/src/consolidation-undo.ts
@@ -27,6 +27,7 @@ import type { StorageManager } from "./storage.js";
 import type { VersioningConfig } from "./page-versioning.js";
 import { bumpMemoryCorpusVersionForDir } from "./memory-corpus-version.js";
 import { requestEntityCanonicalIdReconcile } from "./storage/entity-canonical-id-references.js";
+import { withRawEntityPageMutation } from "./storage/entity-canonical-id-lock.js";
 import { getVersion } from "./page-versioning.js";
 
 /**
@@ -643,6 +644,7 @@ export async function runConsolidationUndo(options: {
       }
       try {
         await mkdir(path.dirname(p.sourcePath), { recursive: true });
+        await withRawEntityPageMutation(memoryDir, p.sourcePath, async () => {
         // Use exclusive create (wx / O_EXCL) so that if another process
         // recreates the source file between planning and execution, this
         // write fails with EEXIST instead of silently overwriting the new
@@ -658,6 +660,7 @@ export async function runConsolidationUndo(options: {
         // Restored bytes predate the current migration journal and can carry
         // legacy entity references (issue #2213) — request one reconcile pass.
         await requestEntityCanonicalIdReconcile(path.join(memoryDir, "state"));
+        });
         result.restores.push({
           entry: p.entry,
           sourcePath: p.sourcePath,

--- a/packages/remnic-core/src/entity-retrieval-boundaries.ts
+++ b/packages/remnic-core/src/entity-retrieval-boundaries.ts
@@ -64,6 +64,19 @@ function isIntlWordBoundary(source: string, index: number): boolean {
   return UNICODE_WORD_SEGMENTER?.segment(source).containing(index)?.index === index;
 }
 
+function isStandaloneJapaneseLeadingParticle(
+  particle: string,
+  source: string,
+  boundaryIndex: number,
+): boolean {
+  if (!JAPANESE_WORD_SEGMENTER || boundaryIndex <= 0 || !JAPANESE_PARTICLE_RE.test(particle)) {
+    return false;
+  }
+  const particleStart = boundaryIndex - particle.length;
+  const segment = JAPANESE_WORD_SEGMENTER.segment(source).containing(particleStart);
+  return segment?.index === particleStart
+    && segment.index + segment.segment.length === boundaryIndex;
+}
 function isKoreanUnspacedQuestionBoundary(suffix: string): boolean {
   return KOREAN_UNSPACED_QUESTION_PARTICLES.some((particle) =>
     suffix.startsWith(particle) &&
@@ -91,18 +104,15 @@ function isUnicodePhraseBoundary(
   source: string = "",
   boundaryIndex: number = -1,
   strictUnicode = false,
-  allowLeadingParticle = false,
 ): boolean {
   return (
     character.length === 0
     || !UNICODE_WORD_OR_NUMBER_RE.test(character)
-    || (allowLeadingParticle && isJapaneseParticleBoundary(character))
     || isJapaneseParticleBoundary(suffix)
     || (!strictUnicode &&
       boundaryIndex >= 0 &&
       !JAPANESE_KANA_RE.test(suffix) &&
       isIntlWordBoundary(source, boundaryIndex))
-    || (allowLeadingParticle && isKoreanParticleBoundary(character))
     || isKoreanParticleBoundary(suffix)
   );
 }
@@ -117,7 +127,10 @@ export function containsPhrase(haystack: string, needle: string): boolean {
     const before = lastUnicodeCharacter(searchHaystack.slice(0, offset));
     const after = searchHaystack.slice(offset + searchNeedle.length);
     if (
-      isUnicodePhraseBoundary(before, "", searchHaystack, offset, caseInsensitive, true)
+      (
+        isUnicodePhraseBoundary(before, "", searchHaystack, offset, caseInsensitive)
+        || isStandaloneJapaneseLeadingParticle(before, searchHaystack, offset)
+      )
       && isUnicodePhraseBoundary(
         firstUnicodeCharacter(after),
         after,

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -403,23 +403,37 @@ async function readCurrentPersistedEntityIndex(
 const namespaceEntityIndexCache = new Map<string, EntityMentionIndex>();
 const MAX_NAMESPACE_ENTITY_INDEX_CACHE_ENTRIES = 32;
 
+function nativeEntityIndexRevision(chunks: NativeKnowledgeChunk[]): string {
+  const projection = chunks.map((chunk) => [
+    chunk.chunkId,
+    chunk.sourcePath,
+    chunk.title,
+    chunk.sourceKind,
+    uniqueStrings(chunk.aliases ?? []),
+    compactLine(chunk.content, 180),
+    chunk.derivedDate ?? null,
+  ]);
+  return createHash("sha256").update(JSON.stringify(projection)).digest("hex");
+}
+
 function namespaceEntityIndexCacheKey(
   storages: StorageManager[],
   recallNamespaces: string[],
+  nativeRevision: string,
 ): string {
-  const namespaceKey = uniqueStrings(recallNamespaces).sort().join("\u001f");
+  const namespaceKey = uniqueStrings(recallNamespaces).join("\u001f");
   const storageKey = storages
     .map((scopedStorage) => {
       const aliases = Object.entries(scopedStorage.entityAliases)
         .sort(([left], [right]) => left.localeCompare(right));
       return (
         `${path.resolve(scopedStorage.dir)}@${scopedStorage.getMemoryStatusVersion()}` +
-        `:${scopedStorage.getMemoryCorpusVersion()}:${scopedStorage.hotCacheKeyId()}:${JSON.stringify(aliases)}`
+        `:${scopedStorage.getMemoryCorpusVersion()}:${scopedStorage.getEntityMutationVersion()}` +
+        `:${scopedStorage.hotCacheKeyId()}:${JSON.stringify(aliases)}`
       );
     })
-    .sort()
     .join("\u001f");
-  return `${namespaceKey}\u001e${storageKey}`;
+  return `${namespaceKey}\u001e${storageKey}\u001e${nativeRevision}`;
 }
 
 function rememberNamespaceEntityIndex(key: string, index: EntityMentionIndex): void {
@@ -1030,6 +1044,9 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
     resolveNamespaceCapabilities(options.config).namespaces &&
     options.namespaceStorage !== undefined &&
     (options.recallNamespaces?.length ?? 0) > 0;
+  if (namespaceScoped) {
+    nativeChunks = await readNativeChunks(options.config, options.recallNamespaces);
+  }
   const resolvedStorages = namespaceScoped
     ? await resolveEntityIndexStorages(
       options.storage,
@@ -1039,8 +1056,12 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
     )
     : undefined;
   const namespaceCacheKey =
-    resolvedStorages && options.recallNamespaces
-      ? namespaceEntityIndexCacheKey(resolvedStorages, options.recallNamespaces)
+    resolvedStorages && options.recallNamespaces && nativeChunks
+      ? namespaceEntityIndexCacheKey(
+        resolvedStorages,
+        options.recallNamespaces,
+        nativeEntityIndexRevision(nativeChunks),
+      )
       : undefined;
   let index: EntityMentionIndex | undefined = namespaceCacheKey
     ? namespaceEntityIndexCache.get(namespaceCacheKey)

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -111,6 +111,7 @@ export {
   serializeEntityFile,
   type MemoryWriteResult,
 } from "./storage.js";
+export { withRawEntityPageMutation } from "./storage/entity-canonical-id-lock.js";
 export {
   composeMemoryEnvelope,
   buildAccessWriteRequestFingerprint,

--- a/packages/remnic-core/src/page-versioning.ts
+++ b/packages/remnic-core/src/page-versioning.ts
@@ -31,6 +31,7 @@ import {
   pathMayCarryEntityRefs,
   requestEntityCanonicalIdReconcile,
 } from "./storage/entity-canonical-id-references.js";
+import { withRawEntityPageMutation } from "./storage/entity-canonical-id-lock.js";
 
 // ---------------------------------------------------------------------------
 // Public interfaces
@@ -335,28 +336,13 @@ export async function revertToVersion(
     resolvedMemoryDir,
   );
 
-  // Write the reverted content to the actual page
-  await writeFile(pagePath, targetContent, "utf-8");
-  // A revert overwrites a memory file out-of-band (not via a StorageManager
-  // mutation), so bump the corpus sentinel when the reverted page lives under a
-  // recall category dir — forcing a warm hot-memories cache to rescan on its
-  // next read (issue #1902, Codex P1). Non-recall pages (entities/artifacts/
-  // profiles) are not in the corpus scan, so they need no bump.
-  // The hot-memories corpus covers the RECALL corpus, which excludes the
-  // non-memory queue dirs (questions/). Use RECALL_FALLBACK_DIRS — a revert of a
-  // questions/ page must NOT bump the recall corpus sentinel and force a rescan.
+  await withRawEntityPageMutation(resolvedMemoryDir, pagePath, async () => {
+    await writeFile(pagePath, targetContent, "utf-8");
+  });
   const revertedTop = relPath(pagePath, resolvedMemoryDir).split(path.sep)[0];
-  const inRecallTier = (RECALL_FALLBACK_DIRS as readonly string[]).includes(revertedTop);
-  if (inRecallTier) {
+  if ((RECALL_FALLBACK_DIRS as readonly string[]).includes(revertedTop)) {
     bumpMemoryCorpusVersionForDir(resolvedMemoryDir);
   }
-  // A pre-migration snapshot can reintroduce a legacy entityRef — or, under
-  // entities/, a legacy relationship target rewriteRelationshipTargets had
-  // migrated — that the target's completed journal already renamed (issue
-  // #2213); the revert keeps the snapshot bytes faithful, so request one
-  // bounded reconcile pass instead. pathMayCarryEntityRefs is the migration's
-  // own scan scope (hot recall + cold + archive + entities), which is wider
-  // than the corpus bump above on purpose.
   if (pathMayCarryEntityRefs(resolvedMemoryDir, pagePath)) {
     await requestEntityCanonicalIdReconcile(path.join(resolvedMemoryDir, "state"));
   }

--- a/packages/remnic-core/src/spaces/index.test.ts
+++ b/packages/remnic-core/src/spaces/index.test.ts
@@ -1,14 +1,15 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import fs, { existsSync } from "node:fs";
-import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
-import { createSpace, loadManifest } from "./index.js";
+import { withEntityCanonicalMutationLock } from "../storage/entity-canonical-id-lock.js";
+import { createSpace, loadManifest, pushToSpace, type SpacePushResult } from "./index.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "../../../..");
@@ -234,6 +235,64 @@ test("loadManifest persists bootstrap when manifest disappears between existence
     assert.equal(originalExistsSync(manifestPath), true);
   } finally {
     fs.existsSync = originalExistsSync;
+    await rm(baseDir, { recursive: true, force: true });
+  }
+});
+
+test("pushToSpace serializes entity-page batches with the target canonical mutation lock", async () => {
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "remnic-spaces-entity-lock-"));
+  const sourceDir = path.join(baseDir, "source");
+  const targetDir = path.join(baseDir, "target");
+  const entityRelativePath = path.join("entities", "serialized-project.md");
+  const sourceEntityPath = path.join(sourceDir, entityRelativePath);
+  const targetEntityPath = path.join(targetDir, entityRelativePath);
+  const entityBytes = Buffer.from(
+    "---\nid: serialized-project\n---\n\n# Serialized Project\n\n**Type:** project\n\nPush bytes.\n",
+    "utf8",
+  );
+  const lockHeld = Promise.withResolvers<void>();
+  const releaseLock = Promise.withResolvers<void>();
+  let lockPromise: Promise<void> | undefined;
+  let pushPromise: Promise<SpacePushResult> | undefined;
+
+  try {
+    const source = createSpace({ baseDir, name: "Source", kind: "project", memoryDir: sourceDir });
+    const target = createSpace({ baseDir, name: "Target", kind: "project", memoryDir: targetDir });
+    await mkdir(path.dirname(sourceEntityPath), { recursive: true });
+    await mkdir(path.join(targetDir, "state"), { recursive: true });
+    await writeFile(sourceEntityPath, entityBytes);
+
+    lockPromise = withEntityCanonicalMutationLock(path.join(targetDir, "state"), async () => {
+      lockHeld.resolve();
+      await releaseLock.promise;
+    });
+    await lockHeld.promise;
+
+    let pushFinished = false;
+    pushPromise = pushToSpace(source.id, target.id, { baseDir });
+    void pushPromise.then(
+      () => {
+        pushFinished = true;
+      },
+      () => {
+        pushFinished = true;
+      },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    assert.equal(pushFinished, false, "the push must not finish while the target entity lock is held");
+    assert.equal(existsSync(targetEntityPath), false, "the entity page must not land before lock release");
+
+    releaseLock.resolve();
+    await lockPromise;
+    const result = await pushPromise;
+
+    assert.equal(result.memoriesPushed, 1);
+    assert.deepEqual(await readFile(targetEntityPath), entityBytes);
+  } finally {
+    releaseLock.resolve();
+    await lockPromise?.catch(() => undefined);
+    await pushPromise?.catch(() => undefined);
     await rm(baseDir, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/spaces/index.ts
+++ b/packages/remnic-core/src/spaces/index.ts
@@ -22,6 +22,7 @@ import {
   repairContentAfterJournalMoveSync,
   requestEntityCanonicalIdReconcileSync,
 } from "../storage/entity-canonical-id-references.js";
+import { withRawEntityPageMutation } from "../storage/entity-canonical-id-lock.js";
 
 // Write-boundary journal cache for promoted copies (issue #2213).
 const historicalIdCache = new HistoricalEntityCanonicalIdCache();
@@ -637,11 +638,11 @@ export function switchSpace(spaceId: string, baseDir?: string): SpaceSwitchResul
 
 // ── Push / Pull ─────────────────────────────────────────────────────────────
 
-export function pushToSpace(
+export async function pushToSpace(
   sourceSpaceId: string,
   targetSpaceId: string,
   options?: { memoryIds?: string[]; force?: boolean; baseDir?: string }
-): SpacePushResult {
+): Promise<SpacePushResult> {
   const startTime = Date.now();
   const manifest = loadManifest(options?.baseDir);
 
@@ -651,7 +652,7 @@ export function pushToSpace(
   if (!source) throw new Error(`Source space "${sourceSpaceId}" not found`);
   if (!target) throw new Error(`Target space "${targetSpaceId}" not found`);
 
-  const result = copyMemories(source.memoryDir, target.memoryDir, {
+  const result = await copyMemories(source.memoryDir, target.memoryDir, {
     filterIds: options?.memoryIds,
     force: options?.force,
   });
@@ -675,11 +676,11 @@ export function pushToSpace(
   };
 }
 
-export function pullFromSpace(
+export async function pullFromSpace(
   sourceSpaceId: string,
   targetSpaceId: string,
   options?: { memoryIds?: string[]; force?: boolean; baseDir?: string }
-): SpacePullResult {
+): Promise<SpacePullResult> {
   const startTime = Date.now();
   const manifest = loadManifest(options?.baseDir);
 
@@ -689,7 +690,7 @@ export function pullFromSpace(
   if (!source) throw new Error(`Source space "${sourceSpaceId}" not found`);
   if (!target) throw new Error(`Target space "${targetSpaceId}" not found`);
 
-  const result = copyMemories(source.memoryDir, target.memoryDir, {
+  const result = await copyMemories(source.memoryDir, target.memoryDir, {
     filterIds: options?.memoryIds,
     force: options?.force,
   });
@@ -744,11 +745,11 @@ export function shareSpace(spaceId: string, members: string[], baseDir?: string)
 
 // ── Promote ──────────────────────────────────────────────────────────────────
 
-export function promoteSpace(
+export async function promoteSpace(
   sourceSpaceId: string,
   targetSpaceId: string,
   options?: { memoryIds?: string[]; force?: boolean; forceOverwrite?: boolean; baseDir?: string }
-): SpacePromoteResult {
+): Promise<SpacePromoteResult> {
   const startTime = Date.now();
   const manifest = loadManifest(options?.baseDir);
 
@@ -765,7 +766,7 @@ export function promoteSpace(
     }
   }
 
-  const result = copyMemories(source.memoryDir, target.memoryDir, {
+  const result = await copyMemories(source.memoryDir, target.memoryDir, {
     filterIds: options?.memoryIds,
     force: options?.forceOverwrite !== undefined ? options.forceOverwrite : (options?.force ?? false),
   });
@@ -791,11 +792,11 @@ export function promoteSpace(
 
 // ── Merge ────────────────────────────────────────────────────────────────────
 
-export function mergeSpaces(
+export async function mergeSpaces(
   sourceSpaceId: string,
   targetSpaceId: string,
   options?: { force?: boolean; baseDir?: string }
-): MergeResult {
+): Promise<MergeResult> {
   const startTime = Date.now();
   const manifest = loadManifest(options?.baseDir);
 
@@ -805,7 +806,7 @@ export function mergeSpaces(
   if (!source) throw new Error(`Source space "${sourceSpaceId}" not found`);
   if (!target) throw new Error(`Target space "${targetSpaceId}" not found`);
 
-  const result = copyMemories(source.memoryDir, target.memoryDir, {
+  const result = await copyMemories(source.memoryDir, target.memoryDir, {
     force: options?.force,
   });
 
@@ -855,15 +856,13 @@ interface CopyOptions {
   force?: boolean;
 }
 
-function copyMemories(
+type CopyResult = { merged: number; conflicts: ConflictEntry[]; skipped: number };
+
+async function copyMemories(
   sourceDir: string,
   targetDir: string,
   options?: CopyOptions
-): { merged: number; conflicts: ConflictEntry[]; skipped: number } {
-  let merged = 0;
-  const conflicts: ConflictEntry[] = [];
-  let skipped = 0;
-
+): Promise<CopyResult> {
   if (!fs.existsSync(sourceDir)) {
     return { merged: 0, conflicts: [], skipped: 0 };
   }
@@ -891,6 +890,33 @@ function copyMemories(
       })
       .map((p) => path.basename(p, ".md")),
   );
+  const firstEntityId = sourceEntityIds.values().next().value;
+  if (firstEntityId === undefined) {
+    return copyPreparedMemories(sourceFiles, sourceRoot, targetRoot, sourceEntityIds, options);
+  }
+  return withRawEntityPageMutation(
+    targetRoot,
+    path.join(targetRoot, "entities", `${firstEntityId}.md`),
+    async () => copyPreparedMemories(
+      sourceFiles,
+      sourceRoot,
+      targetRoot,
+      sourceEntityIds,
+      options,
+    ),
+  );
+}
+
+function copyPreparedMemories(
+  sourceFiles: string[],
+  sourceRoot: string,
+  targetRoot: string,
+  sourceEntityIds: ReadonlySet<string>,
+  options?: CopyOptions,
+): CopyResult {
+  let merged = 0;
+  const conflicts: ConflictEntry[] = [];
+  let skipped = 0;
   // The reconcile marker is published ONCE, after every record landed
   // (Codex P1, round 21): a per-record marker could be consumed by a peer
   // between a legacy-preserving memory write and its colliding entity page,

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2400,15 +2400,14 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
   }
 
   /**
-   * Entity-mutation sentinel: advanced only by entity-store content writes.
-   * The migration fingerprint keys on this instead of memory-status, so
-   * supersede/archive/delete no longer re-trigger discovery scans (#2213).
+   * Entity content revision used by migration discovery and entity-page cache coherence.
    */
   getEntityMutationVersion(): number {
     return this.readSharedVersion("entity-mutation", StorageManager.entityMutationVersionByDir);
   }
 
   protected bumpEntityMutationVersion(): void {
+    invalidateForScope(this.baseDir, "entity-write");
     this.bumpSharedVersion("entity-mutation", StorageManager.entityMutationVersionByDir);
   }
 

--- a/packages/remnic-core/src/storage/entity-canonical-id-lock.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-lock.ts
@@ -1,33 +1,63 @@
-/**
- * Entity canonical-id MUTATION lock (issue #2213).
- *
- * Serializes every writer whose correctness depends on the canonical-id
- * journal not moving mid-write: entity file mutations (entity-store),
- * per-pair file migration and journal pruning (entity-canonical-id-migration),
- * and the final settle attempt of the post-persist repair helpers
- * (entity-canonical-id-references). Lives in its own module so the reference
- * helpers can take the lock without importing the migration module, which
- * itself imports the reference helpers.
- */
+import { appendFileSync, mkdirSync, realpathSync } from "node:fs";
 import path from "node:path";
-import { withHeldFileLock } from "../utils/serialize-mutations.js";
+import { invalidateForScope } from "../memory-cache.js";
+import { serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
 
 const ENTITY_CANONICAL_ID_MUTATION_LOCK_STALE_MS = 60_000;
 const ENTITY_CANONICAL_ID_MUTATION_LOCK_MAX_WAIT_MS = 300_000;
 
-export async function withEntityCanonicalMutationLock<T>(
+export function isEntityPagePath(baseDir: string, filePath: string): boolean {
+  if (path.extname(filePath) !== ".md") return false;
+  const parentDir = path.dirname(path.resolve(filePath));
+  const entitiesDir = path.resolve(baseDir, "entities");
+  if (parentDir === entitiesDir) return true;
+  try {
+    return realpathSync(parentDir) === path.join(realpathSync(baseDir), "entities");
+  } catch {
+    return false;
+  }
+}
+
+function recordRawEntityMutation(baseDir: string, stateDir: string): void {
+  invalidateForScope(baseDir, "entity-write");
+  mkdirSync(stateDir, { recursive: true });
+  appendFileSync(path.join(stateDir, ".entity-mutation-version.log"), "x");
+}
+
+export function withEntityCanonicalMutationLock<T>(
   stateDir: string,
   task: (refreshLock: () => Promise<boolean>) => Promise<T>,
 ): Promise<T> {
-  return withHeldFileLock(
-    path.join(stateDir, "entity-canonical-id-mutation.lock"),
-    {
-      staleMs: ENTITY_CANONICAL_ID_MUTATION_LOCK_STALE_MS,
-      maxWaitMs: ENTITY_CANONICAL_ID_MUTATION_LOCK_MAX_WAIT_MS,
-    },
-    async (acquired, lock) => {
-      if (!acquired) throw new Error("Timed out waiting for entity mutation lock.");
-      return task(() => lock.refresh());
-    },
+  const lockPath = path.join(stateDir, "entity-canonical-id-mutation.lock");
+  return serializeMutations(lockPath, () =>
+    withHeldFileLock(
+      lockPath,
+      {
+        staleMs: ENTITY_CANONICAL_ID_MUTATION_LOCK_STALE_MS,
+        maxWaitMs: ENTITY_CANONICAL_ID_MUTATION_LOCK_MAX_WAIT_MS,
+      },
+      async (acquired, lock) => {
+        if (!acquired) throw new Error("Timed out waiting for entity mutation lock.");
+        return task(() => lock.refresh());
+      },
+    ),
   );
+}
+
+export async function withRawEntityPageMutation<T>(
+  baseDir: string,
+  filePath: string,
+  task: (refreshLock: () => Promise<boolean>) => Promise<T>,
+): Promise<T> {
+  if (!isEntityPagePath(baseDir, filePath)) {
+    return task(async () => true);
+  }
+  const stateDir = path.join(baseDir, "state");
+  return withEntityCanonicalMutationLock(stateDir, async (refreshLock) => {
+    try {
+      return await task(refreshLock);
+    } finally {
+      recordRawEntityMutation(baseDir, stateDir);
+    }
+  });
 }

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   access,
   lstat,
@@ -96,33 +96,63 @@ async function fingerprintPath(filePath: string): Promise<string> {
     : "missing";
 }
 
+async function fingerprintEntityEntries(entitiesDir: string): Promise<string> {
+  let names: string[];
+  try {
+    names = (await readdir(entitiesDir))
+      .filter((name) => path.extname(name) === ".md")
+      .sort();
+  } catch (error) {
+    if (isErrnoCode(error, "ENOENT")) return "missing";
+    throw error;
+  }
+  const hash = createHash("sha256");
+  for (const name of names) {
+    hash.update(`${name.length}:${name}:`);
+    try {
+      const entry = await lstat(path.join(entitiesDir, name), { bigint: true });
+      hash.update(`${entry.dev}:${entry.ino}:${entry.size}:${entry.mtimeNs}:${entry.ctimeNs}`);
+    } catch (error) {
+      if (!isErrnoCode(error, "ENOENT")) throw error;
+      hash.update("missing");
+    }
+    hash.update("\n");
+  }
+  return hash.digest("hex");
+}
+
 /**
- * Completion fingerprint for the migration runner's skip gate. Incorporates
- * only state that can change what a re-run would DO: the entities directory
- * (creates/deletes/renames), the alias table (normalization inputs), the
- * caller-supplied entity-mutation version (store-mediated entity content
- * edits, which touch neither of the first two), and the reconcile-pending
- * marker raw-byte writers touch. It must NOT incorporate the memory-corpus
- * write version: plain memory creates cannot introduce legacy entity
- * references (writes normalize through the historical mapping table), and
- * keying the gate to them re-ran the migration after every fact write — the
- * issue #2213 hot loop.
+ * Completion fingerprint for migration inputs only. Entity entry identities
+ * catch same-path edits that do not change the directory inode; the cooperative
+ * sentinel covers managed writes. Memory-corpus writes stay excluded so plain
+ * fact writes do not reopen migration.
  */
 export async function getFingerprint(
   baseDir: string,
   entitiesDir: string,
   getEntityMutationVersion: () => string,
 ): Promise<string> {
-  const [entityFingerprint, aliasFingerprint, reconcileFingerprint, consumingFingerprint] = await Promise.all([
+  const [
+    entityDirectoryFingerprint,
+    entityEntriesFingerprint,
+    aliasFingerprint,
+    reconcileFingerprint,
+    consumingFingerprint,
+  ] = await Promise.all([
     fingerprintPath(entitiesDir),
+    fingerprintEntityEntries(entitiesDir),
     fingerprintPath(path.join(baseDir, "config", "aliases.json")),
     fingerprintPath(path.join(baseDir, "state", ENTITY_CANONICAL_ID_RECONCILE_MARKER)),
-    // A `.consuming` generation stranded by a crashed PEER process must also
-    // re-invoke a live runner whose cached fingerprint predates it.
     fingerprintPath(path.join(baseDir, "state", ENTITY_CANONICAL_ID_RECONCILE_CONSUMING_MARKER)),
   ]);
-  return [entityFingerprint, aliasFingerprint, reconcileFingerprint, consumingFingerprint, getEntityMutationVersion()]
-    .join(":");
+  return [
+    entityDirectoryFingerprint,
+    entityEntriesFingerprint,
+    aliasFingerprint,
+    reconcileFingerprint,
+    consumingFingerprint,
+    getEntityMutationVersion(),
+  ].join(":");
 }
 
 export async function validateRoots(

--- a/packages/remnic-core/src/storage/entity-store.ts
+++ b/packages/remnic-core/src/storage/entity-store.ts
@@ -58,6 +58,7 @@ export interface EntityStoreDeps {
   currentHistoricalIds(): Readonly<Record<string, string>>;
   findMatchingEntity(proposedName: string, type: string): Promise<string | null>;
   getEntityCacheSecureStoreKey(): string;
+  getEntityMutationVersion(): number;
   getMemoryStatusVersion(): number;
   invalidateKnowledgeIndexCache(): void;
   knowledgeIndexCache: { result: string; builtAt: number } | null;
@@ -483,8 +484,11 @@ export class EntityStore {
    */
   async readAllEntityFiles(): Promise<EntityFile[]> {
     const currentVersion = this.deps.getMemoryStatusVersion();
-    const schemaCacheKey = buildEntitySchemaCacheKey(this.deps.entitySchemas);
-    const cacheKey = `${this.deps.getEntityCacheSecureStoreKey()}\u0000${schemaCacheKey}`;
+    const cacheKey = [
+      this.deps.getEntityCacheSecureStoreKey(),
+      buildEntitySchemaCacheKey(this.deps.entitySchemas),
+      this.deps.getEntityMutationVersion(),
+    ].join("\u0000");
     const cached = getCachedEntities(this.deps.baseDir, currentVersion, cacheKey);
     if (cached) return cached;
 

--- a/packages/remnic-core/src/storage/tombstone-blocked-capture-sync.ts
+++ b/packages/remnic-core/src/storage/tombstone-blocked-capture-sync.ts
@@ -8,6 +8,7 @@ import { markProjectedMemoryPathInvalid } from "../memory-projection-store.js";
 import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
 import { isErrnoCode } from "../utils/errno.js";
 import { pathMayCarryEntityRefs, requestEntityCanonicalIdReconcile } from "./entity-canonical-id-references.js";
+import { withRawEntityPageMutation } from "./entity-canonical-id-lock.js";
 import { readMaybeEncryptedFileFromChunks, writeMaybeEncryptedFileFromChunks } from "../secure-store/secure-fs.js";
 import {
   buildExplicitCaptureDedupKey,
@@ -661,11 +662,15 @@ export abstract class TombstoneBlockedCaptureIndexHost {
   }
 
   protected async writeTombstoneBlockedOfflineSyncFile(target: string, content: Buffer): Promise<void> {
-    await this.runTombstoneBlockedOfflineSyncMutation(
-      target,
-      this.tombstoneBlockedCaptureIndexOptions().parseMemory?.(target, content) ?? null,
-      () => this.writeManagedStorageFile(target, () => this.writeStorageSecureFile(target, content))
-    );
+    const options = this.tombstoneBlockedCaptureIndexOptions();
+    const after = options.parseMemory?.(target, content) ?? null;
+    await withRawEntityPageMutation(path.dirname(options.stateDir), target, async () => {
+      await this.runTombstoneBlockedOfflineSyncMutation(
+        target,
+        after,
+        () => this.writeManagedStorageFile(target, () => this.writeStorageSecureFile(target, content))
+      );
+    });
   }
 
   private async prepareTombstoneBlockedOfflineSyncChunks(
@@ -845,8 +850,9 @@ export abstract class TombstoneBlockedCaptureIndexHost {
       ? await this.prepareTombstoneBlockedOfflineSyncChunks(target, chunks)
       : { after: null, chunks };
     const streamedIdentity = prepared.streamedIdentity;
-    const mutate = async (): Promise<void> => {
-      try {
+    const baseDir = path.dirname(this.tombstoneBlockedCaptureIndexOptions().stateDir);
+    try {
+      await withRawEntityPageMutation(baseDir, target, async () => {
         await this.runTombstoneBlockedOfflineSyncMutation(
           target,
           prepared.after,
@@ -854,32 +860,29 @@ export abstract class TombstoneBlockedCaptureIndexHost {
           coordinate,
           streamedIdentity
         );
-      } finally {
-        if (prepared.stagePath !== undefined) await unlink(prepared.stagePath).catch(() => {});
-      }
-    };
-    await mutate();
+      });
+    } finally {
+      if (prepared.stagePath !== undefined) await unlink(prepared.stagePath).catch(() => {});
+    }
   }
 
   async writeOfflineSyncFile(filePath: string, content: Buffer): Promise<void> {
     const target = this.assertManagedStoragePath(filePath, "storage.writeOfflineSyncFile");
     await this.writeTombstoneBlockedOfflineSyncFile(target, content);
-    await this.requestSyncReconcileIfMemoryPath(target);
+    await this.requestSyncReconcileIfMigrationPath(target);
   }
 
   async writeOfflineSyncFileChunks(filePath: string, chunks: AsyncIterable<Buffer>): Promise<void> {
     const target = this.assertManagedStoragePath(filePath, "storage.writeOfflineSyncFileChunks");
     await this.writeTombstoneBlockedOfflineSyncFileChunks(target, chunks);
-    await this.requestSyncReconcileIfMemoryPath(target);
+    await this.requestSyncReconcileIfMigrationPath(target);
   }
 
   /**
-   * Replicated bytes are opaque (possibly encrypted) and can carry legacy
-   * entity references a completed migration already renamed (issue #2213) —
-   * but only memory-tier markdown can, so transcript/state/other sync traffic
-   * must not trigger the full-corpus reconcile pass.
+   * Opaque replicated bytes can restore legacy memory references or entity
+   * relationship targets. Other sync traffic must not request reconciliation.
    */
-  private async requestSyncReconcileIfMemoryPath(target: string): Promise<void> {
+  private async requestSyncReconcileIfMigrationPath(target: string): Promise<void> {
     const stateDir = this.tombstoneBlockedCaptureIndexOptions().stateDir;
     if (!pathMayCarryEntityRefs(path.dirname(stateDir), target)) return;
     await requestEntityCanonicalIdReconcile(stateDir);
@@ -888,14 +891,18 @@ export abstract class TombstoneBlockedCaptureIndexHost {
   async deleteOfflineSyncFile(filePath: string, deletionMtimeMs?: number | null): Promise<void> {
     const target = this.assertManagedStoragePath(filePath, "storage.deleteOfflineSyncFile");
     await this.deleteTombstoneBlockedOfflineSyncFile(target, deletionMtimeMs);
+    await this.requestSyncReconcileIfMigrationPath(target);
   }
 
   protected async deleteTombstoneBlockedOfflineSyncFile(
     target: string,
     deletionMtimeMs?: number | null
   ): Promise<void> {
-    await this.runTombstoneBlockedOfflineSyncMutation(target, null, async () => {
-      await this.deleteManagedStorageFile(target, deletionMtimeMs);
+    const stateDir = this.tombstoneBlockedCaptureIndexOptions().stateDir;
+    await withRawEntityPageMutation(path.dirname(stateDir), target, async () => {
+      await this.runTombstoneBlockedOfflineSyncMutation(target, null, async () => {
+        await this.deleteManagedStorageFile(target, deletionMtimeMs);
+      });
     });
   }
 

--- a/packages/remnic-core/src/transfer/capsule-import.ts
+++ b/packages/remnic-core/src/transfer/capsule-import.ts
@@ -11,6 +11,7 @@ import {
   repairContentAfterJournalMove,
   requestEntityCanonicalIdReconcile,
 } from "../storage/entity-canonical-id-references.js";
+import { withRawEntityPageMutation } from "../storage/entity-canonical-id-lock.js";
 import {
   createVersion,
   type VersioningConfig,
@@ -422,6 +423,7 @@ export async function importCapsule(
   // between a legacy-preserving memory write and its colliding entity page,
   // canonicalizing the memory onto the wrong claimant irreversibly.
   let reconcileNeeded = false;
+  const applyRecords = async (): Promise<void> => {
   for (const rec of sortedRecords) {
     const targetRel = computeTargetPath(rec.path, mode, capsule.id);
     // Use rootReal (realpath-resolved) to stay consistent with phase 1's
@@ -536,6 +538,17 @@ export async function importCapsule(
   // disk; NOW the reconcile pass can settle collisions safely.
   if (reconcileNeeded) {
     await requestEntityCanonicalIdReconcile(journalStateDir);
+  }
+  };
+  const firstEntityId = capsuleEntityIds.values().next().value;
+  if (firstEntityId === undefined) {
+    await applyRecords();
+  } else {
+    await withRawEntityPageMutation(
+      rootReal,
+      path.join(rootReal, "entities", `${firstEntityId}.md`),
+      applyRecords,
+    );
   }
 
   // Sort skipped for stable output (see comment above).

--- a/packages/remnic-core/src/transfer/capsule-merge.ts
+++ b/packages/remnic-core/src/transfer/capsule-merge.ts
@@ -10,6 +10,7 @@ import {
   repairContentAfterJournalMove,
   requestEntityCanonicalIdReconcile,
 } from "../storage/entity-canonical-id-references.js";
+import { withRawEntityPageMutation } from "../storage/entity-canonical-id-lock.js";
 import {
   createVersion,
   type VersioningConfig,
@@ -440,6 +441,7 @@ export async function mergeCapsule(
     a.path.localeCompare(b.path),
   );
 
+  const applyRecords = async (): Promise<void> => {
   for (const rec of sortedRecords) {
     const targetAbs = path.join(rootReal, fromPosixRelPath(rec.path));
     const entry = manifestIndex.get(rec.path)!; // validated above
@@ -530,6 +532,17 @@ export async function mergeCapsule(
   // disk; NOW the reconcile pass can settle collisions safely.
   if (reconcileNeeded) {
     await requestEntityCanonicalIdReconcile(journalStateDir);
+  }
+  };
+  const firstEntityId = capsuleEntityIds.values().next().value;
+  if (firstEntityId === undefined) {
+    await applyRecords();
+  } else {
+    await withRawEntityPageMutation(
+      rootReal,
+      path.join(rootReal, "entities", `${firstEntityId}.md`),
+      applyRecords,
+    );
   }
 
   // Sort output lists for determinism.

--- a/tests/capsule-import.test.ts
+++ b/tests/capsule-import.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtemp,
   readFile,
   readdir,
+  rm,
   stat,
   symlink,
   writeFile,
@@ -16,9 +17,13 @@ import { gzipSync } from "node:zlib";
 import { exportCapsule } from "../packages/remnic-core/src/transfer/capsule-export.js";
 import {
   importCapsule,
+  type ImportCapsuleResult,
   type ImportCapsuleMode,
 } from "../packages/remnic-core/src/transfer/capsule-import.js";
 import { listVersions } from "../packages/remnic-core/src/page-versioning.js";
+import {
+  withEntityCanonicalMutationLock,
+} from "../packages/remnic-core/src/storage/entity-canonical-id-lock.js";
 import {
   ExportBundleV1Schema,
   type ExportBundleV1,
@@ -1221,4 +1226,66 @@ test("import canonicalizes a legacy entityRef through the target's migration jou
   // Body and unrelated frontmatter stay byte-identical.
   assert.match(written, /id: fact-legacy-ref/);
   assert.match(written, /body\n$/);
+});
+
+test("entity page imports wait for the target canonical mutation lock", async () => {
+  const entityRel = "entities/capsule-import-lock-target.md";
+  const originalEntity = "original import entity bytes\n";
+  const importedEntity = "imported entity bytes\n";
+  const { archivePath, sourceRoot } = await exportTo(
+    [{ rel: entityRel, content: importedEntity }],
+    "entity-lock-import",
+  );
+  const targetRoot = await makeMemoryDir([{ rel: entityRel, content: originalEntity }]);
+  const controlRoot = await makeMemoryDir([{ rel: entityRel, content: originalEntity }]);
+  const entityPath = path.join(targetRoot, entityRel);
+  let importPromise: Promise<ImportCapsuleResult> | undefined;
+
+  try {
+    await mkdir(path.join(targetRoot, "state"), { recursive: true });
+    let importFinished = false;
+
+    await withEntityCanonicalMutationLock(path.join(targetRoot, "state"), async () => {
+      importPromise = importCapsule({
+        archivePath,
+        root: targetRoot,
+        mode: "overwrite",
+      });
+      void importPromise.then(
+        () => {
+          importFinished = true;
+        },
+        () => undefined,
+      );
+
+      const controlResult = await importCapsule({
+        archivePath,
+        root: controlRoot,
+        mode: "overwrite",
+      });
+      assert.equal(controlResult.imported.length, 1);
+      assert.equal(
+        importFinished,
+        false,
+        "the target import must not finish while its entity mutation lock is held",
+      );
+      assert.equal(
+        await readFile(entityPath, "utf-8"),
+        originalEntity,
+        "the target entity write must not enter while its canonical mutation lock is held",
+      );
+    });
+
+    assert.ok(importPromise);
+    const result = await importPromise;
+    assert.equal(result.imported.length, 1);
+    assert.equal(await readFile(entityPath, "utf-8"), importedEntity);
+  } finally {
+    await importPromise?.catch(() => undefined);
+    await Promise.all([
+      rm(sourceRoot, { recursive: true, force: true }),
+      rm(targetRoot, { recursive: true, force: true }),
+      rm(controlRoot, { recursive: true, force: true }),
+    ]);
+  }
 });

--- a/tests/consolidation-undo.test.ts
+++ b/tests/consolidation-undo.test.ts
@@ -25,9 +25,11 @@ import {
   isInsideDirectoryRealpath,
   isActiveMemoryRelativePath,
   formatConsolidationUndoResult,
+  type ConsolidationUndoResult,
 } from "../src/consolidation-undo.ts";
 import { symlink } from "node:fs/promises";
 import type { VersioningConfig } from "@remnic/core";
+import { withEntityCanonicalMutationLock } from "../packages/remnic-core/src/storage/entity-canonical-id-lock.js";
 
 const versioning: VersioningConfig = {
   enabled: true,
@@ -40,6 +42,30 @@ async function makeStorage(dir: string): Promise<StorageManager> {
   storage.setVersioningConfig({ ...versioning });
   await storage.ensureDirectories();
   return storage;
+}
+
+class ConsolidationRestoreBarrierStorage extends StorageManager {
+  restoreTargetPath: string | undefined;
+  readonly restorePrepared = Promise.withResolvers<void>();
+
+  override async readMemoryByPath(filePath: string) {
+    const memory = await super.readMemoryByPath(filePath);
+    if (memory && filePath === this.restoreTargetPath) {
+      const derivedFrom = memory.frontmatter.derived_from;
+      if (Array.isArray(derivedFrom)) {
+        const entries = derivedFrom.slice();
+        const prepared = this.restorePrepared;
+        Object.defineProperty(derivedFrom, Symbol.iterator, {
+          configurable: true,
+          value: function* () {
+            yield* entries;
+            prepared.resolve();
+          },
+        });
+      }
+    }
+    return memory;
+  }
 }
 
 test("runConsolidationUndo restores sources and archives the target on the happy path", async () => {
@@ -778,6 +804,99 @@ test("runConsolidationUndo tolerates non-string derived_from entries without cra
     // reason.
     assert.ok(Array.isArray(result.restores));
   } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("consolidation undo entity restores wait for the canonical mutation lock", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-undo-entity-lock-"));
+  const storage = new ConsolidationRestoreBarrierStorage(dir);
+  const entitySourcePath = path.join(dir, "entities", "undo-lock-source.md");
+  const controlSourcePath = path.join(dir, "facts", "undo-lock-control.md");
+  const originalEntity = "---\nid: undo-lock-source\n---\n\nentity snapshot bytes\n";
+  const originalControl = "---\nid: undo-lock-control\n---\n\ncontrol snapshot bytes\n";
+  let undoPromise: Promise<ConsolidationUndoResult> | undefined;
+
+  try {
+    storage.setVersioningConfig({ ...versioning });
+    await storage.ensureDirectories();
+    await Promise.all([
+      mkdir(path.dirname(entitySourcePath), { recursive: true }),
+      mkdir(path.dirname(controlSourcePath), { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(entitySourcePath, originalEntity, "utf8"),
+      writeFile(controlSourcePath, originalControl, "utf8"),
+    ]);
+    const [entityEntry, controlEntry] = await Promise.all([
+      storage.snapshotForProvenance(entitySourcePath),
+      storage.snapshotForProvenance(controlSourcePath),
+    ]);
+    assert.ok(entityEntry);
+    assert.ok(controlEntry);
+    await Promise.all([unlink(entitySourcePath), unlink(controlSourcePath)]);
+    storage.invalidateAllMemoriesCacheForDir();
+
+    const { id: targetId } = await storage.writeMemory("fact", "entity restore target", {
+      source: "semantic-consolidation",
+      derivedFrom: [entityEntry],
+      derivedVia: "merge",
+    });
+    const { id: controlTargetId } = await storage.writeMemory("fact", "control restore target", {
+      source: "semantic-consolidation",
+      derivedFrom: [controlEntry],
+      derivedVia: "merge",
+    });
+    const memories = await storage.readAllMemories();
+    const target = memories.find((memory) => memory.frontmatter.id === targetId);
+    const controlTarget = memories.find((memory) => memory.frontmatter.id === controlTargetId);
+    assert.ok(target);
+    assert.ok(controlTarget);
+    storage.restoreTargetPath = target.path;
+    let undoFinished = false;
+
+    await withEntityCanonicalMutationLock(path.join(dir, "state"), async () => {
+      undoPromise = runConsolidationUndo({
+        storage,
+        memoryDir: dir,
+        targetPath: target.path,
+        versioning,
+      });
+      void undoPromise.then(
+        () => {
+          undoFinished = true;
+        },
+        () => undefined,
+      );
+
+      await storage.restorePrepared.promise;
+      const controlResult = await runConsolidationUndo({
+        storage,
+        memoryDir: dir,
+        targetPath: controlTarget.path,
+        versioning,
+      });
+      assert.equal(controlResult.error, undefined);
+      assert.equal(await readFile(controlSourcePath, "utf8"), originalControl);
+      assert.equal(
+        undoFinished,
+        false,
+        "the entity restore must not finish while its canonical mutation lock is held",
+      );
+      await assert.rejects(
+        () => readFile(entitySourcePath, "utf8"),
+        /ENOENT/,
+        "the entity restore write must not enter while the canonical mutation lock is held",
+      );
+    });
+
+    assert.ok(undoPromise);
+    const result = await undoPromise;
+    assert.equal(result.error, undefined);
+    assert.equal(result.restores[0]?.outcome, "restored");
+    assert.equal(await readFile(entitySourcePath, "utf8"), originalEntity);
+  } finally {
+    await undoPromise?.catch(() => undefined);
     await rm(dir, { recursive: true, force: true });
   }
 });

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 
 import { StorageManager, normalizeEntityName } from "../packages/remnic-core/src/storage.js";
 import { getFingerprint } from "../packages/remnic-core/src/storage/entity-canonical-id-migration.js";
@@ -481,6 +481,66 @@ test("plain memory writes do not change the migration fingerprint; entity writes
 
     await storage.writeEntity("Nightly Ingest", "automation-cron-job", ["Runs at 02:00."]);
     assert.notEqual(await readFp(), before, "an entity mutation must re-trigger the migration");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("an external in-place entity edit reopens a completed migration", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-external-edit-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const oldCanonical = await storage.writeEntity("Alpha One", "project", ["Tracks the alpha rollout."]);
+    const newCanonical = normalizeEntityName("Bravo Two", "project");
+    assert.notEqual(oldCanonical, newCanonical);
+
+    const memory = await storage.writeMemory("fact", "Alpha One tracks the rollout.");
+    const written = (await storage.readAllMemories()).find(
+      (candidate) => candidate.frontmatter.id === memory.id,
+    );
+    assert.ok(written);
+    await storage.writeMemoryFrontmatter(written, { entityRef: oldCanonical });
+    await storage.ensureDirectories();
+
+    const entitiesDir = path.join(dir, "entities");
+    const oldPath = path.join(entitiesDir, `${oldCanonical}.md`);
+    const beforeFingerprint = await getFingerprint(
+      dir,
+      entitiesDir,
+      () => String(storage.getEntityMutationVersion()),
+    );
+    const beforeMutationVersion = storage.getEntityMutationVersion();
+    const beforeDirectory = await stat(entitiesDir);
+    const externalContent = (await readFile(oldPath, "utf8")).replace("# Alpha One", "# Bravo Two");
+    await writeFile(oldPath, externalContent, "utf8");
+    await utimes(oldPath, new Date("2030-01-01T00:00:00.000Z"), new Date("2030-01-01T00:00:00.000Z"));
+
+    const afterDirectory = await stat(entitiesDir);
+    assert.deepEqual(
+      [afterDirectory.dev, afterDirectory.ino, afterDirectory.mtimeMs, afterDirectory.ctimeMs, afterDirectory.size],
+      [beforeDirectory.dev, beforeDirectory.ino, beforeDirectory.mtimeMs, beforeDirectory.ctimeMs, beforeDirectory.size],
+      "rewriting an existing entry must not rely on parent-directory metadata changing",
+    );
+    assert.equal(
+      storage.getEntityMutationVersion(),
+      beforeMutationVersion,
+      "an external editor cannot advance the cooperative entity-mutation sentinel",
+    );
+    assert.notEqual(
+      await getFingerprint(dir, entitiesDir, () => String(storage.getEntityMutationVersion())),
+      beforeFingerprint,
+      "the migration fingerprint must include metadata for each entity page",
+    );
+
+    await storage.ensureDirectories();
+    await assert.rejects(() => readFile(oldPath, "utf8"));
+    assert.match(await readFile(path.join(entitiesDir, `${newCanonical}.md`), "utf8"), /# Bravo Two/);
+    assert.equal(
+      /^entityRef: (.*)$/m.exec(await readFile(written.path, "utf8"))?.[1],
+      newCanonical,
+      "the reopened migration must rewrite references to the changed canonical id",
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/entity-retrieval.test.ts
+++ b/tests/entity-retrieval.test.ts
@@ -1,10 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { on, once } from "node:events";
+import { createInterface } from "node:readline";
 import os from "node:os";
 import path from "node:path";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { buildEntityRecallSection, entityIndexVersion, readRecentEntityTranscriptEntries } from "../src/entity-retrieval.js";
+import { containsPhrase } from "../packages/remnic-core/src/entity-retrieval-boundaries.js";
 import { Orchestrator } from "../src/orchestrator.js";
 import { StorageManager, normalizeEntityName } from "../src/storage.js";
 import { SecureStoreLockedError } from "../src/secure-store/index.js";
@@ -278,6 +282,75 @@ test("entity retrieval rejects Japanese name prefixes before kana words", async 
   assert.doesNotMatch(section!, /target: 山田 \(person\)|Short-314/);
 });
 
+test("entity retrieval rejects Japanese suffix aliases inside names while preserving particle matches", async (t) => {
+  const { memoryDir, workspaceDir, config, storage } = await buildHarness("engram-entity-japanese-suffix");
+  t.after(async () => {
+    await Promise.all([
+      rm(memoryDir, { recursive: true, force: true }),
+      rm(workspaceDir, { recursive: true, force: true }),
+    ]);
+  });
+  const ruka = await writeEntity(
+    storage,
+    "Moonlight Person",
+    "person",
+    ["Moonlight Person has verification code Ruka-314."],
+    "Moonlight Person has verification code Ruka-314.",
+    ["るか"],
+  );
+  const haruka = await writeEntity(
+    storage,
+    "はるか",
+    "person",
+    ["はるか has verification code Haruka-271."],
+    "はるか has verification code Haruka-271.",
+  );
+  const rukako = await writeEntity(
+    storage,
+    "Beacon Person",
+    "person",
+    ["Beacon Person has verification code Rukako-161."],
+    "Beacon Person has verification code Rukako-161.",
+    ["るかこ"],
+  );
+  const harukako = await writeEntity(
+    storage,
+    "はるかこ",
+    "person",
+    ["はるかこ has verification code Harukako-141."],
+    "はるかこ has verification code Harukako-141.",
+  );
+  assert.notEqual(ruka, haruka);
+  assert.notEqual(rukako, harukako);
+  assert.equal(containsPhrase("「はるかこについて教えて」", "るかこ"), false);
+  assert.equal(containsPhrase("山田と、るかについて教えてください。", "るか"), true);
+
+  const particleMatch = await buildSection(config, storage, "山田と、るかについて教えてください。");
+  assert.ok(particleMatch);
+  assert.match(particleMatch!, /target: Moonlight Person \(person\)/);
+  assert.match(particleMatch!, /Ruka-314/);
+
+  const fullNameMatch = await buildSection(config, storage, "はるかについて教えてください。");
+  assert.ok(fullNameMatch);
+  assert.match(fullNameMatch!, /target: はるか \(person\)/);
+  assert.match(fullNameMatch!, /Haruka-271/);
+  assert.doesNotMatch(fullNameMatch!, /target: Moonlight Person \(person\)|Ruka-314/);
+
+  const quotedFullNameMatch = await buildSection(config, storage, "「はるかについて教えて」");
+  assert.ok(quotedFullNameMatch);
+  assert.match(quotedFullNameMatch!, /target: はるか \(person\)/);
+  assert.doesNotMatch(quotedFullNameMatch!, /target: Moonlight Person \(person\)|Ruka-314/);
+
+  const overlappingSegmentMatch = await buildSection(config, storage, "「はるかこについて教えて」");
+  assert.ok(overlappingSegmentMatch);
+  assert.match(overlappingSegmentMatch!, /target: はるかこ \(person\)/);
+  assert.match(overlappingSegmentMatch!, /Harukako-141/);
+  assert.doesNotMatch(
+    overlappingSegmentMatch!,
+    /target: (?:Moonlight|Beacon) Person \(person\)|Ruka-314|Rukako-161/,
+  );
+});
+
 test("entity retrieval resolves Korean grammatical particles after Unicode mentions", async (t) => {
   const { memoryDir, workspaceDir, config, storage } = await buildHarness("engram-entity-korean-names");
   t.after(async () => {
@@ -316,6 +389,37 @@ test("entity retrieval resolves Korean grammatical particles after Unicode menti
     confidence: 1,
   });
   assert.equal(await buildSection(config, storage, "김도나가 누구야?"), null);
+});
+
+test("entity retrieval rejects Korean suffix names preceded by particle-like syllables", async (t) => {
+  const { memoryDir, workspaceDir, config, storage } = await buildHarness("engram-entity-korean-suffix");
+  t.after(async () => {
+    await Promise.all([
+      rm(memoryDir, { recursive: true, force: true }),
+      rm(workspaceDir, { recursive: true, force: true }),
+    ]);
+  });
+  const shortName = await writeEntity(
+    storage,
+    "민수",
+    "person",
+    ["민수 has verification code Minsu-314."],
+    "민수 has verification code Minsu-314.",
+  );
+  const fullName = await writeEntity(
+    storage,
+    "김가민수",
+    "person",
+    ["김가민수 has verification code Full-271."],
+    "김가민수 has verification code Full-271.",
+  );
+  assert.notEqual(shortName, fullName);
+
+  const section = await buildSection(config, storage, "김가민수는 누구야?");
+  assert.ok(section);
+  assert.match(section!, /target: 김가민수 \(person\)/);
+  assert.match(section!, /Full-271/);
+  assert.doesNotMatch(section!, /target: 민수 \(person\)|Minsu-314/);
 });
 
 test("entity retrieval applies Unicode boundaries to ASCII aliases", async (t) => {
@@ -808,6 +912,330 @@ test("entity retrieval reads entity hints from allowed secondary namespaces only
   assert.match(section!, /Shared Person is visible from the shared namespace/);
   assert.doesNotMatch(section!, /private namespace secret|private-only/);
 });
+
+test("entity retrieval preserves namespace precedence in the namespace index cache key", async (t) => {
+  const { memoryDir, workspaceDir, config } = await buildHarness("engram-entity-namespace-order-cache", {
+    namespacesEnabled: true,
+    defaultNamespace: "alice",
+    sharedNamespace: "shared",
+  });
+  t.after(async () => {
+    await Promise.all([
+      rm(memoryDir, { recursive: true, force: true }),
+      rm(workspaceDir, { recursive: true, force: true }),
+    ]);
+  });
+  const aliceStorage = new StorageManager(path.join(memoryDir, "namespaces", "alice"), config.entitySchemas);
+  const sharedStorage = new StorageManager(path.join(memoryDir, "namespaces", "shared"), config.entitySchemas);
+  await Promise.all([aliceStorage.ensureDirectories(), sharedStorage.ensureDirectories()]);
+  await writeEntity(
+    aliceStorage,
+    "Order Person",
+    "person",
+    ["Alice namespace precedence marker Alice-314."],
+    "Alice namespace precedence marker Alice-314.",
+  );
+  await writeEntity(
+    sharedStorage,
+    "Order Person",
+    "person",
+    ["Shared namespace precedence marker Shared-271."],
+    "Shared namespace precedence marker Shared-271.",
+  );
+  const namespaceStorage = async (namespace: string) => {
+    if (namespace === "alice") return aliceStorage;
+    if (namespace === "shared") return sharedStorage;
+    throw new Error(`unexpected namespace ${namespace}`);
+  };
+  const baseOptions = {
+    config,
+    storage: aliceStorage,
+    namespaceStorage,
+    query: "Who is Order Person?",
+    recentTurns: 6,
+    maxHints: 2,
+    maxSupportingFacts: 6,
+    maxRelatedEntities: 3,
+    maxChars: 2400,
+    transcriptEntries: [],
+  };
+
+  const sharedWins = await buildEntityRecallSection({
+    ...baseOptions,
+    recallNamespaces: ["alice", "shared"],
+  });
+  assert.ok(sharedWins);
+  assert.match(sharedWins!, /Shared-271/);
+  assert.doesNotMatch(sharedWins!, /Alice-314/);
+
+  const aliceWins = await buildEntityRecallSection({
+    ...baseOptions,
+    recallNamespaces: ["shared", "alice"],
+  });
+  assert.ok(aliceWins);
+  assert.match(aliceWins!, /Alice-314/);
+  assert.doesNotMatch(aliceWins!, /Shared-271/);
+});
+
+test("entity retrieval refreshes a namespace negative cache after a relationship revision", async (t) => {
+  const { memoryDir, workspaceDir, config } = await buildHarness("engram-entity-namespace-relationship-cache", {
+    namespacesEnabled: true,
+    defaultNamespace: "alice",
+    sharedNamespace: "shared",
+  });
+  const aliceStorage = new StorageManager(path.join(memoryDir, "namespaces", "alice"), config.entitySchemas);
+  const sharedStorage = new StorageManager(path.join(memoryDir, "namespaces", "shared"), config.entitySchemas);
+  await Promise.all([aliceStorage.ensureDirectories(), sharedStorage.ensureDirectories()]);
+  const canonical = await aliceStorage.writeEntity("Casey Example", "person", []);
+  let entityReads = 0;
+  const originalAliceRead = aliceStorage.readAllEntityFiles.bind(aliceStorage);
+  const originalSharedRead = sharedStorage.readAllEntityFiles.bind(sharedStorage);
+  aliceStorage.readAllEntityFiles = async () => {
+    entityReads += 1;
+    return originalAliceRead();
+  };
+  sharedStorage.readAllEntityFiles = async () => {
+    entityReads += 1;
+    return originalSharedRead();
+  };
+  t.after(async () => {
+    aliceStorage.readAllEntityFiles = originalAliceRead;
+    sharedStorage.readAllEntityFiles = originalSharedRead;
+    await Promise.all([
+      rm(memoryDir, { recursive: true, force: true }),
+      rm(workspaceDir, { recursive: true, force: true }),
+    ]);
+  });
+  const options = {
+    config,
+    storage: aliceStorage,
+    namespaceStorage: async (namespace: string) => {
+      if (namespace === "alice") return aliceStorage;
+      if (namespace === "shared") return sharedStorage;
+      throw new Error(`unexpected namespace ${namespace}`);
+    },
+    recallNamespaces: ["alice", "shared"],
+    query: "Tell me about an unrelated ordinary turn.",
+    recentTurns: 6,
+    maxHints: 2,
+    maxSupportingFacts: 6,
+    maxRelatedEntities: 3,
+    maxChars: 2400,
+    transcriptEntries: [],
+  } satisfies Parameters<typeof buildEntityRecallSection>[0];
+
+  assert.equal(await buildEntityRecallSection(options), null);
+  assert.equal(entityReads, 2);
+  await aliceStorage.addEntityRelationship(canonical, {
+    target: "Rollback Project",
+    label: "supports",
+  });
+
+  const refreshed = await buildEntityRecallSection({
+    ...options,
+    query: "Who is Casey Example?",
+  });
+  assert.ok(refreshed);
+  assert.match(refreshed!, /related entities: Rollback Project/);
+  assert.equal(entityReads, 4);
+});
+
+test("entity retrieval refreshes a reader-process entity cache after a relationship revision", async (t) => {
+  const { memoryDir, workspaceDir, config } = await buildHarness(
+    "engram-entity-namespace-cross-process-relationship-cache",
+    {
+      namespacesEnabled: true,
+      defaultNamespace: "alice",
+      sharedNamespace: "shared",
+    },
+  );
+  const namespaceDir = path.join(memoryDir, "namespaces", "alice");
+  const writerStorage = new StorageManager(namespaceDir, config.entitySchemas);
+  await writerStorage.ensureDirectories();
+  const canonical = await writerStorage.writeEntity("Casey Example", "person", []);
+  const configModuleUrl = new URL("../src/config.js", import.meta.url).href;
+  const retrievalModuleUrl = new URL("../src/entity-retrieval.js", import.meta.url).href;
+  const storageModuleUrl = new URL("../src/storage.js", import.meta.url).href;
+  const childSource = `
+    import path from "node:path";
+    import { createInterface } from "node:readline";
+    import { parseConfig } from ${JSON.stringify(configModuleUrl)};
+    import { buildEntityRecallSection } from ${JSON.stringify(retrievalModuleUrl)};
+    import { StorageManager } from ${JSON.stringify(storageModuleUrl)};
+
+    const memoryDir = process.env.REMNIC_TEST_MEMORY_DIR;
+    const workspaceDir = process.env.REMNIC_TEST_WORKSPACE_DIR;
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      sharedContextEnabled: false,
+      hourlySummariesEnabled: false,
+      transcriptEnabled: true,
+      namespacesEnabled: true,
+      defaultNamespace: "alice",
+      sharedNamespace: "shared",
+      nativeKnowledge: { enabled: false },
+    });
+    const storage = new StorageManager(
+      path.join(memoryDir, "namespaces", "alice"),
+      config.entitySchemas,
+    );
+    const input = createInterface({ input: process.stdin });
+    for await (const line of input) {
+      const message = JSON.parse(line);
+      if (message.type === "shutdown") break;
+      try {
+        const section = await buildEntityRecallSection({
+          config,
+          storage,
+          namespaceStorage: async () => storage,
+          recallNamespaces: ["alice"],
+          query: message.query,
+          recentTurns: 6,
+          maxHints: 2,
+          maxSupportingFacts: 6,
+          maxRelatedEntities: 3,
+          maxChars: 2400,
+          transcriptEntries: [],
+        });
+        process.stdout.write(JSON.stringify({ id: message.id, section }) + "\\n");
+      } catch (error) {
+        process.stdout.write(JSON.stringify({
+          id: message.id,
+          error: error instanceof Error ? error.stack : String(error),
+        }) + "\\n");
+      }
+    }
+  `;
+  const child = spawn(
+    process.execPath,
+    ["--import", import.meta.resolve("tsx"), "--input-type=module", "--eval", childSource],
+    {
+      env: {
+        ...process.env,
+        REMNIC_TEST_MEMORY_DIR: memoryDir,
+        REMNIC_TEST_WORKSPACE_DIR: workspaceDir,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  let childStderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    childStderr += chunk;
+  });
+  const outputLines = createInterface({ input: child.stdout });
+  const responses = on(outputLines, "line");
+  let requestId = 0;
+  const recallInChild = async (query: string): Promise<string | null> => {
+    const id = ++requestId;
+    child.stdin.write(`${JSON.stringify({ type: "recall", id, query })}\n`);
+    const response = await responses.next();
+    if (response.done) {
+      assert.fail(`reader process exited before replying: ${childStderr}`);
+    }
+    const reply = JSON.parse(String(response.value[0])) as {
+      id: number;
+      section?: string | null;
+      error?: string;
+    };
+    assert.equal(reply.id, id);
+    assert.equal(reply.error, undefined, reply.error);
+    return reply.section ?? null;
+  };
+  t.after(async () => {
+    if (child.exitCode === null && child.signalCode === null) {
+      const exited = once(child, "exit");
+      child.stdin.end(`${JSON.stringify({ type: "shutdown" })}\n`);
+      await exited;
+    }
+    outputLines.close();
+    await Promise.all([
+      rm(memoryDir, { recursive: true, force: true }),
+      rm(workspaceDir, { recursive: true, force: true }),
+    ]);
+  });
+
+  assert.equal(await recallInChild("Tell me about an unrelated ordinary turn."), null);
+  const memoryStatusBefore = writerStorage.getMemoryStatusVersion();
+  const entityMutationBefore = writerStorage.getEntityMutationVersion();
+  await writerStorage.addEntityRelationship(canonical, {
+    target: "Rollback Project",
+    label: "supports",
+  });
+  assert.equal(writerStorage.getMemoryStatusVersion(), memoryStatusBefore);
+  assert.notEqual(writerStorage.getEntityMutationVersion(), entityMutationBefore);
+
+  const refreshed = await recallInChild("Who is Casey Example?");
+  assert.ok(refreshed);
+  assert.match(refreshed, /related entities: Rollback Project/);
+});
+
+test("entity retrieval refreshes a namespace negative cache after an activity revision", async (t) => {
+  const { memoryDir, workspaceDir, config } = await buildHarness("engram-entity-namespace-activity-cache", {
+    namespacesEnabled: true,
+    defaultNamespace: "alice",
+    sharedNamespace: "shared",
+  });
+  const aliceStorage = new StorageManager(path.join(memoryDir, "namespaces", "alice"), config.entitySchemas);
+  const sharedStorage = new StorageManager(path.join(memoryDir, "namespaces", "shared"), config.entitySchemas);
+  await Promise.all([aliceStorage.ensureDirectories(), sharedStorage.ensureDirectories()]);
+  const canonical = await aliceStorage.writeEntity("Casey Example", "person", []);
+  let entityReads = 0;
+  const originalAliceRead = aliceStorage.readAllEntityFiles.bind(aliceStorage);
+  const originalSharedRead = sharedStorage.readAllEntityFiles.bind(sharedStorage);
+  aliceStorage.readAllEntityFiles = async () => {
+    entityReads += 1;
+    return originalAliceRead();
+  };
+  sharedStorage.readAllEntityFiles = async () => {
+    entityReads += 1;
+    return originalSharedRead();
+  };
+  t.after(async () => {
+    aliceStorage.readAllEntityFiles = originalAliceRead;
+    sharedStorage.readAllEntityFiles = originalSharedRead;
+    await Promise.all([
+      rm(memoryDir, { recursive: true, force: true }),
+      rm(workspaceDir, { recursive: true, force: true }),
+    ]);
+  });
+  const options = {
+    config,
+    storage: aliceStorage,
+    namespaceStorage: async (namespace: string) => {
+      if (namespace === "alice") return aliceStorage;
+      if (namespace === "shared") return sharedStorage;
+      throw new Error(`unexpected namespace ${namespace}`);
+    },
+    recallNamespaces: ["alice", "shared"],
+    query: "Tell me about an unrelated ordinary turn.",
+    recentTurns: 6,
+    maxHints: 2,
+    maxSupportingFacts: 6,
+    maxRelatedEntities: 3,
+    maxChars: 2400,
+    transcriptEntries: [],
+  } satisfies Parameters<typeof buildEntityRecallSection>[0];
+
+  assert.equal(await buildEntityRecallSection(options), null);
+  assert.equal(entityReads, 2);
+  await aliceStorage.addEntityActivity(canonical, {
+    date: "2026-07-30",
+    note: "Casey completed the rollback review.",
+  }, 10);
+
+  const refreshed = await buildEntityRecallSection({
+    ...options,
+    query: "What happened with Casey Example?",
+  });
+  assert.ok(refreshed);
+  assert.match(refreshed!, /Casey completed the rollback review/);
+  assert.equal(entityReads, 4);
+});
+
 test("entity retrieval caches namespace-scoped negative lookups by corpus version", async () => {
   const { memoryDir, config } = await buildHarness("engram-entity-namespace-negative-cache", {
     namespacesEnabled: true,
@@ -1730,6 +2158,68 @@ test("entity retrieval refreshes native mention aliases without rebuilding unrel
   assert.equal(unrelated, null);
   assert.equal(entityReadCalls, 0);
   assert.equal(memoryReadCalls, 0);
+});
+
+test("entity retrieval refreshes edited native knowledge in namespace mode", async (t) => {
+  const { memoryDir, workspaceDir, config } = await buildHarness("engram-entity-namespace-native-refresh", {
+    namespacesEnabled: true,
+    defaultNamespace: "alice",
+    sharedNamespace: "shared",
+    nativeKnowledge: {
+      enabled: true,
+      includeFiles: ["IDENTITY.md"],
+      maxChunkChars: 400,
+      maxResults: 5,
+      maxChars: 1600,
+      stateDir: "state/native-knowledge",
+      obsidianVaults: [],
+    },
+  });
+  t.after(async () => {
+    await Promise.all([
+      rm(memoryDir, { recursive: true, force: true }),
+      rm(workspaceDir, { recursive: true, force: true }),
+    ]);
+  });
+  const aliceStorage = new StorageManager(path.join(memoryDir, "namespaces", "alice"), config.entitySchemas);
+  const sharedStorage = new StorageManager(path.join(memoryDir, "namespaces", "shared"), config.entitySchemas);
+  await Promise.all([aliceStorage.ensureDirectories(), sharedStorage.ensureDirectories()]);
+  await writeFile(
+    path.join(workspaceDir, "IDENTITY.md"),
+    "# Launch Runbook\n\nThe current rollback approval code is Quartz-111.\n",
+    "utf-8",
+  );
+  const options = {
+    config,
+    storage: aliceStorage,
+    namespaceStorage: async (namespace: string) => {
+      if (namespace === "alice") return aliceStorage;
+      if (namespace === "shared") return sharedStorage;
+      throw new Error(`unexpected namespace ${namespace}`);
+    },
+    recallNamespaces: ["alice", "shared"],
+    query: "Tell me about Launch Runbook",
+    recentTurns: 6,
+    maxHints: 2,
+    maxSupportingFacts: 6,
+    maxRelatedEntities: 3,
+    maxChars: 2400,
+    transcriptEntries: [],
+  } satisfies Parameters<typeof buildEntityRecallSection>[0];
+
+  const initial = await buildEntityRecallSection(options);
+  assert.ok(initial);
+  assert.match(initial!, /Quartz-111/);
+  await writeFile(
+    path.join(workspaceDir, "IDENTITY.md"),
+    "# Launch Runbook\n\nThe current rollback approval code is Saffron-222.\n",
+    "utf-8",
+  );
+
+  const refreshed = await buildEntityRecallSection(options);
+  assert.ok(refreshed);
+  assert.match(refreshed!, /Saffron-222/);
+  assert.doesNotMatch(refreshed!, /Quartz-111/);
 });
 
 test("entity retrieval keeps multi-chunk native-only pseudo entries together", async () => {

--- a/tests/page-versioning.test.ts
+++ b/tests/page-versioning.test.ts
@@ -11,6 +11,7 @@ import {
   diffVersions,
   type VersioningConfig,
 } from "../packages/remnic-core/src/page-versioning.js";
+import { withEntityCanonicalMutationLock } from "../packages/remnic-core/src/storage/entity-canonical-id-lock.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -432,4 +433,49 @@ test("revertToVersion bumps the corpus sentinel for recall pages but not non-rec
   const beforeEnt = await size();
   await revertToVersion(entPath, "1", cfg, undefined, tmp);
   assert.equal(await size(), beforeEnt, "reverting a non-recall page does not bump the corpus sentinel");
+});
+
+test("entity page reverts wait for the canonical mutation lock", async () => {
+  const tmp = await makeTmpDir();
+  let revertPromise: Promise<unknown> | undefined;
+  try {
+    const cfg = config(tmp);
+    const entityPath = path.join(tmp, "entities", "project-versioned.md");
+    await fs.mkdir(path.dirname(entityPath), { recursive: true });
+    await fs.mkdir(path.join(tmp, "state"), { recursive: true });
+    await fs.writeFile(entityPath, "original entity", "utf8");
+    await createVersion(entityPath, "original entity", "write", cfg, undefined, undefined, tmp);
+    await fs.writeFile(entityPath, "current entity", "utf8");
+    await createVersion(entityPath, "current entity", "write", cfg, undefined, undefined, tmp);
+
+    const revertPrepared = Promise.withResolvers<void>();
+    await withEntityCanonicalMutationLock(path.join(tmp, "state"), async () => {
+      revertPromise = revertToVersion(
+        entityPath,
+        "1",
+        cfg,
+        {
+          debug(message) {
+            if (message.includes("created version 3")) revertPrepared.resolve();
+          },
+          warn() {},
+        },
+        tmp,
+      );
+      await revertPrepared.promise;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(
+        await fs.readFile(entityPath, "utf8"),
+        "current entity",
+        "the entity page overwrite must not enter while the canonical lock is held",
+      );
+    });
+
+    assert.ok(revertPromise);
+    await revertPromise;
+    assert.equal(await fs.readFile(entityPath, "utf8"), "original entity");
+  } finally {
+    await revertPromise?.catch(() => undefined);
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
 });

--- a/tests/spaces.test.ts
+++ b/tests/spaces.test.ts
@@ -54,7 +54,7 @@ test("pushToSpace skips symlinked markdown files outside the source space", asyn
     return;
   }
 
-  const result = pushToSpace("source", "target", { baseDir });
+  const result = await pushToSpace("source", "target", { baseDir });
   assert.equal(result.memoriesPushed, 1);
 
   const copiedSafe = await readFile(path.join(targetDir, "facts", "safe.md"), "utf-8");

--- a/tests/transfer/capsule-merge.test.ts
+++ b/tests/transfer/capsule-merge.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtemp,
   readFile,
   readdir,
+  rm,
   symlink,
   writeFile,
 } from "node:fs/promises";
@@ -14,9 +15,15 @@ import { gzipSync } from "node:zlib";
 import { createHash } from "node:crypto";
 
 import { exportCapsule } from "../../packages/remnic-core/src/transfer/capsule-export.js";
-import { mergeCapsule } from "../../packages/remnic-core/src/transfer/capsule-merge.js";
+import {
+  mergeCapsule,
+  type MergeCapsuleResult,
+} from "../../packages/remnic-core/src/transfer/capsule-merge.js";
 import { listVersions } from "../../packages/remnic-core/src/page-versioning.js";
 import { sha256String } from "../../packages/remnic-core/src/transfer/fs-utils.js";
+import {
+  withEntityCanonicalMutationLock,
+} from "../../packages/remnic-core/src/storage/entity-canonical-id-lock.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -800,4 +807,69 @@ test("merge canonicalizes a legacy entityRef and re-merge stays identical-skip",
     second.skipped.map((s) => s.reason),
     ["identical"],
   );
+});
+
+test("entity page merges wait for the target canonical mutation lock", async () => {
+  const entityRel = "entities/capsule-merge-lock-target.md";
+  const originalEntity = "original merge entity bytes\n";
+  const mergedEntity = "merged entity bytes\n";
+  const sourceRoot = await makeMemoryDir([{ rel: entityRel, content: mergedEntity }]);
+  const exported = await exportCapsule({
+    name: "entity-lock-merge",
+    root: sourceRoot,
+    pluginVersion: "9.9.9",
+    now: Date.parse("2026-04-26T00:00:00.000Z"),
+  });
+  const targetRoot = await makeTargetDir([{ rel: entityRel, content: originalEntity }]);
+  const controlRoot = await makeTargetDir([{ rel: entityRel, content: originalEntity }]);
+  const entityPath = path.join(targetRoot, entityRel);
+  let mergePromise: Promise<MergeCapsuleResult> | undefined;
+
+  try {
+    await mkdir(path.join(targetRoot, "state"), { recursive: true });
+    let mergeFinished = false;
+
+    await withEntityCanonicalMutationLock(path.join(targetRoot, "state"), async () => {
+      mergePromise = mergeCapsule({
+        sourceArchive: exported.archivePath,
+        targetRoot,
+        conflictMode: "prefer-source",
+      });
+      void mergePromise.then(
+        () => {
+          mergeFinished = true;
+        },
+        () => undefined,
+      );
+
+      const controlResult = await mergeCapsule({
+        sourceArchive: exported.archivePath,
+        targetRoot: controlRoot,
+        conflictMode: "prefer-source",
+      });
+      assert.equal(controlResult.merged.length, 1);
+      assert.equal(
+        mergeFinished,
+        false,
+        "the target merge must not finish while its entity mutation lock is held",
+      );
+      assert.equal(
+        await readFile(entityPath, "utf-8"),
+        originalEntity,
+        "the target entity write must not enter while its canonical mutation lock is held",
+      );
+    });
+
+    assert.ok(mergePromise);
+    const result = await mergePromise;
+    assert.equal(result.merged.length, 1);
+    assert.equal(await readFile(entityPath, "utf-8"), mergedEntity);
+  } finally {
+    await mergePromise?.catch(() => undefined);
+    await Promise.all([
+      rm(sourceRoot, { recursive: true, force: true }),
+      rm(targetRoot, { recursive: true, force: true }),
+      rm(controlRoot, { recursive: true, force: true }),
+    ]);
+  }
 });


### PR DESCRIPTION
Closes #2207. Remaining deferred findings: CJK boundary segmentation, entity writer lock races, negative namespace cache, fingerprint staleness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes concurrency around entity canonical-id locking and migration/cache invalidation across many storage and sync entry points; mistakes could cause deadlocks, stale recall, or missed migrations, though behavior is heavily regression-tested.
> 
> **Overview**
> Hardens **#2207** by making every **out-of-band `entities/` write** go through **`withRawEntityPageMutation`**: it waits on the existing canonical-id mutation lock, then records a raw mutation (entity-write cache invalidation + `.entity-mutation-version.log`) so peers and caches see edits that bypass `StorageManager`. That wrapper is wired into space copy/promote, capsule import/merge, offline sync, binary redirect rewrites, page revert, consolidation undo, bench session entity cleanup, and related paths; **`pushToSpace` / `pullFromSpace` / `promoteSpace` / `mergeSpaces` are now async**, with CLI `await`s.
> 
> **Migration skip fingerprint** now hashes **per-entity-file metadata** (not just the entities directory), so in-place external edits reopen migration even when directory stats are unchanged. **Entity file caches** key on **`getEntityMutationVersion()`**, and namespace entity-index cache keys keep **recall namespace order**, include **entity-mutation + native-knowledge revision**, and refresh after relationship/activity/native edits.
> 
> **Japanese phrase matching** uses standalone leading-particle detection so suffix aliases (e.g. `るか` inside `はるか`) no longer false-match while list particles like `、るか` still work. Broad lock-ordering regression tests cover the above flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf7f5a8063df8e1ad28fd00fd3fbb92032ba4d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent entity updates, imports, restores, syncs, and reverts from overwriting or deleting changes.
  * Improved detection of externally edited entity files and automatic canonical-ID updates.
  * Fixed stale namespace and entity-list results after content changes.
  * Improved Japanese phrase matching at suffix boundaries.

* **Improvements**
  * Space push, pull, promote, and merge operations now complete asynchronously and reliably before results are shown.
  * Added safer coordination for entity-page changes across transfers and background operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->