### PR TITLE
docs(agents): add tangible-progress and scope-discipline rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,10 @@ OpenClaw `2026.4.1`.
 
 The purpose of this project is working, shippable software delivered
 accretively. Process exists to serve that outcome; it must never become the
-product. Remnic has no ticket tracker of record and no evidence-packet
-workflow, so the currency here is a durable receipt: a merged PR, a passing
-test run, a command output, a linked issue. No receipt, no credit.
+product. GitHub issues and pull requests are this repo's record; there is no
+separate tracker and no evidence-packet workflow, so the currency here is a
+durable receipt: a merged PR, a passing test run, a command output, a linked
+GitHub issue. No receipt, no credit.
 
 - **No process porn.** Ledgers, dashboards, meta-reports, and process
   documents are not progress. A process artifact may exist only when it gates
@@ -108,8 +109,11 @@ test run, a command output, a linked issue. No receipt, no credit.
   shows up in code as gold plating: an abstraction for a second caller that
   does not exist, a config knob nobody asked for, a retry wrapper around a
   call that does not fail, a refactor sitting next to the actual change. Build
-  what was asked, at the size asked. A defect you find mid-task is still yours
-  to fix; an unrequested improvement is not — file it as an issue and move on.
+  what was asked, at the size asked. A defect inside the subsystem you are
+  already changing is yours to fix now; a defect elsewhere, and any
+  unrequested improvement, is not — open a GitHub issue for it and move on,
+  because the one-subsystem-per-PR rule below outranks the urge to widen the
+  diff.
 - **Bound the machinery, then freeze it.** Validators, linters, scaffolds,
   harnesses, and helper scripts obey the same law as any other process
   artifact. Each must gate a named deliverable, and "good enough to keep the
@@ -119,17 +123,22 @@ test run, a command output, a linked issue. No receipt, no credit.
   issue — never built preemptively against a future you are imagining. Keep
   every check that has caught a real defect; kill the tranches that only
   deepen the apparatus.
-- **The deliverable outranks the apparatus.** Shipping the real feature always
-  outranks perfecting the thing that would verify it. Machinery can be
-  reconciled afterwards, as a derivative of what shipped; what ships never
-  waits on machinery completeness.
+- **The deliverable outranks the apparatus.** Shipping the real feature
+  outranks perfecting the *optional* machinery that would verify it. Machinery
+  can be reconciled afterwards, as a derivative of what shipped; what ships
+  never waits on optional-machinery completeness. This never reaches the
+  mandated gates above — the Cleaner PR Workflow checks, `preflight:quick`,
+  `test:entity-hardening`, and the required CI checks are part of the
+  deliverable, not apparatus around it.
 - **Watch the ratio in your own turns.** If your recent activity is mostly
   plans, schema debates, review letters, and status prose while the count of
   shipped units has not moved, you are the one who needs the redirect, and it
   is due mid-task rather than in a retrospective. Apply to yourself the
   threshold you would apply to a subagent you were supervising. Investigation
   that has stopped changing your plan is finished investigation: take the
-  boring default, leave a receipt, and go build.
+  boring default, leave a receipt, and go build. An open question about
+  security, data integrity, host compatibility, or a mandated validation is
+  by definition still changing the plan — run it down before you default.
 
 These rules bind human-directed sessions, delegated subagents, and scheduled
 or otherwise autonomous agent runs alike.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,65 @@ OpenClaw `2026.4.1`.
   `docs/plugins/openclaw.md`, `packages/plugin-openclaw/README.md`, `llms.txt`,
   and the relevant package metadata tests.
 
+## Tangible Progress and Scope Discipline (All Agents)
+
+The purpose of this project is working, shippable software delivered
+accretively. Process exists to serve that outcome; it must never become the
+product. Remnic has no ticket tracker of record and no evidence-packet
+workflow, so the currency here is a durable receipt: a merged PR, a passing
+test run, a command output, a linked issue. No receipt, no credit.
+
+- **No process porn.** Ledgers, dashboards, meta-reports, and process
+  documents are not progress. A process artifact may exist only when it gates
+  a named capability, or when this repo already mandates it. The mandated set
+  is exempt by definition and is never yours to skip or delete: the Cleaner PR
+  Workflow gates, `npm run preflight:quick`, `npm run test:entity-hardening`,
+  the required CI checks, and the Review Prevention Checklist below. What this
+  bans is self-referential paperwork invented outside that set. Choosing
+  process artifacts because they are easy and low-risk is reward hacking.
+- **Honesty is absolute.** Never fake a test, present a fixture or mock as
+  live proof, weaken an assertion to make it pass, hard-code a success path,
+  or close work that is not done. Never claim a command ran without its
+  output. A false close is reopened on the record.
+- **Refusal is not delivery.** A correctly typed refusal beats a fabricated
+  result and is worth far less than the real capability. Implementing only the
+  refusal path never closes a feature issue. Mark refusal-only states
+  explicitly, with a follow-up issue, so they read as unfinished rather than
+  as shipped.
+- **Meta-work is the most seductive work available.** Designing governance
+  feels like the highest-leverage thing you could be doing, reviewing
+  governance feels rigorous, and both extend forever. Capability improves the
+  justification, not the work, so expect this failure mode most strongly when
+  the assignment is itself about process, standards, or quality. The same pull
+  shows up in code as gold plating: an abstraction for a second caller that
+  does not exist, a config knob nobody asked for, a retry wrapper around a
+  call that does not fail, a refactor sitting next to the actual change. Build
+  what was asked, at the size asked. A defect you find mid-task is still yours
+  to fix; an unrequested improvement is not — file it as an issue and move on.
+- **Bound the machinery, then freeze it.** Validators, linters, scaffolds,
+  harnesses, and helper scripts obey the same law as any other process
+  artifact. Each must gate a named deliverable, and "good enough to keep the
+  work honest" is the bar: schema checks, cycle detection, overlap detection,
+  baseline drift. Reach that bar and freeze. Rigor you decide to defer is
+  recorded as explicit debt — a named list of unimplemented checks, or an
+  issue — never built preemptively against a future you are imagining. Keep
+  every check that has caught a real defect; kill the tranches that only
+  deepen the apparatus.
+- **The deliverable outranks the apparatus.** Shipping the real feature always
+  outranks perfecting the thing that would verify it. Machinery can be
+  reconciled afterwards, as a derivative of what shipped; what ships never
+  waits on machinery completeness.
+- **Watch the ratio in your own turns.** If your recent activity is mostly
+  plans, schema debates, review letters, and status prose while the count of
+  shipped units has not moved, you are the one who needs the redirect, and it
+  is due mid-task rather than in a retrospective. Apply to yourself the
+  threshold you would apply to a subagent you were supervising. Investigation
+  that has stopped changing your plan is finished investigation: take the
+  boring default, leave a receipt, and go build.
+
+These rules bind human-directed sessions, delegated subagents, and scheduled
+or otherwise autonomous agent runs alike.
+
 ## Cleaner PR Workflow (Mandatory)
 
 These rules are the default workflow for all agents and contributors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,10 +79,14 @@ OpenClaw `2026.4.1`.
 
 The purpose of this project is working, shippable software delivered
 accretively. Process exists to serve that outcome; it must never become the
-product. GitHub issues and pull requests are this repo's record; there is no
-separate tracker and no evidence-packet workflow, so the currency here is a
-durable receipt: a merged PR, a passing test run, a command output, a linked
-GitHub issue. No receipt, no credit.
+product. Sequencing, dependencies, blockers, and contributor priority live in
+the GitHub Project roadmap that `docs/plans/README.md` designates as the
+source of truth; read it before choosing what to work on. GitHub issues and
+pull requests are the per-change record. There is no evidence-packet workflow
+here, so the currency is a durable receipt: a merged PR, a passing test run, a
+command output, a linked GitHub issue. No receipt, no credit. None of these
+are the "process artifacts" the next bullet prohibits — they are the record
+the work is judged against.
 
 - **No process porn.** Ledgers, dashboards, meta-reports, and process
   documents are not progress. A process artifact may exist only when it gates


### PR DESCRIPTION
`AGENTS.md` had no statement of what counts as progress in this repo, and no guard against the two ways agents drift off the deliverable: inventing process artifacts, and gold-plating code nobody asked for.

Adds one section, `## Tangible Progress and Scope Discipline (All Agents)`, placed just before the Cleaner PR Workflow.

**What it says**

- The currency here is a durable receipt: a merged PR, a passing test run, a command output, a linked issue. Remnic runs no ticket tracker of record and no evidence-packet workflow, so the section says that plainly instead of importing machinery this repo does not have.
- The repo's already-mandated gates are exempt by definition and never yours to skip or delete: the Cleaner PR Workflow gates, `npm run preflight:quick`, `npm run test:entity-hardening`, the required CI checks, and the Review Prevention Checklist. What it bans is self-referential paperwork invented outside that set.
- Honesty and refusal bullets restate the existing bar: no faked tests, no mock presented as live proof, no claim that a command ran without its output, and a refusal path alone never closes a feature issue.
- Four scope rules: meta-work is the most seductive work available (and gold plating is its code-level twin); bound the machinery, then freeze it; the deliverable outranks the apparatus; watch the ratio in your own turns.

`CLAUDE.md` is a symlink to `AGENTS.md`, so it is covered.

**Scope:** documentation only, no code paths touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor/agent guidance with no code, config, or CI path modifications.
> 
> **Overview**
> Adds **`## Tangible Progress and Scope Discipline (All Agents)`** to `AGENTS.md`, immediately before the mandatory Cleaner PR Workflow, so agents have an explicit definition of what counts as progress and how to stay on deliverables.
> 
> The section frames **durable receipts** (merged PRs, test/command output, linked issues) as the bar for credit, points roadmap readers at `docs/plans/README.md`, and states there is no separate evidence-packet workflow. It distinguishes **mandated gates** (Cleaner PR Workflow, `preflight:quick`, `test:entity-hardening`, required CI, Review Prevention Checklist) from banned self-invented process paperwork.
> 
> Bullet rules cover **honesty** (no faked tests or claimed runs without output), **refusal-only work** (cannot close feature issues), **meta-work and gold-plating**, **bounding optional validators/harnesses then freezing**, **deliverable over optional apparatus**, and **self-checking activity ratio** mid-task. The section applies to humans, subagents, and autonomous runs alike.
> 
> **Docs only** — no runtime or CI behavior changes; `CLAUDE.md` symlink coverage is unchanged in mechanism.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7db7b58fd2bff1fc7e42752c607abc9bb496334a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for demonstrating tangible progress and maintaining disciplined scope.
  * Clarified expectations for transparent status reporting, including explicit acknowledgment when work cannot proceed.
  * Emphasized prioritizing delivered capabilities over unnecessary process artifacts.
  * Defined expectations for keeping validation focused on named deliverables and redirecting excessive planning or investigation toward actionable work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->