### PR TITLE
fix(plugin-codex): authenticate the health probe and resolve REMNIC_AUTH_TOKEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Codex hook health probe now sends the configured bearer token, so an auth-gated daemon is detected as healthy instead of being reported as "daemon not running" (which silently skipped auto-recall and auto-observe). Token resolution also accepts the canonical `REMNIC_AUTH_TOKEN` / `ENGRAM_AUTH_TOKEN` names alongside the connector-scoped `OPENCLAW_*_ACCESS_TOKEN` pair, matching `loadDaemonAuth()` in `@remnic/plugin-openclaw`. Without them the documented standalone-server setup — which authenticates the daemon with `REMNIC_AUTH_TOKEN` and never mints a connector token — left the hook with no credential to send.
+
 ## [v9.46.0] — 2026-08-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Codex hook health probe now sends the configured bearer token, so an auth-gated daemon is detected as healthy instead of being reported as "daemon not running" (which silently skipped auto-recall and auto-observe). Token resolution also accepts the canonical `REMNIC_AUTH_TOKEN` / `ENGRAM_AUTH_TOKEN` names alongside the connector-scoped `OPENCLAW_*_ACCESS_TOKEN` pair, matching `loadDaemonAuth()` in `@remnic/plugin-openclaw`. Without them the documented standalone-server setup — which authenticates the daemon with `REMNIC_AUTH_TOKEN` and never mints a connector token — left the hook with no credential to send.
+- Codex hook health probe now sends the configured bearer token, so an auth-gated daemon is detected as healthy instead of being reported as "daemon not running" (which silently skipped auto-recall and auto-observe). Token resolution also accepts the canonical `REMNIC_AUTH_TOKEN` / `ENGRAM_AUTH_TOKEN` names alongside the connector-scoped `OPENCLAW_*_ACCESS_TOKEN` pair, ordered primary-before-legacy so a leftover pre-rename value cannot shadow the credential the daemon is running with. Without them the documented standalone-server setup — which authenticates the daemon with `REMNIC_AUTH_TOKEN` and never mints a connector token — left the hook with no credential to send.
 
 ## [v9.46.0] — 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Codex hook health probe now authenticates with the caller's already-resolved token instead of re-resolving its own. Re-resolution could pick up a rotated `tokens.json` — or an inherited `REMNIC_HOOK_TOKEN`, which the foreground handlers never read — and green-light a probe whose subsequent recall then 401s.
 - Codex hook health probe now sends the configured bearer token, so an auth-gated daemon is detected as healthy instead of being reported as "daemon not running" (which silently skipped auto-recall and auto-observe). Token resolution also accepts the canonical `REMNIC_AUTH_TOKEN` / `ENGRAM_AUTH_TOKEN` names alongside the connector-scoped `OPENCLAW_*_ACCESS_TOKEN` pair, ordered primary-before-legacy so a leftover pre-rename value cannot shadow the credential the daemon is running with. Without them the documented standalone-server setup — which authenticates the daemon with `REMNIC_AUTH_TOKEN` and never mints a connector token — left the hook with no credential to send.
 
 ## [v9.46.0] — 2026-08-01

--- a/packages/plugin-codex/README.md
+++ b/packages/plugin-codex/README.md
@@ -123,6 +123,11 @@ daemon the hook needs one of these: every route, including
 `/engram/v1/health`, returns 401 without a bearer, so an unauthenticated hook
 reports `daemon not running` and silently skips auto-recall and auto-observe.
 
+`REMNIC_HOOK_TOKEN` is not part of this chain — it is an internal channel the
+foreground hook uses to hand its already-resolved token to the detached
+observe worker, so the worker does not re-read the token store. Nothing in
+the foreground path reads it.
+
 ## Hook trust (one-time review)
 
 Codex does not run non-managed command hooks until a human reviews and trusts

--- a/packages/plugin-codex/README.md
+++ b/packages/plugin-codex/README.md
@@ -107,9 +107,19 @@ export REMNIC_DAEMON_URL="http://macstudio.tail-XXXX.ts.net:4318"
   namespace to the compaction flush (parity with `@remnic/plugin-pi`'s
   `config.namespace`). Unset → the daemon resolves the default namespace.
 
-The bearer token still comes from the per-plugin token store
-(`remnic connectors install codex-cli` writes `~/.remnic/tokens.json`) or the
-`OPENCLAW_REMNIC_ACCESS_TOKEN` / `OPENCLAW_ENGRAM_ACCESS_TOKEN` env vars.
+The bearer token is resolved in this order:
+
+1. The per-plugin token store — `remnic connectors install codex-cli` writes
+   `~/.remnic/tokens.json`; legacy `~/.engram/tokens.json` is read as a
+   fallback.
+2. `OPENCLAW_REMNIC_ACCESS_TOKEN`, then `OPENCLAW_ENGRAM_ACCESS_TOKEN`.
+3. `REMNIC_AUTH_TOKEN`, then legacy `ENGRAM_AUTH_TOKEN`.
+
+Step 3 covers the standalone-server setup, which authenticates the daemon with
+`REMNIC_AUTH_TOKEN` and never mints a connector token. Against an auth-gated
+daemon the hook needs one of these: every route, including
+`/engram/v1/health`, returns 401 without a bearer, so an unauthenticated hook
+reports `daemon not running` and silently skips auto-recall and auto-observe.
 
 ## Hook trust (one-time review)
 

--- a/packages/plugin-codex/README.md
+++ b/packages/plugin-codex/README.md
@@ -112,11 +112,13 @@ The bearer token is resolved in this order:
 1. The per-plugin token store — `remnic connectors install codex-cli` writes
    `~/.remnic/tokens.json`; legacy `~/.engram/tokens.json` is read as a
    fallback.
-2. `OPENCLAW_REMNIC_ACCESS_TOKEN`, then `OPENCLAW_ENGRAM_ACCESS_TOKEN`.
-3. `REMNIC_AUTH_TOKEN`, then legacy `ENGRAM_AUTH_TOKEN`.
+2. `OPENCLAW_REMNIC_ACCESS_TOKEN`, then `REMNIC_AUTH_TOKEN`.
+3. Legacy aliases: `OPENCLAW_ENGRAM_ACCESS_TOKEN`, then `ENGRAM_AUTH_TOKEN`.
 
-Step 3 covers the standalone-server setup, which authenticates the daemon with
-`REMNIC_AUTH_TOKEN` and never mints a connector token. Against an auth-gated
+Current names outrank legacy ones, so a leftover pre-rename value cannot
+shadow the credential the daemon is actually running with. `REMNIC_AUTH_TOKEN`
+covers the standalone-server setup, which authenticates the daemon with that
+variable and never mints a connector token. Against an auth-gated
 daemon the hook needs one of these: every route, including
 `/engram/v1/health`, returns 401 without a bearer, so an unauthenticated hook
 reports `daemon not running` and silently skips auto-recall and auto-observe.

--- a/packages/plugin-codex/hooks/bin/remnic-codex-hook.cjs
+++ b/packages/plugin-codex/hooks/bin/remnic-codex-hook.cjs
@@ -220,12 +220,13 @@ function onPath(bin) {
 }
 
 // ── token resolution (per-plugin token store, then env) ────────────────────
-// Env precedence mirrors loadDaemonAuth() in @remnic/plugin-openclaw: the
-// connector-scoped OPENCLAW_* names first, then the canonical daemon
-// credential REMNIC_AUTH_TOKEN and its legacy ENGRAM_AUTH_TOKEN alias. The
-// canonical pair matters because the documented standalone-server setup
-// authenticates the daemon with REMNIC_AUTH_TOKEN alone and never mints a
-// connector token.
+// Env precedence is primary-before-legacy per AGENTS.md §9: the two current
+// names (OPENCLAW_REMNIC_ACCESS_TOKEN, REMNIC_AUTH_TOKEN) before the two
+// legacy aliases (OPENCLAW_ENGRAM_ACCESS_TOKEN, ENGRAM_AUTH_TOKEN), so a
+// stale leftover from a pre-rename install cannot outrank the credential the
+// daemon is actually running with. REMNIC_AUTH_TOKEN matters because the
+// documented standalone-server setup authenticates the daemon with it alone
+// and never mints a connector token.
 function resolveToken() {
   for (const file of [
     path.join(HOME, ".remnic", "tokens.json"),
@@ -251,8 +252,8 @@ function resolveToken() {
   }
   return (
     process.env.OPENCLAW_REMNIC_ACCESS_TOKEN ||
-    process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN ||
     process.env.REMNIC_AUTH_TOKEN ||
+    process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN ||
     process.env.ENGRAM_AUTH_TOKEN ||
     ""
   );

--- a/packages/plugin-codex/hooks/bin/remnic-codex-hook.cjs
+++ b/packages/plugin-codex/hooks/bin/remnic-codex-hook.cjs
@@ -343,14 +343,18 @@ function httpPost(urlPath, token, bodyObj, timeoutMs) {
   });
 }
 
-function httpHealthy(timeoutMs) {
+// `token` is the caller's already-resolved credential, NOT a second
+// resolveToken() call: the probe must authenticate with the exact bearer the
+// operation it gates will send. Re-resolving could pick up a rotated
+// tokens.json (or an inherited REMNIC_HOOK_TOKEN the foreground handlers
+// ignore) and green-light a probe whose recall then 401s.
+//
+// When the daemon has an auth token configured, every route — including
+// /engram/v1/health — returns 401 to unauthenticated requests, so an
+// unauthenticated probe makes the hook wrongly report "daemon not running"
+// and skip recall/observe. Unauthenticated daemons ignore the header.
+function httpHealthy(timeoutMs, token) {
   if (DAEMON_URL === null) return Promise.resolve(false);
-  // When the daemon has an auth token configured, every route — including
-  // /engram/v1/health — returns 401 to unauthenticated requests, so an
-  // unauthenticated probe makes the hook wrongly report "daemon not running"
-  // and skip recall/observe. Send the same bearer token the observe/flush
-  // POSTs use. Unauthenticated daemons ignore the header.
-  const token = process.env.REMNIC_HOOK_TOKEN || resolveToken();
   const transport = DAEMON_URL.protocol === "https:" ? https : http;
   return new Promise((resolve) => {
     const req = transport.request(
@@ -674,7 +678,7 @@ async function handleSessionStart(input, token, log) {
   log(`session=${sessionId} project=${projectName} coding-context=${codingContext ? "yes" : ""}`);
 
   // Health check — start daemon if not running.
-  if (!(await httpHealthy(2000))) {
+  if (!(await httpHealthy(2000, token))) {
     log("daemon not responding, attempting start...");
     // Try `remnic` first, fall through to legacy `engram` when only the older
     // CLI is on PATH. spawn() emits ENOENT *asynchronously* via 'error', so we
@@ -699,7 +703,7 @@ async function handleSessionStart(input, token, log) {
       }
     }
     await new Promise((r) => setTimeout(r, 2000));
-    if (!(await httpHealthy(2000))) {
+    if (!(await httpHealthy(2000, token))) {
       log("daemon still not responding after start attempt");
       emit({
         continue: true,

--- a/packages/plugin-codex/hooks/bin/remnic-codex-hook.cjs
+++ b/packages/plugin-codex/hooks/bin/remnic-codex-hook.cjs
@@ -220,6 +220,12 @@ function onPath(bin) {
 }
 
 // ── token resolution (per-plugin token store, then env) ────────────────────
+// Env precedence mirrors loadDaemonAuth() in @remnic/plugin-openclaw: the
+// connector-scoped OPENCLAW_* names first, then the canonical daemon
+// credential REMNIC_AUTH_TOKEN and its legacy ENGRAM_AUTH_TOKEN alias. The
+// canonical pair matters because the documented standalone-server setup
+// authenticates the daemon with REMNIC_AUTH_TOKEN alone and never mints a
+// connector token.
 function resolveToken() {
   for (const file of [
     path.join(HOME, ".remnic", "tokens.json"),
@@ -246,6 +252,8 @@ function resolveToken() {
   return (
     process.env.OPENCLAW_REMNIC_ACCESS_TOKEN ||
     process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN ||
+    process.env.REMNIC_AUTH_TOKEN ||
+    process.env.ENGRAM_AUTH_TOKEN ||
     ""
   );
 }
@@ -336,6 +344,12 @@ function httpPost(urlPath, token, bodyObj, timeoutMs) {
 
 function httpHealthy(timeoutMs) {
   if (DAEMON_URL === null) return Promise.resolve(false);
+  // When the daemon has an auth token configured, every route — including
+  // /engram/v1/health — returns 401 to unauthenticated requests, so an
+  // unauthenticated probe makes the hook wrongly report "daemon not running"
+  // and skip recall/observe. Send the same bearer token the observe/flush
+  // POSTs use. Unauthenticated daemons ignore the header.
+  const token = process.env.REMNIC_HOOK_TOKEN || resolveToken();
   const transport = DAEMON_URL.protocol === "https:" ? https : http;
   return new Promise((resolve) => {
     const req = transport.request(
@@ -345,6 +359,7 @@ function httpHealthy(timeoutMs) {
         port: DAEMON_URL.port || (DAEMON_URL.protocol === "https:" ? 443 : 80),
         path: DAEMON_BASE_PATH + "/engram/v1/health",
         method: "GET",
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
       },
       (res) => {
         res.resume();

--- a/packages/plugin-codex/hooks/bin/remnic-codex-hook.test.cjs
+++ b/packages/plugin-codex/hooks/bin/remnic-codex-hook.test.cjs
@@ -48,12 +48,12 @@ function mkHome() {
 // stays free to answer the runner's requests while it runs.
 function runHook(event, input, { port, home, env = {} } = {}) {
   return new Promise((resolve) => {
-    // When a test asks for "no token" (env.token === null) we must clear BOTH
-    // token env vars — the runner's resolveToken() falls through from
-    // OPENCLAW_REMNIC_ACCESS_TOKEN to OPENCLAW_ENGRAM_ACCESS_TOKEN, and the
-    // parent process (a real dev shell) often has the latter set, which
-    // previously leaked through `...process.env` and made the no-token
-    // assertions fail outside CI (#1571 test-harness hygiene).
+    // Every env name resolveToken() consults is pinned below — including the
+    // canonical REMNIC_AUTH_TOKEN / ENGRAM_AUTH_TOKEN pair — so a value from
+    // the parent process (a real dev shell, or CI authenticating a local
+    // daemon) cannot leak through `...process.env` and make the no-token
+    // assertions fail outside CI (#1571 test-harness hygiene). Tests that want
+    // a specific name set it via env.extra, which spreads last.
     const noToken = env.token === null;
     const child = spawn(process.execPath, [RUNNER, event], {
       env: {
@@ -65,7 +65,9 @@ function runHook(event, input, { port, home, env = {} } = {}) {
         REMNIC_PORT: String(port),
         REMNIC_CODEX_MATERIALIZE: "0",
         OPENCLAW_REMNIC_ACCESS_TOKEN: noToken ? "" : env.token || "test-token",
-        OPENCLAW_ENGRAM_ACCESS_TOKEN: noToken ? "" : "",
+        OPENCLAW_ENGRAM_ACCESS_TOKEN: "",
+        REMNIC_AUTH_TOKEN: "",
+        ENGRAM_AUTH_TOKEN: "",
         // Clear daemon URL env so a developer shell with REMNIC_DAEMON_URL set
         // can't route tests away from the mock server. Tests that WANT a daemon
         // URL override it via env.extra (which spreads last).
@@ -1087,6 +1089,107 @@ test("pre-compact: REMNIC_PRECOMPACT_LOCK_RETRIES=0 still takes a FREE lock (doe
     // Lock was FREE → acquired on the single attempt → drain + flush ran.
     assert.ok(calls.some((c) => c.url === "/engram/v1/lcm/compaction/flush"), "flush ran (free lock taken despite 0 retries)");
     assert.ok(calls.some((c) => c.url === "/engram/v1/observe"), "tail drain ran (free lock taken despite 0 retries)");
+  } finally {
+    server.close();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+// ── daemon auth: health probe + canonical env credentials ──────────────────
+// An auth-gated daemon 401s EVERY route, including /engram/v1/health. An
+// unauthenticated probe therefore makes the hook report "daemon not running"
+// and skip recall/observe entirely. The credential itself has to be findable:
+// the documented standalone-server setup authenticates the daemon with
+// REMNIC_AUTH_TOKEN and never mints a connector token, so resolveToken() must
+// accept the canonical names as well as the connector-scoped OPENCLAW_* pair.
+
+function authServer() {
+  const seen = { health: "unset", recall: "unset" };
+  return startServer((req, res) => {
+    if (req.url === "/engram/v1/health") {
+      seen.health = req.headers.authorization || null;
+      return res.writeHead(200).end("ok");
+    }
+    if (req.url === "/engram/v1/recall") {
+      seen.recall = req.headers.authorization || null;
+      return res
+        .writeHead(200, { "Content-Type": "application/json" })
+        .end(JSON.stringify({ context: "ctx", count: 1, mode: "auto" }));
+    }
+    res.writeHead(404).end();
+  }).then((started) => ({ ...started, seen }));
+}
+
+test("session-start: health probe carries the bearer token (auth-gated daemons)", async () => {
+  const home = mkHome();
+  const { server, port, seen } = await authServer();
+  try {
+    await runHook("session-start", { session_id: "sAuth", cwd: home }, { port, home });
+    assert.equal(seen.health, "Bearer test-token");
+  } finally {
+    server.close();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+for (const name of ["REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN"]) {
+  test(`token resolution: ${name} authenticates health and recall (no token store)`, async () => {
+    const home = mkHome();
+    const { server, port, seen } = await authServer();
+    try {
+      const res = await runHook(
+        "session-start",
+        { session_id: "sEnv", cwd: home },
+        { port, home, env: { token: null, extra: { [name]: "operator-secret" } } },
+      );
+      assert.equal(seen.health, "Bearer operator-secret");
+      assert.equal(seen.recall, "Bearer operator-secret");
+      assert.doesNotMatch(
+        res.json.hookSpecificOutput.additionalContext,
+        /daemon not running/,
+        "an authenticated daemon must not be reported as down",
+      );
+    } finally {
+      server.close();
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+}
+
+test("token resolution: OPENCLAW_REMNIC_ACCESS_TOKEN outranks REMNIC_AUTH_TOKEN", async () => {
+  const home = mkHome();
+  const { server, port, seen } = await authServer();
+  try {
+    await runHook(
+      "session-start",
+      { session_id: "sPrec", cwd: home },
+      { port, home, env: { token: "connector-tok", extra: { REMNIC_AUTH_TOKEN: "operator-secret" } } },
+    );
+    // Mirrors loadDaemonAuth() in @remnic/plugin-openclaw: connector-scoped
+    // names win, so adding the canonical pair cannot change an install that
+    // already worked.
+    assert.equal(seen.health, "Bearer connector-tok");
+  } finally {
+    server.close();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("token resolution: tokens.json still outranks REMNIC_AUTH_TOKEN", async () => {
+  const home = mkHome();
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+  fs.writeFileSync(
+    path.join(home, ".remnic", "tokens.json"),
+    JSON.stringify({ tokens: [{ connector: "codex-cli", token: "codex-tok" }] }),
+  );
+  const { server, port, seen } = await authServer();
+  try {
+    await runHook(
+      "session-start",
+      { session_id: "sStore", cwd: home },
+      { port, home, env: { token: null, extra: { REMNIC_AUTH_TOKEN: "operator-secret" } } },
+    );
+    assert.equal(seen.health, "Bearer codex-tok");
   } finally {
     server.close();
     fs.rmSync(home, { recursive: true, force: true });

--- a/packages/plugin-codex/hooks/bin/remnic-codex-hook.test.cjs
+++ b/packages/plugin-codex/hooks/bin/remnic-codex-hook.test.cjs
@@ -1165,10 +1165,39 @@ test("token resolution: OPENCLAW_REMNIC_ACCESS_TOKEN outranks REMNIC_AUTH_TOKEN"
       { session_id: "sPrec", cwd: home },
       { port, home, env: { token: "connector-tok", extra: { REMNIC_AUTH_TOKEN: "operator-secret" } } },
     );
-    // Mirrors loadDaemonAuth() in @remnic/plugin-openclaw: connector-scoped
-    // names win, so adding the canonical pair cannot change an install that
-    // already worked.
+    // Both are current names; the connector-scoped one stays first, so an
+    // install that already worked keeps its existing credential.
     assert.equal(seen.health, "Bearer connector-tok");
+  } finally {
+    server.close();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("token resolution: REMNIC_AUTH_TOKEN outranks the legacy OPENCLAW_ENGRAM_ACCESS_TOKEN", async () => {
+  const home = mkHome();
+  const { server, port, seen } = await authServer();
+  try {
+    await runHook(
+      "session-start",
+      { session_id: "sLegacyPrec", cwd: home },
+      {
+        port,
+        home,
+        env: {
+          token: null,
+          extra: {
+            OPENCLAW_ENGRAM_ACCESS_TOKEN: "stale-legacy-tok",
+            REMNIC_AUTH_TOKEN: "operator-secret",
+          },
+        },
+      },
+    );
+    // Primary-before-legacy (AGENTS.md §9). A migrated deployment often still
+    // exports the pre-rename alias; if that stale value outranked the token
+    // the daemon actually runs with, the probe would 401 and land back on
+    // "daemon not running".
+    assert.equal(seen.health, "Bearer operator-secret");
   } finally {
     server.close();
     fs.rmSync(home, { recursive: true, force: true });

--- a/packages/plugin-codex/hooks/bin/remnic-codex-hook.test.cjs
+++ b/packages/plugin-codex/hooks/bin/remnic-codex-hook.test.cjs
@@ -68,6 +68,9 @@ function runHook(event, input, { port, home, env = {} } = {}) {
         OPENCLAW_ENGRAM_ACCESS_TOKEN: "",
         REMNIC_AUTH_TOKEN: "",
         ENGRAM_AUTH_TOKEN: "",
+        // Internal worker-propagation channel, not a user credential. Pinned
+        // so an inherited value cannot reach the detached observe worker.
+        REMNIC_HOOK_TOKEN: "",
         // Clear daemon URL env so a developer shell with REMNIC_DAEMON_URL set
         // can't route tests away from the mock server. Tests that WANT a daemon
         // URL override it via env.extra (which spreads last).
@@ -1219,6 +1222,52 @@ test("token resolution: tokens.json still outranks REMNIC_AUTH_TOKEN", async () 
       { port, home, env: { token: null, extra: { REMNIC_AUTH_TOKEN: "operator-secret" } } },
     );
     assert.equal(seen.health, "Bearer codex-tok");
+  } finally {
+    server.close();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("token resolution: REMNIC_AUTH_TOKEN outranks ENGRAM_AUTH_TOKEN when both are set", async () => {
+  const home = mkHome();
+  const { server, port, seen } = await authServer();
+  try {
+    await runHook(
+      "session-start",
+      { session_id: "sBothCanonical", cwd: home },
+      {
+        port,
+        home,
+        env: {
+          token: null,
+          extra: { REMNIC_AUTH_TOKEN: "current-tok", ENGRAM_AUTH_TOKEN: "legacy-tok" },
+        },
+      },
+    );
+    assert.equal(seen.health, "Bearer current-tok");
+    assert.equal(seen.recall, "Bearer current-tok");
+  } finally {
+    server.close();
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("health probe uses the same bearer as the operation it gates", async () => {
+  const home = mkHome();
+  const { server, port, seen } = await authServer();
+  try {
+    // REMNIC_HOOK_TOKEN is the detached observe worker's internal propagation
+    // channel; the foreground handlers never read it. If the probe consulted
+    // it, an inherited value would authenticate health with one bearer while
+    // recall sent another — a false "healthy" followed by a 401, or the
+    // reverse. Probe and operation must carry one snapshot.
+    await runHook(
+      "session-start",
+      { session_id: "sSnapshot", cwd: home },
+      { port, home, env: { extra: { REMNIC_HOOK_TOKEN: "inherited-worker-tok" } } },
+    );
+    assert.equal(seen.health, "Bearer test-token");
+    assert.equal(seen.recall, seen.health);
   } finally {
     server.close();
     fs.rmSync(home, { recursive: true, force: true });


### PR DESCRIPTION
The Codex hook carries both halves of the defect being fixed for Claude Code in
#2268. Split out per the narrow-scope rule — different package, no shared files.

## The defect

1. **`httpHealthy()` sent no `Authorization` header.** An auth-gated daemon 401s
   every route, including `/engram/v1/health`, so the hook reported
   `daemon not running` and skipped recall and observe entirely.
2. **`resolveToken()` omitted the canonical env names.** It consulted the token
   stores and `OPENCLAW_REMNIC_ACCESS_TOKEN` / `OPENCLAW_ENGRAM_ACCESS_TOKEN`
   only. The documented standalone-server setup (`docs/guides/standalone-server.md`,
   `README.md`) authenticates the daemon with `REMNIC_AUTH_TOKEN` and never mints
   a connector token, so that deployment had no credential to send even once the
   probe started sending one.

Either defect alone is sufficient to break auto-recall and auto-observe against
an authenticated daemon, so both are fixed here — patching one leaves the
subsystem broken.

## The fix

Send the resolved bearer on the probe, and add the canonical
`REMNIC_AUTH_TOKEN` → `ENGRAM_AUTH_TOKEN` fallback **after** the `OPENCLAW_*`
pair, matching `loadDaemonAuth()` in `@remnic/plugin-openclaw`
(`packages/plugin-openclaw/src/bridge.ts:450-459`), which already reads all four.
The ordering means no install that already worked changes credential.

## Verification

Five new tests in `remnic-codex-hook.test.cjs`, all red before this change and
green after (`40 pass / 5 fail` → `45 pass / 0 fail`):

- the probe carries the bearer token
- `REMNIC_AUTH_TOKEN` authenticates health **and** recall with no token store
- `ENGRAM_AUTH_TOKEN` does the same (legacy alias)
- `OPENCLAW_REMNIC_ACCESS_TOKEN` outranks `REMNIC_AUTH_TOKEN`
- `tokens.json` outranks `REMNIC_AUTH_TOKEN`

The last two lock the precedence so the added names cannot silently take over an
existing install.

The harness previously cleared only the two `OPENCLAW_*` names; it now pins all
four, so a developer or CI runner with a real daemon credential in the
environment cannot leak one into the no-token cases.

## CI note

`packages/**/*.test.cjs` is not yet discovered by the root test runner on `main` —
hook runners are standalone CommonJS living beside their tests rather than under
`<pkg>/src`, so neither hook suite has ever executed in CI. #2268 adds that
pattern; this suite starts running in CI once it lands. Until then, run locally:

```
node --test packages/plugin-codex/hooks/bin/remnic-codex-hook.test.cjs
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted hook-runner auth and env precedence with parity to the already-merged Claude Code fix; behavior for installs that already worked is preserved by explicit precedence tests.
> 
> **Overview**
> Brings the Codex hook runner in line with the Claude Code fix (#2268): **authenticated health checks** and **broader token resolution** so auth-gated Remnic daemons are treated as healthy and recall/observe actually run.
> 
> **`httpHealthy`** now takes the caller’s already-resolved bearer and sends `Authorization` on `GET /engram/v1/health`. On daemons with auth enabled, every route (including health) returns 401 without a token, so an unauthenticated probe used to look like “daemon not running” and **auto-recall and auto-observe were skipped** with no obvious error.
> 
> **`resolveToken`** now falls through to **`REMNIC_AUTH_TOKEN`** and **`ENGRAM_AUTH_TOKEN`** after the `OPENCLAW_*` connector env vars (primary before legacy), matching standalone-server setups that only set `REMNIC_AUTH_TOKEN` and never mint a connector token. The probe reuses the same token snapshot as recall—it does **not** re-resolve or honor **`REMNIC_HOOK_TOKEN`** (worker-only), avoiding false “healthy” probes when credentials differ.
> 
> **Docs** (`plugin-codex/README.md`, `CHANGELOG.md`) document the precedence chain and auth behavior. **Tests** add an auth mock server and cases for bearer on health, env token names, precedence, and probe/recall credential parity; the harness pins all four auth env vars (and `REMNIC_HOOK_TOKEN`) so parent-shell leaks don’t break CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e0999820f414eefa293d54bbef2cff9953ad7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now authenticate correctly using configured bearer credentials.
  * Recall and observation requests consistently resolve connector-specific and canonical environment tokens.
  * Unauthenticated health checks correctly report the service as unavailable and skip downstream processing.

* **Documentation**
  * Expanded authentication guidance, including token precedence and expected behavior for unauthorized requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->