### PR TITLE
feat(plugin-openclaw): back the memory-slot capability with the daemon in delegate mode

### DIFF
--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -10,6 +10,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { isIPv4 } from "node:net";
 import { Worker, type WorkerOptions } from "node:worker_threads";
 import { expandTildePath } from "@remnic/core";
 
@@ -257,8 +258,37 @@ function isDaemonServiceConfigured(): boolean {
   return false;
 }
 
+/**
+ * Whether a daemon endpoint names THIS host.
+ *
+ * Literal only: a prefix test would accept a DNS name like
+ * `127.daemon.example` that resolves anywhere. A wildcard bind
+ * (`0.0.0.0` / `::`) names every interface on this host, so it counts as local
+ * — `server.host: "0.0.0.0"` is the documented daemon configuration.
+ */
+export function isLoopbackDaemonHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+  if (normalized === "localhost" || normalized === "::1") return true;
+  if (loopbackForWildcardBind(normalized) !== undefined) return true;
+  return isIPv4(normalized) && normalized.split(".")[0] === "127";
+}
+
 /** Normalize a host for node:http/health use: strip surrounding IPv6 brackets
  * (`[::1]` → `::1`). URL builders re-bracket as needed. */
+/**
+ * A wildcard bind names every interface on THIS host, not a remote one. The
+ * documented `server.host: "0.0.0.0"` daemon config would otherwise be
+ * classified as remote — leaving `auto` embedded beside a same-host daemon on
+ * the same corpus — and is not a portable destination address either, so it is
+ * dialed through the matching loopback.
+ */
+export function loopbackForWildcardBind(host: string): string | undefined {
+  const normalized = host.trim().toLowerCase();
+  if (normalized === "0.0.0.0") return DEFAULT_HOST;
+  if (normalized === "::" || normalized === "[::]") return "::1";
+  return undefined;
+}
+
 function normalizeDaemonHost(value: string): string {
   const match = value.trim().match(/^\[(.+)\]$/);
   return match ? match[1] : value.trim();
@@ -326,6 +356,11 @@ function shouldProbeDaemonHealth(host: string): boolean {
  * readDaemonPort's precedence. Falls back to DEFAULT_HOST.
  */
 function readDaemonHost(): string {
+  const resolved = readConfiguredDaemonHost();
+  return loopbackForWildcardBind(resolved) ?? resolved;
+}
+
+function readConfiguredDaemonHost(): string {
   const envHost = readCompatEnv("REMNIC_HOST", "ENGRAM_HOST");
   if (envHost !== undefined && envHost.trim() !== "") return normalizeDaemonHost(envHost);
   for (const p of configPathCandidates()) {

--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -36,6 +36,26 @@ export interface DaemonAuthToken {
   readonly source: DaemonAuthTokenSource;
 }
 
+/** Everything a delegate-mode request needs to reach the standalone daemon. */
+export interface DelegateDaemonTarget {
+  host: string;
+  port: number;
+  resolveAuthToken: () => DaemonAuthToken;
+}
+
+/** Base URL for a daemon route, bracketing a bare IPv6 literal host. */
+export function daemonUrl(target: DelegateDaemonTarget, pathname: string): string {
+  const host =
+    target.host.includes(":") && !target.host.startsWith("[") ? `[${target.host}]` : target.host;
+  return `http://${host}:${target.port}${pathname}`;
+}
+
+/** Bearer header for a daemon request; empty when no token is configured. */
+export function daemonAuthHeaders(target: DelegateDaemonTarget): Record<string, string> {
+  const auth = target.resolveAuthToken();
+  return auth.token ? { Authorization: `Bearer ${auth.token}` } : {};
+}
+
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 4318;
 const LIVENESS_PATH = "/engram/v1/live";

--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -340,6 +340,7 @@ export function checkDaemonHealthSync(
   }
 }
 
+
 function shouldProbeDaemonHealth(host: string): boolean {
   const normalized = host.trim().toLowerCase();
   return (

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -1310,16 +1310,23 @@ test("a spent caller budget skips the health probe instead of overrunning it", a
     // A real budget probes once and caches the daemon's flat posture.
     assert.equal(await built.resolveScopedNamespace(undefined, 5_000), undefined);
     assert.equal(stub.calls.filter((call) => call.pathname.includes("/health")).length, 1);
-    // Snapshot expired, budget spent: answer from the last known posture
-    // rather than starting a request that would overrun the shared deadline.
+    // Snapshot expired, budget spent: no request is started (it would overrun
+    // the shared deadline) AND an unscoped call fails closed, because the
+    // posture on hand was never confirmed by this call.
     clock += 10 * 60_000;
-    assert.equal(await built.resolveScopedNamespace(undefined, 0), undefined);
+    await assert.rejects(
+      () => built.resolveScopedNamespace(undefined, 0),
+      /namespace posture could not be confirmed/,
+    );
     assert.equal(
       stub.calls.filter((call) => call.pathname.includes("/health")).length,
       1,
       "no second probe once the shared deadline is gone",
     );
-    // With budget again, it re-probes.
+    // An explicit scope is the caller's own and still resolves unprobed.
+    assert.equal(await built.resolveScopedNamespace("team-a", 0), "team-a");
+    assert.equal(stub.calls.filter((call) => call.pathname.includes("/health")).length, 1);
+    // With budget again, it re-probes and the unscoped call works.
     assert.equal(await built.resolveScopedNamespace(undefined, 5_000), undefined);
     assert.equal(stub.calls.filter((call) => call.pathname.includes("/health")).length, 2);
   } finally {
@@ -1410,6 +1417,86 @@ test("a failed probe un-proves a previously flat posture", async () => {
     );
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("a probe failure un-proves the default namespace too", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // A partitioned daemon can change its default across a restart. A retained
+  // stale default is NOT undefined, so it would slip past the unknown-posture
+  // guard and bind a fresh session to the previous tenant.
+  let healthy = true;
+  const server = http.createServer((req, res) => {
+    if ((req.url ?? "").includes("/health") && !healthy) {
+      res.destroy();
+      return;
+    }
+    res.setHeader("content-type", "application/json");
+    res.end(
+      JSON.stringify(
+        (req.url ?? "").includes("/health")
+          ? { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "tenant-a" }
+          : { query: "q", count: 0, results: [] },
+      ),
+    );
+  });
+  const listening = Promise.withResolvers<void>();
+  server.once("error", listening.reject);
+  server.listen(0, "127.0.0.1", listening.resolve);
+  await listening.promise;
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  let clock = 1_000;
+  try {
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(address.port, memoryDir, workspaceDir),
+      resolveSearchNamespace: async () => undefined,
+      verifyNamespaceAuthorization: async () => true,
+      now: () => clock,
+    });
+    assert.equal(await built.resolveScopedNamespace(undefined), "tenant-a");
+    healthy = false;
+    clock += 10 * 60_000;
+    await assert.rejects(
+      () => built.resolveScopedNamespace(undefined),
+      /default namespace is unknown/,
+      "the stale default must not bind a fresh session",
+    );
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate search rejects a malformed score and an invalid minScore", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
+    search: {
+      query: "q",
+      count: 1,
+      results: [{ path: "facts/a.md", snippet: "no score" }],
+    },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    // A missing score is a protocol failure, not a zero ranking.
+    await assert.rejects(
+      () => manager?.search("q") ?? Promise.resolve(),
+      /malformed result entry/,
+    );
+    // An unusable threshold must not silently disable the filter.
+    for (const minScore of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      await assert.rejects(
+        () => manager?.search("q", { minScore }) ?? Promise.resolve(),
+        /minScore must be a finite number/,
+        `minScore: ${String(minScore)} must be rejected`,
+      );
+    }
+  } finally {
+    await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
   }
 });

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -109,6 +109,7 @@ function healthyDaemon(memoryDir: string): Record<string, unknown> {
   return {
     ok: true,
     memoryDir,
+    namespacesEnabled: false,
     searchBackend: "qmd",
     qmdEnabled: true,
     qmd: { enabled: true, active: true, degraded: false, debugStatus: "cli=true" },
@@ -343,6 +344,7 @@ test("delegate status reports a degraded daemon QMD as unavailable", async () =>
   const stub = await startDaemonStub({
     health: {
       memoryDir,
+      namespacesEnabled: false,
       searchBackend: "qmd",
       qmdEnabled: true,
       qmd: { enabled: true, active: true, degraded: true, debugStatus: "collection missing" },

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -118,7 +118,6 @@ function optionsFor(
     allowPromptInjection: true,
     readPromptLines: () => null,
     configuredSearchBackend: "qmd",
-    configuredNamespacesEnabled: false,
     configuredQmdCommand: "qmd",
     searchTimeoutMs: 5_000,
     healthTimeoutMs: 5_000,
@@ -924,7 +923,6 @@ test("delegate file surfaces refuse a namespace-partitioned daemon", async () =>
     try {
       const built = createDelegateMemoryCapability({
         ...optionsFor(stub.port, memoryDir, workspaceDir),
-        configuredNamespacesEnabled: true,
         resolveSearchNamespace: async (sessionKey) => (sessionKey === "s2" ? "team-a" : "default"),
       });
       const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
@@ -1099,18 +1097,22 @@ test("swapping in an authorized token recovers unbound delegate search", async (
   }
 });
 
-test("a single-corpus plugin config resolves scope while the probe is failing", async () => {
+test("a failed probe leaves the posture unknown, so unbound calls fail closed", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  // No daemon answers at all, so the seeded snapshot is all there is. A flat
-  // deployment must still resolve its scope rather than refusing every call
-  // for the duration of an outage.
+  // Nothing answers. The plugin's own config describes the PLUGIN, never the
+  // daemon's partitioning, so there is no local evidence that an absent
+  // namespace is safe - and an unrestricted token would otherwise fan out.
   const built = createDelegateMemoryCapability({
     ...optionsFor(1, memoryDir, workspaceDir),
-    configuredNamespacesEnabled: false,
     resolveSearchNamespace: async () => undefined,
   });
   try {
-    assert.equal(await built.resolveScopedNamespace(undefined), undefined);
+    await assert.rejects(
+      () => built.resolveScopedNamespace(undefined),
+      /default namespace is unknown/,
+    );
+    // An explicit scope is the caller's own and still resolves.
+    assert.equal(await built.resolveScopedNamespace("team-a"), "team-a");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
@@ -1129,7 +1131,6 @@ test("a daemon that ANSWERS without a posture is unknown, not flat", async () =>
   try {
     const built = createDelegateMemoryCapability({
       ...optionsFor(stub.port, memoryDir, workspaceDir),
-      configuredNamespacesEnabled: false,
       resolveSearchNamespace: async () => undefined,
     });
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
@@ -1152,7 +1153,6 @@ test("a partitioned plugin config still fails closed before the first probe", as
   try {
     const built = createDelegateMemoryCapability({
       ...optionsFor(stub.port, memoryDir, workspaceDir),
-      configuredNamespacesEnabled: true,
       resolveSearchNamespace: async () => undefined,
     });
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
@@ -1289,17 +1289,66 @@ test("a spent caller budget skips the health probe instead of overrunning it", a
     health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    // Budget already spent: answer from the seeded snapshot, probe nothing.
+    // A controllable clock so the cached snapshot can be aged out without a
+    // test-only hook in production code.
+    let clock = 1_000;
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      now: () => clock,
+    });
+    // A real budget probes once and caches the daemon's flat posture.
+    assert.equal(await built.resolveScopedNamespace(undefined, 5_000), undefined);
+    assert.equal(stub.calls.filter((call) => call.pathname.includes("/health")).length, 1);
+    // Snapshot expired, budget spent: answer from the last known posture
+    // rather than starting a request that would overrun the shared deadline.
+    clock += 10 * 60_000;
     assert.equal(await built.resolveScopedNamespace(undefined, 0), undefined);
     assert.equal(
       stub.calls.filter((call) => call.pathname.includes("/health")).length,
-      0,
-      "no probe is started once the shared deadline is gone",
+      1,
+      "no second probe once the shared deadline is gone",
     );
-    // A real budget still probes.
-    await built.resolveScopedNamespace(undefined, 5_000);
-    assert.equal(stub.calls.filter((call) => call.pathname.includes("/health")).length, 1);
+    // With budget again, it re-probes.
+    assert.equal(await built.resolveScopedNamespace(undefined, 5_000), undefined);
+    assert.equal(stub.calls.filter((call) => call.pathname.includes("/health")).length, 2);
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("a spent budget skips the authorization probe too", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // The remaining-budget argument must reach the authorization probe, not stop
+  // at health: its own fixed timeout would overrun a nearly-spent flush.
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+    search: { query: "q", count: 0, results: [] },
+  });
+  try {
+    const budgets: Array<number | undefined> = [];
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      resolveSearchNamespace: async () => undefined,
+      verifyNamespaceAuthorization: async (_namespace, timeoutMs) => {
+        budgets.push(timeoutMs);
+        return true;
+      },
+    });
+    // Health is already cached by this first call, so the spent-budget path
+    // below is exercised against the authorization probe specifically.
+    assert.equal(await built.resolveScopedNamespace(undefined, 5_000), "default");
+    assert.deepEqual(budgets, [5_000], "the caller's budget reaches the probe");
+
+    const fresh = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      resolveSearchNamespace: async () => undefined,
+      verifyNamespaceAuthorization: async () => {
+        throw new Error("must not probe once the deadline is spent");
+      },
+    });
+    await fresh.resolveScopedNamespace(undefined, 5_000).catch(() => undefined);
+    assert.equal(await fresh.resolveScopedNamespace(undefined, 0), "default");
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -1062,3 +1062,34 @@ test("delegate does not second-guess an explicit namespace", async () => {
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("swapping in an authorized token recovers unbound delegate search", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // Daemon requests resolve credentials dynamically. Caching a refusal against
+  // the namespace alone would keep rejecting search locally after an operator
+  // replaced an under-scoped token, while recall and observe recovered.
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+    search: { query: "q", count: 0, results: [] },
+  });
+  try {
+    let token = "under-scoped";
+    const base = optionsFor(stub.port, memoryDir, workspaceDir);
+    const built = createDelegateMemoryCapability({
+      ...base,
+      target: { ...base.target, resolveAuthToken: () => ({ token, source: "REMNIC_AUTH_TOKEN" }) },
+      resolveSearchNamespace: async () => undefined,
+      verifyNamespaceAuthorization: async () => token === "authorized",
+    });
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.search("q") ?? Promise.resolve(),
+      /is not authorized for the delegate token/,
+    );
+    token = "authorized";
+    assert.deepEqual(await manager?.search("q"), [], "the new token is re-probed, not refused from cache");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -1366,7 +1366,13 @@ test("a spent budget skips the authorization probe too", async () => {
       },
     });
     await fresh.resolveScopedNamespace(undefined, 5_000).catch(() => undefined);
-    assert.equal(await fresh.resolveScopedNamespace(undefined, 0), "default");
+    // A spent budget cannot revalidate, and an unscoped request will not run
+    // on an unconfirmed posture - so it fails closed WITHOUT reaching the
+    // authorization probe (which would throw if it were attempted).
+    await assert.rejects(
+      () => fresh.resolveScopedNamespace(undefined, 0),
+      /namespace posture could not be confirmed/,
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -1501,10 +1507,11 @@ test("delegate search rejects a malformed score and an invalid minScore", async 
   }
 });
 
-test("a cached flat posture expires far sooner than the rest of the snapshot", async () => {
+test("an unscoped request revalidates the posture instead of trusting the cache", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  // A flat posture is the one value that licenses an UNSCOPED request, so a
-  // daemon repartitioning mid-TTL would turn it into a fan-out.
+  // A flat posture LICENSES an unscoped request. A daemon that restarts
+  // partitioned inside the TTL would otherwise keep that license with no probe
+  // failure to notice it.
   const stub = await startDaemonStub({
     health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
   });
@@ -1516,19 +1523,20 @@ test("a cached flat posture expires far sooner than the rest of the snapshot", a
       now: () => clock,
     });
     await built.resolveScopedNamespace(undefined);
-    const afterFirst = stub.calls.filter((call) => call.pathname.includes("/health")).length;
-    assert.equal(afterFirst, 1);
-    // Still inside the FLAT window: no re-probe.
-    clock += 4_000;
-    await built.resolveScopedNamespace(undefined);
-    assert.equal(stub.calls.filter((call) => call.pathname.includes("/health")).length, 1);
-    // Past it, but well inside the ordinary 30s snapshot TTL: re-probed.
-    clock += 2_000;
     await built.resolveScopedNamespace(undefined);
     assert.equal(
       stub.calls.filter((call) => call.pathname.includes("/health")).length,
       2,
-      "the licensing value is re-confirmed long before the rest of the snapshot",
+      "each unscoped resolution confirms the posture, cache or not",
+    );
+    // An EXPLICIT scope is the caller's own and the daemon enforces it, so it
+    // rides the cache and costs no extra probe.
+    const before = stub.calls.filter((call) => call.pathname.includes("/health")).length;
+    await built.resolveScopedNamespace("team-a");
+    assert.equal(
+      stub.calls.filter((call) => call.pathname.includes("/health")).length,
+      before,
+      "an explicit scope does not force a probe",
     );
   } finally {
     await stub.close();

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -195,7 +195,6 @@ test("delegate search excludes artifact paths and honors minScore", async () => 
         { path: "artifacts/report.md", score: 0.99, snippet: "artifact" },
         { path: "facts/alice.md", score: 0.2, snippet: "low" },
         { path: "facts/bob.md", score: 0.8, snippet: "high" },
-        "not-an-object",
       ],
     },
   });
@@ -206,7 +205,7 @@ test("delegate search excludes artifact paths and honors minScore", async () => 
     assert.deepEqual(
       results?.map((result) => result.citation),
       [path.join("facts", "bob.md")],
-      "artifacts are isolated, sub-threshold hits are dropped, non-objects are skipped",
+      "artifacts are isolated and sub-threshold hits are dropped",
     );
   } finally {
     await stub.close();
@@ -874,6 +873,75 @@ test("delegate search with no budget keeps the daemon's page size on the wire", 
       results.map((hit) => hit.citation),
       [path.join("facts", "one.md"), path.join("facts", "two.md")],
     );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate search rejects a malformed result entry instead of inventing a memory", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // A 200 whose entries are not memories is a version-skewed or corrupt
+  // daemon. Synthesizing `memory-N` would hand the host a path it can then
+  // try to open (AGENTS.md #22).
+  for (const bad of ["not-an-object", { score: 0.9 }, { path: 42 }, { path: "  " }]) {
+    const stub = await startDaemonStub({
+      health: healthyDaemon(memoryDir),
+      search: { results: [{ path: "facts/ok.md", score: 0.9, snippet: "ok" }, bad] },
+    });
+    try {
+      const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+      const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+      await assert.rejects(
+        () => manager?.search("q") ?? Promise.resolve(),
+        /malformed result entry/,
+        `entry ${JSON.stringify(bad)} must be a protocol failure`,
+      );
+    } finally {
+      await stub.close();
+    }
+  }
+  await rm(memoryDir, { recursive: true, force: true });
+});
+
+test("delegate file surfaces refuse a namespace the health snapshot does not describe", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // Health answers without a namespace, so its memoryDir is the DEFAULT
+  // namespace's storage. A session scoped elsewhere would otherwise publish
+  // that namespace's files while omitting its own.
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+  });
+  try {
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      resolveSearchNamespace: async () => "team-a",
+    });
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+      /a local walk cannot be authorized for it/,
+    );
+    assert.deepEqual(await built.listArtifacts(), [], "artifacts are withheld, not cross-published");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate file surfaces stay available on the namespace health describes", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+  });
+  try {
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      resolveSearchNamespace: async () => "default",
+    });
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const read = await manager?.readFile({ relPath: "facts/alice.md" });
+    assert.equal(read?.path, path.join("facts", "alice.md"), "the read is served, not refused");
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -26,6 +26,8 @@ type StubRoutes = {
   /** A literal response body, for shapes `JSON.stringify` would normalize. */
   healthRaw?: string;
   healthStatus?: number;
+  /** Delay the health response, so a test can observe a shared deadline. */
+  healthDelayMs?: number;
   search?: unknown;
   searchStatus?: number;
 };
@@ -40,27 +42,39 @@ async function startDaemonStub(routes: StubRoutes): Promise<DaemonStub> {
       const pathname = (req.url ?? "").split("?")[0] ?? "";
       calls.push({ pathname, body: raw ? JSON.parse(raw) : undefined });
       const isSearch = pathname.endsWith("/memories/search");
-      const status = isSearch ? (routes.searchStatus ?? 200) : (routes.healthStatus ?? 200);
-      res.writeHead(status, { "content-type": "application/json" });
-      if (!isSearch && routes.healthRaw !== undefined) {
-        // A literal body, so a test can send a 200 that is valid JSON but not
-        // a record — the shape `?? {}` would otherwise paper over.
-        res.end(routes.healthRaw);
+      const delayMs = isSearch ? 0 : (routes.healthDelayMs ?? 0);
+      if (delayMs > 0) {
+        setTimeout(() => respond(), delayMs);
         return;
       }
-      let payload = isSearch ? routes.search : routes.health;
-      if (isSearch && payload !== null && typeof payload === "object") {
-        // Honor `maxResults` the way a real daemon does, so a client-side
-        // top-up sees a genuinely truncated page.
-        const requested = (calls[calls.length - 1]?.body as { maxResults?: number } | undefined)
-          ?.maxResults;
-        const page = payload as { results?: unknown[]; count?: number };
-        if (typeof requested === "number" && Array.isArray(page.results)) {
-          const sliced = page.results.slice(0, requested);
-          payload = { ...page, results: sliced, count: sliced.length };
+      respond();
+
+      function respond(): void {
+        const status = isSearch
+          ? (routes.searchStatus ?? 200)
+          : (routes.healthStatus ?? 200);
+        res.writeHead(status, { "content-type": "application/json" });
+        if (!isSearch && routes.healthRaw !== undefined) {
+          // A literal body, so a test can send a 200 that is valid JSON but not
+          // a record — the shape `?? {}` would otherwise paper over.
+          res.end(routes.healthRaw);
+          return;
         }
+        let payload = isSearch ? routes.search : routes.health;
+        if (isSearch && payload !== null && typeof payload === "object") {
+          // Honor `maxResults` the way a real daemon does, so a client-side
+          // top-up sees a genuinely truncated page.
+          const requested = (
+            calls[calls.length - 1]?.body as { maxResults?: number } | undefined
+          )?.maxResults;
+          const page = payload as { results?: unknown[]; count?: number };
+          if (typeof requested === "number" && Array.isArray(page.results)) {
+            const sliced = page.results.slice(0, requested);
+            payload = { ...page, results: sliced, count: sliced.length };
+          }
+        }
+        res.end(JSON.stringify(payload ?? {}));
       }
-      res.end(JSON.stringify(payload ?? {}));
     });
   });
   const listening = Promise.withResolvers<void>();
@@ -83,17 +97,31 @@ async function startDaemonStub(routes: StubRoutes): Promise<DaemonStub> {
   };
 }
 
-async function makeCorpus(): Promise<{ memoryDir: string; workspaceDir: string }> {
-  const root = await realpath(await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-cap-")));
+async function makeCorpus(): Promise<{
+  memoryDir: string;
+  workspaceDir: string;
+}> {
+  const root = await realpath(
+    await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-cap-")),
+  );
   const memoryDir = path.join(root, "memory");
   const workspaceDir = path.join(root, "workspace");
   await mkdir(path.join(memoryDir, "facts"), { recursive: true });
   await mkdir(path.join(memoryDir, "artifacts"), { recursive: true });
   await mkdir(path.join(workspaceDir, "memory"), { recursive: true });
-  await writeFile(path.join(memoryDir, "facts", "alice.md"), "one\ntwo\nthree\nfour\n");
+  await writeFile(
+    path.join(memoryDir, "facts", "alice.md"),
+    "one\ntwo\nthree\nfour\n",
+  );
   // Exists ONLY under the gateway's workspace - the daemon never saw it.
-  await writeFile(path.join(workspaceDir, "memory", "notes.md"), "gateway-only\n");
-  await writeFile(path.join(memoryDir, "artifacts", "report.md"), "secret artifact\n");
+  await writeFile(
+    path.join(workspaceDir, "memory", "notes.md"),
+    "gateway-only\n",
+  );
+  await writeFile(
+    path.join(memoryDir, "artifacts", "report.md"),
+    "secret artifact\n",
+  );
   return { memoryDir, workspaceDir };
 }
 
@@ -108,7 +136,10 @@ function optionsFor(
     target: {
       host: "127.0.0.1",
       port,
-      resolveAuthToken: () => ({ token: "test-token", source: "REMNIC_AUTH_TOKEN" }),
+      resolveAuthToken: () => ({
+        token: "test-token",
+        source: "REMNIC_AUTH_TOKEN",
+      }),
     },
     namespace: "",
     resolveSearchNamespace: async () => undefined,
@@ -133,12 +164,20 @@ function healthyDaemon(memoryDir: string): Record<string, unknown> {
     namespacesEnabled: false,
     searchBackend: "qmd",
     qmdEnabled: true,
-    qmd: { enabled: true, active: true, degraded: false, debugStatus: "cli=true" },
+    qmd: {
+      enabled: true,
+      active: true,
+      degraded: false,
+      debugStatus: "cli=true",
+    },
   };
 }
 
 test.before(() =>
-  initLogger({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }, false),
+  initLogger(
+    { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    false,
+  ),
 );
 test.after(() => resetLogger());
 
@@ -156,8 +195,13 @@ test("delegate search maps daemon hits into runtime results", async () => {
     },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     assert.ok(manager);
     const results = await manager.search("alice", { maxResults: 5 });
     assert.deepEqual(results, [
@@ -180,8 +224,14 @@ test("delegate search maps daemon hits into runtime results", async () => {
         citation: path.join("sessions", "2026-01-01.md"),
       },
     ]);
-    const searchCall = stub.calls.find((call) => call.pathname.endsWith("/memories/search"));
-    assert.deepEqual(searchCall?.body, { query: "alice", maxResults: 5, mode: "search" });
+    const searchCall = stub.calls.find((call) =>
+      call.pathname.endsWith("/memories/search"),
+    );
+    assert.deepEqual(searchCall?.body, {
+      query: "alice",
+      maxResults: 5,
+      mode: "search",
+    });
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -201,8 +251,13 @@ test("delegate search excludes artifact paths and honors minScore", async () => 
     },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     const results = await manager?.search("q", { minScore: 0.5 });
     assert.deepEqual(
       results?.map((result) => result.citation),
@@ -217,7 +272,10 @@ test("delegate search excludes artifact paths and honors minScore", async () => 
 
 test("delegate search scopes the namespace through the session resolver", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir), search: { results: [] } });
+  const stub = await startDaemonStub({
+    health: healthyDaemon(memoryDir),
+    search: { results: [] },
+  });
   const seen: Array<string | undefined> = [];
   try {
     const built = createDelegateMemoryCapability(
@@ -229,17 +287,30 @@ test("delegate search scopes the namespace through the session resolver", async 
         },
       }),
     );
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await manager?.search("q", { sessionKey: "s1" });
     await manager?.search("q");
-    const searches = stub.calls.filter((call) => call.pathname.endsWith("/memories/search"));
-    assert.deepEqual(searches[0]?.body, { query: "q", mode: "search", namespace: "team-a" });
+    const searches = stub.calls.filter((call) =>
+      call.pathname.endsWith("/memories/search"),
+    );
+    assert.deepEqual(searches[0]?.body, {
+      query: "q",
+      mode: "search",
+      namespace: "team-a",
+    });
     assert.deepEqual(
       searches[1]?.body,
       { query: "q", mode: "search", namespace: "fallback-ns" },
       "a search with no session key falls back to the registration-wide namespace",
     );
-    assert.deepEqual(seen, ["s1", undefined], "the host session key reaches the resolver");
+    assert.deepEqual(
+      seen,
+      ["s1", undefined],
+      "the host session key reaches the resolver",
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -250,17 +321,29 @@ test("delegate refuses file-backed surfaces when the daemon serves another corpu
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({
     health: healthyDaemon(path.join(memoryDir, "..", "someone-elses-corpus")),
-    search: { results: [{ path: "facts/alice.md", score: 0.5, snippet: "hit" }] },
+    search: {
+      results: [{ path: "facts/alice.md", score: 0.5, snippet: "hit" }],
+    },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
-      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+      () =>
+        manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
       /delegate readFile unavailable/,
       "reading a same-named local file would serve the wrong corpus",
     );
-    assert.deepEqual(await built.listArtifacts(), [], "artifact listing is disabled too");
+    assert.deepEqual(
+      await built.listArtifacts(),
+      [],
+      "artifact listing is disabled too",
+    );
     const results = await manager?.search("alice");
     assert.equal(results?.length, 1, "daemon-backed search still works");
   } finally {
@@ -273,10 +356,16 @@ test("delegate refuses file-backed surfaces until the corpus is confirmed", asyn
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({ healthStatus: 500, health: {} });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
-      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+      () =>
+        manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
       /delegate readFile unavailable/,
       "an unconfirmed corpus fails closed rather than reading local files",
     );
@@ -288,10 +377,19 @@ test("delegate refuses file-backed surfaces until the corpus is confirmed", asyn
 
 test("delegate search surfaces a daemon failure instead of returning empty", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir), searchStatus: 503, search: {} });
+  const stub = await startDaemonStub({
+    health: healthyDaemon(memoryDir),
+    searchStatus: 503,
+    search: {},
+  });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
       () => manager?.search("q") ?? Promise.resolve([]),
       /responded 503/,
@@ -307,9 +405,18 @@ test("delegate readFile reads the shared corpus and paginates", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
-    const page = await manager?.readFile({ relPath: "facts/alice.md", from: 2, lines: 2 });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
+    const page = await manager?.readFile({
+      relPath: "facts/alice.md",
+      from: 2,
+      lines: 2,
+    });
     assert.equal(page?.text, "two\nthree");
     assert.equal(page?.truncated, true);
     assert.equal(page?.nextFrom, 4);
@@ -325,8 +432,13 @@ test("delegate readFile refuses paths outside the memory roots", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
       () => manager?.readFile({ relPath: "/etc/hosts" }) ?? Promise.resolve(),
       /memory read (outside allowed roots|restricted to \.md files|rejected)/,
@@ -341,18 +453,26 @@ test("delegate status reflects the daemon health snapshot", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     const status = manager?.status();
     assert.equal(status?.backend, "qmd");
     assert.equal(status?.dbPath, memoryDir);
     assert.deepEqual(status?.vector, { enabled: true, available: true });
     assert.equal(await manager?.probeVectorAvailability(), true);
     assert.deepEqual(await manager?.probeEmbeddingAvailability(), { ok: true });
-    assert.deepEqual(built.runtime.resolveMemoryBackendConfig({ cfg: {}, agentId: "main" }), {
-      backend: "qmd",
-      qmd: { command: "qmd" },
-    });
+    assert.deepEqual(
+      built.runtime.resolveMemoryBackendConfig({ cfg: {}, agentId: "main" }),
+      {
+        backend: "qmd",
+        qmd: { command: "qmd" },
+      },
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -367,12 +487,22 @@ test("delegate status reports a degraded daemon QMD as unavailable", async () =>
       namespacesEnabled: false,
       searchBackend: "qmd",
       qmdEnabled: true,
-      qmd: { enabled: true, active: true, degraded: true, debugStatus: "collection missing" },
+      qmd: {
+        enabled: true,
+        active: true,
+        degraded: true,
+        debugStatus: "collection missing",
+      },
     },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     assert.equal(manager?.status().vector?.available, false);
     assert.deepEqual(await manager?.probeEmbeddingAvailability(), {
       ok: false,
@@ -388,8 +518,13 @@ test("delegate status keeps the configured backend when the daemon health probe 
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({ healthStatus: 500, health: {} });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     // A failed probe must not fabricate an outage — the seeded config wins.
     assert.equal(manager?.status().backend, "qmd");
     assert.equal(manager?.status().dbPath, memoryDir);
@@ -409,7 +544,8 @@ test("delegate health is cached and refreshed on the injected clock", async () =
     );
     await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
     await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
-    const healthCalls = () => stub.calls.filter((call) => call.pathname.endsWith("/health")).length;
+    const healthCalls = () =>
+      stub.calls.filter((call) => call.pathname.endsWith("/health")).length;
     assert.equal(healthCalls(), 1, "a warm snapshot is reused");
     clock += 60_000;
     await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
@@ -424,8 +560,13 @@ test("delegate runtime offers no sync — indexing stays the daemon's job", asyn
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     assert.equal(manager?.sync, undefined);
   } finally {
     await stub.close();
@@ -446,7 +587,10 @@ test("delegate flush plan matches the embedded contract", async () => {
     const plan = built.flushPlanResolver();
     assert.equal(plan.forceFlushTranscriptBytes, 48_000);
     assert.equal(plan.model, "gpt-test");
-    assert.equal(plan.relativePath, "state/plugins/openclaw-remnic/flush-plan.md");
+    assert.equal(
+      plan.relativePath,
+      "state/plugins/openclaw-remnic/flush-plan.md",
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -457,12 +601,21 @@ test("delegate publicArtifacts lists the corpus and degrades to empty on failure
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
     const artifacts = await built.listArtifacts();
-    assert.ok(artifacts.length > 0, "the shared corpus yields public artifacts");
+    assert.ok(
+      artifacts.length > 0,
+      "the shared corpus yields public artifacts",
+    );
 
     const missing = createDelegateMemoryCapability(
-      optionsFor(stub.port, path.join(memoryDir, "does-not-exist"), workspaceDir),
+      optionsFor(
+        stub.port,
+        path.join(memoryDir, "does-not-exist"),
+        workspaceDir,
+      ),
     );
     assert.deepEqual(await missing.listArtifacts(), []);
   } finally {
@@ -505,14 +658,23 @@ test("registerDelegateMemoryCapability wires the unified host surface", async ()
     assert.ok(registered.runtime);
     assert.ok(registered.flushPlan);
 
-    const promptBuilder = capability.promptBuilder as (p: { sessionKey?: string }) => string[] | null;
-    assert.deepEqual(promptBuilder({ sessionKey: "s1" }), ["## Memory", "line"]);
+    const promptBuilder = capability.promptBuilder as (p: {
+      sessionKey?: string;
+    }) => string[] | null;
+    assert.deepEqual(promptBuilder({ sessionKey: "s1" }), [
+      "## Memory",
+      "line",
+    ]);
     assert.deepEqual(
       seenSessionKeys,
       ["s1"],
       "the host session key reaches the seam, which owns peek-vs-consume",
     );
-    assert.equal(promptBuilder({}), null, "a missing session key reads the default bucket");
+    assert.equal(
+      promptBuilder({}),
+      null,
+      "a missing session key reads the default bucket",
+    );
     assert.deepEqual(seenSessionKeys, ["s1", "default"]);
   } finally {
     await stub.close();
@@ -531,7 +693,9 @@ test("registerDelegateMemoryCapability omits promptBuilder when injection is dis
           capability = value as Record<string, unknown>;
         },
       },
-      optionsFor(stub.port, memoryDir, workspaceDir, { allowPromptInjection: false }),
+      optionsFor(stub.port, memoryDir, workspaceDir, {
+        allowPromptInjection: false,
+      }),
     );
     assert.ok(capability);
     assert.equal("promptBuilder" in capability, false);
@@ -571,9 +735,16 @@ test("registerDelegateMemoryCapability is a no-op on a host with no memory surfa
   const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
     assert.doesNotThrow(() =>
-      registerDelegateMemoryCapability({}, optionsFor(stub.port, memoryDir, workspaceDir)),
+      registerDelegateMemoryCapability(
+        {},
+        optionsFor(stub.port, memoryDir, workspaceDir),
+      ),
     );
-    assert.equal(stub.calls.length, 0, "nothing is probed when nothing can be registered");
+    assert.equal(
+      stub.calls.length,
+      0,
+      "nothing is probed when nothing can be registered",
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -588,10 +759,19 @@ test("delegate accepts a daemon serving a namespace under the corpus root", asyn
   await writeFile(path.join(namespaceDir, "facts", "alice.md"), "one\ntwo\n");
   const stub = await startDaemonStub({ health: healthyDaemon(namespaceDir) });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     const page = await manager?.readFile({ relPath: "facts/alice.md" });
-    assert.equal(page?.text.startsWith("one"), true, "a migrated default namespace is not foreign");
+    assert.equal(
+      page?.text.startsWith("one"),
+      true,
+      "a migrated default namespace is not foreign",
+    );
     assert.ok((await built.listArtifacts()).length > 0);
   } finally {
     await stub.close();
@@ -601,10 +781,18 @@ test("delegate accepts a daemon serving a namespace under the corpus root", asyn
 
 test("delegate search forwards the host's ranking override", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir), search: { results: [] } });
+  const stub = await startDaemonStub({
+    health: healthyDaemon(memoryDir),
+    search: { results: [] },
+  });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await manager?.search("q", { qmdSearchModeOverride: "vsearch" });
     await manager?.search("q", { qmdSearchModeOverride: "query" });
     await manager?.search("q");
@@ -626,22 +814,35 @@ test("delegate roots reads and artifacts on the daemon's namespace directory", a
   const { memoryDir, workspaceDir } = await makeCorpus();
   const namespaceDir = path.join(memoryDir, "namespaces", "generalist");
   await mkdir(path.join(namespaceDir, "facts"), { recursive: true });
-  await writeFile(path.join(namespaceDir, "facts", "scoped.md"), "namespace fact\n");
+  await writeFile(
+    path.join(namespaceDir, "facts", "scoped.md"),
+    "namespace fact\n",
+  );
   const stub = await startDaemonStub({ health: healthyDaemon(namespaceDir) });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     // The daemon's hits are relative to ITS storage dir, so the read scope must
     // be rooted there, not on the configured corpus root.
     const page = await manager?.readFile({ relPath: "facts/scoped.md" });
     assert.equal(page?.text.trim(), "namespace fact");
-    const artifacts = (await built.listArtifacts()) as Array<{ absolutePath?: string }>;
+    const artifacts = (await built.listArtifacts()) as Array<{
+      absolutePath?: string;
+    }>;
     assert.ok(
       artifacts.some((entry) => entry.absolutePath?.startsWith(namespaceDir)),
       "the active namespace's artifacts are listed",
     );
     assert.equal(
-      artifacts.some((entry) => entry.absolutePath === path.join(memoryDir, "facts", "alice.md")),
+      artifacts.some(
+        (entry) =>
+          entry.absolutePath === path.join(memoryDir, "facts", "alice.md"),
+      ),
       false,
       "flat-root files outside the active namespace are not published for it",
     );
@@ -665,9 +866,14 @@ test("delegate search sends the daemon's default namespace, never an absent one"
         resolveSearchNamespace: async () => undefined,
       }),
     );
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await manager?.search("q");
-    const body = stub.calls.find((call) => call.pathname.endsWith("/memories/search"))?.body;
+    const body = stub.calls.find((call) =>
+      call.pathname.endsWith("/memories/search"),
+    )?.body;
     assert.deepEqual(
       body,
       { query: "q", mode: "search", namespace: "generalist" },
@@ -681,10 +887,18 @@ test("delegate search sends the daemon's default namespace, never an absent one"
 
 test("delegate search returns empty for a zero result budget without calling the daemon", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir), search: { results: [] } });
+  const stub = await startDaemonStub({
+    health: healthyDaemon(memoryDir),
+    search: { results: [] },
+  });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     assert.deepEqual(await manager?.search("q", { maxResults: 0 }), []);
     assert.equal(
       stub.calls.some((call) => call.pathname.endsWith("/memories/search")),
@@ -709,7 +923,13 @@ test("delegate reads a hit from another namespace's storage directory", async ()
   const stub = await startDaemonStub({
     health: healthyDaemon(defaultDir),
     search: {
-      results: [{ path: path.join(otherDir, "facts", "scoped.md"), score: 0.9, snippet: "hit" }],
+      results: [
+        {
+          path: path.join(otherDir, "facts", "scoped.md"),
+          score: 0.9,
+          snippet: "hit",
+        },
+      ],
     },
   });
   try {
@@ -718,11 +938,18 @@ test("delegate reads a hit from another namespace's storage directory", async ()
         resolveSearchNamespace: async () => "team-a",
       }),
     );
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     const [hit] = (await manager?.search("q")) ?? [];
     assert.ok(hit, "the daemon returned a hit");
     const page = await manager?.readFile({ relPath: hit.path });
-    assert.equal(page?.text.trim(), "team-a fact", "the host can open its own search hit");
+    assert.equal(
+      page?.text.trim(),
+      "team-a fact",
+      "the host can open its own search hit",
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -733,7 +960,9 @@ test("delegate refuses file-backed surfaces for a remote daemon with an identica
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({
     health: healthyDaemon(memoryDir),
-    search: { results: [{ path: "facts/alice.md", score: 0.5, snippet: "hit" }] },
+    search: {
+      results: [{ path: "facts/alice.md", score: 0.5, snippet: "hit" }],
+    },
   });
   try {
     const built = createDelegateMemoryCapability(
@@ -747,9 +976,13 @@ test("delegate refuses file-backed surfaces for a remote daemon with an identica
         },
       }),
     );
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
-      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+      () =>
+        manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
       /is not local/,
     );
     assert.deepEqual(await built.listArtifacts(), []);
@@ -763,10 +996,17 @@ test("delegate readFile refuses artifact paths", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
-      () => manager?.readFile({ relPath: "artifacts/report.md" }) ?? Promise.resolve(),
+      () =>
+        manager?.readFile({ relPath: "artifacts/report.md" }) ??
+        Promise.resolve(),
       /artifact path/,
       "search filters artifacts; the read path must not be a way around that",
     );
@@ -795,17 +1035,26 @@ test("delegate search caps AFTER dropping artifacts, not before", async () => {
     },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     const results = (await manager?.search("q", { maxResults: 2 })) ?? [];
     assert.deepEqual(
       results.map((hit) => hit.citation),
       [path.join("facts", "one.md"), path.join("facts", "two.md")],
       "a full page of real memories, and never more than the budget",
     );
-    const searchCalls = stub.calls.filter((call) => call.pathname.includes("/memories/search"));
+    const searchCalls = stub.calls.filter((call) =>
+      call.pathname.includes("/memories/search"),
+    );
     assert.deepEqual(
-      searchCalls.map((call) => (call.body as { maxResults?: number }).maxResults),
+      searchCalls.map(
+        (call) => (call.body as { maxResults?: number }).maxResults,
+      ),
       [2, 4],
       "asks again with a doubled limit rather than returning a thin page",
     );
@@ -821,18 +1070,30 @@ test("delegate health backs off on a 200 with a malformed body", async () => {
   // immediate re-fetch; it backs off exactly like a transport failure.
   const stub = await startDaemonStub({ healthRaw: "null" });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
     // Every entry point that consults health goes through the same refresh, so
     // three back-to-back handouts would mean three probes with no backoff.
     await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
     await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
     await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
-    const healthCalls = stub.calls.filter((call) => call.pathname.includes("/health"));
-    assert.equal(healthCalls.length, 1, "later handouts reuse the backoff, they do not re-probe");
+    const healthCalls = stub.calls.filter((call) =>
+      call.pathname.includes("/health"),
+    );
+    assert.equal(
+      healthCalls.length,
+      1,
+      "later handouts reuse the backoff, they do not re-probe",
+    );
     // And the malformed payload never becomes a corpus claim.
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
-      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+      () =>
+        manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
       /has not been confirmed/,
     );
   } finally {
@@ -856,10 +1117,17 @@ test("delegate search with no budget keeps the daemon's page size on the wire", 
     },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     const results = (await manager?.search("q")) ?? [];
-    const searchCalls = stub.calls.filter((call) => call.pathname.includes("/memories/search"));
+    const searchCalls = stub.calls.filter((call) =>
+      call.pathname.includes("/memories/search"),
+    );
     // First request carries no cap - the caller accepted the daemon's page.
     assert.equal(
       (searchCalls[0]?.body as { maxResults?: number }).maxResults,
@@ -868,7 +1136,9 @@ test("delegate search with no budget keeps the daemon's page size on the wire", 
     );
     // The artifact thinned that page, so it tops up against what was served.
     assert.deepEqual(
-      searchCalls.map((call) => (call.body as { maxResults?: number }).maxResults),
+      searchCalls.map(
+        (call) => (call.body as { maxResults?: number }).maxResults,
+      ),
       [undefined, 6],
     );
     assert.deepEqual(
@@ -886,14 +1156,26 @@ test("delegate search rejects a malformed result entry instead of inventing a me
   // A 200 whose entries are not memories is a version-skewed or corrupt
   // daemon. Synthesizing `memory-N` would hand the host a path it can then
   // try to open (AGENTS.md #22).
-  for (const bad of ["not-an-object", { score: 0.9 }, { path: 42 }, { path: "  " }]) {
+  for (const bad of [
+    "not-an-object",
+    { score: 0.9 },
+    { path: 42 },
+    { path: "  " },
+  ]) {
     const stub = await startDaemonStub({
       health: healthyDaemon(memoryDir),
-      search: { results: [{ path: "facts/ok.md", score: 0.9, snippet: "ok" }, bad] },
+      search: {
+        results: [{ path: "facts/ok.md", score: 0.9, snippet: "ok" }, bad],
+      },
     });
     try {
-      const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-      const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+      const built = createDelegateMemoryCapability(
+        optionsFor(stub.port, memoryDir, workspaceDir),
+      );
+      const { manager } = await built.runtime.getMemorySearchManager({
+        cfg: {},
+        agentId: "main",
+      });
       await assert.rejects(
         () => manager?.search("q") ?? Promise.resolve(),
         /malformed result entry/,
@@ -917,17 +1199,26 @@ test("delegate file surfaces refuse a namespace-partitioned daemon", async () =>
   // is flat" must still fail closed.
   for (const namespacesEnabled of [true, undefined]) {
     const stub = await startDaemonStub({
-      health: { ...healthyDaemon(memoryDir), namespacesEnabled, defaultNamespace: "default" },
+      health: {
+        ...healthyDaemon(memoryDir),
+        namespacesEnabled,
+        defaultNamespace: "default",
+      },
       search: { query: "q", count: 0, results: [] },
     });
     try {
       const built = createDelegateMemoryCapability({
         ...optionsFor(stub.port, memoryDir, workspaceDir),
-        resolveSearchNamespace: async (sessionKey) => (sessionKey === "s2" ? "team-a" : "default"),
+        resolveSearchNamespace: async (sessionKey) =>
+          sessionKey === "s2" ? "team-a" : "default",
       });
-      const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+      const { manager } = await built.runtime.getMemorySearchManager({
+        cfg: {},
+        agentId: "main",
+      });
       await assert.rejects(
-        () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+        () =>
+          manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
         /a local read cannot be authorized/,
         `namespacesEnabled: ${String(namespacesEnabled)} must fail closed`,
       );
@@ -937,7 +1228,9 @@ test("delegate file surfaces refuse a namespace-partitioned daemon", async () =>
         "artifacts are withheld, not cross-published",
       );
       // Search is unaffected: it carries the session and the daemon enforces.
-      assert.ok(Array.isArray(await manager?.search("q", { sessionKey: "s2" })));
+      assert.ok(
+        Array.isArray(await manager?.search("q", { sessionKey: "s2" })),
+      );
     } finally {
       await stub.close();
     }
@@ -951,10 +1244,19 @@ test("delegate file surfaces stay available on a single-corpus daemon", async ()
     health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     const read = await manager?.readFile({ relPath: "facts/alice.md" });
-    assert.equal(read?.path, path.join("facts", "alice.md"), "the read is served, not refused");
+    assert.equal(
+      read?.path,
+      path.join("facts", "alice.md"),
+      "the read is served, not refused",
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -969,8 +1271,13 @@ test("delegate reads do not fall back to the gateway's own workspace", async () 
     health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
       () => manager?.readFile({ relPath: "notes.md" }) ?? Promise.resolve(),
       /memory read rejected/,
@@ -991,7 +1298,11 @@ test("delegate refuses a substituted default namespace the token cannot use", as
   // token scoped elsewhere that would 403 on the very first search; the
   // refusal must name the fix instead.
   const stub = await startDaemonStub({
-    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+    health: {
+      ...healthyDaemon(memoryDir),
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+    },
     search: { query: "q", count: 0, results: [] },
   });
   try {
@@ -1000,7 +1311,10 @@ test("delegate refuses a substituted default namespace the token cannot use", as
       resolveSearchNamespace: async () => undefined,
       verifyNamespaceAuthorization: async () => false,
     });
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
       () => manager?.search("q") ?? Promise.resolve(),
       /is not authorized for the delegate token/,
@@ -1015,7 +1329,11 @@ test("delegate proceeds when the substituted default IS authorized, and on an ol
   const { memoryDir, workspaceDir } = await makeCorpus();
   for (const verdict of [true, undefined]) {
     const stub = await startDaemonStub({
-      health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+      health: {
+        ...healthyDaemon(memoryDir),
+        namespacesEnabled: true,
+        defaultNamespace: "default",
+      },
       search: { query: "q", count: 0, results: [] },
     });
     try {
@@ -1028,10 +1346,17 @@ test("delegate proceeds when the substituted default IS authorized, and on an ol
           return verdict;
         },
       });
-      const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+      const { manager } = await built.runtime.getMemorySearchManager({
+        cfg: {},
+        agentId: "main",
+      });
       assert.deepEqual(await manager?.search("q"), []);
       await manager?.search("q again");
-      assert.equal(probes, 1, "the verdict is cached, not re-probed per search");
+      assert.equal(
+        probes,
+        1,
+        "the verdict is cached, not re-probed per search",
+      );
     } finally {
       await stub.close();
     }
@@ -1042,7 +1367,11 @@ test("delegate proceeds when the substituted default IS authorized, and on an ol
 test("delegate does not second-guess an explicit namespace", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({
-    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+    health: {
+      ...healthyDaemon(memoryDir),
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+    },
     search: { query: "q", count: 0, results: [] },
   });
   try {
@@ -1055,11 +1384,23 @@ test("delegate does not second-guess an explicit namespace", async () => {
         return false;
       },
     });
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     assert.deepEqual(await manager?.search("q"), []);
-    assert.equal(probed, false, "the caller's own scope is the daemon's to enforce");
-    const searchCall = stub.calls.find((call) => call.pathname.includes("/memories/search"));
-    assert.equal((searchCall?.body as { namespace?: string }).namespace, "team-a");
+    assert.equal(
+      probed,
+      false,
+      "the caller's own scope is the daemon's to enforce",
+    );
+    const searchCall = stub.calls.find((call) =>
+      call.pathname.includes("/memories/search"),
+    );
+    assert.equal(
+      (searchCall?.body as { namespace?: string }).namespace,
+      "team-a",
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -1072,7 +1413,11 @@ test("swapping in an authorized token recovers unbound delegate search", async (
   // the namespace alone would keep rejecting search locally after an operator
   // replaced an under-scoped token, while recall and observe recovered.
   const stub = await startDaemonStub({
-    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+    health: {
+      ...healthyDaemon(memoryDir),
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+    },
     search: { query: "q", count: 0, results: [] },
   });
   try {
@@ -1080,17 +1425,27 @@ test("swapping in an authorized token recovers unbound delegate search", async (
     const base = optionsFor(stub.port, memoryDir, workspaceDir);
     const built = createDelegateMemoryCapability({
       ...base,
-      target: { ...base.target, resolveAuthToken: () => ({ token, source: "REMNIC_AUTH_TOKEN" }) },
+      target: {
+        ...base.target,
+        resolveAuthToken: () => ({ token, source: "REMNIC_AUTH_TOKEN" }),
+      },
       resolveSearchNamespace: async () => undefined,
       verifyNamespaceAuthorization: async () => token === "authorized",
     });
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
       () => manager?.search("q") ?? Promise.resolve(),
       /is not authorized for the delegate token/,
     );
     token = "authorized";
-    assert.deepEqual(await manager?.search("q"), [], "the new token is re-probed, not refused from cache");
+    assert.deepEqual(
+      await manager?.search("q"),
+      [],
+      "the new token is re-probed, not refused from cache",
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -1133,7 +1488,10 @@ test("a daemon that ANSWERS without a posture is unknown, not flat", async () =>
       ...optionsFor(stub.port, memoryDir, workspaceDir),
       resolveSearchNamespace: async () => undefined,
     });
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
       () => manager?.search("q") ?? Promise.resolve(),
       /default namespace is unknown/,
@@ -1155,7 +1513,10 @@ test("a partitioned plugin config still fails closed before the first probe", as
       ...optionsFor(stub.port, memoryDir, workspaceDir),
       resolveSearchNamespace: async () => undefined,
     });
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
       () => manager?.search("q") ?? Promise.resolve(),
       /default namespace is unknown/,
@@ -1176,10 +1537,16 @@ test("a health 200 without memoryDir leaves the corpus unconfirmed", async () =>
     search: { query: "q", count: 0, results: [] },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
-      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+      () =>
+        manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
       /daemon serves an unknown memoryDir/,
       "file-backed reads stay disabled until the daemon names its corpus",
     );
@@ -1197,8 +1564,13 @@ test("delegate readFile rejects invalid offsets instead of serving another range
     health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     // Non-finite AND finite-but-invalid: a clamp or truncation would return a
     // different range while looking like a correct answer.
     for (const from of [
@@ -1210,20 +1582,28 @@ test("delegate readFile rejects invalid offsets instead of serving another range
       1.5,
     ]) {
       await assert.rejects(
-        () => manager?.readFile({ relPath: "facts/alice.md", from }) ?? Promise.resolve(),
+        () =>
+          manager?.readFile({ relPath: "facts/alice.md", from }) ??
+          Promise.resolve(),
         /from must be a positive integer/,
         `from: ${String(from)} must be rejected`,
       );
     }
     for (const lines of [Number.NaN, -1, 0, 0.5]) {
       await assert.rejects(
-        () => manager?.readFile({ relPath: "facts/alice.md", lines }) ?? Promise.resolve(),
+        () =>
+          manager?.readFile({ relPath: "facts/alice.md", lines }) ??
+          Promise.resolve(),
         /lines must be a positive integer/,
         `lines: ${String(lines)} must be rejected`,
       );
     }
     // A real range still works.
-    const read = await manager?.readFile({ relPath: "facts/alice.md", from: 2, lines: 1 });
+    const read = await manager?.readFile({
+      relPath: "facts/alice.md",
+      from: 2,
+      lines: 1,
+    });
     assert.equal(read?.text, "two");
   } finally {
     await stub.close();
@@ -1234,7 +1614,9 @@ test("delegate readFile rejects invalid offsets instead of serving another range
 test("delegate search keeps hits when the corpus sits under an `artifacts` ancestor", async () => {
   // <root>/artifacts/remnic is an ordinary corpus. Judging the ABSOLUTE hit
   // path would discard every result the daemon returned.
-  const root = await realpath(await mkdtemp(path.join(os.tmpdir(), "remnic-cap-ancestor-")));
+  const root = await realpath(
+    await mkdtemp(path.join(os.tmpdir(), "remnic-cap-ancestor-")),
+  );
   const memoryDir = path.join(root, "artifacts", "remnic");
   const workspaceDir = path.join(root, "workspace");
   await mkdir(path.join(memoryDir, "facts"), { recursive: true });
@@ -1246,14 +1628,27 @@ test("delegate search keeps hits when the corpus sits under an `artifacts` ances
       query: "q",
       count: 2,
       results: [
-        { path: path.join(memoryDir, "facts", "a.md"), score: 0.9, snippet: "fact" },
-        { path: path.join(memoryDir, "artifacts", "report.md"), score: 0.8, snippet: "artifact" },
+        {
+          path: path.join(memoryDir, "facts", "a.md"),
+          score: 0.9,
+          snippet: "fact",
+        },
+        {
+          path: path.join(memoryDir, "artifacts", "report.md"),
+          score: 0.8,
+          snippet: "artifact",
+        },
       ],
     },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     const results = (await manager?.search("q")) ?? [];
     assert.deepEqual(
       results.map((hit) => hit.citation),
@@ -1273,8 +1668,13 @@ test("delegate search rejects an out-of-range maxResults instead of coercing it"
     search: { query: "q", count: 0, results: [] },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     for (const maxResults of [-1, 2.5, Number.NaN, Number.POSITIVE_INFINITY]) {
       await assert.rejects(
         () => manager?.search("q", { maxResults }) ?? Promise.resolve(),
@@ -1308,8 +1708,14 @@ test("a spent caller budget skips the health probe instead of overrunning it", a
       now: () => clock,
     });
     // A real budget probes once and caches the daemon's flat posture.
-    assert.equal(await built.resolveScopedNamespace(undefined, 5_000), undefined);
-    assert.equal(stub.calls.filter((call) => call.pathname.includes("/health")).length, 1);
+    assert.equal(
+      await built.resolveScopedNamespace(undefined, 5_000),
+      undefined,
+    );
+    assert.equal(
+      stub.calls.filter((call) => call.pathname.includes("/health")).length,
+      1,
+    );
     // Snapshot expired, budget spent: no request is started (it would overrun
     // the shared deadline) AND an unscoped call fails closed, because the
     // posture on hand was never confirmed by this call.
@@ -1325,10 +1731,19 @@ test("a spent caller budget skips the health probe instead of overrunning it", a
     );
     // An explicit scope is the caller's own and still resolves unprobed.
     assert.equal(await built.resolveScopedNamespace("team-a", 0), "team-a");
-    assert.equal(stub.calls.filter((call) => call.pathname.includes("/health")).length, 1);
+    assert.equal(
+      stub.calls.filter((call) => call.pathname.includes("/health")).length,
+      1,
+    );
     // With budget again, it re-probes and the unscoped call works.
-    assert.equal(await built.resolveScopedNamespace(undefined, 5_000), undefined);
-    assert.equal(stub.calls.filter((call) => call.pathname.includes("/health")).length, 2);
+    assert.equal(
+      await built.resolveScopedNamespace(undefined, 5_000),
+      undefined,
+    );
+    assert.equal(
+      stub.calls.filter((call) => call.pathname.includes("/health")).length,
+      2,
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -1340,7 +1755,11 @@ test("a spent budget skips the authorization probe too", async () => {
   // The remaining-budget argument must reach the authorization probe, not stop
   // at health: its own fixed timeout would overrun a nearly-spent flush.
   const stub = await startDaemonStub({
-    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+    health: {
+      ...healthyDaemon(memoryDir),
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+    },
     search: { query: "q", count: 0, results: [] },
   });
   try {
@@ -1355,8 +1774,16 @@ test("a spent budget skips the authorization probe too", async () => {
     });
     // Health is already cached by this first call, so the spent-budget path
     // below is exercised against the authorization probe specifically.
-    assert.equal(await built.resolveScopedNamespace(undefined, 5_000), "default");
-    assert.deepEqual(budgets, [5_000], "the caller's budget reaches the probe");
+    assert.equal(
+      await built.resolveScopedNamespace(undefined, 5_000),
+      "default",
+    );
+    assert.equal(budgets.length, 1, "the caller's budget reaches the probe");
+    const billed = budgets[0];
+    assert.ok(
+      typeof billed === "number" && billed > 0 && billed <= 5_000,
+      `the probe got what the posture probe left, not a fresh budget: ${String(billed)}`,
+    );
 
     const fresh = createDelegateMemoryCapability({
       ...optionsFor(stub.port, memoryDir, workspaceDir),
@@ -1442,7 +1869,11 @@ test("a probe failure un-proves the default namespace too", async () => {
     res.end(
       JSON.stringify(
         (req.url ?? "").includes("/health")
-          ? { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "tenant-a" }
+          ? {
+              ...healthyDaemon(memoryDir),
+              namespacesEnabled: true,
+              defaultNamespace: "tenant-a",
+            }
           : { query: "q", count: 0, results: [] },
       ),
     );
@@ -1486,8 +1917,13 @@ test("delegate search rejects a malformed score and an invalid minScore", async 
     },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     // A missing score is a protocol failure, not a zero ranking.
     await assert.rejects(
       () => manager?.search("q") ?? Promise.resolve(),
@@ -1531,7 +1967,9 @@ test("an unscoped request revalidates the posture instead of trusting the cache"
     );
     // An EXPLICIT scope is the caller's own and the daemon enforces it, so it
     // rides the cache and costs no extra probe.
-    const before = stub.calls.filter((call) => call.pathname.includes("/health")).length;
+    const before = stub.calls.filter((call) =>
+      call.pathname.includes("/health"),
+    ).length;
     await built.resolveScopedNamespace("team-a");
     assert.equal(
       stub.calls.filter((call) => call.pathname.includes("/health")).length,
@@ -1550,7 +1988,11 @@ test("the authorization probe names the operation the caller is performing", asy
   // hard-coded operation would reject those locally before their own route
   // could authorize them.
   const stub = await startDaemonStub({
-    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+    health: {
+      ...healthyDaemon(memoryDir),
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+    },
     search: { query: "q", count: 0, results: [] },
   });
   try {
@@ -1564,7 +2006,10 @@ test("the authorization probe names the operation the caller is performing", asy
         return !(operations ?? []).includes("memory_search");
       },
     });
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
       () => manager?.search("q") ?? Promise.resolve(),
       /is not authorized for the delegate token/,
@@ -1572,7 +2017,9 @@ test("the authorization probe names the operation the caller is performing", asy
     );
     // A flush-scoped resolution names its own operation and is allowed.
     assert.equal(
-      await built.resolveScopedNamespace(undefined, undefined, ["lcm_compaction_flush"]),
+      await built.resolveScopedNamespace(undefined, undefined, [
+        "lcm_compaction_flush",
+      ]),
       "default",
     );
     assert.deepEqual(asked, [["memory_search"], ["lcm_compaction_flush"]]);
@@ -1588,7 +2035,9 @@ test("an invalid caller budget is rejected at the boundary", async () => {
     health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
   });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
     for (const timeoutMs of [Number.NaN, Number.POSITIVE_INFINITY, 12.5]) {
       await assert.rejects(
         () => built.resolveScopedNamespace(undefined, timeoutMs),
@@ -1609,8 +2058,13 @@ test("a health-failure backoff is honored even by an unscoped request", async ()
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({ healthStatus: 500, health: {} });
   try {
-    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     const probes = (): number =>
       stub.calls.filter((call) => call.pathname.includes("/health")).length;
     await assert.rejects(
@@ -1620,9 +2074,19 @@ test("a health-failure backoff is honored even by an unscoped request", async ()
     );
     const afterFirst = probes();
     assert.ok(afterFirst >= 1, "the first unscoped request probes");
-    await assert.rejects(() => manager?.search("q") ?? Promise.resolve(), /could not be confirmed/);
-    await assert.rejects(() => manager?.search("q") ?? Promise.resolve(), /could not be confirmed/);
-    assert.equal(probes(), afterFirst, "the failure backoff suppressed the repeat probes");
+    await assert.rejects(
+      () => manager?.search("q") ?? Promise.resolve(),
+      /could not be confirmed/,
+    );
+    await assert.rejects(
+      () => manager?.search("q") ?? Promise.resolve(),
+      /could not be confirmed/,
+    );
+    assert.equal(
+      probes(),
+      afterFirst,
+      "the failure backoff suppressed the repeat probes",
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -1634,7 +2098,11 @@ test("a zero-budget search is authorized before it answers empty", async () => {
   // answer for a namespace the session may not read.
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({
-    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "team" },
+    health: {
+      ...healthyDaemon(memoryDir),
+      namespacesEnabled: true,
+      defaultNamespace: "team",
+    },
     search: { query: "q", count: 0, results: [] },
   });
   try {
@@ -1642,16 +2110,81 @@ test("a zero-budget search is authorized before it answers empty", async () => {
       ...optionsFor(stub.port, memoryDir, workspaceDir),
       verifyNamespaceAuthorization: async () => false,
     });
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const { manager } = await built.runtime.getMemorySearchManager({
+      cfg: {},
+      agentId: "main",
+    });
     await assert.rejects(
       () => manager?.search("q", { maxResults: 0 }) ?? Promise.resolve(),
       /not authorized/,
       "a zero budget still runs the authorization gate",
     );
     assert.equal(
-      stub.calls.filter((call) => call.pathname.includes("/memories/search")).length,
+      stub.calls.filter((call) => call.pathname.includes("/memories/search"))
+        .length,
       0,
       "and still makes no backend call",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("the posture and authorization probes share one deadline", async () => {
+  // Billing each probe the full remaining budget lets namespace resolution
+  // alone overrun a hook before its own request runs.
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: {
+      ...healthyDaemon(memoryDir),
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+    },
+    healthDelayMs: 300,
+  });
+  try {
+    let authBudget: number | undefined;
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      resolveSearchNamespace: async () => undefined,
+      verifyNamespaceAuthorization: async (_namespace, timeoutMs) => {
+        authBudget = timeoutMs;
+        return true;
+      },
+    });
+    assert.equal(
+      await built.resolveScopedNamespace(undefined, 1_000),
+      "default",
+    );
+    assert.ok(
+      typeof authBudget === "number" && authBudget <= 750,
+      `the ~300ms posture probe came out of the shared 1000ms: ${String(authBudget)}`,
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("an explicit scope needs no probe at all", async () => {
+  // `requireScopedNamespace` returns an explicit scope untouched and the
+  // daemon enforces it on the operation endpoint, so a cold health cache must
+  // not spend the prompt deadline before the recall POST runs.
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
+  try {
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      verifyNamespaceAuthorization: async () => {
+        throw new Error("an explicit scope must not be authorized client-side");
+      },
+    });
+    assert.equal(await built.resolveScopedNamespace("team", 5_000), "team");
+    assert.equal(
+      stub.calls.filter((call) => call.pathname.includes("/health")).length,
+      0,
+      "no posture probe ran for an explicit scope",
     );
   } finally {
     await stub.close();

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -20,6 +20,8 @@ type DaemonStub = {
   calls: RecordedCall[];
   /** Runs when a health request is served, so a test can advance its clock. */
   onHealth?: () => void;
+  /** Replaces the health body from the next request on. */
+  healthOverride?: unknown;
   close: () => Promise<void>;
 };
 
@@ -64,7 +66,9 @@ async function startDaemonStub(routes: StubRoutes): Promise<DaemonStub> {
           res.end(routes.healthRaw);
           return;
         }
-        let payload = isSearch ? routes.search : routes.health;
+        // A test may swap the health body mid-run, to model a daemon that
+        // restarts onto another corpus.
+        let payload = isSearch ? routes.search : (stub?.healthOverride ?? routes.health);
         if (isSearch && payload !== null && typeof payload === "object") {
           // Honor `maxResults` the way a real daemon does, so a client-side
           // top-up sees a genuinely truncated page.
@@ -547,13 +551,22 @@ test("delegate health is cached and refreshed on the injected clock", async () =
     const built = createDelegateMemoryCapability(
       optionsFor(stub.port, memoryDir, workspaceDir, { now: () => clock }),
     );
-    await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
-    await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
     const healthCalls = () =>
       stub.calls.filter((call) => call.pathname.endsWith("/health")).length;
+    // The FIRST handout waits: `status()` is synchronous, so an unprobed
+    // snapshot has nothing truthful to report.
+    await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    assert.equal(healthCalls(), 1, "the first handout probes");
+    await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
     assert.equal(healthCalls(), 1, "a warm snapshot is reused");
+
+    // An expired snapshot converges in the BACKGROUND — later handouts never
+    // block, so the request lands after the call returns.
     clock += 60_000;
     await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    for (let attempt = 0; attempt < 100 && healthCalls() < 2; attempt += 1) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    }
     assert.equal(healthCalls(), 2, "an expired snapshot is refreshed");
   } finally {
     await stub.close();
@@ -2273,6 +2286,76 @@ test("an explicitly scoped search never waits on the health route", async () => 
       2,
       "and both searches reached the daemon",
     );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("a local read revalidates the corpus instead of trusting the cache", async () => {
+  // A daemon that restarts onto ANOTHER corpus inside the cache window leaves
+  // no probe failure behind, so a cached `corpusShared: true` would let a read
+  // return a file from the corpus that is no longer served.
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const otherCorpus = await mkdtemp(path.join(os.tmpdir(), "remnic-other-corpus-"));
+  let served = memoryDir;
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
+  stub.onHealth = () => {
+    stub.healthOverride = { ...healthyDaemon(served), memoryDir: served };
+  };
+  try {
+    // Each surface gets its OWN warmed capability: one revalidation would
+    // otherwise invalidate the shared cache and mask the other's behavior.
+    const reader = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await reader.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await manager?.readFile({ relPath: "facts/alice.md" });
+
+    const lister = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    assert.ok((await lister.listArtifacts()).length >= 0, "the listing warms its own snapshot");
+
+    // The daemon restarts onto a different corpus, well inside the TTL.
+    served = otherCorpus;
+    await assert.rejects(
+      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+      /readFile unavailable/,
+      "the stale shared-corpus fact was revalidated away",
+    );
+    assert.deepEqual(
+      await lister.listArtifacts(),
+      [],
+      "the artifact listing refuses the same way",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(otherCorpus, { recursive: true, force: true });
+  }
+});
+
+test("only the first manager handout waits on health", async () => {
+  // `status()` is synchronous, so the first handout must have a probed
+  // snapshot to report. Every later handout returns immediately: the
+  // operations that need a current posture refresh on their own, and blocking
+  // per handout delays an explicitly scoped search that needs none.
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir), healthDelayMs: 200 });
+  try {
+    let clock = 1_000_000;
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir, { now: () => clock }),
+    );
+    const firstStarted = Date.now();
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const firstElapsed = Date.now() - firstStarted;
+    assert.ok(firstElapsed >= 150, `the first handout probed (${firstElapsed}ms)`);
+    assert.equal(manager?.status().backend, "qmd", "and status has a real posture to report");
+
+    // EXPIRE the posture, so a handout that still awaited would pay the probe.
+    clock += 10 * 60 * 1_000;
+    const laterStarted = Date.now();
+    await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const laterElapsed = Date.now() - laterStarted;
+    assert.ok(laterElapsed < 100, `a later handout did not wait (${laterElapsed}ms)`);
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -89,8 +89,10 @@ async function makeCorpus(): Promise<{ memoryDir: string; workspaceDir: string }
   const workspaceDir = path.join(root, "workspace");
   await mkdir(path.join(memoryDir, "facts"), { recursive: true });
   await mkdir(path.join(memoryDir, "artifacts"), { recursive: true });
-  await mkdir(workspaceDir, { recursive: true });
+  await mkdir(path.join(workspaceDir, "memory"), { recursive: true });
   await writeFile(path.join(memoryDir, "facts", "alice.md"), "one\ntwo\nthree\nfour\n");
+  // Exists ONLY under the gateway's workspace - the daemon never saw it.
+  await writeFile(path.join(workspaceDir, "memory", "notes.md"), "gateway-only\n");
   await writeFile(path.join(memoryDir, "artifacts", "report.md"), "secret artifact\n");
   return { memoryDir, workspaceDir };
 }
@@ -950,6 +952,111 @@ test("delegate file surfaces stay available on a single-corpus daemon", async ()
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
     const read = await manager?.readFile({ relPath: "facts/alice.md" });
     assert.equal(read?.path, path.join("facts", "alice.md"), "the read is served, not refused");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate reads do not fall back to the gateway's own workspace", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // The daemon reports only its memoryDir. A file that exists solely under the
+  // gateway's <workspaceDir>/memory was never searched or authorized by it.
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.readFile({ relPath: "notes.md" }) ?? Promise.resolve(),
+      /memory read rejected/,
+      "a workspace-only file is not readable through the delegate",
+    );
+    // The daemon's own corpus is unaffected.
+    const read = await manager?.readFile({ relPath: "facts/alice.md" });
+    assert.equal(read?.path, path.join("facts", "alice.md"));
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate refuses a substituted default namespace the token cannot use", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // A fresh session has no binding, so the daemon default is SUBSTITUTED. On a
+  // token scoped elsewhere that would 403 on the very first search; the
+  // refusal must name the fix instead.
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+    search: { query: "q", count: 0, results: [] },
+  });
+  try {
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      resolveSearchNamespace: async () => undefined,
+      verifyNamespaceAuthorization: async () => false,
+    });
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.search("q") ?? Promise.resolve(),
+      /is not authorized for the delegate token/,
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate proceeds when the substituted default IS authorized, and on an older daemon", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  for (const verdict of [true, undefined]) {
+    const stub = await startDaemonStub({
+      health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+      search: { query: "q", count: 0, results: [] },
+    });
+    try {
+      let probes = 0;
+      const built = createDelegateMemoryCapability({
+        ...optionsFor(stub.port, memoryDir, workspaceDir),
+        resolveSearchNamespace: async () => undefined,
+        verifyNamespaceAuthorization: async () => {
+          probes += 1;
+          return verdict;
+        },
+      });
+      const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+      assert.deepEqual(await manager?.search("q"), []);
+      await manager?.search("q again");
+      assert.equal(probes, 1, "the verdict is cached, not re-probed per search");
+    } finally {
+      await stub.close();
+    }
+  }
+  await rm(memoryDir, { recursive: true, force: true });
+});
+
+test("delegate does not second-guess an explicit namespace", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+    search: { query: "q", count: 0, results: [] },
+  });
+  try {
+    let probed = false;
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      resolveSearchNamespace: async () => "team-a",
+      verifyNamespaceAuthorization: async () => {
+        probed = true;
+        return false;
+      },
+    });
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    assert.deepEqual(await manager?.search("q"), []);
+    assert.equal(probed, false, "the caller's own scope is the daemon's to enforce");
+    const searchCall = stub.calls.find((call) => call.pathname.includes("/memories/search"));
+    assert.equal((searchCall?.body as { namespace?: string }).namespace, "team-a");
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -1191,7 +1191,7 @@ test("a health 200 without memoryDir leaves the corpus unconfirmed", async () =>
   }
 });
 
-test("delegate readFile rejects non-finite offsets instead of serving another range", async () => {
+test("delegate readFile rejects invalid offsets instead of serving another range", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({
     health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
@@ -1199,18 +1199,29 @@ test("delegate readFile rejects non-finite offsets instead of serving another ra
   try {
     const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
-    for (const from of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+    // Non-finite AND finite-but-invalid: a clamp or truncation would return a
+    // different range while looking like a correct answer.
+    for (const from of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      -2,
+      0,
+      1.5,
+    ]) {
       await assert.rejects(
         () => manager?.readFile({ relPath: "facts/alice.md", from }) ?? Promise.resolve(),
-        /from must be a finite number/,
+        /from must be a positive integer/,
         `from: ${String(from)} must be rejected`,
       );
     }
-    await assert.rejects(
-      () =>
-        manager?.readFile({ relPath: "facts/alice.md", lines: Number.NaN }) ?? Promise.resolve(),
-      /lines must be a finite number/,
-    );
+    for (const lines of [Number.NaN, -1, 0, 0.5]) {
+      await assert.rejects(
+        () => manager?.readFile({ relPath: "facts/alice.md", lines }) ?? Promise.resolve(),
+        /lines must be a positive integer/,
+        `lines: ${String(lines)} must be rejected`,
+      );
+    }
     // A real range still works.
     const read = await manager?.readFile({ relPath: "facts/alice.md", from: 2, lines: 1 });
     assert.equal(read?.text, "two");
@@ -1351,6 +1362,54 @@ test("a spent budget skips the authorization probe too", async () => {
     assert.equal(await fresh.resolveScopedNamespace(undefined, 0), "default");
   } finally {
     await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("a failed probe un-proves a previously flat posture", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // A flat daemon can restart PARTITIONED. Holding the old `false` through the
+  // failure backoff would send an unbound search across the new corpus.
+  let healthy = true;
+  const server = http.createServer((req, res) => {
+    if ((req.url ?? "").includes("/health") && !healthy) {
+      res.destroy();
+      return;
+    }
+    res.setHeader("content-type", "application/json");
+    res.end(
+      JSON.stringify(
+        (req.url ?? "").includes("/health")
+          ? { ...healthyDaemon(memoryDir), namespacesEnabled: false }
+          : { query: "q", count: 0, results: [] },
+      ),
+    );
+  });
+  const listening = Promise.withResolvers<void>();
+  server.once("error", listening.reject);
+  server.listen(0, "127.0.0.1", listening.resolve);
+  await listening.promise;
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  let clock = 1_000;
+  try {
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(address.port, memoryDir, workspaceDir),
+      resolveSearchNamespace: async () => undefined,
+      now: () => clock,
+    });
+    // Proven flat: an absent namespace is safe.
+    assert.equal(await built.resolveScopedNamespace(undefined), undefined);
+    // The daemon comes back partitioned and health starts failing.
+    healthy = false;
+    clock += 10 * 60_000;
+    await assert.rejects(
+      () => built.resolveScopedNamespace(undefined),
+      /default namespace is unknown/,
+      "the stale flat posture must not survive a failed probe",
+    );
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
     await rm(memoryDir, { recursive: true, force: true });
   }
 });

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -1,0 +1,495 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { initLogger, resetLogger } from "@remnic/core/logger";
+
+import {
+  createDelegateMemoryCapability,
+  registerDelegateMemoryCapability,
+  type DelegateCapabilityOptions,
+} from "./delegate-capability.js";
+
+type RecordedCall = { pathname: string; body: unknown };
+
+type DaemonStub = {
+  port: number;
+  calls: RecordedCall[];
+  close: () => Promise<void>;
+};
+
+type StubRoutes = {
+  health?: unknown;
+  healthStatus?: number;
+  search?: unknown;
+  searchStatus?: number;
+};
+
+async function startDaemonStub(routes: StubRoutes): Promise<DaemonStub> {
+  const calls: RecordedCall[] = [];
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8");
+      const pathname = (req.url ?? "").split("?")[0] ?? "";
+      calls.push({ pathname, body: raw ? JSON.parse(raw) : undefined });
+      const isSearch = pathname.endsWith("/memories/search");
+      const status = isSearch ? (routes.searchStatus ?? 200) : (routes.healthStatus ?? 200);
+      const payload = isSearch ? routes.search : routes.health;
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(JSON.stringify(payload ?? {}));
+    });
+  });
+  const listening = Promise.withResolvers<void>();
+  server.on("error", listening.reject);
+  server.listen(0, "127.0.0.1", listening.resolve);
+  await listening.promise;
+  const address = server.address();
+  if (address === null || typeof address !== "object") {
+    server.close();
+    throw new Error("stub did not bind");
+  }
+  return {
+    port: address.port,
+    calls,
+    close: () => {
+      const closed = Promise.withResolvers<void>();
+      server.close(() => closed.resolve());
+      return closed.promise;
+    },
+  };
+}
+
+async function makeCorpus(): Promise<{ memoryDir: string; workspaceDir: string }> {
+  const root = await realpath(await mkdtemp(path.join(os.tmpdir(), "remnic-delegate-cap-")));
+  const memoryDir = path.join(root, "memory");
+  const workspaceDir = path.join(root, "workspace");
+  await mkdir(path.join(memoryDir, "facts"), { recursive: true });
+  await mkdir(path.join(memoryDir, "artifacts"), { recursive: true });
+  await mkdir(workspaceDir, { recursive: true });
+  await writeFile(path.join(memoryDir, "facts", "alice.md"), "one\ntwo\nthree\nfour\n");
+  await writeFile(path.join(memoryDir, "artifacts", "report.md"), "secret artifact\n");
+  return { memoryDir, workspaceDir };
+}
+
+function optionsFor(
+  port: number,
+  memoryDir: string,
+  workspaceDir: string,
+  overrides: Partial<DelegateCapabilityOptions> = {},
+): DelegateCapabilityOptions {
+  return {
+    serviceId: "openclaw-remnic",
+    target: {
+      host: "127.0.0.1",
+      port,
+      resolveAuthToken: () => ({ token: "test-token", source: "REMNIC_AUTH_TOKEN" }),
+    },
+    namespace: "",
+    memoryDir,
+    workspaceDir,
+    agentIds: ["generalist"],
+    allowPromptInjection: true,
+    peekPromptLines: () => null,
+    configuredSearchBackend: "qmd",
+    configuredQmdCommand: "qmd",
+    searchTimeoutMs: 5_000,
+    healthTimeoutMs: 5_000,
+    ...overrides,
+  };
+}
+
+const HEALTHY_DAEMON = {
+  ok: true,
+  memoryDir: "/daemon/memory",
+  searchBackend: "qmd",
+  qmdEnabled: true,
+  qmd: { enabled: true, active: true, degraded: false, debugStatus: "cli=true" },
+};
+
+test.before(() =>
+  initLogger({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }, false),
+);
+test.after(() => resetLogger());
+
+test("delegate search maps daemon hits into runtime results", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: HEALTHY_DAEMON,
+    search: {
+      query: "alice",
+      count: 2,
+      results: [
+        { path: "facts/alice.md", score: 0.9, snippet: "alice likes tea" },
+        { path: "sessions/2026-01-01.md", score: 0.4, snippet: "session note" },
+      ],
+    },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    assert.ok(manager);
+    const results = await manager.search("alice", { maxResults: 5 });
+    assert.deepEqual(results, [
+      {
+        path: path.join(memoryDir, "facts", "alice.md"),
+        startLine: 1,
+        endLine: 1,
+        score: 0.9,
+        snippet: "alice likes tea",
+        source: "memory",
+        citation: path.join("facts", "alice.md"),
+      },
+      {
+        path: path.join(memoryDir, "sessions", "2026-01-01.md"),
+        startLine: 1,
+        endLine: 1,
+        score: 0.4,
+        snippet: "session note",
+        source: "sessions",
+        citation: path.join("sessions", "2026-01-01.md"),
+      },
+    ]);
+    const searchCall = stub.calls.find((call) => call.pathname.endsWith("/memories/search"));
+    assert.deepEqual(searchCall?.body, { query: "alice", maxResults: 5 });
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate search excludes artifact paths and honors minScore", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: HEALTHY_DAEMON,
+    search: {
+      results: [
+        { path: "artifacts/report.md", score: 0.99, snippet: "artifact" },
+        { path: "facts/alice.md", score: 0.2, snippet: "low" },
+        { path: "facts/bob.md", score: 0.8, snippet: "high" },
+        "not-an-object",
+      ],
+    },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const results = await manager?.search("q", { minScore: 0.5 });
+    assert.deepEqual(
+      results?.map((result) => result.citation),
+      [path.join("facts", "bob.md")],
+      "artifacts are isolated, sub-threshold hits are dropped, non-objects are skipped",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate search forwards the configured namespace", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON, search: { results: [] } });
+  try {
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir, { namespace: " team-a " }),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await manager?.search("q");
+    const searchCall = stub.calls.find((call) => call.pathname.endsWith("/memories/search"));
+    assert.deepEqual(searchCall?.body, { query: "q", namespace: "team-a" });
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate search surfaces a daemon failure instead of returning empty", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON, searchStatus: 503, search: {} });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.search("q") ?? Promise.resolve([]),
+      /responded 503/,
+      "a backend failure must not be indistinguishable from no results",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate readFile reads the shared corpus and paginates", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const page = await manager?.readFile({ relPath: "facts/alice.md", from: 2, lines: 2 });
+    assert.equal(page?.text, "two\nthree");
+    assert.equal(page?.truncated, true);
+    assert.equal(page?.nextFrom, 4);
+    const whole = await manager?.readFile({ relPath: "facts/alice.md" });
+    assert.equal(whole?.truncated, undefined);
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate readFile refuses paths outside the memory roots", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.readFile({ relPath: "/etc/hosts" }) ?? Promise.resolve(),
+      /memory read (outside allowed roots|restricted to \.md files|rejected)/,
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate status reflects the daemon health snapshot", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const status = manager?.status();
+    assert.equal(status?.backend, "qmd");
+    assert.equal(status?.dbPath, "/daemon/memory", "the daemon's memoryDir wins over the local one");
+    assert.deepEqual(status?.vector, { enabled: true, available: true });
+    assert.equal(await manager?.probeVectorAvailability(), true);
+    assert.deepEqual(await manager?.probeEmbeddingAvailability(), { ok: true });
+    assert.deepEqual(built.runtime.resolveMemoryBackendConfig({ cfg: {}, agentId: "main" }), {
+      backend: "qmd",
+      qmd: { command: "qmd" },
+    });
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate status reports a degraded daemon QMD as unavailable", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: {
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      qmd: { enabled: true, active: true, degraded: true, debugStatus: "collection missing" },
+    },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    assert.equal(manager?.status().vector?.available, false);
+    assert.deepEqual(await manager?.probeEmbeddingAvailability(), {
+      ok: false,
+      error: "collection missing",
+    });
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate status keeps the configured backend when the daemon health probe fails", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ healthStatus: 500, health: {} });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    // A failed probe must not fabricate an outage — the seeded config wins.
+    assert.equal(manager?.status().backend, "qmd");
+    assert.equal(manager?.status().dbPath, memoryDir);
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate health is cached and refreshed on the injected clock", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  let clock = 1_000;
+  try {
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir, { now: () => clock }),
+    );
+    await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const healthCalls = () => stub.calls.filter((call) => call.pathname.endsWith("/health")).length;
+    assert.equal(healthCalls(), 1, "a warm snapshot is reused");
+    clock += 60_000;
+    await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    assert.equal(healthCalls(), 2, "an expired snapshot is refreshed");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate runtime offers no sync — indexing stays the daemon's job", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    assert.equal(manager?.sync, undefined);
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate flush plan matches the embedded contract", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  try {
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir, {
+        extractionMaxTurnChars: 12_000,
+        flushModel: "gpt-test",
+      }),
+    );
+    const plan = built.flushPlanResolver();
+    assert.equal(plan.forceFlushTranscriptBytes, 48_000);
+    assert.equal(plan.model, "gpt-test");
+    assert.equal(plan.relativePath, "state/plugins/openclaw-remnic/flush-plan.md");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate publicArtifacts lists the corpus and degrades to empty on failure", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const artifacts = await built.listArtifacts();
+    assert.ok(artifacts.length > 0, "the shared corpus yields public artifacts");
+
+    const missing = createDelegateMemoryCapability(
+      optionsFor(stub.port, path.join(memoryDir, "does-not-exist"), workspaceDir),
+    );
+    assert.deepEqual(await missing.listArtifacts(), []);
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("registerDelegateMemoryCapability wires the unified host surface", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  try {
+    const registered: Record<string, unknown> = {};
+    registerDelegateMemoryCapability(
+      {
+        registerMemoryCapability: (capability) => {
+          registered.capability = capability;
+        },
+        registerMemoryRuntime: (runtime) => {
+          registered.runtime = runtime;
+        },
+        registerMemoryFlushPlan: (resolver) => {
+          registered.flushPlan = resolver;
+        },
+      },
+      optionsFor(stub.port, memoryDir, workspaceDir, {
+        peekPromptLines: (sessionKey) => (sessionKey === "s1" ? ["## Memory", "line"] : null),
+      }),
+    );
+    const capability = registered.capability as Record<string, unknown>;
+    assert.ok(capability);
+    assert.equal(typeof capability.promptBuilder, "function");
+    assert.equal(typeof capability.flushPlanResolver, "function");
+    assert.ok(capability.runtime);
+    assert.ok(capability.publicArtifacts);
+    assert.ok(registered.runtime);
+    assert.ok(registered.flushPlan);
+
+    const promptBuilder = capability.promptBuilder as (p: { sessionKey?: string }) => string[] | null;
+    assert.deepEqual(promptBuilder({ sessionKey: "s1" }), ["## Memory", "line"]);
+    assert.deepEqual(
+      promptBuilder({ sessionKey: "s1" }),
+      ["## Memory", "line"],
+      "the capability builder only peeks — the section builder owns the destructive read",
+    );
+    assert.equal(promptBuilder({}), null);
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("registerDelegateMemoryCapability omits promptBuilder when injection is disabled", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  try {
+    let capability: Record<string, unknown> | undefined;
+    registerDelegateMemoryCapability(
+      {
+        registerMemoryCapability: (value) => {
+          capability = value as Record<string, unknown>;
+        },
+      },
+      optionsFor(stub.port, memoryDir, workspaceDir, { allowPromptInjection: false }),
+    );
+    assert.ok(capability);
+    assert.equal("promptBuilder" in capability, false);
+    assert.ok(capability.runtime, "the runtime is still provided");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("registerDelegateMemoryCapability falls back to split host surfaces", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  try {
+    const registered: Record<string, unknown> = {};
+    registerDelegateMemoryCapability(
+      {
+        registerMemoryRuntime: (runtime) => {
+          registered.runtime = runtime;
+        },
+        registerMemoryFlushPlan: (resolver) => {
+          registered.flushPlan = resolver;
+        },
+      },
+      optionsFor(stub.port, memoryDir, workspaceDir),
+    );
+    assert.ok(registered.runtime);
+    assert.ok(registered.flushPlan);
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("registerDelegateMemoryCapability is a no-op on a host with no memory surface", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  try {
+    assert.doesNotThrow(() =>
+      registerDelegateMemoryCapability({}, optionsFor(stub.port, memoryDir, workspaceDir)),
+    );
+    assert.equal(stub.calls.length, 0, "nothing is probed when nothing can be registered");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -159,7 +159,7 @@ test("delegate search maps daemon hits into runtime results", async () => {
       },
     ]);
     const searchCall = stub.calls.find((call) => call.pathname.endsWith("/memories/search"));
-    assert.deepEqual(searchCall?.body, { query: "alice", maxResults: 5 });
+    assert.deepEqual(searchCall?.body, { query: "alice", maxResults: 5, mode: "search" });
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -212,10 +212,10 @@ test("delegate search scopes the namespace through the session resolver", async 
     await manager?.search("q", { sessionKey: "s1" });
     await manager?.search("q");
     const searches = stub.calls.filter((call) => call.pathname.endsWith("/memories/search"));
-    assert.deepEqual(searches[0]?.body, { query: "q", namespace: "team-a" });
+    assert.deepEqual(searches[0]?.body, { query: "q", mode: "search", namespace: "team-a" });
     assert.deepEqual(
       searches[1]?.body,
-      { query: "q", namespace: "fallback-ns" },
+      { query: "q", mode: "search", namespace: "fallback-ns" },
       "a search with no session key falls back to the registration-wide namespace",
     );
     assert.deepEqual(seen, ["s1", undefined], "the host session key reaches the resolver");
@@ -561,9 +561,10 @@ test("registerDelegateMemoryCapability is a no-op on a host with no memory surfa
 test("delegate accepts a daemon serving a namespace under the corpus root", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
   // Health reports the namespace-RESOLVED storage dir, not the corpus root.
-  const stub = await startDaemonStub({
-    health: healthyDaemon(path.join(memoryDir, "namespaces", "generalist")),
-  });
+  const namespaceDir = path.join(memoryDir, "namespaces", "generalist");
+  await mkdir(path.join(namespaceDir, "facts"), { recursive: true });
+  await writeFile(path.join(namespaceDir, "facts", "alice.md"), "one\ntwo\n");
+  const stub = await startDaemonStub({ health: healthyDaemon(namespaceDir) });
   try {
     const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
@@ -590,8 +591,37 @@ test("delegate search forwards the host's ranking override", async () => {
       .map((call) => (call.body as { mode?: unknown }).mode);
     assert.deepEqual(
       searches,
-      ["vector", "search", undefined],
-      "vsearch is vector ranking, query is the search plan, absent keeps the backend default",
+      ["vector", "search", "search"],
+      "vsearch is vector ranking; everything else is the embedded default, never omitted",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate roots reads and artifacts on the daemon's namespace directory", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const namespaceDir = path.join(memoryDir, "namespaces", "generalist");
+  await mkdir(path.join(namespaceDir, "facts"), { recursive: true });
+  await writeFile(path.join(namespaceDir, "facts", "scoped.md"), "namespace fact\n");
+  const stub = await startDaemonStub({ health: healthyDaemon(namespaceDir) });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    // The daemon's hits are relative to ITS storage dir, so the read scope must
+    // be rooted there, not on the configured corpus root.
+    const page = await manager?.readFile({ relPath: "facts/scoped.md" });
+    assert.equal(page?.text.trim(), "namespace fact");
+    const artifacts = (await built.listArtifacts()) as Array<{ absolutePath?: string }>;
+    assert.ok(
+      artifacts.some((entry) => entry.absolutePath?.startsWith(namespaceDir)),
+      "the active namespace's artifacts are listed",
+    );
+    assert.equal(
+      artifacts.some((entry) => entry.absolutePath === path.join(memoryDir, "facts", "alice.md")),
+      false,
+      "flat-root files outside the active namespace are not published for it",
     );
   } finally {
     await stub.close();

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -1601,3 +1601,60 @@ test("an invalid caller budget is rejected at the boundary", async () => {
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("a health-failure backoff is honored even by an unscoped request", async () => {
+  // The posture is already unknown during the backoff, so an immediate second
+  // probe cannot prove anything — it would just spend the hook budget on a
+  // daemon that is down, once per recall/search/observe.
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ healthStatus: 500, health: {} });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const probes = (): number =>
+      stub.calls.filter((call) => call.pathname.includes("/health")).length;
+    await assert.rejects(
+      () => manager?.search("q") ?? Promise.resolve(),
+      /could not be confirmed/,
+      "an unproven posture fails closed for an unscoped search",
+    );
+    const afterFirst = probes();
+    assert.ok(afterFirst >= 1, "the first unscoped request probes");
+    await assert.rejects(() => manager?.search("q") ?? Promise.resolve(), /could not be confirmed/);
+    await assert.rejects(() => manager?.search("q") ?? Promise.resolve(), /could not be confirmed/);
+    assert.equal(probes(), afterFirst, "the failure backoff suppressed the repeat probes");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("a zero-budget search is authorized before it answers empty", async () => {
+  // Shrinking the requested count must not be a way to get a successful
+  // answer for a namespace the session may not read.
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "team" },
+    search: { query: "q", count: 0, results: [] },
+  });
+  try {
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      verifyNamespaceAuthorization: async () => false,
+    });
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.search("q", { maxResults: 0 }) ?? Promise.resolve(),
+      /not authorized/,
+      "a zero budget still runs the authorization gate",
+    );
+    assert.equal(
+      stub.calls.filter((call) => call.pathname.includes("/memories/search")).length,
+      0,
+      "and still makes no backend call",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -95,7 +95,7 @@ function optionsFor(
     workspaceDir,
     agentIds: ["generalist"],
     allowPromptInjection: true,
-    peekPromptLines: () => null,
+    readPromptLines: () => null,
     configuredSearchBackend: "qmd",
     configuredQmdCommand: "qmd",
     searchTimeoutMs: 5_000,
@@ -454,6 +454,7 @@ test("registerDelegateMemoryCapability wires the unified host surface", async ()
   const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
     const registered: Record<string, unknown> = {};
+    const seenSessionKeys: string[] = [];
     registerDelegateMemoryCapability(
       {
         registerMemoryCapability: (capability) => {
@@ -467,7 +468,10 @@ test("registerDelegateMemoryCapability wires the unified host surface", async ()
         },
       },
       optionsFor(stub.port, memoryDir, workspaceDir, {
-        peekPromptLines: (sessionKey) => (sessionKey === "s1" ? ["## Memory", "line"] : null),
+        readPromptLines: (sessionKey) => {
+          seenSessionKeys.push(sessionKey);
+          return sessionKey === "s1" ? ["## Memory", "line"] : null;
+        },
       }),
     );
     const capability = registered.capability as Record<string, unknown>;
@@ -482,11 +486,12 @@ test("registerDelegateMemoryCapability wires the unified host surface", async ()
     const promptBuilder = capability.promptBuilder as (p: { sessionKey?: string }) => string[] | null;
     assert.deepEqual(promptBuilder({ sessionKey: "s1" }), ["## Memory", "line"]);
     assert.deepEqual(
-      promptBuilder({ sessionKey: "s1" }),
-      ["## Memory", "line"],
-      "the capability builder only peeks — the section builder owns the destructive read",
+      seenSessionKeys,
+      ["s1"],
+      "the host session key reaches the seam, which owns peek-vs-consume",
     );
-    assert.equal(promptBuilder({}), null);
+    assert.equal(promptBuilder({}), null, "a missing session key reads the default bucket");
+    assert.deepEqual(seenSessionKeys, ["s1", "default"]);
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -547,6 +552,24 @@ test("registerDelegateMemoryCapability is a no-op on a host with no memory surfa
       registerDelegateMemoryCapability({}, optionsFor(stub.port, memoryDir, workspaceDir)),
     );
     assert.equal(stub.calls.length, 0, "nothing is probed when nothing can be registered");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate accepts a daemon serving a namespace under the corpus root", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // Health reports the namespace-RESOLVED storage dir, not the corpus root.
+  const stub = await startDaemonStub({
+    health: healthyDaemon(path.join(memoryDir, "namespaces", "generalist")),
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const page = await manager?.readFile({ relPath: "facts/alice.md" });
+    assert.equal(page?.text.startsWith("one"), true, "a migrated default namespace is not foreign");
+    assert.ok((await built.listArtifacts()).length > 0);
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -904,41 +904,49 @@ test("delegate search rejects a malformed result entry instead of inventing a me
   await rm(memoryDir, { recursive: true, force: true });
 });
 
-test("delegate file surfaces refuse a namespace the health snapshot does not describe", async () => {
+test("delegate file surfaces refuse a namespace-partitioned daemon", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  // Health answers without a namespace, so its memoryDir is the DEFAULT
-  // namespace's storage. A session scoped elsewhere would otherwise publish
-  // that namespace's files while omitting its own.
-  const stub = await startDaemonStub({
-    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
-  });
-  try {
-    const built = createDelegateMemoryCapability({
-      ...optionsFor(stub.port, memoryDir, workspaceDir),
-      resolveSearchNamespace: async () => "team-a",
+  // `readFile` and `listArtifacts` carry NO session, and health answers
+  // without a namespace, so on a partitioned daemon there is nothing to
+  // authorize the local walk against. A per-registration fallback would open
+  // one namespace's disk for sessions bound to another.
+  for (const namespacesEnabled of [true, undefined]) {
+    const stub = await startDaemonStub({
+      health: { ...healthyDaemon(memoryDir), namespacesEnabled, defaultNamespace: "default" },
+      search: { query: "q", count: 0, results: [] },
     });
-    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
-    await assert.rejects(
-      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
-      /a local walk cannot be authorized for it/,
-    );
-    assert.deepEqual(await built.listArtifacts(), [], "artifacts are withheld, not cross-published");
-  } finally {
-    await stub.close();
-    await rm(memoryDir, { recursive: true, force: true });
+    try {
+      const built = createDelegateMemoryCapability({
+        ...optionsFor(stub.port, memoryDir, workspaceDir),
+        resolveSearchNamespace: async (sessionKey) => (sessionKey === "s2" ? "team-a" : "default"),
+      });
+      const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+      await assert.rejects(
+        () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+        /a local read cannot be authorized/,
+        `namespacesEnabled: ${String(namespacesEnabled)} must fail closed`,
+      );
+      assert.deepEqual(
+        await built.listArtifacts(),
+        [],
+        "artifacts are withheld, not cross-published",
+      );
+      // Search is unaffected: it carries the session and the daemon enforces.
+      assert.ok(Array.isArray(await manager?.search("q", { sessionKey: "s2" })));
+    } finally {
+      await stub.close();
+    }
   }
+  await rm(memoryDir, { recursive: true, force: true });
 });
 
-test("delegate file surfaces stay available on the namespace health describes", async () => {
+test("delegate file surfaces stay available on a single-corpus daemon", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({
-    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
   });
   try {
-    const built = createDelegateMemoryCapability({
-      ...optionsFor(stub.port, memoryDir, workspaceDir),
-      resolveSearchNamespace: async () => "default",
-    });
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
     const read = await manager?.readFile({ relPath: "facts/alice.md" });
     assert.equal(read?.path, path.join("facts", "alice.md"), "the read is served, not refused");

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -575,3 +575,26 @@ test("delegate accepts a daemon serving a namespace under the corpus root", asyn
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("delegate search forwards the host's ranking override", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir), search: { results: [] } });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await manager?.search("q", { qmdSearchModeOverride: "vsearch" });
+    await manager?.search("q", { qmdSearchModeOverride: "query" });
+    await manager?.search("q");
+    const searches = stub.calls
+      .filter((call) => call.pathname.endsWith("/memories/search"))
+      .map((call) => (call.body as { mode?: unknown }).mode);
+    assert.deepEqual(
+      searches,
+      ["vector", "search", undefined],
+      "vsearch is vector ranking, query is the search plan, absent keeps the backend default",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -48,7 +48,18 @@ async function startDaemonStub(routes: StubRoutes): Promise<DaemonStub> {
         res.end(routes.healthRaw);
         return;
       }
-      const payload = isSearch ? routes.search : routes.health;
+      let payload = isSearch ? routes.search : routes.health;
+      if (isSearch && payload !== null && typeof payload === "object") {
+        // Honor `maxResults` the way a real daemon does, so a client-side
+        // top-up sees a genuinely truncated page.
+        const requested = (calls[calls.length - 1]?.body as { maxResults?: number } | undefined)
+          ?.maxResults;
+        const page = payload as { results?: unknown[]; count?: number };
+        if (typeof requested === "number" && Array.isArray(page.results)) {
+          const sliced = page.results.slice(0, requested);
+          payload = { ...page, results: sliced, count: sliced.length };
+        }
+      }
       res.end(JSON.stringify(payload ?? {}));
     });
   });
@@ -168,10 +179,7 @@ test("delegate search maps daemon hits into runtime results", async () => {
       },
     ]);
     const searchCall = stub.calls.find((call) => call.pathname.endsWith("/memories/search"));
-    // Headroom: artifacts and sub-minScore hits are dropped on this side, so
-    // the daemon is asked for more than the caller's budget and the cap lands
-    // on the FILTERED list.
-    assert.deepEqual(searchCall?.body, { query: "alice", maxResults: 15, mode: "search" });
+    assert.deepEqual(searchCall?.body, { query: "alice", maxResults: 5, mode: "search" });
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -794,11 +802,11 @@ test("delegate search caps AFTER dropping artifacts, not before", async () => {
       [path.join("facts", "one.md"), path.join("facts", "two.md")],
       "a full page of real memories, and never more than the budget",
     );
-    const searchCall = stub.calls.find((call) => call.pathname.includes("/memories/search"));
-    assert.equal(
-      (searchCall?.body as { maxResults?: number } | undefined)?.maxResults,
-      6,
-      "asks the daemon for headroom",
+    const searchCalls = stub.calls.filter((call) => call.pathname.includes("/memories/search"));
+    assert.deepEqual(
+      searchCalls.map((call) => (call.body as { maxResults?: number }).maxResults),
+      [2, 4],
+      "asks again with a doubled limit rather than returning a thin page",
     );
   } finally {
     await stub.close();

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -738,3 +738,20 @@ test("delegate refuses file-backed surfaces for a remote daemon with an identica
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("delegate readFile refuses artifact paths", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.readFile({ relPath: "artifacts/report.md" }) ?? Promise.resolve(),
+      /artifact path/,
+      "search filters artifacts; the read path must not be a way around that",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -2242,3 +2242,39 @@ test("a spent budget refuses an unverified substituted default", async () => {
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("an explicitly scoped search never waits on the health route", async () => {
+  // The daemon enforces an explicit scope on `/memories/search`, so a slow or
+  // dead `/health` must not delay a search it would serve. A cached manager
+  // must also cost at most ONE probe, never an eager one plus a revalidating
+  // one.
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+    search: { query: "q", count: 0, results: [] },
+  });
+  try {
+    let clock = 1_000_000;
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir, { now: () => clock }),
+      resolveSearchNamespace: async () => "team",
+    });
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const probes = (): number =>
+      stub.calls.filter((call) => call.pathname.includes("/health")).length;
+    const afterHandout = probes();
+    // Expire the posture cache: an explicit scope must STILL not probe.
+    clock += 10 * 60 * 1_000;
+    assert.deepEqual(await manager?.search("q"), []);
+    assert.deepEqual(await manager?.search("q"), []);
+    assert.equal(probes(), afterHandout, "no posture probe ran for an explicit scope");
+    assert.equal(
+      stub.calls.filter((call) => call.pathname.includes("/memories/search")).length,
+      2,
+      "and both searches reached the daemon",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -706,3 +706,33 @@ test("delegate reads a hit from another namespace's storage directory", async ()
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("delegate refuses file-backed surfaces for a remote daemon with an identical path", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: healthyDaemon(memoryDir),
+    search: { results: [{ path: "facts/alice.md", score: 0.5, snippet: "hit" }] },
+  });
+  try {
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir, {
+        // Canonicalizing two strings on THIS host says nothing about a remote
+        // daemon that happens to use the same absolute pathname.
+        target: {
+          host: "10.0.0.9",
+          port: stub.port,
+          resolveAuthToken: () => ({ token: "t", source: "REMNIC_AUTH_TOKEN" }),
+        },
+      }),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+      /is not local/,
+    );
+    assert.deepEqual(await built.listArtifacts(), []);
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -118,6 +118,7 @@ function optionsFor(
     allowPromptInjection: true,
     readPromptLines: () => null,
     configuredSearchBackend: "qmd",
+    configuredNamespacesEnabled: false,
     configuredQmdCommand: "qmd",
     searchTimeoutMs: 5_000,
     healthTimeoutMs: 5_000,
@@ -912,6 +913,9 @@ test("delegate file surfaces refuse a namespace-partitioned daemon", async () =>
   // without a namespace, so on a partitioned daemon there is nothing to
   // authorize the local walk against. A per-registration fallback would open
   // one namespace's disk for sessions bound to another.
+  // `undefined` from the daemon now falls back to the plugin's own posture, so
+  // the unreported case is paired with a partitioned config - "nobody says it
+  // is flat" must still fail closed.
   for (const namespacesEnabled of [true, undefined]) {
     const stub = await startDaemonStub({
       health: { ...healthyDaemon(memoryDir), namespacesEnabled, defaultNamespace: "default" },
@@ -920,6 +924,7 @@ test("delegate file surfaces refuse a namespace-partitioned daemon", async () =>
     try {
       const built = createDelegateMemoryCapability({
         ...optionsFor(stub.port, memoryDir, workspaceDir),
+        configuredNamespacesEnabled: true,
         resolveSearchNamespace: async (sessionKey) => (sessionKey === "s2" ? "team-a" : "default"),
       });
       const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
@@ -1088,6 +1093,52 @@ test("swapping in an authorized token recovers unbound delegate search", async (
     );
     token = "authorized";
     assert.deepEqual(await manager?.search("q"), [], "the new token is re-probed, not refused from cache");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("a single-corpus plugin config searches before the first health probe", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // The daemon never reports a namespace posture (older build), and the plugin
+  // itself is configured flat. Refusing here would break search on a
+  // single-corpus deployment for a fact the plugin already knows.
+  const stub = await startDaemonStub({
+    health: { ok: true, memoryDir },
+    search: { query: "q", count: 0, results: [] },
+  });
+  try {
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      configuredNamespacesEnabled: false,
+      resolveSearchNamespace: async () => undefined,
+    });
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    assert.deepEqual(await manager?.search("q"), []);
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("a partitioned plugin config still fails closed before the first probe", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: { ok: true, memoryDir },
+    search: { query: "q", count: 0, results: [] },
+  });
+  try {
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      configuredNamespacesEnabled: true,
+      resolveSearchNamespace: async () => undefined,
+    });
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.search("q") ?? Promise.resolve(),
+      /default namespace is unknown/,
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -18,6 +18,8 @@ type RecordedCall = { pathname: string; body: unknown };
 type DaemonStub = {
   port: number;
   calls: RecordedCall[];
+  /** Runs when a health request is served, so a test can advance its clock. */
+  onHealth?: () => void;
   close: () => Promise<void>;
 };
 
@@ -34,6 +36,7 @@ type StubRoutes = {
 
 async function startDaemonStub(routes: StubRoutes): Promise<DaemonStub> {
   const calls: RecordedCall[] = [];
+  let stub: DaemonStub | undefined;
   const server = http.createServer((req, res) => {
     const chunks: Buffer[] = [];
     req.on("data", (chunk: Buffer) => chunks.push(chunk));
@@ -42,6 +45,7 @@ async function startDaemonStub(routes: StubRoutes): Promise<DaemonStub> {
       const pathname = (req.url ?? "").split("?")[0] ?? "";
       calls.push({ pathname, body: raw ? JSON.parse(raw) : undefined });
       const isSearch = pathname.endsWith("/memories/search");
+      if (!isSearch) stub?.onHealth?.();
       const delayMs = isSearch ? 0 : (routes.healthDelayMs ?? 0);
       if (delayMs > 0) {
         setTimeout(() => respond(), delayMs);
@@ -86,7 +90,7 @@ async function startDaemonStub(routes: StubRoutes): Promise<DaemonStub> {
     server.close();
     throw new Error("stub did not bind");
   }
-  return {
+  stub = {
     port: address.port,
     calls,
     close: () => {
@@ -95,6 +99,7 @@ async function startDaemonStub(routes: StubRoutes): Promise<DaemonStub> {
       return closed.promise;
     },
   };
+  return stub;
 }
 
 async function makeCorpus(): Promise<{
@@ -2186,6 +2191,52 @@ test("an explicit scope needs no probe at all", async () => {
       0,
       "no posture probe ran for an explicit scope",
     );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("a spent budget refuses an unverified substituted default", async () => {
+  // The substituted default is an AUTHORIZATION fact. Running the hook under
+  // it because the deadline ran out is fail-open: a partitioned daemon would
+  // serve recall/observe/flush under a scope this token was never verified
+  // for. A CACHED verdict still answers for free.
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+  });
+  try {
+    let probes = 0;
+    // A clock the posture probe advances past the caller's whole budget, so
+    // the posture is FRESH but nothing is left for authorization — the only
+    // shape that reaches this branch.
+    let clock = 1_000_000;
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir, { now: () => clock }),
+      resolveSearchNamespace: async () => undefined,
+      verifyNamespaceAuthorization: async () => {
+        probes += 1;
+        return true;
+      },
+    });
+    const spendBudgetDuringProbe = (): void => {
+      clock += 400;
+    };
+    stub.onHealth = spendBudgetDuringProbe;
+    await assert.rejects(
+      () => built.resolveScopedNamespace(undefined, 300),
+      /could not be verified within the caller's deadline/,
+    );
+    assert.equal(probes, 0, "and it did not send a doomed request either");
+
+    // Once a verdict is cached, a spent budget rides it rather than refusing.
+    stub.onHealth = undefined;
+    assert.equal(await built.resolveScopedNamespace(undefined, 5_000), "default");
+    assert.equal(probes, 1);
+    stub.onHealth = spendBudgetDuringProbe;
+    assert.equal(await built.resolveScopedNamespace(undefined, 300), "default");
+    assert.equal(probes, 1, "the cached verdict answered without a probe");
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -90,6 +90,7 @@ function optionsFor(
       resolveAuthToken: () => ({ token: "test-token", source: "REMNIC_AUTH_TOKEN" }),
     },
     namespace: "",
+    resolveSearchNamespace: async () => undefined,
     memoryDir,
     workspaceDir,
     agentIds: ["generalist"],
@@ -103,13 +104,16 @@ function optionsFor(
   };
 }
 
-const HEALTHY_DAEMON = {
-  ok: true,
-  memoryDir: "/daemon/memory",
-  searchBackend: "qmd",
-  qmdEnabled: true,
-  qmd: { enabled: true, active: true, degraded: false, debugStatus: "cli=true" },
-};
+/** A daemon serving the SAME corpus as the plugin under test. */
+function healthyDaemon(memoryDir: string): Record<string, unknown> {
+  return {
+    ok: true,
+    memoryDir,
+    searchBackend: "qmd",
+    qmdEnabled: true,
+    qmd: { enabled: true, active: true, degraded: false, debugStatus: "cli=true" },
+  };
+}
 
 test.before(() =>
   initLogger({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }, false),
@@ -119,7 +123,7 @@ test.after(() => resetLogger());
 test("delegate search maps daemon hits into runtime results", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({
-    health: HEALTHY_DAEMON,
+    health: healthyDaemon(memoryDir),
     search: {
       query: "alice",
       count: 2,
@@ -165,7 +169,7 @@ test("delegate search maps daemon hits into runtime results", async () => {
 test("delegate search excludes artifact paths and honors minScore", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({
-    health: HEALTHY_DAEMON,
+    health: healthyDaemon(memoryDir),
     search: {
       results: [
         { path: "artifacts/report.md", score: 0.99, snippet: "artifact" },
@@ -190,17 +194,71 @@ test("delegate search excludes artifact paths and honors minScore", async () => 
   }
 });
 
-test("delegate search forwards the configured namespace", async () => {
+test("delegate search scopes the namespace through the session resolver", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON, search: { results: [] } });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir), search: { results: [] } });
+  const seen: Array<string | undefined> = [];
   try {
     const built = createDelegateMemoryCapability(
-      optionsFor(stub.port, memoryDir, workspaceDir, { namespace: " team-a " }),
+      optionsFor(stub.port, memoryDir, workspaceDir, {
+        namespace: "fallback-ns",
+        resolveSearchNamespace: async (sessionKey) => {
+          seen.push(sessionKey);
+          return sessionKey === "s1" ? "team-a" : "fallback-ns";
+        },
+      }),
     );
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await manager?.search("q", { sessionKey: "s1" });
     await manager?.search("q");
-    const searchCall = stub.calls.find((call) => call.pathname.endsWith("/memories/search"));
-    assert.deepEqual(searchCall?.body, { query: "q", namespace: "team-a" });
+    const searches = stub.calls.filter((call) => call.pathname.endsWith("/memories/search"));
+    assert.deepEqual(searches[0]?.body, { query: "q", namespace: "team-a" });
+    assert.deepEqual(
+      searches[1]?.body,
+      { query: "q", namespace: "fallback-ns" },
+      "a search with no session key falls back to the registration-wide namespace",
+    );
+    assert.deepEqual(seen, ["s1", undefined], "the host session key reaches the resolver");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate refuses file-backed surfaces when the daemon serves another corpus", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: healthyDaemon(path.join(memoryDir, "..", "someone-elses-corpus")),
+    search: { results: [{ path: "facts/alice.md", score: 0.5, snippet: "hit" }] },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+      /delegate readFile unavailable/,
+      "reading a same-named local file would serve the wrong corpus",
+    );
+    assert.deepEqual(await built.listArtifacts(), [], "artifact listing is disabled too");
+    const results = await manager?.search("alice");
+    assert.equal(results?.length, 1, "daemon-backed search still works");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate refuses file-backed surfaces until the corpus is confirmed", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ healthStatus: 500, health: {} });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+      /delegate readFile unavailable/,
+      "an unconfirmed corpus fails closed rather than reading local files",
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -209,7 +267,7 @@ test("delegate search forwards the configured namespace", async () => {
 
 test("delegate search surfaces a daemon failure instead of returning empty", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON, searchStatus: 503, search: {} });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir), searchStatus: 503, search: {} });
   try {
     const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
@@ -226,7 +284,7 @@ test("delegate search surfaces a daemon failure instead of returning empty", asy
 
 test("delegate readFile reads the shared corpus and paginates", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
     const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
@@ -244,7 +302,7 @@ test("delegate readFile reads the shared corpus and paginates", async () => {
 
 test("delegate readFile refuses paths outside the memory roots", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
     const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
@@ -260,13 +318,13 @@ test("delegate readFile refuses paths outside the memory roots", async () => {
 
 test("delegate status reflects the daemon health snapshot", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
     const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
     const status = manager?.status();
     assert.equal(status?.backend, "qmd");
-    assert.equal(status?.dbPath, "/daemon/memory", "the daemon's memoryDir wins over the local one");
+    assert.equal(status?.dbPath, memoryDir);
     assert.deepEqual(status?.vector, { enabled: true, available: true });
     assert.equal(await manager?.probeVectorAvailability(), true);
     assert.deepEqual(await manager?.probeEmbeddingAvailability(), { ok: true });
@@ -284,6 +342,7 @@ test("delegate status reports a degraded daemon QMD as unavailable", async () =>
   const { memoryDir, workspaceDir } = await makeCorpus();
   const stub = await startDaemonStub({
     health: {
+      memoryDir,
       searchBackend: "qmd",
       qmdEnabled: true,
       qmd: { enabled: true, active: true, degraded: true, debugStatus: "collection missing" },
@@ -320,7 +379,7 @@ test("delegate status keeps the configured backend when the daemon health probe 
 
 test("delegate health is cached and refreshed on the injected clock", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   let clock = 1_000;
   try {
     const built = createDelegateMemoryCapability(
@@ -341,7 +400,7 @@ test("delegate health is cached and refreshed on the injected clock", async () =
 
 test("delegate runtime offers no sync — indexing stays the daemon's job", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
     const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
@@ -354,7 +413,7 @@ test("delegate runtime offers no sync — indexing stays the daemon's job", asyn
 
 test("delegate flush plan matches the embedded contract", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
     const built = createDelegateMemoryCapability(
       optionsFor(stub.port, memoryDir, workspaceDir, {
@@ -374,7 +433,7 @@ test("delegate flush plan matches the embedded contract", async () => {
 
 test("delegate publicArtifacts lists the corpus and degrades to empty on failure", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
     const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
     const artifacts = await built.listArtifacts();
@@ -392,7 +451,7 @@ test("delegate publicArtifacts lists the corpus and degrades to empty on failure
 
 test("registerDelegateMemoryCapability wires the unified host surface", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
     const registered: Record<string, unknown> = {};
     registerDelegateMemoryCapability(
@@ -436,7 +495,7 @@ test("registerDelegateMemoryCapability wires the unified host surface", async ()
 
 test("registerDelegateMemoryCapability omits promptBuilder when injection is disabled", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
     let capability: Record<string, unknown> | undefined;
     registerDelegateMemoryCapability(
@@ -458,7 +517,7 @@ test("registerDelegateMemoryCapability omits promptBuilder when injection is dis
 
 test("registerDelegateMemoryCapability falls back to split host surfaces", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
     const registered: Record<string, unknown> = {};
     registerDelegateMemoryCapability(
@@ -482,7 +541,7 @@ test("registerDelegateMemoryCapability falls back to split host surfaces", async
 
 test("registerDelegateMemoryCapability is a no-op on a host with no memory surface", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  const stub = await startDaemonStub({ health: HEALTHY_DAEMON });
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir) });
   try {
     assert.doesNotThrow(() =>
       registerDelegateMemoryCapability({}, optionsFor(stub.port, memoryDir, workspaceDir)),

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -1099,11 +1099,29 @@ test("swapping in an authorized token recovers unbound delegate search", async (
   }
 });
 
-test("a single-corpus plugin config searches before the first health probe", async () => {
+test("a single-corpus plugin config resolves scope while the probe is failing", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  // The daemon never reports a namespace posture (older build), and the plugin
-  // itself is configured flat. Refusing here would break search on a
-  // single-corpus deployment for a fact the plugin already knows.
+  // No daemon answers at all, so the seeded snapshot is all there is. A flat
+  // deployment must still resolve its scope rather than refusing every call
+  // for the duration of an outage.
+  const built = createDelegateMemoryCapability({
+    ...optionsFor(1, memoryDir, workspaceDir),
+    configuredNamespacesEnabled: false,
+    resolveSearchNamespace: async () => undefined,
+  });
+  try {
+    assert.equal(await built.resolveScopedNamespace(undefined), undefined);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("a daemon that ANSWERS without a posture is unknown, not flat", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // The plugin config describes the PLUGIN's deployment. A partitioned daemon
+  // on a legacy build would otherwise be marked flat by a flat plugin config,
+  // permitting an absent namespace and fanning search across everything the
+  // token can read.
   const stub = await startDaemonStub({
     health: { ok: true, memoryDir },
     search: { query: "q", count: 0, results: [] },
@@ -1115,7 +1133,10 @@ test("a single-corpus plugin config searches before the first health probe", asy
       resolveSearchNamespace: async () => undefined,
     });
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
-    assert.deepEqual(await manager?.search("q"), []);
+    await assert.rejects(
+      () => manager?.search("q") ?? Promise.resolve(),
+      /default namespace is unknown/,
+    );
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -1145,19 +1166,25 @@ test("a partitioned plugin config still fails closed before the first probe", as
   }
 });
 
-test("a health 200 without memoryDir keeps the configured corpus", async () => {
+test("a health 200 without memoryDir leaves the corpus unconfirmed", async () => {
   const { memoryDir, workspaceDir } = await makeCorpus();
-  // An older daemon (or a token without health access) reports no memoryDir.
-  // Erasing the seed would leave corpusShared false beside a co-located
-  // corpus and silently disable readFile and public artifacts.
+  // An unknown memoryDir is NEVER a match. Substituting the plugin's own path
+  // would compare it to itself and enable file-backed reads with no proof the
+  // daemon serves that corpus at all.
   const stub = await startDaemonStub({
     health: { ok: true, namespacesEnabled: false },
+    search: { query: "q", count: 0, results: [] },
   });
   try {
     const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
     const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
-    const read = await manager?.readFile({ relPath: "facts/alice.md" });
-    assert.equal(read?.path, path.join("facts", "alice.md"), "the read is served, not refused");
+    await assert.rejects(
+      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+      /daemon serves an unknown memoryDir/,
+      "file-backed reads stay disabled until the daemon names its corpus",
+    );
+    // Search is unaffected - it runs through the daemon, which enforces.
+    assert.ok(Array.isArray(await manager?.search("q")));
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -1225,5 +1252,56 @@ test("delegate search keeps hits when the corpus sits under an `artifacts` ances
   } finally {
     await stub.close();
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("delegate search rejects an out-of-range maxResults instead of coercing it", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
+    search: { query: "q", count: 0, results: [] },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    for (const maxResults of [-1, 2.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      await assert.rejects(
+        () => manager?.search("q", { maxResults }) ?? Promise.resolve(),
+        /maxResults must be a non-negative integer/,
+        `maxResults: ${String(maxResults)} must be rejected`,
+      );
+    }
+    // The exact-zero short circuit and ordinary budgets are unchanged.
+    assert.deepEqual(await manager?.search("q", { maxResults: 0 }), []);
+    assert.deepEqual(await manager?.search("q", { maxResults: 3 }), []);
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("a spent caller budget skips the health probe instead of overrunning it", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // The lifecycle flushes share one deadline. Starting a fresh probe with its
+  // own full timeout would overrun the hook and get it abandoned before the
+  // buffer drains.
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    // Budget already spent: answer from the seeded snapshot, probe nothing.
+    assert.equal(await built.resolveScopedNamespace(undefined, 0), undefined);
+    assert.equal(
+      stub.calls.filter((call) => call.pathname.includes("/health")).length,
+      0,
+      "no probe is started once the shared deadline is gone",
+    );
+    // A real budget still probes.
+    await built.resolveScopedNamespace(undefined, 5_000);
+    assert.equal(stub.calls.filter((call) => call.pathname.includes("/health")).length, 1);
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
   }
 });

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -1144,3 +1144,86 @@ test("a partitioned plugin config still fails closed before the first probe", as
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("a health 200 without memoryDir keeps the configured corpus", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // An older daemon (or a token without health access) reports no memoryDir.
+  // Erasing the seed would leave corpusShared false beside a co-located
+  // corpus and silently disable readFile and public artifacts.
+  const stub = await startDaemonStub({
+    health: { ok: true, namespacesEnabled: false },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const read = await manager?.readFile({ relPath: "facts/alice.md" });
+    assert.equal(read?.path, path.join("facts", "alice.md"), "the read is served, not refused");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate readFile rejects non-finite offsets instead of serving another range", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    for (const from of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      await assert.rejects(
+        () => manager?.readFile({ relPath: "facts/alice.md", from }) ?? Promise.resolve(),
+        /from must be a finite number/,
+        `from: ${String(from)} must be rejected`,
+      );
+    }
+    await assert.rejects(
+      () =>
+        manager?.readFile({ relPath: "facts/alice.md", lines: Number.NaN }) ?? Promise.resolve(),
+      /lines must be a finite number/,
+    );
+    // A real range still works.
+    const read = await manager?.readFile({ relPath: "facts/alice.md", from: 2, lines: 1 });
+    assert.equal(read?.text, "two");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate search keeps hits when the corpus sits under an `artifacts` ancestor", async () => {
+  // <root>/artifacts/remnic is an ordinary corpus. Judging the ABSOLUTE hit
+  // path would discard every result the daemon returned.
+  const root = await realpath(await mkdtemp(path.join(os.tmpdir(), "remnic-cap-ancestor-")));
+  const memoryDir = path.join(root, "artifacts", "remnic");
+  const workspaceDir = path.join(root, "workspace");
+  await mkdir(path.join(memoryDir, "facts"), { recursive: true });
+  await mkdir(path.join(memoryDir, "artifacts"), { recursive: true });
+  await mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
+    search: {
+      query: "q",
+      count: 2,
+      results: [
+        { path: path.join(memoryDir, "facts", "a.md"), score: 0.9, snippet: "fact" },
+        { path: path.join(memoryDir, "artifacts", "report.md"), score: 0.8, snippet: "artifact" },
+      ],
+    },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const results = (await manager?.search("q")) ?? [];
+    assert.deepEqual(
+      results.map((hit) => hit.citation),
+      [path.join("facts", "a.md")],
+      "the ordinary hit survives and the corpus's own artifact is still excluded",
+    );
+  } finally {
+    await stub.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -23,6 +23,8 @@ type DaemonStub = {
 
 type StubRoutes = {
   health?: unknown;
+  /** A literal response body, for shapes `JSON.stringify` would normalize. */
+  healthRaw?: string;
   healthStatus?: number;
   search?: unknown;
   searchStatus?: number;
@@ -39,8 +41,14 @@ async function startDaemonStub(routes: StubRoutes): Promise<DaemonStub> {
       calls.push({ pathname, body: raw ? JSON.parse(raw) : undefined });
       const isSearch = pathname.endsWith("/memories/search");
       const status = isSearch ? (routes.searchStatus ?? 200) : (routes.healthStatus ?? 200);
-      const payload = isSearch ? routes.search : routes.health;
       res.writeHead(status, { "content-type": "application/json" });
+      if (!isSearch && routes.healthRaw !== undefined) {
+        // A literal body, so a test can send a 200 that is valid JSON but not
+        // a record — the shape `?? {}` would otherwise paper over.
+        res.end(routes.healthRaw);
+        return;
+      }
+      const payload = isSearch ? routes.search : routes.health;
       res.end(JSON.stringify(payload ?? {}));
     });
   });
@@ -160,7 +168,10 @@ test("delegate search maps daemon hits into runtime results", async () => {
       },
     ]);
     const searchCall = stub.calls.find((call) => call.pathname.endsWith("/memories/search"));
-    assert.deepEqual(searchCall?.body, { query: "alice", maxResults: 5, mode: "search" });
+    // Headroom: artifacts and sub-minScore hits are dropped on this side, so
+    // the daemon is asked for more than the caller's budget and the cap lands
+    // on the FILTERED list.
+    assert.deepEqual(searchCall?.body, { query: "alice", maxResults: 15, mode: "search" });
   } finally {
     await stub.close();
     await rm(memoryDir, { recursive: true, force: true });
@@ -749,6 +760,71 @@ test("delegate readFile refuses artifact paths", async () => {
       () => manager?.readFile({ relPath: "artifacts/report.md" }) ?? Promise.resolve(),
       /artifact path/,
       "search filters artifacts; the read path must not be a way around that",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate search caps AFTER dropping artifacts, not before", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // Every one of the top-ranked hits is an artifact. Capping first would
+  // return an empty page even though valid memories rank right behind them.
+  const stub = await startDaemonStub({
+    health: healthyDaemon(memoryDir),
+    search: {
+      query: "q",
+      count: 5,
+      results: [
+        { path: "artifacts/a1.md", score: 0.99, snippet: "artifact" },
+        { path: "artifacts/a2.md", score: 0.98, snippet: "artifact" },
+        { path: "facts/one.md", score: 0.5, snippet: "one" },
+        { path: "facts/two.md", score: 0.4, snippet: "two" },
+        { path: "facts/three.md", score: 0.3, snippet: "three" },
+      ],
+    },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const results = (await manager?.search("q", { maxResults: 2 })) ?? [];
+    assert.deepEqual(
+      results.map((hit) => hit.citation),
+      [path.join("facts", "one.md"), path.join("facts", "two.md")],
+      "a full page of real memories, and never more than the budget",
+    );
+    const searchCall = stub.calls.find((call) => call.pathname.includes("/memories/search"));
+    assert.equal(
+      (searchCall?.body as { maxResults?: number } | undefined)?.maxResults,
+      6,
+      "asks the daemon for headroom",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate health backs off on a 200 with a malformed body", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // A persistently malformed 200 must not turn every later refresh into an
+  // immediate re-fetch; it backs off exactly like a transport failure.
+  const stub = await startDaemonStub({ healthRaw: "null" });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    // Every entry point that consults health goes through the same refresh, so
+    // three back-to-back handouts would mean three probes with no backoff.
+    await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const healthCalls = stub.calls.filter((call) => call.pathname.includes("/health"));
+    assert.equal(healthCalls.length, 1, "later handouts reuse the backoff, they do not re-probe");
+    // And the malformed payload never becomes a corpus claim.
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.readFile({ relPath: "facts/alice.md" }) ?? Promise.resolve(),
+      /has not been confirmed/,
     );
   } finally {
     await stub.close();

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -839,3 +839,43 @@ test("delegate health backs off on a 200 with a malformed body", async () => {
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("delegate search with no budget keeps the daemon's page size on the wire", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: healthyDaemon(memoryDir),
+    search: {
+      query: "q",
+      count: 3,
+      results: [
+        { path: "artifacts/a1.md", score: 0.9, snippet: "artifact" },
+        { path: "facts/one.md", score: 0.5, snippet: "one" },
+        { path: "facts/two.md", score: 0.4, snippet: "two" },
+      ],
+    },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const results = (await manager?.search("q")) ?? [];
+    const searchCalls = stub.calls.filter((call) => call.pathname.includes("/memories/search"));
+    // First request carries no cap - the caller accepted the daemon's page.
+    assert.equal(
+      (searchCalls[0]?.body as { maxResults?: number }).maxResults,
+      undefined,
+      "no invented budget on the wire",
+    );
+    // The artifact thinned that page, so it tops up against what was served.
+    assert.deepEqual(
+      searchCalls.map((call) => (call.body as { maxResults?: number }).maxResults),
+      [undefined, 6],
+    );
+    assert.deepEqual(
+      results.map((hit) => hit.citation),
+      [path.join("facts", "one.md"), path.join("facts", "two.md")],
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -674,3 +674,35 @@ test("delegate search returns empty for a zero result budget without calling the
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("delegate reads a hit from another namespace's storage directory", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const defaultDir = path.join(memoryDir, "namespaces", "generalist");
+  const otherDir = path.join(memoryDir, "namespaces", "team-a");
+  await mkdir(defaultDir, { recursive: true });
+  await mkdir(path.join(otherDir, "facts"), { recursive: true });
+  await writeFile(path.join(otherDir, "facts", "scoped.md"), "team-a fact\n");
+  // Health answers for the DEFAULT namespace, but a session bound to team-a
+  // gets hits under team-a's directory; the host must be able to open them.
+  const stub = await startDaemonStub({
+    health: healthyDaemon(defaultDir),
+    search: {
+      results: [{ path: path.join(otherDir, "facts", "scoped.md"), score: 0.9, snippet: "hit" }],
+    },
+  });
+  try {
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir, {
+        resolveSearchNamespace: async () => "team-a",
+      }),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const [hit] = (await manager?.search("q")) ?? [];
+    assert.ok(hit, "the daemon returned a hit");
+    const page = await manager?.readFile({ relPath: hit.path });
+    assert.equal(page?.text.trim(), "team-a fact", "the host can open its own search hit");
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -1500,3 +1500,96 @@ test("delegate search rejects a malformed score and an invalid minScore", async 
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("a cached flat posture expires far sooner than the rest of the snapshot", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // A flat posture is the one value that licenses an UNSCOPED request, so a
+  // daemon repartitioning mid-TTL would turn it into a fan-out.
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
+  });
+  try {
+    let clock = 1_000;
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      resolveSearchNamespace: async () => undefined,
+      now: () => clock,
+    });
+    await built.resolveScopedNamespace(undefined);
+    const afterFirst = stub.calls.filter((call) => call.pathname.includes("/health")).length;
+    assert.equal(afterFirst, 1);
+    // Still inside the FLAT window: no re-probe.
+    clock += 4_000;
+    await built.resolveScopedNamespace(undefined);
+    assert.equal(stub.calls.filter((call) => call.pathname.includes("/health")).length, 1);
+    // Past it, but well inside the ordinary 30s snapshot TTL: re-probed.
+    clock += 2_000;
+    await built.resolveScopedNamespace(undefined);
+    assert.equal(
+      stub.calls.filter((call) => call.pathname.includes("/health")).length,
+      2,
+      "the licensing value is re-confirmed long before the rest of the snapshot",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("the authorization probe names the operation the caller is performing", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  // A token may grant recall/observe/flush but not memory_search. Probing a
+  // hard-coded operation would reject those locally before their own route
+  // could authorize them.
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: true, defaultNamespace: "default" },
+    search: { query: "q", count: 0, results: [] },
+  });
+  try {
+    const asked: Array<readonly string[] | undefined> = [];
+    const built = createDelegateMemoryCapability({
+      ...optionsFor(stub.port, memoryDir, workspaceDir),
+      resolveSearchNamespace: async () => undefined,
+      verifyNamespaceAuthorization: async (_ns, _timeout, operations) => {
+        asked.push(operations);
+        // Only memory_search is denied for this token.
+        return !(operations ?? []).includes("memory_search");
+      },
+    });
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await assert.rejects(
+      () => manager?.search("q") ?? Promise.resolve(),
+      /is not authorized for the delegate token/,
+      "search names memory_search and is correctly refused",
+    );
+    // A flush-scoped resolution names its own operation and is allowed.
+    assert.equal(
+      await built.resolveScopedNamespace(undefined, undefined, ["lcm_compaction_flush"]),
+      "default",
+    );
+    assert.deepEqual(asked, [["memory_search"], ["lcm_compaction_flush"]]);
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("an invalid caller budget is rejected at the boundary", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), namespacesEnabled: false },
+  });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    for (const timeoutMs of [Number.NaN, Number.POSITIVE_INFINITY, 12.5]) {
+      await assert.rejects(
+        () => built.resolveScopedNamespace(undefined, timeoutMs),
+        /timeoutMs must be a finite integer/,
+        `timeoutMs: ${String(timeoutMs)} must be rejected`,
+      );
+    }
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-capability.test.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.test.ts
@@ -628,3 +628,49 @@ test("delegate roots reads and artifacts on the daemon's namespace directory", a
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("delegate search sends the daemon's default namespace, never an absent one", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({
+    health: { ...healthyDaemon(memoryDir), defaultNamespace: "generalist" },
+    search: { results: [] },
+  });
+  try {
+    const built = createDelegateMemoryCapability(
+      optionsFor(stub.port, memoryDir, workspaceDir, {
+        // A session bound to the default namespace is stored as "", which the
+        // runtime resolver collapses to undefined.
+        resolveSearchNamespace: async () => undefined,
+      }),
+    );
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    await manager?.search("q");
+    const body = stub.calls.find((call) => call.pathname.endsWith("/memories/search"))?.body;
+    assert.deepEqual(
+      body,
+      { query: "q", mode: "search", namespace: "generalist" },
+      "an absent namespace would be a principal-wide fan-out, not the default scope",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("delegate search returns empty for a zero result budget without calling the daemon", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const stub = await startDaemonStub({ health: healthyDaemon(memoryDir), search: { results: [] } });
+  try {
+    const built = createDelegateMemoryCapability(optionsFor(stub.port, memoryDir, workspaceDir));
+    const { manager } = await built.runtime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    assert.deepEqual(await manager?.search("q", { maxResults: 0 }), []);
+    assert.equal(
+      stub.calls.some((call) => call.pathname.endsWith("/memories/search")),
+      false,
+      "the daemon schema requires maxResults >= 1, so forwarding 0 would 400 a valid request",
+    );
+  } finally {
+    await stub.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -319,21 +319,25 @@ export function createDelegateMemoryCapability(
    * enforces it. A daemon that cannot answer the probe (older build) is
    * treated as before: unproven, not refused.
    */
-  // A separate flag, not `??=` on the verdict: an "unknown" answer is a real
-  // outcome, and re-probing it on every search would put a request in front of
-  // each one against an older daemon.
+  // Keyed by namespace AND token: daemon requests resolve credentials
+  // dynamically, so caching a refusal against the namespace alone would keep
+  // rejecting unbound searches locally after an operator swapped in a token
+  // that IS authorized — recall and observe would recover, search would not.
+  // A map (not `??=`) because "unknown" is a real verdict: re-probing it would
+  // put a request in front of every search against an older daemon.
   const substitutedNamespaceVerdicts = new Map<string, boolean | undefined>();
   const resolveScopedNamespaceChecked = async (explicit?: string): Promise<string | undefined> => {
     const namespace = requireScopedNamespace(explicit);
     if (explicit !== undefined || namespace === undefined) return namespace;
     if (options.verifyNamespaceAuthorization === undefined) return namespace;
-    if (!substitutedNamespaceVerdicts.has(namespace)) {
+    const verdictKey = `${target.resolveAuthToken().token}\u0000${namespace}`;
+    if (!substitutedNamespaceVerdicts.has(verdictKey)) {
       substitutedNamespaceVerdicts.set(
-        namespace,
+        verdictKey,
         await options.verifyNamespaceAuthorization(namespace),
       );
     }
-    if (substitutedNamespaceVerdicts.get(namespace) === false) {
+    if (substitutedNamespaceVerdicts.get(verdictKey) === false) {
       throw new Error(
         `delegate request unavailable: this session has no namespace binding and the daemon's default (${namespace}) is not authorized for the delegate token — bind the session explicitly or configure the namespace this deployment should use`,
       );

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -156,8 +156,12 @@ function readHealth(payload: Record<string, unknown>): DaemonMemoryHealth {
  * `registerDelegateMemoryCapability`, which wires them into the host.
  */
 export type DelegateMemoryCapability = {
-  /** The daemon's default namespace, for callers that must scope concretely. */
-  daemonDefaultNamespace: () => Promise<string | undefined>;
+  /**
+   * Apply the daemon's default to an unresolved namespace and refuse when even
+   * that is unknown on a namespace-partitioned daemon. Shared with the hook
+   * paths so prompt recall cannot fan wider than tool search.
+   */
+  resolveScopedNamespace: (explicit?: string) => Promise<string | undefined>;
   runtime: RemnicCapabilityRuntime;
   flushPlanResolver: () => MemoryFlushPlan;
   listArtifacts: () => Promise<unknown[]>;
@@ -223,6 +227,24 @@ export function createDelegateMemoryCapability(
     throw new Error(`delegate ${surface} unavailable: ${detail}`);
   };
 
+  /**
+   * refreshHealth deliberately swallows probe failures, so a transient or
+   * legacy response can leave both the caller's namespace and the daemon
+   * default undefined. On a namespace-partitioned daemon an absent namespace
+   * means "fan out across everything the principal can read", which is outside
+   * the session's scope — refuse instead of widening it. A flat corpus has
+   * nothing to widen to, so it proceeds unscoped.
+   */
+  const requireScopedNamespace = (explicit?: string): string | undefined => {
+    const namespace = explicit ?? health.defaultNamespace;
+    if (namespace === undefined && health.namespacesEnabled) {
+      throw new Error(
+        "delegate request unavailable: the daemon's default namespace is unknown, so the session scope cannot be resolved",
+      );
+    }
+    return namespace;
+  };
+
   // `status()` is synchronous in the host contract, so the async probe runs in
   // getMemorySearchManager (which IS async) and status() reads the snapshot.
   const refreshHealth = async (): Promise<void> => {
@@ -281,19 +303,9 @@ export function createDelegateMemoryCapability(
     // An empty namespace means "the daemon's default", but the daemon reads an
     // ABSENT namespace as a principal-wide fan-out. Send the concrete default
     // health reports so a default-scoped session cannot see other namespaces.
-    const resolved = await options.resolveSearchNamespace(opts?.sessionKey);
-    const namespace = resolved ?? health.defaultNamespace;
-    // refreshHealth deliberately swallows probe failures, so a transient or
-    // legacy health response can leave BOTH values undefined. On a
-    // namespace-partitioned daemon an absent namespace means "fan out across
-    // everything the principal can read", which is outside the session's
-    // scope — refuse instead of widening it. A flat corpus has nothing to
-    // widen to, so it proceeds.
-    if (namespace === undefined && health.namespacesEnabled) {
-      throw new Error(
-        "delegate search unavailable: the daemon's default namespace is unknown, so the session scope cannot be resolved",
-      );
-    }
+    const namespace = requireScopedNamespace(
+      await options.resolveSearchNamespace(opts?.sessionKey),
+    );
     // Mirror the embedded manager: "vsearch" is vector ranking, "query" is the
     // ordinary search plan, anything else is the backend default.
     // Embedded defaults to "search" when the host passes no override, and an
@@ -428,9 +440,9 @@ export function createDelegateMemoryCapability(
   };
 
   return {
-    daemonDefaultNamespace: async (): Promise<string | undefined> => {
+    resolveScopedNamespace: async (explicit?: string): Promise<string | undefined> => {
       await refreshHealth();
-      return health.defaultNamespace;
+      return requireScopedNamespace(explicit);
     },
     runtime: {
       async getMemorySearchManager() {

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -378,8 +378,15 @@ export function createDelegateMemoryCapability(
     if (!substitutedNamespaceVerdicts.has(verdictKey)) {
       // Inside a shared deadline this must not start its own fixed-timeout
       // request: a flush that already spent most of its budget on capability
-      // and binding work would overrun the hook before draining.
-      if (timeoutMs !== undefined && timeoutMs <= 0) return namespace;
+      // and binding work would overrun the hook before draining. But a
+      // SUBSTITUTED default is an authorization fact, so running unverified is
+      // not the safe degradation — refuse, exactly as an unconfirmed posture
+      // refuses an absent namespace. A cached verdict still answers for free.
+      if (timeoutMs !== undefined && timeoutMs <= 0) {
+        throw new Error(
+          `delegate request unavailable: the delegate token's authorization for the daemon's default namespace (${namespace}) could not be verified within the caller's deadline, so an unscoped request is not safe`,
+        );
+      }
       substitutedNamespaceVerdicts.set(
         verdictKey,
         await options.verifyNamespaceAuthorization(namespace, timeoutMs, operations),

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -197,7 +197,7 @@ export type DelegateMemoryCapability = {
    * that is unknown on a namespace-partitioned daemon. Shared with the hook
    * paths so prompt recall cannot fan wider than tool search.
    */
-  resolveScopedNamespace: (explicit?: string) => Promise<string | undefined>;
+  resolveScopedNamespace: (explicit?: string, timeoutMs?: number) => Promise<string | undefined>;
   runtime: RemnicCapabilityRuntime;
   flushPlanResolver: () => MemoryFlushPlan;
   listArtifacts: () => Promise<unknown[]>;
@@ -342,7 +342,10 @@ export function createDelegateMemoryCapability(
   // A map (not `??=`) because "unknown" is a real verdict: re-probing it would
   // put a request in front of every search against an older daemon.
   const substitutedNamespaceVerdicts = new Map<string, boolean | undefined>();
-  const resolveScopedNamespaceChecked = async (explicit?: string): Promise<string | undefined> => {
+  const resolveScopedNamespaceChecked = async (
+    explicit?: string,
+    timeoutMs?: number,
+  ): Promise<string | undefined> => {
     const namespace = requireScopedNamespace(explicit);
     if (explicit !== undefined || namespace === undefined) return namespace;
     if (options.verifyNamespaceAuthorization === undefined) return namespace;
@@ -363,14 +366,23 @@ export function createDelegateMemoryCapability(
 
   // `status()` is synchronous in the host contract, so the async probe runs in
   // getMemorySearchManager (which IS async) and status() reads the snapshot.
-  const refreshHealth = async (): Promise<void> => {
+  const refreshHealth = async (timeoutMs?: number): Promise<void> => {
     if (now() < healthExpiresAt) return;
+    // A caller inside a shared deadline (the lifecycle flushes) passes what is
+    // LEFT of it. Zero or less means the budget is already spent: starting a
+    // fresh probe here would overrun the hook and get it abandoned before the
+    // buffer drains, so the last known snapshot answers instead.
+    if (timeoutMs !== undefined && timeoutMs <= 0) return;
     if (healthInFlight !== undefined) return healthInFlight;
     healthInFlight = (async () => {
       try {
         const response = await fetch(daemonUrl(target, "/engram/v1/health"), {
           headers: daemonAuthHeaders(target),
-          signal: AbortSignal.timeout(options.healthTimeoutMs),
+          signal: AbortSignal.timeout(
+            timeoutMs === undefined
+              ? options.healthTimeoutMs
+              : Math.min(options.healthTimeoutMs, timeoutMs),
+          ),
         });
         if (!response.ok) {
           await response.body?.cancel();
@@ -384,19 +396,16 @@ export function createDelegateMemoryCapability(
           // immediately and hammer a persistently malformed daemon.
           throw new Error("daemon /engram/v1/health returned a malformed envelope");
         }
-        const reported = readHealth(healthPayload);
-        health = {
-          ...reported,
-          // A daemon that does not report a posture (older build, or a token
-          // without health access) must not ERASE what the plugin already
-          // knows about its own deployment. Anything the daemon does report
-          // wins.
-          namespacesEnabled: reported.namespacesEnabled ?? options.configuredNamespacesEnabled,
-          // Same reason: a 200 that omits `memoryDir` (older build, or a token
-          // without health access) must not ERASE the configured path and
-          // leave `corpusShared` false beside a co-located corpus.
-          memoryDir: reported.memoryDir ?? health.memoryDir,
-        };
+        // VERBATIM. The seeded snapshot covers the window before any probe
+        // answers and the window where one is failing, but a daemon that
+        // ANSWERED and stayed silent about its posture is genuinely unknown -
+        // and the plugin's config describes its OWN deployment, not the
+        // daemon's. Substituting it here would let a flat plugin config mark a
+        // partitioned daemon `false`, permitting an absent namespace and
+        // fanning `/memories/search` across everything the token can read. The
+        // same substitution for `memoryDir` would compare the plugin's path to
+        // itself and enable file-backed reads with no proof at all.
+        health = readHealth(healthPayload);
         healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
         lastHealthFailure = undefined;
         // Path identity is decided by canonicalizing two strings ON THIS
@@ -437,6 +446,18 @@ export function createDelegateMemoryCapability(
     // the daemon schema's `maxResults >= 1` and turn a valid no-results request
     // into a 400 purely by switching bridge mode.
     if (opts?.maxResults === 0) return [];
+    // Beyond the exact-zero short circuit, an out-of-range budget is a caller
+    // bug, not something to reinterpret: coercing a negative to 1, truncating
+    // a fraction, or dropping a non-finite value to the daemon default all
+    // return a valid-looking page for a budget nobody asked for.
+    if (
+      opts?.maxResults !== undefined &&
+      (!Number.isInteger(opts.maxResults) || opts.maxResults < 0)
+    ) {
+      throw new Error(
+        `delegate search rejected (maxResults must be a non-negative integer): ${String(opts.maxResults)}`,
+      );
+    }
     // A cached manager can outlive the probe that handed it out. Without this,
     // a single transient health failure sticks a namespace refusal on every
     // later search while recall/observe recover on their next scoped call.
@@ -445,10 +466,7 @@ export function createDelegateMemoryCapability(
     // minScore are dropped on this side, so asking the daemon for exactly
     // `maxResults` would let a few excluded hits shrink — or empty — a page
     // that has valid lower-ranked memories behind it.
-    const requestedResults =
-      typeof opts?.maxResults === "number" && Number.isFinite(opts.maxResults)
-        ? Math.max(1, Math.floor(opts.maxResults))
-        : undefined;
+    const requestedResults = typeof opts?.maxResults === "number" ? opts.maxResults : undefined;
     // An empty namespace means "the daemon's default", but the daemon reads an
     // ABSENT namespace as a principal-wide fan-out. Send the concrete default
     // health reports so a default-scoped session cannot see other namespaces.
@@ -640,9 +658,12 @@ export function createDelegateMemoryCapability(
   };
 
   return {
-    resolveScopedNamespace: async (explicit?: string): Promise<string | undefined> => {
-      await refreshHealth();
-      return await resolveScopedNamespaceChecked(explicit);
+    resolveScopedNamespace: async (
+      explicit?: string,
+      timeoutMs?: number,
+    ): Promise<string | undefined> => {
+      await refreshHealth(timeoutMs);
+      return await resolveScopedNamespaceChecked(explicit, timeoutMs);
     },
     runtime: {
       async getMemorySearchManager() {

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -778,11 +778,22 @@ export function createDelegateMemoryCapability(
       timeoutMs?: number,
       operations?: readonly string[],
     ): Promise<string | undefined> => {
-      // An explicit scope is the caller's own and the daemon enforces it, so
-      // it rides the cache. An ABSENT one is decided by the posture, which is
-      // an authorization fact and must be current.
-      const fresh = await refreshHealth(timeoutMs, explicit === undefined);
-      return await resolveScopedNamespaceChecked(explicit, timeoutMs, fresh, operations);
+      // An explicit scope is the caller's OWN and the daemon enforces it on
+      // the operation endpoint. It needs no health fact and no authorization
+      // probe, so a cold cache must not spend the hook's deadline here — a
+      // `/health` that eats the prompt budget would drop memory injection for
+      // a recall the daemon was ready to serve.
+      if (explicit !== undefined) {
+        return await resolveScopedNamespaceChecked(explicit, timeoutMs, true, operations);
+      }
+      // An ABSENT scope is decided by the posture, which is an authorization
+      // fact and must be current. The posture probe and the authorization
+      // probe below share ONE deadline: billing each the full remaining budget
+      // would overrun the hook before its own request runs.
+      const deadline = timeoutMs === undefined ? undefined : now() + timeoutMs;
+      const fresh = await refreshHealth(timeoutMs, true);
+      const remaining = deadline === undefined ? undefined : Math.floor(deadline - now());
+      return await resolveScopedNamespaceChecked(undefined, remaining, fresh, operations);
     },
     runtime: {
       async getMemorySearchManager() {

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -117,6 +117,12 @@ export type DelegateCapabilityOptions = {
   flushModel?: string;
   /** Fallback backend facts used until the first health probe answers. */
   configuredSearchBackend: "qmd" | "builtin";
+  /**
+   * The plugin's own `namespacesEnabled`, used to SEED the health snapshot so
+   * a single-corpus deployment is not refused before the first probe answers
+   * (or while one is failing). The daemon's own report overwrites it.
+   */
+  configuredNamespacesEnabled: boolean;
   configuredQmdCommand: string;
   searchTimeoutMs: number;
   healthTimeoutMs: number;
@@ -134,7 +140,13 @@ const HEALTH_CACHE_TTL_MS = 30_000;
  * limit, NOT a stand-in for corpus exhaustion: only a short page or a
  * satisfied budget ends the loop sooner.
  */
-const SEARCH_CANDIDATE_CEILING = 1_000;
+const SEARCH_CANDIDATE_FLOOR = 1_000;
+
+/** Always ABOVE the caller's budget, or one filtered hit could never be
+ * replaced on a large request. Mirrors the core search helper. */
+function searchCandidateCeiling(budget: number): number {
+  return Math.max(SEARCH_CANDIDATE_FLOOR, budget * 4);
+}
 // A failing probe backs off instead of retrying on every hook, so a daemon
 // that is down or rejecting the token cannot turn each turn into a request.
 const HEALTH_FAILURE_BACKOFF_MS = 5_000;
@@ -236,6 +248,10 @@ export function createDelegateMemoryCapability(
     searchBackend: options.configuredSearchBackend,
     qmdEnabled: options.configuredSearchBackend === "qmd",
     qmdAvailable: options.configuredSearchBackend === "qmd",
+    // Same field the daemon reports and `requireScopedNamespace` reads. A
+    // partitioned plugin config seeds `true`, which is the fail-closed value:
+    // only an explicit `false` makes an absent namespace safe.
+    namespacesEnabled: options.configuredNamespacesEnabled,
   };
   let healthExpiresAt = 0;
   let healthInFlight: Promise<void> | undefined;
@@ -368,7 +384,15 @@ export function createDelegateMemoryCapability(
           // immediately and hammer a persistently malformed daemon.
           throw new Error("daemon /engram/v1/health returned a malformed envelope");
         }
-        health = readHealth(healthPayload);
+        const reported = readHealth(healthPayload);
+        health = {
+          ...reported,
+          // A daemon that does not report a posture (older build, or a token
+          // without health access) must not ERASE what the plugin already
+          // knows about its own deployment. Anything the daemon does report
+          // wins.
+          namespacesEnabled: reported.namespacesEnabled ?? options.configuredNamespacesEnabled,
+        };
         healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
         lastHealthFailure = undefined;
         // Path identity is decided by canonicalizing two strings ON THIS
@@ -518,8 +542,9 @@ export function createDelegateMemoryCapability(
       // nothing left, so asking again just replays the same rows.
       const served = limit ?? rawResults.length;
       if (rawResults.length === 0 || rawResults.length < served) break;
-      if (served >= SEARCH_CANDIDATE_CEILING) break;
-      limit = Math.min(served * 2, SEARCH_CANDIDATE_CEILING);
+      const ceiling = searchCandidateCeiling(budget);
+      if (served >= ceiling) break;
+      limit = Math.min(served * 2, ceiling);
     }
     return kept.slice(0, budget);
   };

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -94,9 +94,16 @@ export type DelegateCapabilityOptions = {
    * token gets an actionable refusal instead of a 403 on its first search.
    * `undefined` means the daemon could not answer - unproven, not refused.
    */
+  /**
+   * `operations` names what the CALLER is about to do. A token may grant
+   * recall, observe, and flush but not `memory_search`; probing a hard-coded
+   * operation would reject those otherwise-authorized calls locally, before
+   * their own daemon route could authorize them.
+   */
   verifyNamespaceAuthorization?: (
     namespace: string,
     timeoutMs?: number,
+    operations?: readonly string[],
   ) => Promise<boolean | undefined>;
   memoryDir: string;
   workspaceDir: string;
@@ -128,6 +135,13 @@ export type DelegateCapabilityOptions = {
 };
 
 const HEALTH_CACHE_TTL_MS = 30_000;
+/**
+ * A cached `namespacesEnabled: false` is the one value that LICENSES an
+ * unscoped request, so it is the one a daemon repartitioning mid-TTL turns
+ * into a principal-wide fan-out. It expires far sooner than the rest of the
+ * snapshot; everything else is merely informational.
+ */
+const FLAT_POSTURE_CACHE_TTL_MS = 5_000;
 /**
  * Ceiling on how many candidates one delegate search will ask the daemon for.
  *
@@ -194,7 +208,11 @@ export type DelegateMemoryCapability = {
    * that is unknown on a namespace-partitioned daemon. Shared with the hook
    * paths so prompt recall cannot fan wider than tool search.
    */
-  resolveScopedNamespace: (explicit?: string, timeoutMs?: number) => Promise<string | undefined>;
+  resolveScopedNamespace: (
+    explicit?: string,
+    timeoutMs?: number,
+    operations?: readonly string[],
+  ) => Promise<string | undefined>;
   runtime: RemnicCapabilityRuntime;
   flushPlanResolver: () => MemoryFlushPlan;
   listArtifacts: () => Promise<unknown[]>;
@@ -343,6 +361,7 @@ export function createDelegateMemoryCapability(
     explicit?: string,
     timeoutMs?: number,
     healthIsFresh = true,
+    operations?: readonly string[],
   ): Promise<string | undefined> => {
     // An unconfirmed snapshot cannot license an ABSENT namespace: the daemon
     // may have restarted partitioned since it was taken, and the flush would
@@ -356,7 +375,7 @@ export function createDelegateMemoryCapability(
     const namespace = requireScopedNamespace(explicit);
     if (explicit !== undefined || namespace === undefined) return namespace;
     if (options.verifyNamespaceAuthorization === undefined) return namespace;
-    const verdictKey = `${target.resolveAuthToken().token}\u0000${namespace}`;
+    const verdictKey = `${target.resolveAuthToken().token}\u0000${(operations ?? []).join(",")}\u0000${namespace}`;
     if (!substitutedNamespaceVerdicts.has(verdictKey)) {
       // Inside a shared deadline this must not start its own fixed-timeout
       // request: a flush that already spent most of its budget on capability
@@ -364,7 +383,7 @@ export function createDelegateMemoryCapability(
       if (timeoutMs !== undefined && timeoutMs <= 0) return namespace;
       substitutedNamespaceVerdicts.set(
         verdictKey,
-        await options.verifyNamespaceAuthorization(namespace, timeoutMs),
+        await options.verifyNamespaceAuthorization(namespace, timeoutMs, operations),
       );
     }
     if (substitutedNamespaceVerdicts.get(verdictKey) === false) {
@@ -383,6 +402,14 @@ export function createDelegateMemoryCapability(
    * values on hand are stale — safety facts read from them are unproven.
    */
   const refreshHealth = async (timeoutMs?: number): Promise<boolean> => {
+    // `NaN` would slip past every `<= 0` comparison and reach
+    // `AbortSignal.timeout` as an invalid duration; a fraction would be
+    // silently truncated. Both are caller bugs across an untyped boundary.
+    if (timeoutMs !== undefined && (!Number.isInteger(timeoutMs) || !Number.isFinite(timeoutMs))) {
+      throw new Error(
+        `delegate request rejected (timeoutMs must be a finite integer): ${String(timeoutMs)}`,
+      );
+    }
     if (now() < healthExpiresAt) return true;
     // A caller inside a shared deadline (the lifecycle flushes) passes what is
     // LEFT of it. Zero or less means the budget is already spent: starting a
@@ -444,7 +471,11 @@ export function createDelegateMemoryCapability(
         // same substitution for `memoryDir` would compare the plugin's path to
         // itself and enable file-backed reads with no proof at all.
         health = readHealth(healthPayload);
-        healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
+        healthExpiresAt =
+          now() +
+          (health.namespacesEnabled === false
+            ? FLAT_POSTURE_CACHE_TTL_MS
+            : HEALTH_CACHE_TTL_MS);
         lastHealthFailure = undefined;
         // Path identity is decided by canonicalizing two strings ON THIS
         // HOST, so it proves nothing about a REMOTE daemon that happens to
@@ -534,6 +565,9 @@ export function createDelegateMemoryCapability(
     // health reports so a default-scoped session cannot see other namespaces.
     const namespace = await resolveScopedNamespaceChecked(
       await options.resolveSearchNamespace(opts?.sessionKey),
+      undefined,
+      true,
+      ["memory_search"],
     );
     // Mirror the embedded manager: "vsearch" is vector ranking, "query" is the
     // ordinary search plan, anything else is the backend default.
@@ -727,9 +761,10 @@ export function createDelegateMemoryCapability(
     resolveScopedNamespace: async (
       explicit?: string,
       timeoutMs?: number,
+      operations?: readonly string[],
     ): Promise<string | undefined> => {
       const fresh = await refreshHealth(timeoutMs);
-      return await resolveScopedNamespaceChecked(explicit, timeoutMs, fresh);
+      return await resolveScopedNamespaceChecked(explicit, timeoutMs, fresh, operations);
     },
     runtime: {
       async getMemorySearchManager() {

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -374,7 +374,22 @@ export function createDelegateMemoryCapability(
     // fresh probe here would overrun the hook and get it abandoned before the
     // buffer drains, so the last known snapshot answers instead.
     if (timeoutMs !== undefined && timeoutMs <= 0) return;
-    if (healthInFlight !== undefined) return healthInFlight;
+    if (healthInFlight !== undefined) {
+      // An in-flight probe was started by whoever got here first, possibly on
+      // the full health timeout. A caller inside a shared deadline must not
+      // inherit that: it waits only for what it has left, then answers from
+      // the current snapshot. The probe itself is left running for the caller
+      // that owns it.
+      if (timeoutMs === undefined) return healthInFlight;
+      await Promise.race([
+        healthInFlight,
+        new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, timeoutMs);
+          timer.unref?.();
+        }),
+      ]);
+      return;
+    }
     healthInFlight = (async () => {
       try {
         const response = await fetch(daemonUrl(target, "/engram/v1/health"), {
@@ -426,6 +441,15 @@ export function createDelegateMemoryCapability(
       } catch (err) {
         // Keep the last known snapshot and retry after a backoff. Memory must
         // never break the turn, and a persistent failure must not log per hook.
+        //
+        // But the two SAFETY facts stop being proven the moment a probe fails:
+        // a daemon that was flat may have restarted partitioned, and one that
+        // served this corpus may now serve another. Holding the old values
+        // through the backoff would let an unbound search fan out across a
+        // freshly partitioned corpus, so both revert to unknown and fail
+        // closed until a probe succeeds again.
+        health = { ...health, namespacesEnabled: undefined, memoryDir: undefined };
+        corpusShared = daemonIsLocal ? undefined : false;
         healthExpiresAt = now() + HEALTH_FAILURE_BACKOFF_MS;
         const message = `[${serviceId}] delegate capability health probe failed: ${String(err)}`;
         if (message !== lastHealthFailure) {
@@ -589,17 +613,21 @@ export function createDelegateMemoryCapability(
     // from zero and silently returns the file's head, while `Infinity` returns
     // an empty page and is echoed back as the offset. Neither is the range the
     // caller asked for, so reject rather than serve a different one.
-    if (params.from !== undefined && !Number.isFinite(params.from)) {
-      throw new Error(`memory read rejected (from must be a finite number): ${String(params.from)}`);
-    }
-    if (params.lines !== undefined && !Number.isFinite(params.lines)) {
+    // Clamping a negative to 1 or truncating a fraction returns valid-looking
+    // content for a range the caller did not ask for, which across an untyped
+    // host boundary is indistinguishable from a correct answer.
+    if (params.from !== undefined && (!Number.isInteger(params.from) || params.from < 1)) {
       throw new Error(
-        `memory read rejected (lines must be a finite number): ${String(params.lines)}`,
+        `memory read rejected (from must be a positive integer): ${String(params.from)}`,
       );
     }
-    const from = typeof params.from === "number" ? Math.max(1, Math.floor(params.from)) : 1;
-    const lines =
-      typeof params.lines === "number" ? Math.max(1, Math.floor(params.lines)) : undefined;
+    if (params.lines !== undefined && (!Number.isInteger(params.lines) || params.lines < 1)) {
+      throw new Error(
+        `memory read rejected (lines must be a positive integer): ${String(params.lines)}`,
+      );
+    }
+    const from = typeof params.from === "number" ? params.from : 1;
+    const lines = typeof params.lines === "number" ? params.lines : undefined;
     const startIndex = from - 1;
     const endIndex = typeof lines === "number" ? startIndex + lines : allLines.length;
     const truncated = endIndex < allLines.length;

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -38,7 +38,12 @@ import type {
   RuntimeSearchResult,
   RuntimeStatus,
 } from "./memory-capability-types.js";
-import { createMemoryReadScope, isMemoryArtifactPath } from "./memory-read-scope.js";
+import {
+  createMemoryReadScope,
+  isMemoryArtifactPath,
+  isSessionsMemoryPath,
+  sameMemoryCorpus,
+} from "./memory-read-scope.js";
 import { listRemnicPublicArtifacts } from "./public-artifacts.js";
 
 /** Health facts the runtime surfaces; everything else in the payload is ignored. */
@@ -59,8 +64,19 @@ export type DelegateCapabilityApi = {
 export type DelegateCapabilityOptions = {
   serviceId: string;
   target: DelegateDaemonTarget;
-  /** Session namespace forwarded on daemon calls ("" = daemon default). */
+  /**
+   * Registration-wide fallback namespace ("" = daemon default). Per-search
+   * scoping goes through `resolveSearchNamespace`.
+   */
   namespace: string;
+  /**
+   * Resolve the namespace for one search from the host-supplied session key,
+   * through the SAME per-session binding history the recall/observe/flush
+   * hooks use. Without this, a namespace-enabled deployment would search the
+   * daemon principal's whole readable set while every other delegate path
+   * stayed session-scoped.
+   */
+  resolveSearchNamespace: (sessionKey: string | undefined) => Promise<string | undefined>;
   memoryDir: string;
   workspaceDir: string;
   /** Agent ids this registration owns, for the public-artifact listing. */
@@ -151,6 +167,20 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
   };
   let healthExpiresAt = 0;
   let healthInFlight: Promise<void> | undefined;
+  // Local reads and artifact listing are only valid while the daemon serves
+  // the SAME corpus this plugin is configured for. Until health confirms it,
+  // and after any mismatch, the file-backed surfaces refuse rather than read a
+  // different same-named local file. `undefined` = not yet confirmed.
+  let corpusShared: boolean | undefined;
+  let reportedCorpusMismatch = false;
+  const requireSharedCorpus = (surface: string): void => {
+    if (corpusShared === true) return;
+    const detail =
+      corpusShared === false
+        ? `daemon serves ${health.memoryDir ?? "an unknown memoryDir"}, plugin is configured for ${options.memoryDir}`
+        : "the daemon's corpus has not been confirmed yet";
+    throw new Error(`delegate ${surface} unavailable: ${detail}`);
+  };
 
   // `status()` is synchronous in the host contract, so the async probe runs in
   // getMemorySearchManager (which IS async) and status() reads the snapshot.
@@ -172,6 +202,15 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
         if (healthPayload) {
           health = readHealth(healthPayload);
           healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
+          corpusShared =
+            health.memoryDir !== undefined &&
+            sameMemoryCorpus(options.memoryDir, health.memoryDir);
+          if (!corpusShared && !reportedCorpusMismatch) {
+            reportedCorpusMismatch = true;
+            log.error(
+              `[${serviceId}] delegate capability: the daemon does not serve this plugin's memoryDir (daemon: ${health.memoryDir ?? "unreported"}, plugin: ${options.memoryDir}) — file-backed reads and public artifacts are disabled; search still runs through the daemon`,
+            );
+          }
         }
       } catch (err) {
         // Keep the last known snapshot and retry on the next handout. Memory
@@ -188,7 +227,7 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
     query: string,
     opts?: RuntimeSearchOptions,
   ): Promise<RuntimeSearchResult[]> => {
-    const namespace = options.namespace.trim();
+    const namespace = await options.resolveSearchNamespace(opts?.sessionKey);
     const response = await fetch(daemonUrl(target, "/engram/v1/memories/search"), {
       method: "POST",
       headers: { ...daemonAuthHeaders(target), "Content-Type": "application/json" },
@@ -232,7 +271,7 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
         endLine: 1,
         score,
         snippet: typeof hit.snippet === "string" ? hit.snippet : "",
-        source: citation.includes("sessions/") ? "sessions" : "memory",
+        source: isSessionsMemoryPath(citation) ? "sessions" : "memory",
         citation,
       });
     }
@@ -240,6 +279,7 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
   };
 
   const readMemoryFile = async (params: RuntimeReadParams): Promise<RuntimeReadResult> => {
+    requireSharedCorpus("readFile");
     const requestedPath = readScope.normalizeWorkspacePath(params.relPath);
     const absolutePath = await readScope.resolveReadablePath(params.relPath);
     const allLines = (await readFile(absolutePath, "utf8")).split(/\r?\n/);
@@ -327,6 +367,11 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
       }),
     listArtifacts: async () => {
       try {
+        // The listing walks the LOCAL corpus, so confirm the daemon serves it
+        // before trusting those files. Health may not have been probed yet:
+        // this surface hangs off the capability object, not off a manager.
+        await refreshHealth();
+        requireSharedCorpus("publicArtifacts");
         return await listRemnicPublicArtifacts({
           memoryDir: options.memoryDir,
           workspaceDir: options.workspaceDir,

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -50,6 +50,8 @@ import { listRemnicPublicArtifacts } from "./public-artifacts.js";
 /** Health facts the runtime surfaces; everything else in the payload is ignored. */
 type DaemonMemoryHealth = {
   memoryDir?: string;
+  /** The daemon's configured default namespace, "" on a flat corpus. */
+  defaultNamespace?: string;
   searchBackend: "qmd" | "builtin";
   qmdEnabled: boolean;
   qmdAvailable: boolean;
@@ -128,6 +130,8 @@ function readHealth(payload: Record<string, unknown>): DaemonMemoryHealth {
   const qmdEnabled = searchBackend === "qmd" && payload.qmdEnabled !== false;
   return {
     memoryDir: typeof payload.memoryDir === "string" ? payload.memoryDir : undefined,
+    defaultNamespace:
+      typeof payload.defaultNamespace === "string" ? payload.defaultNamespace : undefined,
     searchBackend,
     qmdEnabled,
     // `active && !degraded` is the daemon's own "search will actually answer"
@@ -241,7 +245,15 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
     query: string,
     opts?: RuntimeSearchOptions,
   ): Promise<RuntimeSearchResult[]> => {
-    const namespace = await options.resolveSearchNamespace(opts?.sessionKey);
+    // Embedded returns an empty set for a zero budget; forwarding 0 would hit
+    // the daemon schema's `maxResults >= 1` and turn a valid no-results request
+    // into a 400 purely by switching bridge mode.
+    if (opts?.maxResults === 0) return [];
+    // An empty namespace means "the daemon's default", but the daemon reads an
+    // ABSENT namespace as a principal-wide fan-out. Send the concrete default
+    // health reports so a default-scoped session cannot see other namespaces.
+    const resolved = await options.resolveSearchNamespace(opts?.sessionKey);
+    const namespace = resolved ?? health.defaultNamespace;
     // Mirror the embedded manager: "vsearch" is vector ranking, "query" is the
     // ordinary search plan, anything else is the backend default.
     // Embedded defaults to "search" when the host passes no override, and an
@@ -257,7 +269,7 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
         // Same override mapping the embedded manager applies, so a host asking
         // for vector or lexical ranking gets the same semantics in either mode.
         mode: searchMode,
-        ...(namespace ? { namespace } : {}),
+        ...(namespace === undefined ? {} : { namespace }),
       }),
       signal: AbortSignal.timeout(options.searchTimeoutMs),
     });

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -136,13 +136,6 @@ export type DelegateCapabilityOptions = {
 
 const HEALTH_CACHE_TTL_MS = 30_000;
 /**
- * A cached `namespacesEnabled: false` is the one value that LICENSES an
- * unscoped request, so it is the one a daemon repartitioning mid-TTL turns
- * into a principal-wide fan-out. It expires far sooner than the rest of the
- * snapshot; everything else is merely informational.
- */
-const FLAT_POSTURE_CACHE_TTL_MS = 5_000;
-/**
  * Ceiling on how many candidates one delegate search will ask the daemon for.
  *
  * A current daemon already excludes artifacts before its own cap, but this
@@ -401,7 +394,17 @@ export function createDelegateMemoryCapability(
    * waiting (spent budget, or a race lost to the caller's deadline) and the
    * values on hand are stale — safety facts read from them are unproven.
    */
-  const refreshHealth = async (timeoutMs?: number): Promise<boolean> => {
+  const refreshHealth = async (
+    timeoutMs?: number,
+    /**
+     * Skip the TTL shortcut. Set when the caller is about to issue an UNSCOPED
+     * request: a cached flat posture is an authorization fact, and a daemon
+     * that restarts partitioned inside the window would turn that request into
+     * a principal-wide fan-out with no probe failure to notice it. An
+     * in-flight probe is still shared, so concurrent callers cost one request.
+     */
+    revalidate = false,
+  ): Promise<boolean> => {
     // `NaN` would slip past every `<= 0` comparison and reach
     // `AbortSignal.timeout` as an invalid duration; a fraction would be
     // silently truncated. Both are caller bugs across an untyped boundary.
@@ -410,7 +413,7 @@ export function createDelegateMemoryCapability(
         `delegate request rejected (timeoutMs must be a finite integer): ${String(timeoutMs)}`,
       );
     }
-    if (now() < healthExpiresAt) return true;
+    if (!revalidate && now() < healthExpiresAt) return true;
     // A caller inside a shared deadline (the lifecycle flushes) passes what is
     // LEFT of it. Zero or less means the budget is already spent: starting a
     // fresh probe here would overrun the hook and get it abandoned before the
@@ -471,11 +474,10 @@ export function createDelegateMemoryCapability(
         // same substitution for `memoryDir` would compare the plugin's path to
         // itself and enable file-backed reads with no proof at all.
         health = readHealth(healthPayload);
-        healthExpiresAt =
-          now() +
-          (health.namespacesEnabled === false
-            ? FLAT_POSTURE_CACHE_TTL_MS
-            : HEALTH_CACHE_TTL_MS);
+        // One TTL for the whole snapshot. The posture does not need a shorter
+        // one because an UNSCOPED request revalidates unconditionally rather
+        // than trusting any cache window.
+        healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
         lastHealthFailure = undefined;
         // Path identity is decided by canonicalizing two strings ON THIS
         // HOST, so it proves nothing about a REMOTE daemon that happens to
@@ -563,12 +565,11 @@ export function createDelegateMemoryCapability(
     // An empty namespace means "the daemon's default", but the daemon reads an
     // ABSENT namespace as a principal-wide fan-out. Send the concrete default
     // health reports so a default-scoped session cannot see other namespaces.
-    const namespace = await resolveScopedNamespaceChecked(
-      await options.resolveSearchNamespace(opts?.sessionKey),
-      undefined,
-      true,
-      ["memory_search"],
-    );
+    const searchScope = await options.resolveSearchNamespace(opts?.sessionKey);
+    const scopeIsFresh = await refreshHealth(undefined, searchScope === undefined);
+    const namespace = await resolveScopedNamespaceChecked(searchScope, undefined, scopeIsFresh, [
+      "memory_search",
+    ]);
     // Mirror the embedded manager: "vsearch" is vector ranking, "query" is the
     // ordinary search plan, anything else is the backend default.
     // Embedded defaults to "search" when the host passes no override, and an
@@ -763,7 +764,10 @@ export function createDelegateMemoryCapability(
       timeoutMs?: number,
       operations?: readonly string[],
     ): Promise<string | undefined> => {
-      const fresh = await refreshHealth(timeoutMs);
+      // An explicit scope is the caller's own and the daemon enforces it, so
+      // it rides the cache. An ABSENT one is decided by the posture, which is
+      // an authorization fact and must be current.
+      const fresh = await refreshHealth(timeoutMs, explicit === undefined);
       return await resolveScopedNamespaceChecked(explicit, timeoutMs, fresh, operations);
     },
     runtime: {

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -169,7 +169,16 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
     if (daemonScope?.dir !== dir) {
       daemonScope = {
         dir,
-        scope: createMemoryReadScope({ memoryDir: dir, workspaceDir: options.workspaceDir }),
+        scope: createMemoryReadScope({
+          // The daemon's own directory comes first, so a relative hit resolves
+          // in the frame the daemon returned it in...
+          memoryDir: dir,
+          workspaceDir: options.workspaceDir,
+          // ...and the corpus ROOT stays readable, so a session bound to a
+          // NON-default namespace can still open the absolute hits its own
+          // search returns from `<root>/namespaces/<other>`.
+          additionalRoots: [options.memoryDir],
+        }),
       };
     }
     return daemonScope.scope;

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -392,6 +392,10 @@ export function createDelegateMemoryCapability(
           // knows about its own deployment. Anything the daemon does report
           // wins.
           namespacesEnabled: reported.namespacesEnabled ?? options.configuredNamespacesEnabled,
+          // Same reason: a 200 that omits `memoryDir` (older build, or a token
+          // without health access) must not ERASE the configured path and
+          // leave `corpusShared` false beside a co-located corpus.
+          memoryDir: reported.memoryDir ?? health.memoryDir,
         };
         healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
         lastHealthFailure = undefined;
@@ -500,7 +504,12 @@ export function createDelegateMemoryCapability(
         // Artifact isolation: the same exclusion the embedded runtime applies.
         // A current daemon already dropped these before its own cap; this
         // keeps the guarantee against an older one.
-        if (isMemoryArtifactPath(rawPath)) continue;
+        //
+        // Judged on the ROOT-RELATIVE citation, never the absolute hit: a
+        // corpus that merely LIVES under a directory named `artifacts`
+        // (`<root>/artifacts/remnic`) would otherwise lose every hit.
+        const citation = sharedScope().relativizeToMemoryRoot(rawPath);
+        if (isMemoryArtifactPath(citation)) continue;
         const score = typeof hit.score === "number" && Number.isFinite(hit.score) ? hit.score : 0;
         if (
           typeof opts?.minScore === "number" &&
@@ -509,7 +518,6 @@ export function createDelegateMemoryCapability(
         ) {
           continue;
         }
-        const citation = sharedScope().relativizeToMemoryRoot(rawPath);
         kept.push({
           // Absolute, so a follow-up readFile is unambiguous when the same
           // relative path exists under more than one allowed root.
@@ -558,11 +566,21 @@ export function createDelegateMemoryCapability(
     const requestedPath = sharedScope().normalizeWorkspacePath(params.relPath);
     const absolutePath = await sharedScope().resolveReadablePath(params.relPath);
     const allLines = (await readFile(absolutePath, "utf8")).split(/\r?\n/);
+    // `NaN` and `Infinity` are numbers: without the finite check `NaN` slices
+    // from zero and silently returns the file's head, while `Infinity` returns
+    // an empty page and is echoed back as the offset. Neither is the range the
+    // caller asked for, so reject rather than serve a different one.
+    if (params.from !== undefined && !Number.isFinite(params.from)) {
+      throw new Error(`memory read rejected (from must be a finite number): ${String(params.from)}`);
+    }
+    if (params.lines !== undefined && !Number.isFinite(params.lines)) {
+      throw new Error(
+        `memory read rejected (lines must be a finite number): ${String(params.lines)}`,
+      );
+    }
     const from = typeof params.from === "number" ? Math.max(1, Math.floor(params.from)) : 1;
     const lines =
-      typeof params.lines === "number" && Number.isFinite(params.lines)
-        ? Math.max(1, Math.floor(params.lines))
-        : undefined;
+      typeof params.lines === "number" ? Math.max(1, Math.floor(params.lines)) : undefined;
     const startIndex = from - 1;
     const endIndex = typeof lines === "number" ? startIndex + lines : allLines.length;
     const truncated = endIndex < allLines.length;

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -27,6 +27,7 @@ import {
   type DelegateDaemonTarget,
   daemonAuthHeaders,
   daemonUrl,
+  isLoopbackDaemonHost,
 } from "./bridge.js";
 import { buildMemoryFlushPlan, type MemoryFlushPlan } from "./memory-flush-plan.js";
 import type {
@@ -216,14 +217,21 @@ export function createDelegateMemoryCapability(
   // the SAME corpus this plugin is configured for. Until health confirms it,
   // and after any mismatch, the file-backed surfaces refuse rather than read a
   // different same-named local file. `undefined` = not yet confirmed.
-  let corpusShared: boolean | undefined;
+  // Locality is knowable without a probe, and it is decisive: canonicalizing
+  // two path strings ON THIS HOST proves nothing about a remote daemon that
+  // happens to use the same absolute pathname. Settle it up front so a remote
+  // target reports the accurate reason instead of "not confirmed yet".
+  const daemonIsLocal = isLoopbackDaemonHost(target.host);
+  let corpusShared: boolean | undefined = daemonIsLocal ? undefined : false;
   let reportedCorpusMismatch = false;
   const requireSharedCorpus = (surface: string): void => {
     if (corpusShared === true) return;
     const detail =
-      corpusShared === false
-        ? `daemon serves ${health.memoryDir ?? "an unknown memoryDir"}, plugin is configured for ${options.memoryDir}`
-        : "the daemon's corpus has not been confirmed yet";
+      corpusShared !== false
+        ? "the daemon's corpus has not been confirmed yet"
+        : daemonIsLocal
+          ? `daemon serves ${health.memoryDir ?? "an unknown memoryDir"}, plugin is configured for ${options.memoryDir}`
+          : `daemon at ${target.host} is not local, so its corpus is not this host's files`;
     throw new Error(`delegate ${surface} unavailable: ${detail}`);
   };
 
@@ -266,10 +274,15 @@ export function createDelegateMemoryCapability(
           health = readHealth(healthPayload);
           healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
           lastHealthFailure = undefined;
+          // Path identity is decided by canonicalizing two strings ON THIS
+          // HOST, so it proves nothing about a REMOTE daemon that happens to
+          // use the same absolute pathname. Explicit `delegate` may target a
+          // remote daemon; the file-backed surfaces may not follow it there.
           corpusShared =
+            daemonIsLocal &&
             health.memoryDir !== undefined &&
             daemonServesCorpus(options.memoryDir, health.memoryDir);
-          if (!corpusShared && !reportedCorpusMismatch) {
+          if (!corpusShared && daemonIsLocal && !reportedCorpusMismatch) {
             reportedCorpusMismatch = true;
             log.error(
               `[${serviceId}] delegate capability: the daemon does not serve this plugin's memoryDir (daemon: ${health.memoryDir ?? "unreported"}, plugin: ${options.memoryDir}) — file-backed reads and public artifacts are disabled; search still runs through the daemon`,

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -88,6 +88,13 @@ export type DelegateCapabilityOptions = {
    * stayed session-scoped.
    */
   resolveSearchNamespace: (sessionKey: string | undefined) => Promise<string | undefined>;
+  /**
+   * Ask the daemon whether the delegate token may use a namespace. Used only
+   * for a SUBSTITUTED default (a session with no binding), so a restricted
+   * token gets an actionable refusal instead of a 403 on its first search.
+   * `undefined` means the daemon could not answer - unproven, not refused.
+   */
+  verifyNamespaceAuthorization?: (namespace: string) => Promise<boolean | undefined>;
   memoryDir: string;
   workspaceDir: string;
   /** Agent ids this registration owns, for the public-artifact listing. */
@@ -207,6 +214,11 @@ export function createDelegateMemoryCapability(
           // in the frame the daemon returned it in...
           memoryDir: dir,
           workspaceDir: options.workspaceDir,
+          // The gateway's own workspace is NOT a readable root here: health
+          // validates `memoryDir` only, so a relative path absent from the
+          // daemon corpus must not be served from a workspace the daemon
+          // never searched or authorized.
+          includeWorkspaceRoot: false,
           // ...and the corpus ROOT stays readable, so a session bound to a
           // NON-default namespace can still open the absolute hits its own
           // search returns from `<root>/namespaces/<other>`.
@@ -295,6 +307,40 @@ export function createDelegateMemoryCapability(
     return namespace;
   };
 
+  /**
+   * The daemon default is a SUBSTITUTION, not something the caller asked for:
+   * a session with no binding yet gets it silently. On a token restricted to
+   * another namespace that turns the very first search into a 403 the host
+   * sees as "memory is broken".
+   *
+   * So a substituted default is verified once against the daemon's own
+   * namespace-aware authorization probe before it is used. An explicit scope
+   * is the caller's own and is not second-guessed here — the daemon still
+   * enforces it. A daemon that cannot answer the probe (older build) is
+   * treated as before: unproven, not refused.
+   */
+  // A separate flag, not `??=` on the verdict: an "unknown" answer is a real
+  // outcome, and re-probing it on every search would put a request in front of
+  // each one against an older daemon.
+  const substitutedNamespaceVerdicts = new Map<string, boolean | undefined>();
+  const resolveScopedNamespaceChecked = async (explicit?: string): Promise<string | undefined> => {
+    const namespace = requireScopedNamespace(explicit);
+    if (explicit !== undefined || namespace === undefined) return namespace;
+    if (options.verifyNamespaceAuthorization === undefined) return namespace;
+    if (!substitutedNamespaceVerdicts.has(namespace)) {
+      substitutedNamespaceVerdicts.set(
+        namespace,
+        await options.verifyNamespaceAuthorization(namespace),
+      );
+    }
+    if (substitutedNamespaceVerdicts.get(namespace) === false) {
+      throw new Error(
+        `delegate request unavailable: this session has no namespace binding and the daemon's default (${namespace}) is not authorized for the delegate token — bind the session explicitly or configure the namespace this deployment should use`,
+      );
+    }
+    return namespace;
+  };
+
   // `status()` is synchronous in the host contract, so the async probe runs in
   // getMemorySearchManager (which IS async) and status() reads the snapshot.
   const refreshHealth = async (): Promise<void> => {
@@ -374,7 +420,7 @@ export function createDelegateMemoryCapability(
     // An empty namespace means "the daemon's default", but the daemon reads an
     // ABSENT namespace as a principal-wide fan-out. Send the concrete default
     // health reports so a default-scoped session cannot see other namespaces.
-    const namespace = requireScopedNamespace(
+    const namespace = await resolveScopedNamespaceChecked(
       await options.resolveSearchNamespace(opts?.sessionKey),
     );
     // Mirror the embedded manager: "vsearch" is vector ranking, "query" is the
@@ -549,7 +595,7 @@ export function createDelegateMemoryCapability(
   return {
     resolveScopedNamespace: async (explicit?: string): Promise<string | undefined> => {
       await refreshHealth();
-      return requireScopedNamespace(explicit);
+      return await resolveScopedNamespaceChecked(explicit);
     },
     runtime: {
       async getMemorySearchManager() {

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -53,8 +53,13 @@ type DaemonMemoryHealth = {
   memoryDir?: string;
   /** The daemon's configured default namespace, "" on a flat corpus. */
   defaultNamespace?: string;
-  /** Whether the daemon partitions storage by namespace at all. */
-  namespacesEnabled: boolean;
+  /**
+   * Whether the daemon partitions storage by namespace. `undefined` when the
+   * payload never said — a malformed or truncated health response must not
+   * read as "flat corpus", which would silently disable the fail-closed
+   * namespace rule for a partitioned deployment.
+   */
+  namespacesEnabled?: boolean;
   searchBackend: "qmd" | "builtin";
   qmdEnabled: boolean;
   qmdAvailable: boolean;
@@ -138,7 +143,8 @@ function readHealth(payload: Record<string, unknown>): DaemonMemoryHealth {
     memoryDir: typeof payload.memoryDir === "string" ? payload.memoryDir : undefined,
     defaultNamespace:
       typeof payload.defaultNamespace === "string" ? payload.defaultNamespace : undefined,
-    namespacesEnabled: payload.namespacesEnabled === true,
+    namespacesEnabled:
+      typeof payload.namespacesEnabled === "boolean" ? payload.namespacesEnabled : undefined,
     searchBackend,
     qmdEnabled,
     // `active && !degraded` is the daemon's own "search will actually answer"
@@ -205,7 +211,6 @@ export function createDelegateMemoryCapability(
   // outage before the first probe answers; the daemon's health overwrites it.
   let health: DaemonMemoryHealth = {
     memoryDir: options.memoryDir,
-    namespacesEnabled: false,
     searchBackend: options.configuredSearchBackend,
     qmdEnabled: options.configuredSearchBackend === "qmd",
     qmdAvailable: options.configuredSearchBackend === "qmd",
@@ -245,7 +250,10 @@ export function createDelegateMemoryCapability(
    */
   const requireScopedNamespace = (explicit?: string): string | undefined => {
     const namespace = explicit ?? health.defaultNamespace;
-    if (namespace === undefined && health.namespacesEnabled) {
+    // `false` is the only value that makes an absent namespace safe. `true`
+    // and `undefined` (never reported, or a probe that failed) both mean the
+    // scope cannot be proven, so both refuse.
+    if (namespace === undefined && health.namespacesEnabled !== false) {
       throw new Error(
         "delegate request unavailable: the daemon's default namespace is unknown, so the session scope cannot be resolved",
       );

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -228,12 +228,23 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
     opts?: RuntimeSearchOptions,
   ): Promise<RuntimeSearchResult[]> => {
     const namespace = await options.resolveSearchNamespace(opts?.sessionKey);
+    // Mirror the embedded manager: "vsearch" is vector ranking, "query" is the
+    // ordinary search plan, anything else is the backend default.
+    const searchMode =
+      opts?.qmdSearchModeOverride === "vsearch"
+        ? "vector"
+        : opts?.qmdSearchModeOverride === "query"
+          ? "search"
+          : undefined;
     const response = await fetch(daemonUrl(target, "/engram/v1/memories/search"), {
       method: "POST",
       headers: { ...daemonAuthHeaders(target), "Content-Type": "application/json" },
       body: JSON.stringify({
         query,
         ...(typeof opts?.maxResults === "number" ? { maxResults: opts.maxResults } : {}),
+        // Same override mapping the embedded manager applies, so a host asking
+        // for vector or lexical ranking gets the same semantics in either mode.
+        ...(searchMode ? { mode: searchMode } : {}),
         ...(namespace ? { namespace } : {}),
       }),
       signal: AbortSignal.timeout(options.searchTimeoutMs),

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -94,7 +94,10 @@ export type DelegateCapabilityOptions = {
    * token gets an actionable refusal instead of a 403 on its first search.
    * `undefined` means the daemon could not answer - unproven, not refused.
    */
-  verifyNamespaceAuthorization?: (namespace: string) => Promise<boolean | undefined>;
+  verifyNamespaceAuthorization?: (
+    namespace: string,
+    timeoutMs?: number,
+  ) => Promise<boolean | undefined>;
   memoryDir: string;
   workspaceDir: string;
   /** Agent ids this registration owns, for the public-artifact listing. */
@@ -117,12 +120,6 @@ export type DelegateCapabilityOptions = {
   flushModel?: string;
   /** Fallback backend facts used until the first health probe answers. */
   configuredSearchBackend: "qmd" | "builtin";
-  /**
-   * The plugin's own `namespacesEnabled`, used to SEED the health snapshot so
-   * a single-corpus deployment is not refused before the first probe answers
-   * (or while one is failing). The daemon's own report overwrites it.
-   */
-  configuredNamespacesEnabled: boolean;
   configuredQmdCommand: string;
   searchTimeoutMs: number;
   healthTimeoutMs: number;
@@ -248,10 +245,10 @@ export function createDelegateMemoryCapability(
     searchBackend: options.configuredSearchBackend,
     qmdEnabled: options.configuredSearchBackend === "qmd",
     qmdAvailable: options.configuredSearchBackend === "qmd",
-    // Same field the daemon reports and `requireScopedNamespace` reads. A
-    // partitioned plugin config seeds `true`, which is the fail-closed value:
-    // only an explicit `false` makes an absent namespace safe.
-    namespacesEnabled: options.configuredNamespacesEnabled,
+    // Deliberately NOT seeded from the plugin's config: that describes this
+    // plugin's own deployment, never the daemon's partitioning. Only a
+    // successful probe can prove a flat corpus, and until one does, an absent
+    // namespace fails closed.
   };
   let healthExpiresAt = 0;
   let healthInFlight: Promise<void> | undefined;
@@ -351,9 +348,13 @@ export function createDelegateMemoryCapability(
     if (options.verifyNamespaceAuthorization === undefined) return namespace;
     const verdictKey = `${target.resolveAuthToken().token}\u0000${namespace}`;
     if (!substitutedNamespaceVerdicts.has(verdictKey)) {
+      // Inside a shared deadline this must not start its own fixed-timeout
+      // request: a flush that already spent most of its budget on capability
+      // and binding work would overrun the hook before draining.
+      if (timeoutMs !== undefined && timeoutMs <= 0) return namespace;
       substitutedNamespaceVerdicts.set(
         verdictKey,
-        await options.verifyNamespaceAuthorization(namespace),
+        await options.verifyNamespaceAuthorization(namespace, timeoutMs),
       );
     }
     if (substitutedNamespaceVerdicts.get(verdictKey) === false) {

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -268,6 +268,10 @@ export function createDelegateMemoryCapability(
   // probe cannot prove anything and would spend the hook budget on a daemon
   // that is down.
   let healthCacheIsFailure = false;
+  // Whether ANY probe has settled. Until one has, the snapshot is all zeroes
+  // and the synchronous `status()` reader would report a daemon posture that
+  // was never observed.
+  let healthEverResolved = false;
   let healthInFlight: Promise<void> | undefined;
   let lastHealthFailure: string | undefined;
   // Local reads and artifact listing are only valid while the daemon serves
@@ -495,6 +499,7 @@ export function createDelegateMemoryCapability(
         // than trusting any cache window.
         healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
         healthCacheIsFailure = false;
+        healthEverResolved = true;
         lastHealthFailure = undefined;
         // Path identity is decided by canonicalizing two strings ON THIS
         // HOST, so it proves nothing about a REMOTE daemon that happens to
@@ -533,6 +538,9 @@ export function createDelegateMemoryCapability(
         corpusShared = daemonIsLocal ? undefined : false;
         healthExpiresAt = now() + HEALTH_FAILURE_BACKOFF_MS;
         healthCacheIsFailure = true;
+        // A failed probe settles the posture too: it is now KNOWN-unavailable
+        // rather than never observed, and the backoff owns the retry.
+        healthEverResolved = true;
         const message = `[${serviceId}] delegate capability health probe failed: ${String(err)}`;
         if (message !== lastHealthFailure) {
           lastHealthFailure = message;
@@ -696,9 +704,13 @@ export function createDelegateMemoryCapability(
   };
 
   const readMemoryFile = async (params: RuntimeReadParams): Promise<RuntimeReadResult> => {
-    // Same reason as `search`: a cached manager can outlive its probe, and a
-    // stale "corpus not confirmed" must not stick past a recovered daemon.
-    await refreshHealth();
+    // REVALIDATED, not merely refreshed. `corpusShared` is a safety fact, and
+    // a daemon that restarts onto another corpus inside the cache window
+    // produces no probe failure to invalidate it — the cached `true` would let
+    // this return a file from the corpus that is no longer being served. The
+    // failure backoff still applies, so a down daemon degrades immediately
+    // rather than probing per read.
+    await refreshHealth(undefined, true);
     requireSharedCorpus("readFile");
     requireSingleCorpusNamespacing("readFile");
     const requestedPath = sharedScope().normalizeWorkspacePath(params.relPath);
@@ -806,7 +818,16 @@ export function createDelegateMemoryCapability(
     },
     runtime: {
       async getMemorySearchManager() {
-        await refreshHealth();
+        // `status()` is SYNCHRONOUS by the host's interface, so it can only
+        // report what a probe has already established. The FIRST handout
+        // therefore waits — an unprobed snapshot has nothing truthful to say.
+        // Afterwards it never waits again: every operation that needs a
+        // current posture refreshes on its own, so blocking per handout only
+        // delays an explicitly scoped search that needs no posture at all, and
+        // pays for two sequential probes on an unscoped one that revalidates.
+        // A background refresh keeps the synchronous reader converging.
+        if (!healthEverResolved) await refreshHealth();
+        else void refreshHealth().catch(() => undefined);
         return { manager };
       },
       resolveMemoryBackendConfig() {
@@ -824,10 +845,13 @@ export function createDelegateMemoryCapability(
       }),
     listArtifacts: async () => {
       try {
-        // The listing walks the LOCAL corpus, so confirm the daemon serves it
-        // before trusting those files. Health may not have been probed yet:
-        // this surface hangs off the capability object, not off a manager.
-        await refreshHealth();
+        // The listing walks the LOCAL corpus, so confirm the daemon still
+        // serves it before trusting those files — revalidated for the same
+        // reason `readFile` is: a restart onto another corpus inside the cache
+        // window leaves no failure behind to notice. Health may also not have
+        // been probed at all yet: this surface hangs off the capability
+        // object, not off a manager.
+        await refreshHealth(undefined, true);
         requireSharedCorpus("publicArtifacts");
         requireSingleCorpusNamespacing("publicArtifacts");
         return await listRemnicPublicArtifacts({

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -42,7 +42,7 @@ import {
   createMemoryReadScope,
   isMemoryArtifactPath,
   isSessionsMemoryPath,
-  sameMemoryCorpus,
+  daemonServesCorpus,
 } from "./memory-read-scope.js";
 import { listRemnicPublicArtifacts } from "./public-artifacts.js";
 
@@ -88,11 +88,11 @@ export type DelegateCapabilityOptions = {
    */
   allowPromptInjection: boolean;
   /**
-   * Non-destructive peek at the recall lines the delegate hook precomputed for
-   * a session. The registered prompt *section* builder owns the destructive
-   * read; the capability builder must not consume the same lines twice.
+   * Read the recall lines the delegate hook precomputed for a session. The
+   * caller decides destructiveness: it peeks when a prompt *section* builder
+   * owns eviction, and consumes when this capability is the sole consumer.
    */
-  peekPromptLines: (sessionKey: string) => string[] | null;
+  readPromptLines: (sessionKey: string) => string[] | null;
   /** Flush-plan sizing input (`extractionMaxTurnChars`). */
   extractionMaxTurnChars?: unknown;
   /** Flush-plan model (`summaryModel` or the task chain primary). */
@@ -204,7 +204,7 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
           healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
           corpusShared =
             health.memoryDir !== undefined &&
-            sameMemoryCorpus(options.memoryDir, health.memoryDir);
+            daemonServesCorpus(options.memoryDir, health.memoryDir);
           if (!corpusShared && !reportedCorpusMismatch) {
             reportedCorpusMismatch = true;
             log.error(
@@ -383,7 +383,7 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
       }
     },
     promptBuilder: (params: { sessionKey?: string }) =>
-      options.peekPromptLines(params?.sessionKey ?? "default"),
+      options.readPromptLines(params?.sessionKey ?? "default"),
   };
 }
 

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -342,7 +342,17 @@ export function createDelegateMemoryCapability(
   const resolveScopedNamespaceChecked = async (
     explicit?: string,
     timeoutMs?: number,
+    healthIsFresh = true,
   ): Promise<string | undefined> => {
+    // An unconfirmed snapshot cannot license an ABSENT namespace: the daemon
+    // may have restarted partitioned since it was taken, and the flush would
+    // fan out under the new posture. An explicit scope is the caller's own and
+    // the daemon still enforces it.
+    if (!healthIsFresh && explicit === undefined) {
+      throw new Error(
+        "delegate request unavailable: the daemon's namespace posture could not be confirmed within the caller's deadline, so an unscoped request is not safe",
+      );
+    }
     const namespace = requireScopedNamespace(explicit);
     if (explicit !== undefined || namespace === undefined) return namespace;
     if (options.verifyNamespaceAuthorization === undefined) return namespace;
@@ -367,28 +377,40 @@ export function createDelegateMemoryCapability(
 
   // `status()` is synchronous in the host contract, so the async probe runs in
   // getMemorySearchManager (which IS async) and status() reads the snapshot.
-  const refreshHealth = async (timeoutMs?: number): Promise<void> => {
-    if (now() < healthExpiresAt) return;
+  /**
+   * Returns whether the snapshot is CURRENT. `false` means this call gave up
+   * waiting (spent budget, or a race lost to the caller's deadline) and the
+   * values on hand are stale — safety facts read from them are unproven.
+   */
+  const refreshHealth = async (timeoutMs?: number): Promise<boolean> => {
+    if (now() < healthExpiresAt) return true;
     // A caller inside a shared deadline (the lifecycle flushes) passes what is
     // LEFT of it. Zero or less means the budget is already spent: starting a
     // fresh probe here would overrun the hook and get it abandoned before the
     // buffer drains, so the last known snapshot answers instead.
-    if (timeoutMs !== undefined && timeoutMs <= 0) return;
+    if (timeoutMs !== undefined && timeoutMs <= 0) return false;
     if (healthInFlight !== undefined) {
       // An in-flight probe was started by whoever got here first, possibly on
       // the full health timeout. A caller inside a shared deadline must not
       // inherit that: it waits only for what it has left, then answers from
       // the current snapshot. The probe itself is left running for the caller
       // that owns it.
-      if (timeoutMs === undefined) return healthInFlight;
-      await Promise.race([
-        healthInFlight,
-        new Promise<void>((resolve) => {
-          const timer = setTimeout(resolve, timeoutMs);
+      if (timeoutMs === undefined) {
+        await healthInFlight;
+        return true;
+      }
+      const TIMED_OUT = Symbol("timed-out");
+      const outcome = await Promise.race([
+        healthInFlight.then(() => undefined),
+        new Promise<typeof TIMED_OUT>((resolve) => {
+          const timer = setTimeout(() => resolve(TIMED_OUT), timeoutMs);
           timer.unref?.();
         }),
       ]);
-      return;
+      // Losing the race means the snapshot on hand was never confirmed by this
+      // call, so the caller must treat it as unproven rather than acting on a
+      // posture the daemon may have changed.
+      return outcome !== TIMED_OUT;
     }
     healthInFlight = (async () => {
       try {
@@ -448,7 +470,16 @@ export function createDelegateMemoryCapability(
         // through the backoff would let an unbound search fan out across a
         // freshly partitioned corpus, so both revert to unknown and fail
         // closed until a probe succeeds again.
-        health = { ...health, namespacesEnabled: undefined, memoryDir: undefined };
+        // `defaultNamespace` goes too: a partitioned daemon can change it
+        // across a restart, and a stale one is NOT undefined, so it would slip
+        // past the unknown-posture guard and bind a fresh session to the
+        // previous tenant's namespace.
+        health = {
+          ...health,
+          namespacesEnabled: undefined,
+          defaultNamespace: undefined,
+          memoryDir: undefined,
+        };
         corpusShared = daemonIsLocal ? undefined : false;
         healthExpiresAt = now() + HEALTH_FAILURE_BACKOFF_MS;
         const message = `[${serviceId}] delegate capability health probe failed: ${String(err)}`;
@@ -460,7 +491,8 @@ export function createDelegateMemoryCapability(
         healthInFlight = undefined;
       }
     })();
-    return healthInFlight;
+    await healthInFlight;
+    return true;
   };
 
   const search = async (
@@ -471,6 +503,11 @@ export function createDelegateMemoryCapability(
     // the daemon schema's `maxResults >= 1` and turn a valid no-results request
     // into a 400 purely by switching bridge mode.
     if (opts?.maxResults === 0) return [];
+    if (opts?.minScore !== undefined && !Number.isFinite(opts.minScore)) {
+      throw new Error(
+        `delegate search rejected (minScore must be a finite number): ${String(opts.minScore)}`,
+      );
+    }
     // Beyond the exact-zero short circuit, an out-of-range budget is a caller
     // bug, not something to reinterpret: coercing a negative to 1, truncating
     // a fraction, or dropping a non-finite value to the daemon default all
@@ -553,14 +590,14 @@ export function createDelegateMemoryCapability(
         // (`<root>/artifacts/remnic`) would otherwise lose every hit.
         const citation = sharedScope().relativizeToMemoryRoot(rawPath);
         if (isMemoryArtifactPath(citation)) continue;
-        const score = typeof hit.score === "number" && Number.isFinite(hit.score) ? hit.score : 0;
-        if (
-          typeof opts?.minScore === "number" &&
-          Number.isFinite(opts.minScore) &&
-          score < opts.minScore
-        ) {
-          continue;
+        // A missing or non-finite score is a protocol failure, not a zero: it
+        // would silently drop the hit under `minScore` and hand callers a
+        // fabricated ranking without one.
+        if (typeof hit.score !== "number" || !Number.isFinite(hit.score)) {
+          throw new Error("daemon /engram/v1/memories/search returned a malformed result entry");
         }
+        const score = hit.score;
+        if (typeof opts?.minScore === "number" && score < opts.minScore) continue;
         kept.push({
           // Absolute, so a follow-up readFile is unambiguous when the same
           // relative path exists under more than one allowed root.
@@ -691,8 +728,8 @@ export function createDelegateMemoryCapability(
       explicit?: string,
       timeoutMs?: number,
     ): Promise<string | undefined> => {
-      await refreshHealth(timeoutMs);
-      return await resolveScopedNamespaceChecked(explicit, timeoutMs);
+      const fresh = await refreshHealth(timeoutMs);
+      return await resolveScopedNamespaceChecked(explicit, timeoutMs, fresh);
     },
     runtime: {
       async getMemorySearchManager() {

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -254,21 +254,23 @@ export function createDelegateMemoryCapability(
    * File-backed surfaces walk ONE local directory: the `memoryDir` health
    * reports. The daemon answers `/engram/v1/health` without a namespace, so
    * that directory is the DEFAULT namespace's storage — not necessarily the
-   * one this capability is scoped to, and not necessarily one the token may
+   * one a given session is scoped to, and not necessarily one the token may
    * read. Corpus containment proves physical co-location, never authorization.
    *
-   * So the local walk is allowed only when there is exactly one corpus to walk
-   * (namespaces disabled) or the scope resolves to the very namespace health
-   * described. Anything else would publish another namespace's facts,
-   * entities, and artifacts while omitting the session's own.
+   * The host contract makes this decidable only one way: `readFile` and
+   * `listArtifacts` carry NO session, so on a namespace-partitioned daemon
+   * there is no scope to check them against — a per-registration fallback
+   * would authorize one namespace's disk for sessions bound to another.
+   * Search is unaffected: it carries `sessionKey` and the daemon enforces.
+   *
+   * So the local walk requires a daemon with exactly one corpus to walk.
+   * Unknown namespacing (older build, or a token without health access) fails
+   * closed the same way.
    */
-  const requireHealthNamespaceScope = async (surface: string): Promise<void> => {
+  const requireSingleCorpusNamespacing = (surface: string): void => {
     if (health.namespacesEnabled === false) return;
-    const scoped = await options.resolveSearchNamespace(undefined);
-    const resolved = scoped ?? health.defaultNamespace;
-    if (resolved !== undefined && resolved === health.defaultNamespace) return;
     throw new Error(
-      `delegate ${surface} unavailable: the daemon reports the ${health.defaultNamespace ?? "unknown"} namespace's storage, but this session is scoped to ${resolved ?? "an unresolved namespace"} — a local walk cannot be authorized for it`,
+      `delegate ${surface} unavailable: the daemon partitions namespaces (${health.namespacesEnabled === true ? `default: ${health.defaultNamespace ?? "unreported"}` : "namespacing unreported"}) and this surface carries no session, so a local read cannot be authorized for the caller's namespace`,
     );
   };
 
@@ -477,7 +479,7 @@ export function createDelegateMemoryCapability(
     // stale "corpus not confirmed" must not stick past a recovered daemon.
     await refreshHealth();
     requireSharedCorpus("readFile");
-    await requireHealthNamespaceScope("readFile");
+    requireSingleCorpusNamespacing("readFile");
     const requestedPath = sharedScope().normalizeWorkspacePath(params.relPath);
     const absolutePath = await sharedScope().resolveReadablePath(params.relPath);
     const allLines = (await readFile(absolutePath, "utf8")).split(/\r?\n/);
@@ -574,7 +576,7 @@ export function createDelegateMemoryCapability(
         // this surface hangs off the capability object, not off a manager.
         await refreshHealth();
         requireSharedCorpus("publicArtifacts");
-        await requireHealthNamespaceScope("publicArtifacts");
+        requireSingleCorpusNamespacing("publicArtifacts");
         return await listRemnicPublicArtifacts({
           memoryDir: health.memoryDir ?? options.memoryDir,
           workspaceDir: options.workspaceDir,

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -119,12 +119,12 @@ export type DelegateCapabilityOptions = {
 
 const HEALTH_CACHE_TTL_MS = 30_000;
 /**
- * Candidate headroom for the delegate search: this side drops artifact paths
- * and sub-`minScore` hits after the daemon ranks, so the request asks for more
- * than the caller's budget and the cap is applied to the filtered list.
+ * Candidate top-up rounds for the delegate search. A current daemon already
+ * excludes artifacts before its own cap, but this side still drops artifacts
+ * (older daemons) and sub-`minScore` hits, so a short page re-asks with a
+ * doubled limit instead of returning fewer memories than the caller budgeted.
  */
-const SEARCH_HEADROOM_FACTOR = 3;
-const SEARCH_HEADROOM_CEILING = 200;
+const SEARCH_TOPUP_ROUNDS = 4;
 // A failing probe backs off instead of retrying on every hook, so a daemon
 // that is down or rejecting the token cannot turn each turn into a request.
 const HEALTH_FAILURE_BACKOFF_MS = 5_000;
@@ -291,24 +291,22 @@ export function createDelegateMemoryCapability(
           // immediately and hammer a persistently malformed daemon.
           throw new Error("daemon /engram/v1/health returned a malformed envelope");
         }
-        {
-          health = readHealth(healthPayload);
-          healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
-          lastHealthFailure = undefined;
-          // Path identity is decided by canonicalizing two strings ON THIS
-          // HOST, so it proves nothing about a REMOTE daemon that happens to
-          // use the same absolute pathname. Explicit `delegate` may target a
-          // remote daemon; the file-backed surfaces may not follow it there.
-          corpusShared =
-            daemonIsLocal &&
-            health.memoryDir !== undefined &&
-            daemonServesCorpus(options.memoryDir, health.memoryDir);
-          if (!corpusShared && daemonIsLocal && !reportedCorpusMismatch) {
-            reportedCorpusMismatch = true;
-            log.error(
-              `[${serviceId}] delegate capability: the daemon does not serve this plugin's memoryDir (daemon: ${health.memoryDir ?? "unreported"}, plugin: ${options.memoryDir}) — file-backed reads and public artifacts are disabled; search still runs through the daemon`,
-            );
-          }
+        health = readHealth(healthPayload);
+        healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
+        lastHealthFailure = undefined;
+        // Path identity is decided by canonicalizing two strings ON THIS
+        // HOST, so it proves nothing about a REMOTE daemon that happens to
+        // use the same absolute pathname. Explicit `delegate` may target a
+        // remote daemon; the file-backed surfaces may not follow it there.
+        corpusShared =
+          daemonIsLocal &&
+          health.memoryDir !== undefined &&
+          daemonServesCorpus(options.memoryDir, health.memoryDir);
+        if (!corpusShared && daemonIsLocal && !reportedCorpusMismatch) {
+          reportedCorpusMismatch = true;
+          log.error(
+            `[${serviceId}] delegate capability: the daemon does not serve this plugin's memoryDir (daemon: ${health.memoryDir ?? "unreported"}, plugin: ${options.memoryDir}) — file-backed reads and public artifacts are disabled; search still runs through the daemon`,
+          );
         }
       } catch (err) {
         // Keep the last known snapshot and retry after a backoff. Memory must
@@ -336,17 +334,12 @@ export function createDelegateMemoryCapability(
     if (opts?.maxResults === 0) return [];
     // Cap-after-filter (AGENTS.md retrieval contract): artifact paths and
     // minScore are dropped on this side, so asking the daemon for exactly
-    // `maxResults` would let a few artifact hits shrink — or empty — a page
-    // that has valid lower-ranked memories behind it. Ask for headroom, then
-    // cap the FILTERED list.
+    // `maxResults` would let a few excluded hits shrink — or empty — a page
+    // that has valid lower-ranked memories behind it.
     const requestedResults =
       typeof opts?.maxResults === "number" && Number.isFinite(opts.maxResults)
         ? Math.max(1, Math.floor(opts.maxResults))
         : undefined;
-    const candidateResults =
-      requestedResults === undefined
-        ? undefined
-        : Math.min(SEARCH_HEADROOM_CEILING, requestedResults * SEARCH_HEADROOM_FACTOR);
     // An empty namespace means "the daemon's default", but the daemon reads an
     // ABSENT namespace as a principal-wide fan-out. Send the concrete default
     // health reports so a default-scoped session cannot see other namespaces.
@@ -359,64 +352,82 @@ export function createDelegateMemoryCapability(
     // omitted mode sends a flat corpus down the legacy direct-QMD path — a
     // different ranking for the same request. Always send one.
     const searchMode = opts?.qmdSearchModeOverride === "vsearch" ? "vector" : "search";
-    const response = await fetch(daemonUrl(target, "/engram/v1/memories/search"), {
-      method: "POST",
-      headers: { ...daemonAuthHeaders(target), "Content-Type": "application/json" },
-      body: JSON.stringify({
-        query,
-        ...(candidateResults === undefined ? {} : { maxResults: candidateResults }),
-        // Same override mapping the embedded manager applies, so a host asking
-        // for vector or lexical ranking gets the same semantics in either mode.
-        mode: searchMode,
-        ...(namespace === undefined ? {} : { namespace }),
-      }),
-      signal: AbortSignal.timeout(options.searchTimeoutMs),
-    });
-    if (!response.ok) {
-      await response.body?.cancel();
-      throw new Error(`daemon /engram/v1/memories/search responded ${response.status}`);
-    }
-    const payload: unknown = await response.json();
-    const body = asRecord(payload);
-    if (!Array.isArray(body?.results)) {
-      // A 200 with no usable `results` is a protocol or version failure.
-      // Returning [] would make it indistinguishable from a valid empty
-      // search and quietly report that no memories exist (AGENTS.md #22).
-      throw new Error("daemon /engram/v1/memories/search returned a malformed envelope");
-    }
-    const results: RuntimeSearchResult[] = [];
-    const rawResults = body.results;
-    for (const [index, raw] of rawResults.entries()) {
-      const hit = asRecord(raw);
-      if (!hit) continue;
-      const rawPath = typeof hit.path === "string" ? hit.path : `memory-${index + 1}`;
-      // Artifact isolation: the same exclusion the embedded runtime applies.
-      if (isMemoryArtifactPath(rawPath)) continue;
-      const score = typeof hit.score === "number" && Number.isFinite(hit.score) ? hit.score : 0;
-      if (
-        typeof opts?.minScore === "number" &&
-        Number.isFinite(opts.minScore) &&
-        score < opts.minScore
-      ) {
-        continue;
-      }
-      const citation = sharedScope().relativizeToMemoryRoot(rawPath);
-      results.push({
-        // Absolute, so a follow-up readFile is unambiguous when the same
-        // relative path exists under more than one allowed root.
-        path: sharedScope().absolutize(rawPath),
-        // The daemon's ranked search returns whole-memory hits with no line
-        // span; the embedded runtime reports the same 1..1 default.
-        startLine: 1,
-        endLine: 1,
-        score,
-        snippet: typeof hit.snippet === "string" ? hit.snippet : "",
-        source: isSessionsMemoryPath(citation) ? "sessions" : "memory",
-        citation,
+    const fetchPage = async (limit: number | undefined): Promise<unknown[]> => {
+      const response = await fetch(daemonUrl(target, "/engram/v1/memories/search"), {
+        method: "POST",
+        headers: { ...daemonAuthHeaders(target), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          query,
+          ...(limit === undefined ? {} : { maxResults: limit }),
+          // Same override mapping the embedded manager applies, so a host asking
+          // for vector or lexical ranking gets the same semantics in either mode.
+          mode: searchMode,
+          ...(namespace === undefined ? {} : { namespace }),
+        }),
+        signal: AbortSignal.timeout(options.searchTimeoutMs),
       });
-      if (requestedResults !== undefined && results.length >= requestedResults) break;
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new Error(`daemon /engram/v1/memories/search responded ${response.status}`);
+      }
+      const payload: unknown = await response.json();
+      const body = asRecord(payload);
+      if (!Array.isArray(body?.results)) {
+        // A 200 with no usable `results` is a protocol or version failure.
+        // Returning [] would make it indistinguishable from a valid empty
+        // search and quietly report that no memories exist (AGENTS.md #22).
+        throw new Error("daemon /engram/v1/memories/search returned a malformed envelope");
+      }
+      return body.results;
+    };
+    const keep = (rawResults: unknown[]): RuntimeSearchResult[] => {
+      const kept: RuntimeSearchResult[] = [];
+      for (const [index, raw] of rawResults.entries()) {
+        const hit = asRecord(raw);
+        if (!hit) continue;
+        const rawPath = typeof hit.path === "string" ? hit.path : `memory-${index + 1}`;
+        // Artifact isolation: the same exclusion the embedded runtime applies.
+        // A current daemon already dropped these before its own cap; this
+        // keeps the guarantee against an older one.
+        if (isMemoryArtifactPath(rawPath)) continue;
+        const score = typeof hit.score === "number" && Number.isFinite(hit.score) ? hit.score : 0;
+        if (
+          typeof opts?.minScore === "number" &&
+          Number.isFinite(opts.minScore) &&
+          score < opts.minScore
+        ) {
+          continue;
+        }
+        const citation = sharedScope().relativizeToMemoryRoot(rawPath);
+        kept.push({
+          // Absolute, so a follow-up readFile is unambiguous when the same
+          // relative path exists under more than one allowed root.
+          path: sharedScope().absolutize(rawPath),
+          // The daemon's ranked search returns whole-memory hits with no line
+          // span; the embedded runtime reports the same 1..1 default.
+          startLine: 1,
+          endLine: 1,
+          score,
+          snippet: typeof hit.snippet === "string" ? hit.snippet : "",
+          source: isSessionsMemoryPath(citation) ? "sessions" : "memory",
+          citation,
+        });
+      }
+      return kept;
+    };
+    // No budget: the caller accepted the daemon's own page size, so there is
+    // no cap on this side that a filtered hit could fall short of.
+    if (requestedResults === undefined) return keep(await fetchPage(undefined));
+    let kept: RuntimeSearchResult[] = [];
+    let limit = requestedResults;
+    for (let round = 0; round < SEARCH_TOPUP_ROUNDS; round += 1) {
+      const rawResults = await fetchPage(limit);
+      kept = keep(rawResults);
+      // Enough after filtering, or the daemon has nothing left to give.
+      if (kept.length >= requestedResults || rawResults.length < limit) break;
+      limit *= 2;
     }
-    return results;
+    return kept.slice(0, requestedResults);
   };
 
   const readMemoryFile = async (params: RuntimeReadParams): Promise<RuntimeReadResult> => {

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -262,6 +262,12 @@ export function createDelegateMemoryCapability(
     // namespace fails closed.
   };
   let healthExpiresAt = 0;
+  // Whether the live `healthExpiresAt` window came from a FAILURE. A
+  // revalidating caller bypasses a successful posture cache, but must honor a
+  // failure backoff: the posture is already unknown, so another immediate
+  // probe cannot prove anything and would spend the hook budget on a daemon
+  // that is down.
+  let healthCacheIsFailure = false;
   let healthInFlight: Promise<void> | undefined;
   let lastHealthFailure: string | undefined;
   // Local reads and artifact listing are only valid while the daemon serves
@@ -413,7 +419,10 @@ export function createDelegateMemoryCapability(
         `delegate request rejected (timeoutMs must be a finite integer): ${String(timeoutMs)}`,
       );
     }
-    if (!revalidate && now() < healthExpiresAt) return true;
+    if (now() < healthExpiresAt) {
+      if (healthCacheIsFailure) return false;
+      if (!revalidate) return true;
+    }
     // A caller inside a shared deadline (the lifecycle flushes) passes what is
     // LEFT of it. Zero or less means the budget is already spent: starting a
     // fresh probe here would overrun the hook and get it abandoned before the
@@ -478,6 +487,7 @@ export function createDelegateMemoryCapability(
         // one because an UNSCOPED request revalidates unconditionally rather
         // than trusting any cache window.
         healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
+        healthCacheIsFailure = false;
         lastHealthFailure = undefined;
         // Path identity is decided by canonicalizing two strings ON THIS
         // HOST, so it proves nothing about a REMOTE daemon that happens to
@@ -515,6 +525,7 @@ export function createDelegateMemoryCapability(
         };
         corpusShared = daemonIsLocal ? undefined : false;
         healthExpiresAt = now() + HEALTH_FAILURE_BACKOFF_MS;
+        healthCacheIsFailure = true;
         const message = `[${serviceId}] delegate capability health probe failed: ${String(err)}`;
         if (message !== lastHealthFailure) {
           lastHealthFailure = message;
@@ -532,19 +543,16 @@ export function createDelegateMemoryCapability(
     query: string,
     opts?: RuntimeSearchOptions,
   ): Promise<RuntimeSearchResult[]> => {
-    // Embedded returns an empty set for a zero budget; forwarding 0 would hit
-    // the daemon schema's `maxResults >= 1` and turn a valid no-results request
-    // into a 400 purely by switching bridge mode.
-    if (opts?.maxResults === 0) return [];
     if (opts?.minScore !== undefined && !Number.isFinite(opts.minScore)) {
       throw new Error(
         `delegate search rejected (minScore must be a finite number): ${String(opts.minScore)}`,
       );
     }
-    // Beyond the exact-zero short circuit, an out-of-range budget is a caller
-    // bug, not something to reinterpret: coercing a negative to 1, truncating
-    // a fraction, or dropping a non-finite value to the daemon default all
-    // return a valid-looking page for a budget nobody asked for.
+    // An out-of-range budget is a caller bug, not something to reinterpret:
+    // coercing a negative to 1, truncating a fraction, or dropping a
+    // non-finite value to the daemon default all return a valid-looking page
+    // for a budget nobody asked for. Zero is the one accepted edge, handled
+    // below once the request has been authorized.
     if (
       opts?.maxResults !== undefined &&
       (!Number.isInteger(opts.maxResults) || opts.maxResults < 0)
@@ -570,6 +578,12 @@ export function createDelegateMemoryCapability(
     const namespace = await resolveScopedNamespaceChecked(searchScope, undefined, scopeIsFresh, [
       "memory_search",
     ]);
+    // Embedded returns an empty set for a zero budget, and forwarding 0 would
+    // hit the daemon schema's `maxResults >= 1` — a 400 purely from switching
+    // bridge mode. The short circuit lands HERE, after scope and authorization
+    // resolution: shrinking the requested count must never be a way to get a
+    // successful answer for a namespace the session may not read.
+    if (opts?.maxResults === 0) return [];
     // Mirror the embedded manager: "vsearch" is vector ranking, "query" is the
     // ordinary search plan, anything else is the backend default.
     // Embedded defaults to "search" when the host passes no override, and an

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -52,6 +52,8 @@ type DaemonMemoryHealth = {
   memoryDir?: string;
   /** The daemon's configured default namespace, "" on a flat corpus. */
   defaultNamespace?: string;
+  /** Whether the daemon partitions storage by namespace at all. */
+  namespacesEnabled: boolean;
   searchBackend: "qmd" | "builtin";
   qmdEnabled: boolean;
   qmdAvailable: boolean;
@@ -110,6 +112,9 @@ export type DelegateCapabilityOptions = {
 };
 
 const HEALTH_CACHE_TTL_MS = 30_000;
+// A failing probe backs off instead of retrying on every hook, so a daemon
+// that is down or rejecting the token cannot turn each turn into a request.
+const HEALTH_FAILURE_BACKOFF_MS = 5_000;
 
 /**
  * Narrow an unvalidated JSON value to a readable record. A type guard rather
@@ -132,6 +137,7 @@ function readHealth(payload: Record<string, unknown>): DaemonMemoryHealth {
     memoryDir: typeof payload.memoryDir === "string" ? payload.memoryDir : undefined,
     defaultNamespace:
       typeof payload.defaultNamespace === "string" ? payload.defaultNamespace : undefined,
+    namespacesEnabled: payload.namespacesEnabled === true,
     searchBackend,
     qmdEnabled,
     // `active && !degraded` is the daemon's own "search will actually answer"
@@ -149,12 +155,18 @@ function readHealth(payload: Record<string, unknown>): DaemonMemoryHealth {
  * Build the delegate-backed capability pieces. Exported for tests and for
  * `registerDelegateMemoryCapability`, which wires them into the host.
  */
-export function createDelegateMemoryCapability(options: DelegateCapabilityOptions): {
+export type DelegateMemoryCapability = {
+  /** The daemon's default namespace, for callers that must scope concretely. */
+  daemonDefaultNamespace: () => Promise<string | undefined>;
   runtime: RemnicCapabilityRuntime;
   flushPlanResolver: () => MemoryFlushPlan;
   listArtifacts: () => Promise<unknown[]>;
   promptBuilder: (params: { sessionKey?: string }) => string[] | null;
-} {
+};
+
+export function createDelegateMemoryCapability(
+  options: DelegateCapabilityOptions,
+): DelegateMemoryCapability {
   const { target, serviceId } = options;
   const now = options.now ?? Date.now;
   // The read scope and the artifact listing are rooted on the directory the
@@ -188,12 +200,14 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
   // outage before the first probe answers; the daemon's health overwrites it.
   let health: DaemonMemoryHealth = {
     memoryDir: options.memoryDir,
+    namespacesEnabled: false,
     searchBackend: options.configuredSearchBackend,
     qmdEnabled: options.configuredSearchBackend === "qmd",
     qmdAvailable: options.configuredSearchBackend === "qmd",
   };
   let healthExpiresAt = 0;
   let healthInFlight: Promise<void> | undefined;
+  let lastHealthFailure: string | undefined;
   // Local reads and artifact listing are only valid while the daemon serves
   // the SAME corpus this plugin is configured for. Until health confirms it,
   // and after any mismatch, the file-backed surfaces refuse rather than read a
@@ -229,6 +243,7 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
         if (healthPayload) {
           health = readHealth(healthPayload);
           healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
+          lastHealthFailure = undefined;
           corpusShared =
             health.memoryDir !== undefined &&
             daemonServesCorpus(options.memoryDir, health.memoryDir);
@@ -240,9 +255,14 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
           }
         }
       } catch (err) {
-        // Keep the last known snapshot and retry on the next handout. Memory
-        // must never break the turn.
-        log.warn(`[${serviceId}] delegate capability health probe failed: ${String(err)}`);
+        // Keep the last known snapshot and retry after a backoff. Memory must
+        // never break the turn, and a persistent failure must not log per hook.
+        healthExpiresAt = now() + HEALTH_FAILURE_BACKOFF_MS;
+        const message = `[${serviceId}] delegate capability health probe failed: ${String(err)}`;
+        if (message !== lastHealthFailure) {
+          lastHealthFailure = message;
+          log.warn(message);
+        }
       } finally {
         healthInFlight = undefined;
       }
@@ -263,6 +283,17 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
     // health reports so a default-scoped session cannot see other namespaces.
     const resolved = await options.resolveSearchNamespace(opts?.sessionKey);
     const namespace = resolved ?? health.defaultNamespace;
+    // refreshHealth deliberately swallows probe failures, so a transient or
+    // legacy health response can leave BOTH values undefined. On a
+    // namespace-partitioned daemon an absent namespace means "fan out across
+    // everything the principal can read", which is outside the session's
+    // scope — refuse instead of widening it. A flat corpus has nothing to
+    // widen to, so it proceeds.
+    if (namespace === undefined && health.namespacesEnabled) {
+      throw new Error(
+        "delegate search unavailable: the daemon's default namespace is unknown, so the session scope cannot be resolved",
+      );
+    }
     // Mirror the embedded manager: "vsearch" is vector ranking, "query" is the
     // ordinary search plan, anything else is the backend default.
     // Embedded defaults to "search" when the host passes no override, and an
@@ -287,9 +318,15 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
       throw new Error(`daemon /engram/v1/memories/search responded ${response.status}`);
     }
     const payload: unknown = await response.json();
-    const results: RuntimeSearchResult[] = [];
     const body = asRecord(payload);
-    const rawResults = Array.isArray(body?.results) ? body.results : [];
+    if (!Array.isArray(body?.results)) {
+      // A 200 with no usable `results` is a protocol or version failure.
+      // Returning [] would make it indistinguishable from a valid empty
+      // search and quietly report that no memories exist (AGENTS.md #22).
+      throw new Error("daemon /engram/v1/memories/search returned a malformed envelope");
+    }
+    const results: RuntimeSearchResult[] = [];
+    const rawResults = body.results;
     for (const [index, raw] of rawResults.entries()) {
       const hit = asRecord(raw);
       if (!hit) continue;
@@ -391,6 +428,10 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
   };
 
   return {
+    daemonDefaultNamespace: async (): Promise<string | undefined> => {
+      await refreshHealth();
+      return health.defaultNamespace;
+    },
     runtime: {
       async getMemorySearchManager() {
         await refreshHealth();
@@ -440,7 +481,10 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
 export function registerDelegateMemoryCapability(
   api: DelegateCapabilityApi,
   options: DelegateCapabilityOptions,
-): void {
+): DelegateMemoryCapability {
+  // Always BUILT, even when the host registers none of it: the caller reuses
+  // `daemonDefaultNamespace` so the hook paths scope exactly like search.
+  const built = createDelegateMemoryCapability(options);
   const hasUnified = typeof api.registerMemoryCapability === "function";
   const hasRuntime = typeof api.registerMemoryRuntime === "function";
   const hasFlushPlan = typeof api.registerMemoryFlushPlan === "function";
@@ -448,10 +492,9 @@ export function registerDelegateMemoryCapability(
     log.debug(
       `[${options.serviceId}] delegate: host exposes no memory capability surface — nothing to register`,
     );
-    return;
+    return built;
   }
 
-  const built = createDelegateMemoryCapability(options);
   if (hasUnified) {
     api.registerMemoryCapability?.({
       ...(options.allowPromptInjection ? { promptBuilder: built.promptBuilder } : {}),
@@ -470,4 +513,5 @@ export function registerDelegateMemoryCapability(
     ? " and promptBuilder"
     : " (promptBuilder omitted — injection disabled by policy)";
   log.info(`[${options.serviceId}] delegate: registered daemon-backed ${surface}${builder}`);
+  return built;
 }

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -119,12 +119,15 @@ export type DelegateCapabilityOptions = {
 
 const HEALTH_CACHE_TTL_MS = 30_000;
 /**
- * Candidate top-up rounds for the delegate search. A current daemon already
- * excludes artifacts before its own cap, but this side still drops artifacts
- * (older daemons) and sub-`minScore` hits, so a short page re-asks with a
- * doubled limit instead of returning fewer memories than the caller budgeted.
+ * Ceiling on how many candidates one delegate search will ask the daemon for.
+ *
+ * A current daemon already excludes artifacts before its own cap, but this
+ * side still drops artifacts (older daemons) and sub-`minScore` hits, so a
+ * thinned page re-asks with a doubled limit. The bound is a daemon-safety
+ * limit, NOT a stand-in for corpus exhaustion: only a short page or a
+ * satisfied budget ends the loop sooner.
  */
-const SEARCH_TOPUP_ROUNDS = 4;
+const SEARCH_CANDIDATE_CEILING = 1_000;
 // A failing probe backs off instead of retrying on every hook, so a daemon
 // that is down or rejecting the token cannot turn each turn into a request.
 const HEALTH_FAILURE_BACKOFF_MS = 5_000;
@@ -248,6 +251,28 @@ export function createDelegateMemoryCapability(
   };
 
   /**
+   * File-backed surfaces walk ONE local directory: the `memoryDir` health
+   * reports. The daemon answers `/engram/v1/health` without a namespace, so
+   * that directory is the DEFAULT namespace's storage — not necessarily the
+   * one this capability is scoped to, and not necessarily one the token may
+   * read. Corpus containment proves physical co-location, never authorization.
+   *
+   * So the local walk is allowed only when there is exactly one corpus to walk
+   * (namespaces disabled) or the scope resolves to the very namespace health
+   * described. Anything else would publish another namespace's facts,
+   * entities, and artifacts while omitting the session's own.
+   */
+  const requireHealthNamespaceScope = async (surface: string): Promise<void> => {
+    if (health.namespacesEnabled === false) return;
+    const scoped = await options.resolveSearchNamespace(undefined);
+    const resolved = scoped ?? health.defaultNamespace;
+    if (resolved !== undefined && resolved === health.defaultNamespace) return;
+    throw new Error(
+      `delegate ${surface} unavailable: the daemon reports the ${health.defaultNamespace ?? "unknown"} namespace's storage, but this session is scoped to ${resolved ?? "an unresolved namespace"} — a local walk cannot be authorized for it`,
+    );
+  };
+
+  /**
    * refreshHealth deliberately swallows probe failures, so a transient or
    * legacy response can leave both the caller's namespace and the daemon
    * default undefined. On a namespace-partitioned daemon an absent namespace
@@ -332,6 +357,10 @@ export function createDelegateMemoryCapability(
     // the daemon schema's `maxResults >= 1` and turn a valid no-results request
     // into a 400 purely by switching bridge mode.
     if (opts?.maxResults === 0) return [];
+    // A cached manager can outlive the probe that handed it out. Without this,
+    // a single transient health failure sticks a namespace refusal on every
+    // later search while recall/observe recover on their next scoped call.
+    await refreshHealth();
     // Cap-after-filter (AGENTS.md retrieval contract): artifact paths and
     // minScore are dropped on this side, so asking the daemon for exactly
     // `maxResults` would let a few excluded hits shrink — or empty — a page
@@ -382,10 +411,16 @@ export function createDelegateMemoryCapability(
     };
     const keep = (rawResults: unknown[]): RuntimeSearchResult[] => {
       const kept: RuntimeSearchResult[] = [];
-      for (const [index, raw] of rawResults.entries()) {
+      for (const raw of rawResults) {
         const hit = asRecord(raw);
-        if (!hit) continue;
-        const rawPath = typeof hit.path === "string" ? hit.path : `memory-${index + 1}`;
+        // A hit without a string `path` is a version-skewed or corrupt daemon.
+        // Synthesizing `memory-N` would present that as a real memory the host
+        // could then try to open (AGENTS.md #22: a protocol failure must not
+        // masquerade as data).
+        if (!hit || typeof hit.path !== "string" || hit.path.trim() === "") {
+          throw new Error("daemon /engram/v1/memories/search returned a malformed result entry");
+        }
+        const rawPath = hit.path;
         // Artifact isolation: the same exclusion the embedded runtime applies.
         // A current daemon already dropped these before its own cap; this
         // keeps the guarantee against an older one.
@@ -416,26 +451,33 @@ export function createDelegateMemoryCapability(
       return kept;
     };
     // A caller that named no budget keeps the daemon's own page size on the
-    // wire; the page it served becomes the budget the filtered list is
-    // measured against, so an excluded hit still cannot thin it out.
+    // wire, and the FIRST page it serves fixes the budget once. Recomputing it
+    // per round would let the target grow with every doubled request, so a
+    // default page of 10 could return 80 rows while never "reaching" it.
     let kept: RuntimeSearchResult[] = [];
+    let budget = requestedResults;
     let limit: number | undefined = requestedResults;
-    for (let round = 0; round < SEARCH_TOPUP_ROUNDS; round += 1) {
+    for (;;) {
       const rawResults = await fetchPage(limit);
       kept = keep(rawResults);
-      const budget = requestedResults ?? rawResults.length;
-      if (kept.length >= budget) return requestedResults === undefined ? kept : kept.slice(0, budget);
+      budget ??= rawResults.length;
+      if (kept.length >= budget) break;
       // What the daemon actually served this round. A short page means it has
       // nothing left, so asking again just replays the same rows.
       const served = limit ?? rawResults.length;
       if (rawResults.length === 0 || rawResults.length < served) break;
-      limit = served * 2;
+      if (served >= SEARCH_CANDIDATE_CEILING) break;
+      limit = Math.min(served * 2, SEARCH_CANDIDATE_CEILING);
     }
-    return requestedResults === undefined ? kept : kept.slice(0, requestedResults);
+    return kept.slice(0, budget);
   };
 
   const readMemoryFile = async (params: RuntimeReadParams): Promise<RuntimeReadResult> => {
+    // Same reason as `search`: a cached manager can outlive its probe, and a
+    // stale "corpus not confirmed" must not stick past a recovered daemon.
+    await refreshHealth();
     requireSharedCorpus("readFile");
+    await requireHealthNamespaceScope("readFile");
     const requestedPath = sharedScope().normalizeWorkspacePath(params.relPath);
     const absolutePath = await sharedScope().resolveReadablePath(params.relPath);
     const allLines = (await readFile(absolutePath, "utf8")).split(/\r?\n/);
@@ -532,6 +574,7 @@ export function createDelegateMemoryCapability(
         // this surface hangs off the capability object, not off a manager.
         await refreshHealth();
         requireSharedCorpus("publicArtifacts");
+        await requireHealthNamespaceScope("publicArtifacts");
         return await listRemnicPublicArtifacts({
           memoryDir: health.memoryDir ?? options.memoryDir,
           workspaceDir: options.workspaceDir,

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -118,6 +118,13 @@ export type DelegateCapabilityOptions = {
 };
 
 const HEALTH_CACHE_TTL_MS = 30_000;
+/**
+ * Candidate headroom for the delegate search: this side drops artifact paths
+ * and sub-`minScore` hits after the daemon ranks, so the request asks for more
+ * than the caller's budget and the cap is applied to the filtered list.
+ */
+const SEARCH_HEADROOM_FACTOR = 3;
+const SEARCH_HEADROOM_CEILING = 200;
 // A failing probe backs off instead of retrying on every hook, so a daemon
 // that is down or rejecting the token cannot turn each turn into a request.
 const HEALTH_FAILURE_BACKOFF_MS = 5_000;
@@ -278,7 +285,13 @@ export function createDelegateMemoryCapability(
         }
         const payload: unknown = await response.json();
         const healthPayload = asRecord(payload);
-        if (healthPayload) {
+        if (!healthPayload) {
+          // A 200 carrying a non-record body is a protocol failure, not a
+          // success: without a backoff every later refresh would re-fetch
+          // immediately and hammer a persistently malformed daemon.
+          throw new Error("daemon /engram/v1/health returned a malformed envelope");
+        }
+        {
           health = readHealth(healthPayload);
           healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
           lastHealthFailure = undefined;
@@ -321,6 +334,19 @@ export function createDelegateMemoryCapability(
     // the daemon schema's `maxResults >= 1` and turn a valid no-results request
     // into a 400 purely by switching bridge mode.
     if (opts?.maxResults === 0) return [];
+    // Cap-after-filter (AGENTS.md retrieval contract): artifact paths and
+    // minScore are dropped on this side, so asking the daemon for exactly
+    // `maxResults` would let a few artifact hits shrink — or empty — a page
+    // that has valid lower-ranked memories behind it. Ask for headroom, then
+    // cap the FILTERED list.
+    const requestedResults =
+      typeof opts?.maxResults === "number" && Number.isFinite(opts.maxResults)
+        ? Math.max(1, Math.floor(opts.maxResults))
+        : undefined;
+    const candidateResults =
+      requestedResults === undefined
+        ? undefined
+        : Math.min(SEARCH_HEADROOM_CEILING, requestedResults * SEARCH_HEADROOM_FACTOR);
     // An empty namespace means "the daemon's default", but the daemon reads an
     // ABSENT namespace as a principal-wide fan-out. Send the concrete default
     // health reports so a default-scoped session cannot see other namespaces.
@@ -338,7 +364,7 @@ export function createDelegateMemoryCapability(
       headers: { ...daemonAuthHeaders(target), "Content-Type": "application/json" },
       body: JSON.stringify({
         query,
-        ...(typeof opts?.maxResults === "number" ? { maxResults: opts.maxResults } : {}),
+        ...(candidateResults === undefined ? {} : { maxResults: candidateResults }),
         // Same override mapping the embedded manager applies, so a host asking
         // for vector or lexical ranking gets the same semantics in either mode.
         mode: searchMode,
@@ -388,6 +414,7 @@ export function createDelegateMemoryCapability(
         source: isSessionsMemoryPath(citation) ? "sessions" : "memory",
         citation,
       });
+      if (requestedResults !== undefined && results.length >= requestedResults) break;
     }
     return results;
   };

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -415,19 +415,23 @@ export function createDelegateMemoryCapability(
       }
       return kept;
     };
-    // No budget: the caller accepted the daemon's own page size, so there is
-    // no cap on this side that a filtered hit could fall short of.
-    if (requestedResults === undefined) return keep(await fetchPage(undefined));
+    // A caller that named no budget keeps the daemon's own page size on the
+    // wire; the page it served becomes the budget the filtered list is
+    // measured against, so an excluded hit still cannot thin it out.
     let kept: RuntimeSearchResult[] = [];
-    let limit = requestedResults;
+    let limit: number | undefined = requestedResults;
     for (let round = 0; round < SEARCH_TOPUP_ROUNDS; round += 1) {
       const rawResults = await fetchPage(limit);
       kept = keep(rawResults);
-      // Enough after filtering, or the daemon has nothing left to give.
-      if (kept.length >= requestedResults || rawResults.length < limit) break;
-      limit *= 2;
+      const budget = requestedResults ?? rawResults.length;
+      if (kept.length >= budget) return requestedResults === undefined ? kept : kept.slice(0, budget);
+      // What the daemon actually served this round. A short page means it has
+      // nothing left, so asking again just replays the same rows.
+      const served = limit ?? rawResults.length;
+      if (rawResults.length === 0 || rawResults.length < served) break;
+      limit = served * 2;
     }
-    return kept.slice(0, requestedResults);
+    return requestedResults === undefined ? kept : kept.slice(0, requestedResults);
   };
 
   const readMemoryFile = async (params: RuntimeReadParams): Promise<RuntimeReadResult> => {

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -39,6 +39,7 @@ import type {
   RuntimeStatus,
 } from "./memory-capability-types.js";
 import {
+  type MemoryReadScope,
   createMemoryReadScope,
   isMemoryArtifactPath,
   isSessionsMemoryPath,
@@ -152,10 +153,23 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
 } {
   const { target, serviceId } = options;
   const now = options.now ?? Date.now;
-  const readScope = createMemoryReadScope({
-    memoryDir: options.memoryDir,
-    workspaceDir: options.workspaceDir,
-  });
+  // The read scope and the artifact listing are rooted on the directory the
+  // DAEMON reports, not the plugin's configured corpus root. Health returns the
+  // namespace-resolved storage dir, so scanning the root instead would miss the
+  // active namespace's files while publishing flat-root files for the wrong
+  // scope. `daemonServesCorpus` has already proved that directory belongs to
+  // the configured corpus, so the root remains the trust anchor.
+  let daemonScope: { dir: string; scope: MemoryReadScope } | undefined;
+  const sharedScope = (): MemoryReadScope => {
+    const dir = health.memoryDir ?? options.memoryDir;
+    if (daemonScope?.dir !== dir) {
+      daemonScope = {
+        dir,
+        scope: createMemoryReadScope({ memoryDir: dir, workspaceDir: options.workspaceDir }),
+      };
+    }
+    return daemonScope.scope;
+  };
 
   // Seeded from the plugin's own config so `status()` never reports a false
   // outage before the first probe answers; the daemon's health overwrites it.
@@ -230,12 +244,10 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
     const namespace = await options.resolveSearchNamespace(opts?.sessionKey);
     // Mirror the embedded manager: "vsearch" is vector ranking, "query" is the
     // ordinary search plan, anything else is the backend default.
-    const searchMode =
-      opts?.qmdSearchModeOverride === "vsearch"
-        ? "vector"
-        : opts?.qmdSearchModeOverride === "query"
-          ? "search"
-          : undefined;
+    // Embedded defaults to "search" when the host passes no override, and an
+    // omitted mode sends a flat corpus down the legacy direct-QMD path — a
+    // different ranking for the same request. Always send one.
+    const searchMode = opts?.qmdSearchModeOverride === "vsearch" ? "vector" : "search";
     const response = await fetch(daemonUrl(target, "/engram/v1/memories/search"), {
       method: "POST",
       headers: { ...daemonAuthHeaders(target), "Content-Type": "application/json" },
@@ -244,7 +256,7 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
         ...(typeof opts?.maxResults === "number" ? { maxResults: opts.maxResults } : {}),
         // Same override mapping the embedded manager applies, so a host asking
         // for vector or lexical ranking gets the same semantics in either mode.
-        ...(searchMode ? { mode: searchMode } : {}),
+        mode: searchMode,
         ...(namespace ? { namespace } : {}),
       }),
       signal: AbortSignal.timeout(options.searchTimeoutMs),
@@ -271,11 +283,11 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
       ) {
         continue;
       }
-      const citation = readScope.relativizeToMemoryRoot(rawPath);
+      const citation = sharedScope().relativizeToMemoryRoot(rawPath);
       results.push({
         // Absolute, so a follow-up readFile is unambiguous when the same
         // relative path exists under more than one allowed root.
-        path: readScope.absolutize(rawPath),
+        path: sharedScope().absolutize(rawPath),
         // The daemon's ranked search returns whole-memory hits with no line
         // span; the embedded runtime reports the same 1..1 default.
         startLine: 1,
@@ -291,8 +303,8 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
 
   const readMemoryFile = async (params: RuntimeReadParams): Promise<RuntimeReadResult> => {
     requireSharedCorpus("readFile");
-    const requestedPath = readScope.normalizeWorkspacePath(params.relPath);
-    const absolutePath = await readScope.resolveReadablePath(params.relPath);
+    const requestedPath = sharedScope().normalizeWorkspacePath(params.relPath);
+    const absolutePath = await sharedScope().resolveReadablePath(params.relPath);
     const allLines = (await readFile(absolutePath, "utf8")).split(/\r?\n/);
     const from = typeof params.from === "number" ? Math.max(1, Math.floor(params.from)) : 1;
     const lines =
@@ -384,7 +396,7 @@ export function createDelegateMemoryCapability(options: DelegateCapabilityOption
         await refreshHealth();
         requireSharedCorpus("publicArtifacts");
         return await listRemnicPublicArtifacts({
-          memoryDir: options.memoryDir,
+          memoryDir: health.memoryDir ?? options.memoryDir,
           workspaceDir: options.workspaceDir,
           agentIds: options.agentIds,
         });

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -1,0 +1,384 @@
+/**
+ * Daemon-backed memory-slot capability for delegate bridge mode (issue #2120).
+ *
+ * Delegate mode skips the embedded orchestrator, so the capability object the
+ * host registers — prompt builder, memory runtime, flush plan, public
+ * artifacts — has no orchestrator to close over. This module rebuilds it on
+ * the standalone daemon's HTTP API plus direct reads of the corpus the daemon
+ * already serves.
+ *
+ *   - search  → POST /engram/v1/memories/search (ranked, QMD-backed)
+ *   - status  → GET  /engram/v1/health          (cached per manager handout)
+ *   - read    → the local corpus, through the shared memory read scope
+ *
+ * Reading the corpus directly is sound because delegate mode's precondition is
+ * a daemon serving the SAME memoryDir on the SAME host: the plugin is not
+ * running a second orchestrator, it is reading files whose writer is the
+ * daemon. Indexing stays the daemon's job — the runtime deliberately exposes
+ * no `sync`, because a plugin-side reindex would resurrect the second QMD
+ * writer this issue exists to remove.
+ */
+
+import { readFile } from "node:fs/promises";
+
+import { log } from "@remnic/core/logger";
+
+import {
+  type DelegateDaemonTarget,
+  daemonAuthHeaders,
+  daemonUrl,
+} from "./bridge.js";
+import { buildMemoryFlushPlan, type MemoryFlushPlan } from "./memory-flush-plan.js";
+import type {
+  RemnicCapabilityRuntime,
+  RuntimeManager,
+  RuntimeReadParams,
+  RuntimeReadResult,
+  RuntimeSearchOptions,
+  RuntimeSearchResult,
+  RuntimeStatus,
+} from "./memory-capability-types.js";
+import { createMemoryReadScope, isMemoryArtifactPath } from "./memory-read-scope.js";
+import { listRemnicPublicArtifacts } from "./public-artifacts.js";
+
+/** Health facts the runtime surfaces; everything else in the payload is ignored. */
+type DaemonMemoryHealth = {
+  memoryDir?: string;
+  searchBackend: "qmd" | "builtin";
+  qmdEnabled: boolean;
+  qmdAvailable: boolean;
+  qmdDebug?: string;
+};
+
+export type DelegateCapabilityApi = {
+  registerMemoryCapability?(capability: unknown): void;
+  registerMemoryRuntime?(runtime: unknown): void;
+  registerMemoryFlushPlan?(resolver: () => MemoryFlushPlan): void;
+};
+
+export type DelegateCapabilityOptions = {
+  serviceId: string;
+  target: DelegateDaemonTarget;
+  /** Session namespace forwarded on daemon calls ("" = daemon default). */
+  namespace: string;
+  memoryDir: string;
+  workspaceDir: string;
+  /** Agent ids this registration owns, for the public-artifact listing. */
+  agentIds: string[];
+  /**
+   * Mirrors `hooks.allowPromptInjection`. When false the capability omits its
+   * promptBuilder, exactly as the embedded path does, and still provides the
+   * runtime, flush plan, and public artifacts.
+   */
+  allowPromptInjection: boolean;
+  /**
+   * Non-destructive peek at the recall lines the delegate hook precomputed for
+   * a session. The registered prompt *section* builder owns the destructive
+   * read; the capability builder must not consume the same lines twice.
+   */
+  peekPromptLines: (sessionKey: string) => string[] | null;
+  /** Flush-plan sizing input (`extractionMaxTurnChars`). */
+  extractionMaxTurnChars?: unknown;
+  /** Flush-plan model (`summaryModel` or the task chain primary). */
+  flushModel?: string;
+  /** Fallback backend facts used until the first health probe answers. */
+  configuredSearchBackend: "qmd" | "builtin";
+  configuredQmdCommand: string;
+  searchTimeoutMs: number;
+  healthTimeoutMs: number;
+  /** Injectable clock for the health-cache TTL. */
+  now?: () => number;
+};
+
+const HEALTH_CACHE_TTL_MS = 30_000;
+
+/**
+ * Narrow an unvalidated JSON value to a readable record. A type guard rather
+ * than a cast: daemon payloads are external input, so every field read below
+ * is `unknown` until its own `typeof` check passes.
+ */
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readHealth(payload: Record<string, unknown>): DaemonMemoryHealth {
+  const qmd = asRecord(payload.qmd) ?? {};
+  // The daemon reports `searchBackend` explicitly; anything other than the two
+  // known values is treated as builtin rather than trusted blindly.
+  const searchBackend = payload.searchBackend === "qmd" ? "qmd" : "builtin";
+  const qmdEnabled = searchBackend === "qmd" && payload.qmdEnabled !== false;
+  return {
+    memoryDir: typeof payload.memoryDir === "string" ? payload.memoryDir : undefined,
+    searchBackend,
+    qmdEnabled,
+    // `active && !degraded` is the daemon's own "search will actually answer"
+    // signal. A missing `active` means an older daemon, so fall back to
+    // `enabled` rather than reporting a false outage.
+    qmdAvailable:
+      qmdEnabled &&
+      (typeof qmd.active === "boolean" ? qmd.active : qmd.enabled !== false) &&
+      qmd.degraded !== true,
+    qmdDebug: typeof qmd.debugStatus === "string" ? qmd.debugStatus : undefined,
+  };
+}
+
+/**
+ * Build the delegate-backed capability pieces. Exported for tests and for
+ * `registerDelegateMemoryCapability`, which wires them into the host.
+ */
+export function createDelegateMemoryCapability(options: DelegateCapabilityOptions): {
+  runtime: RemnicCapabilityRuntime;
+  flushPlanResolver: () => MemoryFlushPlan;
+  listArtifacts: () => Promise<unknown[]>;
+  promptBuilder: (params: { sessionKey?: string }) => string[] | null;
+} {
+  const { target, serviceId } = options;
+  const now = options.now ?? Date.now;
+  const readScope = createMemoryReadScope({
+    memoryDir: options.memoryDir,
+    workspaceDir: options.workspaceDir,
+  });
+
+  // Seeded from the plugin's own config so `status()` never reports a false
+  // outage before the first probe answers; the daemon's health overwrites it.
+  let health: DaemonMemoryHealth = {
+    memoryDir: options.memoryDir,
+    searchBackend: options.configuredSearchBackend,
+    qmdEnabled: options.configuredSearchBackend === "qmd",
+    qmdAvailable: options.configuredSearchBackend === "qmd",
+  };
+  let healthExpiresAt = 0;
+  let healthInFlight: Promise<void> | undefined;
+
+  // `status()` is synchronous in the host contract, so the async probe runs in
+  // getMemorySearchManager (which IS async) and status() reads the snapshot.
+  const refreshHealth = async (): Promise<void> => {
+    if (now() < healthExpiresAt) return;
+    if (healthInFlight !== undefined) return healthInFlight;
+    healthInFlight = (async () => {
+      try {
+        const response = await fetch(daemonUrl(target, "/engram/v1/health"), {
+          headers: daemonAuthHeaders(target),
+          signal: AbortSignal.timeout(options.healthTimeoutMs),
+        });
+        if (!response.ok) {
+          await response.body?.cancel();
+          throw new Error(`daemon /engram/v1/health responded ${response.status}`);
+        }
+        const payload: unknown = await response.json();
+        const healthPayload = asRecord(payload);
+        if (healthPayload) {
+          health = readHealth(healthPayload);
+          healthExpiresAt = now() + HEALTH_CACHE_TTL_MS;
+        }
+      } catch (err) {
+        // Keep the last known snapshot and retry on the next handout. Memory
+        // must never break the turn.
+        log.warn(`[${serviceId}] delegate capability health probe failed: ${String(err)}`);
+      } finally {
+        healthInFlight = undefined;
+      }
+    })();
+    return healthInFlight;
+  };
+
+  const search = async (
+    query: string,
+    opts?: RuntimeSearchOptions,
+  ): Promise<RuntimeSearchResult[]> => {
+    const namespace = options.namespace.trim();
+    const response = await fetch(daemonUrl(target, "/engram/v1/memories/search"), {
+      method: "POST",
+      headers: { ...daemonAuthHeaders(target), "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query,
+        ...(typeof opts?.maxResults === "number" ? { maxResults: opts.maxResults } : {}),
+        ...(namespace ? { namespace } : {}),
+      }),
+      signal: AbortSignal.timeout(options.searchTimeoutMs),
+    });
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new Error(`daemon /engram/v1/memories/search responded ${response.status}`);
+    }
+    const payload: unknown = await response.json();
+    const results: RuntimeSearchResult[] = [];
+    const body = asRecord(payload);
+    const rawResults = Array.isArray(body?.results) ? body.results : [];
+    for (const [index, raw] of rawResults.entries()) {
+      const hit = asRecord(raw);
+      if (!hit) continue;
+      const rawPath = typeof hit.path === "string" ? hit.path : `memory-${index + 1}`;
+      // Artifact isolation: the same exclusion the embedded runtime applies.
+      if (isMemoryArtifactPath(rawPath)) continue;
+      const score = typeof hit.score === "number" && Number.isFinite(hit.score) ? hit.score : 0;
+      if (
+        typeof opts?.minScore === "number" &&
+        Number.isFinite(opts.minScore) &&
+        score < opts.minScore
+      ) {
+        continue;
+      }
+      const citation = readScope.relativizeToMemoryRoot(rawPath);
+      results.push({
+        // Absolute, so a follow-up readFile is unambiguous when the same
+        // relative path exists under more than one allowed root.
+        path: readScope.absolutize(rawPath),
+        // The daemon's ranked search returns whole-memory hits with no line
+        // span; the embedded runtime reports the same 1..1 default.
+        startLine: 1,
+        endLine: 1,
+        score,
+        snippet: typeof hit.snippet === "string" ? hit.snippet : "",
+        source: citation.includes("sessions/") ? "sessions" : "memory",
+        citation,
+      });
+    }
+    return results;
+  };
+
+  const readMemoryFile = async (params: RuntimeReadParams): Promise<RuntimeReadResult> => {
+    const requestedPath = readScope.normalizeWorkspacePath(params.relPath);
+    const absolutePath = await readScope.resolveReadablePath(params.relPath);
+    const allLines = (await readFile(absolutePath, "utf8")).split(/\r?\n/);
+    const from = typeof params.from === "number" ? Math.max(1, Math.floor(params.from)) : 1;
+    const lines =
+      typeof params.lines === "number" && Number.isFinite(params.lines)
+        ? Math.max(1, Math.floor(params.lines))
+        : undefined;
+    const startIndex = from - 1;
+    const endIndex = typeof lines === "number" ? startIndex + lines : allLines.length;
+    const truncated = endIndex < allLines.length;
+    return {
+      text: allLines.slice(startIndex, endIndex).join("\n"),
+      path: requestedPath,
+      truncated: truncated || undefined,
+      from,
+      lines,
+      nextFrom: truncated ? endIndex + 1 : undefined,
+    };
+  };
+
+  const status = (): RuntimeStatus => {
+    const usesQmd = health.searchBackend === "qmd";
+    return {
+      backend: usesQmd ? "qmd" : "builtin",
+      provider: usesQmd ? "qmd" : "builtin",
+      requestedProvider: usesQmd ? "qmd" : "builtin",
+      model: usesQmd ? options.configuredQmdCommand : "builtin",
+      dirty: false,
+      workspaceDir: options.workspaceDir,
+      dbPath: health.memoryDir ?? options.memoryDir,
+      sources: ["memory"],
+      sourceCounts: [],
+      vector: usesQmd ? { enabled: true, available: health.qmdAvailable } : { enabled: false },
+      fts: { enabled: true, available: usesQmd ? health.qmdAvailable : true },
+      custom: {
+        remnic: {
+          bridgeMode: "delegate",
+          daemon: `${target.host}:${target.port}`,
+          qmdAvailable: health.qmdAvailable,
+          qmdDebug: health.qmdDebug,
+          memoryDir: health.memoryDir ?? options.memoryDir,
+        },
+      },
+    };
+  };
+
+  const manager: RuntimeManager = {
+    search,
+    readFile: readMemoryFile,
+    status,
+    // No `sync`: indexing belongs to the daemon in delegate mode. Omitting the
+    // optional member is honest — the host will not call what is not offered.
+    async probeEmbeddingAvailability() {
+      await refreshHealth();
+      if (health.searchBackend !== "qmd") return { ok: true };
+      if (health.qmdAvailable) return { ok: true };
+      return { ok: false, error: health.qmdDebug ?? "Remnic daemon QMD backend unavailable" };
+    },
+    async probeVectorAvailability() {
+      await refreshHealth();
+      return health.searchBackend === "qmd" && health.qmdAvailable;
+    },
+    async close() {},
+  };
+
+  return {
+    runtime: {
+      async getMemorySearchManager() {
+        await refreshHealth();
+        return { manager };
+      },
+      resolveMemoryBackendConfig() {
+        return health.searchBackend === "qmd"
+          ? { backend: "qmd", qmd: { command: options.configuredQmdCommand } }
+          : { backend: "builtin" };
+      },
+      async closeAllMemorySearchManagers() {},
+    },
+    flushPlanResolver: () =>
+      buildMemoryFlushPlan({
+        serviceId,
+        extractionMaxTurnChars: options.extractionMaxTurnChars,
+        flushModel: options.flushModel,
+      }),
+    listArtifacts: async () => {
+      try {
+        return await listRemnicPublicArtifacts({
+          memoryDir: options.memoryDir,
+          workspaceDir: options.workspaceDir,
+          agentIds: options.agentIds,
+        });
+      } catch (err) {
+        log.error(`[${serviceId}] delegate publicArtifacts.listArtifacts failed`, err);
+        return [];
+      }
+    },
+    promptBuilder: (params: { sessionKey?: string }) =>
+      options.peekPromptLines(params?.sessionKey ?? "default"),
+  };
+}
+
+/**
+ * Register the delegate-backed memory capability against the host, mirroring
+ * the embedded path's unified/split SDK handling: newer hosts take the unified
+ * capability object, older split-only hosts take the runtime and flush plan
+ * through their own registration functions.
+ */
+export function registerDelegateMemoryCapability(
+  api: DelegateCapabilityApi,
+  options: DelegateCapabilityOptions,
+): void {
+  const hasUnified = typeof api.registerMemoryCapability === "function";
+  const hasRuntime = typeof api.registerMemoryRuntime === "function";
+  const hasFlushPlan = typeof api.registerMemoryFlushPlan === "function";
+  if (!hasUnified && !hasRuntime && !hasFlushPlan) {
+    log.debug(
+      `[${options.serviceId}] delegate: host exposes no memory capability surface — nothing to register`,
+    );
+    return;
+  }
+
+  const built = createDelegateMemoryCapability(options);
+  if (hasUnified) {
+    api.registerMemoryCapability?.({
+      ...(options.allowPromptInjection ? { promptBuilder: built.promptBuilder } : {}),
+      flushPlanResolver: built.flushPlanResolver,
+      runtime: built.runtime,
+      publicArtifacts: { listArtifacts: built.listArtifacts },
+    });
+  }
+  if (hasRuntime) api.registerMemoryRuntime?.(built.runtime);
+  if (hasFlushPlan) api.registerMemoryFlushPlan?.(built.flushPlanResolver);
+
+  const surface = hasUnified
+    ? "memory capability with publicArtifacts provider"
+    : "split memory runtime/flush-plan surfaces";
+  const builder = options.allowPromptInjection
+    ? " and promptBuilder"
+    : " (promptBuilder omitted — injection disabled by policy)";
+  log.info(`[${options.serviceId}] delegate: registered daemon-backed ${surface}${builder}`);
+}

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -568,10 +568,6 @@ export function createDelegateMemoryCapability(
         `delegate search rejected (maxResults must be a non-negative integer): ${String(opts.maxResults)}`,
       );
     }
-    // A cached manager can outlive the probe that handed it out. Without this,
-    // a single transient health failure sticks a namespace refusal on every
-    // later search while recall/observe recover on their next scoped call.
-    await refreshHealth();
     // Cap-after-filter (AGENTS.md retrieval contract): artifact paths and
     // minScore are dropped on this side, so asking the daemon for exactly
     // `maxResults` would let a few excluded hits shrink — or empty — a page
@@ -581,7 +577,13 @@ export function createDelegateMemoryCapability(
     // ABSENT namespace as a principal-wide fan-out. Send the concrete default
     // health reports so a default-scoped session cannot see other namespaces.
     const searchScope = await options.resolveSearchNamespace(opts?.sessionKey);
-    const scopeIsFresh = await refreshHealth(undefined, searchScope === undefined);
+    // The scope decides whether a posture probe is needed at all. An EXPLICIT
+    // one is enforced by the daemon on the search endpoint, so a slow or dead
+    // `/health` must not delay a search the daemon would serve; an ABSENT one
+    // is decided by the posture, which is an authorization fact and must be
+    // current. Resolving the scope first also means a cached manager costs at
+    // most ONE probe here, never one eager plus one revalidating.
+    const scopeIsFresh = searchScope === undefined ? await refreshHealth(undefined, true) : true;
     const namespace = await resolveScopedNamespaceChecked(searchScope, undefined, scopeIsFresh, [
       "memory_search",
     ]);

--- a/packages/plugin-openclaw/src/delegate-namespaces.ts
+++ b/packages/plugin-openclaw/src/delegate-namespaces.ts
@@ -19,13 +19,14 @@ import { log } from "@remnic/core/logger";
 export async function withNamespace(
   namespace: string | undefined,
   body: Record<string, unknown>,
-  daemonDefaultNamespace: () => Promise<string | undefined>,
+  resolveScopedNamespace: (explicit?: string) => Promise<string | undefined>,
 ): Promise<Record<string, unknown>> {
   // An ABSENT namespace is a principal-wide fan-out to the daemon, not "the
-  // default scope", so fall back to the daemon's concrete default exactly as
-  // the memory-slot search does. Otherwise prompt recall would range wider
-  // than tool search on the same session.
-  const scoped = namespace || (await daemonDefaultNamespace());
+  // default scope". The shared resolver applies the daemon's concrete default
+  // and REFUSES when even that is unknown on a namespace-partitioned daemon —
+  // the same rule the memory-slot search follows, so prompt recall can never
+  // range wider than tool search on the same session.
+  const scoped = await resolveScopedNamespace(namespace || undefined);
   return scoped === undefined ? body : { ...body, namespace: scoped };
 }
 

--- a/packages/plugin-openclaw/src/delegate-namespaces.ts
+++ b/packages/plugin-openclaw/src/delegate-namespaces.ts
@@ -1,0 +1,129 @@
+/**
+ * Session-namespace resolution for the delegate hook paths (issue #2120).
+ *
+ * Recall, observe, and the lifecycle flushes all have to answer the same
+ * question — "which namespace is this session bound to?" — from a host event
+ * that may or may not carry one, a durable binding history, and the daemon's
+ * own default. Keeping that in one module is what stops the three paths from
+ * drifting apart, and from drifting away from the memory-slot search that
+ * resolves the same way.
+ */
+
+import {
+  SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH,
+  SESSION_NAMESPACE_BINDING_MAX_NAMESPACES,
+  type SessionNamespaceBindingStore,
+} from "@remnic/core/session-namespace-bindings";
+import { log } from "@remnic/core/logger";
+
+export async function withNamespace(
+  namespace: string | undefined,
+  body: Record<string, unknown>,
+  daemonDefaultNamespace: () => Promise<string | undefined>,
+): Promise<Record<string, unknown>> {
+  // An ABSENT namespace is a principal-wide fan-out to the daemon, not "the
+  // default scope", so fall back to the daemon's concrete default exactly as
+  // the memory-slot search does. Otherwise prompt recall would range wider
+  // than tool search on the same session.
+  const scoped = namespace || (await daemonDefaultNamespace());
+  return scoped === undefined ? body : { ...body, namespace: scoped };
+}
+
+interface ExplicitSessionNamespace {
+  namespace: string | undefined;
+}
+
+export function explicitSessionNamespaceFrom(
+  sessionKey: string,
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>,
+): ExplicitSessionNamespace | undefined {
+  const eventSessionKey = typeof event.sessionKey === "string" ? event.sessionKey : undefined;
+  const ctxSessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : undefined;
+  const sources =
+    eventSessionKey === sessionKey
+      ? [event, ctx]
+      : ctxSessionKey === sessionKey
+        ? [ctx, event]
+        : [ctx, event];
+  for (const source of sources) {
+    const sourceSessionKey = typeof source.sessionKey === "string" ? source.sessionKey : undefined;
+    if (sourceSessionKey !== sessionKey) continue;
+    const runtime = source.runtime;
+    if (typeof runtime !== "object" || runtime === null) continue;
+    const agent = (runtime as Record<string, unknown>).agent;
+    if (typeof agent !== "object" || agent === null) continue;
+    const session = (agent as Record<string, unknown>).session;
+    if (typeof session !== "object" || session === null) continue;
+    const namespace = (session as Record<string, unknown>).namespace;
+    if (namespace !== undefined && typeof namespace !== "string") {
+      throw new Error("delegate session namespace metadata must be a string");
+    }
+    return { namespace: typeof namespace === "string" ? namespace.trim() || undefined : undefined };
+  }
+  return undefined;
+}
+
+export async function rememberedNamespacesFor(
+  sessionKey: string,
+  namespaceBindings: SessionNamespaceBindingStore,
+): Promise<string[]> {
+  return namespaceBindings.namespacesFor(sessionKey);
+}
+
+export async function rememberNamespace(
+  sessionKey: string,
+  namespace: string,
+  namespaceBindings: SessionNamespaceBindingStore,
+): Promise<void> {
+  if (namespace.length > SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH) {
+    throw new Error(
+      `delegate session namespace exceeds the daemon limit of ${SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH} characters`,
+    );
+  }
+  try {
+    await namespaceBindings.remember(sessionKey, namespace);
+  } catch (err) {
+    log.warn(`delegate namespace binding persistence failed: ${String(err)}`);
+    throw err;
+  }
+}
+
+export async function sessionNamespaceFrom(
+  sessionKey: string,
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>,
+  fallback: string,
+  namespaceBindings: SessionNamespaceBindingStore,
+): Promise<string | undefined> {
+  const explicit = explicitSessionNamespaceFrom(sessionKey, event, ctx);
+  if (explicit !== undefined) {
+    await rememberNamespace(sessionKey, explicit.namespace ?? "", namespaceBindings);
+    return explicit.namespace;
+  }
+  const remembered = await rememberedNamespacesFor(sessionKey, namespaceBindings);
+  return remembered.length > 0 ? remembered.at(-1) || undefined : fallback.trim() || undefined;
+}
+
+export async function lifecycleSessionNamespacesFrom(
+  sessionKey: string,
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>,
+  fallback: string,
+  namespaceBindings: SessionNamespaceBindingStore,
+): Promise<Array<string | undefined>> {
+  const explicit = explicitSessionNamespaceFrom(sessionKey, event, ctx);
+  if (explicit !== undefined) {
+    await rememberNamespace(sessionKey, explicit.namespace ?? "", namespaceBindings);
+  }
+  const remembered = await rememberedNamespacesFor(sessionKey, namespaceBindings);
+  if (explicit !== undefined) {
+    const explicitNamespace = explicit.namespace ?? "";
+    const namespaces = remembered.includes(explicitNamespace)
+      ? remembered
+      : [...remembered, explicitNamespace];
+    return namespaces.map((namespace) => namespace || undefined);
+  }
+  if (remembered.length > 0) return remembered.map((namespace) => namespace || undefined);
+  return [fallback.trim() || undefined];
+}

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -21,6 +21,19 @@ import {
   createInMemorySessionNamespaceBindingStore,
 } from "@remnic/core/session-namespace-bindings";
 
+/**
+ * Capability inputs shared by every delegate registration in this file. The
+ * daemon-backed capability is exercised on its own in
+ * delegate-capability.test.ts; here it only needs to construct.
+ */
+const TEST_CAPABILITY: DelegateRuntimeOptions["capability"] = {
+  memoryDir: path.join(os.tmpdir(), "remnic-delegate-runtime-memory"),
+  workspaceDir: path.join(os.tmpdir(), "remnic-delegate-runtime-workspace"),
+  agentIds: ["generalist"],
+  configuredSearchBackend: "qmd",
+  configuredQmdCommand: "qmd",
+};
+
 type HookHandler = (
   event: Record<string, unknown>,
   ctx: Record<string, unknown>,
@@ -181,6 +194,7 @@ function optionsFor(port: number, overrides: Partial<DelegateRuntimeOptions> = {
     hookTimeoutMs: 5_000,
     shouldSkipRecall: () => false,
     flushOnResetEnabled: true,
+    capability: TEST_CAPABILITY,
     recallTimeoutMs: 5_000,
     observeTimeoutMs: 5_000,
     flushTimeoutMs: 5_000,
@@ -1142,6 +1156,7 @@ test("delegate reloads a persisted namespace binding after its daemon host confi
       hookTimeoutMs: 5_000,
       shouldSkipRecall: () => false,
       flushOnResetEnabled: true,
+      capability: TEST_CAPABILITY,
     };
     const firstApi = recordingApi();
     assert.equal(maybeRegisterDelegateRuntime(firstApi, common, { checkHealth: () => true }), true);
@@ -1250,6 +1265,7 @@ test("delegate ignores a corrupt legacy binding file when canonical scope is ava
           hookTimeoutMs: 5_000,
           shouldSkipRecall: () => false,
           flushOnResetEnabled: true,
+          capability: TEST_CAPABILITY,
         },
         { checkHealth: () => true },
       ),
@@ -1350,6 +1366,7 @@ test("delegate restores full canonical history during concurrent explicit legacy
           hookTimeoutMs: 5_000,
           shouldSkipRecall: () => false,
           flushOnResetEnabled: true,
+          capability: TEST_CAPABILITY,
         },
         { checkHealth: () => true },
       ),
@@ -1372,6 +1389,7 @@ test("delegate restores full canonical history during concurrent explicit legacy
           hookTimeoutMs: 5_000,
           shouldSkipRecall: () => false,
           flushOnResetEnabled: true,
+          capability: TEST_CAPABILITY,
         },
         { checkHealth: () => true },
       ),
@@ -1467,6 +1485,7 @@ test("delegate bounds completed legacy migration sessions and rechecks evicted k
       hookTimeoutMs: 5_000,
       shouldSkipRecall: () => false,
       flushOnResetEnabled: true,
+      capability: TEST_CAPABILITY,
     };
     const api = recordingApi();
     assert.equal(maybeRegisterDelegateRuntime(api, common, { checkHealth: () => true }), true);
@@ -1556,6 +1575,7 @@ test("delegate preserves legacy bindings while the legacy adapter is active", as
       hookTimeoutMs: 5_000,
       shouldSkipRecall: () => false,
       flushOnResetEnabled: true,
+      capability: TEST_CAPABILITY,
     };
     const legacyApi = recordingApi();
     const canonicalApi = recordingApi();
@@ -1967,6 +1987,7 @@ test("maybeRegisterDelegateRuntime deduplicates hook binding per api object", as
         hookTimeoutMs: 5_000,
         shouldSkipRecall: () => false,
         flushOnResetEnabled: true,
+        capability: TEST_CAPABILITY,
       };
       const healthDeps = { checkHealth: () => true };
       const first = maybeRegisterDelegateRuntime(api, opts, healthDeps);
@@ -2138,6 +2159,7 @@ test("maybeRegister stays embedded after a daemon-down fallback (no stacking)", 
       hookTimeoutMs: 5_000,
       shouldSkipRecall: () => false,
       flushOnResetEnabled: true,
+      capability: TEST_CAPABILITY,
     };
     // First call: daemon down -> falls back to embedded.
     let first = maybeRegisterDelegateRuntime(api, opts, { checkHealth: () => false });
@@ -2182,6 +2204,7 @@ test("maybeRegister passes the configured timeout to the daemon health preflight
         hookTimeoutMs: 5_000,
         shouldSkipRecall: () => false,
         flushOnResetEnabled: true,
+        capability: TEST_CAPABILITY,
       },
       {
         checkHealth: (_host, _port, timeoutMs) => {
@@ -2226,6 +2249,7 @@ test("maybeRegister rejects an invalid delegate timeout and falls back to embedd
         hookTimeoutMs: 5_000,
         shouldSkipRecall: () => false,
         flushOnResetEnabled: true,
+        capability: TEST_CAPABILITY,
       },
       {
         checkHealth: () => {
@@ -2322,6 +2346,7 @@ test("maybeRegister: invalid bridgeMode logs and falls back to embedded (no thro
       hookTimeoutMs: 5_000,
       shouldSkipRecall: () => false,
       flushOnResetEnabled: true,
+      capability: TEST_CAPABILITY,
     };
     let handled = true;
     assert.doesNotThrow(() => {
@@ -2353,6 +2378,7 @@ test("maybeRegister: passive registration does not poison a later active one", (
       hookTimeoutMs: 5_000,
       shouldSkipRecall: () => false,
       flushOnResetEnabled: true,
+      capability: TEST_CAPABILITY,
     };
     const healthDeps = { checkHealth: () => true };
     assert.equal(maybeRegisterDelegateRuntime(api, opts, healthDeps), true, "passive handled");
@@ -2406,6 +2432,7 @@ test("maybeRegister: an embedded-mode registration blocks a later delegate flip 
       hookTimeoutMs: 5_000,
       shouldSkipRecall: () => false,
       flushOnResetEnabled: true,
+      capability: TEST_CAPABILITY,
     };
     const healthDeps = { checkHealth: () => true };
     assert.equal(maybeRegisterDelegateRuntime(api, opts, healthDeps), false, "embedded mode");
@@ -2667,6 +2694,7 @@ test("delegate activation warns each service once and keeps its memory hooks", a
     hookTimeoutMs: 5_000,
     shouldSkipRecall: () => false,
     flushOnResetEnabled: true,
+    capability: TEST_CAPABILITY,
   };
   let probeCalls = 0;
   const probedOperations: Array<readonly string[]> = [];
@@ -2725,6 +2753,7 @@ test("delegate authorization preflight probes only the operations enabled by con
     hookTimeoutMs: 5_000,
     shouldSkipRecall: () => false,
     flushOnResetEnabled: true,
+    capability: TEST_CAPABILITY,
   };
   try {
     for (const disabledRecall of [

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -2816,3 +2816,36 @@ test("delegate authorization preflight probes only the operations enabled by con
     else process.env.REMNIC_BRIDGE_MODE = priorMode;
   }
 });
+
+test("a short query evicts the previous turn's cached recall", async () => {
+  // On a builder host the hook does not inject; if prompt construction aborted
+  // last turn the lines are still cached. A short query must not leave them
+  // there for the builder to splice into the NEXT prompt.
+  const stub = await startDaemonStub(() => ({ context: "stale daemon context" }));
+  try {
+    const api = recordingApi();
+    const captured: {
+      builder: null | ((params: { sessionKey?: string }) => string[] | null);
+    } = { builder: null };
+    const sectionApi = Object.assign(api, {
+      registerMemoryPromptSection(builder: (params: { sessionKey?: string }) => string[] | null): void {
+        captured.builder = builder;
+      },
+    });
+    registerDelegateRuntime(sectionApi, optionsFor(stub.port));
+    const builder = captured.builder;
+    if (builder === null) throw new Error("section builder was not registered");
+
+    // Turn 1 populates the cache; prompt construction never consumes it.
+    await invoke(api, "before_prompt_build", { prompt: "a real query worth recalling" }, { sessionKey: "s" });
+    // Turn 2 is too short to recall for.
+    await invoke(api, "before_prompt_build", { prompt: "hi" }, { sessionKey: "s" });
+    assert.equal(
+      builder({ sessionKey: "s" }),
+      null,
+      "the short turn cleared the stale lines instead of re-injecting them",
+    );
+  } finally {
+    await stub.close();
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -31,7 +31,6 @@ const TEST_CAPABILITY: DelegateRuntimeOptions["capability"] = {
   workspaceDir: path.join(os.tmpdir(), "remnic-delegate-runtime-workspace"),
   agentIds: ["generalist"],
   configuredSearchBackend: "qmd",
-  configuredNamespacesEnabled: false,
   configuredQmdCommand: "qmd",
 };
 

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -31,6 +31,7 @@ const TEST_CAPABILITY: DelegateRuntimeOptions["capability"] = {
   workspaceDir: path.join(os.tmpdir(), "remnic-delegate-runtime-workspace"),
   agentIds: ["generalist"],
   configuredSearchBackend: "qmd",
+  configuredNamespacesEnabled: false,
   configuredQmdCommand: "qmd",
 };
 

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -103,7 +103,14 @@ async function startDaemonStub(
           ? options.capabilityResponses?.[capabilityResponseIndex++]
           : undefined;
       const responsePromise =
-        pathname === "/engram/v1/capabilities" && capabilityResponse !== undefined
+        // A real daemon always answers health with its namespace posture; the
+        // capability refuses to scope a request without it.
+        pathname === "/engram/v1/health"
+          ? Promise.resolve({
+              status: 200,
+              body: { ok: true, memoryDir: TEST_CAPABILITY.memoryDir, namespacesEnabled: false },
+            })
+          : pathname === "/engram/v1/capabilities" && capabilityResponse !== undefined
           ? Promise.resolve(capabilityResponse)
           : pathname === "/engram/v1/capabilities" && options.batchFlush !== false
             ? Promise.resolve({ status: 200, body: { lcmCompactionFlushBatch: true } })
@@ -2459,6 +2466,10 @@ test("delegate runtime reloads a rotated daemon token without re-registering hoo
       receivedAuthorization.push(req.headers.authorization);
     }
     res.setHeader("content-type", "application/json");
+    if (String(req.url).startsWith("/engram/v1/health")) {
+      res.end(JSON.stringify({ ok: true, namespacesEnabled: false }));
+      return;
+    }
     if (req.headers.authorization !== "Bearer accepted-token") {
       res.writeHead(401);
       res.end(JSON.stringify({ error: "unauthorized" }));
@@ -2530,6 +2541,13 @@ test("delegate daemon auth failures log one sanitized error per route and status
   const paths: string[] = [];
   const server = http.createServer((req, res) => {
     paths.push(req.url ?? "");
+    // Health stays readable: this test is about the MEMORY routes rejecting a
+    // token, and the capability needs a namespace posture to scope with.
+    if (String(req.url).startsWith("/engram/v1/health")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, namespacesEnabled: false }));
+      return;
+    }
     res.writeHead(status, { "content-type": "application/json" });
     res.end(JSON.stringify({ error: "unauthorized" }));
   });
@@ -2588,20 +2606,15 @@ test("delegate daemon auth failures log one sanitized error per route and status
       "/engram/v1/observe",
       "/engram/v1/lcm/compaction/flush",
     ]));
-    assert.equal(errors.length, 4, "each route/status pair emits one error");
-    assert.deepEqual(
-      warnings.filter((message) => !message.includes("health probe failed")),
-      [],
-      "auth failures replace generic degradation warnings on the memory routes",
-    );
-    assert.equal(
-      warnings.filter((message) => message.includes("health probe failed")).length,
-      2,
-      "a persistently failing health probe warns once per registration, not once per hook",
-    );
-    assert.equal(errors.filter((message) => message.includes("(401;")).length, 1);
-    assert.equal(errors.filter((message) => message.includes("(403;")).length, 3);
-    for (const message of errors) {
+    // This test is about the AUTHORIZATION log; the capability separately
+    // reports that the stub daemon serves no confirmable corpus, which is
+    // correct and covered in delegate-capability.test.ts.
+    const authErrors = errors.filter((message) => message.includes("authorization failed"));
+    assert.equal(authErrors.length, 4, "each route/status pair emits one error");
+    assert.deepEqual(warnings, [], "auth failures replace generic degradation warnings");
+    assert.equal(authErrors.filter((message) => message.includes("(401;")).length, 1);
+    assert.equal(authErrors.filter((message) => message.includes("(403;")).length, 3);
+    for (const message of authErrors) {
       assert.match(message, /token source: OPENCLAW_REMNIC_ACCESS_TOKEN/);
       assert.doesNotMatch(message, /test-token/);
     }

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -2453,7 +2453,11 @@ test("delegate runtime reloads a rotated daemon token without re-registering hoo
   let currentToken = "expired-token";
   const receivedAuthorization: Array<string | undefined> = [];
   const server = http.createServer((req, res) => {
-    receivedAuthorization.push(req.headers.authorization);
+    // The capability's health probe rides the same server; this test is about
+    // the RECALL route's token, so record only that one.
+    if (String(req.url).startsWith("/engram/v1/recall")) {
+      receivedAuthorization.push(req.headers.authorization);
+    }
     res.setHeader("content-type", "application/json");
     if (req.headers.authorization !== "Bearer accepted-token") {
       res.writeHead(401);
@@ -2577,12 +2581,24 @@ test("delegate daemon auth failures log one sanitized error per route and status
     await invoke(api, "before_compaction", {}, { sessionKey: "auth" });
 
     assert.deepEqual(new Set(paths), new Set([
+      // The capability probes health to resolve the daemon's default namespace
+      // before each scoped write; it is not one of the auth-logged routes.
+      "/engram/v1/health",
       "/engram/v1/recall",
       "/engram/v1/observe",
       "/engram/v1/lcm/compaction/flush",
     ]));
     assert.equal(errors.length, 4, "each route/status pair emits one error");
-    assert.equal(warnings.length, 0, "auth failures replace generic degradation warnings");
+    assert.deepEqual(
+      warnings.filter((message) => !message.includes("health probe failed")),
+      [],
+      "auth failures replace generic degradation warnings on the memory routes",
+    );
+    assert.equal(
+      warnings.filter((message) => message.includes("health probe failed")).length,
+      2,
+      "a persistently failing health probe warns once per registration, not once per hook",
+    );
     assert.equal(errors.filter((message) => message.includes("(401;")).length, 1);
     assert.equal(errors.filter((message) => message.includes("(403;")).length, 3);
     for (const message of errors) {

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -2603,7 +2603,7 @@ test("delegate authorization probe reports grant, rejection, and network failure
     assert.equal(req.method, "GET");
     assert.match(
       String(req.url),
-      /\/engram\/v1\/authorization\?op=recall&op=observe&op=lcm_compaction_flush&namespace=/,
+      /\/engram\/v1\/authorization\?op=recall&op=observe&op=lcm_compaction_flush&op=memory_search&namespace=/,
     );
     receivedAuthorization.push(req.headers.authorization);
     res.writeHead(responseStatus, { "content-type": "application/json" });
@@ -2731,8 +2731,8 @@ test("delegate activation warns each service once and keeps its memory hooks", a
   assert.equal(probeCalls, 2, "each service receives a preflight");
   assert.equal(warnings.length, 2);
   assert.deepEqual(probedOperations, [
-    ["recall", "observe", "lcm_compaction_flush"],
-    ["observe", "lcm_compaction_flush"],
+    ["recall", "observe", "lcm_compaction_flush", "memory_search"],
+    ["observe", "lcm_compaction_flush", "memory_search"],
   ]);
 });
 
@@ -2780,7 +2780,7 @@ test("delegate authorization preflight probes only the operations enabled by con
         true,
       );
       await new Promise<void>((resolve) => setImmediate(resolve));
-      assert.deepEqual(operations, ["observe", "lcm_compaction_flush"]);
+      assert.deepEqual(operations, ["observe", "lcm_compaction_flush", "memory_search"]);
     }
   } finally {
     if (priorMode === undefined) Reflect.deleteProperty(process.env, "REMNIC_BRIDGE_MODE");

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -454,7 +454,7 @@ export function registerDelegateRuntime(
               ...(cwd ? { cwd } : {}),
               ...(options.projectTag ? { projectTag: options.projectTag } : {}),
             },
-            capability.daemonDefaultNamespace,
+            capability.resolveScopedNamespace,
           ),
           options.recallTimeoutMs,
         );
@@ -554,7 +554,7 @@ export function registerDelegateRuntime(
             ...(cwd ? { cwd } : {}),
             ...(options.projectTag ? { projectTag: options.projectTag } : {}),
           },
-          capability.daemonDefaultNamespace,
+          capability.resolveScopedNamespace,
         ),
         options.observeTimeoutMs,
       );
@@ -638,7 +638,7 @@ export function registerDelegateRuntime(
           target,
           options.serviceId,
           "/engram/v1/lcm/compaction/flush",
-          await withNamespace(sessionNamespace, { sessionKey }, capability.daemonDefaultNamespace),
+          await withNamespace(sessionNamespace, { sessionKey }, capability.resolveScopedNamespace),
           remainingTimeout(),
         );
       const flushIndividually = async (): Promise<boolean> => {

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -388,6 +388,12 @@ export function registerDelegateRuntime(
       }
       return namespace.trim() || undefined;
     },
+    // The daemon's own namespace-aware probe, so a substituted default is
+    // proven usable before the first search rather than 403-ing on it.
+    verifyNamespaceAuthorization: async (candidate) => {
+      const probe = await probeDelegateAuthorization(target, candidate, ["memory_search"]);
+      return probe.state === "unavailable" ? undefined : probe.state === "authorized";
+    },
     memoryDir: options.capability.memoryDir,
     workspaceDir: options.capability.workspaceDir,
     agentIds: options.capability.agentIds,
@@ -415,9 +421,13 @@ export function registerDelegateRuntime(
       ctx: Record<string, unknown>,
     ): Promise<Record<string, unknown> | undefined> => {
       const query = recallQueryFrom(event);
-      if (query.trim().length < 5) return undefined;
       const sessionKey = sessionKeyFrom(event, ctx);
+      // Evict BEFORE the short-query exit. On a capability-only host the
+      // builder is the sole consumer, so a turn whose prompt construction
+      // aborted leaves lines behind; returning early without clearing would
+      // inject the PREVIOUS query's memory into this prompt.
       if (cachePromptLines) promptLinesBySession.delete(sessionKey);
+      if (query.trim().length < 5) return undefined;
       try {
         if (options.shouldSkipRecall(sessionKey)) {
           log.debug(`delegate recall skipped: cron policy excludes ${sessionKey}`);

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -655,22 +655,21 @@ export function registerDelegateRuntime(
           const response = await flushNamespace(namespaces[0]);
           return response !== null && response.flushed === true;
         }
+        // Each entry goes through the SAME resolver as the singular flush and
+        // every other delegate call, so a batch cannot widen scope where a
+        // one-at-a-time flush would refuse. The RESOLVED list is what the
+        // daemon echoes, so it is also what the response is validated against.
+        const requestNamespaces = await Promise.all(
+          namespaces.map(async (sessionNamespace) =>
+            (await capability.resolveScopedNamespace(sessionNamespace || undefined)) ?? "",
+          ),
+        );
         try {
           const response = await postJson(
             target,
             options.serviceId,
             "/engram/v1/lcm/compaction/flush",
-            {
-              sessionKey,
-              // Each entry goes through the SAME resolver as the singular
-              // flush and every other delegate call, so a batch cannot widen
-              // scope where a one-at-a-time flush would refuse.
-              namespaces: await Promise.all(
-                namespaces.map(async (sessionNamespace) =>
-                  (await capability.resolveScopedNamespace(sessionNamespace || undefined)) ?? "",
-                ),
-              ),
-            },
+            { sessionKey, namespaces: requestNamespaces },
             remainingTimeout(),
           );
           if (response === null) {
@@ -682,12 +681,11 @@ export function registerDelegateRuntime(
           const isBatchResponse =
             Array.isArray(responseNamespaces) &&
             Array.isArray(responseResults) &&
-            responseNamespaces.length === namespaces.length &&
+            responseNamespaces.length === requestNamespaces.length &&
             responseNamespaces.every(
-              (responseNamespace, index) =>
-                responseNamespace === (namespaces[index] ?? ""),
+              (responseNamespace, index) => responseNamespace === requestNamespaces[index],
             ) &&
-            responseResults.length === namespaces.length;
+            responseResults.length === requestNamespaces.length;
           if (!isBatchResponse) {
             invalidateCachedBatchFlushSupport();
             return flushIndividually();

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -110,8 +110,6 @@ export interface DelegateRuntimeOptions {
     extractionMaxTurnChars?: unknown;
     flushModel?: string;
     configuredSearchBackend: "qmd" | "builtin";
-    /** Seeds the capability's health snapshot; see DelegateCapabilityOptions. */
-    configuredNamespacesEnabled: boolean;
     configuredQmdCommand: string;
   };
   /** Injectable clock for capability-cache expiry tests and deterministic hosts. */
@@ -165,10 +163,14 @@ function reportDaemonAuthorizationFailure(
   );
 }
 
+const AUTHORIZATION_PROBE_TIMEOUT_MS = 2_000;
+
 export async function probeDelegateAuthorization(
   target: DelegateDaemonTarget,
   namespace = "",
   operations: readonly DelegateAuthorizationOperation[] = DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS,
+  /** Cap from a caller's shared deadline; the default is this probe's own. */
+  timeoutMs?: number,
 ): Promise<DelegateAuthorizationPreflight> {
   const auth = target.resolveAuthToken();
   const headers = auth.token ? { Authorization: `Bearer ${auth.token}` } : undefined;
@@ -178,7 +180,9 @@ export async function probeDelegateAuthorization(
   try {
     const response = await fetch(daemonUrl(target, `/engram/v1/authorization?${query}`), {
       headers,
-      signal: AbortSignal.timeout(2_000),
+      signal: AbortSignal.timeout(
+        timeoutMs === undefined ? AUTHORIZATION_PROBE_TIMEOUT_MS : Math.min(AUTHORIZATION_PROBE_TIMEOUT_MS, timeoutMs),
+      ),
     });
     await response.body?.cancel();
     if (response.status === 200) {
@@ -392,8 +396,13 @@ export function registerDelegateRuntime(
     },
     // The daemon's own namespace-aware probe, so a substituted default is
     // proven usable before the first search rather than 403-ing on it.
-    verifyNamespaceAuthorization: async (candidate) => {
-      const probe = await probeDelegateAuthorization(target, candidate, ["memory_search"]);
+    verifyNamespaceAuthorization: async (candidate, timeoutMs) => {
+      const probe = await probeDelegateAuthorization(
+        target,
+        candidate,
+        ["memory_search"],
+        timeoutMs,
+      );
       return probe.state === "unavailable" ? undefined : probe.state === "authorized";
     },
     memoryDir: options.capability.memoryDir,
@@ -411,7 +420,6 @@ export function registerDelegateRuntime(
     extractionMaxTurnChars: options.capability.extractionMaxTurnChars,
     flushModel: options.capability.flushModel,
     configuredSearchBackend: options.capability.configuredSearchBackend,
-    configuredNamespacesEnabled: options.capability.configuredNamespacesEnabled,
     configuredQmdCommand: options.capability.configuredQmdCommand,
     searchTimeoutMs: options.recallTimeoutMs,
     healthTimeoutMs: options.recallTimeoutMs,

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -651,7 +651,11 @@ export function registerDelegateRuntime(
           target,
           options.serviceId,
           "/engram/v1/lcm/compaction/flush",
-          await withNamespace(sessionNamespace, { sessionKey }, capability.resolveScopedNamespace),
+          await withNamespace(sessionNamespace, { sessionKey }, (explicit) =>
+            // Inside the flush's SHARED deadline: a health probe started here
+            // with its own full timeout would overrun the hook.
+            capability.resolveScopedNamespace(explicit, remainingTimeout()),
+          ),
           remainingTimeout(),
         );
       const flushIndividually = async (): Promise<boolean> => {
@@ -674,7 +678,10 @@ export function registerDelegateRuntime(
         // daemon echoes, so it is also what the response is validated against.
         const requestNamespaces = await Promise.all(
           namespaces.map(async (sessionNamespace) =>
-            (await capability.resolveScopedNamespace(sessionNamespace || undefined)) ?? "",
+            (await capability.resolveScopedNamespace(
+              sessionNamespace || undefined,
+              remainingTimeout(),
+            )) ?? "",
           ),
         );
         try {

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -396,11 +396,14 @@ export function registerDelegateRuntime(
     },
     // The daemon's own namespace-aware probe, so a substituted default is
     // proven usable before the first search rather than 403-ing on it.
-    verifyNamespaceAuthorization: async (candidate, timeoutMs) => {
+    verifyNamespaceAuthorization: async (candidate, timeoutMs, operations) => {
       const probe = await probeDelegateAuthorization(
         target,
         candidate,
-        ["memory_search"],
+        // What the caller is about to do. A token that grants recall/observe/
+        // flush but not memory_search must not have those rejected locally.
+        (operations as readonly DelegateAuthorizationOperation[] | undefined) ??
+          DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS,
         timeoutMs,
       );
       return probe.state === "unavailable" ? undefined : probe.state === "authorized";
@@ -439,6 +442,11 @@ export function registerDelegateRuntime(
       // inject the PREVIOUS query's memory into this prompt.
       if (cachePromptLines) promptLinesBySession.delete(sessionKey);
       if (query.trim().length < 5) return undefined;
+      // The host abandons this hook at `hookTimeoutMs`, so namespace
+      // resolution and the recall POST share ONE deadline rather than each
+      // taking its own full timeout and together overrunning it.
+      const promptDeadline = Date.now() + Math.min(options.hookTimeoutMs, options.recallTimeoutMs);
+      const promptRemaining = (): number => promptDeadline - Date.now();
       try {
         if (options.shouldSkipRecall(sessionKey)) {
           log.debug(`delegate recall skipped: cron policy excludes ${sessionKey}`);
@@ -475,9 +483,13 @@ export function registerDelegateRuntime(
               ...(cwd ? { cwd } : {}),
               ...(options.projectTag ? { projectTag: options.projectTag } : {}),
             },
-            capability.resolveScopedNamespace,
+            // ONE deadline for the whole hook: health resolution followed by
+            // a full-timeout recall could otherwise run past `hookTimeoutMs`
+            // and have the host abandon it with nothing injected.
+            (explicit) =>
+              capability.resolveScopedNamespace(explicit, promptRemaining(), ["recall"]),
           ),
-          options.recallTimeoutMs,
+          Math.max(1, promptRemaining()),
         );
         const rawContext = response?.context;
         if (typeof rawContext !== "string" || rawContext.trim().length === 0) {
@@ -555,6 +567,9 @@ export function registerDelegateRuntime(
       );
     if (turn.length === 0) return;
     try {
+      const observeDeadline =
+        Date.now() + Math.min(options.hookTimeoutMs, options.observeTimeoutMs);
+      const observeRemaining = (): number => observeDeadline - Date.now();
       const cwd = cwdFrom(event, ctx, options.cwd);
       const scopedNamespace = await sessionNamespaceFrom(
         sessionKey,
@@ -575,9 +590,10 @@ export function registerDelegateRuntime(
             ...(cwd ? { cwd } : {}),
             ...(options.projectTag ? { projectTag: options.projectTag } : {}),
           },
-          capability.resolveScopedNamespace,
+          (explicit) =>
+            capability.resolveScopedNamespace(explicit, observeRemaining(), ["observe"]),
         ),
-        options.observeTimeoutMs,
+        Math.max(1, observeRemaining()),
       );
     } catch (err) {
       log.warn(`delegate observe failed: ${String(err)}`);
@@ -666,7 +682,9 @@ export function registerDelegateRuntime(
           await withNamespace(sessionNamespace, { sessionKey }, (explicit) =>
             // Inside the flush's SHARED deadline: a health probe started here
             // with its own full timeout would overrun the hook.
-            capability.resolveScopedNamespace(explicit, remainingBudget()),
+            capability.resolveScopedNamespace(explicit, remainingBudget(), [
+              "lcm_compaction_flush",
+            ]),
           ),
           remainingTimeout(),
         );
@@ -690,10 +708,9 @@ export function registerDelegateRuntime(
         // daemon echoes, so it is also what the response is validated against.
         const requestNamespaces = await Promise.all(
           namespaces.map(async (sessionNamespace) =>
-            (await capability.resolveScopedNamespace(
-              sessionNamespace || undefined,
-              remainingBudget(),
-            )) ?? "",
+            (await capability.resolveScopedNamespace(sessionNamespace || undefined, remainingBudget(), [
+              "lcm_compaction_flush",
+            ])) ?? "",
           ),
         );
         try {

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -28,10 +28,15 @@ import { log } from "@remnic/core/logger";
 import {
   SESSION_NAMESPACE_BINDING_MAX_ENTRIES,
   SESSION_NAMESPACE_BINDING_MAX_NAMESPACES,
-  SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH,
   type SessionNamespaceBindingStore,
   createFileSessionNamespaceBindingStore,
 } from "@remnic/core/session-namespace-bindings";
+import {
+  lifecycleSessionNamespacesFrom,
+  rememberedNamespacesFor,
+  sessionNamespaceFrom,
+  withNamespace,
+} from "./delegate-namespaces.js";
 import { createFileToggleStore } from "@remnic/core/session-toggles";
 import {
   type DaemonAuthToken,
@@ -307,118 +312,6 @@ function cwdFrom(
     if (typeof candidate === "string" && candidate.length > 0) return candidate;
   }
   return fallback;
-}
-
-async function withNamespace(
-  namespace: string | undefined,
-  body: Record<string, unknown>,
-  daemonDefaultNamespace: () => Promise<string | undefined>,
-): Promise<Record<string, unknown>> {
-  // An ABSENT namespace is a principal-wide fan-out to the daemon, not "the
-  // default scope", so fall back to the daemon's concrete default exactly as
-  // the memory-slot search does. Otherwise prompt recall would range wider
-  // than tool search on the same session.
-  const scoped = namespace || (await daemonDefaultNamespace());
-  return scoped === undefined ? body : { ...body, namespace: scoped };
-}
-
-interface ExplicitSessionNamespace {
-  namespace: string | undefined;
-}
-
-function explicitSessionNamespaceFrom(
-  sessionKey: string,
-  event: Record<string, unknown>,
-  ctx: Record<string, unknown>,
-): ExplicitSessionNamespace | undefined {
-  const eventSessionKey = typeof event.sessionKey === "string" ? event.sessionKey : undefined;
-  const ctxSessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : undefined;
-  const sources =
-    eventSessionKey === sessionKey
-      ? [event, ctx]
-      : ctxSessionKey === sessionKey
-        ? [ctx, event]
-        : [ctx, event];
-  for (const source of sources) {
-    const sourceSessionKey = typeof source.sessionKey === "string" ? source.sessionKey : undefined;
-    if (sourceSessionKey !== sessionKey) continue;
-    const runtime = source.runtime;
-    if (typeof runtime !== "object" || runtime === null) continue;
-    const agent = (runtime as Record<string, unknown>).agent;
-    if (typeof agent !== "object" || agent === null) continue;
-    const session = (agent as Record<string, unknown>).session;
-    if (typeof session !== "object" || session === null) continue;
-    const namespace = (session as Record<string, unknown>).namespace;
-    if (namespace !== undefined && typeof namespace !== "string") {
-      throw new Error("delegate session namespace metadata must be a string");
-    }
-    return { namespace: typeof namespace === "string" ? namespace.trim() || undefined : undefined };
-  }
-  return undefined;
-}
-
-async function rememberedNamespacesFor(
-  sessionKey: string,
-  namespaceBindings: SessionNamespaceBindingStore,
-): Promise<string[]> {
-  return namespaceBindings.namespacesFor(sessionKey);
-}
-
-async function rememberNamespace(
-  sessionKey: string,
-  namespace: string,
-  namespaceBindings: SessionNamespaceBindingStore,
-): Promise<void> {
-  if (namespace.length > SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH) {
-    throw new Error(
-      `delegate session namespace exceeds the daemon limit of ${SESSION_NAMESPACE_BINDING_MAX_NAMESPACE_LENGTH} characters`,
-    );
-  }
-  try {
-    await namespaceBindings.remember(sessionKey, namespace);
-  } catch (err) {
-    log.warn(`delegate namespace binding persistence failed: ${String(err)}`);
-    throw err;
-  }
-}
-
-async function sessionNamespaceFrom(
-  sessionKey: string,
-  event: Record<string, unknown>,
-  ctx: Record<string, unknown>,
-  fallback: string,
-  namespaceBindings: SessionNamespaceBindingStore,
-): Promise<string | undefined> {
-  const explicit = explicitSessionNamespaceFrom(sessionKey, event, ctx);
-  if (explicit !== undefined) {
-    await rememberNamespace(sessionKey, explicit.namespace ?? "", namespaceBindings);
-    return explicit.namespace;
-  }
-  const remembered = await rememberedNamespacesFor(sessionKey, namespaceBindings);
-  return remembered.length > 0 ? remembered.at(-1) || undefined : fallback.trim() || undefined;
-}
-
-async function lifecycleSessionNamespacesFrom(
-  sessionKey: string,
-  event: Record<string, unknown>,
-  ctx: Record<string, unknown>,
-  fallback: string,
-  namespaceBindings: SessionNamespaceBindingStore,
-): Promise<Array<string | undefined>> {
-  const explicit = explicitSessionNamespaceFrom(sessionKey, event, ctx);
-  if (explicit !== undefined) {
-    await rememberNamespace(sessionKey, explicit.namespace ?? "", namespaceBindings);
-  }
-  const remembered = await rememberedNamespacesFor(sessionKey, namespaceBindings);
-  if (explicit !== undefined) {
-    const explicitNamespace = explicit.namespace ?? "";
-    const namespaces = remembered.includes(explicitNamespace)
-      ? remembered
-      : [...remembered, explicitNamespace];
-    return namespaces.map((namespace) => namespace || undefined);
-  }
-  if (remembered.length > 0) return remembered.map((namespace) => namespace || undefined);
-  return [fallback.trim() || undefined];
 }
 
 function readContextComposition(

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -662,7 +662,14 @@ export function registerDelegateRuntime(
             "/engram/v1/lcm/compaction/flush",
             {
               sessionKey,
-              namespaces: namespaces.map((sessionNamespace) => sessionNamespace ?? ""),
+              // Each entry goes through the SAME resolver as the singular
+              // flush and every other delegate call, so a batch cannot widen
+              // scope where a one-at-a-time flush would refuse.
+              namespaces: await Promise.all(
+                namespaces.map(async (sessionNamespace) =>
+                  (await capability.resolveScopedNamespace(sessionNamespace || undefined)) ?? "",
+                ),
+              ),
             },
             remainingTimeout(),
           );

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -641,7 +641,11 @@ export function registerDelegateRuntime(
   ): Promise<boolean> => {
     try {
       const deadline = Date.now() + options.flushTimeoutMs;
+      // The floor of 1 keeps a doomed POST from being sent with a zero timeout
+      // (which some clients read as "no timeout"), but it must not disguise a
+      // spent deadline from callers that can legitimately SKIP work.
       const remainingTimeout = (): number => Math.max(1, deadline - Date.now());
+      const remainingBudget = (): number => deadline - Date.now();
       const sessionKey = lifecycleSessionKeyFrom(event, ctx);
       if (sessionKey === undefined) {
         log.warn("delegate flush skipped: lifecycle event has malformed session key");
@@ -662,7 +666,7 @@ export function registerDelegateRuntime(
           await withNamespace(sessionNamespace, { sessionKey }, (explicit) =>
             // Inside the flush's SHARED deadline: a health probe started here
             // with its own full timeout would overrun the hook.
-            capability.resolveScopedNamespace(explicit, remainingTimeout()),
+            capability.resolveScopedNamespace(explicit, remainingBudget()),
           ),
           remainingTimeout(),
         );
@@ -688,7 +692,7 @@ export function registerDelegateRuntime(
           namespaces.map(async (sessionNamespace) =>
             (await capability.resolveScopedNamespace(
               sessionNamespace || undefined,
-              remainingTimeout(),
+              remainingBudget(),
             )) ?? "",
           ),
         );

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -463,8 +463,16 @@ export function registerDelegateRuntime(
   const promptLinesBySession = new Map<string, string[]>();
   // Embedded zero-limit contract: recallBudgetChars === 0 disables injection.
   const promptInjectionEnabled = options.allowPromptInjection && options.recallBudgetChars !== 0;
+  const useSectionBuilder = typeof api.registerMemoryPromptSection === "function";
+  // A host with no section builder but a unified memory capability injects
+  // through the capability's promptBuilder, which reads the same cache. Only
+  // when NEITHER exists does the hook return the injection fields itself —
+  // otherwise the capability builder would always see an empty cache while the
+  // hook injected separately (or, worse, both would inject).
+  const useCapabilityBuilder =
+    !useSectionBuilder && typeof api.registerMemoryCapability === "function";
+  const cachePromptLines = useSectionBuilder || useCapabilityBuilder;
   if (promptInjectionEnabled) {
-    const useSectionBuilder = typeof api.registerMemoryPromptSection === "function";
 
     const recallHandler = async (
       event: Record<string, unknown>,
@@ -473,7 +481,7 @@ export function registerDelegateRuntime(
       const query = recallQueryFrom(event);
       if (query.trim().length < 5) return undefined;
       const sessionKey = sessionKeyFrom(event, ctx);
-      if (useSectionBuilder) promptLinesBySession.delete(sessionKey);
+      if (cachePromptLines) promptLinesBySession.delete(sessionKey);
       try {
         if (options.shouldSkipRecall(sessionKey)) {
           log.debug(`delegate recall skipped: cron policy excludes ${sessionKey}`);
@@ -520,10 +528,9 @@ export function registerDelegateRuntime(
         });
         if (!rendered) return undefined;
         const prompt = rendered.prompt;
-        if (useSectionBuilder) {
-          // Section-builder hosts inject through the registered builder; the
-          // hook only pre-computes. Returning injection fields here too would
-          // double-inject.
+        if (cachePromptLines) {
+          // A registered builder injects; the hook only pre-computes.
+          // Returning injection fields here too would double-inject.
           promptLinesBySession.set(sessionKey, rendered.lines);
           return undefined;
         }
@@ -781,7 +788,14 @@ export function registerDelegateRuntime(
     workspaceDir: options.capability.workspaceDir,
     agentIds: options.capability.agentIds,
     allowPromptInjection: promptInjectionEnabled,
-    peekPromptLines: (sessionKey) => promptLinesBySession.get(sessionKey) ?? null,
+    // The section builder owns the destructive read when it exists; otherwise
+    // the capability builder IS the sole consumer and must evict, or a stale
+    // section would be re-injected on the next turn.
+    readPromptLines: (sessionKey) => {
+      const lines = promptLinesBySession.get(sessionKey) ?? null;
+      if (!useSectionBuilder) promptLinesBySession.delete(sessionKey);
+      return lines;
+    },
     extractionMaxTurnChars: options.capability.extractionMaxTurnChars,
     flushModel: options.capability.flushModel,
     configuredSearchBackend: options.capability.configuredSearchBackend,

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -127,6 +127,11 @@ const DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS = [
   "recall",
   "observe",
   "lcm_compaction_flush",
+  // The daemon-backed memory-slot capability searches through
+  // /engram/v1/memories/search, which enforces its own `memory_search`
+  // operation. Omitting it here would let the preflight report a
+  // least-privilege token authorized while every capability search 403s.
+  "memory_search",
 ] as const;
 
 type DelegateAuthorizationOperation = (typeof DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS)[number];
@@ -760,6 +765,18 @@ export function registerDelegateRuntime(
     serviceId: options.serviceId,
     target,
     namespace,
+    // Capability searches scope through the SAME per-session binding history
+    // the hooks use (the non-explicit branch of sessionNamespaceFrom): the
+    // host hands the runtime a sessionKey but no event/ctx to read an explicit
+    // namespace from, so the remembered binding — else the registration-wide
+    // fallback — is the correct scope.
+    resolveSearchNamespace: async (sessionKey) => {
+      if (sessionKey) {
+        const remembered = await rememberedNamespacesFor(sessionKey, namespaceBindings);
+        if (remembered.length > 0) return remembered.at(-1) || undefined;
+      }
+      return namespace.trim() || undefined;
+    },
     memoryDir: options.capability.memoryDir,
     workspaceDir: options.capability.workspaceDir,
     agentIds: options.capability.agentIds,
@@ -821,9 +838,12 @@ export interface MaybeRegisterDelegateOptions {
 function activeDelegateAuthorizationOperations(
   options: MaybeRegisterDelegateOptions,
 ): readonly DelegateAuthorizationOperation[] {
+  // `recall` is exercised only when prompt injection is on; observe, flush,
+  // and the capability's memory_search always are. Filter by name rather than
+  // slicing so reordering the list cannot silently drop the wrong operation.
   return options.allowPromptInjection && options.recallBudgetChars !== 0
     ? DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS
-    : DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS.slice(1);
+    : DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS.filter((operation) => operation !== "recall");
 }
 const delegateNamespaceMigrationChains = new Map<string, Map<string, Promise<void>>>();
 const queueDelegateNamespaceMigration = <T>(

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -35,7 +35,9 @@ import {
 import { createFileToggleStore } from "@remnic/core/session-toggles";
 import {
   type DaemonAuthToken,
+  type DelegateDaemonTarget,
   checkDaemonHealthSync,
+  daemonUrl,
   loadDaemonAuth,
   parseOpenClawBridgeConfig,
   resolveBridgeMode,
@@ -48,12 +50,10 @@ import {
   extractLastTurn,
   extractTextContent,
 } from "./transcript-turns.js";
-
-export interface DelegateDaemonTarget {
-  host: string;
-  port: number;
-  resolveAuthToken: () => DaemonAuthToken;
-}
+import {
+  type DelegateCapabilityApi,
+  registerDelegateMemoryCapability,
+} from "./delegate-capability.js";
 
 export interface DelegateRuntimeOptions {
   serviceId: string;
@@ -93,11 +93,25 @@ export interface DelegateRuntimeOptions {
   recallTimeoutMs: number;
   observeTimeoutMs: number;
   flushTimeoutMs: number;
+  /**
+   * Memory-slot capability inputs (issue #2120). The daemon-backed capability
+   * gives delegate mode the same host surface as embedded: prompt builder,
+   * memory runtime, flush plan, and public artifacts.
+   */
+  capability: {
+    memoryDir: string;
+    workspaceDir: string;
+    agentIds: string[];
+    extractionMaxTurnChars?: unknown;
+    flushModel?: string;
+    configuredSearchBackend: "qmd" | "builtin";
+    configuredQmdCommand: string;
+  };
   /** Injectable clock for capability-cache expiry tests and deterministic hosts. */
   now?: () => number;
 }
 
-export interface DelegateHookApi {
+export interface DelegateHookApi extends DelegateCapabilityApi {
   on(
     hook: string,
     handler: (event: Record<string, unknown>, ctx: Record<string, unknown>) => unknown,
@@ -107,7 +121,6 @@ export interface DelegateHookApi {
   // builder parameter is a wider SDK union — remains assignable.
   registerMemoryPromptSection?(builder: (params: { sessionKey?: string }) => string[] | null): void;
 }
-const MEMORY_CONTEXT_HEADER = "## Memory Context (Remnic)";
 const DELEGATE_BATCH_FLUSH_CACHE_TTL_MS = 30_000;
 
 const DEFAULT_DELEGATE_AUTHORIZATION_OPERATIONS = [
@@ -122,13 +135,6 @@ export interface DelegateAuthorizationPreflight {
   readonly state: "authorized" | "unauthorized" | "unavailable";
   readonly tokenSource: DaemonAuthToken["source"];
   readonly status?: 401 | 403;
-}
-
-function daemonUrl(target: DelegateDaemonTarget, pathname: string): string {
-  const host = target.host.includes(":") && !target.host.startsWith("[")
-    ? `[${target.host}]`
-    : target.host;
-  return `http://${host}:${target.port}${pathname}`;
 }
 
 const daemonAuthFailureLogKeys = new Set<string>();
@@ -444,12 +450,15 @@ export function registerDelegateRuntime(
     return;
   }
 
+  // Session-scoped cache of precomputed recall lines, mirroring the embedded
+  // pre-compute-then-consume contract: the recall hook fills it, the
+  // synchronous section builder consumes (and evicts) it, and the capability's
+  // prompt builder only peeks so the two cannot double-consume. Declared
+  // outside the injection gate so the capability can be registered either way.
+  const promptLinesBySession = new Map<string, string[]>();
   // Embedded zero-limit contract: recallBudgetChars === 0 disables injection.
-  if (options.allowPromptInjection && options.recallBudgetChars !== 0) {
-    // Session-scoped cache for the section-builder path, mirroring the
-    // embedded pre-compute-then-consume contract: the hook fills it, the
-    // synchronous builder consumes (and evicts) it.
-    const promptLinesBySession = new Map<string, string[]>();
+  const promptInjectionEnabled = options.allowPromptInjection && options.recallBudgetChars !== 0;
+  if (promptInjectionEnabled) {
     const useSectionBuilder = typeof api.registerMemoryPromptSection === "function";
 
     const recallHandler = async (
@@ -747,9 +756,27 @@ export function registerDelegateRuntime(
     api.on("session_end", flushEndedSession);
   }
 
+  registerDelegateMemoryCapability(api, {
+    serviceId: options.serviceId,
+    target,
+    namespace,
+    memoryDir: options.capability.memoryDir,
+    workspaceDir: options.capability.workspaceDir,
+    agentIds: options.capability.agentIds,
+    allowPromptInjection: promptInjectionEnabled,
+    peekPromptLines: (sessionKey) => promptLinesBySession.get(sessionKey) ?? null,
+    extractionMaxTurnChars: options.capability.extractionMaxTurnChars,
+    flushModel: options.capability.flushModel,
+    configuredSearchBackend: options.capability.configuredSearchBackend,
+    configuredQmdCommand: options.capability.configuredQmdCommand,
+    searchTimeoutMs: options.recallTimeoutMs,
+    healthTimeoutMs: options.recallTimeoutMs,
+    now: options.now,
+  });
+
   log.info(
     `[${options.serviceId}] bridge mode delegate: memory loop backed by daemon at ` +
-      `${target.host}:${target.port} (embedded orchestrator skipped; tools/CLI/surfaces stay daemon-side)`,
+      `${target.host}:${target.port} (embedded orchestrator skipped; tools/CLI stay daemon-side)`,
   );
 }
 
@@ -783,6 +810,12 @@ export interface MaybeRegisterDelegateOptions {
   projectTag?: string;
   /** Embedded parity: gate buffer flush on reset/session_end. */
   flushOnResetEnabled: boolean;
+  /**
+   * Memory-slot capability inputs (issue #2120) — forwarded verbatim to the
+   * daemon-backed capability so delegate mode keeps the host surface embedded
+   * mode provides.
+   */
+  capability: DelegateRuntimeOptions["capability"];
 }
 
 function activeDelegateAuthorizationOperations(
@@ -1082,6 +1115,7 @@ export function maybeRegisterDelegateRuntime(
     cwd: options.cwd,
     projectTag: options.projectTag,
     flushOnResetEnabled: options.flushOnResetEnabled,
+    capability: options.capability,
     recallTimeoutMs: 25_000,
     observeTimeoutMs: 120_000,
     flushTimeoutMs: 55_000,

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -309,11 +309,17 @@ function cwdFrom(
   return fallback;
 }
 
-function withNamespace(
+async function withNamespace(
   namespace: string | undefined,
   body: Record<string, unknown>,
-): Record<string, unknown> {
-  return namespace ? { ...body, namespace } : body;
+  daemonDefaultNamespace: () => Promise<string | undefined>,
+): Promise<Record<string, unknown>> {
+  // An ABSENT namespace is a principal-wide fan-out to the daemon, not "the
+  // default scope", so fall back to the daemon's concrete default exactly as
+  // the memory-slot search does. Otherwise prompt recall would range wider
+  // than tool search on the same session.
+  const scoped = namespace || (await daemonDefaultNamespace());
+  return scoped === undefined ? body : { ...body, namespace: scoped };
 }
 
 interface ExplicitSessionNamespace {
@@ -472,6 +478,43 @@ export function registerDelegateRuntime(
   const useCapabilityBuilder =
     !useSectionBuilder && typeof api.registerMemoryCapability === "function";
   const cachePromptLines = useSectionBuilder || useCapabilityBuilder;
+
+  const capability = registerDelegateMemoryCapability(api, {
+    serviceId: options.serviceId,
+    target,
+    namespace,
+    // Capability searches scope through the SAME per-session binding history
+    // the hooks use (the non-explicit branch of sessionNamespaceFrom): the
+    // host hands the runtime a sessionKey but no event/ctx to read an explicit
+    // namespace from, so the remembered binding — else the registration-wide
+    // fallback — is the correct scope.
+    resolveSearchNamespace: async (sessionKey) => {
+      if (sessionKey) {
+        const remembered = await rememberedNamespacesFor(sessionKey, namespaceBindings);
+        if (remembered.length > 0) return remembered.at(-1) || undefined;
+      }
+      return namespace.trim() || undefined;
+    },
+    memoryDir: options.capability.memoryDir,
+    workspaceDir: options.capability.workspaceDir,
+    agentIds: options.capability.agentIds,
+    allowPromptInjection: promptInjectionEnabled,
+    // The section builder owns the destructive read when it exists; otherwise
+    // the capability builder IS the sole consumer and must evict, or a stale
+    // section would be re-injected on the next turn.
+    readPromptLines: (sessionKey) => {
+      const lines = promptLinesBySession.get(sessionKey) ?? null;
+      if (!useSectionBuilder) promptLinesBySession.delete(sessionKey);
+      return lines;
+    },
+    extractionMaxTurnChars: options.capability.extractionMaxTurnChars,
+    flushModel: options.capability.flushModel,
+    configuredSearchBackend: options.capability.configuredSearchBackend,
+    configuredQmdCommand: options.capability.configuredQmdCommand,
+    searchTimeoutMs: options.recallTimeoutMs,
+    healthTimeoutMs: options.recallTimeoutMs,
+    now: options.now,
+  });
   if (promptInjectionEnabled) {
 
     const recallHandler = async (
@@ -509,13 +552,17 @@ export function registerDelegateRuntime(
           target,
           options.serviceId,
           "/engram/v1/recall",
-          withNamespace(scopedNamespace, {
-            query,
-            sessionKey,
-            mode: "auto",
-            ...(cwd ? { cwd } : {}),
-            ...(options.projectTag ? { projectTag: options.projectTag } : {}),
-          }),
+          await withNamespace(
+            scopedNamespace,
+            {
+              query,
+              sessionKey,
+              mode: "auto",
+              ...(cwd ? { cwd } : {}),
+              ...(options.projectTag ? { projectTag: options.projectTag } : {}),
+            },
+            capability.daemonDefaultNamespace,
+          ),
           options.recallTimeoutMs,
         );
         const rawContext = response?.context;
@@ -606,12 +653,16 @@ export function registerDelegateRuntime(
         target,
         options.serviceId,
         "/engram/v1/observe",
-        withNamespace(scopedNamespace, {
-          sessionKey,
-          messages: turn,
-          ...(cwd ? { cwd } : {}),
-          ...(options.projectTag ? { projectTag: options.projectTag } : {}),
-        }),
+        await withNamespace(
+          scopedNamespace,
+          {
+            sessionKey,
+            messages: turn,
+            ...(cwd ? { cwd } : {}),
+            ...(options.projectTag ? { projectTag: options.projectTag } : {}),
+          },
+          capability.daemonDefaultNamespace,
+        ),
         options.observeTimeoutMs,
       );
     } catch (err) {
@@ -689,12 +740,12 @@ export function registerDelegateRuntime(
         namespace,
         namespaceBindings,
       );
-      const flushNamespace = (sessionNamespace: string | undefined) =>
+      const flushNamespace = async (sessionNamespace: string | undefined) =>
         postJson(
           target,
           options.serviceId,
           "/engram/v1/lcm/compaction/flush",
-          withNamespace(sessionNamespace, { sessionKey }),
+          await withNamespace(sessionNamespace, { sessionKey }, capability.daemonDefaultNamespace),
           remainingTimeout(),
         );
       const flushIndividually = async (): Promise<boolean> => {
@@ -768,42 +819,6 @@ export function registerDelegateRuntime(
     api.on("session_end", flushEndedSession);
   }
 
-  registerDelegateMemoryCapability(api, {
-    serviceId: options.serviceId,
-    target,
-    namespace,
-    // Capability searches scope through the SAME per-session binding history
-    // the hooks use (the non-explicit branch of sessionNamespaceFrom): the
-    // host hands the runtime a sessionKey but no event/ctx to read an explicit
-    // namespace from, so the remembered binding — else the registration-wide
-    // fallback — is the correct scope.
-    resolveSearchNamespace: async (sessionKey) => {
-      if (sessionKey) {
-        const remembered = await rememberedNamespacesFor(sessionKey, namespaceBindings);
-        if (remembered.length > 0) return remembered.at(-1) || undefined;
-      }
-      return namespace.trim() || undefined;
-    },
-    memoryDir: options.capability.memoryDir,
-    workspaceDir: options.capability.workspaceDir,
-    agentIds: options.capability.agentIds,
-    allowPromptInjection: promptInjectionEnabled,
-    // The section builder owns the destructive read when it exists; otherwise
-    // the capability builder IS the sole consumer and must evict, or a stale
-    // section would be re-injected on the next turn.
-    readPromptLines: (sessionKey) => {
-      const lines = promptLinesBySession.get(sessionKey) ?? null;
-      if (!useSectionBuilder) promptLinesBySession.delete(sessionKey);
-      return lines;
-    },
-    extractionMaxTurnChars: options.capability.extractionMaxTurnChars,
-    flushModel: options.capability.flushModel,
-    configuredSearchBackend: options.capability.configuredSearchBackend,
-    configuredQmdCommand: options.capability.configuredQmdCommand,
-    searchTimeoutMs: options.recallTimeoutMs,
-    healthTimeoutMs: options.recallTimeoutMs,
-    now: options.now,
-  });
 
   log.info(
     `[${options.serviceId}] bridge mode delegate: memory loop backed by daemon at ` +

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -110,6 +110,8 @@ export interface DelegateRuntimeOptions {
     extractionMaxTurnChars?: unknown;
     flushModel?: string;
     configuredSearchBackend: "qmd" | "builtin";
+    /** Seeds the capability's health snapshot; see DelegateCapabilityOptions. */
+    configuredNamespacesEnabled: boolean;
     configuredQmdCommand: string;
   };
   /** Injectable clock for capability-cache expiry tests and deterministic hosts. */
@@ -409,6 +411,7 @@ export function registerDelegateRuntime(
     extractionMaxTurnChars: options.capability.extractionMaxTurnChars,
     flushModel: options.capability.flushModel,
     configuredSearchBackend: options.capability.configuredSearchBackend,
+    configuredNamespacesEnabled: options.capability.configuredNamespacesEnabled,
     configuredQmdCommand: options.capability.configuredQmdCommand,
     searchTimeoutMs: options.recallTimeoutMs,
     healthTimeoutMs: options.recallTimeoutMs,

--- a/packages/plugin-openclaw/src/memory-flush-plan.ts
+++ b/packages/plugin-openclaw/src/memory-flush-plan.ts
@@ -1,0 +1,62 @@
+/**
+ * Flush-plan resolver for the OpenClaw memory-slot capability.
+ *
+ * The host asks the memory plugin how to spill a long transcript into durable
+ * memory: thresholds, the model to plan with, and the single file the write
+ * tool is allowed to append to. The answer is pure configuration, so both
+ * bridge modes resolve it identically — a delegate-side copy would drift the
+ * prompts and the allowed path apart from the embedded ones.
+ */
+
+export type MemoryFlushPlan = {
+  softThresholdTokens: number;
+  forceFlushTranscriptBytes: number;
+  reserveTokensFloor: number;
+  model?: string;
+  prompt: string;
+  systemPrompt: string;
+  relativePath: string;
+};
+
+export type MemoryFlushPlanOptions = {
+  /** Plugin service id — scopes the allowed flush-plan file. */
+  serviceId: string;
+  /** `extractionMaxTurnChars`; non-finite values fall back to the default. */
+  extractionMaxTurnChars?: unknown;
+  /**
+   * Model to plan the flush with. Callers pass `summaryModel` or the task
+   * chain's primary — NEVER `cfg.model`, which is direct-compatible and may be
+   * a bare id the Gateway cannot route (issue #1469). Empty is omitted so the
+   * Gateway default wins.
+   */
+  flushModel?: string;
+};
+
+const DEFAULT_MAX_TURN_CHARS = 8_000;
+const MIN_MAX_TURN_CHARS = 1_000;
+
+const FLUSH_PROMPT =
+  "Flush the recent OpenClaw transcript into Remnic memory by appending to the allowed flush-plan file only. Preserve durable user preferences, project facts, decisions, corrections, and commitments. Ignore runtime metadata, credentials, and transient command noise.";
+const FLUSH_SYSTEM_PROMPT =
+  "You are Remnic's memory flush planner. Read the transcript and append concise durable memory notes to the file the write tool allows. Do not create files, directories, or dated paths; use only the allowed flush-plan file. Ignore runtime metadata, credentials, transient command noise, and content that is not worth remembering.";
+
+export function buildMemoryFlushPlan(options: MemoryFlushPlanOptions): MemoryFlushPlan {
+  const maxTurnChars =
+    typeof options.extractionMaxTurnChars === "number" &&
+    Number.isFinite(options.extractionMaxTurnChars)
+      ? Math.max(MIN_MAX_TURN_CHARS, Math.floor(options.extractionMaxTurnChars))
+      : DEFAULT_MAX_TURN_CHARS;
+  const flushModel =
+    typeof options.flushModel === "string" && options.flushModel.length > 0
+      ? options.flushModel
+      : undefined;
+  return {
+    softThresholdTokens: 24_000,
+    forceFlushTranscriptBytes: Math.max(16_384, maxTurnChars * 4),
+    reserveTokensFloor: 2_000,
+    ...(flushModel ? { model: flushModel } : {}),
+    prompt: FLUSH_PROMPT,
+    systemPrompt: FLUSH_SYSTEM_PROMPT,
+    relativePath: ["state", "plugins", options.serviceId, "flush-plan.md"].join("/"),
+  };
+}

--- a/packages/plugin-openclaw/src/memory-read-scope.test.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.test.ts
@@ -336,3 +336,11 @@ test("daemonServesCorpus resolves an aliased PARENT but rejects a symlinked root
   assert.equal(daemonServesCorpus(memoryDir, linkedRoot), false);
   await rm(root, { recursive: true, force: true });
 });
+
+test("daemonServesCorpus keeps a drive/filesystem root intact", async () => {
+  const { memoryDir } = await makeCorpus();
+  // Trailing separators are trimmed, but never past the root: on Windows a
+  // corpus at `C:\\` must not collapse to the drive-relative `C:`.
+  assert.equal(daemonServesCorpus(`${memoryDir}///`, memoryDir), true);
+  assert.equal(daemonServesCorpus(path.parse(memoryDir).root, path.parse(memoryDir).root), true);
+});

--- a/packages/plugin-openclaw/src/memory-read-scope.test.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.test.ts
@@ -22,10 +22,12 @@ async function makeCorpus(): Promise<{
   const workspaceDir = path.join(root, "workspace");
   const outsideDir = path.join(root, "outside");
   await mkdir(path.join(memoryDir, "facts"), { recursive: true });
+  await mkdir(path.join(memoryDir, "artifacts"), { recursive: true });
   await mkdir(path.join(workspaceDir, "memory"), { recursive: true });
   await mkdir(outsideDir, { recursive: true });
   await writeFile(path.join(memoryDir, "facts", "alice.md"), "# alice\nline two\n");
   await writeFile(path.join(memoryDir, "index.json"), "{}\n");
+  await writeFile(path.join(memoryDir, "artifacts", "report.md"), "# artifact\n");
   await writeFile(path.join(workspaceDir, "memory", "notes.md"), "# notes\n");
   await writeFile(path.join(outsideDir, "secret.md"), "# secret\n");
   return { memoryDir, workspaceDir, outsideDir };
@@ -343,4 +345,31 @@ test("daemonServesCorpus keeps a drive/filesystem root intact", async () => {
   // corpus at `C:\\` must not collapse to the drive-relative `C:`.
   assert.equal(daemonServesCorpus(`${memoryDir}///`, memoryDir), true);
   assert.equal(daemonServesCorpus(path.parse(memoryDir).root, path.parse(memoryDir).root), true);
+});
+
+test("resolveReadablePath refuses artifact files even when contained and markdown", async () => {
+  const { memoryDir, workspaceDir } = await makeCorpus();
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  // Artifacts are served only through the dedicated verbatim path; a generic
+  // memory reader must never open them, however the caller spells the path.
+  await assert.rejects(
+    () => scope.resolveReadablePath("artifacts/report.md"),
+    /memory read excluded \(artifact path\)/,
+  );
+  await assert.rejects(
+    () => scope.resolveReadablePath(path.join(memoryDir, "artifacts", "report.md")),
+    /memory read excluded \(artifact path\)/,
+  );
+  // A symlink alias outside artifacts/ must not route around the exclusion.
+  const alias = path.join(memoryDir, "facts", "alias.md");
+  await symlink(path.join(memoryDir, "artifacts", "report.md"), alias);
+  await assert.rejects(
+    () => scope.resolveReadablePath("facts/alias.md"),
+    /memory read excluded \(artifact path\)/,
+  );
+  // Non-artifact reads are unaffected.
+  assert.equal(
+    await scope.resolveReadablePath("facts/alice.md"),
+    path.join(memoryDir, "facts", "alice.md"),
+  );
 });

--- a/packages/plugin-openclaw/src/memory-read-scope.test.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.test.ts
@@ -4,7 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { createMemoryReadScope, isSessionsMemoryPath } from "./memory-read-scope.js";
+import {
+  createMemoryReadScope,
+  daemonServesCorpus,
+  isSessionsMemoryPath,
+} from "./memory-read-scope.js";
 
 async function makeCorpus(): Promise<{
   memoryDir: string;
@@ -247,4 +251,40 @@ test("resolveReadablePath rejects a missing path as a domain error", async () =>
       String(bad),
     );
   }
+});
+
+test("daemonServesCorpus accepts the namespace-resolved storage dir under the corpus root", async () => {
+  const { memoryDir } = await makeCorpus();
+  // GET /engram/v1/health reports storage.dir, which is <root>/namespaces/<ns>
+  // once the default namespace migrates out of the flat root.
+  assert.equal(daemonServesCorpus(memoryDir, memoryDir), true);
+  assert.equal(
+    daemonServesCorpus(memoryDir, path.join(memoryDir, "namespaces", "generalist")),
+    true,
+  );
+  assert.equal(daemonServesCorpus(memoryDir, `${memoryDir}/`), true);
+});
+
+test("daemonServesCorpus rejects a foreign, relative, or blank corpus", async () => {
+  const { memoryDir, outsideDir } = await makeCorpus();
+  assert.equal(daemonServesCorpus(memoryDir, outsideDir), false);
+  assert.equal(
+    daemonServesCorpus(memoryDir, path.dirname(memoryDir)),
+    false,
+    "the daemon serving a PARENT of the corpus root is not the same corpus",
+  );
+  // A relative path names a different directory in each process's cwd, so
+  // resolving both here would manufacture a match between distinct corpora.
+  assert.equal(daemonServesCorpus("./memory", "./memory"), false);
+  assert.equal(daemonServesCorpus(memoryDir, "./memory"), false);
+  assert.equal(daemonServesCorpus("", memoryDir), false);
+  assert.equal(daemonServesCorpus(memoryDir, "   "), false);
+});
+
+test("daemonServesCorpus resolves symlinked spellings of one corpus", async () => {
+  const { memoryDir } = await makeCorpus();
+  const link = path.join(path.dirname(memoryDir), "linked-memory");
+  await symlink(memoryDir, link);
+  assert.equal(daemonServesCorpus(link, memoryDir), true);
+  assert.equal(daemonServesCorpus(memoryDir, link), true);
 });

--- a/packages/plugin-openclaw/src/memory-read-scope.test.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.test.ts
@@ -373,3 +373,40 @@ test("resolveReadablePath refuses artifact files even when contained and markdow
     path.join(memoryDir, "facts", "alice.md"),
   );
 });
+
+test("an `artifacts` ancestor of the corpus does not poison every read", async () => {
+  // A corpus at /srv/artifacts/remnic is ordinary. Judging the ABSOLUTE path
+  // would reject every markdown file in it.
+  const root = await realpath(await mkdtemp(path.join(os.tmpdir(), "remnic-artifacts-ancestor-")));
+  const memoryDir = path.join(root, "artifacts", "remnic");
+  const workspaceDir = path.join(root, "workspace");
+  await mkdir(path.join(memoryDir, "facts"), { recursive: true });
+  await mkdir(path.join(memoryDir, "artifacts"), { recursive: true });
+  await mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+  await writeFile(path.join(memoryDir, "facts", "a.md"), "# a\n");
+  await writeFile(path.join(memoryDir, "artifacts", "report.md"), "# artifact\n");
+  const scope = createMemoryReadScope({ memoryDir, workspaceDir });
+  try {
+    assert.equal(
+      await scope.resolveReadablePath("facts/a.md"),
+      path.join(memoryDir, "facts", "a.md"),
+      "an ordinary read under an artifacts-named ancestor still resolves",
+    );
+    assert.equal(
+      await scope.resolveReadablePath(path.join(memoryDir, "facts", "a.md")),
+      path.join(memoryDir, "facts", "a.md"),
+      "including when the caller passes the absolute path a search returned",
+    );
+    // The corpus's OWN artifacts directory is still excluded.
+    await assert.rejects(
+      () => scope.resolveReadablePath("artifacts/report.md"),
+      /memory read excluded \(artifact path\)/,
+    );
+    await assert.rejects(
+      () => scope.resolveReadablePath(path.join(memoryDir, "artifacts", "report.md")),
+      /memory read excluded \(artifact path\)/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/memory-read-scope.test.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.test.ts
@@ -257,12 +257,25 @@ test("daemonServesCorpus accepts the namespace-resolved storage dir under the co
   const { memoryDir } = await makeCorpus();
   // GET /engram/v1/health reports storage.dir, which is <root>/namespaces/<ns>
   // once the default namespace migrates out of the flat root.
+  const namespaceDir = path.join(memoryDir, "namespaces", "generalist");
+  await mkdir(namespaceDir, { recursive: true });
   assert.equal(daemonServesCorpus(memoryDir, memoryDir), true);
-  assert.equal(
-    daemonServesCorpus(memoryDir, path.join(memoryDir, "namespaces", "generalist")),
-    true,
-  );
+  assert.equal(daemonServesCorpus(memoryDir, namespaceDir), true);
   assert.equal(daemonServesCorpus(memoryDir, `${memoryDir}/`), true);
+});
+
+test("daemonServesCorpus rejects a directory that does not exist or escapes by symlink", async () => {
+  const { memoryDir, outsideDir } = await makeCorpus();
+  assert.equal(
+    daemonServesCorpus(memoryDir, path.join(memoryDir, "namespaces", "never-created")),
+    false,
+    "an unresolvable daemon directory is not a corpus",
+  );
+  // Lexically contained, but a component resolves outside the root: accepting
+  // it would hand local reads a different corpus than the daemon serves.
+  const escape = path.join(memoryDir, "escape");
+  await symlink(outsideDir, escape);
+  assert.equal(daemonServesCorpus(memoryDir, escape), false);
 });
 
 test("daemonServesCorpus rejects a foreign, relative, or blank corpus", async () => {

--- a/packages/plugin-openclaw/src/memory-read-scope.test.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.test.ts
@@ -278,6 +278,23 @@ test("daemonServesCorpus rejects a directory that does not exist or escapes by s
   assert.equal(daemonServesCorpus(memoryDir, escape), false);
 });
 
+test("daemonServesCorpus rejects any descendant that is not a namespace directory", async () => {
+  const { memoryDir } = await makeCorpus();
+  // A daemon independently configured for a nested corpus is NOT this corpus;
+  // accepting it would silently redirect every recall and write into it.
+  const nested = path.join(memoryDir, "archive");
+  const deep = path.join(memoryDir, "namespaces", "team", "extra");
+  await mkdir(nested, { recursive: true });
+  await mkdir(deep, { recursive: true });
+  assert.equal(daemonServesCorpus(memoryDir, nested), false);
+  assert.equal(daemonServesCorpus(memoryDir, deep), false, "only one level under namespaces/");
+  assert.equal(
+    daemonServesCorpus(memoryDir, path.join(memoryDir, "namespaces")),
+    false,
+    "the namespaces container itself is not a namespace corpus",
+  );
+});
+
 test("daemonServesCorpus rejects a foreign, relative, or blank corpus", async () => {
   const { memoryDir, outsideDir } = await makeCorpus();
   assert.equal(daemonServesCorpus(memoryDir, outsideDir), false);

--- a/packages/plugin-openclaw/src/memory-read-scope.test.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, realpath, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -311,10 +311,28 @@ test("daemonServesCorpus rejects a foreign, relative, or blank corpus", async ()
   assert.equal(daemonServesCorpus(memoryDir, "   "), false);
 });
 
-test("daemonServesCorpus resolves symlinked spellings of one corpus", async () => {
-  const { memoryDir } = await makeCorpus();
-  const link = path.join(path.dirname(memoryDir), "linked-memory");
-  await symlink(memoryDir, link);
-  assert.equal(daemonServesCorpus(link, memoryDir), true);
-  assert.equal(daemonServesCorpus(memoryDir, link), true);
+test("daemonServesCorpus resolves an aliased PARENT but rejects a symlinked root", async () => {
+  // A dedicated root: the alias must live INSIDE the fixture, not in the
+  // shared temp directory where parallel runs would collide.
+  const root = await realpath(await mkdtemp(path.join(os.tmpdir(), "remnic-corpus-alias-")));
+  const holder = path.join(root, "holder");
+  const memoryDir = path.join(holder, "memory");
+  await mkdir(memoryDir, { recursive: true });
+
+  // An aliased ancestor is the ordinary case (think /var vs /private/var): the
+  // two spellings name one directory, and splitting them would start a second
+  // orchestrator beside the daemon on the same files.
+  const aliasedHolder = path.join(root, "aliased-holder");
+  await symlink(holder, aliasedHolder);
+  const viaAlias = path.join(aliasedHolder, "memory");
+  assert.equal(daemonServesCorpus(memoryDir, viaAlias), true);
+  assert.equal(daemonServesCorpus(viaAlias, memoryDir), true);
+
+  // The ROOT itself being a link is different: it is a mutable trust anchor,
+  // and retargeting it after validation would move the corpus underneath us.
+  const linkedRoot = path.join(root, "linked-memory");
+  await symlink(memoryDir, linkedRoot);
+  assert.equal(daemonServesCorpus(linkedRoot, memoryDir), false);
+  assert.equal(daemonServesCorpus(memoryDir, linkedRoot), false);
+  await rm(root, { recursive: true, force: true });
 });

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -64,15 +64,14 @@ export function daemonServesCorpus(
   const expandedRoot = expandTildePath(corpusRoot.trim());
   const expandedDaemon = expandTildePath(daemonMemoryDir.trim());
   if (!path.isAbsolute(expandedRoot) || !path.isAbsolute(expandedDaemon)) return false;
-  const lexical = (value: string): string =>
-    trimTrailingSeparators(path.normalize(path.resolve(value)));
-  const rootLexical = lexical(expandedRoot);
-  const daemonLexical = lexical(expandedDaemon);
-  if (isContained(rootLexical, daemonLexical)) return true;
+  // Canonicalize BOTH sides FIRST. A lexical accept would admit a path that
+  // merely looks contained while one of its components symlinks to another
+  // corpus — precisely the escape this gate exists to stop. Both must resolve:
+  // an unresolvable path (missing directory, broken link) is never a match.
   try {
     return isContained(
-      trimTrailingSeparators(path.normalize(realpath(rootLexical))),
-      trimTrailingSeparators(path.normalize(realpath(daemonLexical))),
+      trimTrailingSeparators(path.normalize(realpath(path.resolve(expandedRoot)))),
+      trimTrailingSeparators(path.normalize(realpath(path.resolve(expandedDaemon)))),
     );
   } catch {
     return false;

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -13,7 +13,7 @@
  * already closed.
  */
 
-import { realpathSync } from "node:fs";
+import { lstatSync, realpathSync } from "node:fs";
 import { realpath as fsRealpath } from "node:fs/promises";
 import path from "node:path";
 
@@ -31,6 +31,16 @@ function trimTrailingSeparators(value: string): string {
   let end = value.length;
   while (end > 1 && (value[end - 1] === "/" || value[end - 1] === "\\")) end -= 1;
   return value.slice(0, end);
+}
+
+function defaultIsSymlink(target: string): boolean {
+  try {
+    return lstatSync(target).isSymbolicLink();
+  } catch {
+    // A missing path is rejected by the canonicalization below; report it as
+    // "not a symlink" so the failure surfaces there with the right reason.
+    return false;
+  }
 }
 
 /** The only descendant layout that still names the configured corpus. */
@@ -65,11 +75,18 @@ export function daemonServesCorpus(
   corpusRoot: string,
   daemonMemoryDir: string,
   realpath: (target: string) => string = realpathSync,
+  isSymlink: (target: string) => boolean = defaultIsSymlink,
 ): boolean {
   if (!corpusRoot?.trim() || !daemonMemoryDir?.trim()) return false;
   const expandedRoot = expandTildePath(corpusRoot.trim());
   const expandedDaemon = expandTildePath(daemonMemoryDir.trim());
   if (!path.isAbsolute(expandedRoot) || !path.isAbsolute(expandedDaemon)) return false;
+  // A root that is ITSELF a symlink is a mutable trust anchor: realpath would
+  // erase that fact, and retargeting the link after validation would silently
+  // move the directory treated as the corpus. Reject it outright.
+  if (isSymlink(path.resolve(expandedRoot)) || isSymlink(path.resolve(expandedDaemon))) {
+    return false;
+  }
   let canonicalRoot: string;
   let canonicalDaemon: string;
   try {

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -34,31 +34,45 @@ function trimTrailingSeparators(value: string): string {
 }
 
 /**
- * Whether two `memoryDir` values name the same corpus.
+ * Whether a daemon's reported memory directory belongs to the corpus this
+ * plugin is configured for.
  *
- * Lexical first (tilde-expanded, resolved, normalized, trailing separators
- * trimmed), then a `realpath` comparison so two symlink spellings of one
- * directory are recognized as identical — otherwise a co-located gateway and
- * daemon on the same files would be judged different and both run, which is
- * exactly the duplicate-orchestrator deployment this check exists to prevent.
+ * Deliberately asymmetric and containment-based. `GET /engram/v1/health`
+ * reports the NAMESPACE-RESOLVED storage directory, so a deployment whose
+ * default namespace has migrated out of the flat root answers
+ * `<corpusRoot>/namespaces/<token>` while the plugin is configured with
+ * `<corpusRoot>`. Requiring equality would mark that healthy co-located daemon
+ * foreign and disable every file-backed surface.
  *
- * Fails CLOSED: a path that cannot be resolved is never a match.
+ * Both sides must be ABSOLUTE. A relative `memoryDir` names a different
+ * directory in each process's working directory, so resolving both against the
+ * gateway's cwd would manufacture a match between two distinct corpora.
+ *
+ * Compared lexically first, then by `realpath`, so two symlink spellings of
+ * one directory match — otherwise a co-located gateway and daemon on the same
+ * files would be judged different and both run, exactly the
+ * duplicate-orchestrator deployment this check exists to prevent.
+ *
+ * Fails CLOSED: relative, blank, or unresolvable paths are never a match.
  */
-export function sameMemoryCorpus(
-  left: string,
-  right: string,
+export function daemonServesCorpus(
+  corpusRoot: string,
+  daemonMemoryDir: string,
   realpath: (target: string) => string = realpathSync,
 ): boolean {
-  if (!left?.trim() || !right?.trim()) return false;
+  if (!corpusRoot?.trim() || !daemonMemoryDir?.trim()) return false;
+  const expandedRoot = expandTildePath(corpusRoot.trim());
+  const expandedDaemon = expandTildePath(daemonMemoryDir.trim());
+  if (!path.isAbsolute(expandedRoot) || !path.isAbsolute(expandedDaemon)) return false;
   const lexical = (value: string): string =>
-    trimTrailingSeparators(path.normalize(path.resolve(expandTildePath(value.trim()))));
-  const leftLexical = lexical(left);
-  const rightLexical = lexical(right);
-  if (leftLexical === rightLexical) return true;
+    trimTrailingSeparators(path.normalize(path.resolve(value)));
+  const rootLexical = lexical(expandedRoot);
+  const daemonLexical = lexical(expandedDaemon);
+  if (isContained(rootLexical, daemonLexical)) return true;
   try {
-    return (
-      trimTrailingSeparators(path.normalize(realpath(leftLexical))) ===
-      trimTrailingSeparators(path.normalize(realpath(rightLexical)))
+    return isContained(
+      trimTrailingSeparators(path.normalize(realpath(rootLexical))),
+      trimTrailingSeparators(path.normalize(realpath(daemonLexical))),
     );
   } catch {
     return false;

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -118,6 +118,13 @@ export type MemoryReadScopeOptions = {
    * relative hits against the namespace directory the daemon reports first.
    */
   additionalRoots?: readonly string[];
+  /**
+   * Whether `<workspaceDir>/memory` is a readable root. Default `true`
+   * (embedded parity). Delegate mode sets `false`: the daemon reports only its
+   * `memoryDir`, so a gateway-local workspace it never searched cannot be
+   * authorized just because the two processes share a corpus.
+   */
+  includeWorkspaceRoot?: boolean;
   /** Canonicalizer seam. Defaults to `fs.promises.realpath`; tests inject. */
   realpath?: (filePath: string) => Promise<string>;
 }
@@ -189,7 +196,12 @@ export function createMemoryReadScope(options: MemoryReadScopeOptions): MemoryRe
   // workspace's memory subdirectory qualify.
   const allowedRoots = [
     memoryDir,
-    workspaceDir ? path.join(workspaceDir, "memory") : undefined,
+    // Delegate mode drops this: the daemon reports only its `memoryDir`, so a
+    // gateway-local workspace it never searched or authorized must not be a
+    // readable root just because the two processes share a corpus.
+    workspaceDir && options.includeWorkspaceRoot !== false
+      ? path.join(workspaceDir, "memory")
+      : undefined,
     ...(options.additionalRoots ?? []),
   ].filter((root): root is string => typeof root === "string" && root.length > 0);
 

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -28,8 +28,13 @@ import { expandTildePath } from "@remnic/core";
  * CodeQL flags on uncontrolled data.
  */
 function trimTrailingSeparators(value: string): string {
+  // Never strip past the root. On Windows a corpus at `C:\\` would otherwise
+  // become `C:`, which node:path treats as DRIVE-RELATIVE — `path.relative`
+  // would then measure against the gateway's cwd and reject a daemon serving
+  // `C:\\namespaces\\<ns>`.
+  const floor = Math.max(1, path.parse(value).root.length);
   let end = value.length;
-  while (end > 1 && (value[end - 1] === "/" || value[end - 1] === "\\")) end -= 1;
+  while (end > floor && (value[end - 1] === "/" || value[end - 1] === "\\")) end -= 1;
   return value.slice(0, end);
 }
 

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -90,6 +90,12 @@ export type MemoryReadScopeOptions = {
   memoryDir: string;
   /** Agent workspace root. `<workspaceDir>/memory` becomes a second root. */
   workspaceDir: string;
+  /**
+   * Extra allowed roots, appended after the two above and searched in order.
+   * Delegate mode uses this to keep the corpus ROOT readable while resolving
+   * relative hits against the namespace directory the daemon reports first.
+   */
+  additionalRoots?: readonly string[];
   /** Canonicalizer seam. Defaults to `fs.promises.realpath`; tests inject. */
   realpath?: (filePath: string) => Promise<string>;
 }
@@ -162,6 +168,7 @@ export function createMemoryReadScope(options: MemoryReadScopeOptions): MemoryRe
   const allowedRoots = [
     memoryDir,
     workspaceDir ? path.join(workspaceDir, "memory") : undefined,
+    ...(options.additionalRoots ?? []),
   ].filter((root): root is string => typeof root === "string" && root.length > 0);
 
   // Init-time canonicalization tolerates realpath failure: the roots may not

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -287,6 +287,13 @@ export function createMemoryReadScope(options: MemoryReadScopeOptions): MemoryRe
       if (!canonicalPath.toLowerCase().endsWith(".md")) {
         throw new Error(`memory read restricted to .md files: ${requestedPath}`);
       }
+      // Artifact isolation is a contract, not a search-ranking detail: generic
+      // memory readers must never open artifact files, which are served only
+      // through the dedicated verbatim path. Checked on the CANONICAL path so
+      // a symlink alias cannot route around it.
+      if (isMemoryArtifactPath(canonicalPath) || isMemoryArtifactPath(requestedPath)) {
+        throw new Error(`memory read excluded (artifact path): ${requestedPath}`);
+      }
       return canonicalPath;
     },
   };

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -13,8 +13,57 @@
  * already closed.
  */
 
+import { realpathSync } from "node:fs";
 import { realpath as fsRealpath } from "node:fs/promises";
 import path from "node:path";
+
+import { expandTildePath } from "@remnic/core";
+
+/**
+ * Strip trailing separators from an already-normalized path.
+ *
+ * A character loop rather than a `/[\\/]+$/` regex: the inputs are
+ * externally supplied (daemon health payloads, config files), and a
+ * quantified trailing-separator class is the polynomial-backtracking shape
+ * CodeQL flags on uncontrolled data.
+ */
+function trimTrailingSeparators(value: string): string {
+  let end = value.length;
+  while (end > 1 && (value[end - 1] === "/" || value[end - 1] === "\\")) end -= 1;
+  return value.slice(0, end);
+}
+
+/**
+ * Whether two `memoryDir` values name the same corpus.
+ *
+ * Lexical first (tilde-expanded, resolved, normalized, trailing separators
+ * trimmed), then a `realpath` comparison so two symlink spellings of one
+ * directory are recognized as identical — otherwise a co-located gateway and
+ * daemon on the same files would be judged different and both run, which is
+ * exactly the duplicate-orchestrator deployment this check exists to prevent.
+ *
+ * Fails CLOSED: a path that cannot be resolved is never a match.
+ */
+export function sameMemoryCorpus(
+  left: string,
+  right: string,
+  realpath: (target: string) => string = realpathSync,
+): boolean {
+  if (!left?.trim() || !right?.trim()) return false;
+  const lexical = (value: string): string =>
+    trimTrailingSeparators(path.normalize(path.resolve(expandTildePath(value.trim()))));
+  const leftLexical = lexical(left);
+  const rightLexical = lexical(right);
+  if (leftLexical === rightLexical) return true;
+  try {
+    return (
+      trimTrailingSeparators(path.normalize(realpath(leftLexical))) ===
+      trimTrailingSeparators(path.normalize(realpath(rightLexical)))
+    );
+  } catch {
+    return false;
+  }
+}
 
 export type MemoryReadScopeOptions = {
   /** Remnic memory root — the primary allowed read root. */

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -33,25 +33,31 @@ function trimTrailingSeparators(value: string): string {
   return value.slice(0, end);
 }
 
+/** The only descendant layout that still names the configured corpus. */
+const NAMESPACE_STORAGE_SEGMENT = "namespaces";
+
 /**
- * Whether a daemon's reported memory directory belongs to the corpus this
- * plugin is configured for.
+ * Whether a daemon's reported memory directory names the corpus this plugin
+ * is configured for.
  *
- * Deliberately asymmetric and containment-based. `GET /engram/v1/health`
- * reports the NAMESPACE-RESOLVED storage directory, so a deployment whose
- * default namespace has migrated out of the flat root answers
- * `<corpusRoot>/namespaces/<token>` while the plugin is configured with
- * `<corpusRoot>`. Requiring equality would mark that healthy co-located daemon
- * foreign and disable every file-backed surface.
+ * Accepts exactly two shapes: the root itself, or one namespace storage
+ * directory beneath it (`<corpusRoot>/namespaces/<namespace>`).
+ * `GET /engram/v1/health` reports the NAMESPACE-RESOLVED storage directory, so
+ * a deployment whose default namespace has migrated out of the flat root
+ * answers the second shape and requiring equality would mark a healthy
+ * co-located daemon foreign. Any OTHER descendant — say a daemon independently
+ * configured for `<corpusRoot>/archive` — is a different corpus, and accepting
+ * it would silently redirect every recall and write into it.
  *
  * Both sides must be ABSOLUTE. A relative `memoryDir` names a different
  * directory in each process's working directory, so resolving both against the
  * gateway's cwd would manufacture a match between two distinct corpora.
  *
- * Compared lexically first, then by `realpath`, so two symlink spellings of
- * one directory match — otherwise a co-located gateway and daemon on the same
- * files would be judged different and both run, exactly the
- * duplicate-orchestrator deployment this check exists to prevent.
+ * Both sides are canonicalized BEFORE the shape is judged, so two symlink
+ * spellings of one directory match — otherwise a co-located gateway and daemon
+ * on the same files would be judged different and both run, exactly the
+ * duplicate-orchestrator deployment this check exists to prevent — and a
+ * component symlinking out of the corpus cannot masquerade as contained.
  *
  * Fails CLOSED: relative, blank, or unresolvable paths are never a match.
  */
@@ -64,18 +70,19 @@ export function daemonServesCorpus(
   const expandedRoot = expandTildePath(corpusRoot.trim());
   const expandedDaemon = expandTildePath(daemonMemoryDir.trim());
   if (!path.isAbsolute(expandedRoot) || !path.isAbsolute(expandedDaemon)) return false;
-  // Canonicalize BOTH sides FIRST. A lexical accept would admit a path that
-  // merely looks contained while one of its components symlinks to another
-  // corpus — precisely the escape this gate exists to stop. Both must resolve:
-  // an unresolvable path (missing directory, broken link) is never a match.
+  let canonicalRoot: string;
+  let canonicalDaemon: string;
   try {
-    return isContained(
-      trimTrailingSeparators(path.normalize(realpath(path.resolve(expandedRoot)))),
-      trimTrailingSeparators(path.normalize(realpath(path.resolve(expandedDaemon)))),
-    );
+    canonicalRoot = trimTrailingSeparators(path.normalize(realpath(path.resolve(expandedRoot))));
+    canonicalDaemon = trimTrailingSeparators(path.normalize(realpath(path.resolve(expandedDaemon))));
   } catch {
     return false;
   }
+  if (canonicalRoot === canonicalDaemon) return true;
+  const relative = path.relative(canonicalRoot, canonicalDaemon);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) return false;
+  const segments = relative.split(path.sep).filter((segment) => segment.length > 0);
+  return segments.length === 2 && segments[0] === NAMESPACE_STORAGE_SEGMENT;
 }
 
 export type MemoryReadScopeOptions = {

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -64,6 +64,16 @@ export function isSessionsMemoryPath(relativePath: string): boolean {
 }
 
 /**
+ * Artifact-backed files are served only through the dedicated verbatim
+ * artifact path, so every generic memory reader must exclude them. Both bridge
+ * modes filter search results with this predicate; a mode that skipped it
+ * would bypass the isolation every other reader honors.
+ */
+export function isMemoryArtifactPath(candidate: string): boolean {
+  return /(?:^|[\\/])artifacts(?:[\\/]|$)/i.test(candidate);
+}
+
+/**
  * Containment predicate shared by every check below: `path.relative` yields
  * `""` for the root itself, a `..`-prefixed path for an escape, and an
  * absolute path when the two live on different Windows volumes.

--- a/packages/plugin-openclaw/src/memory-read-scope.ts
+++ b/packages/plugin-openclaw/src/memory-read-scope.ts
@@ -293,7 +293,8 @@ export function createMemoryReadScope(options: MemoryReadScopeOptions): MemoryRe
         throw new Error(`memory read rejected (path unresolvable): ${requestedPath}`);
       }
       const canonicalRoots = await canonicalRootsPromise;
-      if (!canonicalRoots.some((root) => isContained(root, canonicalPath))) {
+      const containingRoot = canonicalRoots.find((root) => isContained(root, canonicalPath));
+      if (containingRoot === undefined) {
         throw new Error(`memory read outside allowed roots: ${requestedPath}`);
       }
       if (!canonicalPath.toLowerCase().endsWith(".md")) {
@@ -301,9 +302,23 @@ export function createMemoryReadScope(options: MemoryReadScopeOptions): MemoryRe
       }
       // Artifact isolation is a contract, not a search-ranking detail: generic
       // memory readers must never open artifact files, which are served only
-      // through the dedicated verbatim path. Checked on the CANONICAL path so
-      // a symlink alias cannot route around it.
-      if (isMemoryArtifactPath(canonicalPath) || isMemoryArtifactPath(requestedPath)) {
+      // through the dedicated verbatim path.
+      //
+      // Judged ROOT-RELATIVE, on the canonical path so a symlink alias cannot
+      // route around it. An absolute test would match any corpus that merely
+      // LIVES under a directory named `artifacts` (`/srv/artifacts/remnic`)
+      // and reject every ordinary read in it.
+      const rootRelative = path.relative(containingRoot, canonicalPath);
+      if (rootRelative.startsWith("..") || path.isAbsolute(rootRelative)) {
+        // Containment already passed, so this is unreachable in practice; a
+        // path that escapes on the second look is refused rather than trusted.
+        throw new Error(`memory read outside allowed roots: ${requestedPath}`);
+      }
+      // The raw request is judged only when it is RELATIVE — it is then
+      // already corpus-relative by construction. An absolute request would
+      // reintroduce the ancestor-directory false positive this fix removes.
+      const rawIsArtifact = !path.isAbsolute(requestedPath) && isMemoryArtifactPath(requestedPath);
+      if (isMemoryArtifactPath(rootRelative) || rawIsArtifact) {
         throw new Error(`memory read excluded (artifact path): ${requestedPath}`);
       }
       return canonicalPath;

--- a/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
@@ -144,6 +144,7 @@ function optionsFor(port: number, namespaceBindings: SessionNamespaceBindingStor
       workspaceDir: path.join(os.tmpdir(), "remnic-delegate-matrix-workspace"),
       agentIds: ["generalist"],
       configuredSearchBackend: "qmd",
+      configuredNamespacesEnabled: false,
       configuredQmdCommand: "qmd",
     },
   };

--- a/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
@@ -68,6 +68,9 @@ async function startDaemonStub(): Promise<DaemonStub> {
       const response =
         req.url === "/engram/v1/recall"
           ? { context: "remembered" }
+          // A real daemon always reports its namespace posture on health.
+          : req.url === "/engram/v1/health"
+            ? { ok: true, namespacesEnabled: false }
           : req.url === "/engram/v1/capabilities"
             ? { lcmCompactionFlushBatch: true }
             : requestedNamespaces !== undefined

--- a/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
@@ -136,6 +136,13 @@ function optionsFor(port: number, namespaceBindings: SessionNamespaceBindingStor
     recallTimeoutMs: 5_000,
     observeTimeoutMs: 5_000,
     flushTimeoutMs: 5_000,
+    capability: {
+      memoryDir: path.join(os.tmpdir(), "remnic-delegate-matrix-memory"),
+      workspaceDir: path.join(os.tmpdir(), "remnic-delegate-matrix-workspace"),
+      agentIds: ["generalist"],
+      configuredSearchBackend: "qmd",
+      configuredQmdCommand: "qmd",
+    },
   };
 }
 

--- a/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/testing/subjects/openclaw-delegate-runtime.test.ts
@@ -144,7 +144,6 @@ function optionsFor(port: number, namespaceBindings: SessionNamespaceBindingStor
       workspaceDir: path.join(os.tmpdir(), "remnic-delegate-matrix-workspace"),
       agentIds: ["generalist"],
       configuredSearchBackend: "qmd",
-      configuredNamespacesEnabled: false,
       configuredQmdCommand: "qmd",
     },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1490,6 +1490,9 @@ const pluginDefinition = {
           (cfg.searchBackend ?? "qmd") === "qmd" && cfg.qmdEnabled !== false
             ? "qmd"
             : "builtin",
+        // Only an explicit `false` means a single corpus; anything else -
+        // including an unset legacy config - stays fail-closed.
+        configuredNamespacesEnabled: cfg.namespacesEnabled !== false,
         configuredQmdCommand:
           typeof cfg.qmdPath === "string" && cfg.qmdPath.trim().length > 0
             ? cfg.qmdPath.trim()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1490,9 +1490,6 @@ const pluginDefinition = {
           (cfg.searchBackend ?? "qmd") === "qmd" && cfg.qmdEnabled !== false
             ? "qmd"
             : "builtin",
-        // Only an explicit `false` means a single corpus; anything else -
-        // including an unset legacy config - stays fail-closed.
-        configuredNamespacesEnabled: cfg.namespacesEnabled !== false,
         configuredQmdCommand:
           typeof cfg.qmdPath === "string" && cfg.qmdPath.trim().length > 0
             ? cfg.qmdPath.trim()

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,7 @@ import {
 } from "../packages/plugin-openclaw/src/transcript-turns.js";
 import {
   createMemoryReadScope,
+  isMemoryArtifactPath,
   isSessionsMemoryPath,
 } from "../packages/plugin-openclaw/src/memory-read-scope.js";
 import type {
@@ -89,6 +90,10 @@ import type {
   RuntimeSearchOptions,
   RuntimeSearchResult,
 } from "../packages/plugin-openclaw/src/memory-capability-types.js";
+import {
+  buildMemoryFlushPlan,
+  type MemoryFlushPlan,
+} from "../packages/plugin-openclaw/src/memory-flush-plan.js";
 import { createFileToggleStore } from "@remnic/core/session-toggles";
 import { appendRecallAuditEntry, pruneRecallAuditEntries } from "@remnic/core/recall-audit";
 import { createActiveRecallEngine } from "@remnic/core/active-recall";
@@ -174,10 +179,6 @@ const NODE_FS_MODULE_ID = ["node", "fs"].join(":");
 const NODE_FS_PROMISES_MODULE_ID = ["node", "fs/promises"].join(":");
 const READ_FILE_SYNC_FIELD = ["read", "File", "Sync"].join("");
 const EXISTS_SYNC_FIELD = ["exists", "Sync"].join("");
-
-function isMemoryArtifactPath(p: string): boolean {
-  return /(?:^|[\\/])artifacts(?:[\\/]|$)/i.test(p);
-}
 
 function readTextFileNow(filePath: string): string {
   const nodeRequire = createRequire(import.meta.url);
@@ -1098,11 +1099,34 @@ function registerOpenClawHostEmbeddingProvider(params: {
   return unregister;
 }
 
-function getOpenClawRuntimeWorkspaceDir(api: OpenClawPluginApi): string | undefined {
-  const runtimeWorkspaceDir = (api as any).runtime?.agent?.workspaceDir;
-  return typeof runtimeWorkspaceDir === "string" && runtimeWorkspaceDir.length > 0
-    ? runtimeWorkspaceDir
+/**
+ * The registration-time runtime agent, narrowed from the host api without an
+ * `any` escape: older SDK shapes omit `runtime`, and every field below is
+ * `unknown` until its own check passes.
+ */
+function getOpenClawRuntimeAgent(api: OpenClawPluginApi): Record<string, unknown> | undefined {
+  if (!("runtime" in api)) return undefined;
+  const runtime: unknown = api.runtime;
+  if (typeof runtime !== "object" || runtime === null || !("agent" in runtime)) return undefined;
+  const agent: unknown = runtime.agent;
+  return typeof agent === "object" && agent !== null
+    ? (agent as Record<string, unknown>)
     : undefined;
+}
+
+function getOpenClawRuntimeWorkspaceDir(api: OpenClawPluginApi): string | undefined {
+  const workspaceDir = getOpenClawRuntimeAgent(api)?.workspaceDir;
+  return typeof workspaceDir === "string" && workspaceDir.length > 0 ? workspaceDir : undefined;
+}
+
+/**
+ * Agent id owning this registration. Each register() call is scoped to one
+ * agent, so the runtime's agent id is authoritative for this registry; older
+ * SDK shapes that expose none yield undefined and callers fall back.
+ */
+function getOpenClawRuntimeAgentId(api: OpenClawPluginApi): string | undefined {
+  const agentId = getOpenClawRuntimeAgent(api)?.id;
+  return typeof agentId === "string" && agentId.length > 0 ? agentId : undefined;
 }
 
 function stableOpenClawConfigSignature(value: unknown, seen = new WeakSet<object>()): string {
@@ -1449,6 +1473,28 @@ const pluginDefinition = {
       shouldSkipRecall: (sk: string) => shouldSkipRecallForSession(sk, cfg),
       cwd: getOpenClawRuntimeWorkspaceDir(api),
       flushOnResetEnabled: cfg.flushOnResetEnabled,
+      // Memory-slot capability inputs. Mirrors the embedded derivation: the
+      // registration-time runtime agent owns this memory, and QMD is the
+      // backend only when it is both selected and enabled.
+      capability: {
+        memoryDir: cfg.memoryDir,
+        workspaceDir:
+          getOpenClawRuntimeWorkspaceDir(api) ?? cfg.workspaceDir ?? defaultWorkspaceDir(),
+        agentIds: [getOpenClawRuntimeAgentId(api) ?? "generalist"],
+        extractionMaxTurnChars: cfg.extractionMaxTurnChars,
+        flushModel:
+          typeof cfg.summaryModel === "string" && cfg.summaryModel.length > 0
+            ? cfg.summaryModel
+            : cfg.taskModelChain?.primary,
+        configuredSearchBackend:
+          (cfg.searchBackend ?? "qmd") === "qmd" && cfg.qmdEnabled !== false
+            ? "qmd"
+            : "builtin",
+        configuredQmdCommand:
+          typeof cfg.qmdPath === "string" && cfg.qmdPath.trim().length > 0
+            ? cfg.qmdPath.trim()
+            : "qmd",
+      },
     });
     if (delegateHandled) return;
 
@@ -3443,19 +3489,12 @@ const pluginDefinition = {
 
       // Derive the agent id owning this memory from the registration-time
       // runtime context. Each plugin register() call is scoped to one agent
-      // (see singleton guard comment above), so api.runtime?.agent?.id is
+      // (see singleton guard comment above), so the runtime agent id is
       // authoritative for this registry. Fall back to "generalist" only when
       // the runtime does not expose an agent id (older new-SDK shapes).
-      const runtimeAgent = (api as any).runtime?.agent;
-      const runtimeAgentId =
-        typeof runtimeAgent?.id === "string" && runtimeAgent.id.length > 0
-          ? runtimeAgent.id
-          : undefined;
-      const capabilityAgentIds = runtimeAgentId ? [runtimeAgentId] : ["generalist"];
+      const capabilityAgentIds = [getOpenClawRuntimeAgentId(api) ?? "generalist"];
       const capabilityWorkspaceDir =
-        (typeof runtimeAgent?.workspaceDir === "string" && runtimeAgent.workspaceDir.length > 0
-          ? runtimeAgent.workspaceDir
-          : undefined) ??
+        getOpenClawRuntimeWorkspaceDir(api) ??
         orchestrator.config.workspaceDir ??
         defaultWorkspaceDir();
       const remnicUsesQmd =
@@ -3672,31 +3711,17 @@ const pluginDefinition = {
         },
         async closeAllMemorySearchManagers() {},
       };
-      const remnicMemoryFlushPlanResolver = () => {
-        const maxTurnChars =
-          typeof cfg.extractionMaxTurnChars === "number" && Number.isFinite(cfg.extractionMaxTurnChars)
-            ? Math.max(1_000, Math.floor(cfg.extractionMaxTurnChars))
-            : 8_000;
-        // `summaryModel` already resolves explicit summary/base model → gateway
-        // task-chain primary → "" (gateway mode). Do NOT fall back to `cfg.model`
-        // here: it is direct-compatible and may be a bare id the Gateway can't
-        // route (issue #1469). Empty → omit so the Gateway default wins.
-        const flushModel =
-          typeof cfg.summaryModel === "string" && cfg.summaryModel.length > 0
-            ? cfg.summaryModel
-            : cfg.taskModelChain?.primary;
-        return {
-          softThresholdTokens: 24_000,
-          forceFlushTranscriptBytes: Math.max(16_384, maxTurnChars * 4),
-          reserveTokensFloor: 2_000,
-          ...(flushModel ? { model: flushModel } : {}),
-          prompt:
-            "Flush the recent OpenClaw transcript into Remnic memory by appending to the allowed flush-plan file only. Preserve durable user preferences, project facts, decisions, corrections, and commitments. Ignore runtime metadata, credentials, and transient command noise.",
-          systemPrompt:
-            "You are Remnic's memory flush planner. Read the transcript and append concise durable memory notes to the file the write tool allows. Do not create files, directories, or dated paths; use only the allowed flush-plan file. Ignore runtime metadata, credentials, transient command noise, and content that is not worth remembering.",
-          relativePath: ["state", "plugins", serviceId, "flush-plan.md"].join("/"),
-        };
-      };
+      const remnicMemoryFlushPlanResolver = (): MemoryFlushPlan =>
+        buildMemoryFlushPlan({
+          serviceId,
+          extractionMaxTurnChars: cfg.extractionMaxTurnChars,
+          // `summaryModel` already resolves explicit summary/base model →
+          // gateway task-chain primary → "" (gateway mode).
+          flushModel:
+            typeof cfg.summaryModel === "string" && cfg.summaryModel.length > 0
+              ? cfg.summaryModel
+              : cfg.taskModelChain?.primary,
+        });
 
       const memoryCapability: import("openclaw/plugin-sdk").MemoryPluginCapability = {
         // Include the promptBuilder so runtimes that treat unified capability


### PR DESCRIPTION
Part of #2120. Layer 3 of 4.

## Problem
Delegate v1 (PR 2127) wired the memory **loop** (recall / observe / flush) to the daemon but returned from `register()` before it built the memory-slot **capability**. A delegate gateway therefore handed the host no prompt builder, no memory runtime, no flush plan, and no public-artifact provider — the surfaces #2120 explicitly asks to back with the daemon's HTTP API.

## Change
New **`delegate-capability.ts`** rebuilds all four without an orchestrator:

| Surface | Backing |
|---|---|
| `search` | `POST /engram/v1/memories/search`, with the embedded runtime's own artifact isolation, `minScore` filter, absolute-path emission, and root-relative citations |
| `status` | `GET /engram/v1/health`, cached behind an injectable clock because the host's `status()` is synchronous while the probe is not. A failed probe keeps the last snapshot (seeded from local config) rather than fabricating an outage |
| `readFile` | the shared memory read scope over the corpus the daemon serves |
| flush plan / public artifacts | the same builders the embedded path uses |

Reading the corpus directly is sound because delegate mode's precondition is *one daemon on the same `memoryDir`*: the plugin reads files whose writer is the daemon, not a second orchestrator.

The runtime deliberately exposes **no `sync`** — reindexing belongs to the daemon, and a plugin-side reindex would resurrect the second QMD writer this issue exists to remove. The optional member is omitted rather than stubbed, so the host cannot call a no-op.

Extracted so the two modes cannot drift: `buildMemoryFlushPlan` (prompts, thresholds, the single allowed flush-plan path), `isMemoryArtifactPath`, and `DelegateDaemonTarget` / `daemonUrl` / `daemonAuthHeaders` (now in `bridge.ts`, deleting `delegate-runtime`'s private copy). `getOpenClawRuntimeAgent` replaces two `as any` runtime reads in `src/index.ts`, and a dead duplicate of core's `MEMORY_CONTEXT_HEADER` is gone.

## Tests
17 new capability tests: hit mapping, artifact isolation + `minScore` + non-object skipping, namespace forwarding, backend-failure propagation (a 5xx rejects instead of masquerading as "no results"), read pagination and containment, health snapshot / degraded QMD / failed-probe seeding, TTL caching on an injected clock, the absent `sync`, artifact listing and its empty-on-failure degrade, and unified / split / no-op host registration shapes.

## Verification
`delegate-capability.test.ts` 17/17; `delegate-runtime.test.ts` 58/58; full `plugin-openclaw` suite + lifecycle-matrix subjects 207/207; root and plugin `tsc` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes namespace scoping, token authorization, and when local files may be read relative to daemon health; behavior is heavily tested and mostly fail-closed, but mistakes could widen search scope or expose the wrong corpus.
> 
> **Overview**
> **Delegate gateways get the same memory-slot surfaces as embedded mode** — prompt builder, runtime, flush plan, and public artifacts — without starting a second orchestrator.
> 
> A new **`delegate-capability`** module drives **search** and **status** from `POST /engram/v1/memories/search` and `GET /engram/v1/health` (cached, with fail-closed behavior on bad health, corpus mismatch, remote daemons, and namespace-partitioned deployments). **readFile** and artifact listing use the shared read scope only when health proves the daemon serves the same local corpus; **`sync` is omitted** so indexing stays on the daemon. **`delegate-runtime`** registers this capability alongside recall/observe/flush, routes all scoped calls through **`resolveScopedNamespace`** (shared deadlines with hooks), adds **`memory_search`** to authorization preflight, and fixes recall cache eviction on very short prompts.
> 
> **`bridge.ts`** centralizes **`DelegateDaemonTarget`**, URL/auth helpers, and **loopback / wildcard bind** handling (`0.0.0.0`, `::`) so auto-delegate and health probes dial the right host. Namespace wiring moves to **`delegate-namespaces.ts`**; flush-plan building to **`memory-flush-plan.ts`**; **`daemonServesCorpus`** and artifact read guards land in **`memory-read-scope`**, with a large **`delegate-capability.test.ts`** suite covering the safety edges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3f4b19cc51161028dab43dd8d6835302f03617d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

