### PR TITLE
docs(agents): budget the AI review loop and decline past round two

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,9 +149,10 @@ the work is judged against.
   reviewer will always find one more hypothetical. **From round three on, only
   these are actionable:** a correctness, security, or data-integrity defect
   in the behavior this change ships, whether already deployed or still in
-  the PR; a failing *required* check; a factual claim that is wrong
-  against the tree; or a rule this repo mandates that the PR actually
-  violates. Everything else — style, hypothetical mutations of code or
+  the PR; a performance or capacity regression (an N+1 query, an unbounded
+  loop, a latency or memory blowup); a failing *required* check; a factual
+  claim that is wrong against the tree; or a rule this repo mandates that
+  the PR actually violates. Everything else — style, hypothetical mutations of code or
   wording nobody would write, further tightening of a check that already fails
   on the regression it names — is **declined in-thread with the reason and
   the thread resolved**, not fixed. The Cleaner PR Workflow's "zero unresolved

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,20 @@ the work is judged against.
   boring default, leave a receipt, and go build. An open question about
   security, data integrity, host compatibility, or a mandated validation is
   by definition still changing the plan — run it down before you default.
+- **Budget the review loop, then decline.** The AI review gates here find real
+  defects for about two rounds. After that they generate adversarial cases
+  against the previous round's fix, which is unbounded by construction — a
+  reviewer will always find one more hypothetical. **From round three on, only
+  these are actionable:** a correctness, security, or data-integrity defect in
+  shipped behavior; a failing *required* check; a factual claim that is wrong
+  against the tree; or a rule this repo mandates that the PR actually
+  violates. Everything else — style, hypothetical mutations of code or
+  wording nobody would write, further tightening of a check that already fails
+  on the regression it names — is **declined in-thread with the reason and
+  the thread resolved**, not fixed. The Cleaner PR Workflow's "zero unresolved
+  threads" bar is satisfied by a reasoned decline exactly as much as by a fix;
+  it asks for resolution, not obedience. Three rounds on a change with no
+  runtime behavior is itself the signal to stop.
 
 These rules bind human-directed sessions, delegated subagents, and scheduled
 or otherwise autonomous agent runs alike.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,8 +147,9 @@ the work is judged against.
   defects for about two rounds. After that they generate adversarial cases
   against the previous round's fix, which is unbounded by construction — a
   reviewer will always find one more hypothetical. **From round three on, only
-  these are actionable:** a correctness, security, or data-integrity defect in
-  shipped behavior; a failing *required* check; a factual claim that is wrong
+  these are actionable:** a correctness, security, or data-integrity defect
+  in the behavior this change ships, whether already deployed or still in
+  the PR; a failing *required* check; a factual claim that is wrong
   against the tree; or a rule this repo mandates that the PR actually
   violates. Everything else — style, hypothetical mutations of code or
   wording nobody would write, further tightening of a check that already fails

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,11 +149,12 @@ the work is judged against.
   reviewer will always find one more hypothetical. **From round three on, only
   these are actionable:** a correctness, security, or data-integrity defect
   in the behavior this change ships, whether already deployed or still in
-  the PR; a performance or capacity regression (an N+1 query, an unbounded
-  loop, a latency or memory blowup); a failing *required* check; a factual
-  claim that is wrong against the tree; or a rule this repo mandates that
-  the PR actually violates. Everything else — style, hypothetical mutations of code or
-  wording nobody would write, further tightening of a check that already fails
+  the PR; a performance, capacity, or reliability regression (an N+1 query, an
+  unbounded loop, a latency or memory blowup, retry-induced overload); a
+  failing *required* check; a factual claim that is wrong against the tree; or
+  a rule this repo mandates that the PR actually violates. Everything else —
+  style, hypothetical mutations of code or wording nobody would write, further
+  tightening of a check that already fails
   on the regression it names — is **declined in-thread with the reason and
   the thread resolved**, not fixed. The Cleaner PR Workflow's "zero unresolved
   threads" bar is satisfied by a reasoned decline exactly as much as by a fix;


### PR DESCRIPTION
Follow-on to #2295.

The scope-discipline section says to bound machinery and freeze it, but said nothing about the review loop itself — which is the machinery agents actually get stuck in.

Adds a fifth bullet: AI review gates find real defects for about two rounds, then start generating adversarial cases against the previous round's fix, which is unbounded by construction. From round three, only a correctness/security/data-integrity defect in shipped behavior, a failing **required** check, a factually wrong claim, or an actual violation of a mandated rule is actionable. Everything else is **declined in-thread with the reason and the thread resolved**, not fixed.

It also states the thing that makes the rule usable here: the Cleaner PR Workflow's "zero unresolved review threads" bar asks for *resolution*, not obedience — a reasoned decline satisfies it.

**Evidence:** a documentation-only change in a sibling repo ran eight review rounds this week. Rounds 1-2 found genuinely important defects. Rounds 3-8 were reviewers reviewing the test written to satisfy an earlier reviewer, ending in mutations like `non-*optional* machinery` and `do not run it down before you default` — sentences no one would write.

Documentation only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent workflow guidance; no runtime, security, or CI behavior changes.
> 
> **Overview**
> Extends **Tangible Progress and Scope Discipline** with guidance to **cap AI review churn**: expect meaningful findings for about two rounds, then treat later feedback as unbounded adversarial refinement unless it hits a narrow actionable set.
> 
> **From round three onward**, agents should act only on shipped-behavior correctness/security/data-integrity issues, perf/capacity/reliability regressions, failing **required** checks, factual errors against the tree, or real violations of mandated repo rules. Other items (style, hypothetical wording, extra tightening on checks that already catch the named regression) should be **declined in-thread with a reason and the thread resolved**, not “fixed” indefinitely.
> 
> The change also states explicitly that the Cleaner PR Workflow’s **zero unresolved review threads** requirement is met by a **reasoned decline** as well as by a fix—resolution, not blind obedience—and that three+ rounds on changes with no runtime behavior is a signal to stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437738f3de96febf3b130616f44e476a58e22ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for AI-assisted review loops, including limits on actionable findings after the third review round.
  * Clarified when reviews should stop and which issue types require action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->