### PR TITLE
fix(core): harden external wiki filesystem reads and root isolation

### DIFF
--- a/.changeset/secure-wiki-reads.md
+++ b/.changeset/secure-wiki-reads.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Harden external wiki reads against path races, canonical root aliases, unbounded fallback scans, and nested catalog paths.

--- a/packages/remnic-core/src/external-wiki-config.ts
+++ b/packages/remnic-core/src/external-wiki-config.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { assertExternalWikiRootOutsideMemoryDir } from "./external-wiki-guard.js";
 import type { ExternalWikiRoot } from "./types.js";
 import { expandTildePath } from "./utils/path.js";
 
@@ -30,11 +31,6 @@ function parseRootDir(value: unknown, keyName: string): string {
     throw new Error(`${keyName} must be an absolute path or start with ~/`);
   }
   return path.resolve(expandTildePath(raw));
-}
-
-function pathsOverlap(left: string, right: string): boolean {
-  const relative = path.relative(left, right);
-  return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
 }
 
 function parseRootRelativePath(value: unknown, fallback: string, keyName: string): string {
@@ -75,11 +71,8 @@ export function parseExternalWikiRoots(value: unknown, memoryDir?: string): Exte
     }
 
     const rootDir = parseRootDir(raw.rootDir, `${keyName}.rootDir`);
-    if (
-      memoryDir !== undefined &&
-      (pathsOverlap(path.resolve(memoryDir), rootDir) || pathsOverlap(rootDir, path.resolve(memoryDir)))
-    ) {
-      throw new Error(`${keyName}.rootDir must be outside memoryDir`);
+    if (memoryDir !== undefined) {
+      assertExternalWikiRootOutsideMemoryDir(memoryDir, rootDir);
     }
 
     const label = raw.label === undefined ? undefined : requireString(raw.label, `${keyName}.label`);

--- a/packages/remnic-core/src/external-wiki-guard.ts
+++ b/packages/remnic-core/src/external-wiki-guard.ts
@@ -1,3 +1,4 @@
+import { realpath } from "node:fs/promises";
 import path from "node:path";
 
 export const EXTERNAL_WIKI_COLLECTION_PREFIX = "external-wiki-";
@@ -15,4 +16,25 @@ export function assertExternalWikiRootOutsideMemoryDir(memoryDir: string, rootDi
   if (isInsideMemoryDir) {
     throw new Error(`external wiki rootDir must be outside memoryDir: ${rootDir}`);
   }
+}
+
+async function canonicalPathIfPresent(candidate: string): Promise<string> {
+  const resolved = path.resolve(candidate);
+  try {
+    return await realpath(resolved);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return resolved;
+    throw error;
+  }
+}
+
+export async function assertExternalWikiRootOutsideMemoryDirCanonical(
+  memoryDir: string,
+  rootDir: string
+): Promise<void> {
+  const [canonicalMemoryDir, canonicalRootDir] = await Promise.all([
+    canonicalPathIfPresent(memoryDir),
+    canonicalPathIfPresent(rootDir),
+  ]);
+  assertExternalWikiRootOutsideMemoryDir(canonicalMemoryDir, canonicalRootDir);
 }

--- a/packages/remnic-core/src/external-wiki-guard.ts
+++ b/packages/remnic-core/src/external-wiki-guard.ts
@@ -18,13 +18,19 @@ export function assertExternalWikiRootOutsideMemoryDir(memoryDir: string, rootDi
   }
 }
 
-async function canonicalPathIfPresent(candidate: string): Promise<string> {
-  const resolved = path.resolve(candidate);
-  try {
-    return await realpath(resolved);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return resolved;
-    throw error;
+async function canonicalPath(candidate: string): Promise<string> {
+  let existing = path.resolve(candidate);
+  const suffix: string[] = [];
+  while (true) {
+    try {
+      return path.join(await realpath(existing), ...suffix);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = path.dirname(existing);
+      if (parent === existing) throw error;
+      suffix.unshift(path.basename(existing));
+      existing = parent;
+    }
   }
 }
 
@@ -32,9 +38,6 @@ export async function assertExternalWikiRootOutsideMemoryDirCanonical(
   memoryDir: string,
   rootDir: string
 ): Promise<void> {
-  const [canonicalMemoryDir, canonicalRootDir] = await Promise.all([
-    canonicalPathIfPresent(memoryDir),
-    canonicalPathIfPresent(rootDir),
-  ]);
+  const [canonicalMemoryDir, canonicalRootDir] = await Promise.all([canonicalPath(memoryDir), canonicalPath(rootDir)]);
   assertExternalWikiRootOutsideMemoryDir(canonicalMemoryDir, canonicalRootDir);
 }

--- a/packages/remnic-core/src/external-wiki.test.ts
+++ b/packages/remnic-core/src/external-wiki.test.ts
@@ -107,6 +107,22 @@ test("parses markdown and wiki-link catalog entries deterministically", () => {
   ]);
 });
 
+test("resolves markdown catalog links relative to a nested index file", () => {
+  const parsed = externalWiki.parseExternalWikiCatalog(
+    "- [Nested concept](../wiki/nested.md) - Nested catalog entry.\n",
+    wikiConfig("/srv/wiki", { indexFile: "catalog/INDEX.md" })
+  );
+
+  assert.deepEqual(parsed, [
+    {
+      title: "Nested concept",
+      path: "nested.md",
+      indexBlurb: "Nested catalog entry.",
+      indexLine: 1,
+    },
+  ]);
+});
+
 test("loads a bounded index and falls back to a sorted page listing", async () => {
   await withWiki(async (rootDir) => {
     await mkdir(path.join(rootDir, "wiki", "nested"), { recursive: true });
@@ -147,6 +163,22 @@ test("loads a bounded index and falls back to a sorted page listing", async () =
     await assert.rejects(
       () => externalWiki.loadExternalWikiCatalog(wikiConfig(rootDir), { maxIndexBytes: 8 }),
       /INDEX\.md exceeds 8 bytes/
+    );
+  });
+});
+
+test("bounds all filesystem entries visited by catalog fallback", async () => {
+  await withWiki(async (rootDir) => {
+    await mkdir(path.join(rootDir, "wiki"));
+    await Promise.all(
+      Array.from({ length: 101 }, (_, index) =>
+        writeFile(path.join(rootDir, "wiki", `ignored-${index}.txt`), "ignored\n")
+      )
+    );
+
+    await assert.rejects(
+      () => externalWiki.loadExternalWikiCatalog(wikiConfig(rootDir), { maxEntries: 1 }),
+      /more than 100 filesystem entries/
     );
   });
 });

--- a/packages/remnic-core/src/external-wiki.ts
+++ b/packages/remnic-core/src/external-wiki.ts
@@ -1,4 +1,6 @@
+import { constants } from "node:fs";
 import { open, opendir, realpath, stat } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import type { ExternalWikiRoot } from "./types.js";
 
@@ -9,6 +11,8 @@ const DEFAULT_MAX_DIRECTORY_DEPTH = 32;
 const MAX_READ_BYTES = 16_777_216;
 const MAX_CATALOG_ENTRIES = 100_000;
 const MAX_DIRECTORY_DEPTH = 128;
+const MIN_VISITED_ENTRIES = 100;
+const MAX_VISITED_ENTRIES = 1_000_000;
 
 export type { ExternalWikiRoot } from "./types.js";
 
@@ -146,7 +150,9 @@ export async function validateExternalWikiLayout(config: ExternalWikiRoot): Prom
   };
 }
 
-function normalizeCatalogPath(target: string, config: ExternalWikiRoot): string | null {
+type CatalogPathBase = "index" | "pages";
+
+function normalizeCatalogPath(target: string, config: ExternalWikiRoot, base: CatalogPathBase): string | null {
   let decoded: string;
   try {
     decoded = decodeURIComponent(target.trim());
@@ -157,25 +163,26 @@ function normalizeCatalogPath(target: string, config: ExternalWikiRoot): string 
   if (
     withoutFragment.length === 0 ||
     withoutFragment.startsWith("/") ||
-    withoutFragment.startsWith("\\") ||
+    withoutFragment.includes("\\") ||
     /^[a-z][a-z0-9+.-]*:/i.test(withoutFragment)
   ) {
     return null;
   }
 
-  let relative = withoutFragment.replaceAll("\\", "/").replace(/^\.\//, "");
-  const pagesPrefix = `${config.pagesDir.replaceAll("\\", "/").replace(/\/$/, "")}/`;
-  if (relative.startsWith(pagesPrefix)) relative = relative.slice(pagesPrefix.length);
-  const normalized = path.posix.normalize(relative);
+  const pagesDir = path.posix.normalize(config.pagesDir);
+  const baseDir = base === "index" ? path.posix.dirname(config.indexFile) : pagesDir;
+  const rootRelativeTarget = path.posix.normalize(path.posix.join(baseDir, withoutFragment));
+  const relative = path.posix.relative(pagesDir, rootRelativeTarget);
   if (
-    normalized === ".." ||
-    normalized.startsWith("../") ||
-    normalized === "." ||
-    !normalized.toLowerCase().endsWith(".md")
+    relative === ".." ||
+    relative.startsWith("../") ||
+    path.posix.isAbsolute(relative) ||
+    relative === "." ||
+    !relative.toLowerCase().endsWith(".md")
   ) {
     return null;
   }
-  return normalized;
+  return relative;
 }
 
 function catalogBlurb(line: string, matchEnd: number): string | undefined {
@@ -203,20 +210,23 @@ export function parseExternalWikiCatalog(
     let target: string;
     let title: string;
     let matchEnd: number;
+    let pathBase: CatalogPathBase;
     if (markdownMatch) {
       title = markdownMatch[1]?.trim() ?? "";
       target = markdownMatch[2]?.trim() ?? "";
       matchEnd = (markdownMatch.index ?? 0) + markdownMatch[0].length;
+      pathBase = "index";
     } else if (wikiMatch) {
       const wikiTarget = wikiMatch[1]?.trim() ?? "";
       title = wikiMatch[2]?.trim() || humanizePagePath(wikiTarget);
       target = wikiTarget.toLowerCase().endsWith(".md") ? wikiTarget : `${wikiTarget}.md`;
       matchEnd = (wikiMatch.index ?? 0) + wikiMatch[0].length;
+      pathBase = "pages";
     } else {
       continue;
     }
 
-    const pagePath = normalizeCatalogPath(target, config);
+    const pagePath = normalizeCatalogPath(target, config, pathBase);
     if (!pagePath || title.length === 0 || seenPaths.has(pagePath)) continue;
     if (entries.length >= maxEntries) {
       throw new Error(`catalog contains more than ${maxEntries} entries`);
@@ -238,10 +248,40 @@ interface BoundedUtf8Read {
   bytes: number;
 }
 
-async function readBoundedUtf8(filePath: string, maxBytes: number, displayPath: string): Promise<BoundedUtf8Read> {
-  assertPositiveInteger(maxBytes, "maxBytes", MAX_READ_BYTES);
-  const handle = await open(filePath, "r");
+async function canonicalOpenedFile(handle: FileHandle, filePath: string, displayPath: string): Promise<string> {
+  if (process.platform === "linux") {
+    const descriptorPath = await realpath(`/proc/self/fd/${handle.fd}`).catch(() => undefined);
+    if (descriptorPath !== undefined) return descriptorPath;
+  }
+
+  let canonical: string;
   try {
+    canonical = await realpath(filePath);
+  } catch {
+    throw new Error(`${displayPath} changed while being opened`);
+  }
+  const [openedStat, pathStat] = await Promise.all([handle.stat(), stat(canonical)]);
+  if (openedStat.dev !== pathStat.dev || openedStat.ino !== pathStat.ino) {
+    throw new Error(`${displayPath} changed while being opened`);
+  }
+  return canonical;
+}
+
+async function readBoundedUtf8(
+  filePath: string,
+  allowedRoot: string,
+  maxBytes: number,
+  displayPath: string
+): Promise<BoundedUtf8Read> {
+  assertPositiveInteger(maxBytes, "maxBytes", MAX_READ_BYTES);
+  const handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const openedStat = await handle.stat();
+    if (!openedStat.isFile()) throw new Error(`${displayPath} is not a file`);
+    const canonical = await canonicalOpenedFile(handle, filePath, displayPath);
+    if (!isInside(allowedRoot, canonical)) {
+      throw new Error(`${displayPath} escapes configured root`);
+    }
     const buffer = Buffer.allocUnsafe(maxBytes + 1);
     const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
     if (bytesRead > maxBytes) throw new Error(`${displayPath} exceeds ${maxBytes} bytes`);
@@ -271,10 +311,16 @@ async function listMarkdownPages(
   assertPositiveInteger(maxEntries, "maxEntries", MAX_CATALOG_ENTRIES);
   assertPositiveInteger(maxDepth, "maxDepth", MAX_DIRECTORY_DEPTH);
   const paths: string[] = [];
+  const maxVisitedEntries = Math.min(MAX_VISITED_ENTRIES, Math.max(MIN_VISITED_ENTRIES, maxEntries * 100));
+  let visitedEntries = 0;
   const walk = async (directory: string, relativeDirectory: string, depth: number): Promise<void> => {
     if (depth > maxDepth) throw new Error(`pages directory exceeds maxDepth ${maxDepth}`);
     const dir = await opendir(directory);
     for await (const entry of dir) {
+      visitedEntries += 1;
+      if (visitedEntries > maxVisitedEntries) {
+        throw new Error(`pages directory contains more than ${maxVisitedEntries} filesystem entries`);
+      }
       const relativePath = relativeDirectory ? path.posix.join(relativeDirectory, entry.name) : entry.name;
       if (entry.isDirectory()) {
         await walk(path.join(directory, entry.name), relativePath, depth + 1);
@@ -312,7 +358,7 @@ export async function loadExternalWikiCatalog(
   const layout = await validateExternalWikiLayout(config);
   const entries = layout.indexPresent
     ? parseExternalWikiCatalog(
-        (await readBoundedUtf8(layout.indexFile, maxIndexBytes, config.indexFile)).content,
+        (await readBoundedUtf8(layout.indexFile, layout.rootDir, maxIndexBytes, config.indexFile)).content,
         config,
         { maxEntries }
       )
@@ -361,7 +407,7 @@ export async function readExternalWikiPage(
     throw new Error("page path must stay within the pages directory");
   }
   if (!(await stat(canonical)).isFile()) throw new Error(`external wiki page is not a file: ${pagePath}`);
-  const page = await readBoundedUtf8(canonical, maxBytes, pagePath);
+  const page = await readBoundedUtf8(canonical, layout.pagesDir, maxBytes, pagePath);
   return {
     wikiId: config.id,
     path: pagePath,

--- a/packages/remnic-core/src/orchestration/external-wiki-recall-guard.test.ts
+++ b/packages/remnic-core/src/orchestration/external-wiki-recall-guard.test.ts
@@ -1,13 +1,23 @@
 import assert from "node:assert/strict";
+import { mkdir, symlink } from "node:fs/promises";
+import path from "node:path";
 import test from "node:test";
 
 import type { QmdSearchResult } from "../types.js";
-import { assertExternalWikiRootOutsideMemoryDir } from "../external-wiki-guard.js";
+import * as wikiGuard from "../external-wiki-guard.js";
+import { withTempDir } from "../testing/tmp-dir.js";
 import {
   filterRecallCandidates,
   isExternalWikiCollectionName,
   isGenericRecallExcludedPath,
 } from "./generic-recall-paths.js";
+
+const { assertExternalWikiRootOutsideMemoryDir } = wikiGuard;
+const assertCanonicalIsolation = (
+  wikiGuard as typeof wikiGuard & {
+    assertExternalWikiRootOutsideMemoryDirCanonical(memoryDir: string, rootDir: string): Promise<void>;
+  }
+).assertExternalWikiRootOutsideMemoryDirCanonical;
 
 function hit(path: string, snippet: string): QmdSearchResult {
   return { docid: path, path, score: 1, snippet };
@@ -62,4 +72,17 @@ test("external wiki roots cannot enter the primary memory collection walk", () =
     /must be outside memoryDir/
   );
   assert.doesNotThrow(() => assertExternalWikiRootOutsideMemoryDir("/data/memory", "/data/compiled-wiki"));
+});
+
+test("external wiki root isolation resolves filesystem aliases", async () => {
+  assert.equal(typeof assertCanonicalIsolation, "function");
+  await withTempDir(async (rootDir) => {
+    const memoryDir = path.join(rootDir, "memory");
+    const nestedWiki = path.join(memoryDir, "compiled-wiki");
+    const wikiAlias = path.join(rootDir, "wiki-alias");
+    await mkdir(nestedWiki, { recursive: true });
+    await symlink(nestedWiki, wikiAlias);
+
+    await assert.rejects(() => assertCanonicalIsolation(memoryDir, wikiAlias), /must be outside memoryDir/);
+  }, "remnic-external-wiki-guard-");
 });

--- a/packages/remnic-core/src/orchestration/external-wiki-recall-guard.test.ts
+++ b/packages/remnic-core/src/orchestration/external-wiki-recall-guard.test.ts
@@ -82,7 +82,13 @@ test("external wiki root isolation resolves filesystem aliases", async () => {
     const wikiAlias = path.join(rootDir, "wiki-alias");
     await mkdir(nestedWiki, { recursive: true });
     await symlink(nestedWiki, wikiAlias);
+    const memoryAlias = path.join(rootDir, "memory-alias");
+    await symlink(memoryDir, memoryAlias);
 
     await assert.rejects(() => assertCanonicalIsolation(memoryDir, wikiAlias), /must be outside memoryDir/);
+    await assert.rejects(
+      () => assertCanonicalIsolation(memoryDir, path.join(memoryAlias, "future-wiki")),
+      /must be outside memoryDir/
+    );
   }, "remnic-external-wiki-guard-");
 });

--- a/packages/remnic-core/src/orchestration/orchestrator-init.ts
+++ b/packages/remnic-core/src/orchestration/orchestrator-init.ts
@@ -20,12 +20,21 @@
 import { readdir, stat, unlink } from "node:fs/promises";
 import path from "node:path";
 import { SmartBuffer } from "../buffer.js";
-import { resolveIndexingCapabilities, resolveLocalLlmCapabilities, resolveMemoryLifecycleCapabilities, resolveNamespaceCapabilities, resolveQmdCapabilities, resolveRecallAuxiliaryCapabilities, resolveUtilityLearningCapabilities } from "../capabilities.js";
+import {
+  resolveIndexingCapabilities,
+  resolveLocalLlmCapabilities,
+  resolveMemoryLifecycleCapabilities,
+  resolveNamespaceCapabilities,
+  resolveQmdCapabilities,
+  resolveRecallAuxiliaryCapabilities,
+  resolveUtilityLearningCapabilities,
+} from "../capabilities.js";
 import { CompoundingEngine } from "../compounding/engine.js";
 import type { ConversationIndexBackend } from "../conversation-index/backend.js";
 import type { CorrectionService } from "../correction/correction-service.js";
 import { EmbeddingFallback } from "../embedding-fallback.js";
 import { ContentHashIndex, StorageManager } from "../index.js";
+import { assertExternalWikiRootOutsideMemoryDirCanonical } from "../external-wiki-guard.js";
 import { log } from "../logger.js";
 import { migrateFromEngram } from "../migrate/from-engram.js";
 import { NamespaceCatalog } from "../namespaces/catalog.js";
@@ -69,10 +78,7 @@ export interface OrchestratorInitDeps {
   getMeetingsService(namespace?: string): Promise<MeetingsService>;
   readonly handleHistory: RecallHandleHistoryStore;
   readonly lastRecall: LastRecallStore;
-  maintenanceNamespaces(
-    jobName?: string,
-    budgetMode?: "cycle" | "unbounded",
-  ): Promise<string[]>;
+  maintenanceNamespaces(jobName?: string, budgetMode?: "cycle" | "unbounded"): Promise<string[]>;
   readonly maintenanceScheduler: MaintenanceScheduler;
   readonly namespaceCatalog: NamespaceCatalog;
   readonly namespaceSearchRouter: NamespaceSearchRouter;
@@ -97,9 +103,7 @@ export interface OrchestratorInitDeps {
 }
 
 export class OrchestratorInitCoordinator {
-  constructor(
-    private readonly deps: OrchestratorInitDeps,
-  ) {}
+  constructor(private readonly deps: OrchestratorInitDeps) {}
 
   async initialize(): Promise<void> {
     // Recreate the deferred-ready gate on every initialize() call.
@@ -118,6 +122,11 @@ export class OrchestratorInitCoordinator {
       });
       await this.deps.storage.loadAliases();
       await this.deps.storage.ensureDirectories();
+      await Promise.all(
+        this.deps.config.externalWikis.map((wiki) =>
+          assertExternalWikiRootOutsideMemoryDirCanonical(this.deps.config.memoryDir, wiki.rootDir)
+        )
+      );
       if (resolveNamespaceCapabilities(this.deps.config).namespaces) {
         const namespaces = new Set<string>([
           this.deps.config.defaultNamespace,
@@ -152,16 +161,20 @@ export class OrchestratorInitCoordinator {
             for (const rec of await this.deps.namespaceCatalog.listNamespaces()) {
               correctionNamespaces.add(rec.namespace);
             }
-          } catch { /* best-effort */ }
+          } catch {
+            /* best-effort */
+          }
         }
-        const recovered = await this.deps.passiveCorrectionService().recoverStaleApplyingPlans(
-          [...correctionNamespaces],
-        );
+        const recovered = await this.deps
+          .passiveCorrectionService()
+          .recoverStaleApplyingPlans([...correctionNamespaces]);
         if (recovered > 0) {
           log.info(`correction: recovered ${recovered} stale applying plan(s) on startup`);
         }
       } catch (staleErr) {
-        log.debug(`correction: stale-plan recovery skipped: ${staleErr instanceof Error ? staleErr.message : String(staleErr)}`);
+        log.debug(
+          `correction: stale-plan recovery skipped: ${staleErr instanceof Error ? staleErr.message : String(staleErr)}`
+        );
       }
       await this.deps.relevance.load();
       await this.deps.negatives.load();
@@ -184,9 +197,7 @@ export class OrchestratorInitCoordinator {
       if (resolveRecallAuxiliaryCapabilities(this.deps.config).factDeduplication) {
         try {
           this.deps.contentHashIndex = await this.deps.storage.getAuthoritativeFactHashIndex();
-          log.info(
-            `content-hash dedup: rebuilt authoritative index with ${this.deps.contentHashIndex.size} hashes`,
-          );
+          log.info(`content-hash dedup: rebuilt authoritative index with ${this.deps.contentHashIndex.size} hashes`);
         } catch (err) {
           // PR #2016: the locked corpus rebuild could not run at init (transient
           // cross-process contention). Pre-warm with the shared instance instead
@@ -196,7 +207,7 @@ export class OrchestratorInitCoordinator {
           this.deps.contentHashIndex = await this.deps.storage.getSharedFactHashIndex();
           log.warn(
             `content-hash dedup: authoritative rebuild deferred at init (${err instanceof Error ? err.message : String(err)}); ` +
-              `using the shared index, will retry the locked rebuild on next use`,
+              `using the shared index, will retry the locked rebuild on next use`
           );
         }
       }
@@ -214,9 +225,7 @@ export class OrchestratorInitCoordinator {
       try {
         await this.deps.buffer.load();
       } catch (bufErr) {
-        log.error(
-          `buffer.load() failed (init gate will still open): ${bufErr}`,
-        );
+        log.error(`buffer.load() failed (init gate will still open): ${bufErr}`);
         this.deps.buffer.resetToEmpty();
       }
       if (resolveRecallAuxiliaryCapabilities(this.deps.config).compactionReset) {
@@ -262,45 +271,36 @@ export class OrchestratorInitCoordinator {
               const collectionCheckAbort = new AbortController();
               const state = await qmdStartupCollectionCheckWithTimeout(
                 resolveNamespaceCapabilities(this.deps.config).namespaces
-                  ? this.deps.namespaceSearchRouter.ensureNamespaceCollection(
-                      namespace,
-                      { signal: collectionCheckAbort.signal },
-                    )
-                  : this.deps.qmd.ensureCollection(
-                      this.deps.config.memoryDir,
-                      this.deps.config.qmdCollection,
-                      { signal: collectionCheckAbort.signal },
-                    ),
+                  ? this.deps.namespaceSearchRouter.ensureNamespaceCollection(namespace, {
+                      signal: collectionCheckAbort.signal,
+                    })
+                  : this.deps.qmd.ensureCollection(this.deps.config.memoryDir, this.deps.config.qmdCollection, {
+                      signal: collectionCheckAbort.signal,
+                    }),
                 collectionCheckAbort,
-                namespace,
+                namespace
               );
               return { namespace, state };
-            }),
+            })
           );
           const defaultState =
-            states.find(
-              (entry) => entry.namespace === this.deps.config.defaultNamespace,
-            )?.state ?? "unknown";
+            states.find((entry) => entry.namespace === this.deps.config.defaultNamespace)?.state ?? "unknown";
           if (defaultState === "missing") {
             await this.deps.disposeSearchBackendIfNeeded();
             this.deps.qmd = new NoopSearchBackend();
             log.warn(
-              "Search collection missing for Remnic memory store; disabling search retrieval for this runtime (fallback retrieval remains enabled)",
+              "Search collection missing for Remnic memory store; disabling search retrieval for this runtime (fallback retrieval remains enabled)"
             );
           } else if (defaultState === "unknown") {
-            log.warn(
-              "Search collection check unavailable; keeping search retrieval enabled for fail-open behavior",
-            );
+            log.warn("Search collection check unavailable; keeping search retrieval enabled for fail-open behavior");
           } else if (defaultState === "skipped") {
-            log.debug(
-              "Search collection check skipped (remote or daemon-only mode)",
-            );
+            log.debug("Search collection check skipped (remote or daemon-only mode)");
           }
           for (const entry of states) {
             if (entry.namespace === this.deps.config.defaultNamespace) continue;
             if (entry.state === "missing") {
               log.warn(
-                `Search collection missing for namespace '${entry.namespace}'; namespace retrieval will fail open to non-search paths`,
+                `Search collection missing for namespace '${entry.namespace}'; namespace retrieval will fail open to non-search paths`
               );
             }
           }
@@ -338,7 +338,8 @@ export class OrchestratorInitCoordinator {
       const resolveDeferred = this.deps.resolveDeferredReady;
       this.deps.resolveDeferredReady = null;
       this.deps.deferredInitAbort = new AbortController();
-      this.deps.deferredInitialize(this.deps.deferredInitAbort.signal)
+      this.deps
+        .deferredInitialize(this.deps.deferredInitAbort.signal)
         .catch((err) => {
           log.error(`deferred initialization failed (non-fatal): ${err}`);
         })
@@ -383,10 +384,7 @@ export class OrchestratorInitCoordinator {
           // a dynamic namespace written before a daemon restart must be synced on
           // boot, not only by the debounced runQmdMaintenance() path. Same union +
           // catalog-read-failure fallback as runQmdMaintenance.
-          await this.deps.namespaceSearchRouter.updateNamespaces(
-            await this.deps.maintenanceNamespaces(),
-            { signal },
-          );
+          await this.deps.namespaceSearchRouter.updateNamespaces(await this.deps.maintenanceNamespaces(), { signal });
         } else {
           await this.deps.qmd.update({ signal });
         }
@@ -396,7 +394,7 @@ export class OrchestratorInitCoordinator {
         log.warn(`QMD startup sync failed (non-fatal): ${err}`);
         // deferredSyncSucceeded stays false — server retry will attempt sync
       }
-    } else if (!(this.deps.qmd.isAvailable())) {
+    } else if (!this.deps.qmd.isAvailable()) {
       // QMD not available at deferred init time — server retry will handle it
     } else {
       // QMD available but maintenance disabled — consider sync not needed
@@ -419,7 +417,7 @@ export class OrchestratorInitCoordinator {
           })
           .catch((err) => {
             log.debug(`QMD warmup search failed (non-fatal): ${err}`);
-          }),
+          })
       );
     }
     if (resolveMemoryLifecycleCapabilities(this.deps.config).embeddingFallback) {
@@ -427,13 +425,11 @@ export class OrchestratorInitCoordinator {
         this.deps.embeddingFallback
           .isAvailable()
           .then((ok) => {
-            log.info(
-              `Embedding fallback warmup: ${ok ? "available" : "unavailable (no provider)"}`,
-            );
+            log.info(`Embedding fallback warmup: ${ok ? "available" : "unavailable (no provider)"}`);
           })
           .catch((err) => {
             log.debug(`Embedding fallback warmup failed (non-fatal): ${err}`);
-          }),
+          })
       );
     }
     await Promise.all(warmupPromises);
@@ -453,11 +449,21 @@ export class OrchestratorInitCoordinator {
           } catch (err) {
             log.debug(`Knowledge Index warmup failed (non-fatal): ${err}`);
           }
-        })(),
+        })()
       );
     }
-    cacheWarmups.push(this.deps.storage.readAllMemories().then(() => {}).catch(() => {}));
-    cacheWarmups.push(this.deps.storage.readAllEntityFiles().then(() => {}).catch(() => {}));
+    cacheWarmups.push(
+      this.deps.storage
+        .readAllMemories()
+        .then(() => {})
+        .catch(() => {})
+    );
+    cacheWarmups.push(
+      this.deps.storage
+        .readAllEntityFiles()
+        .then(() => {})
+        .catch(() => {})
+    );
     await Promise.all(cacheWarmups);
     if (signal.aborted) return;
 
@@ -509,8 +515,7 @@ export class OrchestratorInitCoordinator {
     if (signal.aborted) return;
     if (lifecycleCaps.lifecyclePolicy && resolveQmdCapabilities(this.deps.config).qmdTierMigration) {
       try {
-        const { runFirstStartMigration } = await import("../maintenance/first-start-migration.js"
-        );
+        const { runFirstStartMigration } = await import("../maintenance/first-start-migration.js");
         const result = await runFirstStartMigration({
           storage: this.deps.storage,
           config: this.deps.config,
@@ -521,7 +526,7 @@ export class OrchestratorInitCoordinator {
         });
         if (!result.skipped) {
           log.info(
-            `first-start lifecycle migration: demoted ${result.demotedCount} of ${result.candidateCount} candidates (cap=${result.cappedAt})`,
+            `first-start lifecycle migration: demoted ${result.demotedCount} of ${result.candidateCount} candidates (cap=${result.cappedAt})`
           );
         } else {
           log.debug(`first-start lifecycle migration skipped: ${result.skipReason}`);
@@ -572,16 +577,14 @@ export class OrchestratorInitCoordinator {
               info: (message) => log.info(message),
               warn: (message) => log.warn(message),
             },
-          },
+          }
         );
         log.info(
-          `wearables auto-sync started: every ${this.deps.config.wearables.autoSyncIntervalMinutes}m over ${this.deps.config.wearables.autoSyncDays}d (deep ${this.deps.config.wearables.autoSyncDeepDays}d daily)`,
+          `wearables auto-sync started: every ${this.deps.config.wearables.autoSyncIntervalMinutes}m over ${this.deps.config.wearables.autoSyncDays}d (deep ${this.deps.config.wearables.autoSyncDeepDays}d daily)`
         );
       } catch (err) {
         const { displayErrorDetail } = await import("../runtime/better-sqlite.js");
-        log.warn(
-          `wearables auto-sync failed to start (non-fatal): ${displayErrorDetail(err)}`,
-        );
+        log.warn(`wearables auto-sync failed to start (non-fatal): ${displayErrorDetail(err)}`);
       }
     }
 
@@ -635,8 +638,10 @@ export class OrchestratorInitCoordinator {
         namespace,
         state: resolveNamespaceCapabilities(this.deps.config).namespaces
           ? await this.deps.namespaceSearchRouter.ensureNamespaceCollection(namespace, { signal })
-          : await this.deps.qmd.ensureCollection(this.deps.config.memoryDir, this.deps.config.qmdCollection, { signal }),
-      })),
+          : await this.deps.qmd.ensureCollection(this.deps.config.memoryDir, this.deps.config.qmdCollection, {
+              signal,
+            }),
+      }))
     );
 
     if (signal?.aborted) {
@@ -644,8 +649,7 @@ export class OrchestratorInitCoordinator {
       return false;
     }
 
-    const defaultState =
-      states.find((e) => e.namespace === this.deps.config.defaultNamespace)?.state ?? "unknown";
+    const defaultState = states.find((e) => e.namespace === this.deps.config.defaultNamespace)?.state ?? "unknown";
     if (defaultState === "missing") {
       // Reset the real backend's available flag before replacing it with noop.
       // probe() set available=true earlier in this call; without this reset,
@@ -670,9 +674,10 @@ export class OrchestratorInitCoordinator {
     // long-running `qmd update` process is killed promptly on shutdown.
     if (resolveQmdCapabilities(this.deps.config).qmdMaintenance) {
       try {
-        const failTsBefore = "lastUpdateFailedAtMs" in this.deps.qmd
-          ? (this.deps.qmd as any).lastUpdateFailedAtMs as number | null
-          : null;
+        const failTsBefore =
+          "lastUpdateFailedAtMs" in this.deps.qmd
+            ? ((this.deps.qmd as any).lastUpdateFailedAtMs as number | null)
+            : null;
         const hasRunTs = "lastUpdateRanAtMs" in this.deps.qmd;
         if ("resetUpdateThrottles" in this.deps.qmd) {
           (this.deps.qmd as any).resetUpdateThrottles();
@@ -680,10 +685,7 @@ export class OrchestratorInitCoordinator {
         log.info("startupSearchSync: updating index to match current disk state");
         let namespacesUpdated = 0;
         if (resolveNamespaceCapabilities(this.deps.config).namespaces) {
-          namespacesUpdated = await this.deps.namespaceSearchRouter.updateNamespaces(
-            namespaces,
-            { signal },
-          );
+          namespacesUpdated = await this.deps.namespaceSearchRouter.updateNamespaces(namespaces, { signal });
         } else {
           await this.deps.qmd.update({ signal });
         }
@@ -691,22 +693,25 @@ export class OrchestratorInitCoordinator {
           log.debug("startupSearchSync: aborted after update");
           return false;
         }
-        const failTsAfter = "lastUpdateFailedAtMs" in this.deps.qmd
-          ? (this.deps.qmd as any).lastUpdateFailedAtMs as number | null
-          : null;
-        const runTsAfter = hasRunTs
-          ? (this.deps.qmd as any).lastUpdateRanAtMs as number | null
-          : null;
+        const failTsAfter =
+          "lastUpdateFailedAtMs" in this.deps.qmd
+            ? ((this.deps.qmd as any).lastUpdateFailedAtMs as number | null)
+            : null;
+        const runTsAfter = hasRunTs ? ((this.deps.qmd as any).lastUpdateRanAtMs as number | null) : null;
         if (failTsAfter !== null && failTsAfter !== failTsBefore) {
           log.warn("startupSearchSync: update silently failed (detected via fail timestamp)");
           return false;
         }
         if (resolveNamespaceCapabilities(this.deps.config).namespaces) {
           if (namespacesUpdated === 0) {
-            log.warn("startupSearchSync: no namespace backends were eligible for update (all unavailable or collections missing)");
+            log.warn(
+              "startupSearchSync: no namespace backends were eligible for update (all unavailable or collections missing)"
+            );
             return false;
           }
-          log.info(`startupSearchSync: namespace updates succeeded (${namespacesUpdated}/${namespaces.length} namespaces updated)`);
+          log.info(
+            `startupSearchSync: namespace updates succeeded (${namespacesUpdated}/${namespaces.length} namespaces updated)`
+          );
         } else if (hasRunTs && runTsAfter === null) {
           log.warn("startupSearchSync: update was throttled/skipped (run timestamp is null after reset + update)");
           return false;

--- a/packages/remnic-core/src/orchestration/orchestrator-init.ts
+++ b/packages/remnic-core/src/orchestration/orchestrator-init.ts
@@ -20,15 +20,7 @@
 import { readdir, stat, unlink } from "node:fs/promises";
 import path from "node:path";
 import { SmartBuffer } from "../buffer.js";
-import {
-  resolveIndexingCapabilities,
-  resolveLocalLlmCapabilities,
-  resolveMemoryLifecycleCapabilities,
-  resolveNamespaceCapabilities,
-  resolveQmdCapabilities,
-  resolveRecallAuxiliaryCapabilities,
-  resolveUtilityLearningCapabilities,
-} from "../capabilities.js";
+import { resolveIndexingCapabilities, resolveLocalLlmCapabilities, resolveMemoryLifecycleCapabilities, resolveNamespaceCapabilities, resolveQmdCapabilities, resolveRecallAuxiliaryCapabilities, resolveUtilityLearningCapabilities } from "../capabilities.js";
 import { CompoundingEngine } from "../compounding/engine.js";
 import type { ConversationIndexBackend } from "../conversation-index/backend.js";
 import type { CorrectionService } from "../correction/correction-service.js";
@@ -78,7 +70,10 @@ export interface OrchestratorInitDeps {
   getMeetingsService(namespace?: string): Promise<MeetingsService>;
   readonly handleHistory: RecallHandleHistoryStore;
   readonly lastRecall: LastRecallStore;
-  maintenanceNamespaces(jobName?: string, budgetMode?: "cycle" | "unbounded"): Promise<string[]>;
+  maintenanceNamespaces(
+    jobName?: string,
+    budgetMode?: "cycle" | "unbounded",
+  ): Promise<string[]>;
   readonly maintenanceScheduler: MaintenanceScheduler;
   readonly namespaceCatalog: NamespaceCatalog;
   readonly namespaceSearchRouter: NamespaceSearchRouter;
@@ -103,7 +98,9 @@ export interface OrchestratorInitDeps {
 }
 
 export class OrchestratorInitCoordinator {
-  constructor(private readonly deps: OrchestratorInitDeps) {}
+  constructor(
+    private readonly deps: OrchestratorInitDeps,
+  ) {}
 
   async initialize(): Promise<void> {
     // Recreate the deferred-ready gate on every initialize() call.
@@ -124,8 +121,11 @@ export class OrchestratorInitCoordinator {
       await this.deps.storage.ensureDirectories();
       await Promise.all(
         this.deps.config.externalWikis.map((wiki) =>
-          assertExternalWikiRootOutsideMemoryDirCanonical(this.deps.config.memoryDir, wiki.rootDir)
-        )
+          assertExternalWikiRootOutsideMemoryDirCanonical(
+            this.deps.config.memoryDir,
+            wiki.rootDir,
+          ),
+        ),
       );
       if (resolveNamespaceCapabilities(this.deps.config).namespaces) {
         const namespaces = new Set<string>([
@@ -161,20 +161,16 @@ export class OrchestratorInitCoordinator {
             for (const rec of await this.deps.namespaceCatalog.listNamespaces()) {
               correctionNamespaces.add(rec.namespace);
             }
-          } catch {
-            /* best-effort */
-          }
+          } catch { /* best-effort */ }
         }
-        const recovered = await this.deps
-          .passiveCorrectionService()
-          .recoverStaleApplyingPlans([...correctionNamespaces]);
+        const recovered = await this.deps.passiveCorrectionService().recoverStaleApplyingPlans(
+          [...correctionNamespaces],
+        );
         if (recovered > 0) {
           log.info(`correction: recovered ${recovered} stale applying plan(s) on startup`);
         }
       } catch (staleErr) {
-        log.debug(
-          `correction: stale-plan recovery skipped: ${staleErr instanceof Error ? staleErr.message : String(staleErr)}`
-        );
+        log.debug(`correction: stale-plan recovery skipped: ${staleErr instanceof Error ? staleErr.message : String(staleErr)}`);
       }
       await this.deps.relevance.load();
       await this.deps.negatives.load();
@@ -197,7 +193,9 @@ export class OrchestratorInitCoordinator {
       if (resolveRecallAuxiliaryCapabilities(this.deps.config).factDeduplication) {
         try {
           this.deps.contentHashIndex = await this.deps.storage.getAuthoritativeFactHashIndex();
-          log.info(`content-hash dedup: rebuilt authoritative index with ${this.deps.contentHashIndex.size} hashes`);
+          log.info(
+            `content-hash dedup: rebuilt authoritative index with ${this.deps.contentHashIndex.size} hashes`,
+          );
         } catch (err) {
           // PR #2016: the locked corpus rebuild could not run at init (transient
           // cross-process contention). Pre-warm with the shared instance instead
@@ -207,7 +205,7 @@ export class OrchestratorInitCoordinator {
           this.deps.contentHashIndex = await this.deps.storage.getSharedFactHashIndex();
           log.warn(
             `content-hash dedup: authoritative rebuild deferred at init (${err instanceof Error ? err.message : String(err)}); ` +
-              `using the shared index, will retry the locked rebuild on next use`
+              `using the shared index, will retry the locked rebuild on next use`,
           );
         }
       }
@@ -225,7 +223,9 @@ export class OrchestratorInitCoordinator {
       try {
         await this.deps.buffer.load();
       } catch (bufErr) {
-        log.error(`buffer.load() failed (init gate will still open): ${bufErr}`);
+        log.error(
+          `buffer.load() failed (init gate will still open): ${bufErr}`,
+        );
         this.deps.buffer.resetToEmpty();
       }
       if (resolveRecallAuxiliaryCapabilities(this.deps.config).compactionReset) {
@@ -271,36 +271,45 @@ export class OrchestratorInitCoordinator {
               const collectionCheckAbort = new AbortController();
               const state = await qmdStartupCollectionCheckWithTimeout(
                 resolveNamespaceCapabilities(this.deps.config).namespaces
-                  ? this.deps.namespaceSearchRouter.ensureNamespaceCollection(namespace, {
-                      signal: collectionCheckAbort.signal,
-                    })
-                  : this.deps.qmd.ensureCollection(this.deps.config.memoryDir, this.deps.config.qmdCollection, {
-                      signal: collectionCheckAbort.signal,
-                    }),
+                  ? this.deps.namespaceSearchRouter.ensureNamespaceCollection(
+                      namespace,
+                      { signal: collectionCheckAbort.signal },
+                    )
+                  : this.deps.qmd.ensureCollection(
+                      this.deps.config.memoryDir,
+                      this.deps.config.qmdCollection,
+                      { signal: collectionCheckAbort.signal },
+                    ),
                 collectionCheckAbort,
-                namespace
+                namespace,
               );
               return { namespace, state };
-            })
+            }),
           );
           const defaultState =
-            states.find((entry) => entry.namespace === this.deps.config.defaultNamespace)?.state ?? "unknown";
+            states.find(
+              (entry) => entry.namespace === this.deps.config.defaultNamespace,
+            )?.state ?? "unknown";
           if (defaultState === "missing") {
             await this.deps.disposeSearchBackendIfNeeded();
             this.deps.qmd = new NoopSearchBackend();
             log.warn(
-              "Search collection missing for Remnic memory store; disabling search retrieval for this runtime (fallback retrieval remains enabled)"
+              "Search collection missing for Remnic memory store; disabling search retrieval for this runtime (fallback retrieval remains enabled)",
             );
           } else if (defaultState === "unknown") {
-            log.warn("Search collection check unavailable; keeping search retrieval enabled for fail-open behavior");
+            log.warn(
+              "Search collection check unavailable; keeping search retrieval enabled for fail-open behavior",
+            );
           } else if (defaultState === "skipped") {
-            log.debug("Search collection check skipped (remote or daemon-only mode)");
+            log.debug(
+              "Search collection check skipped (remote or daemon-only mode)",
+            );
           }
           for (const entry of states) {
             if (entry.namespace === this.deps.config.defaultNamespace) continue;
             if (entry.state === "missing") {
               log.warn(
-                `Search collection missing for namespace '${entry.namespace}'; namespace retrieval will fail open to non-search paths`
+                `Search collection missing for namespace '${entry.namespace}'; namespace retrieval will fail open to non-search paths`,
               );
             }
           }
@@ -338,8 +347,7 @@ export class OrchestratorInitCoordinator {
       const resolveDeferred = this.deps.resolveDeferredReady;
       this.deps.resolveDeferredReady = null;
       this.deps.deferredInitAbort = new AbortController();
-      this.deps
-        .deferredInitialize(this.deps.deferredInitAbort.signal)
+      this.deps.deferredInitialize(this.deps.deferredInitAbort.signal)
         .catch((err) => {
           log.error(`deferred initialization failed (non-fatal): ${err}`);
         })
@@ -384,7 +392,10 @@ export class OrchestratorInitCoordinator {
           // a dynamic namespace written before a daemon restart must be synced on
           // boot, not only by the debounced runQmdMaintenance() path. Same union +
           // catalog-read-failure fallback as runQmdMaintenance.
-          await this.deps.namespaceSearchRouter.updateNamespaces(await this.deps.maintenanceNamespaces(), { signal });
+          await this.deps.namespaceSearchRouter.updateNamespaces(
+            await this.deps.maintenanceNamespaces(),
+            { signal },
+          );
         } else {
           await this.deps.qmd.update({ signal });
         }
@@ -394,7 +405,7 @@ export class OrchestratorInitCoordinator {
         log.warn(`QMD startup sync failed (non-fatal): ${err}`);
         // deferredSyncSucceeded stays false — server retry will attempt sync
       }
-    } else if (!this.deps.qmd.isAvailable()) {
+    } else if (!(this.deps.qmd.isAvailable())) {
       // QMD not available at deferred init time — server retry will handle it
     } else {
       // QMD available but maintenance disabled — consider sync not needed
@@ -417,7 +428,7 @@ export class OrchestratorInitCoordinator {
           })
           .catch((err) => {
             log.debug(`QMD warmup search failed (non-fatal): ${err}`);
-          })
+          }),
       );
     }
     if (resolveMemoryLifecycleCapabilities(this.deps.config).embeddingFallback) {
@@ -425,11 +436,13 @@ export class OrchestratorInitCoordinator {
         this.deps.embeddingFallback
           .isAvailable()
           .then((ok) => {
-            log.info(`Embedding fallback warmup: ${ok ? "available" : "unavailable (no provider)"}`);
+            log.info(
+              `Embedding fallback warmup: ${ok ? "available" : "unavailable (no provider)"}`,
+            );
           })
           .catch((err) => {
             log.debug(`Embedding fallback warmup failed (non-fatal): ${err}`);
-          })
+          }),
       );
     }
     await Promise.all(warmupPromises);
@@ -449,21 +462,11 @@ export class OrchestratorInitCoordinator {
           } catch (err) {
             log.debug(`Knowledge Index warmup failed (non-fatal): ${err}`);
           }
-        })()
+        })(),
       );
     }
-    cacheWarmups.push(
-      this.deps.storage
-        .readAllMemories()
-        .then(() => {})
-        .catch(() => {})
-    );
-    cacheWarmups.push(
-      this.deps.storage
-        .readAllEntityFiles()
-        .then(() => {})
-        .catch(() => {})
-    );
+    cacheWarmups.push(this.deps.storage.readAllMemories().then(() => {}).catch(() => {}));
+    cacheWarmups.push(this.deps.storage.readAllEntityFiles().then(() => {}).catch(() => {}));
     await Promise.all(cacheWarmups);
     if (signal.aborted) return;
 
@@ -515,7 +518,8 @@ export class OrchestratorInitCoordinator {
     if (signal.aborted) return;
     if (lifecycleCaps.lifecyclePolicy && resolveQmdCapabilities(this.deps.config).qmdTierMigration) {
       try {
-        const { runFirstStartMigration } = await import("../maintenance/first-start-migration.js");
+        const { runFirstStartMigration } = await import("../maintenance/first-start-migration.js"
+        );
         const result = await runFirstStartMigration({
           storage: this.deps.storage,
           config: this.deps.config,
@@ -526,7 +530,7 @@ export class OrchestratorInitCoordinator {
         });
         if (!result.skipped) {
           log.info(
-            `first-start lifecycle migration: demoted ${result.demotedCount} of ${result.candidateCount} candidates (cap=${result.cappedAt})`
+            `first-start lifecycle migration: demoted ${result.demotedCount} of ${result.candidateCount} candidates (cap=${result.cappedAt})`,
           );
         } else {
           log.debug(`first-start lifecycle migration skipped: ${result.skipReason}`);
@@ -577,14 +581,16 @@ export class OrchestratorInitCoordinator {
               info: (message) => log.info(message),
               warn: (message) => log.warn(message),
             },
-          }
+          },
         );
         log.info(
-          `wearables auto-sync started: every ${this.deps.config.wearables.autoSyncIntervalMinutes}m over ${this.deps.config.wearables.autoSyncDays}d (deep ${this.deps.config.wearables.autoSyncDeepDays}d daily)`
+          `wearables auto-sync started: every ${this.deps.config.wearables.autoSyncIntervalMinutes}m over ${this.deps.config.wearables.autoSyncDays}d (deep ${this.deps.config.wearables.autoSyncDeepDays}d daily)`,
         );
       } catch (err) {
         const { displayErrorDetail } = await import("../runtime/better-sqlite.js");
-        log.warn(`wearables auto-sync failed to start (non-fatal): ${displayErrorDetail(err)}`);
+        log.warn(
+          `wearables auto-sync failed to start (non-fatal): ${displayErrorDetail(err)}`,
+        );
       }
     }
 
@@ -638,10 +644,8 @@ export class OrchestratorInitCoordinator {
         namespace,
         state: resolveNamespaceCapabilities(this.deps.config).namespaces
           ? await this.deps.namespaceSearchRouter.ensureNamespaceCollection(namespace, { signal })
-          : await this.deps.qmd.ensureCollection(this.deps.config.memoryDir, this.deps.config.qmdCollection, {
-              signal,
-            }),
-      }))
+          : await this.deps.qmd.ensureCollection(this.deps.config.memoryDir, this.deps.config.qmdCollection, { signal }),
+      })),
     );
 
     if (signal?.aborted) {
@@ -649,7 +653,8 @@ export class OrchestratorInitCoordinator {
       return false;
     }
 
-    const defaultState = states.find((e) => e.namespace === this.deps.config.defaultNamespace)?.state ?? "unknown";
+    const defaultState =
+      states.find((e) => e.namespace === this.deps.config.defaultNamespace)?.state ?? "unknown";
     if (defaultState === "missing") {
       // Reset the real backend's available flag before replacing it with noop.
       // probe() set available=true earlier in this call; without this reset,
@@ -674,10 +679,9 @@ export class OrchestratorInitCoordinator {
     // long-running `qmd update` process is killed promptly on shutdown.
     if (resolveQmdCapabilities(this.deps.config).qmdMaintenance) {
       try {
-        const failTsBefore =
-          "lastUpdateFailedAtMs" in this.deps.qmd
-            ? ((this.deps.qmd as any).lastUpdateFailedAtMs as number | null)
-            : null;
+        const failTsBefore = "lastUpdateFailedAtMs" in this.deps.qmd
+          ? (this.deps.qmd as any).lastUpdateFailedAtMs as number | null
+          : null;
         const hasRunTs = "lastUpdateRanAtMs" in this.deps.qmd;
         if ("resetUpdateThrottles" in this.deps.qmd) {
           (this.deps.qmd as any).resetUpdateThrottles();
@@ -685,7 +689,10 @@ export class OrchestratorInitCoordinator {
         log.info("startupSearchSync: updating index to match current disk state");
         let namespacesUpdated = 0;
         if (resolveNamespaceCapabilities(this.deps.config).namespaces) {
-          namespacesUpdated = await this.deps.namespaceSearchRouter.updateNamespaces(namespaces, { signal });
+          namespacesUpdated = await this.deps.namespaceSearchRouter.updateNamespaces(
+            namespaces,
+            { signal },
+          );
         } else {
           await this.deps.qmd.update({ signal });
         }
@@ -693,25 +700,22 @@ export class OrchestratorInitCoordinator {
           log.debug("startupSearchSync: aborted after update");
           return false;
         }
-        const failTsAfter =
-          "lastUpdateFailedAtMs" in this.deps.qmd
-            ? ((this.deps.qmd as any).lastUpdateFailedAtMs as number | null)
-            : null;
-        const runTsAfter = hasRunTs ? ((this.deps.qmd as any).lastUpdateRanAtMs as number | null) : null;
+        const failTsAfter = "lastUpdateFailedAtMs" in this.deps.qmd
+          ? (this.deps.qmd as any).lastUpdateFailedAtMs as number | null
+          : null;
+        const runTsAfter = hasRunTs
+          ? (this.deps.qmd as any).lastUpdateRanAtMs as number | null
+          : null;
         if (failTsAfter !== null && failTsAfter !== failTsBefore) {
           log.warn("startupSearchSync: update silently failed (detected via fail timestamp)");
           return false;
         }
         if (resolveNamespaceCapabilities(this.deps.config).namespaces) {
           if (namespacesUpdated === 0) {
-            log.warn(
-              "startupSearchSync: no namespace backends were eligible for update (all unavailable or collections missing)"
-            );
+            log.warn("startupSearchSync: no namespace backends were eligible for update (all unavailable or collections missing)");
             return false;
           }
-          log.info(
-            `startupSearchSync: namespace updates succeeded (${namespacesUpdated}/${namespaces.length} namespaces updated)`
-          );
+          log.info(`startupSearchSync: namespace updates succeeded (${namespacesUpdated}/${namespaces.length} namespaces updated)`);
         } else if (hasRunTs && runTsAfter === null) {
           log.warn("startupSearchSync: update was throttled/skipped (run timestamp is null after reset + update)");
           return false;


### PR DESCRIPTION
Follow-up hardening for external wiki read paths (#2058).

- Bind descriptor containment checks to open file handle to eliminate symlink swap race windows.
- Walk non-existent parent paths in  to resolve parent symlinks before directory creation.
- Cap total visited entries in directory fallback walker to prevent unindexed directory traversal DOS.
- Resolve catalog Markdown links relative to  parent directory instead of assuming .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive filesystem containment and startup validation for external wikis; behavior changes are defensive but could reject previously accepted symlink/alias configurations.
> 
> **Overview**
> Follow-up hardening for external wiki read paths.
> 
> **Filesystem reads** now open with `O_NOFOLLOW`, pin the opened inode (including via `/proc/self/fd` on Linux), and verify the descriptor still lies under the configured root (`rootDir` for index reads, `pagesDir` for pages) before bounded UTF-8 reads proceed.
> 
> **Root isolation** centralizes the memory-dir overlap check in `external-wiki-guard` and adds `assertExternalWikiRootOutsideMemoryDirCanonical`, which resolves symlinks (including for not-yet-created paths under aliased parents). Orchestrator startup runs this canonical check for every configured external wiki.
> 
> **Catalog behavior** resolves Markdown links relative to the index file’s directory (wiki-links still use `pagesDir`), and the no-index fallback walker caps total **visited** directory entries (not just `.md` count) to limit traversal DoS when many non-markdown files exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 645f57e6e3023cc6cde1f5003c744d0f2e8a5254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external wiki path validation, including nested paths and symlink aliases.
  * Prevented wiki roots from overlapping the application’s memory directory.
  * Fixed catalog links for nested index files and pages directories.
  * Blocked catalog entries that escape the configured pages directory or target non-Markdown files.
  * Added limits to directory scanning to prevent unbounded fallback discovery.
  * Strengthened file reads against path replacement and symlink changes.

* **Tests**
  * Added coverage for nested catalog paths, filesystem scan limits, and conflicting wiki roots.

* **Release**
  * Prepared a patch release for `@remnic/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->