### PR TITLE
refactor(plugin-openclaw): extract the memory-slot read scope into a shared module

### DIFF
--- a/packages/plugin-openclaw/src/memory-capability-types.ts
+++ b/packages/plugin-openclaw/src/memory-capability-types.ts
@@ -1,0 +1,93 @@
+/**
+ * Structural types for the OpenClaw memory-slot capability.
+ *
+ * These mirror the host SDK's memory runtime contract without importing it, so
+ * the plugin keeps building against SDK versions that predate a given field.
+ * Both bridge modes implement the same shapes: embedded backs them with the
+ * in-process orchestrator, delegate backs them with the standalone daemon.
+ */
+
+export type RuntimeMemorySource = "memory" | "sessions";
+
+export type RuntimeSearchOptions = {
+  maxResults?: number;
+  minScore?: number;
+  sessionKey?: string;
+  qmdSearchModeOverride?: "query" | "search" | "vsearch";
+}
+
+export type RuntimeSearchResult = {
+  path: string;
+  startLine: number;
+  endLine: number;
+  score: number;
+  snippet: string;
+  source: RuntimeMemorySource;
+  citation?: string;
+}
+
+export type RuntimeReadParams = {
+  relPath: string;
+  from?: number;
+  lines?: number;
+}
+
+export type RuntimeReadResult = {
+  text: string;
+  path: string;
+  truncated?: boolean;
+  from?: number;
+  lines?: number;
+  nextFrom?: number;
+}
+
+export type RuntimeStatus = {
+  backend: "builtin" | "qmd";
+  provider: string;
+  requestedProvider?: string;
+  model?: string;
+  dirty?: boolean;
+  workspaceDir?: string;
+  dbPath?: string;
+  sources?: RuntimeMemorySource[];
+  sourceCounts?: Array<{
+    source: RuntimeMemorySource;
+    files: number;
+    chunks: number;
+  }>;
+  vector?: {
+    enabled: boolean;
+    available?: boolean;
+  };
+  fts?: {
+    enabled: boolean;
+    available: boolean;
+  };
+  custom?: Record<string, unknown>;
+}
+
+export type RuntimeManager = {
+  search(query: string, opts?: RuntimeSearchOptions): Promise<RuntimeSearchResult[]>;
+  readFile(params: RuntimeReadParams): Promise<RuntimeReadResult>;
+  status(): RuntimeStatus;
+  sync?(params?: { reason?: string; force?: boolean }): Promise<void>;
+  probeEmbeddingAvailability(): Promise<{ ok: boolean; error?: string }>;
+  probeVectorAvailability(): Promise<boolean>;
+  close?(): Promise<void>;
+}
+
+export type RemnicCapabilityRuntime = {
+  getMemorySearchManager(params: {
+    cfg: unknown;
+    agentId: string;
+    purpose?: "default" | "status";
+  }): Promise<{
+    manager: RuntimeManager | null;
+    error?: string;
+  }>;
+  resolveMemoryBackendConfig(params: {
+    cfg: unknown;
+    agentId: string;
+  }): { backend: "builtin" } | { backend: "qmd"; qmd?: { command?: string } };
+  closeAllMemorySearchManagers(): Promise<void>;
+}

--- a/packages/plugin-openclaw/src/memory-read-scope.test.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.test.ts
@@ -234,3 +234,17 @@ test("isSessionsMemoryPath classifies session transcripts on either separator", 
     assert.equal(isSessionsMemoryPath(relative), false, relative);
   }
 });
+
+test("resolveReadablePath rejects a missing path as a domain error", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  // The host SDK boundary is untyped, so undefined can arrive despite the
+  // signature; node:path would otherwise raise a bare TypeError.
+  for (const bad of [undefined, null, "", 42]) {
+    await assert.rejects(
+      () => scope.resolveReadablePath(bad as unknown as string),
+      /memory read rejected \(missing path\)/,
+      String(bad),
+    );
+  }
+});

--- a/packages/plugin-openclaw/src/memory-read-scope.test.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { createMemoryReadScope } from "./memory-read-scope.js";
+import { createMemoryReadScope, isSessionsMemoryPath } from "./memory-read-scope.js";
 
 async function makeCorpus(): Promise<{
   memoryDir: string;
@@ -214,4 +214,23 @@ test("the injected canonicalizer is used for both roots and reads", async () => 
     seen.includes(path.join(memoryDir, "facts", "alice.md")),
     "read canonicalization goes through the seam",
   );
+});
+
+test("isSessionsMemoryPath classifies session transcripts on either separator", () => {
+  for (const relative of [
+    "sessions/2026-01-01.md",
+    "sessions\\2026-01-01.md",
+    path.join("nested", "sessions", "a.md"),
+    "Sessions/a.md",
+  ]) {
+    assert.equal(isSessionsMemoryPath(relative), true, relative);
+  }
+  for (const relative of [
+    "facts/alice.md",
+    "sessions.md",
+    "my-sessions/a.md",
+    path.join("facts", "sessions-notes.md"),
+  ]) {
+    assert.equal(isSessionsMemoryPath(relative), false, relative);
+  }
 });

--- a/packages/plugin-openclaw/src/memory-read-scope.test.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, realpath, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createMemoryReadScope } from "./memory-read-scope.js";
+
+async function makeCorpus(): Promise<{
+  memoryDir: string;
+  workspaceDir: string;
+  outsideDir: string;
+}> {
+  // realpath the temp root: macOS resolves /var -> /private/var, and the scope
+  // canonicalizes before containment, so an unresolved root would never match.
+  const root = await realpath(await mkdtemp(path.join(os.tmpdir(), "remnic-read-scope-")));
+  const memoryDir = path.join(root, "memory-local");
+  const workspaceDir = path.join(root, "workspace");
+  const outsideDir = path.join(root, "outside");
+  await mkdir(path.join(memoryDir, "facts"), { recursive: true });
+  await mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+  await mkdir(outsideDir, { recursive: true });
+  await writeFile(path.join(memoryDir, "facts", "alice.md"), "# alice\nline two\n");
+  await writeFile(path.join(memoryDir, "index.json"), "{}\n");
+  await writeFile(path.join(workspaceDir, "memory", "notes.md"), "# notes\n");
+  await writeFile(path.join(outsideDir, "secret.md"), "# secret\n");
+  return { memoryDir, workspaceDir, outsideDir };
+}
+
+test("resolveReadablePath resolves a memoryDir-relative hit", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  assert.equal(
+    await scope.resolveReadablePath("facts/alice.md"),
+    path.join(memoryDir, "facts", "alice.md"),
+  );
+});
+
+test("resolveReadablePath resolves a workspace-memory-relative hit", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  assert.equal(
+    await scope.resolveReadablePath("notes.md"),
+    path.join(workspaceDir, "memory", "notes.md"),
+  );
+});
+
+test("resolveReadablePath accepts an absolute path inside an allowed root", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  const absolute = path.join(memoryDir, "facts", "alice.md");
+  assert.equal(await scope.resolveReadablePath(absolute), absolute);
+});
+
+test("resolveReadablePath rejects a path outside every allowed root", async () => {
+  const { memoryDir, workspaceDir, outsideDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  await assert.rejects(
+    () => scope.resolveReadablePath(path.join(outsideDir, "secret.md")),
+    /memory read outside allowed roots/,
+  );
+});
+
+test("resolveReadablePath rejects traversal that escapes an allowed root", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  await assert.rejects(
+    () => scope.resolveReadablePath(path.join("..", "outside", "secret.md")),
+    /memory read outside allowed roots/,
+  );
+});
+
+test("resolveReadablePath rejects a symlink escaping the allowed roots", async () => {
+  const { memoryDir, workspaceDir, outsideDir } = await makeCorpus();
+  await symlink(path.join(outsideDir, "secret.md"), path.join(memoryDir, "leak.md"));
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  await assert.rejects(
+    () => scope.resolveReadablePath("leak.md"),
+    /memory read outside allowed roots/,
+  );
+});
+
+test("resolveReadablePath rejects non-markdown files inside an allowed root", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  await assert.rejects(
+    () => scope.resolveReadablePath("index.json"),
+    /memory read restricted to \.md files/,
+  );
+});
+
+test("resolveReadablePath rejects a path that does not exist", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  await assert.rejects(
+    () => scope.resolveReadablePath("facts/missing.md"),
+    /memory read rejected \(path unresolvable\)/,
+  );
+});
+
+test("relativizeToMemoryRoot yields a root-relative form, not a workspace-relative one", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  // The workspace-relative form of this hit would be "../memory-local/facts/alice.md";
+  // relativizing against the owning root is what lets it feed back into
+  // resolveReadablePath without a doubled path segment.
+  assert.equal(
+    scope.relativizeToMemoryRoot(path.join(memoryDir, "facts", "alice.md")),
+    path.join("facts", "alice.md"),
+  );
+  assert.equal(
+    scope.relativizeToMemoryRoot(path.join(workspaceDir, "memory", "notes.md")),
+    "notes.md",
+  );
+});
+
+test("relativizeToMemoryRoot round-trips back through resolveReadablePath", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  const absolute = path.join(memoryDir, "facts", "alice.md");
+  assert.equal(
+    await scope.resolveReadablePath(scope.relativizeToMemoryRoot(absolute)),
+    absolute,
+  );
+});
+
+test("relativizeToMemoryRoot falls back to the workspace form outside every root", async () => {
+  const { memoryDir, workspaceDir, outsideDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  // The workspace-relative form would escape the workspace, so the raw input
+  // survives verbatim — a display-only value that resolveReadablePath rejects.
+  const escaping = path.join(outsideDir, "secret.md");
+  assert.equal(scope.relativizeToMemoryRoot(escaping), escaping);
+  assert.equal(
+    scope.relativizeToMemoryRoot(path.join(workspaceDir, "notes-outside-memory.md")),
+    "notes-outside-memory.md",
+  );
+});
+
+test("relativizeToMemoryRoot and normalizeWorkspacePath default missing input to memory", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  assert.equal(scope.relativizeToMemoryRoot(undefined), "memory");
+  assert.equal(scope.normalizeWorkspacePath(undefined), "memory");
+  assert.equal(scope.normalizeWorkspacePath(""), "memory");
+});
+
+test("normalizeWorkspacePath returns the input unchanged when it escapes the workspace", async () => {
+  const { memoryDir, workspaceDir, outsideDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  const escaping = path.join(outsideDir, "secret.md");
+  assert.equal(scope.normalizeWorkspacePath(escaping), escaping);
+  assert.equal(
+    scope.normalizeWorkspacePath(path.join(workspaceDir, "memory", "notes.md")),
+    path.join("memory", "notes.md"),
+  );
+});
+
+test("absolutize prefers the first allowed root that contains a relative hit", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  // "notes.md" is lexically contained by BOTH roots; memoryDir is first.
+  assert.equal(scope.absolutize("notes.md"), path.join(memoryDir, "notes.md"));
+  assert.equal(
+    scope.absolutize(path.join(memoryDir, "facts", "alice.md")),
+    path.join(memoryDir, "facts", "alice.md"),
+  );
+});
+
+test("absolutize falls back to the workspace root when no allowed root contains the path", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  const escaping = path.join("..", "..", "elsewhere.md");
+  assert.equal(scope.absolutize(escaping), path.resolve(workspaceDir, escaping));
+});
+
+test("allowedRoots omits the workspace memory root when no workspace is configured", async () => {
+  const { memoryDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir: "" });
+  assert.deepEqual(scope.allowedRoots, [memoryDir]);
+  assert.equal(
+    await scope.resolveReadablePath("facts/alice.md"),
+    path.join(memoryDir, "facts", "alice.md"),
+  );
+});
+
+test("root canonicalization tolerates a root that does not exist yet", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({
+    memoryDir: path.join(memoryDir, "not-created-yet"),
+    workspaceDir,
+  });
+  // The missing root must not poison the surviving one.
+  assert.equal(
+    await scope.resolveReadablePath("notes.md"),
+    path.join(workspaceDir, "memory", "notes.md"),
+  );
+});
+
+test("the injected canonicalizer is used for both roots and reads", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const seen: string[] = [];
+  const scope = createMemoryReadScope({
+    memoryDir,
+    workspaceDir,
+    realpath: async (filePath: string) => {
+      seen.push(filePath);
+      return realpath(filePath);
+    },
+  });
+  await scope.resolveReadablePath("facts/alice.md");
+  assert.ok(seen.includes(memoryDir), "root canonicalization goes through the seam");
+  assert.ok(
+    seen.includes(path.join(memoryDir, "facts", "alice.md")),
+    "read canonicalization goes through the seam",
+  );
+});

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -147,6 +147,12 @@ export function createMemoryReadScope(options: MemoryReadScopeOptions): MemoryRe
       return normalizeWorkspacePath(rawPath);
     },
     async resolveReadablePath(requestedPath: string): Promise<string> {
+      // The host SDK calls this across an untyped boundary, so a missing or
+      // non-string path can arrive despite the signature. Reject it as a
+      // domain error rather than letting node:path raise a raw TypeError.
+      if (typeof requestedPath !== "string" || requestedPath.length === 0) {
+        throw new Error("memory read rejected (missing path)");
+      }
       // Search results return paths relative to memoryDir (e.g.
       // "facts/alice.md"), not the workspace root. Try each allowed root and
       // take the first whose realpath lands inside the allowlist, so a hit can

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -1,0 +1,168 @@
+/**
+ * Read scope for the OpenClaw memory-slot capability.
+ *
+ * The capability runtime hands agents a `readFile` primitive over the memory
+ * corpus. The allowed roots contain more than memories (attachments, index
+ * files, snapshots, logs), so every read is canonicalized and contained before
+ * it opens a descriptor, and narrowed to markdown.
+ *
+ * Both bridge modes share this module: the embedded runtime resolves reads
+ * against the orchestrator's memoryDir, and the delegate runtime resolves them
+ * against the same on-disk corpus the daemon serves. Forking the containment
+ * logic per mode would let one path drift into a traversal hole the other
+ * already closed.
+ */
+
+import { realpath as fsRealpath } from "node:fs/promises";
+import path from "node:path";
+
+export type MemoryReadScopeOptions = {
+  /** Remnic memory root — the primary allowed read root. */
+  memoryDir: string;
+  /** Agent workspace root. `<workspaceDir>/memory` becomes a second root. */
+  workspaceDir: string;
+  /** Canonicalizer seam. Defaults to `fs.promises.realpath`; tests inject. */
+  realpath?: (filePath: string) => Promise<string>;
+}
+
+export type MemoryReadScope = {
+  /** Canonical containment targets, in resolution order. */
+  readonly allowedRoots: readonly string[];
+  /**
+   * Absolute form of a search-result path. Relative hits resolve against the
+   * first allowed root that lexically contains them, else the workspace root.
+   */
+  absolutize(rawPath: string): string;
+  /** Workspace-relative display form, or the input when it escapes the workspace. */
+  normalizeWorkspacePath(rawPath: string | undefined): string;
+  /**
+   * Display form relative to whichever allowed root contains the path.
+   *
+   * Search results must NOT be relativized against the workspace root: a hit
+   * at `<workspace>/memory/local/facts/a.md` would render as
+   * `memory/local/facts/a.md`, which `resolveReadablePath` then re-joins to
+   * every allowed root, producing a doubled `memory/` segment and a failed read.
+   */
+  relativizeToMemoryRoot(rawPath: string | undefined): string;
+  /**
+   * Canonicalize and contain a requested path, returning the real path safe to
+   * open. Throws when the path is unresolvable, escapes the allowed roots, or
+   * is not markdown.
+   */
+  resolveReadablePath(requestedPath: string): Promise<string>;
+}
+
+/**
+ * Containment predicate shared by every check below: `path.relative` yields
+ * `""` for the root itself, a `..`-prefixed path for an escape, and an
+ * absolute path when the two live on different Windows volumes.
+ */
+function isContained(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export function createMemoryReadScope(options: MemoryReadScopeOptions): MemoryReadScope {
+  const { memoryDir, workspaceDir } = options;
+  const realpath = options.realpath ?? fsRealpath;
+
+  // Reads are allowlisted to memory files only. The agent workspace root would
+  // be far too broad (logs, configs, secrets), so only the memory root and the
+  // workspace's memory subdirectory qualify.
+  const allowedRoots = [
+    memoryDir,
+    workspaceDir ? path.join(workspaceDir, "memory") : undefined,
+  ].filter((root): root is string => typeof root === "string" && root.length > 0);
+
+  // Init-time canonicalization tolerates realpath failure: the roots may not
+  // exist yet at plugin start. The lexical fallback is safe because these
+  // values are only ever containment targets, never paths we open.
+  const canonicalRootsPromise = Promise.all(
+    allowedRoots.map(async (root) => {
+      const resolved = path.resolve(root);
+      try {
+        return path.normalize(await realpath(resolved));
+      } catch {
+        return path.normalize(resolved);
+      }
+    }),
+  );
+
+  // Check-time canonicalization is strict: realpath failure means the file does
+  // not exist or its symlink chain is broken. A lexical fallback here would
+  // reopen the TOCTOU window by letting a non-existent path pass containment,
+  // after which a symlink could be created before the read.
+  const canonicalizeForRead = async (rawPath: string): Promise<string> =>
+    path.normalize(await realpath(path.resolve(rawPath)));
+
+  const normalizeWorkspacePath = (rawPath: string | undefined): string => {
+    if (!rawPath || typeof rawPath !== "string") return "memory";
+    const resolved = path.isAbsolute(rawPath)
+      ? path.resolve(rawPath)
+      : path.resolve(workspaceDir, rawPath);
+    const relative = path.relative(workspaceDir, resolved);
+    return relative && !relative.startsWith("..") && !path.isAbsolute(relative)
+      ? relative
+      : rawPath;
+  };
+
+  const absolutize = (rawPath: string): string => {
+    if (path.isAbsolute(rawPath)) return path.resolve(rawPath);
+    for (const root of allowedRoots) {
+      const candidate = path.resolve(root, rawPath);
+      if (isContained(root, candidate)) return candidate;
+    }
+    return path.resolve(workspaceDir, rawPath);
+  };
+
+  return {
+    allowedRoots,
+    absolutize,
+    normalizeWorkspacePath,
+    relativizeToMemoryRoot(rawPath: string | undefined): string {
+      if (!rawPath || typeof rawPath !== "string") return "memory";
+      const resolved = path.isAbsolute(rawPath)
+        ? path.resolve(rawPath)
+        : path.resolve(workspaceDir, rawPath);
+      for (const root of allowedRoots) {
+        const relative = path.relative(root, resolved);
+        if (relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+          return relative;
+        }
+      }
+      // Not inside any allowed root: fall back to the workspace-relative form
+      // for display. Search may surface such a hit informationally even though
+      // resolveReadablePath would reject a read of it.
+      return normalizeWorkspacePath(rawPath);
+    },
+    async resolveReadablePath(requestedPath: string): Promise<string> {
+      // Search results return paths relative to memoryDir (e.g.
+      // "facts/alice.md"), not the workspace root. Try each allowed root and
+      // take the first whose realpath lands inside the allowlist, so a hit can
+      // feed straight into readFile without the caller knowing which root owns it.
+      const candidates = path.isAbsolute(requestedPath)
+        ? [path.resolve(requestedPath)]
+        : allowedRoots.map((root) => path.resolve(root, requestedPath));
+      let canonicalPath: string | undefined;
+      for (const candidate of candidates) {
+        try {
+          canonicalPath = await canonicalizeForRead(candidate);
+          break;
+        } catch {
+          // Try the next root; all-failed is reported below.
+        }
+      }
+      if (canonicalPath === undefined) {
+        throw new Error(`memory read rejected (path unresolvable): ${requestedPath}`);
+      }
+      const canonicalRoots = await canonicalRootsPromise;
+      if (!canonicalRoots.some((root) => isContained(root, canonicalPath))) {
+        throw new Error(`memory read outside allowed roots: ${requestedPath}`);
+      }
+      if (!canonicalPath.toLowerCase().endsWith(".md")) {
+        throw new Error(`memory read restricted to .md files: ${requestedPath}`);
+      }
+      return canonicalPath;
+    },
+  };
+}

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -53,6 +53,17 @@ export type MemoryReadScope = {
 }
 
 /**
+ * Whether a memory-root-relative path lives under a session transcript
+ * directory, which the host runtime reports as a distinct search `source`.
+ *
+ * `relativizeToMemoryRoot` emits platform separators, so a literal
+ * `includes("sessions/")` silently classifies every Windows hit as `memory`.
+ */
+export function isSessionsMemoryPath(relativePath: string): boolean {
+  return /(?:^|[\\/])sessions[\\/]/i.test(relativePath);
+}
+
+/**
  * Containment predicate shared by every check below: `path.relative` yields
  * `""` for the root itself, a `..`-prefixed path for an escape, and an
  * absolute path when the two live on different Windows volumes.

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,10 @@ import {
   extractLastTurn,
   extractTextContent,
 } from "../packages/plugin-openclaw/src/transcript-turns.js";
-import { createMemoryReadScope } from "../packages/plugin-openclaw/src/memory-read-scope.js";
+import {
+  createMemoryReadScope,
+  isSessionsMemoryPath,
+} from "../packages/plugin-openclaw/src/memory-read-scope.js";
 import type {
   RemnicCapabilityRuntime,
   RuntimeReadParams,
@@ -3559,7 +3562,7 @@ const pluginDefinition = {
                         : typeof candidate.text === "string"
                           ? candidate.text
                           : "",
-                    source: normalizedPath.includes("sessions/") ? "sessions" : "memory",
+                    source: isSessionsMemoryPath(normalizedPath) ? "sessions" : "memory",
                     citation: normalizedPath,
                   };
                 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,13 @@ import {
   extractLastTurn,
   extractTextContent,
 } from "../packages/plugin-openclaw/src/transcript-turns.js";
+import { createMemoryReadScope } from "../packages/plugin-openclaw/src/memory-read-scope.js";
+import type {
+  RemnicCapabilityRuntime,
+  RuntimeReadParams,
+  RuntimeSearchOptions,
+  RuntimeSearchResult,
+} from "../packages/plugin-openclaw/src/memory-capability-types.js";
 import { createFileToggleStore } from "@remnic/core/session-toggles";
 import { appendRecallAuditEntry, pruneRecallAuditEntries } from "@remnic/core/recall-audit";
 import { createActiveRecallEngine } from "@remnic/core/active-recall";
@@ -3455,219 +3462,15 @@ const pluginDefinition = {
         typeof orchestrator.config.qmdPath === "string" && orchestrator.config.qmdPath.trim().length > 0
           ? orchestrator.config.qmdPath.trim()
           : "qmd";
-      // Runtime reads are restricted to memory files only. The agent
-      // workspace root would be too broad (it contains logs, configs,
-      // secrets, etc.), so we allowlist only the memory root plus the
-      // workspace's memory subdirectory if it exists. The extension
-      // check in resolveReadablePath further narrows to markdown.
-      const readAllowedRoots = [
-        orchestrator.config.memoryDir,
-        capabilityWorkspaceDir ? path.join(capabilityWorkspaceDir, "memory") : undefined,
-      ].filter((root): root is string => typeof root === "string" && root.length > 0);
-      // Init-time canonicalization tolerates realpath failure (roots may
-      // not exist yet at plugin start) — the lexical fallback is fine
-      // because readAllowedCanonicalRootsPromise is only used as the
-      // containment target, not as a path we open.
-      const canonicalizeRootForContainment = async (rawPath: string): Promise<string> => {
-        const resolved = path.resolve(rawPath);
-        try {
-          return path.normalize(await realPathLater(resolved));
-        } catch {
-          return path.normalize(resolved);
-        }
-      };
-      // Check-time canonicalization is strict — realpath failure means
-      // the file does not exist or its symlink chain is broken. Falling
-      // back to lexical normalization there would re-open the TOCTOU
-      // window by letting a non-existent path pass the containment
-      // check; a symlink could then be created between check and open.
-      const canonicalizeForRead = async (rawPath: string): Promise<string> => {
-        const resolved = path.resolve(rawPath);
-        const real = await realPathLater(resolved);
-        return path.normalize(real);
-      };
-      const readAllowedCanonicalRootsPromise = Promise.all(
-        readAllowedRoots.map((root) => canonicalizeRootForContainment(root)),
-      );
-      const isWithinAllowedRoot = async (candidatePath: string): Promise<boolean> => {
-        // Use strict canonicalization here too so callers of this helper
-        // (if any) benefit from the same TOCTOU protection as
-        // resolveReadablePath. Kept for backwards compatibility with any
-        // downstream consumer; resolveReadablePath now short-circuits
-        // past this helper.
-        let canonicalCandidatePath: string;
-        try {
-          canonicalCandidatePath = await canonicalizeForRead(candidatePath);
-        } catch {
-          return false;
-        }
-        const canonicalRoots = await readAllowedCanonicalRootsPromise;
-        return canonicalRoots.some((root) => {
-          const relative = path.relative(root, canonicalCandidatePath);
-          return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-        });
-      };
-      const normalizeWorkspacePath = (rawPath: string | undefined): string => {
-        if (!rawPath || typeof rawPath !== "string") return "memory";
-        const resolved = path.isAbsolute(rawPath)
-          ? path.resolve(rawPath)
-          : path.resolve(capabilityWorkspaceDir, rawPath);
-        const relative = path.relative(capabilityWorkspaceDir, resolved);
-        return relative && !relative.startsWith("..") && !path.isAbsolute(relative)
-          ? relative
-          : rawPath;
-      };
-      // Relativize a path against whichever allowed read root actually
-      // contains it. Required for search results: returning the path
-      // relative to capabilityWorkspaceDir produces forms like
-      // "memory/local/facts/a.md", which resolveReadablePath would then
-      // join to every allowed root (memoryDir + <workspace>/memory),
-      // producing doubled "memory/" segments and failed reads.
-      const relativizeToMemoryRoot = (rawPath: string | undefined): string => {
-        if (!rawPath || typeof rawPath !== "string") return "memory";
-        const resolved = path.isAbsolute(rawPath)
-          ? path.resolve(rawPath)
-          : path.resolve(capabilityWorkspaceDir, rawPath);
-        for (const root of readAllowedRoots) {
-          const relative = path.relative(root, resolved);
-          if (
-            relative !== "" &&
-            !relative.startsWith("..") &&
-            !path.isAbsolute(relative)
-          ) {
-            return relative;
-          }
-        }
-        // Fall back to the workspace-relative form for display if the
-        // path is not inside any allowed root (search may still surface
-        // it as an informational hit even when reads would be rejected).
-        return normalizeWorkspacePath(rawPath);
-      };
-      const resolveReadablePath = async (requestedPath: string): Promise<string> => {
-        // QMD search results return paths relative to memoryDir (e.g.
-        // "facts/alice.md"), not the agent workspace root. Resolve
-        // relative paths against each allowlisted root and take the
-        // first one whose realpath lands inside the allowlist. This
-        // keeps absolute paths working while letting search hits feed
-        // straight into readFile() without the caller having to know
-        // which root owns them.
-        const candidateAbsolutePaths = path.isAbsolute(requestedPath)
-          ? [path.resolve(requestedPath)]
-          : readAllowedRoots.map((root) => path.resolve(root, requestedPath));
-        // Canonicalize strictly: realpath failure = reject. A lexical
-        // fallback would let a non-existent path pass the containment
-        // check, after which a symlink could be created pointing
-        // outside the allowlist before readFile() runs.
-        let canonicalPath: string | undefined;
-        let lastError: unknown;
-        for (const absolutePath of candidateAbsolutePaths) {
-          try {
-            canonicalPath = await canonicalizeForRead(absolutePath);
-            break;
-          } catch (err) {
-            lastError = err;
-          }
-        }
-        if (canonicalPath === undefined) {
-          throw new Error(
-            `memory read rejected (path unresolvable): ${requestedPath}`,
-          );
-        }
-        const canonicalRoots = await readAllowedCanonicalRootsPromise;
-        const contained = canonicalRoots.some((root) => {
-          const relative = path.relative(root, canonicalPath);
-          return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-        });
-        if (!contained) {
-          throw new Error(`memory read outside allowed roots: ${requestedPath}`);
-        }
-        // Restrict to markdown memory files — the allowed roots contain
-        // other file types (attachments, index files, snapshots) that
-        // should not be readable via this runtime capability.
-        if (!canonicalPath.toLowerCase().endsWith(".md")) {
-          throw new Error(
-            `memory read restricted to .md files: ${requestedPath}`,
-          );
-        }
-        return canonicalPath;
-      };
-      type RuntimeMemorySource = "memory" | "sessions";
-      type RuntimeSearchOptions = {
-        maxResults?: number;
-        minScore?: number;
-        sessionKey?: string;
-        qmdSearchModeOverride?: "query" | "search" | "vsearch";
-      };
-      type RuntimeSearchResult = {
-        path: string;
-        startLine: number;
-        endLine: number;
-        score: number;
-        snippet: string;
-        source: RuntimeMemorySource;
-        citation?: string;
-      };
-      type RuntimeReadParams = {
-        relPath: string;
-        from?: number;
-        lines?: number;
-      };
-      type RuntimeReadResult = {
-        text: string;
-        path: string;
-        truncated?: boolean;
-        from?: number;
-        lines?: number;
-        nextFrom?: number;
-      };
-      type RuntimeStatus = {
-        backend: "builtin" | "qmd";
-        provider: string;
-        requestedProvider?: string;
-        model?: string;
-        dirty?: boolean;
-        workspaceDir?: string;
-        dbPath?: string;
-        sources?: RuntimeMemorySource[];
-        sourceCounts?: Array<{
-          source: RuntimeMemorySource;
-          files: number;
-          chunks: number;
-        }>;
-        vector?: {
-          enabled: boolean;
-          available?: boolean;
-        };
-        fts?: {
-          enabled: boolean;
-          available: boolean;
-        };
-        custom?: Record<string, unknown>;
-      };
-      type RuntimeManager = {
-        search(query: string, opts?: RuntimeSearchOptions): Promise<RuntimeSearchResult[]>;
-        readFile(params: RuntimeReadParams): Promise<RuntimeReadResult>;
-        status(): RuntimeStatus;
-        sync?(params?: { reason?: string; force?: boolean }): Promise<void>;
-        probeEmbeddingAvailability(): Promise<{ ok: boolean; error?: string }>;
-        probeVectorAvailability(): Promise<boolean>;
-        close?(): Promise<void>;
-      };
-      type RemnicCapabilityRuntime = {
-        getMemorySearchManager(params: {
-          cfg: unknown;
-          agentId: string;
-          purpose?: "default" | "status";
-        }): Promise<{
-          manager: RuntimeManager | null;
-          error?: string;
-        }>;
-        resolveMemoryBackendConfig(params: {
-          cfg: unknown;
-          agentId: string;
-        }): { backend: "builtin" } | { backend: "qmd"; qmd?: { command?: string } };
-        closeAllMemorySearchManagers(): Promise<void>;
-      };
+      // Reads are restricted to memory files only — memory-read-scope.ts owns
+      // the allowlist, strict canonicalization, containment, and the markdown
+      // narrowing. Both bridge modes share it so neither can drift into a
+      // traversal hole the other already closed.
+      const readScope = createMemoryReadScope({
+        memoryDir: orchestrator.config.memoryDir,
+        workspaceDir: capabilityWorkspaceDir,
+        realpath: realPathLater,
+      });
       const remnicMemoryRuntime: RemnicCapabilityRuntime = {
         async getMemorySearchManager(_params: {
           cfg: unknown;
@@ -3732,22 +3535,8 @@ const pluginDefinition = {
                   // paths that exist under both memoryDir and
                   // <workspace>/memory would otherwise pick whichever
                   // root realpath succeeded against first).
-                  const absolutePath = path.isAbsolute(rawPath)
-                    ? path.resolve(rawPath)
-                    : (() => {
-                        for (const root of readAllowedRoots) {
-                          const candidateAbs = path.resolve(root, rawPath);
-                          const relative = path.relative(root, candidateAbs);
-                          if (
-                            !relative.startsWith("..") &&
-                            !path.isAbsolute(relative)
-                          ) {
-                            return candidateAbs;
-                          }
-                        }
-                        return path.resolve(capabilityWorkspaceDir, rawPath);
-                      })();
-                  const normalizedPath = relativizeToMemoryRoot(rawPath);
+                  const absolutePath = readScope.absolutize(rawPath);
+                  const normalizedPath = readScope.relativizeToMemoryRoot(rawPath);
                   const startLine =
                     typeof candidate.startLine === "number" && Number.isFinite(candidate.startLine)
                       ? Math.max(1, Math.floor(candidate.startLine))
@@ -3785,8 +3574,8 @@ const pluginDefinition = {
                 );
               },
               async readFile(params: RuntimeReadParams) {
-                const requestedPath = normalizeWorkspacePath(params.relPath);
-                const absolutePath = await resolveReadablePath(params.relPath);
+                const requestedPath = readScope.normalizeWorkspacePath(params.relPath);
+                const absolutePath = await readScope.resolveReadablePath(params.relPath);
                 const text = await readTextFileLater(absolutePath);
                 const allLines = text.split(/\r?\n/);
                 const from = typeof params.from === "number" ? Math.max(1, Math.floor(params.from)) : 1;


### PR DESCRIPTION
Part of #2120. Layer 1 of 4 — no behavior change.

## Problem
The OpenClaw memory-slot capability's read path — allowed-root allowlist, strict `realpath` canonicalization, containment, markdown narrowing — lived inline inside `register()` in `src/index.ts` and was reachable only from the embedded-orchestrator branch. Delegate bridge mode needs the identical boundary, and a second copy of security-critical containment logic is exactly how one path drifts into a traversal hole the other already closed.

## Change
- **`packages/plugin-openclaw/src/memory-read-scope.ts`** (new): `createMemoryReadScope({ memoryDir, workspaceDir, realpath? })` owns `allowedRoots`, `absolutize`, `normalizeWorkspacePath`, `relativizeToMemoryRoot`, and `resolveReadablePath`, with an injectable canonicalizer seam.
- **`packages/plugin-openclaw/src/memory-capability-types.ts`** (new): the runtime shapes both bridge modes implement.
- **`src/index.ts`**: consumes both and drops ~210 inline lines, including the unreachable `isWithinAllowedRoot()` helper (a closure-local `const` with no call site).

Behavior-preserving: same roots, same strict-canonicalize-then-contain order, same error messages.

## Tests
18 new tests in `memory-read-scope.test.ts`: traversal escape, symlink escape, non-markdown rejection, unresolvable paths, multi-root precedence, missing-root tolerance, the relativize→resolve round trip, and that the injected canonicalizer is used for both roots and reads.

## Verification
`memory-read-scope.test.ts` 18/18; root `tsc --noEmit` clean; `plugin-openclaw` `check-types` clean; `check-ratchets` OK (`src/index.ts` shrinks).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Centralizes security-sensitive path containment; the refactor is intended to be behavior-preserving and is heavily tested, but any mistake could affect agent memory reads.
> 
> **Overview**
> Moves OpenClaw memory-slot **read path containment** out of inline `register()` code in `src/index.ts` into **`createMemoryReadScope`** in `packages/plugin-openclaw/src/memory-read-scope.ts`, so embedded and future delegate bridge modes share one allowlist, `realpath` canonicalization, root containment, and `.md`-only reads.
> 
> Adds **`memory-capability-types.ts`** for the runtime shapes previously defined inline, and wires the embedded memory manager to **`readScope.absolutize`**, **`relativizeToMemoryRoot`**, **`normalizeWorkspacePath`**, and **`resolveReadablePath`**. Session hits use **`isSessionsMemoryPath`** instead of a literal `sessions/` check (Windows-safe). Drops the unused **`isWithinAllowedRoot`** helper; **`resolveReadablePath`** now rejects missing/non-string paths at the SDK boundary.
> 
> **18 unit tests** cover traversal, symlinks, multi-root resolution, and round-trip path handling. Described as behavior-preserving (same roots, order of checks, error messages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2737cb6b595fd114efed9bb3b29ad5ea158c0b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure memory-file access for configured memory and workspace locations.
  * Added runtime memory capabilities for searching, reading files, checking status, and managing supported backends.
  * Added Markdown-only filtering, path normalization, and protection against traversal and symlink escapes.

* **Bug Fixes**
  * Improved consistency for memory paths, workspace-relative paths, and session-memory detection.
  * Centralized access validation for more reliable and secure memory reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->