### PR TITLE
test(bridge-mode): give the liveness probes a CI-survivable budget

### DIFF
--- a/tests/integration/bridge-mode.test.ts
+++ b/tests/integration/bridge-mode.test.ts
@@ -9,6 +9,27 @@ import { Worker } from "node:worker_threads";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "../..");
+// Liveness-probe timings, shared by every checkDaemonHealth/checkDaemonHealthSync
+// test below so the sync and async pairs cannot drift apart.
+//
+// bridge.ts derives every request timeout from ONE deadline
+// (`deadline = Date.now() + timeoutMs`, then `remainingMs = deadline - now()`),
+// so the budget is the TOTAL for a liveness probe plus its detailed-health
+// fallback — not a per-request allowance.
+//
+// STALLED_DETAILED_HEALTH_MS must stay above PROBE_BUDGET_MS: that gap is what
+// makes "returns true" prove the liveness path short-circuited. A probe that
+// regressed into waiting on detailed health would exhaust the budget and
+// return false, failing the test. The async tests previously budgeted 100 ms,
+// which is not a reliable margin for one loopback round-trip on a loaded CI
+// runner — let alone two (issue #2287).
+//
+// The stall is a real timer on purpose: it lives inside a worker-thread HTTP
+// server (a separate JS realm), and the sync variant under test blocks the main
+// thread with Atomics.wait. Fake timers can drive neither side, so the only
+// lever available is a wide margin between the two constants below.
+const PROBE_BUDGET_MS = 2_500;
+const STALLED_DETAILED_HEALTH_MS = 3_000;
 const HEALTH_SERVER_WORKER_SOURCE = `
 import { createServer } from "node:http";
 import { workerData } from "node:worker_threads";
@@ -47,7 +68,7 @@ const server = createServer((req, res) => {
   setTimeout(() => {
     res.writeHead(200);
     res.end();
-  }, 3_000);
+  }, ${STALLED_DETAILED_HEALTH_MS});
 });
 
 server.listen(0, "127.0.0.1", () => {
@@ -204,14 +225,14 @@ test("checkDaemonHealth uses liveness without waiting for detailed health", asyn
     setTimeout(() => {
       res.writeHead(200);
       res.end();
-    }, 500);
+    }, STALLED_DETAILED_HEALTH_MS);
   });
 
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   const port = (server.address() as { port: number }).port;
   try {
     const { checkDaemonHealth } = await import(path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts"));
-    assert.equal(await checkDaemonHealth("127.0.0.1", port, 100), true);
+    assert.equal(await checkDaemonHealth("127.0.0.1", port, PROBE_BUDGET_MS), true);
     assert.deepEqual(paths, ["/engram/v1/live"]);
   } finally {
     await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
@@ -231,7 +252,7 @@ test("checkDaemonHealthSync uses liveness without waiting for detailed health", 
 
   try {
     const { checkDaemonHealthSync } = await import(path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts"));
-    assert.equal(checkDaemonHealthSync("127.0.0.1", port, 2_500), true);
+    assert.equal(checkDaemonHealthSync("127.0.0.1", port, PROBE_BUDGET_MS), true);
     assert.equal(Atomics.load(view, 2), 1);
   } finally {
     await serverWorker.terminate();
@@ -251,7 +272,7 @@ test("checkDaemonHealthSync falls back to detailed health for older daemons", as
 
   try {
     const { checkDaemonHealthSync } = await import(path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts"));
-    assert.equal(checkDaemonHealthSync("127.0.0.1", port, 2_500), true);
+    assert.equal(checkDaemonHealthSync("127.0.0.1", port, PROBE_BUDGET_MS), true);
     assert.equal(Atomics.load(view, 2), 2);
   } finally {
     await serverWorker.terminate();
@@ -270,11 +291,21 @@ test("checkDaemonHealth falls back to detailed health for older daemons", async 
   const port = (server.address() as { port: number }).port;
   try {
     const { checkDaemonHealth } = await import(path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts"));
-    assert.equal(await checkDaemonHealth("127.0.0.1", port, 100), true);
+    assert.equal(await checkDaemonHealth("127.0.0.1", port, PROBE_BUDGET_MS), true);
     assert.deepEqual(paths, ["/engram/v1/live", "/engram/v1/health"]);
   } finally {
     await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
   }
+});
+
+test("liveness probe budget stays under the stalled detailed-health delay", () => {
+  // Guards the four tests above. Raising PROBE_BUDGET_MS past the stall would
+  // leave them passing while proving nothing: a probe that wrongly waited on
+  // detailed health would then finish inside the budget and still return true.
+  assert.ok(
+    PROBE_BUDGET_MS < STALLED_DETAILED_HEALTH_MS,
+    `PROBE_BUDGET_MS (${PROBE_BUDGET_MS}) must stay below STALLED_DETAILED_HEALTH_MS (${STALLED_DETAILED_HEALTH_MS})`,
+  );
 });
 
 test("checkDaemonHealth falls back to legacy token file when remnic tokens are malformed", async () => {


### PR DESCRIPTION
Fixes #2287.

## The defect

The two **async** liveness tests budgeted 100 ms for `checkDaemonHealth`:

```js
assert.equal(await checkDaemonHealth("127.0.0.1", port, 100), true);
```

That is a **total** budget, not a per-request allowance — `bridge.ts` derives
every request timeout from one deadline
(`deadline = Date.now() + timeoutMs`, then `remainingMs = deadline - now()`).
So *"falls back to detailed health for older daemons"* had to land **two**
sequential loopback round-trips inside 100 ms. On a loaded CI runner that is not
a reliable margin; the probe timed out and returned `false`, failing
`tests (root)` and, through it, the required `quality` gate.

## The fix

The two **sync** tests in the same file already had this right: a `2_500` ms
budget against a `3_000` ms stall. Apply that same pair to the async tests
rather than inventing a new number, and name both values so the sync and async
pairs cannot drift apart again:

```js
const PROBE_BUDGET_MS = 2_500;
const STALLED_DETAILED_HEALTH_MS = 3_000;
```

Six magic numbers across four tests and one worker-source template collapse to
these two.

## The assertions stay load-bearing

The point of the tight budget was to prove the liveness path short-circuits. The
**gap** between the constants is what does that, not the small absolute value: a
probe that regressed into waiting on detailed health would exhaust the budget
and return `false`.

Verified, not assumed — deleting the liveness short-circuit from the mock server
so the probe falls through to the stalled route still fails the test at the new
budget:

```
not ok 1 - checkDaemonHealth uses liveness without waiting for detailed health
```

A new guard test asserts `PROBE_BUDGET_MS < STALLED_DETAILED_HEALTH_MS`, so a
future raise past the stall can't silently gut the four tests while leaving them
green. Also verified to discriminate — setting the budget to `4_000` fails it
with `PROBE_BUDGET_MS (4000) must stay below STALLED_DETAILED_HEALTH_MS (3000)`.

## Real timers

The `ts-no-test-timers` rule applies, and this is its documented exception. The
stall lives inside a **worker-thread** HTTP server (a separate JS realm) and the
sync variant under test blocks the main thread with `Atomics.wait`; fake timers
can drive neither side, so margin is the only available lever. A comment names
that in the file.

## Verification

`21/21` on `tests/integration/bridge-mode.test.ts`, five consecutive runs. No
runtime code touched — test file only, so no CHANGELOG entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to integration test timeouts and constants; no runtime or bridge behavior is modified.
> 
> **Overview**
> Fixes flaky **`checkDaemonHealth`** integration tests on loaded CI runners (#2287) by replacing the **100 ms** async probe budget with the same **2_500 ms** budget the sync tests already used, against a **3_000 ms** stalled detailed-health mock.
> 
> Introduces shared **`PROBE_BUDGET_MS`** and **`STALLED_DETAILED_HEALTH_MS`** (with comments on total-deadline semantics in `bridge.ts`) so sync/async liveness and legacy-fallback cases stay aligned, and adds a guard test asserting **`PROBE_BUDGET_MS < STALLED_DETAILED_HEALTH_MS`** so raising the budget past the stall cannot silently weaken the short-circuit assertions.
> 
> **Test file only** — no production changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8825cce0b2ecaf9782576203cf5fe7e98974946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved health-check test coverage for both asynchronous and synchronous modes.
  * Added verification that liveness checks respond within the intended probe window, even when detailed health checks are delayed.
  * Confirmed compatibility behavior for legacy daemons that require fallback to detailed health information.
  * Documented timing expectations to help prevent regressions in health-check responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->