### PR TITLE
fix(core): raise wiki catalog scan limit from 40 to 100

### DIFF
--- a/packages/remnic-core/src/external-wiki-search.ts
+++ b/packages/remnic-core/src/external-wiki-search.ts
@@ -13,7 +13,7 @@ const DEFAULT_LIMIT = 6;
 const MAX_LIMIT = 20;
 const DEFAULT_MAX_CHARS_PER_HIT = 1_000;
 const MAX_CHARS_PER_HIT = 8_000;
-const DEFAULT_MAX_CANDIDATE_FILES = 40;
+const DEFAULT_MAX_CANDIDATE_FILES = 100;
 const MAX_CANDIDATE_FILES = 100;
 
 export interface ExternalWikiSearchInput {


### PR DESCRIPTION
One-line fix: wikis with >40 catalog entries silently returned empty. Raises the default to match the existing max.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change in search breadth with no auth or data-model impact; slightly more I/O on large wikis when the default applies.
> 
> **Overview**
> Raises **`DEFAULT_MAX_CANDIDATE_FILES`** in external wiki search from **40** to **100**, aligning the default with the existing **`MAX_CANDIDATE_FILES`** ceiling.
> 
> That default drives how many catalog entries are loaded and ranked per wiki when callers do not pass **`maxCandidateFiles`**. Wikis with more than 40 pages could be truncated before scoring, which could make search look empty or miss relevant pages; the new default allows the full allowed scan width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09a877a9e0e0c31bf285bbd023e921dafa765d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the default maximum number of files considered during wiki searches from 40 to 100, enabling broader search coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->