### PR TITLE
docs: make review-round budget mechanical

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,15 @@ the work is judged against.
   the thread resolved**, not fixed. The Cleaner PR Workflow's "zero unresolved
   threads" bar is satisfied by a reasoned decline exactly as much as by a fix;
   it asks for resolution, not obedience. Three rounds on a change with no
-  runtime behavior is itself the signal to stop.
+  runtime behavior is itself the signal to stop. Hard cap: four fix rounds per
+  PR (a round is one batched fix commit pushed after all reviewer bots have
+  finished with the current head). At the cap, decline every remaining
+  non-critical thread in-thread with a reason, resolve it, file one GitHub issue
+  listing the declined items with links, and merge once required checks are
+  green. The issue is the escalation — do not park the PR. Critical findings
+  (correctness, security, or data integrity) stay actionable at any round; the
+  cap never ships a real defect. Doc-only diffs (`*.md` only) get one fix round;
+  after it, only factual errors are actionable.
 
 These rules bind human-directed sessions, delegated subagents, and scheduled
 or otherwise autonomous agent runs alike.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,12 +162,16 @@ the work is judged against.
   runtime behavior is itself the signal to stop. Hard cap: four fix rounds per
   PR (a round is one batched fix commit pushed after all reviewer bots have
   finished with the current head). At the cap, decline every remaining
-  non-critical thread in-thread with a reason, resolve it, file one GitHub issue
+  non-critical thread in-thread with a reason, resolve it, file ONE GitHub issue
   listing the declined items with links, and merge once required checks are
-  green. The issue is the escalation — do not park the PR. Critical findings
-  (correctness, security, or data integrity) stay actionable at any round; the
+  green and no critical finding or performance, capacity, or reliability
+  regression remains. The issue is the escalation — do not park the PR. Critical
+  findings (correctness, security, or data integrity) and performance, capacity,
+  or reliability regressions stay actionable at any round and take precedence
+  over the cap; resolve them before merging, even after the fourth round. The
   cap never ships a real defect. Doc-only diffs (`*.md` only) get one fix round;
-  after it, only factual errors are actionable.
+  after it, only factual errors are actionable, and those exceptions do not
+  reopen general review.
 
 These rules bind human-directed sessions, delegated subagents, and scheduled
 or otherwise autonomous agent runs alike.


### PR DESCRIPTION
This makes the review-round budget mechanical: each PR has a hard four-round cap with a GitHub-issue backlog valve for declined non-critical threads. Markdown-only diffs get one fix round, after which only factual errors remain actionable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent/review workflow guidance; no runtime or CI behavior changes.
> 
> **Overview**
> Extends **Budget the review loop, then decline** in `AGENTS.md` with a **hard cap of four fix rounds** per PR (one round = a batched fix commit after reviewer bots finish on the current head).
> 
> At the cap, authors **decline** remaining non-critical threads in-thread, **resolve** them, open **one** GitHub issue listing declined items with links, and **merge** when required checks are green and no critical or performance/capacity/reliability regressions remain — escalation via issue, not an indefinite open PR. **Critical** correctness, security, data-integrity, and perf/capacity/reliability findings stay actionable past the cap and must be fixed before merge.
> 
> **Doc-only** PRs (`*.md` only) are limited to **one** fix round; afterward only factual errors are actionable, without reopening general review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24630594fb1b6c9661abdd7627fe8d4f750bc79a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the review process to limit pull requests to four fix rounds.
  * Clarified how remaining non-critical findings are handled, including issue tracking and merge readiness.
  * Preserved escalation requirements for critical correctness, security, and data-integrity findings.
  * Limited documentation-only changes to one fix round, with factual errors remaining actionable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->