### PR TITLE
feat(core): external compiled knowledge wiki config + layout + catalog (#2058)

### DIFF
--- a/.changeset/warm-wikis-read.md
+++ b/.changeset/warm-wikis-read.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add configuration, layout validation, catalog parsing, and bounded concept-page reads for external compiled knowledge wikis.

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -62,6 +62,7 @@ import { parseCodingKnowledgeConfig } from "./coding/coding-knowledge-config.js"
 import { parseChatConfig } from "./chat/chat-config.js";
 import { parseCorrectionIntentConfig, parseFaithfulnessGateConfig } from "./faithfulness-config.js";
 import { parseOfflineSyncExcludes } from "./offline-sync.js";
+import { parseExternalWikiRoots } from "./external-wiki-config.js";
 import {
   parseScopeProfiles,
   parseScopeTeams,
@@ -1705,6 +1706,7 @@ export function parseConfig(
         ? cfg.qmdPath
         : undefined,
     memoryDir,
+    externalWikis: parseExternalWikiRoots(cfg.externalWikis, memoryDir),
     debug: cfg.debug === true,
     identityEnabled: cfg.identityEnabled !== false,
     identityContinuityEnabled,

--- a/packages/remnic-core/src/external-wiki-config.test.ts
+++ b/packages/remnic-core/src/external-wiki-config.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { parseConfig } from "./config.js";
+
+test("externalWikis applies safe read-only defaults and expands the root directory", () => {
+  const config = parseConfig({
+    externalWikis: [{ id: "reading", rootDir: "~/knowledge" }],
+  });
+
+  assert.deepEqual(config.externalWikis, [
+    {
+      id: "reading",
+      rootDir: path.join(os.homedir(), "knowledge"),
+      enabled: true,
+      pagesDir: "wiki",
+      indexFile: "INDEX.md",
+      indexInQmd: false,
+      includeInDefaultRecall: false,
+    },
+  ]);
+});
+
+test("externalWikis preserves explicit labels, paths, and opt-in indexing", () => {
+  const config = parseConfig({
+    externalWikis: [
+      {
+        id: "operations",
+        rootDir: "/srv/operations-wiki",
+        enabled: false,
+        label: "Operations handbook",
+        pagesDir: "pages",
+        indexFile: "CATALOG.md",
+        indexInQmd: true,
+      },
+    ],
+  });
+
+  assert.deepEqual(config.externalWikis, [
+    {
+      id: "operations",
+      rootDir: "/srv/operations-wiki",
+      enabled: false,
+      label: "Operations handbook",
+      pagesDir: "pages",
+      indexFile: "CATALOG.md",
+      indexInQmd: true,
+      includeInDefaultRecall: false,
+    },
+  ]);
+});
+
+test("externalWikis rejects default-recall inclusion", () => {
+  assert.throws(
+    () => parseConfig({
+      externalWikis: [
+        {
+          id: "reading",
+          rootDir: "/srv/reading-wiki",
+          includeInDefaultRecall: true,
+        },
+      ],
+    }),
+    /externalWikis\[0\]\.includeInDefaultRecall=true is not supported/,
+  );
+});
+
+test("externalWikis rejects ambiguous or escaping layouts", () => {
+  assert.throws(
+    () => parseConfig({ externalWikis: [{ id: "reading", rootDir: "relative/wiki" }] }),
+    /rootDir must be an absolute path or start with ~\//,
+  );
+  assert.throws(
+    () => parseConfig({
+      externalWikis: [{ id: "reading", rootDir: "/srv/wiki", pagesDir: "../other" }],
+    }),
+    /pagesDir must be a relative path within rootDir/,
+  );
+  assert.throws(
+    () => parseConfig({
+      externalWikis: [
+        { id: "reading", rootDir: "/srv/a" },
+        { id: "reading", rootDir: "/srv/b" },
+      ],
+    }),
+    /duplicate id "reading"/,
+  );
+});
+
+test("externalWikis rejects roots inside the primary memory directory", () => {
+  assert.throws(
+    () => parseConfig({
+      memoryDir: "/srv/remnic/memory",
+      externalWikis: [
+        { id: "reading", rootDir: "/srv/remnic/memory/external/reading" },
+      ],
+    }),
+    /rootDir must be outside memoryDir/,
+  );
+});

--- a/packages/remnic-core/src/external-wiki-config.test.ts
+++ b/packages/remnic-core/src/external-wiki-config.test.ts
@@ -53,49 +53,83 @@ test("externalWikis preserves explicit labels, paths, and opt-in indexing", () =
 
 test("externalWikis rejects default-recall inclusion", () => {
   assert.throws(
-    () => parseConfig({
-      externalWikis: [
-        {
-          id: "reading",
-          rootDir: "/srv/reading-wiki",
-          includeInDefaultRecall: true,
-        },
-      ],
-    }),
-    /externalWikis\[0\]\.includeInDefaultRecall=true is not supported/,
+    () =>
+      parseConfig({
+        externalWikis: [
+          {
+            id: "reading",
+            rootDir: "/srv/reading-wiki",
+            includeInDefaultRecall: true,
+          },
+        ],
+      }),
+    /externalWikis\[0\]\.includeInDefaultRecall=true is not supported/
   );
 });
 
 test("externalWikis rejects ambiguous or escaping layouts", () => {
   assert.throws(
     () => parseConfig({ externalWikis: [{ id: "reading", rootDir: "relative/wiki" }] }),
-    /rootDir must be an absolute path or start with ~\//,
+    /rootDir must be an absolute path or start with ~\//
   );
   assert.throws(
-    () => parseConfig({
-      externalWikis: [{ id: "reading", rootDir: "/srv/wiki", pagesDir: "../other" }],
-    }),
-    /pagesDir must be a relative path within rootDir/,
+    () =>
+      parseConfig({
+        externalWikis: [{ id: "reading", rootDir: "/srv/wiki", pagesDir: "../other" }],
+      }),
+    /pagesDir must be a relative path within rootDir/
   );
   assert.throws(
-    () => parseConfig({
-      externalWikis: [
-        { id: "reading", rootDir: "/srv/a" },
-        { id: "reading", rootDir: "/srv/b" },
-      ],
-    }),
-    /duplicate id "reading"/,
+    () =>
+      parseConfig({
+        externalWikis: [
+          { id: "reading", rootDir: "/srv/a" },
+          { id: "reading", rootDir: "/srv/b" },
+        ],
+      }),
+    /duplicate id "reading"/
+  );
+});
+
+test("externalWikis rejects malformed values and non-portable relative paths", () => {
+  assert.throws(() => parseConfig({ externalWikis: {} }), /externalWikis must be an array/);
+  assert.throws(
+    () =>
+      parseConfig({
+        externalWikis: [{ id: "Reading Wiki", rootDir: "/srv/wiki" }],
+      }),
+    /externalWikis\[0\]\.id must match/
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        externalWikis: [{ id: "reading", rootDir: "/srv/wiki", enabled: "false" }],
+      }),
+    /externalWikis\[0\]\.enabled must be a boolean/
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        externalWikis: [{ id: "reading", rootDir: "/srv/wiki", pagesDir: "nested\\wiki" }],
+      }),
+    /pagesDir must use POSIX separators/
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        externalWikis: [{ id: "reading", rootDir: "/srv/wiki", indexFile: "/tmp/INDEX.md" }],
+      }),
+    /indexFile must be a relative path within rootDir/
   );
 });
 
 test("externalWikis rejects roots inside the primary memory directory", () => {
   assert.throws(
-    () => parseConfig({
-      memoryDir: "/srv/remnic/memory",
-      externalWikis: [
-        { id: "reading", rootDir: "/srv/remnic/memory/external/reading" },
-      ],
-    }),
-    /rootDir must be outside memoryDir/,
+    () =>
+      parseConfig({
+        memoryDir: "/srv/remnic/memory",
+        externalWikis: [{ id: "reading", rootDir: "/srv/remnic/memory/external/reading" }],
+      }),
+    /rootDir must be outside memoryDir/
   );
 });

--- a/packages/remnic-core/src/external-wiki-config.ts
+++ b/packages/remnic-core/src/external-wiki-config.ts
@@ -1,0 +1,112 @@
+import path from "node:path";
+import type { ExternalWikiRoot } from "./types.js";
+import { expandTildePath } from "./utils/path.js";
+
+const EXTERNAL_WIKI_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+function requireObject(value: unknown, keyName: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${keyName} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, keyName: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${keyName} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function parseBoolean(value: unknown, fallback: boolean, keyName: string): boolean {
+  if (value === undefined) return fallback;
+  if (typeof value !== "boolean") throw new Error(`${keyName} must be a boolean`);
+  return value;
+}
+
+function parseRootDir(value: unknown, keyName: string): string {
+  const raw = requireString(value, keyName);
+  if (!path.isAbsolute(raw) && !raw.startsWith("~/")) {
+    throw new Error(`${keyName} must be an absolute path or start with ~/`);
+  }
+  return path.resolve(expandTildePath(raw));
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  const relative = path.relative(left, right);
+  return relative === "" || (
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+function parseRootRelativePath(
+  value: unknown,
+  fallback: string,
+  keyName: string,
+): string {
+  const candidate = value === undefined ? fallback : requireString(value, keyName);
+  const normalized = path.normalize(candidate);
+  if (
+    path.isAbsolute(candidate) ||
+    normalized === ".." ||
+    normalized.startsWith(`..${path.sep}`) ||
+    normalized === "."
+  ) {
+    throw new Error(`${keyName} must be a relative path within rootDir`);
+  }
+  return normalized;
+}
+
+export function parseExternalWikiRoots(
+  value: unknown,
+  memoryDir?: string,
+): ExternalWikiRoot[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new Error("externalWikis must be an array");
+
+  const seenIds = new Set<string>();
+  return value.map((entry, index) => {
+    const keyName = `externalWikis[${index}]`;
+    const raw = requireObject(entry, keyName);
+    const id = requireString(raw.id, `${keyName}.id`);
+    if (!EXTERNAL_WIKI_ID_PATTERN.test(id)) {
+      throw new Error(`${keyName}.id must match ${EXTERNAL_WIKI_ID_PATTERN}`);
+    }
+    if (seenIds.has(id)) throw new Error(`externalWikis contains duplicate id "${id}"`);
+    seenIds.add(id);
+
+    const includeInDefaultRecall = parseBoolean(
+      raw.includeInDefaultRecall,
+      false,
+      `${keyName}.includeInDefaultRecall`,
+    );
+    if (includeInDefaultRecall) {
+      throw new Error(`${keyName}.includeInDefaultRecall=true is not supported yet`);
+    }
+
+    const rootDir = parseRootDir(raw.rootDir, `${keyName}.rootDir`);
+    if (
+      memoryDir !== undefined &&
+      (pathsOverlap(path.resolve(memoryDir), rootDir) ||
+        pathsOverlap(rootDir, path.resolve(memoryDir)))
+    ) {
+      throw new Error(`${keyName}.rootDir must be outside memoryDir`);
+    }
+
+    const label = raw.label === undefined
+      ? undefined
+      : requireString(raw.label, `${keyName}.label`);
+    return {
+      id,
+      rootDir,
+      enabled: parseBoolean(raw.enabled, true, `${keyName}.enabled`),
+      ...(label === undefined ? {} : { label }),
+      pagesDir: parseRootRelativePath(raw.pagesDir, "wiki", `${keyName}.pagesDir`),
+      indexFile: parseRootRelativePath(raw.indexFile, "INDEX.md", `${keyName}.indexFile`),
+      indexInQmd: parseBoolean(raw.indexInQmd, false, `${keyName}.indexInQmd`),
+      includeInDefaultRecall: false,
+    };
+  });
+}

--- a/packages/remnic-core/src/external-wiki-config.ts
+++ b/packages/remnic-core/src/external-wiki-config.ts
@@ -34,19 +34,14 @@ function parseRootDir(value: unknown, keyName: string): string {
 
 function pathsOverlap(left: string, right: string): boolean {
   const relative = path.relative(left, right);
-  return relative === "" || (
-    relative !== ".." &&
-    !relative.startsWith(`..${path.sep}`) &&
-    !path.isAbsolute(relative)
-  );
+  return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
 }
 
-function parseRootRelativePath(
-  value: unknown,
-  fallback: string,
-  keyName: string,
-): string {
+function parseRootRelativePath(value: unknown, fallback: string, keyName: string): string {
   const candidate = value === undefined ? fallback : requireString(value, keyName);
+  if (candidate.includes("\\")) {
+    throw new Error(`${keyName} must use POSIX separators`);
+  }
   const normalized = path.normalize(candidate);
   if (
     path.isAbsolute(candidate) ||
@@ -59,10 +54,7 @@ function parseRootRelativePath(
   return normalized;
 }
 
-export function parseExternalWikiRoots(
-  value: unknown,
-  memoryDir?: string,
-): ExternalWikiRoot[] {
+export function parseExternalWikiRoots(value: unknown, memoryDir?: string): ExternalWikiRoot[] {
   if (value === undefined) return [];
   if (!Array.isArray(value)) throw new Error("externalWikis must be an array");
 
@@ -77,11 +69,7 @@ export function parseExternalWikiRoots(
     if (seenIds.has(id)) throw new Error(`externalWikis contains duplicate id "${id}"`);
     seenIds.add(id);
 
-    const includeInDefaultRecall = parseBoolean(
-      raw.includeInDefaultRecall,
-      false,
-      `${keyName}.includeInDefaultRecall`,
-    );
+    const includeInDefaultRecall = parseBoolean(raw.includeInDefaultRecall, false, `${keyName}.includeInDefaultRecall`);
     if (includeInDefaultRecall) {
       throw new Error(`${keyName}.includeInDefaultRecall=true is not supported yet`);
     }
@@ -89,15 +77,12 @@ export function parseExternalWikiRoots(
     const rootDir = parseRootDir(raw.rootDir, `${keyName}.rootDir`);
     if (
       memoryDir !== undefined &&
-      (pathsOverlap(path.resolve(memoryDir), rootDir) ||
-        pathsOverlap(rootDir, path.resolve(memoryDir)))
+      (pathsOverlap(path.resolve(memoryDir), rootDir) || pathsOverlap(rootDir, path.resolve(memoryDir)))
     ) {
       throw new Error(`${keyName}.rootDir must be outside memoryDir`);
     }
 
-    const label = raw.label === undefined
-      ? undefined
-      : requireString(raw.label, `${keyName}.label`);
+    const label = raw.label === undefined ? undefined : requireString(raw.label, `${keyName}.label`);
     return {
       id,
       rootDir,

--- a/packages/remnic-core/src/external-wiki.test.ts
+++ b/packages/remnic-core/src/external-wiki.test.ts
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import * as core from "./index.js";
+import type { ExternalWikiRoot } from "./types.js";
+import type {
+  loadExternalWikiCatalog,
+  parseExternalWikiCatalog,
+  readExternalWikiPage,
+  validateExternalWikiLayout,
+} from "./external-wiki.js";
+
+const externalWiki = core as typeof core & {
+  loadExternalWikiCatalog: typeof loadExternalWikiCatalog;
+  parseExternalWikiCatalog: typeof parseExternalWikiCatalog;
+  readExternalWikiPage: typeof readExternalWikiPage;
+  validateExternalWikiLayout: typeof validateExternalWikiLayout;
+};
+
+function wikiConfig(rootDir: string, overrides: Partial<ExternalWikiRoot> = {}): ExternalWikiRoot {
+  return {
+    id: "reading",
+    rootDir,
+    enabled: true,
+    pagesDir: "wiki",
+    indexFile: "INDEX.md",
+    indexInQmd: false,
+    includeInDefaultRecall: false,
+    ...overrides,
+  };
+}
+
+async function withWiki(
+  run: (rootDir: string) => Promise<void>,
+): Promise<void> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "remnic-external-wiki-"));
+  try {
+    await run(rootDir);
+  } finally {
+    await rm(rootDir, { recursive: true, force: true });
+  }
+}
+
+test("external wiki reader APIs are exported from core", () => {
+  assert.equal(typeof externalWiki.validateExternalWikiLayout, "function");
+  assert.equal(typeof externalWiki.parseExternalWikiCatalog, "function");
+  assert.equal(typeof externalWiki.loadExternalWikiCatalog, "function");
+  assert.equal(typeof externalWiki.readExternalWikiPage, "function");
+});
+
+test("validates the required pages directory and optional wiki layout", async () => {
+  await withWiki(async (rootDir) => {
+    await mkdir(path.join(rootDir, "wiki"));
+    await mkdir(path.join(rootDir, "raw"));
+    await mkdir(path.join(rootDir, "outputs"));
+    await writeFile(path.join(rootDir, "INDEX.md"), "# Catalog\n");
+
+    const layout = await externalWiki.validateExternalWikiLayout(wikiConfig(rootDir));
+
+    assert.equal(layout.rootDir, rootDir);
+    assert.equal(layout.pagesDir, path.join(rootDir, "wiki"));
+    assert.equal(layout.indexFile, path.join(rootDir, "INDEX.md"));
+    assert.equal(layout.indexPresent, true);
+    assert.equal(layout.rawDir, path.join(rootDir, "raw"));
+    assert.equal(layout.outputsDir, path.join(rootDir, "outputs"));
+  });
+});
+
+test("rejects missing pages directories and symlink escapes", async () => {
+  await withWiki(async (rootDir) => {
+    await assert.rejects(
+      () => externalWiki.validateExternalWikiLayout(wikiConfig(rootDir)),
+      /pages directory does not exist/,
+    );
+
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-wiki-outside-"));
+    try {
+      await symlink(outsideDir, path.join(rootDir, "wiki"));
+      await assert.rejects(
+        () => externalWiki.validateExternalWikiLayout(wikiConfig(rootDir)),
+        /pages directory escapes rootDir/,
+      );
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test("parses markdown and wiki-link catalog entries deterministically", () => {
+  const parsed = externalWiki.parseExternalWikiCatalog(
+    [
+      "# Catalog",
+      "- [Cache consistency](wiki/cache-consistency.md) - Invalidation and ownership.",
+      "- [[distributed-systems|Distributed systems]]: Coordination foundations.",
+      "- [External](https://example.com/external.md) - ignored",
+      "- [Escape](../outside.md) - ignored",
+      "- [Duplicate](wiki/cache-consistency.md) - ignored",
+    ].join("\n"),
+    wikiConfig("/srv/wiki"),
+  );
+
+  assert.deepEqual(parsed, [
+    {
+      title: "Cache consistency",
+      path: "cache-consistency.md",
+      indexBlurb: "Invalidation and ownership.",
+      indexLine: 2,
+    },
+    {
+      title: "Distributed systems",
+      path: "distributed-systems.md",
+      indexBlurb: "Coordination foundations.",
+      indexLine: 3,
+    },
+  ]);
+});
+
+test("loads a bounded index and falls back to a sorted page listing", async () => {
+  await withWiki(async (rootDir) => {
+    await mkdir(path.join(rootDir, "wiki", "nested"), { recursive: true });
+    await writeFile(path.join(rootDir, "wiki", "zeta.md"), "# Zeta\n");
+    await writeFile(path.join(rootDir, "wiki", "nested", "alpha.md"), "# Alpha\n");
+    await writeFile(path.join(rootDir, "wiki", "ignored.txt"), "ignored\n");
+
+    const fallback = await externalWiki.loadExternalWikiCatalog(wikiConfig(rootDir));
+    assert.equal(fallback.wikiId, "reading");
+    assert.equal(fallback.indexPresent, false);
+    assert.deepEqual(fallback.entries, [
+      { title: "Alpha", path: "nested/alpha.md" },
+      { title: "Zeta", path: "zeta.md" },
+    ]);
+
+    await writeFile(
+      path.join(rootDir, "INDEX.md"),
+      "- [Zeta](wiki/zeta.md) - Last page.\n",
+    );
+    const indexed = await externalWiki.loadExternalWikiCatalog(wikiConfig(rootDir));
+    assert.equal(indexed.indexPresent, true);
+    assert.deepEqual(indexed.entries, [
+      { title: "Zeta", path: "zeta.md", indexBlurb: "Last page.", indexLine: 1 },
+    ]);
+
+    await assert.rejects(
+      () => externalWiki.loadExternalWikiCatalog(wikiConfig(rootDir), { maxIndexBytes: 8 }),
+      /INDEX\.md exceeds 8 bytes/,
+    );
+  });
+});
+
+test("loads concept pages on demand with containment and byte limits", async () => {
+  await withWiki(async (rootDir) => {
+    await mkdir(path.join(rootDir, "wiki"));
+    await writeFile(path.join(rootDir, "wiki", "concept.md"), "# Concept\n\nSource-backed synthesis.\n");
+    await writeFile(path.join(rootDir, "secret.md"), "not a concept page\n");
+
+    const page = await externalWiki.readExternalWikiPage(
+      wikiConfig(rootDir),
+      "concept.md",
+      1_024,
+    );
+    assert.deepEqual(page, {
+      wikiId: "reading",
+      path: "concept.md",
+      title: "Concept",
+      content: "# Concept\n\nSource-backed synthesis.\n",
+      bytes: 36,
+    });
+
+    await assert.rejects(
+      () => externalWiki.readExternalWikiPage(wikiConfig(rootDir), "../secret.md", 1_024),
+      /page path must stay within the pages directory/,
+    );
+    await assert.rejects(
+      () => externalWiki.readExternalWikiPage(wikiConfig(rootDir), "concept.txt", 1_024),
+      /page path must end in \.md/,
+    );
+    await assert.rejects(
+      () => externalWiki.readExternalWikiPage(wikiConfig(rootDir), "concept.md", 8),
+      /concept\.md exceeds 8 bytes/,
+    );
+  });
+});

--- a/packages/remnic-core/src/external-wiki.test.ts
+++ b/packages/remnic-core/src/external-wiki.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 import * as core from "./index.js";
@@ -11,6 +10,7 @@ import type {
   readExternalWikiPage,
   validateExternalWikiLayout,
 } from "./external-wiki.js";
+import { withTempDir } from "./testing/tmp-dir.js";
 
 const externalWiki = core as typeof core & {
   loadExternalWikiCatalog: typeof loadExternalWikiCatalog;
@@ -33,12 +33,7 @@ function wikiConfig(rootDir: string, overrides: Partial<ExternalWikiRoot> = {}):
 }
 
 async function withWiki(run: (rootDir: string) => Promise<void>): Promise<void> {
-  const rootDir = await mkdtemp(path.join(os.tmpdir(), "remnic-external-wiki-"));
-  try {
-    await run(rootDir);
-  } finally {
-    await rm(rootDir, { recursive: true, force: true });
-  }
+  await withTempDir(run, "remnic-external-wiki-");
 }
 
 test("external wiki reader APIs are exported from core", () => {
@@ -73,16 +68,13 @@ test("rejects missing pages directories and symlink escapes", async () => {
       /pages directory does not exist/
     );
 
-    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-wiki-outside-"));
-    try {
+    await withTempDir(async (outsideDir) => {
       await symlink(outsideDir, path.join(rootDir, "wiki"));
       await assert.rejects(
         () => externalWiki.validateExternalWikiLayout(wikiConfig(rootDir)),
         /pages directory escapes rootDir/
       );
-    } finally {
-      await rm(outsideDir, { recursive: true, force: true });
-    }
+    }, "remnic-wiki-outside-");
   });
 });
 
@@ -137,6 +129,14 @@ test("loads a bounded index and falls back to a sorted page listing", async () =
     await assert.rejects(
       () => externalWiki.loadExternalWikiCatalog(wikiConfig(rootDir, { enabled: false })),
       /external wiki "reading" is disabled/
+    );
+    await assert.rejects(
+      () => externalWiki.loadExternalWikiCatalog(wikiConfig(rootDir), { maxEntries: 100_001 }),
+      /maxEntries must be at most 100000/
+    );
+    await assert.rejects(
+      () => externalWiki.loadExternalWikiCatalog(wikiConfig(rootDir), { maxDepth: 129 }),
+      /maxDepth must be at most 128/
     );
 
     await writeFile(path.join(rootDir, "INDEX.md"), "- [Zeta](wiki/zeta.md) - Last page.\n");

--- a/packages/remnic-core/src/external-wiki.test.ts
+++ b/packages/remnic-core/src/external-wiki.test.ts
@@ -32,9 +32,7 @@ function wikiConfig(rootDir: string, overrides: Partial<ExternalWikiRoot> = {}):
   };
 }
 
-async function withWiki(
-  run: (rootDir: string) => Promise<void>,
-): Promise<void> {
+async function withWiki(run: (rootDir: string) => Promise<void>): Promise<void> {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "remnic-external-wiki-"));
   try {
     await run(rootDir);
@@ -72,7 +70,7 @@ test("rejects missing pages directories and symlink escapes", async () => {
   await withWiki(async (rootDir) => {
     await assert.rejects(
       () => externalWiki.validateExternalWikiLayout(wikiConfig(rootDir)),
-      /pages directory does not exist/,
+      /pages directory does not exist/
     );
 
     const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-wiki-outside-"));
@@ -80,7 +78,7 @@ test("rejects missing pages directories and symlink escapes", async () => {
       await symlink(outsideDir, path.join(rootDir, "wiki"));
       await assert.rejects(
         () => externalWiki.validateExternalWikiLayout(wikiConfig(rootDir)),
-        /pages directory escapes rootDir/,
+        /pages directory escapes rootDir/
       );
     } finally {
       await rm(outsideDir, { recursive: true, force: true });
@@ -98,7 +96,7 @@ test("parses markdown and wiki-link catalog entries deterministically", () => {
       "- [Escape](../outside.md) - ignored",
       "- [Duplicate](wiki/cache-consistency.md) - ignored",
     ].join("\n"),
-    wikiConfig("/srv/wiki"),
+    wikiConfig("/srv/wiki")
   );
 
   assert.deepEqual(parsed, [
@@ -132,19 +130,23 @@ test("loads a bounded index and falls back to a sorted page listing", async () =
       { title: "Zeta", path: "zeta.md" },
     ]);
 
-    await writeFile(
-      path.join(rootDir, "INDEX.md"),
-      "- [Zeta](wiki/zeta.md) - Last page.\n",
+    await assert.rejects(
+      () => externalWiki.loadExternalWikiCatalog(wikiConfig(rootDir), { maxEntries: 1 }),
+      /more than 1 markdown files/
     );
+    await assert.rejects(
+      () => externalWiki.loadExternalWikiCatalog(wikiConfig(rootDir, { enabled: false })),
+      /external wiki "reading" is disabled/
+    );
+
+    await writeFile(path.join(rootDir, "INDEX.md"), "- [Zeta](wiki/zeta.md) - Last page.\n");
     const indexed = await externalWiki.loadExternalWikiCatalog(wikiConfig(rootDir));
     assert.equal(indexed.indexPresent, true);
-    assert.deepEqual(indexed.entries, [
-      { title: "Zeta", path: "zeta.md", indexBlurb: "Last page.", indexLine: 1 },
-    ]);
+    assert.deepEqual(indexed.entries, [{ title: "Zeta", path: "zeta.md", indexBlurb: "Last page.", indexLine: 1 }]);
 
     await assert.rejects(
       () => externalWiki.loadExternalWikiCatalog(wikiConfig(rootDir), { maxIndexBytes: 8 }),
-      /INDEX\.md exceeds 8 bytes/,
+      /INDEX\.md exceeds 8 bytes/
     );
   });
 });
@@ -155,11 +157,7 @@ test("loads concept pages on demand with containment and byte limits", async () 
     await writeFile(path.join(rootDir, "wiki", "concept.md"), "# Concept\n\nSource-backed synthesis.\n");
     await writeFile(path.join(rootDir, "secret.md"), "not a concept page\n");
 
-    const page = await externalWiki.readExternalWikiPage(
-      wikiConfig(rootDir),
-      "concept.md",
-      1_024,
-    );
+    const page = await externalWiki.readExternalWikiPage(wikiConfig(rootDir), "concept.md", 1_024);
     assert.deepEqual(page, {
       wikiId: "reading",
       path: "concept.md",
@@ -170,15 +168,41 @@ test("loads concept pages on demand with containment and byte limits", async () 
 
     await assert.rejects(
       () => externalWiki.readExternalWikiPage(wikiConfig(rootDir), "../secret.md", 1_024),
-      /page path must stay within the pages directory/,
+      /page path must stay within the pages directory/
     );
     await assert.rejects(
       () => externalWiki.readExternalWikiPage(wikiConfig(rootDir), "concept.txt", 1_024),
-      /page path must end in \.md/,
+      /page path must end in \.md/
     );
     await assert.rejects(
       () => externalWiki.readExternalWikiPage(wikiConfig(rootDir), "concept.md", 8),
-      /concept\.md exceeds 8 bytes/,
+      /concept\.md exceeds 8 bytes/
+    );
+  });
+});
+
+test("rejects non-portable paths, symlink escapes, invalid UTF-8, and excessive limits", async () => {
+  await withWiki(async (rootDir) => {
+    await mkdir(path.join(rootDir, "wiki"));
+    await writeFile(path.join(rootDir, "wiki", "invalid.md"), Buffer.from([0xc3, 0x28]));
+    await writeFile(path.join(rootDir, "outside.md"), "# Outside\n");
+    await symlink(path.join(rootDir, "outside.md"), path.join(rootDir, "wiki", "escape.md"));
+
+    await assert.rejects(
+      () => externalWiki.readExternalWikiPage(wikiConfig(rootDir), "nested\\page.md"),
+      /page path must use POSIX separators/
+    );
+    await assert.rejects(
+      () => externalWiki.readExternalWikiPage(wikiConfig(rootDir), "escape.md"),
+      /page path must stay within the pages directory/
+    );
+    await assert.rejects(
+      () => externalWiki.readExternalWikiPage(wikiConfig(rootDir), "invalid.md"),
+      /invalid\.md is not valid UTF-8/
+    );
+    await assert.rejects(
+      () => externalWiki.readExternalWikiPage(wikiConfig(rootDir), "invalid.md", 16_777_217),
+      /maxBytes must be at most 16777216/
     );
   });
 });

--- a/packages/remnic-core/src/external-wiki.ts
+++ b/packages/remnic-core/src/external-wiki.ts
@@ -6,6 +6,7 @@ const DEFAULT_MAX_INDEX_BYTES = 1_048_576;
 const DEFAULT_MAX_PAGE_BYTES = 1_048_576;
 const DEFAULT_MAX_CATALOG_ENTRIES = 10_000;
 const DEFAULT_MAX_DIRECTORY_DEPTH = 32;
+const MAX_READ_BYTES = 16_777_216;
 
 export type { ExternalWikiRoot } from "./types.js";
 
@@ -53,11 +54,7 @@ function assertPositiveInteger(value: number, keyName: string): void {
 
 function isInside(baseDir: string, candidate: string): boolean {
   const relative = path.relative(baseDir, candidate);
-  return relative === "" || (
-    relative !== ".." &&
-    !relative.startsWith(`..${path.sep}`) &&
-    !path.isAbsolute(relative)
-  );
+  return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
 }
 
 function resolveInside(baseDir: string, relativePath: string, keyName: string): string {
@@ -68,11 +65,7 @@ function resolveInside(baseDir: string, relativePath: string, keyName: string): 
   return resolved;
 }
 
-async function requireDirectory(
-  candidate: string,
-  rootDir: string,
-  description: string,
-): Promise<string> {
+async function requireDirectory(candidate: string, rootDir: string, description: string): Promise<string> {
   let canonical: string;
   try {
     canonical = await realpath(candidate);
@@ -87,10 +80,7 @@ async function requireDirectory(
   return canonical;
 }
 
-async function optionalDirectory(
-  rootDir: string,
-  name: "raw" | "outputs",
-): Promise<string | undefined> {
+async function optionalDirectory(rootDir: string, name: "raw" | "outputs"): Promise<string | undefined> {
   const candidate = path.join(rootDir, name);
   let canonical: string;
   try {
@@ -104,10 +94,7 @@ async function optionalDirectory(
   return canonical;
 }
 
-async function optionalIndexFile(
-  candidate: string,
-  rootDir: string,
-): Promise<string | undefined> {
+async function optionalIndexFile(candidate: string, rootDir: string): Promise<string | undefined> {
   let canonical: string;
   try {
     canonical = await realpath(candidate);
@@ -120,9 +107,7 @@ async function optionalIndexFile(
   return canonical;
 }
 
-export async function validateExternalWikiLayout(
-  config: ExternalWikiRoot,
-): Promise<ExternalWikiLayout> {
+export async function validateExternalWikiLayout(config: ExternalWikiRoot): Promise<ExternalWikiLayout> {
   let rootDir: string;
   try {
     rootDir = await realpath(config.rootDir);
@@ -137,7 +122,7 @@ export async function validateExternalWikiLayout(
   const pagesDir = await requireDirectory(
     resolveInside(rootDir, config.pagesDir, "pages directory"),
     rootDir,
-    "pages directory",
+    "pages directory"
   );
   const configuredIndexFile = resolveInside(rootDir, config.indexFile, "catalog index");
   const canonicalIndexFile = await optionalIndexFile(configuredIndexFile, rootDir);
@@ -189,14 +174,18 @@ function normalizeCatalogPath(target: string, config: ExternalWikiRoot): string 
 }
 
 function catalogBlurb(line: string, matchEnd: number): string | undefined {
-  const blurb = line.slice(matchEnd).trim().replace(/^[-:|]\s*/, "").trim();
+  const blurb = line
+    .slice(matchEnd)
+    .trim()
+    .replace(/^[-:|]\s*/, "")
+    .trim();
   return blurb.length === 0 ? undefined : blurb;
 }
 
 export function parseExternalWikiCatalog(
   content: string,
   config: ExternalWikiRoot,
-  limits: Pick<ExternalWikiCatalogLimits, "maxEntries"> = {},
+  limits: Pick<ExternalWikiCatalogLimits, "maxEntries"> = {}
 ): ExternalWikiCatalogEntry[] {
   const maxEntries = limits.maxEntries ?? DEFAULT_MAX_CATALOG_ENTRIES;
   assertPositiveInteger(maxEntries, "maxEntries");
@@ -239,18 +228,28 @@ export function parseExternalWikiCatalog(
   return entries;
 }
 
-async function readBoundedUtf8(
-  filePath: string,
-  maxBytes: number,
-  displayPath: string,
-): Promise<string> {
+interface BoundedUtf8Read {
+  content: string;
+  bytes: number;
+}
+
+async function readBoundedUtf8(filePath: string, maxBytes: number, displayPath: string): Promise<BoundedUtf8Read> {
   assertPositiveInteger(maxBytes, "maxBytes");
+  if (maxBytes > MAX_READ_BYTES) {
+    throw new Error(`maxBytes must be at most ${MAX_READ_BYTES}`);
+  }
   const handle = await open(filePath, "r");
   try {
     const buffer = Buffer.allocUnsafe(maxBytes + 1);
     const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
     if (bytesRead > maxBytes) throw new Error(`${displayPath} exceeds ${maxBytes} bytes`);
-    return buffer.subarray(0, bytesRead).toString("utf8");
+    let content: string;
+    try {
+      content = new TextDecoder("utf-8", { fatal: true }).decode(buffer.subarray(0, bytesRead));
+    } catch {
+      throw new Error(`${displayPath} is not valid UTF-8`);
+    }
+    return { content, bytes: bytesRead };
   } finally {
     await handle.close();
   }
@@ -265,7 +264,7 @@ function humanizePagePath(pagePath: string): string {
 async function listMarkdownPages(
   pagesDir: string,
   maxEntries: number,
-  maxDepth: number,
+  maxDepth: number
 ): Promise<ExternalWikiCatalogEntry[]> {
   assertPositiveInteger(maxEntries, "maxEntries");
   assertPositiveInteger(maxDepth, "maxDepth");
@@ -274,9 +273,7 @@ async function listMarkdownPages(
     if (depth > maxDepth) throw new Error(`pages directory exceeds maxDepth ${maxDepth}`);
     const dir = await opendir(directory);
     for await (const entry of dir) {
-      const relativePath = relativeDirectory
-        ? path.posix.join(relativeDirectory, entry.name)
-        : entry.name;
+      const relativePath = relativeDirectory ? path.posix.join(relativeDirectory, entry.name) : entry.name;
       if (entry.isDirectory()) {
         await walk(path.join(directory, entry.name), relativePath, depth + 1);
       } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".md")) {
@@ -288,10 +285,12 @@ async function listMarkdownPages(
     }
   };
   await walk(pagesDir, "", 1);
-  return paths.sort((left, right) => left.localeCompare(right)).map((pagePath) => ({
-    title: humanizePagePath(pagePath),
-    path: pagePath,
-  }));
+  return paths
+    .sort((left, right) => left.localeCompare(right))
+    .map((pagePath) => ({
+      title: humanizePagePath(pagePath),
+      path: pagePath,
+    }));
 }
 
 function assertWikiEnabled(config: ExternalWikiRoot): void {
@@ -300,7 +299,7 @@ function assertWikiEnabled(config: ExternalWikiRoot): void {
 
 export async function loadExternalWikiCatalog(
   config: ExternalWikiRoot,
-  limits: ExternalWikiCatalogLimits = {},
+  limits: ExternalWikiCatalogLimits = {}
 ): Promise<ExternalWikiCatalog> {
   assertWikiEnabled(config);
   const maxIndexBytes = limits.maxIndexBytes ?? DEFAULT_MAX_INDEX_BYTES;
@@ -309,22 +308,20 @@ export async function loadExternalWikiCatalog(
   const layout = await validateExternalWikiLayout(config);
   const entries = layout.indexPresent
     ? parseExternalWikiCatalog(
-        await readBoundedUtf8(layout.indexFile, maxIndexBytes, config.indexFile),
+        (await readBoundedUtf8(layout.indexFile, maxIndexBytes, config.indexFile)).content,
         config,
-        { maxEntries },
+        { maxEntries }
       )
     : await listMarkdownPages(layout.pagesDir, maxEntries, maxDepth);
   return { wikiId: config.id, indexPresent: layout.indexPresent, entries };
 }
 
 function normalizePagePath(relativePath: string): string {
-  const normalized = path.posix.normalize(relativePath.replaceAll("\\", "/"));
-  if (
-    normalized === "." ||
-    normalized === ".." ||
-    normalized.startsWith("../") ||
-    normalized.startsWith("/")
-  ) {
+  if (relativePath.includes("\\")) {
+    throw new Error("page path must use POSIX separators");
+  }
+  const normalized = path.posix.normalize(relativePath);
+  if (normalized === "." || normalized === ".." || normalized.startsWith("../") || normalized.startsWith("/")) {
     throw new Error("page path must stay within the pages directory");
   }
   if (!normalized.toLowerCase().endsWith(".md")) {
@@ -341,7 +338,7 @@ function pageTitle(content: string, pagePath: string): string {
 export async function readExternalWikiPage(
   config: ExternalWikiRoot,
   relativePath: string,
-  maxBytes = DEFAULT_MAX_PAGE_BYTES,
+  maxBytes = DEFAULT_MAX_PAGE_BYTES
 ): Promise<ExternalWikiPage> {
   assertWikiEnabled(config);
   const pagePath = normalizePagePath(relativePath);
@@ -360,12 +357,12 @@ export async function readExternalWikiPage(
     throw new Error("page path must stay within the pages directory");
   }
   if (!(await stat(canonical)).isFile()) throw new Error(`external wiki page is not a file: ${pagePath}`);
-  const content = await readBoundedUtf8(canonical, maxBytes, pagePath);
+  const page = await readBoundedUtf8(canonical, maxBytes, pagePath);
   return {
     wikiId: config.id,
     path: pagePath,
-    title: pageTitle(content, pagePath),
-    content,
-    bytes: Buffer.byteLength(content),
+    title: pageTitle(page.content, pagePath),
+    content: page.content,
+    bytes: page.bytes,
   };
 }

--- a/packages/remnic-core/src/external-wiki.ts
+++ b/packages/remnic-core/src/external-wiki.ts
@@ -1,0 +1,371 @@
+import { open, opendir, realpath, stat } from "node:fs/promises";
+import path from "node:path";
+import type { ExternalWikiRoot } from "./types.js";
+
+const DEFAULT_MAX_INDEX_BYTES = 1_048_576;
+const DEFAULT_MAX_PAGE_BYTES = 1_048_576;
+const DEFAULT_MAX_CATALOG_ENTRIES = 10_000;
+const DEFAULT_MAX_DIRECTORY_DEPTH = 32;
+
+export type { ExternalWikiRoot } from "./types.js";
+
+export interface ExternalWikiLayout {
+  rootDir: string;
+  pagesDir: string;
+  indexFile: string;
+  indexPresent: boolean;
+  rawDir?: string;
+  outputsDir?: string;
+}
+
+export interface ExternalWikiCatalogEntry {
+  title: string;
+  path: string;
+  indexBlurb?: string;
+  indexLine?: number;
+}
+
+export interface ExternalWikiCatalog {
+  wikiId: string;
+  indexPresent: boolean;
+  entries: ExternalWikiCatalogEntry[];
+}
+
+export interface ExternalWikiCatalogLimits {
+  maxIndexBytes?: number;
+  maxEntries?: number;
+  maxDepth?: number;
+}
+
+export interface ExternalWikiPage {
+  wikiId: string;
+  path: string;
+  title: string;
+  content: string;
+  bytes: number;
+}
+
+function assertPositiveInteger(value: number, keyName: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${keyName} must be a positive integer`);
+  }
+}
+
+function isInside(baseDir: string, candidate: string): boolean {
+  const relative = path.relative(baseDir, candidate);
+  return relative === "" || (
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+function resolveInside(baseDir: string, relativePath: string, keyName: string): string {
+  const resolved = path.resolve(baseDir, relativePath);
+  if (!isInside(baseDir, resolved) || resolved === baseDir) {
+    throw new Error(`${keyName} must stay within ${baseDir}`);
+  }
+  return resolved;
+}
+
+async function requireDirectory(
+  candidate: string,
+  rootDir: string,
+  description: string,
+): Promise<string> {
+  let canonical: string;
+  try {
+    canonical = await realpath(candidate);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`${description} does not exist: ${candidate}`);
+    }
+    throw error;
+  }
+  if (!isInside(rootDir, canonical)) throw new Error(`${description} escapes rootDir`);
+  if (!(await stat(canonical)).isDirectory()) throw new Error(`${description} is not a directory`);
+  return canonical;
+}
+
+async function optionalDirectory(
+  rootDir: string,
+  name: "raw" | "outputs",
+): Promise<string | undefined> {
+  const candidate = path.join(rootDir, name);
+  let canonical: string;
+  try {
+    canonical = await realpath(candidate);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+  if (!isInside(rootDir, canonical)) throw new Error(`${name} directory escapes rootDir`);
+  if (!(await stat(canonical)).isDirectory()) throw new Error(`${name} path is not a directory`);
+  return canonical;
+}
+
+async function optionalIndexFile(
+  candidate: string,
+  rootDir: string,
+): Promise<string | undefined> {
+  let canonical: string;
+  try {
+    canonical = await realpath(candidate);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+  if (!isInside(rootDir, canonical)) throw new Error("catalog index escapes rootDir");
+  if (!(await stat(canonical)).isFile()) throw new Error("catalog index is not a file");
+  return canonical;
+}
+
+export async function validateExternalWikiLayout(
+  config: ExternalWikiRoot,
+): Promise<ExternalWikiLayout> {
+  let rootDir: string;
+  try {
+    rootDir = await realpath(config.rootDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`external wiki root does not exist: ${config.rootDir}`);
+    }
+    throw error;
+  }
+  if (!(await stat(rootDir)).isDirectory()) throw new Error("external wiki root is not a directory");
+
+  const pagesDir = await requireDirectory(
+    resolveInside(rootDir, config.pagesDir, "pages directory"),
+    rootDir,
+    "pages directory",
+  );
+  const configuredIndexFile = resolveInside(rootDir, config.indexFile, "catalog index");
+  const canonicalIndexFile = await optionalIndexFile(configuredIndexFile, rootDir);
+  const [rawDir, outputsDir] = await Promise.all([
+    optionalDirectory(rootDir, "raw"),
+    optionalDirectory(rootDir, "outputs"),
+  ]);
+
+  return {
+    rootDir,
+    pagesDir,
+    indexFile: canonicalIndexFile ?? configuredIndexFile,
+    indexPresent: canonicalIndexFile !== undefined,
+    ...(rawDir === undefined ? {} : { rawDir }),
+    ...(outputsDir === undefined ? {} : { outputsDir }),
+  };
+}
+
+function normalizeCatalogPath(target: string, config: ExternalWikiRoot): string | null {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(target.trim());
+  } catch {
+    return null;
+  }
+  const withoutFragment = decoded.split(/[?#]/, 1)[0] ?? "";
+  if (
+    withoutFragment.length === 0 ||
+    withoutFragment.startsWith("/") ||
+    withoutFragment.startsWith("\\") ||
+    /^[a-z][a-z0-9+.-]*:/i.test(withoutFragment)
+  ) {
+    return null;
+  }
+
+  let relative = withoutFragment.replaceAll("\\", "/").replace(/^\.\//, "");
+  const pagesPrefix = `${config.pagesDir.replaceAll("\\", "/").replace(/\/$/, "")}/`;
+  if (relative.startsWith(pagesPrefix)) relative = relative.slice(pagesPrefix.length);
+  const normalized = path.posix.normalize(relative);
+  if (
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized === "." ||
+    !normalized.toLowerCase().endsWith(".md")
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+function catalogBlurb(line: string, matchEnd: number): string | undefined {
+  const blurb = line.slice(matchEnd).trim().replace(/^[-:|]\s*/, "").trim();
+  return blurb.length === 0 ? undefined : blurb;
+}
+
+export function parseExternalWikiCatalog(
+  content: string,
+  config: ExternalWikiRoot,
+  limits: Pick<ExternalWikiCatalogLimits, "maxEntries"> = {},
+): ExternalWikiCatalogEntry[] {
+  const maxEntries = limits.maxEntries ?? DEFAULT_MAX_CATALOG_ENTRIES;
+  assertPositiveInteger(maxEntries, "maxEntries");
+  const entries: ExternalWikiCatalogEntry[] = [];
+  const seenPaths = new Set<string>();
+
+  for (const [lineIndex, line] of content.split(/\r?\n/).entries()) {
+    const markdownMatch = /\[([^\]]+)]\(([^)\s]+)(?:\s+"[^"]*")?\)/.exec(line);
+    const wikiMatch = /\[\[([^\]|]+)(?:\|([^\]]+))?]]/.exec(line);
+    let target: string;
+    let title: string;
+    let matchEnd: number;
+    if (markdownMatch) {
+      title = markdownMatch[1]?.trim() ?? "";
+      target = markdownMatch[2]?.trim() ?? "";
+      matchEnd = (markdownMatch.index ?? 0) + markdownMatch[0].length;
+    } else if (wikiMatch) {
+      const wikiTarget = wikiMatch[1]?.trim() ?? "";
+      title = wikiMatch[2]?.trim() || humanizePagePath(wikiTarget);
+      target = wikiTarget.toLowerCase().endsWith(".md") ? wikiTarget : `${wikiTarget}.md`;
+      matchEnd = (wikiMatch.index ?? 0) + wikiMatch[0].length;
+    } else {
+      continue;
+    }
+
+    const pagePath = normalizeCatalogPath(target, config);
+    if (!pagePath || title.length === 0 || seenPaths.has(pagePath)) continue;
+    if (entries.length >= maxEntries) {
+      throw new Error(`catalog contains more than ${maxEntries} entries`);
+    }
+    seenPaths.add(pagePath);
+    const indexBlurb = catalogBlurb(line, matchEnd);
+    entries.push({
+      title,
+      path: pagePath,
+      ...(indexBlurb === undefined ? {} : { indexBlurb }),
+      indexLine: lineIndex + 1,
+    });
+  }
+  return entries;
+}
+
+async function readBoundedUtf8(
+  filePath: string,
+  maxBytes: number,
+  displayPath: string,
+): Promise<string> {
+  assertPositiveInteger(maxBytes, "maxBytes");
+  const handle = await open(filePath, "r");
+  try {
+    const buffer = Buffer.allocUnsafe(maxBytes + 1);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    if (bytesRead > maxBytes) throw new Error(`${displayPath} exceeds ${maxBytes} bytes`);
+    return buffer.subarray(0, bytesRead).toString("utf8");
+  } finally {
+    await handle.close();
+  }
+}
+
+function humanizePagePath(pagePath: string): string {
+  const stem = path.posix.basename(pagePath, path.posix.extname(pagePath));
+  const words = stem.replace(/[-_]+/g, " ").trim();
+  return words.length === 0 ? stem : `${words[0]?.toUpperCase() ?? ""}${words.slice(1)}`;
+}
+
+async function listMarkdownPages(
+  pagesDir: string,
+  maxEntries: number,
+  maxDepth: number,
+): Promise<ExternalWikiCatalogEntry[]> {
+  assertPositiveInteger(maxEntries, "maxEntries");
+  assertPositiveInteger(maxDepth, "maxDepth");
+  const paths: string[] = [];
+  const walk = async (directory: string, relativeDirectory: string, depth: number): Promise<void> => {
+    if (depth > maxDepth) throw new Error(`pages directory exceeds maxDepth ${maxDepth}`);
+    const dir = await opendir(directory);
+    for await (const entry of dir) {
+      const relativePath = relativeDirectory
+        ? path.posix.join(relativeDirectory, entry.name)
+        : entry.name;
+      if (entry.isDirectory()) {
+        await walk(path.join(directory, entry.name), relativePath, depth + 1);
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".md")) {
+        if (paths.length >= maxEntries) {
+          throw new Error(`pages directory contains more than ${maxEntries} markdown files`);
+        }
+        paths.push(relativePath);
+      }
+    }
+  };
+  await walk(pagesDir, "", 1);
+  return paths.sort((left, right) => left.localeCompare(right)).map((pagePath) => ({
+    title: humanizePagePath(pagePath),
+    path: pagePath,
+  }));
+}
+
+function assertWikiEnabled(config: ExternalWikiRoot): void {
+  if (!config.enabled) throw new Error(`external wiki "${config.id}" is disabled`);
+}
+
+export async function loadExternalWikiCatalog(
+  config: ExternalWikiRoot,
+  limits: ExternalWikiCatalogLimits = {},
+): Promise<ExternalWikiCatalog> {
+  assertWikiEnabled(config);
+  const maxIndexBytes = limits.maxIndexBytes ?? DEFAULT_MAX_INDEX_BYTES;
+  const maxEntries = limits.maxEntries ?? DEFAULT_MAX_CATALOG_ENTRIES;
+  const maxDepth = limits.maxDepth ?? DEFAULT_MAX_DIRECTORY_DEPTH;
+  const layout = await validateExternalWikiLayout(config);
+  const entries = layout.indexPresent
+    ? parseExternalWikiCatalog(
+        await readBoundedUtf8(layout.indexFile, maxIndexBytes, config.indexFile),
+        config,
+        { maxEntries },
+      )
+    : await listMarkdownPages(layout.pagesDir, maxEntries, maxDepth);
+  return { wikiId: config.id, indexPresent: layout.indexPresent, entries };
+}
+
+function normalizePagePath(relativePath: string): string {
+  const normalized = path.posix.normalize(relativePath.replaceAll("\\", "/"));
+  if (
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.startsWith("/")
+  ) {
+    throw new Error("page path must stay within the pages directory");
+  }
+  if (!normalized.toLowerCase().endsWith(".md")) {
+    throw new Error("page path must end in .md");
+  }
+  return normalized;
+}
+
+function pageTitle(content: string, pagePath: string): string {
+  const heading = /^#\s+(.+?)\s*$/m.exec(content)?.[1]?.trim();
+  return heading && heading.length > 0 ? heading : humanizePagePath(pagePath);
+}
+
+export async function readExternalWikiPage(
+  config: ExternalWikiRoot,
+  relativePath: string,
+  maxBytes = DEFAULT_MAX_PAGE_BYTES,
+): Promise<ExternalWikiPage> {
+  assertWikiEnabled(config);
+  const pagePath = normalizePagePath(relativePath);
+  const layout = await validateExternalWikiLayout(config);
+  const candidate = resolveInside(layout.pagesDir, pagePath, "page path");
+  let canonical: string;
+  try {
+    canonical = await realpath(candidate);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`external wiki page does not exist: ${pagePath}`);
+    }
+    throw error;
+  }
+  if (!isInside(layout.pagesDir, canonical)) {
+    throw new Error("page path must stay within the pages directory");
+  }
+  if (!(await stat(canonical)).isFile()) throw new Error(`external wiki page is not a file: ${pagePath}`);
+  const content = await readBoundedUtf8(canonical, maxBytes, pagePath);
+  return {
+    wikiId: config.id,
+    path: pagePath,
+    title: pageTitle(content, pagePath),
+    content,
+    bytes: Buffer.byteLength(content),
+  };
+}

--- a/packages/remnic-core/src/external-wiki.ts
+++ b/packages/remnic-core/src/external-wiki.ts
@@ -7,6 +7,8 @@ const DEFAULT_MAX_PAGE_BYTES = 1_048_576;
 const DEFAULT_MAX_CATALOG_ENTRIES = 10_000;
 const DEFAULT_MAX_DIRECTORY_DEPTH = 32;
 const MAX_READ_BYTES = 16_777_216;
+const MAX_CATALOG_ENTRIES = 100_000;
+const MAX_DIRECTORY_DEPTH = 128;
 
 export type { ExternalWikiRoot } from "./types.js";
 
@@ -46,9 +48,12 @@ export interface ExternalWikiPage {
   bytes: number;
 }
 
-function assertPositiveInteger(value: number, keyName: string): void {
+function assertPositiveInteger(value: number, keyName: string, maximum?: number): void {
   if (!Number.isSafeInteger(value) || value <= 0) {
     throw new Error(`${keyName} must be a positive integer`);
+  }
+  if (maximum !== undefined && value > maximum) {
+    throw new Error(`${keyName} must be at most ${maximum}`);
   }
 }
 
@@ -188,7 +193,7 @@ export function parseExternalWikiCatalog(
   limits: Pick<ExternalWikiCatalogLimits, "maxEntries"> = {}
 ): ExternalWikiCatalogEntry[] {
   const maxEntries = limits.maxEntries ?? DEFAULT_MAX_CATALOG_ENTRIES;
-  assertPositiveInteger(maxEntries, "maxEntries");
+  assertPositiveInteger(maxEntries, "maxEntries", MAX_CATALOG_ENTRIES);
   const entries: ExternalWikiCatalogEntry[] = [];
   const seenPaths = new Set<string>();
 
@@ -234,10 +239,7 @@ interface BoundedUtf8Read {
 }
 
 async function readBoundedUtf8(filePath: string, maxBytes: number, displayPath: string): Promise<BoundedUtf8Read> {
-  assertPositiveInteger(maxBytes, "maxBytes");
-  if (maxBytes > MAX_READ_BYTES) {
-    throw new Error(`maxBytes must be at most ${MAX_READ_BYTES}`);
-  }
+  assertPositiveInteger(maxBytes, "maxBytes", MAX_READ_BYTES);
   const handle = await open(filePath, "r");
   try {
     const buffer = Buffer.allocUnsafe(maxBytes + 1);
@@ -266,8 +268,8 @@ async function listMarkdownPages(
   maxEntries: number,
   maxDepth: number
 ): Promise<ExternalWikiCatalogEntry[]> {
-  assertPositiveInteger(maxEntries, "maxEntries");
-  assertPositiveInteger(maxDepth, "maxDepth");
+  assertPositiveInteger(maxEntries, "maxEntries", MAX_CATALOG_ENTRIES);
+  assertPositiveInteger(maxDepth, "maxDepth", MAX_DIRECTORY_DEPTH);
   const paths: string[] = [];
   const walk = async (directory: string, relativeDirectory: string, depth: number): Promise<void> => {
     if (depth > maxDepth) throw new Error(`pages directory exceeds maxDepth ${maxDepth}`);
@@ -305,6 +307,8 @@ export async function loadExternalWikiCatalog(
   const maxIndexBytes = limits.maxIndexBytes ?? DEFAULT_MAX_INDEX_BYTES;
   const maxEntries = limits.maxEntries ?? DEFAULT_MAX_CATALOG_ENTRIES;
   const maxDepth = limits.maxDepth ?? DEFAULT_MAX_DIRECTORY_DEPTH;
+  assertPositiveInteger(maxEntries, "maxEntries", MAX_CATALOG_ENTRIES);
+  assertPositiveInteger(maxDepth, "maxDepth", MAX_DIRECTORY_DEPTH);
   const layout = await validateExternalWikiLayout(config);
   const entries = layout.indexPresent
     ? parseExternalWikiCatalog(

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -28,6 +28,7 @@ export { resolvePluginEntry, type PluginEntryResolverOptions } from "./plugin-en
 
 export { parseConfig, isOpenaiApiKeyDisabled, resolveEnvVars } from "./config.js";
 export { resolveRemnicConfigRecord } from "./config-record.js";
+export * from "./external-wiki.js";
 export {
   parseFlexibleIsoTimestamp,
   parseIsoOffsetTimestamp,

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -670,6 +670,17 @@ export interface SemanticChunkingConfigShape {
   fallbackToRecursive: boolean;
 }
 
+export interface ExternalWikiRoot {
+  id: string;
+  rootDir: string;
+  enabled: boolean;
+  label?: string;
+  pagesDir: string;
+  indexFile: string;
+  indexInQmd: boolean;
+  includeInDefaultRecall: false;
+}
+
 export interface PluginConfig extends BoundedJsonlStateConfig {
   openaiApiKey: string | undefined;
   openaiBaseUrl: string | undefined;
@@ -785,6 +796,7 @@ export interface PluginConfig extends BoundedJsonlStateConfig {
   /** Optional absolute path to qmd binary. If unset, PATH/fallback discovery is used. */
   qmdPath?: string;
   memoryDir: string;
+  externalWikis: ExternalWikiRoot[];
   debug: boolean;
   identityEnabled: boolean;
   identityContinuityEnabled: boolean;


### PR DESCRIPTION
Closes #2058. ExternalWikiRoot config, filesystem layout reader, catalog/index parser, concept-page loader.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New filesystem reads with path containment and symlink checks; misconfiguration could still expose unintended paths, but writes and default recall are out of scope.
> 
> **Overview**
> Adds **`externalWikis`** to plugin config so Remnic can point at read-only, compiled knowledge wikis outside **`memoryDir`**. Each root gets an id, absolute/`~` **`rootDir`**, optional label, **`pagesDir`** / **`indexFile`**, and flags like **`indexInQmd`**; **`includeInDefaultRecall`** is parsed but rejected if set true.
> 
> New **`external-wiki`** APIs validate layout (pages dir, optional index, `raw`/`outputs`), **`realpath`** containment against symlink escapes, parse **`INDEX.md`** markdown/wiki-link catalogs (or fall back to a sorted `.md` tree walk), and load concept pages with UTF-8 and byte/depth/entry caps. **`@remnic/core`** re-exports these helpers for callers; this PR does not wire them into default recall or tools yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f751897c6fdf0baac28a9e883641262ef92ddb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring external knowledge wikis.
  * Added catalog loading, Markdown page discovery, and page title detection.
  * Added secure, bounded page reading with validation for paths, symlinks, file sizes, directory depth, and entry counts.
  * Supports indexed wikis and recursive discovery when no index is available.

* **Bug Fixes**
  * Improved configuration validation for invalid paths, duplicate identifiers, unsupported options, and unsafe wiki locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->