### PR TITLE
fix(plugin-openclaw): rank daemon auth env vars primary-before-legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `loadDaemonAuth()` in `@remnic/plugin-openclaw` now ranks daemon-credential environment variables primary-before-legacy: `OPENCLAW_REMNIC_ACCESS_TOKEN`, `REMNIC_AUTH_TOKEN`, then the pre-rename aliases `OPENCLAW_ENGRAM_ACCESS_TOKEN` and `ENGRAM_AUTH_TOKEN`. A deployment migrated off the Engram-era naming commonly still exports the old alias from a shell profile or unit file; that stale value previously outranked the `REMNIC_AUTH_TOKEN` the daemon was running with, so every delegate and health request 401'd while the reported token source named the wrong variable. This was the last resolver still on the old ordering — the Claude Code and Codex hooks were corrected in v9.46.0.
+
 ## [v9.46.0] — 2026-08-01
 
 ### Added

--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -446,12 +446,19 @@ function isOpenClawTokenEntry(value: unknown): value is { token: string } {
 /**
  * Load daemon credentials from the environment, standard token stores, or
  * daemon configuration. Shared by health and delegate requests.
+ *
+ * Environment precedence is primary-before-legacy (AGENTS.md §9): both current
+ * names outrank both pre-rename aliases. A migrated deployment commonly still
+ * exports `OPENCLAW_ENGRAM_ACCESS_TOKEN` from an old shell profile or unit
+ * file; if that stale value outranked the `REMNIC_AUTH_TOKEN` the daemon is
+ * actually running with, every request would 401 and the reported `source`
+ * would point the operator at the wrong variable (issue #2286).
  */
 export function loadDaemonAuth(): DaemonAuthToken {
   const environmentTokens = [
     ["OPENCLAW_REMNIC_ACCESS_TOKEN", readEnv("OPENCLAW_REMNIC_ACCESS_TOKEN")],
-    ["OPENCLAW_ENGRAM_ACCESS_TOKEN", readEnv("OPENCLAW_ENGRAM_ACCESS_TOKEN")],
     ["REMNIC_AUTH_TOKEN", readEnv("REMNIC_AUTH_TOKEN")],
+    ["OPENCLAW_ENGRAM_ACCESS_TOKEN", readEnv("OPENCLAW_ENGRAM_ACCESS_TOKEN")],
     ["ENGRAM_AUTH_TOKEN", readEnv("ENGRAM_AUTH_TOKEN")],
   ] as const;
   for (const [source, token] of environmentTokens) {

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -1680,22 +1680,53 @@ test("delegate honors allowPromptInjection=false but keeps observe/flush", async
 });
 
 
-test("loadDaemonAuth selects only the OpenClaw token from multi-connector stores", () => {
-  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-openclaw-token-"));
+const DAEMON_AUTH_ENV_VARS = [
+  "OPENCLAW_REMNIC_ACCESS_TOKEN",
+  "REMNIC_AUTH_TOKEN",
+  "OPENCLAW_ENGRAM_ACCESS_TOKEN",
+  "ENGRAM_AUTH_TOKEN",
+] as const;
+type DaemonAuthEnvVar = (typeof DAEMON_AUTH_ENV_VARS)[number];
+
+/**
+ * Run `body` against a scratch HOME with the daemon-auth environment set to
+ * exactly `env` — every name not listed is unset, so an ambient credential on
+ * the developer's machine or the CI runner cannot reach loadDaemonAuth().
+ */
+function withDaemonAuthEnv(
+  env: Partial<Record<DaemonAuthEnvVar, string>>,
+  body: (home: string) => void,
+): void {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-daemon-auth-"));
   const priorHome = process.env.HOME;
-  const authVariables = [
-    "OPENCLAW_REMNIC_ACCESS_TOKEN",
-    "OPENCLAW_ENGRAM_ACCESS_TOKEN",
-    "REMNIC_AUTH_TOKEN",
-    "ENGRAM_AUTH_TOKEN",
-  ] as const;
-  const priorAuth = new Map(authVariables.map((name) => [name, process.env[name]]));
+  const priorAuth: Record<string, string | undefined> = {};
+  for (const name of DAEMON_AUTH_ENV_VARS) priorAuth[name] = process.env[name];
   try {
-    for (const name of authVariables) Reflect.deleteProperty(process.env, name);
-    process.env.HOME = tempHome;
-    fs.mkdirSync(path.join(tempHome, ".remnic"), { recursive: true });
+    process.env.HOME = home;
+    for (const name of DAEMON_AUTH_ENV_VARS) {
+      const value = env[name];
+      if (value === undefined) Reflect.deleteProperty(process.env, name);
+      else process.env[name] = value;
+    }
+    body(home);
+  } finally {
+    if (priorHome === undefined) Reflect.deleteProperty(process.env, "HOME");
+    else process.env.HOME = priorHome;
+    for (const name of DAEMON_AUTH_ENV_VARS) {
+      const value = priorAuth[name];
+      if (value === undefined) Reflect.deleteProperty(process.env, name);
+      else process.env[name] = value;
+    }
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+test("loadDaemonAuth selects only the OpenClaw token from multi-connector stores", () => {
+  withDaemonAuthEnv({}, (home) => {
+    const store = path.join(home, ".remnic", "tokens.json");
+    fs.mkdirSync(path.dirname(store), { recursive: true });
     fs.writeFileSync(
-      path.join(tempHome, ".remnic", "tokens.json"),
+      store,
       JSON.stringify({
         tokens: [
           { token: "remnic_other_token", connector: "other", createdAt: "2026-01-01T00:00:00.000Z" },
@@ -1703,14 +1734,13 @@ test("loadDaemonAuth selects only the OpenClaw token from multi-connector stores
         ],
       }),
     );
-
     assert.deepEqual(loadDaemonAuth(), {
       token: "remnic_openclaw_token",
       source: "remnic token store",
     });
 
     fs.writeFileSync(
-      path.join(tempHome, ".remnic", "tokens.json"),
+      store,
       JSON.stringify({
         tokens: [
           { token: "remnic_other_token", connector: "other", createdAt: "2026-01-01T00:00:00.000Z" },
@@ -1721,14 +1751,82 @@ test("loadDaemonAuth selects only the OpenClaw token from multi-connector stores
       token: "",
       source: "no configured token",
     });
-  } finally {
-    if (priorHome === undefined) Reflect.deleteProperty(process.env, "HOME");
-    else process.env.HOME = priorHome;
-    for (const [name, value] of priorAuth) {
-      if (value === undefined) Reflect.deleteProperty(process.env, name);
-      else process.env[name] = value;
-    }
-    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+});
+
+test("loadDaemonAuth prefers REMNIC_AUTH_TOKEN over the legacy OPENCLAW_ENGRAM_ACCESS_TOKEN", () => {
+  withDaemonAuthEnv(
+    { REMNIC_AUTH_TOKEN: "current-token", OPENCLAW_ENGRAM_ACCESS_TOKEN: "stale-legacy-token" },
+    () => {
+      assert.deepEqual(loadDaemonAuth(), {
+        token: "current-token",
+        source: "REMNIC_AUTH_TOKEN",
+      });
+    },
+  );
+});
+
+test("loadDaemonAuth ranks both current names above both legacy aliases", () => {
+  withDaemonAuthEnv(
+    {
+      OPENCLAW_REMNIC_ACCESS_TOKEN: "connector-token",
+      REMNIC_AUTH_TOKEN: "operator-token",
+      OPENCLAW_ENGRAM_ACCESS_TOKEN: "legacy-connector-token",
+      ENGRAM_AUTH_TOKEN: "legacy-operator-token",
+    },
+    () => {
+      assert.deepEqual(loadDaemonAuth(), {
+        token: "connector-token",
+        source: "OPENCLAW_REMNIC_ACCESS_TOKEN",
+      });
+    },
+  );
+  // Drop the winner and the next current name takes over — not a legacy alias.
+  withDaemonAuthEnv(
+    {
+      REMNIC_AUTH_TOKEN: "operator-token",
+      OPENCLAW_ENGRAM_ACCESS_TOKEN: "legacy-connector-token",
+      ENGRAM_AUTH_TOKEN: "legacy-operator-token",
+    },
+    () => {
+      assert.deepEqual(loadDaemonAuth(), {
+        token: "operator-token",
+        source: "REMNIC_AUTH_TOKEN",
+      });
+    },
+  );
+});
+
+test("loadDaemonAuth still accepts each legacy alias when no current name is set", () => {
+  withDaemonAuthEnv(
+    { OPENCLAW_ENGRAM_ACCESS_TOKEN: "legacy-connector-token", ENGRAM_AUTH_TOKEN: "legacy-operator-token" },
+    () => {
+      assert.deepEqual(loadDaemonAuth(), {
+        token: "legacy-connector-token",
+        source: "OPENCLAW_ENGRAM_ACCESS_TOKEN",
+      });
+    },
+  );
+  withDaemonAuthEnv({ ENGRAM_AUTH_TOKEN: "legacy-operator-token" }, () => {
+    assert.deepEqual(loadDaemonAuth(), {
+      token: "legacy-operator-token",
+      source: "ENGRAM_AUTH_TOKEN",
+    });
+  });
+});
+
+test("loadDaemonAuth reports the variable it actually used", () => {
+  // `source` drives the operator-facing auth error. Naming the wrong variable
+  // sends someone rotating a credential that was never sent.
+  for (const name of [
+    "OPENCLAW_REMNIC_ACCESS_TOKEN",
+    "REMNIC_AUTH_TOKEN",
+    "OPENCLAW_ENGRAM_ACCESS_TOKEN",
+    "ENGRAM_AUTH_TOKEN",
+  ] as const) {
+    withDaemonAuthEnv({ [name]: `token-via-${name}` }, () => {
+      assert.deepEqual(loadDaemonAuth(), { token: `token-via-${name}`, source: name });
+    });
   }
 });
 test("resolveBridgeMode is explicit-only: config delegate activates, absence stays embedded", () => {


### PR DESCRIPTION
Fixes #2286.

## The defect

`loadDaemonAuth()` read all four daemon-credential names, but in this order:

```
OPENCLAW_REMNIC_ACCESS_TOKEN
OPENCLAW_ENGRAM_ACCESS_TOKEN   <- legacy
REMNIC_AUTH_TOKEN              <- current
ENGRAM_AUTH_TOKEN
```

A pre-rename alias sat ahead of a current name, inverting the precedence
AGENTS.md §9 requires: *"primary `REMNIC_*` / `OPENCLAW_*` must be checked
before legacy `ENGRAM_*` / `OPENCLAW_ENGRAM_*` everywhere."*

A deployment migrated off the Engram-era naming commonly still exports
`OPENCLAW_ENGRAM_ACCESS_TOKEN` from an old shell profile or unit file. When that
value is stale and the daemon runs on `REMNIC_AUTH_TOKEN`, the stale alias won:
every delegate and health request 401s, and — worse for debugging — the `source`
reported in the auth error names the wrong variable, sending the operator to
rotate a credential that was never sent.

## The fix

```
OPENCLAW_REMNIC_ACCESS_TOKEN
REMNIC_AUTH_TOKEN
OPENCLAW_ENGRAM_ACCESS_TOKEN
ENGRAM_AUTH_TOKEN
```

This was the **last resolver on the old ordering**. The Claude Code hook (#2268)
and Codex hook (#2285) were corrected in v9.46.0, so all four now agree.
`packages/remnic-core/src/config.ts` resolves a different concern (the
server-side `agentAccessHttp.authToken` default) from a two-name chain that was
already primary-first.

No caller reimplements the chain — `bridge.ts` (health probe, delegate request)
and `delegate-runtime.ts` (`resolveAuthToken`) all route through this function,
so the correction propagates without further edits.

## Verification

Four tests, run against `packages/plugin-openclaw/src/delegate-runtime.test.ts`:

- `REMNIC_AUTH_TOKEN` beats a stale `OPENCLAW_ENGRAM_ACCESS_TOKEN`
- both current names outrank both legacy aliases, and dropping the winner
  promotes the *next current name* rather than an alias
- each legacy alias still resolves on its own — the reorder must not quietly
  drop legacy support
- `source` names the variable actually used, checked for all four

The first two are **red under the old ordering** (`3 pass / 2 fail`), green after
(`5 pass`). The last two pass either way by design: they are regression guards on
behavior that must *not* change.

Suites run: `delegate-runtime.test.ts` 62/62, `openclaw-adapter-scenarios` +
`bridge-mode` 63/63.

## Incidental cleanup

The pre-existing `loadDaemonAuth` test hand-rolled its own env save/restore. That
is now one `withDaemonAuthEnv` helper — scratch `HOME` plus an exactly-specified
auth environment, so an ambient credential on a developer machine or CI runner
cannot reach `loadDaemonAuth()`, and the tests cannot drift apart. Net effect is
one idiom instead of two, and the `Map` the old version used is gone in favour of
a `Record` per the repo's `ts-set-map` rule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow auth-resolution change with regression tests; only affects which env token is chosen when multiple are set, matching hooks fixed in v9.46.0.
> 
> **Overview**
> Fixes **#2286** by aligning `loadDaemonAuth()` in `@remnic/plugin-openclaw` with **primary-before-legacy** env precedence (AGENTS.md §9). The chain is now `OPENCLAW_REMNIC_ACCESS_TOKEN` → `REMNIC_AUTH_TOKEN` → `OPENCLAW_ENGRAM_ACCESS_TOKEN` → `ENGRAM_AUTH_TOKEN`; previously `OPENCLAW_ENGRAM_ACCESS_TOKEN` could win over `REMNIC_AUTH_TOKEN`, so migrated installs with a stale legacy export sent the wrong bearer to delegate and health probes (401s) while auth errors cited the wrong `source`.
> 
> Health checks, delegate traffic, and `resolveAuthToken` all use this helper, so the fix applies everywhere without duplicate chains. **Unreleased** changelog documents the behavior.
> 
> Tests add `withDaemonAuthEnv` (isolated HOME + exact env) and cases for current-over-legacy ranking, legacy-only fallback, and accurate `source` reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d68d46b43bd70fa155b7f39376e21ba30945fa03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected daemon authentication credential selection.
  * The canonical authentication token environment variables now take precedence over legacy aliases.
  * Existing fallback behavior remains supported, improving reliability for installations transitioning from legacy configuration.

* **Documentation**
  * Added an Unreleased changelog entry describing the corrected credential precedence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->