### PR TITLE
test(converge): isolate base-only namespace fixture

### DIFF
--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -167,7 +167,10 @@ test("remnic converge plan: validates a namespace present only in provided base 
   ]);
 
   await assert.rejects(
-    computeConvergePlan({ baseFilesByNamespace: baseMap }),
+    computeConvergePlan({
+      baseFilesByNamespace: baseMap,
+      localFilesByNamespace: new Map(),
+    }),
     /aliasing paths/,
   );
 });


### PR DESCRIPTION
## Summary
- pin an explicit empty local snapshot in the base-only namespace validation test
- prevent the fixture from reading an ambient default home-directory corpus
- preserve production local-disk discovery when callers omit the local snapshot

## Validation
- isolated-home reproduction: 1 passed, 0 failed
- complete convergence suite: 42 passed, 0 failed
- project lint: passed
- workspace type check: passed

Part of post-merge release validation from #2277.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production logic modified.
> 
> **Overview**
> The **base-only namespace** aliasing-path test now passes an explicit empty `localFilesByNamespace: new Map()` into `computeConvergePlan`, alongside `baseFilesByNamespace` only.
> 
> That stops the plan from **auto-discovering local corpus files** from the default home/memory directory when the local snapshot is omitted, so the fixture stays isolated and still asserts rejection with `/aliasing paths/`. Runtime behavior for callers that omit the local map is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cc9f762aac581d9457bc927b139971d8c978c01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated namespace-validation coverage to provide an empty local file map.
  * Retained verification of existing base-state aliasing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->