### PR TITLE
feat(core): optional dedicated QMD collection for wiki concept pages (#2060)

### DIFF
--- a/packages/remnic-core/src/external-wiki-collection-registration.test.ts
+++ b/packages/remnic-core/src/external-wiki-collection-registration.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  type ExternalWikiCollectionRefreshTarget,
+  ExternalWikiCollectionRegistrar,
+} from "./external-wiki-collection-registration.js";
+import type { ExternalWikiCollectionRoot } from "./external-wiki-collection.js";
+
+interface TimerFixture {
+  schedule(callback: () => void, intervalMs: number): object;
+  cancel(handle: object): void;
+  callbacks: Array<() => void>;
+  intervals: number[];
+  cancelled: object[];
+}
+
+function makeTimerFixture(): TimerFixture {
+  const callbacks: Array<() => void> = [];
+  const intervals: number[] = [];
+  const cancelled: object[] = [];
+  return {
+    schedule(callback, intervalMs) {
+      callbacks.push(callback);
+      intervals.push(intervalMs);
+      return { callback };
+    },
+    cancel(handle) {
+      cancelled.push(handle);
+    },
+    callbacks,
+    intervals,
+    cancelled,
+  };
+}
+
+const roots: ExternalWikiCollectionRoot[] = [
+  {
+    id: "reading",
+    rootDir: "/tmp/wiki",
+    enabled: true,
+    pagesDir: "wiki",
+    indexInQmd: true,
+  },
+];
+
+test("registrar refreshes at startup and on its documented maintenance interval", async () => {
+  const timers = makeTimerFixture();
+  const calls: ExternalWikiCollectionRoot[][] = [];
+  const target: ExternalWikiCollectionRefreshTarget = {
+    refresh: async (configuredRoots) => {
+      calls.push([...configuredRoots]);
+      return [];
+    },
+  };
+  const registrar = new ExternalWikiCollectionRegistrar({
+    target,
+    getRoots: () => roots,
+    intervalMs: 15 * 60_000,
+    timers,
+  });
+
+  await registrar.register();
+  timers.callbacks[0]?.();
+  await registrar.waitForIdle();
+
+  assert.equal(calls.length, 2);
+  assert.deepEqual(timers.intervals, [15 * 60_000]);
+  await registrar.dispose();
+  assert.equal(timers.cancelled.length, 1);
+});
+
+test("registrar single-flights overlapping maintenance ticks", async () => {
+  const timers = makeTimerFixture();
+  let release!: () => void;
+  const blocked = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let callCount = 0;
+  const target: ExternalWikiCollectionRefreshTarget = {
+    refresh: async () => {
+      callCount += 1;
+      if (callCount > 1) await blocked;
+      return [];
+    },
+  };
+  const registrar = new ExternalWikiCollectionRegistrar({
+    target,
+    getRoots: () => roots,
+    intervalMs: 1000,
+    timers,
+  });
+  await registrar.register();
+
+  timers.callbacks[0]?.();
+  timers.callbacks[0]?.();
+  await Promise.resolve();
+  assert.equal(callCount, 2);
+
+  release();
+  await registrar.waitForIdle();
+  await registrar.dispose();
+});
+
+test("a failed maintenance tick clears singleflight state for the next tick", async () => {
+  const timers = makeTimerFixture();
+  let callCount = 0;
+  const target: ExternalWikiCollectionRefreshTarget = {
+    refresh: async () => {
+      callCount += 1;
+      if (callCount === 2) throw new Error("backend unavailable");
+      return [];
+    },
+  };
+  const registrar = new ExternalWikiCollectionRegistrar({
+    target,
+    getRoots: () => roots,
+    intervalMs: 1000,
+    timers,
+  });
+  await registrar.register();
+
+  timers.callbacks[0]?.();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  timers.callbacks[0]?.();
+  await registrar.waitForIdle();
+
+  assert.equal(callCount, 3);
+  await registrar.dispose();
+});
+
+test("dispose aborts and drains an in-flight refresh", async () => {
+  const timers = makeTimerFixture();
+  let observedSignal: AbortSignal | undefined;
+  let release!: () => void;
+  const blocked = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let callCount = 0;
+  const target: ExternalWikiCollectionRefreshTarget = {
+    refresh: async (_configuredRoots, execution) => {
+      callCount += 1;
+      observedSignal = execution?.signal;
+      if (callCount > 1) await blocked;
+      return [];
+    },
+  };
+  const registrar = new ExternalWikiCollectionRegistrar({
+    target,
+    getRoots: () => roots,
+    intervalMs: 1000,
+    timers,
+  });
+  await registrar.register();
+  timers.callbacks[0]?.();
+  await Promise.resolve();
+
+  const disposing = registrar.dispose();
+  assert.equal(observedSignal?.aborted, true);
+  release();
+  await disposing;
+
+  assert.equal(timers.cancelled.length, 1);
+});

--- a/packages/remnic-core/src/external-wiki-collection-registration.ts
+++ b/packages/remnic-core/src/external-wiki-collection-registration.ts
@@ -1,0 +1,101 @@
+import type { ExternalWikiCollectionRoot, ExternalWikiCollectionStatus } from "./external-wiki-collection.js";
+import type { SearchExecutionOptions } from "./search/port.js";
+
+export interface ExternalWikiCollectionRefreshTarget {
+  refresh(
+    roots: readonly ExternalWikiCollectionRoot[],
+    execution?: SearchExecutionOptions
+  ): Promise<ExternalWikiCollectionStatus[]>;
+}
+
+export interface ExternalWikiCollectionTimers {
+  schedule(callback: () => void, intervalMs: number): object;
+  cancel(handle: object): void;
+}
+
+export interface ExternalWikiCollectionRegistrarOptions {
+  target: ExternalWikiCollectionRefreshTarget;
+  getRoots: () => readonly ExternalWikiCollectionRoot[];
+  intervalMs: number;
+  timers?: ExternalWikiCollectionTimers;
+}
+
+const defaultTimers: ExternalWikiCollectionTimers = {
+  schedule(callback, intervalMs) {
+    const handle = setInterval(callback, intervalMs);
+    handle.unref();
+    return handle;
+  },
+  cancel(handle) {
+    clearInterval(handle as NodeJS.Timeout);
+  },
+};
+
+export class ExternalWikiCollectionRegistrar {
+  private readonly timers: ExternalWikiCollectionTimers;
+  private timer: object | null = null;
+  private controller: AbortController | null = null;
+  private inFlight: Promise<void> | null = null;
+  private disposed = true;
+  private parentSignal: AbortSignal | null = null;
+  private parentAbortListener: (() => void) | null = null;
+
+  constructor(private readonly options: ExternalWikiCollectionRegistrarOptions) {
+    this.timers = options.timers ?? defaultTimers;
+  }
+
+  async register(signal?: AbortSignal): Promise<void> {
+    await this.dispose();
+    if (signal?.aborted) return;
+
+    this.disposed = false;
+    this.controller = new AbortController();
+    if (signal) {
+      this.parentSignal = signal;
+      this.parentAbortListener = () => this.controller?.abort();
+      signal.addEventListener("abort", this.parentAbortListener, { once: true });
+    }
+
+    await this.refreshNow();
+    if (this.disposed || this.controller.signal.aborted) return;
+    this.timer = this.timers.schedule(() => {
+      void this.refreshNow().catch(() => undefined);
+    }, this.options.intervalMs);
+  }
+
+  async refreshNow(): Promise<void> {
+    if (this.disposed || this.controller?.signal.aborted) return;
+    if (this.inFlight) return this.inFlight;
+
+    const execution = this.controller ? { signal: this.controller.signal } : undefined;
+    const running = this.options.target.refresh(this.options.getRoots(), execution).then(() => undefined);
+    this.inFlight = running;
+    const clearInFlight = () => {
+      if (this.inFlight === running) this.inFlight = null;
+    };
+    void running.then(clearInFlight, clearInFlight);
+    return running;
+  }
+
+  async waitForIdle(): Promise<void> {
+    while (this.inFlight) {
+      await this.inFlight;
+    }
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    if (this.timer) {
+      this.timers.cancel(this.timer);
+      this.timer = null;
+    }
+    this.controller?.abort();
+    if (this.parentSignal && this.parentAbortListener) {
+      this.parentSignal.removeEventListener("abort", this.parentAbortListener);
+    }
+    this.parentSignal = null;
+    this.parentAbortListener = null;
+    await this.waitForIdle();
+    this.controller = null;
+  }
+}

--- a/packages/remnic-core/src/external-wiki-collection.test.ts
+++ b/packages/remnic-core/src/external-wiki-collection.test.ts
@@ -1,0 +1,502 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  type ExternalWikiCollectionBackend,
+  ExternalWikiCollectionManager,
+  type ExternalWikiCollectionRoot,
+  externalWikiCollectionName,
+} from "./external-wiki-collection.js";
+import { NoopSearchBackend } from "./search/noop-backend.js";
+import type { SearchResult } from "./search/port.js";
+
+interface BackendFixture {
+  backend: ExternalWikiCollectionBackend;
+  calls: string[];
+  results: SearchResult[];
+  collectionCounts: Map<string, number>;
+  collectionRoots: Map<string, string>;
+}
+
+function makeBackendFixture(overrides: Partial<ExternalWikiCollectionBackend> = {}): BackendFixture {
+  const calls: string[] = [];
+  const results: SearchResult[] = [];
+  const collectionCounts = new Map<string, number>([["memories", 7]]);
+  const collectionRoots = new Map<string, string>();
+  const backend: ExternalWikiCollectionBackend = {
+    supportsAdditionalCollections: () => true,
+    ensureCollection: async (rootDir, collection) => {
+      calls.push(`ensure:${collection}:${rootDir}`);
+      if (!collectionRoots.has(collection)) {
+        collectionCounts.set(collection, 1);
+        collectionRoots.set(collection, rootDir);
+      }
+      return "present";
+    },
+    excludeCollectionFromGlobalSearch: async (collection) => {
+      calls.push(`exclude:${collection}`);
+    },
+    updateCollectionStrict: async (collection) => {
+      calls.push(`update:${collection}`);
+    },
+    embedCollection: async (collection) => {
+      calls.push(`embed:${collection}`);
+    },
+    embedCollectionStrict: async (collection) => {
+      calls.push(`embed:${collection}`);
+    },
+    hybridSearch: async (_query, collection) => {
+      calls.push(`search:${collection}`);
+      return results;
+    },
+    collectionRoot: async (collection) => collectionRoots.get(collection) ?? null,
+    deleteCollection: async (collection) => {
+      calls.push(`delete:${collection}`);
+      collectionCounts.delete(collection);
+      collectionRoots.delete(collection);
+      return true;
+    },
+    collectionStatus: async (collection) => ({
+      totalFiles: collectionCounts.get(collection) ?? null,
+    }),
+  };
+  Object.assign(backend, overrides);
+  return { backend, calls, results, collectionCounts, collectionRoots };
+}
+
+async function makeWiki(): Promise<{ rootDir: string; pagesDir: string }> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "remnic-external-wiki-"));
+  const pagesDir = path.join(rootDir, "wiki");
+  await mkdir(pagesDir);
+  await mkdir(path.join(rootDir, "raw"));
+  await writeFile(path.join(pagesDir, "retrieval.md"), "# Retrieval\n\nMeaning before exact words.\n", "utf8");
+  await writeFile(path.join(rootDir, "raw", "capture.md"), "raw source", "utf8");
+  return { rootDir, pagesDir };
+}
+
+function root(rootDir: string, overrides: Partial<ExternalWikiCollectionRoot> = {}): ExternalWikiCollectionRoot {
+  return {
+    id: "reading",
+    rootDir,
+    enabled: true,
+    pagesDir: "wiki",
+    indexInQmd: true,
+    ...overrides,
+  };
+}
+
+test("external wiki collection names are dedicated and predictable", () => {
+  assert.equal(externalWikiCollectionName("Reading Notes"), "external-wiki-reading-notes");
+  assert.throws(() => externalWikiCollectionName("---"), /usable characters/i);
+});
+
+test("wiki ids that sanitize to the same collection are rejected together", async () => {
+  const wiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture();
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+
+    const statuses = await manager.refresh([
+      root(wiki.rootDir, { id: "Reading Notes" }),
+      root(wiki.rootDir, { id: "reading-notes" }),
+    ]);
+
+    assert.deepEqual(
+      statuses.map((status) => status.state),
+      ["error", "error"]
+    );
+    assert.ok(statuses.every((status) => status.lastError?.includes("same dedicated collection")));
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("opt-in indexing targets only pagesDir and preserves the default collection", async () => {
+  const wiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture();
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+
+    const statuses = await manager.refresh([root(wiki.rootDir)]);
+
+    assert.deepEqual(fixture.calls, [
+      `ensure:external-wiki-reading:${wiki.pagesDir}`,
+      "exclude:external-wiki-reading",
+      "update:external-wiki-reading",
+      "embed:external-wiki-reading",
+    ]);
+    assert.equal(fixture.collectionCounts.get("memories"), 7);
+    assert.equal(statuses[0]?.collection, "external-wiki-reading");
+    assert.equal(statuses[0]?.documentCount, 1);
+    assert.equal(statuses[0]?.state, "healthy");
+    assert.ok(statuses[0]?.lastIndexedAt);
+  } finally {
+
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+test("changing a wiki pages root rebinds its existing collection", async () => {
+  const firstWiki = await makeWiki();
+  const secondWiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture();
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+    await manager.refresh([root(firstWiki.rootDir)]);
+    fixture.calls.length = 0;
+
+    const statuses = await manager.refresh([root(secondWiki.rootDir)]);
+
+    assert.equal(statuses[0]?.state, "healthy");
+    assert.deepEqual(fixture.calls, [
+      `ensure:external-wiki-reading:${secondWiki.pagesDir}`,
+      "delete:external-wiki-reading",
+      `ensure:external-wiki-reading:${secondWiki.pagesDir}`,
+      "exclude:external-wiki-reading",
+      "update:external-wiki-reading",
+      "embed:external-wiki-reading",
+    ]);
+    assert.equal(fixture.collectionRoots.get("external-wiki-reading"), secondWiki.pagesDir);
+  } finally {
+    await rm(firstWiki.rootDir, { recursive: true, force: true });
+    await rm(secondWiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("unchanged pages skip work and changed pages trigger an incremental refresh", async () => {
+  const wiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture();
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+    const configuredRoot = root(wiki.rootDir);
+    await manager.refresh([configuredRoot]);
+    fixture.calls.length = 0;
+
+    await manager.refresh([configuredRoot]);
+    assert.deepEqual(fixture.calls, []);
+
+    await writeFile(
+      path.join(wiki.pagesDir, "retrieval.md"),
+      "# Retrieval\n\nMeaning survives a paraphrase and a changed page.\n",
+      "utf8"
+    );
+    await manager.refresh([configuredRoot]);
+
+    assert.deepEqual(fixture.calls, [
+      `ensure:external-wiki-reading:${wiki.pagesDir}`,
+      "exclude:external-wiki-reading",
+      "update:external-wiki-reading",
+      "embed:external-wiki-reading",
+    ]);
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("pagesDir cannot escape the configured wiki root", async () => {
+  const wiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture();
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+
+    const statuses = await manager.refresh([root(wiki.rootDir, { pagesDir: "../raw" })]);
+
+    assert.equal(statuses[0]?.state, "error");
+    assert.match(statuses[0]?.lastError ?? "", /pagesDir must stay inside/i);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("pagesDir symlinks cannot escape the configured wiki root", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "remnic-external-wiki-root-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-external-wiki-outside-"));
+  try {
+    await writeFile(path.join(outsideDir, "outside.md"), "# Outside", "utf8");
+    await symlink(outsideDir, path.join(rootDir, "wiki"), "dir");
+    const fixture = makeBackendFixture();
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+
+    const statuses = await manager.refresh([root(rootDir)]);
+
+    assert.equal(statuses[0]?.state, "error");
+    assert.match(statuses[0]?.lastError ?? "", /pagesDir must stay inside/i);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    await rm(rootDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("default-off and disabled roots never touch the search backend", async () => {
+  const wiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture();
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+
+    const statuses = await manager.refresh([
+      root(wiki.rootDir, { id: "off", indexInQmd: false }),
+      root(wiki.rootDir, { id: "disabled", enabled: false }),
+    ]);
+
+    assert.deepEqual(fixture.calls, []);
+    assert.deepEqual(
+      statuses.map((status) => status.state),
+      ["disabled", "disabled"]
+    );
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("unsupported extra collections report a clear error and search fails open", async () => {
+  const wiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture({ supportsAdditionalCollections: () => false });
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+
+    const statuses = await manager.refresh([root(wiki.rootDir)]);
+    const results = await manager.search("reading", "ideas expressed with different words", 5);
+
+    assert.equal(statuses[0]?.state, "error");
+    assert.match(statuses[0]?.lastError ?? "", /does not support dedicated external wiki collections/i);
+    assert.equal(results, null);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("a backend with no additional-collection capability keeps indexing fail-open", async () => {
+  const wiki = await makeWiki();
+  try {
+    const manager = new ExternalWikiCollectionManager(new NoopSearchBackend(), "memories");
+
+    const statuses = await manager.refresh([root(wiki.rootDir)]);
+
+    assert.equal(statuses[0]?.state, "error");
+    assert.match(statuses[0]?.lastError ?? "", /does not support dedicated external wiki collections/i);
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("healthy collection search uses hybrid retrieval and rejects results outside pagesDir", async () => {
+  const wiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture();
+    fixture.results.push(
+      {
+        docid: "retrieval",
+        path: path.join(wiki.pagesDir, "retrieval.md"),
+        snippet: "Meaning before exact words.",
+        score: 0.91,
+      },
+      {
+        docid: "raw-capture",
+        path: path.join(wiki.rootDir, "raw", "capture.md"),
+
+        snippet: "raw source",
+        score: 0.99,
+      }
+    );
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+    await manager.refresh([root(wiki.rootDir)]);
+
+    const results = await manager.search("reading", "ideas expressed with different words", 5);
+
+    assert.deepEqual(
+      results?.map((result) => result.docid),
+      ["retrieval"]
+    );
+    assert.equal(fixture.calls.at(-1), "search:external-wiki-reading");
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+test("failed global exclusion rolls back the collection before reporting an error", async () => {
+  const wiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture({
+      excludeCollectionFromGlobalSearch: async () => {
+        throw new Error("exclude failed");
+      },
+    });
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+
+    const statuses = await manager.refresh([root(wiki.rootDir)]);
+
+    assert.equal(statuses[0]?.state, "error");
+    assert.equal(fixture.collectionRoots.has("external-wiki-reading"), false);
+    assert.equal(fixture.calls.at(-1), "delete:external-wiki-reading");
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("degraded hybrid search marks the collection unhealthy and falls back", async () => {
+  const wiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture({
+      hybridSearch: async (_query, _collection, _limit, execution) => {
+        execution?.onDegradation?.({
+          backend: "qmd",
+          code: "backend_unavailable",
+        });
+        return [];
+      },
+    });
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+    await manager.refresh([root(wiki.rootDir)]);
+
+    const results = await manager.search("reading", "paraphrase", 5);
+
+    assert.equal(results, null);
+    assert.equal(manager.statuses()[0]?.state, "error");
+    assert.match(manager.statuses()[0]?.lastError ?? "", /search degraded/i);
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("a collection name collision with primary memory is refused", async () => {
+  const wiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture();
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "external-wiki-reading");
+
+    const statuses = await manager.refresh([root(wiki.rootDir)]);
+
+    assert.equal(statuses[0]?.state, "error");
+    assert.match(statuses[0]?.lastError ?? "", /default memory collection/i);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("concurrent config refreshes serialize so disable wins after enable", async () => {
+  const wiki = await makeWiki();
+  try {
+    let releaseEnsure!: () => void;
+    const blockedEnsure = new Promise<void>((resolve) => {
+      releaseEnsure = resolve;
+    });
+    let signalEnsureStarted!: () => void;
+    const ensureStarted = new Promise<void>((resolve) => {
+      signalEnsureStarted = resolve;
+    });
+    const fixture = makeBackendFixture({
+      ensureCollection: async (pagesDir, collection) => {
+        fixture.calls.push(`ensure:${collection}:${pagesDir}`);
+        signalEnsureStarted();
+        await blockedEnsure;
+        fixture.collectionCounts.set(collection, 1);
+        return "present";
+      },
+    });
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+
+    const enabling = manager.refresh([root(wiki.rootDir)]);
+    await ensureStarted;
+    const disabling = manager.refresh([root(wiki.rootDir, { indexInQmd: false })]);
+    releaseEnsure();
+    await enabling;
+    const disabledStatuses = await disabling;
+
+    assert.equal(disabledStatuses[0]?.state, "disabled");
+    assert.equal(manager.statuses()[0]?.state, "disabled");
+    assert.equal(fixture.calls.at(-1), "delete:external-wiki-reading");
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("purge serializes behind an in-flight refresh", async () => {
+  const wiki = await makeWiki();
+  try {
+    let releaseEnsure!: () => void;
+    const blockedEnsure = new Promise<void>((resolve) => {
+      releaseEnsure = resolve;
+    });
+    let signalEnsureStarted!: () => void;
+    const ensureStarted = new Promise<void>((resolve) => {
+      signalEnsureStarted = resolve;
+    });
+    const fixture = makeBackendFixture({
+      ensureCollection: async (pagesDir, collection) => {
+        fixture.calls.push(`ensure:${collection}:${pagesDir}`);
+        signalEnsureStarted();
+        await blockedEnsure;
+        fixture.collectionCounts.set(collection, 1);
+        return "present";
+      },
+    });
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+
+    const indexing = manager.refresh([root(wiki.rootDir)]);
+    await ensureStarted;
+    const purging = manager.purge("reading");
+    releaseEnsure();
+    await indexing;
+    assert.equal(await purging, true);
+
+    assert.deepEqual(manager.statuses(), []);
+    assert.equal(fixture.calls.at(-1), "delete:external-wiki-reading");
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("a removed collection delete failure does not abort remaining wiki refreshes", async () => {
+  const wiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture({
+      deleteCollection: async (collection) => {
+        if (collection === "external-wiki-first") throw new Error("delete failed");
+        return true;
+      },
+    });
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+    await manager.refresh([root(wiki.rootDir, { id: "first" }), root(wiki.rootDir, { id: "second" })]);
+
+    const statuses = await manager.refresh([root(wiki.rootDir, { id: "second" })]);
+
+    assert.equal(statuses[0]?.wikiId, "second");
+    assert.equal(statuses[0]?.state, "healthy");
+    assert.equal(manager.statuses().find((status) => status.wikiId === "first")?.state, "error");
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("turning indexing off removes a collection managed by this process", async () => {
+  const wiki = await makeWiki();
+  try {
+    const fixture = makeBackendFixture();
+    const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+    await manager.refresh([root(wiki.rootDir)]);
+    fixture.calls.length = 0;
+
+    const statuses = await manager.refresh([root(wiki.rootDir, { indexInQmd: false })]);
+
+    assert.deepEqual(fixture.calls, ["delete:external-wiki-reading"]);
+    assert.equal(statuses[0]?.state, "disabled");
+  } finally {
+    await rm(wiki.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("purge deletes a predictable dedicated collection without touching memory", async () => {
+  const fixture = makeBackendFixture();
+  const manager = new ExternalWikiCollectionManager(fixture.backend, "memories");
+
+  const removed = await manager.purge("reading");
+
+  assert.equal(removed, true);
+  assert.deepEqual(fixture.calls, ["delete:external-wiki-reading"]);
+  assert.equal(fixture.collectionCounts.get("memories"), 7);
+});

--- a/packages/remnic-core/src/external-wiki-collection.ts
+++ b/packages/remnic-core/src/external-wiki-collection.ts
@@ -1,0 +1,503 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readdir, realpath } from "node:fs/promises";
+import path from "node:path";
+import type { SearchBackend, SearchExecutionOptions, SearchResult } from "./search/port.js";
+
+const COLLECTION_PREFIX = "external-wiki-";
+
+export interface ExternalWikiCollectionRoot {
+  id: string;
+  rootDir: string;
+  enabled?: boolean;
+  pagesDir?: string;
+  indexInQmd?: boolean;
+}
+
+export type ExternalWikiCollectionBackend = Pick<
+  SearchBackend,
+  | "updateCollectionStrict"
+  | "updateCollectionFromDir"
+  | "embedCollection"
+  | "embedCollectionStrict"
+  | "hybridSearch"
+  | "collectionStatus"
+> & {
+  ensureCollection(
+    rootDir: string,
+    collection: string,
+    execution?: SearchExecutionOptions
+  ): Promise<"present" | "missing" | "unknown" | "skipped">;
+} & Required<
+  Pick<
+    SearchBackend,
+    | "supportsAdditionalCollections"
+    | "excludeCollectionFromGlobalSearch"
+    | "deleteCollection"
+    | "collectionRoot"
+  >
+>;
+
+export type ExternalWikiCollectionState = "disabled" | "healthy" | "error";
+
+export interface ExternalWikiCollectionStatus {
+  wikiId: string;
+  collection: string;
+  state: ExternalWikiCollectionState;
+  documentCount: number | null;
+  lastIndexedAt: string | null;
+  lastError: string | null;
+}
+
+interface ManagedWikiCollection {
+  status: ExternalWikiCollectionStatus;
+  pagesDir: string | null;
+  fingerprint: string | null;
+  managed: boolean;
+}
+
+interface PagesFingerprint {
+  fingerprint: string;
+  documentCount: number;
+}
+
+export function externalWikiCollectionName(wikiId: string): string {
+  const slug = wikiId
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!slug) {
+    throw new Error("External wiki id must contain usable characters for a collection name");
+  }
+  return `${COLLECTION_PREFIX}${slug}`;
+}
+
+export function supportsExternalWikiCollections(
+  backend: SearchBackend | ExternalWikiCollectionBackend
+): backend is ExternalWikiCollectionBackend {
+  return (
+    backend.supportsAdditionalCollections?.() === true &&
+    typeof backend.excludeCollectionFromGlobalSearch === "function" &&
+    typeof backend.deleteCollection === "function" &&
+    typeof backend.collectionRoot === "function"
+  );
+}
+
+export class ExternalWikiCollectionManager {
+  private readonly managedByWikiId = new Map<string, ManagedWikiCollection>();
+  private operationTail: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly backend: SearchBackend | ExternalWikiCollectionBackend,
+    private readonly defaultCollection: string,
+    private readonly now: () => Date = () => new Date()
+  ) {}
+
+  statuses(): ExternalWikiCollectionStatus[] {
+    return [...this.managedByWikiId.values()].map(({ status }) => ({ ...status }));
+  }
+
+  refresh(
+    roots: readonly ExternalWikiCollectionRoot[],
+    execution?: SearchExecutionOptions
+  ): Promise<ExternalWikiCollectionStatus[]> {
+    const snapshot = roots.map((root) => ({ ...root }));
+    return this.enqueueOperation(() => this.refreshSerial(snapshot, execution));
+  }
+
+  private async refreshSerial(
+    roots: readonly ExternalWikiCollectionRoot[],
+    execution?: SearchExecutionOptions
+  ): Promise<ExternalWikiCollectionStatus[]> {
+    const configuredWikiIds = new Set(roots.map((root) => root.id));
+    for (const [wikiId, managed] of this.managedByWikiId) {
+      if (!configuredWikiIds.has(wikiId)) {
+        if (!managed.managed) {
+          this.managedByWikiId.delete(wikiId);
+          continue;
+        }
+        try {
+          await this.removeManagedCollection(wikiId, managed, execution);
+          this.managedByWikiId.delete(wikiId);
+        } catch (error) {
+          this.rememberError(
+            wikiId,
+            managed.status.collection,
+            safeBackendError("External wiki collection removal failed", error)
+          );
+        }
+      }
+    }
+
+    const collectionOwnerByName = new Map<string, string>();
+    const collidingWikiIds = new Set<string>();
+    for (const root of roots) {
+      if (root.enabled === false || root.indexInQmd !== true) continue;
+      try {
+        const collection = externalWikiCollectionName(root.id);
+        const owner = collectionOwnerByName.get(collection);
+        if (owner) {
+          collidingWikiIds.add(owner);
+          collidingWikiIds.add(root.id);
+        } else {
+          collectionOwnerByName.set(collection, root.id);
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    const statuses: ExternalWikiCollectionStatus[] = [];
+    for (const root of roots) {
+      if (collidingWikiIds.has(root.id)) {
+        statuses.push(
+          this.rememberError(
+            root.id,
+            externalWikiCollectionName(root.id),
+            "External wiki ids must not resolve to the same dedicated collection"
+          )
+        );
+        continue;
+      }
+      statuses.push(await this.refreshRoot(root, execution));
+    }
+    return statuses;
+  }
+
+  async search(
+    wikiId: string,
+    query: string,
+    limit: number,
+    execution?: SearchExecutionOptions
+  ): Promise<SearchResult[] | null> {
+    const managed = this.managedByWikiId.get(wikiId);
+    if (!managed || managed.status.state !== "healthy" || !managed.pagesDir) return null;
+
+    let degradationCode: string | null = null;
+    try {
+      const results = await this.backend.hybridSearch(query, managed.status.collection, limit, {
+        ...execution,
+        onDegradation: (detail) => {
+          degradationCode = detail.code;
+          execution?.onDegradation?.(detail);
+        },
+      });
+      if (degradationCode) {
+        managed.status = {
+          ...managed.status,
+          state: "error",
+          lastError: `External wiki collection search degraded (${degradationCode})`,
+        };
+        return null;
+      }
+      return results.filter((result) => isPageResult(result.path, managed.pagesDir!, managed.status.collection));
+    } catch (error) {
+      managed.status = {
+        ...managed.status,
+        state: "error",
+        lastError: safeBackendError("External wiki collection search failed", error),
+      };
+      return null;
+    }
+  }
+
+  purge(wikiId: string, execution?: SearchExecutionOptions): Promise<boolean> {
+    return this.enqueueOperation(async () => {
+      const collection = externalWikiCollectionName(wikiId);
+      this.assertDedicatedCollection(collection);
+      if (!this.backend.deleteCollection) return false;
+      const removed = await this.backend.deleteCollection(collection, execution);
+      this.managedByWikiId.delete(wikiId);
+      return removed;
+    });
+  }
+
+  private enqueueOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const running = this.operationTail.then(operation);
+    this.operationTail = running.then(
+      () => undefined,
+      () => undefined
+    );
+    return running;
+  }
+
+  private async refreshRoot(
+    root: ExternalWikiCollectionRoot,
+    execution?: SearchExecutionOptions
+  ): Promise<ExternalWikiCollectionStatus> {
+    let collection: string;
+    try {
+      collection = externalWikiCollectionName(root.id);
+      this.assertDedicatedCollection(collection);
+    } catch (error) {
+      return this.rememberError(root.id, `${COLLECTION_PREFIX}invalid`, configError(error));
+    }
+
+    const prior = this.managedByWikiId.get(root.id);
+    if (root.enabled === false || root.indexInQmd !== true) {
+      if (prior?.managed) {
+        try {
+          await this.removeManagedCollection(root.id, prior, execution);
+        } catch (error) {
+          return this.rememberError(
+            root.id,
+            collection,
+            safeBackendError("External wiki collection removal failed", error)
+          );
+        }
+      }
+      return this.rememberDisabled(root.id, collection);
+    }
+
+    const dedicatedBackend = supportsExternalWikiCollections(this.backend) ? this.backend : null;
+    if (!dedicatedBackend) {
+      return this.rememberError(
+        root.id,
+        collection,
+        "Active search backend does not support dedicated external wiki collections"
+      );
+    }
+
+    let pagesDir: string;
+    let pages: PagesFingerprint;
+    try {
+      pagesDir = await resolvePagesDir(root);
+      pages = await fingerprintMarkdownPages(pagesDir);
+    } catch (error) {
+      return this.rememberError(root.id, collection, configError(error));
+    }
+
+    if (
+      prior?.managed &&
+      prior.status.state === "healthy" &&
+      prior.pagesDir === pagesDir &&
+      prior.fingerprint === pages.fingerprint
+    ) {
+      return { ...prior.status };
+    }
+
+    let rollbackCollection = false;
+    let managedAfterFailure = prior?.managed ?? false;
+    try {
+      let collectionState = await dedicatedBackend.ensureCollection(pagesDir, collection, execution);
+      if (collectionState !== "present") {
+        throw new Error(`Dedicated collection could not be prepared (${collectionState})`);
+      }
+      rollbackCollection = true;
+      managedAfterFailure = true;
+      let boundRoot = await dedicatedBackend.collectionRoot(collection, execution);
+      if (!boundRoot) {
+        throw new Error("Dedicated collection source root could not be verified");
+      }
+      if ((await realpath(boundRoot)) !== pagesDir) {
+        await dedicatedBackend.deleteCollection(collection, execution);
+        rollbackCollection = false;
+        managedAfterFailure = false;
+        collectionState = await dedicatedBackend.ensureCollection(pagesDir, collection, execution);
+        if (collectionState !== "present") {
+          throw new Error(`Dedicated collection could not be rebound (${collectionState})`);
+        }
+        rollbackCollection = true;
+        managedAfterFailure = true;
+        boundRoot = await dedicatedBackend.collectionRoot(collection, execution);
+        if (!boundRoot || (await realpath(boundRoot)) !== pagesDir) {
+          throw new Error("Dedicated collection source root did not match the configured pagesDir");
+        }
+      }
+      await dedicatedBackend.excludeCollectionFromGlobalSearch(collection, execution);
+      if (dedicatedBackend.updateCollectionFromDir) {
+        await dedicatedBackend.updateCollectionFromDir(collection, pagesDir, execution);
+      } else if (dedicatedBackend.updateCollectionStrict) {
+        await dedicatedBackend.updateCollectionStrict(collection, execution);
+      } else {
+        throw new Error("Active search backend cannot refresh a dedicated collection");
+      }
+      if (dedicatedBackend.embedCollectionStrict) {
+        await dedicatedBackend.embedCollectionStrict(collection);
+      } else {
+        await dedicatedBackend.embedCollection(collection);
+      }
+      const backendStatus = await dedicatedBackend.collectionStatus?.(collection);
+      const status: ExternalWikiCollectionStatus = {
+        wikiId: root.id,
+        collection,
+        state: "healthy",
+        documentCount: backendStatus?.totalFiles ?? pages.documentCount,
+        lastIndexedAt: this.now().toISOString(),
+        lastError: null,
+      };
+      this.managedByWikiId.set(root.id, {
+        status,
+        pagesDir,
+        fingerprint: pages.fingerprint,
+        managed: true,
+      });
+      return { ...status };
+    } catch (error) {
+      let cleanupError: unknown;
+      if (rollbackCollection) {
+        try {
+          await dedicatedBackend.deleteCollection(collection, execution);
+          managedAfterFailure = false;
+        } catch (rollbackError) {
+          cleanupError = rollbackError;
+          managedAfterFailure = true;
+        }
+      }
+      const refreshError = safeBackendError("External wiki collection refresh failed", error);
+      const lastError = cleanupError
+        ? `${refreshError}; ${safeBackendError("collection rollback failed", cleanupError)}`
+        : refreshError;
+      const status = this.rememberError(root.id, collection, lastError);
+      const failed = this.managedByWikiId.get(root.id);
+      if (failed) {
+        this.managedByWikiId.set(root.id, {
+          ...failed,
+          pagesDir: managedAfterFailure ? (prior?.pagesDir ?? pagesDir) : null,
+          fingerprint: managedAfterFailure ? prior?.fingerprint ?? null : null,
+          managed: managedAfterFailure,
+        });
+      }
+      return status;
+    }
+  }
+
+  private assertDedicatedCollection(collection: string): void {
+    if (collection === this.defaultCollection || !collection.startsWith(COLLECTION_PREFIX)) {
+      throw new Error("External wiki collection must not target the default memory collection");
+    }
+  }
+
+  private rememberDisabled(wikiId: string, collection: string): ExternalWikiCollectionStatus {
+    const status: ExternalWikiCollectionStatus = {
+      wikiId,
+      collection,
+      state: "disabled",
+      documentCount: null,
+      lastIndexedAt: null,
+      lastError: null,
+    };
+    this.managedByWikiId.set(wikiId, { status, pagesDir: null, fingerprint: null, managed: false });
+    return { ...status };
+  }
+
+  private rememberError(wikiId: string, collection: string, lastError: string): ExternalWikiCollectionStatus {
+    const prior = this.managedByWikiId.get(wikiId);
+    const status: ExternalWikiCollectionStatus = {
+      wikiId,
+      collection,
+      state: "error",
+      documentCount: prior?.status.documentCount ?? null,
+      lastIndexedAt: prior?.status.lastIndexedAt ?? null,
+      lastError,
+    };
+    this.managedByWikiId.set(wikiId, {
+      status,
+      pagesDir: prior?.pagesDir ?? null,
+      fingerprint: prior?.fingerprint ?? null,
+      managed: prior?.managed ?? false,
+    });
+    return { ...status };
+  }
+
+  private async removeManagedCollection(
+    wikiId: string,
+    managed: ManagedWikiCollection,
+    execution?: SearchExecutionOptions
+  ): Promise<void> {
+    if (!this.backend.deleteCollection) {
+      throw new Error("Active search backend cannot delete a dedicated collection; use a backend purge command");
+    }
+    await this.backend.deleteCollection(managed.status.collection, execution);
+    this.managedByWikiId.set(wikiId, {
+      status: managed.status,
+      pagesDir: null,
+      fingerprint: null,
+      managed: false,
+    });
+  }
+}
+
+async function resolvePagesDir(root: ExternalWikiCollectionRoot): Promise<string> {
+  const lexicalRootDir = path.resolve(root.rootDir);
+  const lexicalPagesDir = path.resolve(lexicalRootDir, root.pagesDir ?? "wiki");
+  const lexicalRelative = path.relative(lexicalRootDir, lexicalPagesDir);
+  if (!lexicalRelative || lexicalRelative.startsWith("..") || path.isAbsolute(lexicalRelative)) {
+    throw new Error("External wiki pagesDir must stay inside the configured rootDir");
+  }
+  const [rootDir, pagesDir] = await Promise.all([realpath(lexicalRootDir), realpath(lexicalPagesDir)]);
+  const canonicalRelative = path.relative(rootDir, pagesDir);
+  if (!canonicalRelative || canonicalRelative.startsWith("..") || path.isAbsolute(canonicalRelative)) {
+    throw new Error("External wiki pagesDir must stay inside the configured rootDir");
+  }
+  return pagesDir;
+}
+
+async function fingerprintMarkdownPages(pagesDir: string): Promise<PagesFingerprint> {
+  const markdownPaths: string[] = [];
+  const pending = [pagesDir];
+  while (pending.length > 0) {
+    const directory = pending.pop()!;
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+      } else if (entry.isSymbolicLink()) {
+        throw new Error("External wiki pagesDir must not contain symbolic links");
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".md")) {
+        markdownPaths.push(entryPath);
+      }
+    }
+  }
+  markdownPaths.sort();
+  const fingerprint = createHash("sha256");
+  for (const markdownPath of markdownPaths) {
+    fingerprint.update(path.relative(pagesDir, markdownPath));
+    fingerprint.update("\0");
+    for await (const chunk of createReadStream(markdownPath)) {
+      fingerprint.update(chunk);
+    }
+    fingerprint.update("\0");
+  }
+  return {
+    fingerprint: fingerprint.digest("hex"),
+    documentCount: markdownPaths.length,
+  };
+}
+
+function isPageResult(resultPath: string, pagesDir: string, collection: string): boolean {
+  let candidate = resultPath;
+  const qmdPrefix = `qmd://${collection}/`;
+  if (candidate.startsWith(qmdPrefix)) candidate = candidate.slice(qmdPrefix.length);
+  const resolved = path.isAbsolute(candidate) ? path.resolve(candidate) : path.resolve(pagesDir, candidate);
+  const relative = path.relative(pagesDir, resolved);
+  return (
+    Boolean(relative) &&
+    !relative.startsWith("..") &&
+    !path.isAbsolute(relative) &&
+    resolved.toLowerCase().endsWith(".md")
+  );
+}
+
+function configError(error: unknown): string {
+  if (error instanceof Error && error.message.startsWith("External wiki")) {
+    return error.message;
+  }
+  const code = typeof error === "object" && error !== null && "code" in error ? String(error.code) : null;
+  return code
+    ? `External wiki pages directory could not be scanned (${code})`
+    : "Invalid external wiki collection configuration";
+}
+
+function safeBackendError(prefix: string, error: unknown): string {
+  if (error instanceof Error && error.message.startsWith("Dedicated collection")) {
+    return error.message;
+  }
+  if (error instanceof Error && error.message.startsWith("Active search backend")) {
+    return error.message;
+  }
+  const name = error instanceof Error && error.name ? error.name : "Error";
+  return `${prefix} (${name})`;
+}

--- a/packages/remnic-core/src/qmd-client.test.ts
+++ b/packages/remnic-core/src/qmd-client.test.ts
@@ -13,11 +13,7 @@ test("QmdClient rechecks daemon availability before returning unavailable", asyn
     available: boolean;
     daemonAvailable: boolean;
     probeDaemon: () => Promise<boolean>;
-    searchViaDaemon: (
-      query: string,
-      collection: string | undefined,
-      maxResults: number,
-    ) => Promise<QmdSearchResult[]>;
+    searchViaDaemon: (query: string, collection: string | undefined, maxResults: number) => Promise<QmdSearchResult[]>;
   };
   let probeCount = 0;
   internals.available = false;
@@ -49,13 +45,9 @@ type SubprocessInternals = {
   runQmdCommand: (
     args: string[],
     timeoutMs?: number,
-    signal?: AbortSignal,
+    signal?: AbortSignal
   ) => Promise<{ stdout: string; stderr: string }>;
-  searchViaSubprocess: (
-    query: string,
-    collection: string,
-    maxResults: number,
-  ) => Promise<QmdSearchResult[]>;
+  searchViaSubprocess: (query: string, collection: string, maxResults: number) => Promise<QmdSearchResult[]>;
   searchGlobalViaSubprocess: (query: string, maxResults: number) => Promise<QmdSearchResult[]>;
 };
 
@@ -79,7 +71,7 @@ test("updateStrict respects QMD update min-interval throttles", async () => {
     await client.updateStrict();
     await assert.rejects(
       () => client.updateStrict(),
-      /QMD update skipped by min-interval gate|QMD update skipped by global min-interval gate/,
+      /QMD update skipped by min-interval gate|QMD update skipped by global min-interval gate/
     );
   } finally {
     client.resetUpdateThrottles();
@@ -100,10 +92,7 @@ test("embedCollectionStrict rejects QMD embed subprocess failures", async () => 
   };
 
   try {
-    await assert.rejects(
-      () => client.embedCollectionStrict("memories--project"),
-      /embed subprocess failed/,
-    );
+    await assert.rejects(() => client.embedCollectionStrict("memories--project"), /embed subprocess failed/);
   } finally {
     client.resetUpdateThrottles();
   }
@@ -120,7 +109,7 @@ test("embedCollectionStrict respects QMD embed min-interval throttles", async ()
     await client.embedCollectionStrict("memories--project");
     await assert.rejects(
       () => client.embedCollectionStrict("memories--project"),
-      /QMD embed skipped by per-collection min-interval gate/,
+      /QMD embed skipped by per-collection min-interval gate/
     );
   } finally {
     client.resetUpdateThrottles();
@@ -196,6 +185,78 @@ test("ensureCollection rechecks collection state after auto-create failure", asy
     ["collection", "add", "/tmp/remnic-memory", "--name", "memories"],
     ["collection", "list"],
   ]);
+});
+
+test("QmdClient advertises isolated additional collection support", () => {
+  const client = new QmdClient("memories", 3, {});
+
+  assert.equal(client.supportsAdditionalCollections(), true);
+});
+
+test("QmdClient excludes a dedicated collection from global search", async () => {
+  const client = new QmdClient("memories", 3, {});
+  const calls = captureSubprocessArgs(client);
+  const controller = new AbortController();
+
+  await client.excludeCollectionFromGlobalSearch("external-wiki-reading", {
+    signal: controller.signal,
+  });
+
+  assert.deepEqual(calls, [["collection", "exclude", "external-wiki-reading"]]);
+});
+
+test("QmdClient reports status for a named collection", async () => {
+  const client = new QmdClient("memories", 3, {});
+  const internals = client as unknown as SubprocessInternals & {
+    qmdCapabilities: { safeStatusDeviceProbe: boolean };
+  };
+  const calls: string[][] = [];
+  internals.available = true;
+  internals.qmdCapabilities = { safeStatusDeviceProbe: true };
+  internals.runQmdCommand = async (args) => {
+    calls.push(args);
+    return { stdout: "Total: 12\nVectors: 10\nPending: 2", stderr: "" };
+  };
+
+  const status = await client.collectionStatus("external-wiki-reading");
+
+  assert.equal(status.totalFiles, 12);
+  assert.deepEqual(calls, [["status", "-c", "external-wiki-reading"]]);
+});
+
+test("QmdClient reports the configured root for a named collection", async () => {
+  const client = new QmdClient("memories", 3, {});
+  const internals = client as unknown as SubprocessInternals;
+  const calls: string[][] = [];
+  internals.available = true;
+  internals.runQmdCommand = async (args) => {
+    calls.push(args);
+    return {
+      stdout: [
+        "Collection: external-wiki-reading",
+        "  Path:     /srv/reading/wiki",
+        "  Pattern:  **/*.md",
+        "  Include:  no",
+      ].join("\n"),
+      stderr: "",
+    };
+  };
+
+  const root = await client.collectionRoot("external-wiki-reading");
+
+  assert.equal(root, "/srv/reading/wiki");
+  assert.deepEqual(calls, [["collection", "show", "external-wiki-reading"]]);
+});
+
+test("QmdClient removes a dedicated collection but refuses its primary collection", async () => {
+  const client = new QmdClient("memories", 3, {});
+  const calls = captureSubprocessArgs(client);
+
+  await assert.rejects(() => client.deleteCollection("memories"), /primary QMD collection/i);
+  const removed = await client.deleteCollection("external-wiki-reading");
+
+  assert.equal(removed, true);
+  assert.deepEqual(calls, [["collection", "remove", "external-wiki-reading"]]);
 });
 
 test("subprocess fallback defaults to `qmd query` for scoped and global recall", async () => {

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -1,39 +1,35 @@
 import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
+import { abortError, isAbortError, throwIfAborted } from "./abort-error.js";
 import { log } from "./logger.js";
 import { clearQmdResultCaches, getCachedQmdSearch, setCachedQmdSearch } from "./memory-cache.js";
 import {
-  abortError,
-  isAbortError,
-  throwIfAborted,
-} from "./abort-error.js";
-import type { QmdSearchExplain, QmdSearchResult } from "./types.js";
-import {
-  resolveEnsureCollectionArgs,
-  type SearchBackend,
-  type SearchDegradation,
-  type SearchExecutionOptions,
-  type SearchQueryOptions,
-} from "./search/port.js";
-import { launchProcess, type CommandChildProcess } from "./runtime/child-process.js";
-import { mergeEnv } from "./runtime/env.js";
-import {
+  QMD_PROBE_RETRY_BACKOFF_MS,
+  QMD_PROBE_TIMEOUT_MS,
+  QMD_SUPPORTED_VERSION,
+  type QmdProbeFailureKind,
   classifyProbeFailure,
   compareQmdVersions,
   getQmdPostInstallProbeTargets,
   parseQmdVersion,
   parseQmdVersionOutput,
-  QMD_PROBE_RETRY_BACKOFF_MS,
-  QMD_PROBE_TIMEOUT_MS,
-  QMD_SUPPORTED_VERSION,
   qmdVersionToString,
   resolveQmdCapabilities,
   shouldAutoUpgradeQmd,
   versionAtLeast,
-  type QmdProbeFailureKind,
 } from "./qmd-preflight.js";
-import { fetchQmdStatus, embedQmdFiles, EMPTY_QMD_STATUS, type QmdStatusReport } from "./qmd-status.js";
+import { EMPTY_QMD_STATUS, type QmdStatusReport, embedQmdFiles, fetchQmdStatus } from "./qmd-status.js";
+import { type CommandChildProcess, launchProcess } from "./runtime/child-process.js";
+import { mergeEnv } from "./runtime/env.js";
+import {
+  type SearchBackend,
+  type SearchDegradation,
+  type SearchExecutionOptions,
+  type SearchQueryOptions,
+  resolveEnsureCollectionArgs,
+} from "./search/port.js";
+import type { QmdSearchExplain, QmdSearchResult } from "./types.js";
 // Re-export version-check / probe-preflight helpers (moved to qmd-preflight.ts,
 // issue #1841) so existing imports from "./qmd.js" keep resolving.
 export {
@@ -225,7 +221,12 @@ function sleep(ms: number): Promise<void> {
 function errorMessage(err: unknown): string {
   if (typeof err === "string") return err;
   if (err instanceof Error) return err.message;
-  if (err && typeof err === "object" && "message" in err && typeof (err as { message?: unknown }).message === "string") {
+  if (
+    err &&
+    typeof err === "object" &&
+    "message" in err &&
+    typeof (err as { message?: unknown }).message === "string"
+  ) {
     return (err as { message: string }).message;
   }
   return String(err);
@@ -340,12 +341,11 @@ function normalizeStructuredSearches(value: unknown): QmdStructuredSearch[] {
 }
 
 function buildSyntheticHydeQuery(query: string, intent?: string): string {
-  const base = intent && intent.trim().length > 0
-    ? `A relevant Remnic memory for ${intent.trim()} would answer: ${query.trim()}`
-    : `A relevant Remnic memory would answer: ${query.trim()}`;
-  return base.length > QMD_STRUCTURED_HYDE_MAX_CHARS
-    ? base.slice(0, QMD_STRUCTURED_HYDE_MAX_CHARS)
-    : base;
+  const base =
+    intent && intent.trim().length > 0
+      ? `A relevant Remnic memory for ${intent.trim()} would answer: ${query.trim()}`
+      : `A relevant Remnic memory would answer: ${query.trim()}`;
+  return base.length > QMD_STRUCTURED_HYDE_MAX_CHARS ? base.slice(0, QMD_STRUCTURED_HYDE_MAX_CHARS) : base;
 }
 
 /**
@@ -361,7 +361,7 @@ function buildSyntheticHydeQuery(query: string, intent?: string): string {
 export function buildDefaultStructuredSearches(
   query: string,
   options?: SearchQueryOptions,
-  strategy: QmdSearchStrategy = "hybrid",
+  strategy: QmdSearchStrategy = "hybrid"
 ): QmdStructuredSearch[] {
   const explicit = normalizeStructuredSearches(options?.structuredSearches);
   if (explicit.length > 0) return explicit;
@@ -371,11 +371,7 @@ export function buildDefaultStructuredSearches(
   if (strategy === "lex") return [lex];
   const vec: QmdStructuredSearch = { type: "vec", query: trimmed };
   if (strategy === "lex-vec") return [lex, vec];
-  return [
-    lex,
-    vec,
-    { type: "hyde", query: buildSyntheticHydeQuery(trimmed, options?.intent) },
-  ];
+  return [lex, vec, { type: "hyde", query: buildSyntheticHydeQuery(trimmed, options?.intent) }];
 }
 
 function parseExplainScores(value: unknown): number[] | undefined {
@@ -390,24 +386,21 @@ export function parseQmdExplain(value: unknown): QmdSearchExplain | undefined {
   const rrf =
     typeof candidate.rrf === "number"
       ? candidate.rrf
-      : candidate.rrf && typeof candidate.rrf === "object" &&
-        typeof (candidate.rrf as Record<string, unknown>).totalScore === "number"
-      ? ((candidate.rrf as Record<string, unknown>).totalScore as number)
-      : undefined;
+      : candidate.rrf &&
+          typeof candidate.rrf === "object" &&
+          typeof (candidate.rrf as Record<string, unknown>).totalScore === "number"
+        ? ((candidate.rrf as Record<string, unknown>).totalScore as number)
+        : undefined;
   const rrfObj =
-    candidate.rrf && typeof candidate.rrf === "object"
-      ? (candidate.rrf as Record<string, unknown>)
-      : undefined;
+    candidate.rrf && typeof candidate.rrf === "object" ? (candidate.rrf as Record<string, unknown>) : undefined;
   const parsed: QmdSearchExplain = {
     ftsScores: parseExplainScores(candidate.ftsScores),
     vectorScores: parseExplainScores(candidate.vectorScores),
     rrf,
     rrfRank: typeof rrfObj?.rank === "number" ? rrfObj.rank : undefined,
-    rrfPositionScore:
-      typeof rrfObj?.positionScore === "number" ? rrfObj.positionScore : undefined,
+    rrfPositionScore: typeof rrfObj?.positionScore === "number" ? rrfObj.positionScore : undefined,
     rrfBaseScore: typeof rrfObj?.baseScore === "number" ? rrfObj.baseScore : undefined,
-    rrfTopRankBonus:
-      typeof rrfObj?.topRankBonus === "number" ? rrfObj.topRankBonus : undefined,
+    rrfTopRankBonus: typeof rrfObj?.topRankBonus === "number" ? rrfObj.topRankBonus : undefined,
     rerankScore: typeof candidate.rerankScore === "number" ? candidate.rerankScore : undefined,
     blendedScore: typeof candidate.blendedScore === "number" ? candidate.blendedScore : undefined,
   };
@@ -482,9 +475,9 @@ const QMD_MUTEX = new AsyncMutex();
 function runQmd(
   args: string[],
   timeoutMs: number = QMD_TIMEOUT_MS,
-  qmdPath: string = "qmd",
+  qmdPath = "qmd",
   signal?: AbortSignal,
-  runtimeEnv?: QmdRuntimeEnv,
+  runtimeEnv?: QmdRuntimeEnv
 ): Promise<{ stdout: string; stderr: string }> {
   // Serialize all qmd calls. This avoids SQLite lock contention when multiple
   // channels/agents trigger QMD operations at nearly the same time.
@@ -539,7 +532,7 @@ function runQmdOnce(
   timeoutMs: number,
   qmdPath: string,
   signal?: AbortSignal,
-  runtimeEnv?: QmdRuntimeEnv,
+  runtimeEnv?: QmdRuntimeEnv
 ): Promise<{ stdout: string; stderr: string }> {
   const isVersionCheck = args.length === 1 && args[0] === "--version";
   return runCommandWithTimeout(qmdPath, args, {
@@ -560,7 +553,7 @@ function runCommandWithTimeout(
     env?: QmdRuntimeEnv;
     label?: string;
     isSuccessExitCode?: (code: number | null) => boolean;
-  },
+  }
 ): Promise<{ stdout: string; stderr: string }> {
   const label = options.label ?? `${command} ${args.join(" ")}`;
   const isSuccessExitCode = options.isSuccessExitCode ?? ((code: number | null) => code === 0);
@@ -588,7 +581,7 @@ function runCommandWithTimeout(
       reject(
         Object.assign(new Error(`${label} timed out after ${options.timeoutMs}ms`), {
           timedOut: true as const,
-        }),
+        })
       );
     }, options.timeoutMs);
     const onAbort = () => {
@@ -625,11 +618,7 @@ function runCommandWithTimeout(
       if (isSuccessExitCode(code)) {
         resolve({ stdout, stderr });
       } else {
-        reject(
-          new Error(
-            `${label} failed (code ${code}): ${truncateForLog(stderr || stdout)}`,
-          ),
-        );
+        reject(new Error(`${label} failed (code ${code}): ${truncateForLog(stderr || stdout)}`));
       }
     });
   });
@@ -639,7 +628,7 @@ function runProcessCommand(
   command: string,
   args: string[],
   timeoutMs: number,
-  signal?: AbortSignal,
+  signal?: AbortSignal
 ): Promise<{ stdout: string; stderr: string }> {
   return runCommandWithTimeout(command, args, {
     timeoutMs,
@@ -744,7 +733,7 @@ class QmdDaemonSession {
             capabilities: {},
             clientInfo: { name: "openclaw-remnic", version: "1.0.0" },
           },
-          60_000,
+          60_000
         );
         if (!result) {
           // Null result (non-timeout failure) — kill and let the next probe respawn.
@@ -779,8 +768,8 @@ class QmdDaemonSession {
   async callTool(
     name: string,
     args: Record<string, unknown>,
-    timeoutMs: number = 30_000,
-    signal?: AbortSignal,
+    timeoutMs = 30_000,
+    signal?: AbortSignal
   ): Promise<unknown> {
     if (!this.child || this.child.killed || !this.initialized) {
       throw new Error("QMD mcp process not running");
@@ -834,7 +823,7 @@ class QmdDaemonSession {
     method: string,
     params: Record<string, unknown>,
     timeoutMs: number,
-    signal?: AbortSignal,
+    signal?: AbortSignal
   ): Promise<unknown> {
     return new Promise((resolve, reject) => {
       throwIfAborted(signal, `QMD mcp ${method} aborted before request`);
@@ -954,10 +943,7 @@ const QMD_RESULT_LINE_RE = /^#([0-9a-fA-F]+)\s+(\d+)%\s+(.+)/;
  */
 const QMD_PATH_TITLE_RE = /^(.+?\.[a-zA-Z]{2,10})\s+-\s+(.*)$/;
 
-function parseQmdMarkdownResultText(
-  text: string,
-  transport: QmdSearchResult["transport"],
-): QmdSearchResult[] {
+function parseQmdMarkdownResultText(text: string, transport: QmdSearchResult["transport"]): QmdSearchResult[] {
   const results: QmdSearchResult[] = [];
   for (const line of text.split("\n")) {
     const m = QMD_RESULT_LINE_RE.exec(line.trim());
@@ -970,17 +956,14 @@ function parseQmdMarkdownResultText(
       docid: m[1],
       path: pathTitleSplit[1] ?? "unknown",
       snippet: "",
-      score: parseInt(m[2], 10) / 100,
+      score: Number.parseInt(m[2], 10) / 100,
       transport,
     });
   }
   return results;
 }
 
-function parseMcpSearchResult(
-  result: unknown,
-  transport: QmdSearchResult["transport"] = "daemon",
-): QmdSearchResult[] {
+function parseMcpSearchResult(result: unknown, transport: QmdSearchResult["transport"] = "daemon"): QmdSearchResult[] {
   const resultObj = result as Record<string, unknown> | null;
   if (!resultObj) return [];
   const results: QmdSearchResult[] = [];
@@ -989,16 +972,17 @@ function parseMcpSearchResult(
       const d = doc as Record<string, unknown>;
       results.push({
         docid: typeof d.docid === "string" ? d.docid.replace(/^#/, "") : "",
-        path: typeof d.file === "string"
-          ? d.file
-          : typeof d.path === "string"
-          ? d.path
-          : (typeof d.docid === "string" ? d.docid.replace(/^#/, "") : "unknown"),
+        path:
+          typeof d.file === "string"
+            ? d.file
+            : typeof d.path === "string"
+              ? d.path
+              : typeof d.docid === "string"
+                ? d.docid.replace(/^#/, "")
+                : "unknown",
         snippet: typeof d.snippet === "string" ? d.snippet : "",
         score: typeof d.score === "number" ? d.score : 0,
-        line: typeof d.line === "number" && Number.isFinite(d.line)
-          ? Math.max(1, Math.floor(d.line))
-          : undefined,
+        line: typeof d.line === "number" && Number.isFinite(d.line) ? Math.max(1, Math.floor(d.line)) : undefined,
         explain: parseQmdExplain(d.explain),
         transport,
       });
@@ -1037,7 +1021,7 @@ function parseMcpSearchResult(
 
 function parseQmdSearchStdout(
   stdout: string,
-  transport: QmdSearchResult["transport"] = "subprocess",
+  transport: QmdSearchResult["transport"] = "subprocess"
 ): QmdSearchResult[] {
   const trimmedOut = stdout.trim();
   if (!trimmedOut || trimmedOut === "No results found.") return [];
@@ -1046,19 +1030,14 @@ function parseQmdSearchStdout(
   return parsed.map(
     (entry: Record<string, unknown>): QmdSearchResult => ({
       docid: (entry.docid as string) ?? "",
-      path:
-        (entry.file as string) ??
-        (entry.path as string) ??
-        (entry.docid as string) ??
-        "unknown",
+      path: (entry.file as string) ?? (entry.path as string) ?? (entry.docid as string) ?? "unknown",
       snippet: (entry.snippet as string) ?? "",
       score: typeof entry.score === "number" ? entry.score : 0,
-      line: typeof entry.line === "number" && Number.isFinite(entry.line)
-        ? Math.max(1, Math.floor(entry.line))
-        : undefined,
+      line:
+        typeof entry.line === "number" && Number.isFinite(entry.line) ? Math.max(1, Math.floor(entry.line)) : undefined,
       explain: parseQmdExplain(entry.explain),
       transport,
-    }),
+    })
   );
 }
 
@@ -1073,15 +1052,11 @@ function stableRuntimeEnvKey(runtimeEnv: QmdRuntimeEnv): string {
   return JSON.stringify(
     Object.keys(runtimeEnv)
       .sort()
-      .map((key) => [key, runtimeEnv[key]]),
+      .map((key) => [key, runtimeEnv[key]])
   );
 }
 
-function recordAutoUpgradeStatus(
-  state: QmdGlobalState,
-  targetKey: string,
-  status: string,
-): void {
+function recordAutoUpgradeStatus(state: QmdGlobalState, targetKey: string, status: string): void {
   state.lastAutoUpgradeStatusByTarget[targetKey] = status;
   state.lastAutoUpgradeStatus = status;
 }
@@ -1090,7 +1065,7 @@ function retainSharedDaemonSession(
   qmdPath: string,
   runtimeEnv: QmdRuntimeEnv = {},
   indexName?: string,
-  cliVersion?: string | null,
+  cliVersion?: string | null
 ): QmdDaemonSession {
   const normalizedPath = qmdPath.trim() || "qmd";
   const normalizedIndex = indexName?.trim() || "";
@@ -1197,7 +1172,7 @@ export class QmdClient implements SearchBackend {
   constructor(
     private readonly collection: string,
     private readonly maxResults: number,
-    opts?: QmdClientOptions,
+    opts?: QmdClientOptions
   ) {
     this.slowLog = opts?.slowLog;
     this.updateTimeoutMs = opts?.updateTimeoutMs ?? 120_000;
@@ -1210,12 +1185,10 @@ export class QmdClient implements SearchBackend {
     this.qmdAutoUpgradeEnabled = opts?.qmdAutoUpgradeEnabled === true;
     this.qmdAutoUpgradeCheckIntervalMs = Math.max(
       60_000,
-      Math.floor(opts?.qmdAutoUpgradeCheckIntervalMs ?? QMD_AUTO_UPGRADE_CHECK_INTERVAL_MS),
+      Math.floor(opts?.qmdAutoUpgradeCheckIntervalMs ?? QMD_AUTO_UPGRADE_CHECK_INTERVAL_MS)
     );
     this.qmdChunkStrategy =
-      opts?.qmdChunkStrategy === "auto" || opts?.qmdChunkStrategy === "regex"
-        ? opts.qmdChunkStrategy
-        : undefined;
+      opts?.qmdChunkStrategy === "auto" || opts?.qmdChunkStrategy === "regex" ? opts.qmdChunkStrategy : undefined;
     this.qmdCandidateLimit =
       typeof opts?.qmdCandidateLimit === "number" &&
       Number.isFinite(opts.qmdCandidateLimit) &&
@@ -1225,9 +1198,7 @@ export class QmdClient implements SearchBackend {
     this.qmdQueryRerankEnabled = opts?.qmdQueryRerankEnabled !== false;
     this.qmdIndexName = opts?.qmdIndexName?.trim() || undefined;
     this.qmdSearchStrategy =
-      opts?.qmdSearchStrategy === "lex" || opts?.qmdSearchStrategy === "lex-vec"
-        ? opts.qmdSearchStrategy
-        : "hybrid";
+      opts?.qmdSearchStrategy === "lex" || opts?.qmdSearchStrategy === "lex-vec" ? opts.qmdSearchStrategy : "hybrid";
     this.qmdSubprocessStrategy = opts?.qmdSubprocessStrategy === "search" ? "search" : "query";
     this.qmdFallbackPaths = opts?.qmdFallbackPaths
       ? opts.qmdFallbackPaths.map((candidate) => candidate.trim()).filter(Boolean)
@@ -1246,7 +1217,7 @@ export class QmdClient implements SearchBackend {
     this.daemonRecheckIntervalMs = opts?.daemonRecheckIntervalMs ?? 15_000;
   }
 
-  private qmdPath: string = "qmd";
+  private qmdPath = "qmd";
 
   private buildRuntimeEnv(opts?: QmdClientOptions): QmdRuntimeEnv {
     const env: QmdRuntimeEnv = {};
@@ -1302,10 +1273,7 @@ export class QmdClient implements SearchBackend {
   private async probeDaemon(): Promise<boolean> {
     this.lastDaemonCheckAtMs = Date.now();
     const normalizedPath = this.qmdPath.trim() || "qmd";
-    const daemonIndexName =
-      this.qmdIndexName && this.qmdCapabilities.mcpIndexSelection
-        ? this.qmdIndexName
-        : undefined;
+    const daemonIndexName = this.qmdIndexName && this.qmdCapabilities.mcpIndexSelection ? this.qmdIndexName : undefined;
     const daemonSessionPath = `${normalizedPath}\0${daemonIndexName ?? ""}\0${this.cliVersion ?? ""}`;
     if (!this.daemonSession || this.daemonSessionPath !== daemonSessionPath) {
       await releaseSharedDaemonSession(this.daemonSession);
@@ -1313,7 +1281,7 @@ export class QmdClient implements SearchBackend {
         normalizedPath,
         this.qmdRuntimeEnv,
         daemonIndexName,
-        this.cliVersion,
+        this.cliVersion
       );
       this.daemonSessionPath = daemonSessionPath;
     }
@@ -1327,7 +1295,9 @@ export class QmdClient implements SearchBackend {
       ]);
       if (!ok) {
         const loading = this.daemonSession.isLoading();
-        log.debug(`QMD daemon: stdio session not ready within ${PROBE_QUICK_TIMEOUT_MS}ms probe window${loading ? " (still loading)" : ""}`);
+        log.debug(
+          `QMD daemon: stdio session not ready within ${PROBE_QUICK_TIMEOUT_MS}ms probe window${loading ? " (still loading)" : ""}`
+        );
         this.daemonAvailable = false;
         return false;
       }
@@ -1342,10 +1312,7 @@ export class QmdClient implements SearchBackend {
     }
   }
 
-  private runVersionProbe(
-    qmdPath: string,
-    signal?: AbortSignal,
-  ): Promise<{ stdout: string; stderr: string }> {
+  private runVersionProbe(qmdPath: string, signal?: AbortSignal): Promise<{ stdout: string; stderr: string }> {
     return runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, qmdPath, signal, this.qmdRuntimeEnv);
   }
 
@@ -1354,18 +1321,19 @@ export class QmdClient implements SearchBackend {
       allowAutoUpgrade?: boolean;
       preserveStateOnFailure?: boolean;
       signal?: AbortSignal;
-    } = {},
+    } = {}
   ): Promise<boolean> {
-    const priorState = options.preserveStateOnFailure === true
-      ? {
-        available: this.available,
-        qmdPath: this.qmdPath,
-        qmdPathSource: this.qmdPathSource,
-        cliVersion: this.cliVersion,
-        lastCliProbeError: this.lastCliProbeError,
-        qmdCapabilities: this.qmdCapabilities,
-      }
-      : null;
+    const priorState =
+      options.preserveStateOnFailure === true
+        ? {
+            available: this.available,
+            qmdPath: this.qmdPath,
+            qmdPathSource: this.qmdPathSource,
+            cliVersion: this.cliVersion,
+            lastCliProbeError: this.lastCliProbeError,
+            qmdCapabilities: this.qmdCapabilities,
+          }
+        : null;
     const restorePriorState = (): void => {
       if (!priorState) return;
       this.available = priorState.available;
@@ -1388,7 +1356,7 @@ export class QmdClient implements SearchBackend {
     const recordProbeSuccess = async (
       result: { stdout: string; stderr: string },
       qmdPath: string,
-      source: typeof this.qmdPathSource,
+      source: typeof this.qmdPathSource
     ): Promise<void> => {
       this.available = true;
       this.qmdPath = qmdPath;
@@ -1423,15 +1391,9 @@ export class QmdClient implements SearchBackend {
           failureKind = classifyProbeFailure(err);
           // Never retry a hard misconfiguration (missing/not-executable) — only
           // transient slowness. (Caller cancellation is handled above.)
-          if (
-            failureKind === "transient" &&
-            attempt < QMD_PROBE_RETRY_BACKOFF_MS.length
-          ) {
+          if (failureKind === "transient" && attempt < QMD_PROBE_RETRY_BACKOFF_MS.length) {
             try {
-              await sleepWithSignal(
-                QMD_PROBE_RETRY_BACKOFF_MS[attempt] ?? 500,
-                options.signal,
-              );
+              await sleepWithSignal(QMD_PROBE_RETRY_BACKOFF_MS[attempt] ?? 500, options.signal);
             } catch {
               // Aborted mid-backoff: caller cancelled — stop, emit no warning.
               callerCancelled = true;
@@ -1447,17 +1409,15 @@ export class QmdClient implements SearchBackend {
       if (!callerCancelled) {
         if (failureKind === "transient") {
           this.logCliProbeWarning(
-            `QMD: qmdPath ${configuredPath} version check timed out (host may be under load); retried ${retries} time${retries === 1 ? "" : "s"}`,
+            `QMD: qmdPath ${configuredPath} version check timed out (host may be under load); retried ${retries} time${retries === 1 ? "" : "s"}`
           );
         } else if (failureKind === "missing") {
           this.logCliProbeWarning(
-            `QMD: configured qmdPath not found or not executable (${configuredPath}): ${this.lastCliProbeError}`,
+            `QMD: configured qmdPath not found or not executable (${configuredPath}): ${this.lastCliProbeError}`
           );
         } else {
           // Preserve the historical generic message for exit-code/other failures.
-          this.logCliProbeWarning(
-            `QMD: configured qmdPath failed (${configuredPath}): ${this.lastCliProbeError}`,
-          );
+          this.logCliProbeWarning(`QMD: configured qmdPath failed (${configuredPath}): ${this.lastCliProbeError}`);
         }
       }
     }
@@ -1503,10 +1463,7 @@ export class QmdClient implements SearchBackend {
     const targetKey = this.autoUpgradeTargetKey();
     const now = Date.now();
     const lastCheckAtMs = state.lastAutoUpgradeCheckByTargetMs[targetKey];
-    if (
-      Number.isFinite(lastCheckAtMs) &&
-      now - lastCheckAtMs < this.qmdAutoUpgradeCheckIntervalMs
-    ) {
+    if (Number.isFinite(lastCheckAtMs) && now - lastCheckAtMs < this.qmdAutoUpgradeCheckIntervalMs) {
       return;
     }
     state.lastAutoUpgradeCheckByTargetMs[targetKey] = now;
@@ -1524,7 +1481,7 @@ export class QmdClient implements SearchBackend {
       recordAutoUpgradeStatus(
         state,
         targetKey,
-        `current: installed=${qmdVersionToString(installed)} supported=${qmdVersionToString(supported)}`,
+        `current: installed=${qmdVersionToString(installed)} supported=${qmdVersionToString(supported)}`
       );
       return;
     }
@@ -1532,7 +1489,7 @@ export class QmdClient implements SearchBackend {
       const status = `skipped: configured qmdPath=${this.qmdPath}`;
       recordAutoUpgradeStatus(state, targetKey, status);
       log.warn(
-        `QMD auto-upgrade skipped because qmdPath is explicitly configured (${this.qmdPath}); install ${QMD_PACKAGE_NAME}@${this.qmdSupportedVersion} manually for that path.`,
+        `QMD auto-upgrade skipped because qmdPath is explicitly configured (${this.qmdPath}); install ${QMD_PACKAGE_NAME}@${this.qmdSupportedVersion} manually for that path.`
       );
       return;
     }
@@ -1540,13 +1497,9 @@ export class QmdClient implements SearchBackend {
     const packageSpec = `${QMD_PACKAGE_NAME}@${this.qmdSupportedVersion}`;
     try {
       log.warn(
-        `QMD auto-upgrade: installed=${qmdVersionToString(installed)} supported=${qmdVersionToString(supported)}; running npm install -g ${packageSpec}`,
+        `QMD auto-upgrade: installed=${qmdVersionToString(installed)} supported=${qmdVersionToString(supported)}; running npm install -g ${packageSpec}`
       );
-      await runProcessCommand(
-        "npm",
-        ["install", "-g", packageSpec],
-        QMD_AUTO_UPGRADE_TIMEOUT_MS,
-      );
+      await runProcessCommand("npm", ["install", "-g", packageSpec], QMD_AUTO_UPGRADE_TIMEOUT_MS);
       const postInstall = await this.probePostInstallQmdVersion(supported);
       this.qmdPath = postInstall.qmdPath;
       this.qmdPathSource = postInstall.source;
@@ -1567,7 +1520,7 @@ export class QmdClient implements SearchBackend {
       recordAutoUpgradeStatus(
         state,
         targetKey,
-        `upgraded: installed=${this.cliVersion ?? "unknown"} target=${this.qmdSupportedVersion}`,
+        `upgraded: installed=${this.cliVersion ?? "unknown"} target=${this.qmdSupportedVersion}`
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -1590,7 +1543,7 @@ export class QmdClient implements SearchBackend {
           QMD_PROBE_TIMEOUT_MS,
           candidate.qmdPath,
           undefined,
-          this.qmdRuntimeEnv,
+          this.qmdRuntimeEnv
         );
         const postInstall = {
           ...candidate,
@@ -1622,8 +1575,7 @@ export class QmdClient implements SearchBackend {
   private logCliProbeWarning(message: string): void {
     const state = getGlobalQmdState();
     const now = Date.now();
-    const canWarn =
-      state.lastCliWarnAtMs === null || now - state.lastCliWarnAtMs >= QMD_CLI_WARN_THROTTLE_MS;
+    const canWarn = state.lastCliWarnAtMs === null || now - state.lastCliWarnAtMs >= QMD_CLI_WARN_THROTTLE_MS;
     if (!canWarn) {
       log.debug(message);
       return;
@@ -1666,8 +1618,7 @@ export class QmdClient implements SearchBackend {
       .join(",");
     const globalState = getGlobalQmdState();
     const autoUpgradeStatus =
-      globalState.lastAutoUpgradeStatusByTarget[this.autoUpgradeTargetKey()] ??
-      globalState.lastAutoUpgradeStatus;
+      globalState.lastAutoUpgradeStatusByTarget[this.autoUpgradeTargetKey()] ?? globalState.lastAutoUpgradeStatus;
     const probeError = this.lastCliProbeError ? ` cliProbeError=${this.lastCliProbeError}` : "";
     return `cli=${this.available} daemon=${this.daemonAvailable} session=${!!this.daemonSession} cliPath=${cliPath} cliPathSource=${this.qmdPathSource} cliVersion=${cliVersion} supportedVersion=${status.supportedVersion} upgradeAvailable=${status.upgradeAvailable} qmdFeatures=${enabledFeatures || "none"}${autoUpgradeStatus ? ` autoUpgrade=${autoUpgradeStatus}` : ""}${probeError}`;
   }
@@ -1728,6 +1679,18 @@ export class QmdClient implements SearchBackend {
     return fetchQmdStatus((args, timeoutMs) => this.runQmdCommand(args, timeoutMs), this.collection, QMD_TIMEOUT_MS);
   }
 
+  async collectionStatus(collection: string): Promise<Pick<QmdStatusReport, "totalFiles">> {
+    if (!this.isAvailable() || !this.qmdCapabilities.safeStatusDeviceProbe) {
+      return { totalFiles: null };
+    }
+    const report = await fetchQmdStatus(
+      (args, timeoutMs) => this.runQmdCommand(args, timeoutMs),
+      collection,
+      QMD_TIMEOUT_MS
+    );
+    return { totalFiles: report.totalFiles };
+  }
+
   isDaemonMode(): boolean {
     return this.daemonAvailable;
   }
@@ -1763,24 +1726,26 @@ export class QmdClient implements SearchBackend {
     }
     this.daemonTransientFailures += 1;
     if (this.daemonTransientFailures >= QmdClient.DAEMON_MAX_TRANSIENT_FAILURES) {
-      log.debug(`QMD daemon ${label} failed after ${durationMs}ms (${this.daemonTransientFailures} consecutive failures, invalidating): ${err}`);
+      log.debug(
+        `QMD daemon ${label} failed after ${durationMs}ms (${this.daemonTransientFailures} consecutive failures, invalidating): ${err}`
+      );
       this.daemonSession?.invalidate();
       this.daemonAvailable = false;
       this.daemonTransientFailures = 0;
     } else {
-      log.debug(`QMD daemon ${label} failed after ${durationMs}ms (transient ${this.daemonTransientFailures}/${QmdClient.DAEMON_MAX_TRANSIENT_FAILURES}): ${err}`);
+      log.debug(
+        `QMD daemon ${label} failed after ${durationMs}ms (transient ${this.daemonTransientFailures}/${QmdClient.DAEMON_MAX_TRANSIENT_FAILURES}): ${err}`
+      );
     }
   }
 
   private async runQmdCommand(
     args: string[],
     timeoutMs: number,
-    signal?: AbortSignal,
+    signal?: AbortSignal
   ): Promise<{ stdout: string; stderr: string }> {
     const commandArgs =
-      this.qmdIndexName && this.qmdCapabilities.mcpIndexSelection
-        ? ["--index", this.qmdIndexName, ...args]
-        : args;
+      this.qmdIndexName && this.qmdCapabilities.mcpIndexSelection ? ["--index", this.qmdIndexName, ...args] : args;
     return runQmd(commandArgs, timeoutMs, this.qmdPath, signal, this.qmdRuntimeEnv);
   }
 
@@ -1886,10 +1851,7 @@ export class QmdClient implements SearchBackend {
     }
   }
 
-  private addResolvedSearchOptionsToMcpArgs(
-    args: Record<string, unknown>,
-    options?: SearchQueryOptions,
-  ): void {
+  private addResolvedSearchOptionsToMcpArgs(args: Record<string, unknown>, options?: SearchQueryOptions): void {
     if (options?.intent) {
       args.intent = options.intent;
     }
@@ -1921,7 +1883,7 @@ export class QmdClient implements SearchBackend {
     collection?: string,
     maxResults?: number,
     options?: SearchQueryOptions,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<QmdSearchResult[]> {
     const trimmed = query.trim();
     if (!trimmed) return [];
@@ -2003,7 +1965,7 @@ export class QmdClient implements SearchBackend {
       (degradation) => {
         subprocessDegraded = true;
         this.notifyDegradation(execution?.onDegradation, degradation.code, degradation.detail);
-      },
+      }
     );
     // Never cache a degraded empty result: a 60s TTL hit would serve the
     // failure as a genuine no-matches WITHOUT re-reporting the degradation
@@ -2017,7 +1979,7 @@ export class QmdClient implements SearchBackend {
   async searchGlobal(
     query: string,
     maxResults?: number,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<QmdSearchResult[]> {
     const trimmed = query.trim();
     if (!trimmed) return [];
@@ -2062,13 +2024,7 @@ export class QmdClient implements SearchBackend {
     }
 
     // Subprocess fallback (only reached when daemon is unavailable and not loading)
-    return this.searchGlobalViaSubprocess(
-      trimmed,
-      n,
-      searchOptions,
-      execution?.signal,
-      execution?.onDegradation,
-    );
+    return this.searchGlobalViaSubprocess(trimmed, n, searchOptions, execution?.signal, execution?.onDegradation);
   }
 
   /**
@@ -2078,7 +2034,7 @@ export class QmdClient implements SearchBackend {
     query: string,
     collection?: string,
     maxResults?: number,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<QmdSearchResult[]> {
     const trimmed = query.trim();
     if (!trimmed) return [];
@@ -2128,7 +2084,7 @@ export class QmdClient implements SearchBackend {
     query: string,
     collection?: string,
     maxResults?: number,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<QmdSearchResult[]> {
     const trimmed = query.trim();
     if (!trimmed) return [];
@@ -2179,7 +2135,7 @@ export class QmdClient implements SearchBackend {
     query: string,
     collection?: string,
     maxResults?: number,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<QmdSearchResult[]> {
     const n = maxResults ?? this.maxResults;
     const trimmed = query.trim();
@@ -2204,9 +2160,7 @@ export class QmdClient implements SearchBackend {
     }
 
     // Sort by score descending, take top N
-    return [...merged.values()]
-      .sort((a, b) => b.score - a.score)
-      .slice(0, n);
+    return [...merged.values()].sort((a, b) => b.score - a.score).slice(0, n);
   }
 
   private async searchViaDaemon(
@@ -2214,7 +2168,7 @@ export class QmdClient implements SearchBackend {
     collection: string | undefined,
     maxResults: number,
     options?: SearchQueryOptions,
-    signal?: AbortSignal,
+    signal?: AbortSignal
   ): Promise<QmdSearchResult[] | null> {
     if (!this.daemonSession || !this.daemonAvailable) return null;
 
@@ -2248,7 +2202,7 @@ export class QmdClient implements SearchBackend {
 
       if (this.slowLog?.enabled && durationMs >= this.slowLog.thresholdMs) {
         log.warn(
-          `SLOW QMD daemon query: durationMs=${durationMs} collection=${collection ?? "global"} maxResults=${maxResults} queryChars=${query.length} v2=${v2}`,
+          `SLOW QMD daemon query: durationMs=${durationMs} collection=${collection ?? "global"} maxResults=${maxResults} queryChars=${query.length} v2=${v2}`
         );
       }
 
@@ -2278,7 +2232,7 @@ export class QmdClient implements SearchBackend {
     query: string,
     collection: string,
     maxResults: number,
-    signal?: AbortSignal,
+    signal?: AbortSignal
   ): Promise<QmdSearchResult[] | null> {
     if (!this.daemonSession || !this.daemonAvailable) return null;
 
@@ -2296,7 +2250,7 @@ export class QmdClient implements SearchBackend {
             limit: maxResults,
           },
           this.daemonTimeoutMs,
-          signal,
+          signal
         );
       } else {
         // QMD v1: dedicated `search` tool for BM25
@@ -2304,7 +2258,7 @@ export class QmdClient implements SearchBackend {
           "search",
           { query, limit: maxResults, collection },
           this.daemonTimeoutMs,
-          signal,
+          signal
         );
       }
       const durationMs = Date.now() - startedAtMs;
@@ -2331,7 +2285,7 @@ export class QmdClient implements SearchBackend {
     query: string,
     collection: string,
     maxResults: number,
-    signal?: AbortSignal,
+    signal?: AbortSignal
   ): Promise<QmdSearchResult[] | null> {
     if (!this.daemonSession || !this.daemonAvailable) return null;
 
@@ -2349,7 +2303,7 @@ export class QmdClient implements SearchBackend {
             limit: maxResults,
           },
           this.daemonTimeoutMs,
-          signal,
+          signal
         );
       } else {
         // QMD v1: dedicated `vsearch` tool for vector search
@@ -2357,7 +2311,7 @@ export class QmdClient implements SearchBackend {
           "vsearch",
           { query, limit: maxResults, collection },
           this.daemonTimeoutMs,
-          signal,
+          signal
         );
       }
       const durationMs = Date.now() - startedAtMs;
@@ -2389,7 +2343,7 @@ export class QmdClient implements SearchBackend {
   private notifyDegradation(
     onDegradation: SearchExecutionOptions["onDegradation"],
     code: SearchDegradation["code"],
-    detail?: string,
+    detail?: string
   ): void {
     if (!onDegradation) return;
     try {
@@ -2436,7 +2390,7 @@ export class QmdClient implements SearchBackend {
     maxResults: number,
     options?: SearchQueryOptions,
     signal?: AbortSignal,
-    onDegradation?: SearchExecutionOptions["onDegradation"],
+    onDegradation?: SearchExecutionOptions["onDegradation"]
   ): Promise<QmdSearchResult[]> {
     if (this.available === false) return [];
 
@@ -2461,7 +2415,7 @@ export class QmdClient implements SearchBackend {
       const durationMs = Date.now() - startedAtMs;
       if (this.slowLog?.enabled && durationMs >= this.slowLog.thresholdMs) {
         log.warn(
-          `SLOW QMD query: durationMs=${durationMs} collection=${collection} maxResults=${maxResults} queryChars=${query.length}`,
+          `SLOW QMD query: durationMs=${durationMs} collection=${collection} maxResults=${maxResults} queryChars=${query.length}`
         );
       }
 
@@ -2484,7 +2438,7 @@ export class QmdClient implements SearchBackend {
     collection: string,
     maxResults: number,
     signal?: AbortSignal,
-    onDegradation?: SearchExecutionOptions["onDegradation"],
+    onDegradation?: SearchExecutionOptions["onDegradation"]
   ): Promise<QmdSearchResult[]> {
     if (this.available === false) return [];
     const startedAtMs = Date.now();
@@ -2511,7 +2465,7 @@ export class QmdClient implements SearchBackend {
     collection: string,
     maxResults: number,
     signal?: AbortSignal,
-    onDegradation?: SearchExecutionOptions["onDegradation"],
+    onDegradation?: SearchExecutionOptions["onDegradation"]
   ): Promise<QmdSearchResult[]> {
     if (this.available === false) return [];
     const startedAtMs = Date.now();
@@ -2519,7 +2473,7 @@ export class QmdClient implements SearchBackend {
       const { stdout } = await this.runQmdCommand(
         ["vsearch", query, "-c", collection, "--json", "-n", String(maxResults)],
         QMD_TIMEOUT_MS,
-        signal,
+        signal
       );
       log.debug(`QMD vsearch: ${Date.now() - startedAtMs}ms`);
       return parseQmdSearchStdout(stdout);
@@ -2539,7 +2493,7 @@ export class QmdClient implements SearchBackend {
     maxResults: number,
     options?: SearchQueryOptions,
     signal?: AbortSignal,
-    onDegradation?: SearchExecutionOptions["onDegradation"],
+    onDegradation?: SearchExecutionOptions["onDegradation"]
   ): Promise<QmdSearchResult[]> {
     if (this.available === false) return [];
 
@@ -2562,7 +2516,7 @@ export class QmdClient implements SearchBackend {
       const durationMs = Date.now() - startedAtMs;
       if (this.slowLog?.enabled && durationMs >= this.slowLog.thresholdMs) {
         log.warn(
-          `SLOW QMD global ${bm25 ? "search" : "query"}: durationMs=${durationMs} maxResults=${maxResults} queryChars=${query.length}`,
+          `SLOW QMD global ${bm25 ? "search" : "query"}: durationMs=${durationMs} maxResults=${maxResults} queryChars=${query.length}`
         );
       }
 
@@ -2579,40 +2533,26 @@ export class QmdClient implements SearchBackend {
   }
 
   async update(execution?: SearchExecutionOptions): Promise<void> {
-    await this.runUpdateForCollection(
-      this.collection,
-      { perCollectionThrottle: false },
-      execution?.signal,
-    );
+    await this.runUpdateForCollection(this.collection, { perCollectionThrottle: false }, execution?.signal);
   }
 
   async updateStrict(execution?: SearchExecutionOptions): Promise<void> {
     await this.runUpdateForCollection(
       this.collection,
       { perCollectionThrottle: false, strict: true },
-      execution?.signal,
+      execution?.signal
     );
   }
 
-  async updateCollection(
-    collection: string,
-    execution?: SearchExecutionOptions,
-  ): Promise<void> {
-    await this.runUpdateForCollection(
-      collection,
-      { perCollectionThrottle: true },
-      execution?.signal,
-    );
+  async updateCollection(collection: string, execution?: SearchExecutionOptions): Promise<void> {
+    await this.runUpdateForCollection(collection, { perCollectionThrottle: true }, execution?.signal);
   }
 
-  async updateCollectionStrict(
-    collection: string,
-    execution?: SearchExecutionOptions,
-  ): Promise<void> {
+  async updateCollectionStrict(collection: string, execution?: SearchExecutionOptions): Promise<void> {
     await this.runUpdateForCollection(
       collection,
       { perCollectionThrottle: true, strict: true, force: true },
-      execution?.signal,
+      execution?.signal
     );
   }
 
@@ -2623,7 +2563,7 @@ export class QmdClient implements SearchBackend {
   private async runUpdateForCollection(
     collection: string,
     options: { perCollectionThrottle: boolean; strict?: boolean; force?: boolean },
-    signal?: AbortSignal,
+    signal?: AbortSignal
   ): Promise<void> {
     if (this.available === false) {
       if (options.strict) {
@@ -2641,61 +2581,40 @@ export class QmdClient implements SearchBackend {
     const globalState = getGlobalQmdState();
     const now = Date.now();
     if (!options.force && options.perCollectionThrottle) {
-      if (
-        globalState.lastGlobalUpdateFailAtMs &&
-        now - globalState.lastGlobalUpdateFailAtMs < QMD_UPDATE_BACKOFF_MS
-      ) {
+      if (globalState.lastGlobalUpdateFailAtMs && now - globalState.lastGlobalUpdateFailAtMs < QMD_UPDATE_BACKOFF_MS) {
         log.debug("QMD update: suppressed by global failure backoff");
         if (options.strict) throw new Error("QMD update skipped by global failure backoff");
         return;
       }
       const lastCollectionRun = globalState.lastUpdateByCollectionMs[name];
-      if (
-        Number.isFinite(lastCollectionRun) &&
-        now - lastCollectionRun < this.updateMinIntervalMs
-      ) {
+      if (Number.isFinite(lastCollectionRun) && now - lastCollectionRun < this.updateMinIntervalMs) {
         log.debug(`QMD update: suppressed by per-collection min-interval gate (${name})`);
         if (options.strict) throw new Error("QMD update skipped by per-collection min-interval gate");
         return;
       }
       const lastCollectionFail = globalState.lastUpdateFailByCollectionMs[name];
-      if (
-        Number.isFinite(lastCollectionFail) &&
-        now - lastCollectionFail < QMD_UPDATE_BACKOFF_MS
-      ) {
+      if (Number.isFinite(lastCollectionFail) && now - lastCollectionFail < QMD_UPDATE_BACKOFF_MS) {
         log.debug(`QMD update: suppressed by per-collection failure backoff (${name})`);
         if (options.strict) throw new Error("QMD update skipped by per-collection failure backoff");
         return;
       }
     } else if (!options.force) {
-      if (
-        this.lastUpdateRunAtMs &&
-        now - this.lastUpdateRunAtMs < this.updateMinIntervalMs
-      ) {
+      if (this.lastUpdateRunAtMs && now - this.lastUpdateRunAtMs < this.updateMinIntervalMs) {
         log.debug("QMD update: suppressed due to min-interval gate");
         if (options.strict) throw new Error("QMD update skipped by min-interval gate");
         return;
       }
-      if (
-        this._lastUpdateFailAtMs &&
-        now - this._lastUpdateFailAtMs < QMD_UPDATE_BACKOFF_MS
-      ) {
+      if (this._lastUpdateFailAtMs && now - this._lastUpdateFailAtMs < QMD_UPDATE_BACKOFF_MS) {
         log.debug("QMD update: suppressed due to recent failures (backoff)");
         if (options.strict) throw new Error("QMD update skipped by recent failure backoff");
         return;
       }
-      if (
-        globalState.lastGlobalUpdateRunAtMs &&
-        now - globalState.lastGlobalUpdateRunAtMs < this.updateMinIntervalMs
-      ) {
+      if (globalState.lastGlobalUpdateRunAtMs && now - globalState.lastGlobalUpdateRunAtMs < this.updateMinIntervalMs) {
         log.debug("QMD update: suppressed by global min-interval gate");
         if (options.strict) throw new Error("QMD update skipped by global min-interval gate");
         return;
       }
-      if (
-        globalState.lastGlobalUpdateFailAtMs &&
-        now - globalState.lastGlobalUpdateFailAtMs < QMD_UPDATE_BACKOFF_MS
-      ) {
+      if (globalState.lastGlobalUpdateFailAtMs && now - globalState.lastGlobalUpdateFailAtMs < QMD_UPDATE_BACKOFF_MS) {
         log.debug("QMD update: suppressed by global failure backoff");
         if (options.strict) throw new Error("QMD update skipped by global failure backoff");
         return;
@@ -2705,7 +2624,7 @@ export class QmdClient implements SearchBackend {
       if (!globalState.warnedGlobalUpdateBehavior) {
         globalState.warnedGlobalUpdateBehavior = true;
         log.warn(
-          "QMD update runs globally across collections in current CLI versions; Engram now rate-limits update calls to reduce gateway load.",
+          "QMD update runs globally across collections in current CLI versions; Engram now rate-limits update calls to reduce gateway load."
         );
       }
       const startedAtMs = Date.now();
@@ -2773,7 +2692,7 @@ export class QmdClient implements SearchBackend {
       this.collection,
       filePaths,
       300_000,
-      this.buildEmbedArgs(this.collection),
+      this.buildEmbedArgs(this.collection)
     );
     if (result.ok) clearQmdResultCaches();
     return result.ok;
@@ -2781,7 +2700,7 @@ export class QmdClient implements SearchBackend {
 
   private async runEmbedForCollection(
     collection: string,
-    options: { perCollectionThrottle: boolean; strict?: boolean },
+    options: { perCollectionThrottle: boolean; strict?: boolean }
   ): Promise<void> {
     if (this.available === false) {
       if (options.strict) throw new Error("QMD unavailable");
@@ -2795,53 +2714,35 @@ export class QmdClient implements SearchBackend {
     const globalState = getGlobalQmdState();
     const now = Date.now();
     if (options.perCollectionThrottle) {
-      if (
-        globalState.lastGlobalEmbedFailAtMs &&
-        now - globalState.lastGlobalEmbedFailAtMs < QMD_EMBED_BACKOFF_MS
-      ) {
+      if (globalState.lastGlobalEmbedFailAtMs && now - globalState.lastGlobalEmbedFailAtMs < QMD_EMBED_BACKOFF_MS) {
         log.debug(`QMD embed: suppressed by global failure backoff (${name})`);
         if (options.strict) throw new Error("QMD embed skipped by global failure backoff");
         return;
       }
       const lastCollectionRun = globalState.lastEmbedByCollectionMs[name];
-      if (
-        Number.isFinite(lastCollectionRun) &&
-        now - lastCollectionRun < this.updateMinIntervalMs
-      ) {
+      if (Number.isFinite(lastCollectionRun) && now - lastCollectionRun < this.updateMinIntervalMs) {
         log.debug(`QMD embed: suppressed by per-collection min-interval gate (${name})`);
         if (options.strict) throw new Error("QMD embed skipped by per-collection min-interval gate");
         return;
       }
       const lastCollectionFail = globalState.lastEmbedFailByCollectionMs[name];
-      if (
-        Number.isFinite(lastCollectionFail) &&
-        now - lastCollectionFail < QMD_EMBED_BACKOFF_MS
-      ) {
+      if (Number.isFinite(lastCollectionFail) && now - lastCollectionFail < QMD_EMBED_BACKOFF_MS) {
         log.debug(`QMD embed: suppressed by per-collection failure backoff (${name})`);
         if (options.strict) throw new Error("QMD embed skipped by per-collection failure backoff");
         return;
       }
     } else {
-      if (
-        this.lastEmbedFailAtMs &&
-        now - this.lastEmbedFailAtMs < QMD_EMBED_BACKOFF_MS
-      ) {
+      if (this.lastEmbedFailAtMs && now - this.lastEmbedFailAtMs < QMD_EMBED_BACKOFF_MS) {
         log.debug("QMD embed: suppressed due to recent failures (backoff)");
         if (options.strict) throw new Error("QMD embed skipped by recent failure backoff");
         return;
       }
-      if (
-        globalState.lastGlobalEmbedRunAtMs &&
-        now - globalState.lastGlobalEmbedRunAtMs < this.updateMinIntervalMs
-      ) {
+      if (globalState.lastGlobalEmbedRunAtMs && now - globalState.lastGlobalEmbedRunAtMs < this.updateMinIntervalMs) {
         log.debug("QMD embed: suppressed by global min-interval gate");
         if (options.strict) throw new Error("QMD embed skipped by global min-interval gate");
         return;
       }
-      if (
-        globalState.lastGlobalEmbedFailAtMs &&
-        now - globalState.lastGlobalEmbedFailAtMs < QMD_EMBED_BACKOFF_MS
-      ) {
+      if (globalState.lastGlobalEmbedFailAtMs && now - globalState.lastGlobalEmbedFailAtMs < QMD_EMBED_BACKOFF_MS) {
         log.debug("QMD embed: suppressed by global failure backoff");
         if (options.strict) throw new Error("QMD embed skipped by global failure backoff");
         return;
@@ -2903,14 +2804,37 @@ export class QmdClient implements SearchBackend {
     }
   }
 
+  supportsAdditionalCollections(): boolean {
+    return true;
+  }
+
+  async collectionRoot(collection: string, execution?: SearchExecutionOptions): Promise<string | null> {
+    const { stdout } = await this.runQmdCommand(
+      ["collection", "show", collection],
+      QMD_TIMEOUT_MS,
+      execution?.signal
+    );
+    const match = stdout.match(/^\s*Path:\s*(.+?)\s*$/m);
+    return match?.[1]?.trim() || null;
+  }
+
+  async excludeCollectionFromGlobalSearch(collection: string, execution?: SearchExecutionOptions): Promise<void> {
+    await this.runQmdCommand(["collection", "exclude", collection], QMD_TIMEOUT_MS, execution?.signal);
+  }
+
+  async deleteCollection(collection: string, execution?: SearchExecutionOptions): Promise<boolean> {
+    if (collection === this.collection) {
+      throw new Error("Refusing to delete the primary QMD collection");
+    }
+    await this.runQmdCommand(["collection", "remove", collection], QMD_TIMEOUT_MS, execution?.signal);
+    return true;
+  }
+
   async checkCollection(
     collectionOrExecution?: string | SearchExecutionOptions,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<"present" | "missing" | "unknown" | "skipped"> {
-    const { collection, execution: effectiveExecution } = resolveEnsureCollectionArgs(
-      collectionOrExecution,
-      execution,
-    );
+    const { collection, execution: effectiveExecution } = resolveEnsureCollectionArgs(collectionOrExecution, execution);
     if (this.available === false && !this.daemonAvailable) return "unknown";
     // If only daemon is available (no CLI), skip collection check
     if (this.available === false) return "skipped";
@@ -2918,10 +2842,7 @@ export class QmdClient implements SearchBackend {
     try {
       const { stdout } = await this.runQmdCommand(["collection", "list"], QMD_TIMEOUT_MS, effectiveExecution?.signal);
       // Parse text output: "openclaw-engram (qmd://openclaw-engram/)"
-      const collectionRegex = new RegExp(
-        `^${escapeRegExp(targetCollection)}\\s+\\(qmd://`,
-        "m",
-      );
+      const collectionRegex = new RegExp(`^${escapeRegExp(targetCollection)}\\s+\\(qmd://`, "m");
       if (collectionRegex.test(stdout)) {
         return "present";
       }
@@ -2930,7 +2851,7 @@ export class QmdClient implements SearchBackend {
       // Treat command/probe failures as unknown so callers do not disable features
       // permanently after a transient CLI or daemon hiccup.
       log.debug(
-        `QMD collection check unavailable for "${targetCollection}" (will not disable features): ${err instanceof Error ? err.message : String(err)}`,
+        `QMD collection check unavailable for "${targetCollection}" (will not disable features): ${err instanceof Error ? err.message : String(err)}`
       );
       return "unknown";
     }
@@ -2939,12 +2860,9 @@ export class QmdClient implements SearchBackend {
   async ensureCollection(
     memoryDir: string,
     collectionOrExecution?: string | SearchExecutionOptions,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<"present" | "missing" | "unknown" | "skipped"> {
-    const { collection, execution: effectiveExecution } = resolveEnsureCollectionArgs(
-      collectionOrExecution,
-      execution,
-    );
+    const { collection, execution: effectiveExecution } = resolveEnsureCollectionArgs(collectionOrExecution, execution);
     const targetCollection = collection ?? this.collection;
     const collectionState = await this.checkCollection(targetCollection, effectiveExecution);
     if (collectionState !== "missing") return collectionState;
@@ -2953,37 +2871,29 @@ export class QmdClient implements SearchBackend {
       await this.runQmdCommand(
         ["collection", "add", memoryDir, "--name", targetCollection],
         QMD_TIMEOUT_MS,
-        effectiveExecution?.signal,
+        effectiveExecution?.signal
       );
-      log.info(
-        `QMD collection "${targetCollection}" auto-created at ${memoryDir}`,
-      );
+      log.info(`QMD collection "${targetCollection}" auto-created at ${memoryDir}`);
       return "present";
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (isCallerCancellation(err, effectiveExecution?.signal)) {
         log.debug(
-          `QMD collection auto-create for "${targetCollection}" was cancelled; keeping collection state unknown`,
+          `QMD collection auto-create for "${targetCollection}" was cancelled; keeping collection state unknown`
         );
         return "unknown";
       }
       const postCreateState = await this.checkCollection(targetCollection, effectiveExecution);
       if (postCreateState === "present") {
-        log.info(
-          `QMD collection "${targetCollection}" is present after auto-create failure; continuing`,
-        );
+        log.info(`QMD collection "${targetCollection}" is present after auto-create failure; continuing`);
         return "present";
       }
       if (/\balready exists\b|\bexists already\b/i.test(msg)) {
-        log.info(
-          `QMD collection "${targetCollection}" already exists after concurrent auto-create; continuing`,
-        );
+        log.info(`QMD collection "${targetCollection}" already exists after concurrent auto-create; continuing`);
         return "present";
       }
       if (postCreateState !== "missing") return postCreateState;
-      log.warn(
-        `QMD collection "${targetCollection}" not found and auto-create failed: ${msg}`,
-      );
+      log.warn(`QMD collection "${targetCollection}" not found and auto-create failed: ${msg}`);
       return "missing";
     }
   }

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -45,7 +45,7 @@ export interface SearchExecutionOptions {
 
 export function reportSearchDegradation(
   execution: SearchExecutionOptions | undefined,
-  degradation: SearchDegradation,
+  degradation: SearchDegradation
 ): void {
   try {
     execution?.onDegradation?.(degradation);
@@ -56,7 +56,7 @@ export function reportSearchDegradation(
 
 export function resolveEnsureCollectionArgs(
   collectionOrExecution?: string | SearchExecutionOptions,
-  execution?: SearchExecutionOptions,
+  execution?: SearchExecutionOptions
 ): { collection?: string; execution?: SearchExecutionOptions } {
   if (typeof collectionOrExecution === "string") {
     return { collection: collectionOrExecution, execution };
@@ -108,26 +108,26 @@ export interface SearchBackend {
     collection?: string,
     maxResults?: number,
     options?: SearchQueryOptions,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<SearchResult[]>;
   searchGlobal(query: string, maxResults?: number, execution?: SearchExecutionOptions): Promise<SearchResult[]>;
   bm25Search(
     query: string,
     collection?: string,
     maxResults?: number,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<SearchResult[]>;
   vectorSearch(
     query: string,
     collection?: string,
     maxResults?: number,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<SearchResult[]>;
   hybridSearch(
     query: string,
     collection?: string,
     maxResults?: number,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<SearchResult[]>;
 
   // ── Maintenance ──
@@ -178,21 +178,37 @@ export interface SearchBackend {
 
   // ── Collection management ──
   /**
+   * True only when the backend can bind, isolate, search, and delete collections
+   * outside Remnic's primary memory roots.
+   */
+  supportsAdditionalCollections?(): boolean;
+  /**
+   * Prevent a collection from participating in unscoped/global searches.
+   * Dedicated corpora must call this immediately after collection creation.
+   */
+  excludeCollectionFromGlobalSearch?(collection: string, execution?: SearchExecutionOptions): Promise<void>;
+  /** Remove a non-primary collection and its backend-owned index state. */
+  deleteCollection?(collection: string, execution?: SearchExecutionOptions): Promise<boolean>;
+  /** Canonical source root currently bound to a named collection. */
+  collectionRoot?(collection: string, execution?: SearchExecutionOptions): Promise<string | null>;
+  /** Collection-scoped status for observability surfaces. */
+  collectionStatus?(collection: string): Promise<Pick<SearchBackendStatus, "totalFiles">>;
+  /**
    * Optional non-mutating collection probe. Backends that can distinguish a
    * missing collection from a transient probe failure should implement this so
    * callers can avoid auto-creating collections in unsafe layouts.
    */
   checkCollection?(
     collectionOrExecution?: string | SearchExecutionOptions,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<"present" | "missing" | "unknown" | "skipped">;
   ensureCollection(
     memoryDir: string,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<"present" | "missing" | "unknown" | "skipped">;
   ensureCollection(
     memoryDir: string,
     collection?: string,
-    execution?: SearchExecutionOptions,
+    execution?: SearchExecutionOptions
   ): Promise<"present" | "missing" | "unknown" | "skipped">;
 }


### PR DESCRIPTION
Closes #2060. Opt-in per-wiki QMD collection (default false), never default hot-facts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches QMD collection lifecycle and global-search isolation; mistakes could leak wiki pages into default recall or delete the wrong collection, though primary-collection deletion is explicitly refused and rollback paths are tested.
> 
> **Overview**
> Adds **opt-in, per-wiki QMD indexing** for external wiki concept pages (`indexInQmd`, default off). Each enabled wiki gets a predictable `external-wiki-*` collection that indexes only `pagesDir` markdown, stays out of global memory search, and never targets the primary memory collection.
> 
> **`ExternalWikiCollectionManager`** drives ensure → exclude-from-global → update → embed, with content fingerprinting to skip unchanged pages, serialized refresh/purge, rollback on failed exclusion, path/symlink guards for `pagesDir`, and wiki-scoped hybrid search that filters hits to indexed pages (fail-open when unsupported or degraded).
> 
> **`ExternalWikiCollectionRegistrar`** runs an initial refresh plus interval maintenance with single-flight ticks, abort propagation on dispose, and injectable timers for tests.
> 
> **`SearchBackend` / `QmdClient`** gain optional APIs for additional collections: `supportsAdditionalCollections`, `excludeCollectionFromGlobalSearch`, `deleteCollection`, `collectionRoot`, and `collectionStatus` (wired to `qmd collection exclude/remove/show` and per-collection `status`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a63437631abfc2815d1de2a165f91e32f2da98fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for indexing external wiki collections for search.
  * External wiki content can now be refreshed immediately or on a schedule.
  * Search results can be scoped to a specific wiki while excluding wiki collections from global search.
  * Added collection status reporting, root detection, and support for managing collection lifecycle.
* **Bug Fixes**
  * Improved handling of refresh failures, stale content, disabled collections, unsafe paths, and collection name conflicts.
  * Prevented deletion of the primary search collection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->