### PR TITLE
test(recall): replace the phase-one abort timing budget with a handshake

### DIFF
--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -532,21 +532,28 @@ test("recallInternal aborts while phase-one preamble promises are still pending"
   const callerAbortController = new AbortController();
   (orchestrator as any).isRecallSectionEnabled = (id: string) =>
     id === "shared-context";
+  // Deterministic handshake instead of a wall-clock poll: the stub signals when
+  // the preamble read has started, and never completes until this test releases
+  // it. A time budget here only measured machine load (issue #2300).
   let releaseSharedRead: (() => void) | null = null;
-  let sharedReadStarted = false;
+  let sharedReadCompleted = false;
+  let signalSharedReadStarted: (() => void) | null = null;
+  const sharedReadStarted = new Promise<void>((resolve) => {
+    signalSharedReadStarted = resolve;
+  });
   (orchestrator as any).sharedContext = {
     readPriorities: async () => {
-      sharedReadStarted = true;
+      signalSharedReadStarted?.();
       await new Promise<void>((resolve) => {
         releaseSharedRead = resolve;
       });
+      sharedReadCompleted = true;
       return "slow priorities";
     },
     readLatestRoundtable: async () => null,
     readLatestCrossSignals: async () => null,
   };
 
-  const startedAt = Date.now();
   const recallPromise = (orchestrator as any).recallInternal(
     "phase one abort test",
     "agent:test:phase-one",
@@ -556,26 +563,20 @@ test("recallInternal aborts while phase-one preamble promises are still pending"
     },
   );
 
-  const waitForStartDeadline = Date.now() + 100;
-  while (!sharedReadStarted && Date.now() < waitForStartDeadline) {
-    await new Promise((resolve) => setTimeout(resolve, 1));
-  }
+  await sharedReadStarted;
   callerAbortController.abort();
 
   await assert.rejects(
     recallPromise,
     (err: unknown) => err instanceof Error && err.name === "AbortError",
   );
-  const elapsedMs = Date.now() - startedAt;
+
+  // The contract, stated directly: the abort surfaced without waiting for the
+  // preamble, which is still pending because only this test can release it.
+  assert.equal(sharedReadCompleted, false, "recall rejected while the preamble read was still pending");
 
   const release = releaseSharedRead as (() => void) | null;
   release?.();
-
-  assert.equal(sharedReadStarted, true);
-  assert.ok(
-    elapsedMs < 80,
-    `expected phase-one abort before slow shared-context read completed, saw ${elapsedMs}ms`,
-  );
 });
 
 test("recallInternal does not launch phase-one preamble work for an already-aborted signal", async () => {

--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -564,19 +564,23 @@ test("recallInternal aborts while phase-one preamble promises are still pending"
   );
 
   await sharedReadStarted;
-  callerAbortController.abort();
+  try {
+    callerAbortController.abort();
 
-  await assert.rejects(
-    recallPromise,
-    (err: unknown) => err instanceof Error && err.name === "AbortError",
-  );
+    await assert.rejects(
+      recallPromise,
+      (err: unknown) => err instanceof Error && err.name === "AbortError",
+    );
 
-  // The contract, stated directly: the abort surfaced without waiting for the
-  // preamble, which is still pending because only this test can release it.
-  assert.equal(sharedReadCompleted, false, "recall rejected while the preamble read was still pending");
-
-  const release = releaseSharedRead as (() => void) | null;
-  release?.();
+    // The contract, stated directly: the abort surfaced without waiting for the
+    // preamble, which is still pending because only this test can release it.
+    assert.equal(sharedReadCompleted, false, "recall rejected while the preamble read was still pending");
+  } finally {
+    // Always release: a failing assertion must not leave the stubbed read
+    // pending and its promise unsettled for the rest of the run.
+    const release = releaseSharedRead as (() => void) | null;
+    release?.();
+  }
 });
 
 test("recallInternal does not launch phase-one preamble work for an already-aborted signal", async () => {


### PR DESCRIPTION
Closes #2300.

## Problem

`tests/recall-hardening.test.ts` → "recallInternal aborts while phase-one
preamble promises are still pending" fails intermittently under full-suite load:

```
not ok 14947 - recallInternal aborts while phase-one preamble promises are still pending
```

It passes 3/3 in isolation, so the flake tracks CPU contention rather than any
behavior under test.

## Cause

Two wall-clock dependencies:

```js
const waitForStartDeadline = Date.now() + 100;
while (!sharedReadStarted && Date.now() < waitForStartDeadline) { ... }
...
assert.ok(elapsedMs < 80, ...);
```

100 ms is comfortable alone and marginal when the root suite saturates the
machine. The `elapsedMs < 80` bound was also standing in for something already
structurally guaranteed — the stubbed read can only complete when the test
releases it, which happens *after* the rejection.

## Fix

- The stub resolves a promise the test awaits, so "the read has started" is
  observed rather than timed.
- The elapsed-time bound is replaced by the contract it was proxying: the recall
  rejected while the preamble read was still pending (`sharedReadCompleted ===
  false`).

No time budget remains, so there is no number to tune later.

Still non-vacuous: if the abort waited for the preamble, the read never
completes and `assert.rejects` never settles, so the test fails rather than
passing quietly.

## Verification

- `tests/recall-hardening.test.ts` — 34/34, three consecutive runs
- `npm test` — 17506 tests, 0 fail
- `npm run preflight:quick` — OK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or recall logic modifications.
> 
> **Overview**
> Fixes intermittent failures in **recallInternal aborts while phase-one preamble promises are still pending** (#2300) by removing wall-clock timing from the test.
> 
> The stubbed `sharedContext.readPriorities` now signals start via a **Promise** the test awaits instead of polling for up to 100ms. The old **`elapsedMs < 80`** check is replaced with **`sharedReadCompleted === false`** after `assert.rejects`, which directly asserts recall aborted before the manually gated preamble finished. A **`try/finally`** always releases the stub so a failed assertion cannot leave a pending promise for the rest of the suite.
> 
> No production behavior changes—only test synchronization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aaa295b2f922b714e00fec1c244471e1617e82a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for aborting recall operations while a shared-context read is still pending.
  * Replaced timing-based checks with deterministic synchronization for more reliable test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->