### PR TITLE
fix(release): verify the packlist covers the build, not a chunk count

### DIFF
--- a/scripts/verify-openclaw-clawpack.mjs
+++ b/scripts/verify-openclaw-clawpack.mjs
@@ -31,7 +31,10 @@ function assertRealDirectory(dir, label) {
 }
 
 assertRealDirectory(packageDir, "package directory");
-const distDirExists = assertRealDirectory(distDir, "dist directory");
+// Checked here so a redirected root is rejected before `npm pack` runs any
+// lifecycle script; existence is re-read after the pack, because a `prepack`
+// script may legitimately create dist/.
+assertRealDirectory(distDir, "dist directory");
 
 function parsePackOutput(stdout) {
   const candidates = [0];
@@ -110,7 +113,7 @@ for (const requiredFile of requiredFiles) {
 // requirement; removing that module in #2279 left the assertion unsatisfiable
 // and blocked every release from 2026-07-31 on.
 const distFiles = [...files].filter((file) => file.startsWith("dist/"));
-const builtDistFiles = distDirExists
+const builtDistFiles = assertRealDirectory(distDir, "dist directory")
   ? readdirSync(distDir, { recursive: true })
       .map((relative) => String(relative).split(path.sep).join("/"))
       .filter((relative) => {

--- a/scripts/verify-openclaw-clawpack.mjs
+++ b/scripts/verify-openclaw-clawpack.mjs
@@ -63,6 +63,29 @@ function parsePackOutput(stdout) {
   throw new Error("could not find npm pack JSON array in stdout");
 }
 
+/**
+ * Walk dist/ one level at a time, `lstat`-ing every entry BEFORE descending.
+ * Node's recursive `readdirSync` follows directory symlinks while building its
+ * result, so a post-hoc filter would already have enumerated whatever the link
+ * pointed at — possibly outside the package, possibly a cycle.
+ */
+function listBuiltDistFiles() {
+  const found = [];
+  const pending = [""];
+  while (pending.length > 0) {
+    const relativeDir = pending.pop();
+    for (const name of readdirSync(path.join(distDir, relativeDir))) {
+      const relative = relativeDir === "" ? name : `${relativeDir}/${name}`;
+      const stats = lstatSync(path.join(distDir, relative), { throwIfNoEntry: false });
+      if (stats === undefined) fail(`dist/${relative} disappeared while scanning`);
+      if (stats.isSymbolicLink()) fail(`dist/${relative} is a symlink; build output must be real files`);
+      if (stats.isDirectory()) pending.push(relative);
+      else if (stats.isFile()) found.push(`dist/${relative}`);
+    }
+  }
+  return found;
+}
+
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
 const pack = spawnSync("npm", ["pack", "--dry-run", "--json"], {
   cwd: packageDir,
@@ -113,17 +136,7 @@ for (const requiredFile of requiredFiles) {
 // requirement; removing that module in #2279 left the assertion unsatisfiable
 // and blocked every release from 2026-07-31 on.
 const distFiles = [...files].filter((file) => file.startsWith("dist/"));
-const builtDistFiles = assertRealDirectory(distDir, "dist directory")
-  ? readdirSync(distDir, { recursive: true })
-      .map((relative) => String(relative).split(path.sep).join("/"))
-      .filter((relative) => {
-        const stats = lstatSync(path.join(distDir, relative), { throwIfNoEntry: false });
-        if (stats === undefined) fail(`dist/${relative} disappeared while scanning`);
-        if (stats.isSymbolicLink()) fail(`dist/${relative} is a symlink; build output must be real files`);
-        return stats.isFile();
-      })
-      .map((relative) => `dist/${relative}`)
-  : [];
+const builtDistFiles = assertRealDirectory(distDir, "dist directory") ? listBuiltDistFiles() : [];
 if (builtDistFiles.length === 0) {
   fail(`${packageJson.name}@${packageJson.version} has no built dist/ — run the package build before packing`);
 }

--- a/scripts/verify-openclaw-clawpack.mjs
+++ b/scripts/verify-openclaw-clawpack.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { lstatSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -13,6 +13,25 @@ function fail(message) {
   console.error(`OpenClaw ClawPack verification failed: ${message}`);
   process.exit(1);
 }
+
+/**
+ * A symlinked scan root or entry would let the release gate inspect artifacts
+ * outside the package it was asked about, and a dangling one would abort the
+ * verifier with an uncaught filesystem error. Everything under `dist/` must be
+ * a real file or directory (AGENTS.md: reject symlink traversal in directory
+ * scans). Runs before `npm pack` so a redirected root is reported as such
+ * rather than as whatever downstream assertion happens to notice first.
+ */
+function assertRealDirectory(dir, label) {
+  const stats = lstatSync(dir, { throwIfNoEntry: false });
+  if (stats === undefined) return false;
+  if (stats.isSymbolicLink()) fail(`${label} is a symlink (${dir}); refusing to scan outside the package`);
+  if (!stats.isDirectory()) fail(`${label} is not a directory (${dir})`);
+  return true;
+}
+
+assertRealDirectory(packageDir, "package directory");
+const distDirExists = assertRealDirectory(distDir, "dist directory");
 
 function parsePackOutput(stdout) {
   const candidates = [0];
@@ -91,10 +110,15 @@ for (const requiredFile of requiredFiles) {
 // requirement; removing that module in #2279 left the assertion unsatisfiable
 // and blocked every release from 2026-07-31 on.
 const distFiles = [...files].filter((file) => file.startsWith("dist/"));
-const builtDistFiles = existsSync(distDir)
+const builtDistFiles = distDirExists
   ? readdirSync(distDir, { recursive: true })
       .map((relative) => String(relative).split(path.sep).join("/"))
-      .filter((relative) => statSync(path.join(distDir, relative)).isFile())
+      .filter((relative) => {
+        const stats = lstatSync(path.join(distDir, relative), { throwIfNoEntry: false });
+        if (stats === undefined) fail(`dist/${relative} disappeared while scanning`);
+        if (stats.isSymbolicLink()) fail(`dist/${relative} is a symlink; build output must be real files`);
+        return stats.isFile();
+      })
       .map((relative) => `dist/${relative}`)
   : [];
 if (builtDistFiles.length === 0) {

--- a/scripts/verify-openclaw-clawpack.mjs
+++ b/scripts/verify-openclaw-clawpack.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -7,6 +7,7 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
 const packageDir = path.resolve(repoRoot, process.argv[2] ?? "packages/plugin-openclaw");
 const packageJsonPath = path.join(packageDir, "package.json");
+const distDir = path.join(packageDir, "dist");
 
 function fail(message) {
   console.error(`OpenClaw ClawPack verification failed: ${message}`);
@@ -82,9 +83,38 @@ for (const requiredFile of requiredFiles) {
   }
 }
 
+// Every emitted dist file must be IN the tarball. This is the invariant that
+// matters: tsup code-splits whenever the entry gains a dynamic import, and a
+// split chunk missing from the packlist breaks the plugin at runtime with a
+// module-not-found the tests never see. It replaces an older `>= 2 dist files`
+// proxy that silently encoded one such chunk (`legacy-hook-compat-*.js`) as a
+// requirement; removing that module in #2279 left the assertion unsatisfiable
+// and blocked every release from 2026-07-31 on.
 const distFiles = [...files].filter((file) => file.startsWith("dist/"));
-if (distFiles.length < 2) {
-  fail(`${packageJson.name}@${packageJson.version} packlist only includes ${distFiles.length} dist file(s)`);
+const builtDistFiles = existsSync(distDir)
+  ? readdirSync(distDir, { recursive: true })
+      .map((relative) => String(relative).split(path.sep).join("/"))
+      .filter((relative) => statSync(path.join(distDir, relative)).isFile())
+      .map((relative) => `dist/${relative}`)
+  : [];
+if (builtDistFiles.length === 0) {
+  fail(`${packageJson.name}@${packageJson.version} has no built dist/ — run the package build before packing`);
+}
+const unpacked = builtDistFiles.filter((file) => !files.has(file));
+if (unpacked.length > 0) {
+  fail(`${packageJson.name}@${packageJson.version} built ${unpacked.join(", ")} but the packlist omits them`);
+}
+
+// Deliberately no byte floor on the entry bundle: this script also verifies
+// the shim package, whose legitimate build is a few hundred bytes, so any
+// size threshold is a number rather than an invariant. "The build ran and
+// everything it emitted is packed" is the property that holds for both.
+const entryBundle = entries.find((entry) => entry.path === "dist/index.js");
+if (!entryBundle || typeof entryBundle.size !== "number") {
+  fail("npm pack output has no size for dist/index.js");
+}
+if (entryBundle.size === 0) {
+  fail(`${packageJson.name}@${packageJson.version} packs an empty dist/index.js`);
 }
 
 // OpenClaw rejects plugin manifests >= 256 KiB (MAX_PLUGIN_MANIFEST_BYTES) with

--- a/tests/verify-openclaw-clawpack.test.mjs
+++ b/tests/verify-openclaw-clawpack.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -109,4 +109,37 @@ test("an oversized manifest fails the OpenClaw 256 KiB host cap", () => {
 
   assert.equal(result.status, 1);
   assert.match(result.stderr, /OpenClaw rejects manifests/);
+});
+
+test("a symlinked package root is refused rather than scanned", () => {
+  const real = makeFixture();
+  const link = path.join(path.dirname(real), "linked-pkg");
+  symlinkSync(real, link, "dir");
+
+  const result = run(link);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /package directory is a symlink/);
+});
+
+test("a symlinked dist root is refused rather than scanned", () => {
+  const pkgDir = makeFixture();
+  const elsewhere = path.join(path.dirname(pkgDir), "elsewhere");
+  renameSync(path.join(pkgDir, "dist"), elsewhere);
+  symlinkSync(elsewhere, path.join(pkgDir, "dist"), "dir");
+
+  const result = run(pkgDir);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /dist directory is a symlink/);
+});
+
+test("a symlink inside dist is refused, dangling or not", () => {
+  const pkgDir = makeFixture();
+  symlinkSync("/nonexistent/target.js", path.join(pkgDir, "dist", "linked.js"));
+
+  const result = run(pkgDir);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /dist\/linked\.js is a symlink/);
 });

--- a/tests/verify-openclaw-clawpack.test.mjs
+++ b/tests/verify-openclaw-clawpack.test.mjs
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test } from "node:test";
+import { after, test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 /**
@@ -17,9 +17,20 @@ import { fileURLToPath } from "node:url";
 
 const SCRIPT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "scripts", "verify-openclaw-clawpack.mjs");
 
+/** Every temp root these fixtures create, removed once at the end. */
+const tempRoots = [];
+function makeTempRoot() {
+  const root = mkdtempSync(path.join(tmpdir(), "clawpack-test-"));
+  tempRoots.push(root);
+  return root;
+}
+after(() => {
+  for (const root of tempRoots) rmSync(root, { recursive: true, force: true });
+});
+
 /** A minimal package that satisfies the gate: manifest, README, one real bundle. */
 function makeFixture(overrides = {}) {
-  const root = mkdtempSync(path.join(tmpdir(), "clawpack-test-"));
+  const root = makeTempRoot();
   const pkgDir = path.join(root, "pkg");
   mkdirSync(path.join(pkgDir, "dist"), { recursive: true });
   writeFileSync(
@@ -73,7 +84,7 @@ test("a code-split chunk left out of the packlist fails", () => {
 });
 
 test("an unbuilt package fails instead of publishing an empty plugin", () => {
-  const root = mkdtempSync(path.join(tmpdir(), "clawpack-test-"));
+  const root = makeTempRoot();
   const pkgDir = path.join(root, "pkg");
   mkdirSync(pkgDir, { recursive: true });
   writeFileSync(
@@ -157,7 +168,7 @@ test("a symlink inside dist pointing at a real file is refused too", () => {
 test("a prepack script that creates dist/ is honored, not pre-judged", () => {
   // Existence is re-read after `npm pack`, so a package whose prepack builds
   // into dist/ is not rejected on the pre-pack snapshot.
-  const root = mkdtempSync(path.join(tmpdir(), "clawpack-test-"));
+  const root = makeTempRoot();
   const pkgDir = path.join(root, "pkg");
   mkdirSync(pkgDir, { recursive: true });
   writeFileSync(
@@ -177,4 +188,21 @@ test("a prepack script that creates dist/ is honored, not pre-judged", () => {
   const result = run(pkgDir);
 
   assert.equal(result.status, 0, result.stderr);
+});
+
+test("a symlinked directory inside dist is refused before it is descended into", () => {
+  // Node's recursive readdirSync follows directory links while building its
+  // result, so the walk must lstat each entry before descending or it will have
+  // already enumerated whatever the link points at.
+  const pkgDir = makeFixture();
+  const outside = path.join(path.dirname(pkgDir), "outside");
+  mkdirSync(outside, { recursive: true });
+  writeFileSync(path.join(outside, "leaked.js"), "export const leaked = 1;\n");
+  symlinkSync(outside, path.join(pkgDir, "dist", "nested"), "dir");
+
+  const result = run(pkgDir);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /dist\/nested is a symlink/);
+  assert.doesNotMatch(result.stderr, /leaked\.js/, "the link target was never enumerated");
 });

--- a/tests/verify-openclaw-clawpack.test.mjs
+++ b/tests/verify-openclaw-clawpack.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The ClawPack packlist gate is the last thing between a broken build and a
+ * published plugin nobody can install. It regressed once already: an older
+ * `>= 2 dist files` assertion silently encoded one code-split chunk as a
+ * requirement, and deleting that module left the gate unsatisfiable, blocking
+ * every release for days. These tests pin what the gate actually promises, so
+ * the next packaging change fails here rather than on npm.
+ */
+
+const SCRIPT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "scripts", "verify-openclaw-clawpack.mjs");
+
+/** A minimal package that satisfies the gate: manifest, README, one real bundle. */
+function makeFixture(overrides = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "clawpack-test-"));
+  const pkgDir = path.join(root, "pkg");
+  mkdirSync(path.join(pkgDir, "dist"), { recursive: true });
+  writeFileSync(
+    path.join(pkgDir, "package.json"),
+    JSON.stringify({
+      name: "@remnic/plugin-openclaw-fixture",
+      version: "0.0.0",
+      type: "module",
+      main: "dist/index.js",
+      files: overrides.files ?? ["dist", "openclaw.plugin.json"],
+    }),
+  );
+  writeFileSync(path.join(pkgDir, "README.md"), "# fixture\n");
+  writeFileSync(path.join(pkgDir, "openclaw.plugin.json"), JSON.stringify({ id: "fixture" }));
+  writeFileSync(path.join(pkgDir, "dist", "index.js"), overrides.entry ?? "x".repeat(64 * 1024));
+  for (const [name, body] of Object.entries(overrides.extraDist ?? {})) {
+    writeFileSync(path.join(pkgDir, "dist", name), body);
+  }
+  return pkgDir;
+}
+
+function run(pkgDir) {
+  return spawnSync(process.execPath, [SCRIPT, pkgDir], { encoding: "utf8" });
+}
+
+test("a complete package passes", () => {
+  const result = run(makeFixture());
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Verified/);
+});
+
+test("a single-file dist passes — chunk count is not the contract", () => {
+  // The exact regression: one dist file is a perfectly valid build.
+  const result = run(makeFixture());
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /1 dist files/);
+});
+
+test("a code-split chunk left out of the packlist fails", () => {
+  // The invariant the old count was reaching for: an emitted chunk that npm
+  // does not pack breaks the plugin at runtime with a module-not-found.
+  const pkgDir = makeFixture({
+    files: ["dist/index.js", "openclaw.plugin.json"],
+    extraDist: { "legacy-chunk-ABCD1234.js": "export const x = 1;\n" },
+  });
+
+  const result = run(pkgDir);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /built dist\/legacy-chunk-ABCD1234\.js but the packlist omits them/);
+});
+
+test("an unbuilt package fails instead of publishing an empty plugin", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "clawpack-test-"));
+  const pkgDir = path.join(root, "pkg");
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(
+    path.join(pkgDir, "package.json"),
+    JSON.stringify({ name: "fixture", version: "0.0.0", type: "module", files: ["dist", "openclaw.plugin.json"] }),
+  );
+  writeFileSync(path.join(pkgDir, "README.md"), "# fixture\n");
+  writeFileSync(path.join(pkgDir, "openclaw.plugin.json"), JSON.stringify({ id: "fixture" }));
+
+  const result = run(pkgDir);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /missing dist\/index\.js|no built dist/);
+});
+
+test("a small but real entry bundle passes — the shim package legitimately ships one", () => {
+  const result = run(makeFixture({ entry: "export * from \"@remnic/core\";\n" }));
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("an empty entry bundle fails", () => {
+  const result = run(makeFixture({ entry: "" }));
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /packs an empty dist\/index\.js/);
+});
+
+test("an oversized manifest fails the OpenClaw 256 KiB host cap", () => {
+  const pkgDir = makeFixture();
+  writeFileSync(path.join(pkgDir, "openclaw.plugin.json"), JSON.stringify({ pad: "p".repeat(300 * 1024) }));
+
+  const result = run(pkgDir);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /OpenClaw rejects manifests/);
+});

--- a/tests/verify-openclaw-clawpack.test.mjs
+++ b/tests/verify-openclaw-clawpack.test.mjs
@@ -134,7 +134,7 @@ test("a symlinked dist root is refused rather than scanned", () => {
   assert.match(result.stderr, /dist directory is a symlink/);
 });
 
-test("a symlink inside dist is refused, dangling or not", () => {
+test("a dangling symlink inside dist is refused, not thrown on", () => {
   const pkgDir = makeFixture();
   symlinkSync("/nonexistent/target.js", path.join(pkgDir, "dist", "linked.js"));
 
@@ -142,4 +142,39 @@ test("a symlink inside dist is refused, dangling or not", () => {
 
   assert.equal(result.status, 1);
   assert.match(result.stderr, /dist\/linked\.js is a symlink/);
+});
+
+test("a symlink inside dist pointing at a real file is refused too", () => {
+  const pkgDir = makeFixture();
+  symlinkSync(path.join(pkgDir, "dist", "index.js"), path.join(pkgDir, "dist", "linked.js"), "file");
+
+  const result = run(pkgDir);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /dist\/linked\.js is a symlink/);
+});
+
+test("a prepack script that creates dist/ is honored, not pre-judged", () => {
+  // Existence is re-read after `npm pack`, so a package whose prepack builds
+  // into dist/ is not rejected on the pre-pack snapshot.
+  const root = mkdtempSync(path.join(tmpdir(), "clawpack-test-"));
+  const pkgDir = path.join(root, "pkg");
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(
+    path.join(pkgDir, "package.json"),
+    JSON.stringify({
+      name: "prepack-fixture",
+      version: "0.0.0",
+      type: "module",
+      main: "dist/index.js",
+      files: ["dist", "openclaw.plugin.json"],
+      scripts: { prepack: "node -e \"require('node:fs').mkdirSync('dist',{recursive:true});require('node:fs').writeFileSync('dist/index.js','export const x=1;\\n')\"" },
+    }),
+  );
+  writeFileSync(path.join(pkgDir, "README.md"), "# fixture\n");
+  writeFileSync(path.join(pkgDir, "openclaw.plugin.json"), JSON.stringify({ id: "fixture" }));
+
+  const result = run(pkgDir);
+
+  assert.equal(result.status, 0, result.stderr);
 });


### PR DESCRIPTION
Closes #2298.

## Problem

Every `Release and Publish` run since 2026-07-31 fails at **Verify OpenClaw
ClawHub artifact packlist**:

```
OpenClaw ClawPack verification failed: @remnic/plugin-openclaw@9.46.0 packlist only includes 1 dist file(s)
```

npm still serves `9.45.5` while the workspace is at `9.46.0`, so several days of
merged work cannot reach any installation that consumes the published packages.

## Root cause

The `distFiles.length < 2` assertion was an empirical snapshot, not an
invariant. The plugin's tsup config emits a single entry bundle; the second file
in older tarballs was a code-split chunk that existed only because the entry
dynamically imported a legacy-hook compatibility module:

```
$ npm pack @remnic/plugin-openclaw@9.45.5 && tar -tzf *.tgz | grep package/dist/
package/dist/index.js
package/dist/legacy-hook-compat-QHHKF4GK.js
```

Removing that surface in #2279 dropped the chunk, the count fell to 1, and the
assertion became permanently unsatisfiable. The artifact itself is fine.

## Fix

The risk the count was reaching for is real — tsup code-splits whenever the
entry gains a dynamic import, and a chunk npm does not pack breaks the plugin at
runtime with a module-not-found no test exercises. So the gate now asserts that
directly instead of by proxy:

1. Every file the build emitted into `dist/` appears in the packlist.
2. `dist/` is non-empty (the build actually ran) and the packed entry bundle is
   non-empty.
3. **No byte floor.** The same script verifies the shim package, whose
   legitimate bundle is a few hundred bytes — I tried a 32 KiB floor first and
   it failed that package immediately, which is the tell that any threshold here
   is a number rather than an invariant.

## Verification

- `node scripts/verify-openclaw-clawpack.mjs` — passes for `@remnic/plugin-openclaw@9.46.0` (6 files, 1 dist file)
- `node scripts/verify-openclaw-clawpack.mjs packages/shim-openclaw-engram` — passes (9 files, 4 dist files)
- New `tests/verify-openclaw-clawpack.test.mjs` — 7 tests: the exact regression
  (one dist file is valid), the case the old rule was reaching for (an emitted
  chunk omitted from the packlist), an unbuilt package, an empty entry bundle, a
  small-but-real shim-shaped bundle, and the existing 256 KiB manifest cap.
- `npm test` — 17500 tests, 0 fail
- `npm run preflight:quick` — OK

Packaging and release only; no runtime behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/packaging validation only; no runtime or published artifact behavior changes beyond unblocking CI.
> 
> **Overview**
> Unblocks **Release and Publish** by replacing the broken **`>= 2 dist files`** packlist check with rules that match what packaging actually needs.
> 
> **`scripts/verify-openclaw-clawpack.mjs`** now walks **`dist/`** with **`lstat`** (no symlink traversal), requires every built **`dist/`** file to appear in **`npm pack`**, fails on missing/empty **`dist/`** and zero-byte **`dist/index.js`**, and drops any minimum bundle size so the shim package still passes. Symlinked package or **`dist`** roots are rejected before **`npm pack`**.
> 
> **`tests/verify-openclaw-clawpack.test.mjs`** adds fixture-driven coverage for the single-file regression, omitted code-split chunks, unbuilt/empty bundles, manifest size cap, **`prepack`**-created **`dist/`**, and symlink refusal paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89bfa353ac5b34a4307d0607827ab47322ef7966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened package validation to ensure every built file is included in published packages.
  * Added checks for missing or empty build output and confirmed the main entry file is present and valid.
  * Added protection against invalid or symlinked package and build directories.
  * Updated validation to support single-file and small package bundles.

* **Tests**
  * Added comprehensive coverage for successful packaging and common failures, including omitted files, oversized manifests, missing builds, and symlinked paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->