### PR TITLE
fix(recall): bound optional phase-one core sections by the section deadline

### DIFF
--- a/.changeset/2291-bound-core-recall-sections.md
+++ b/.changeset/2291-bound-core-recall-sections.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Bound the optional phase-one recall providers by the core section deadline. `entity-retrieval` and `verbatim-artifacts` scan the memory tree and could block the whole recall for minutes on a large or network/bind-mounted store; they now degrade to no section, are recorded as `timeout` in the section metrics, and receive a cancellation signal that also fires on caller abort (issue #2291).

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -199,9 +199,9 @@ QMD, hot facts, or default recall. See [External wiki search](external-wikis.md)
 | `maxMemoryTokens` | `2000` | Legacy token cap. Only used to compute `recallBudgetChars` when that setting is absent. **Prefer setting `recallBudgetChars` directly.** |
 | `recallMaxConcurrentPerPrincipal` | `4` | Maximum concurrent recalls executed per principal (issue #1906); recalls beyond the cap queue FIFO. `0` = unlimited; set `1` to restore exact serialization. |
 | `recallSingleFlightEnabled` | `true` | Coalesce identical concurrent recalls for the same principal into a single in-flight execution (issue #1906); each caller still receives its own cloned response. Set `false` to restore per-request execution. |
-| `recallCoreDeadlineMs` | `75000` | **Per-section deadline for optional core recall providers.** `entity-retrieval` and `verbatim-artifacts` scan the memory tree, which can take minutes on a large or network/bind-mounted store; when one exceeds this budget the section is dropped, logged as `timeout(<ms>)` in the recall section metrics, and signalled to stop, while the rest of the recall still returns (issue #2291). Lower it (for example `5000`) when recall is consumed by a **synchronous** prompt-injection hook that cannot wait. `0` disables the bound. |
+| `recallCoreDeadlineMs` | `75000` | **Per-section deadline for optional core recall providers.** `entity-retrieval` and `verbatim-artifacts` scan the memory tree, which can take minutes on a large or network/bind-mounted store; when one exceeds this budget the section is dropped, logged as `timeout(<ms>)` in the recall section metrics, and signalled to stop, while the rest of the recall still returns (issue #2291). Lower it (for example `5000`) when recall is consumed by a **synchronous** prompt-injection hook that cannot wait. `0` disables the bound. **The effective value is capped at 80% of `recallOuterTimeoutMs`** — see the note below. |
 | `recallEnrichmentDeadlineMs` | `25000` | Shared budget for the deferred enrichment sections assembled after the core phase. `0` disables the bound. |
-| `recallOuterTimeoutMs` | `75000` | Outer ceiling for a whole recall request. `0` disables the bound. |
+| `recallOuterTimeoutMs` | `75000` | Outer ceiling for a whole recall request; on breach the recall is aborted and fails rather than degrading. `0` disables the bound. |
 | `qmdEnabled` | `true` | Use QMD for hybrid search |
 | `qmdCollection` | `openclaw-engram` | QMD collection name |
 | `externalWikis` | `[]` | External compiled-wiki roots for on-demand search. Each item requires `id` and an absolute or `~/` `rootDir`; optional fields are `enabled`, `label`, `pagesDir`, `indexFile`, `indexInQmd`, and the false-only `includeInDefaultRecall` guard. |
@@ -256,6 +256,16 @@ QMD, hot facts, or default recall. See [External wiki search](external-wikis.md)
 | `recallDirectAnswerEligibleTaxonomyBuckets` | `["decisions","principles","conventions","runbooks","entities"]` | Taxonomy category IDs eligible for direct-answer routing. Set to `[]` to disable the gate without unsetting `enabled`. |
 | `hotMemoriesCacheEnabled` | `true` | Serve `readAllMemories()` from a version-keyed in-process cache of the full parsed corpus (issue #1902), eliminating repeated full-corpus disk scans on the recall hot path. Cross-process coherence is preserved by an on-disk corpus version sentinel; single-file writes patch the cache in place. Set `false` to force disk scans on memory-constrained hosts (behavior then matches the pre-#1902 scan path). Version invalidation is the primary coherence mechanism; `hotMemoriesCacheTtlMs` bounds staleness from external edits. |
 | `hotMemoriesCacheTtlMs` | `60000` | Max age (ms) a hot-cache entry is served before a fresh disk scan (issue #1902). The version sentinel gives immediate coherence for writers that go through StorageManager or the corpus-bump helper, but direct filesystem edits (manual, git checkout, external tools) don't bump it; this TTL bounds how long such an edit stays stale. Set `0` to disable the TTL (version invalidation only; max performance for pure-daemon deployments with no external edits). |
+
+**Effective core section deadline.** A section budget only helps if it fires
+*before* the request ceiling that cancels everything, so the effective value is
+`min(recallCoreDeadlineMs, floor(recallOuterTimeoutMs * 0.8))`. With both
+defaults at `75000` that is **60000** — raising `recallCoreDeadlineMs` alone has
+no effect, because at 75s the outer timeout would abort the whole recall instead
+of dropping one section. To give sections a longer budget, raise
+`recallOuterTimeoutMs` too. The effective value is what appears as `deadlineMs`
+in the recall section metric log, so the number in effect is always observable.
+Either bound set to `0` is left alone.
 
 ### `recallPipeline` entries
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -199,7 +199,7 @@ QMD, hot facts, or default recall. See [External wiki search](external-wikis.md)
 | `maxMemoryTokens` | `2000` | Legacy token cap. Only used to compute `recallBudgetChars` when that setting is absent. **Prefer setting `recallBudgetChars` directly.** |
 | `recallMaxConcurrentPerPrincipal` | `4` | Maximum concurrent recalls executed per principal (issue #1906); recalls beyond the cap queue FIFO. `0` = unlimited; set `1` to restore exact serialization. |
 | `recallSingleFlightEnabled` | `true` | Coalesce identical concurrent recalls for the same principal into a single in-flight execution (issue #1906); each caller still receives its own cloned response. Set `false` to restore per-request execution. |
-| `recallCoreDeadlineMs` | `75000` | **Per-section deadline for optional core recall providers.** `entity-retrieval` and `verbatim-artifacts` scan the memory tree, which can take minutes on a large or network/bind-mounted store; when one exceeds this budget the section is dropped, logged as `timeout(<ms>)` in the recall section metrics, and signalled to stop, while the rest of the recall still returns (issue #2291). Lower it (for example `5000`) when recall is consumed by a **synchronous** prompt-injection hook that cannot wait. `0` disables the bound. **The effective value is capped at 80% of `recallOuterTimeoutMs`** — see the note below. |
+| `recallCoreDeadlineMs` | `75000` | **Per-section deadline for optional core recall providers.** `entity-retrieval` and `verbatim-artifacts` scan the memory tree, which can take minutes on a large or network/bind-mounted store; when one exceeds this budget the section is dropped, logged as `timeout(<ms>)` in the recall section metrics, and signalled to stop, while the rest of the recall still returns (issue #2291). Lower it (for example `5000`) when recall is consumed by a **synchronous** prompt-injection hook that cannot wait. `0` disables the bound. **The effective value is capped at 80% of the request budget still remaining when the section starts** — see the note below. |
 | `recallEnrichmentDeadlineMs` | `25000` | Shared budget for the deferred enrichment sections assembled after the core phase. `0` disables the bound. |
 | `recallOuterTimeoutMs` | `75000` | Outer ceiling for a whole recall request; on breach the recall is aborted and fails rather than degrading. `0` disables the bound. |
 | `qmdEnabled` | `true` | Use QMD for hybrid search |
@@ -257,15 +257,19 @@ QMD, hot facts, or default recall. See [External wiki search](external-wikis.md)
 | `hotMemoriesCacheEnabled` | `true` | Serve `readAllMemories()` from a version-keyed in-process cache of the full parsed corpus (issue #1902), eliminating repeated full-corpus disk scans on the recall hot path. Cross-process coherence is preserved by an on-disk corpus version sentinel; single-file writes patch the cache in place. Set `false` to force disk scans on memory-constrained hosts (behavior then matches the pre-#1902 scan path). Version invalidation is the primary coherence mechanism; `hotMemoriesCacheTtlMs` bounds staleness from external edits. |
 | `hotMemoriesCacheTtlMs` | `60000` | Max age (ms) a hot-cache entry is served before a fresh disk scan (issue #1902). The version sentinel gives immediate coherence for writers that go through StorageManager or the corpus-bump helper, but direct filesystem edits (manual, git checkout, external tools) don't bump it; this TTL bounds how long such an edit stays stale. Set `0` to disable the TTL (version invalidation only; max performance for pure-daemon deployments with no external edits). |
 
-**Effective core section deadline.** A section budget only helps if it fires
-*before* the request ceiling that cancels everything, so the effective value is
-`min(recallCoreDeadlineMs, floor(recallOuterTimeoutMs * 0.8))`. With both
-defaults at `75000` that is **60000** — raising `recallCoreDeadlineMs` alone has
-no effect, because at 75s the outer timeout would abort the whole recall instead
-of dropping one section. To give sections a longer budget, raise
-`recallOuterTimeoutMs` too. The effective value is what appears as `deadlineMs`
-in the recall section metric log, so the number in effect is always observable.
-Either bound set to `0` is left alone.
+**Effective core section deadline.** A section budget only helps if it expires
+*before* the request ceiling that cancels everything, and sections start after
+planning and namespace resolution — so the budget is resolved when each section
+starts, against the request budget still left at that moment:
+`min(recallCoreDeadlineMs, floor(remaining * 0.8))`, where `remaining` is
+`recallOuterTimeoutMs` minus the time the request has already spent. With both
+defaults at `75000` a section starting immediately gets **60000**; one starting 20
+seconds in gets **44000**. Raising `recallCoreDeadlineMs` past that share has no
+effect — raise `recallOuterTimeoutMs` too. The effective value is what appears as
+`deadlineMs` in the recall section metric log, so the number in force is always
+observable. `recallOuterTimeoutMs: 0` (unbounded request) leaves
+`recallCoreDeadlineMs` alone; a request already over budget degrades its optional
+sections immediately.
 
 ### `recallPipeline` entries
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -260,16 +260,19 @@ QMD, hot facts, or default recall. See [External wiki search](external-wikis.md)
 **Effective core section deadline.** A section budget only helps if it expires
 *before* the request ceiling that cancels everything, and sections start after
 planning and namespace resolution — so the budget is resolved when each section
-starts, against the request budget still left at that moment:
+starts, against the request budget still left at that moment. When
+`recallCoreDeadlineMs > 0` and the request is bounded, the effective value is
 `min(recallCoreDeadlineMs, floor(remaining * 0.8))`, where `remaining` is
 `recallOuterTimeoutMs` minus the time the request has already spent. With both
 defaults at `75000` a section starting immediately gets **60000**; one starting 20
 seconds in gets **44000**. Raising `recallCoreDeadlineMs` past that share has no
 effect — raise `recallOuterTimeoutMs` too. The effective value is what appears as
 `deadlineMs` in the recall section metric log, so the number in force is always
-observable. `recallOuterTimeoutMs: 0` (unbounded request) leaves
-`recallCoreDeadlineMs` alone; a request already over budget degrades its optional
-sections immediately.
+observable. Either bound set to `0` is left alone: `recallCoreDeadlineMs: 0`
+leaves the sections unbounded, and `recallOuterTimeoutMs: 0` (unbounded request)
+means there is no remainder to reserve headroom against, so the configured
+`recallCoreDeadlineMs` applies verbatim. A request already over budget degrades
+its optional sections immediately.
 
 ### `recallPipeline` entries
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -199,6 +199,9 @@ QMD, hot facts, or default recall. See [External wiki search](external-wikis.md)
 | `maxMemoryTokens` | `2000` | Legacy token cap. Only used to compute `recallBudgetChars` when that setting is absent. **Prefer setting `recallBudgetChars` directly.** |
 | `recallMaxConcurrentPerPrincipal` | `4` | Maximum concurrent recalls executed per principal (issue #1906); recalls beyond the cap queue FIFO. `0` = unlimited; set `1` to restore exact serialization. |
 | `recallSingleFlightEnabled` | `true` | Coalesce identical concurrent recalls for the same principal into a single in-flight execution (issue #1906); each caller still receives its own cloned response. Set `false` to restore per-request execution. |
+| `recallCoreDeadlineMs` | `75000` | **Per-section deadline for optional core recall providers.** `entity-retrieval` and `verbatim-artifacts` scan the memory tree, which can take minutes on a large or network/bind-mounted store; when one exceeds this budget the section is dropped, logged as `timeout(<ms>)` in the recall section metrics, and signalled to stop, while the rest of the recall still returns (issue #2291). Lower it (for example `5000`) when recall is consumed by a **synchronous** prompt-injection hook that cannot wait. `0` disables the bound. |
+| `recallEnrichmentDeadlineMs` | `25000` | Shared budget for the deferred enrichment sections assembled after the core phase. `0` disables the bound. |
+| `recallOuterTimeoutMs` | `75000` | Outer ceiling for a whole recall request. `0` disables the bound. |
 | `qmdEnabled` | `true` | Use QMD for hybrid search |
 | `qmdCollection` | `openclaw-engram` | QMD collection name |
 | `externalWikis` | `[]` | External compiled-wiki roots for on-demand search. Each item requires `id` and an absolute or `~/` `rootDir`; optional fields are `enabled`, `label`, `pagesDir`, `indexFile`, `indexInQmd`, and the false-only `includeInDefaultRecall` guard. |

--- a/packages/remnic-core/src/artifact-search.test.ts
+++ b/packages/remnic-core/src/artifact-search.test.ts
@@ -19,7 +19,7 @@ function artifact(id: string, content: string, tags: string[] = []): MemoryFile 
 
 test("artifact scan ranks by query token overlap and applies the result cap", async () => {
   const matches = await selectArtifactMatches(
-    [
+    async () => [
       artifact("a", "the deploy runbook covers rollback"),
       artifact("b", "unrelated grocery list"),
       artifact("c", "runbook", ["deploy", "rollback"]),
@@ -34,23 +34,51 @@ test("artifact scan ranks by query token overlap and applies the result cap", as
   );
 });
 
-test("artifact scan ignores stopword-only queries", async () => {
-  assert.deepEqual(
-    await selectArtifactMatches([artifact("a", "the and of")], "the and of", 5),
-    [],
+test("a stopword-only query never reads the artifact tier", async () => {
+  // Reading the tier is a full recursive filesystem scan on a cold cache, so a
+  // query that cannot match anything must not pay for it (issue #2291).
+  let loaded = 0;
+  const matches = await selectArtifactMatches(
+    async () => {
+      loaded += 1;
+      return [artifact("a", "the and of")];
+    },
+    "the and of",
+    5,
   );
+
+  assert.deepEqual(matches, []);
+  assert.equal(loaded, 0);
+});
+
+test("an already-aborted caller never reads the artifact tier", async () => {
+  const aborted = new AbortController();
+  aborted.abort();
+  let loaded = 0;
+
+  await assert.rejects(
+    selectArtifactMatches(
+      async () => {
+        loaded += 1;
+        return [artifact("a", "deploy runbook")];
+      },
+      "deploy runbook",
+      5,
+      { abortSignal: aborted.signal },
+    ),
+    (err: unknown) => err instanceof Error && err.name === "AbortError",
+  );
+  assert.equal(loaded, 0);
 });
 
 test("artifact scan stops at the caller's signal instead of scanning the tier", async () => {
   // Yield/abort checkpoints land every 256 documents, so the corpus must cross
-  // that boundary for cancellation to be observable at all (issue #2291).
+  // that boundary for cancellation to be observable mid-scan (issue #2291).
   const artifacts = Array.from({ length: 600 }, (_unused, index) =>
     artifact(`doc-${index}`, "deploy runbook rollback"),
   );
   const aborted = new AbortController();
   let scannedBeforeAbort = 0;
-  // Abort from a timer: the scan yields to the event loop, which is precisely
-  // what lets a deadline (or an abort) interrupt a long scan.
   const artifactsWithProbe = artifacts.map((memory) => ({
     get content() {
       scannedBeforeAbort += 1;
@@ -62,7 +90,7 @@ test("artifact scan stops at the caller's signal instead of scanning the tier", 
   })) as unknown as MemoryFile[];
 
   await assert.rejects(
-    selectArtifactMatches(artifactsWithProbe, "deploy runbook", 5, {
+    selectArtifactMatches(async () => artifactsWithProbe, "deploy runbook", 5, {
       abortSignal: aborted.signal,
     }),
     (err: unknown) => err instanceof Error && err.name === "AbortError",

--- a/packages/remnic-core/src/artifact-search.test.ts
+++ b/packages/remnic-core/src/artifact-search.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { selectArtifactMatches, tokenizeArtifactSearchText } from "./artifact-search.js";
+import type { MemoryFile } from "./types.js";
+
+function artifact(id: string, content: string, tags: string[] = []): MemoryFile {
+  return {
+    path: `artifacts/${id}.md`,
+    content,
+    frontmatter: {
+      id,
+      category: "artifact",
+      created: "2026-08-01T00:00:00.000Z",
+      updated: "2026-08-01T00:00:00.000Z",
+      ...(tags.length > 0 ? { tags } : {}),
+    },
+  } as unknown as MemoryFile;
+}
+
+test("artifact scan ranks by query token overlap and applies the result cap", async () => {
+  const matches = await selectArtifactMatches(
+    [
+      artifact("a", "the deploy runbook covers rollback"),
+      artifact("b", "unrelated grocery list"),
+      artifact("c", "runbook", ["deploy", "rollback"]),
+    ],
+    "deploy rollback runbook",
+    2,
+  );
+
+  assert.deepEqual(
+    matches.map((m) => m.frontmatter.id),
+    ["a", "c"],
+  );
+});
+
+test("artifact scan ignores stopword-only queries", async () => {
+  assert.deepEqual(
+    await selectArtifactMatches([artifact("a", "the and of")], "the and of", 5),
+    [],
+  );
+});
+
+test("artifact scan stops at the caller's signal instead of scanning the tier", async () => {
+  // Yield/abort checkpoints land every 256 documents, so the corpus must cross
+  // that boundary for cancellation to be observable at all (issue #2291).
+  const artifacts = Array.from({ length: 600 }, (_unused, index) =>
+    artifact(`doc-${index}`, "deploy runbook rollback"),
+  );
+  const aborted = new AbortController();
+  let scannedBeforeAbort = 0;
+  // Abort from a timer: the scan yields to the event loop, which is precisely
+  // what lets a deadline (or an abort) interrupt a long scan.
+  const artifactsWithProbe = artifacts.map((memory) => ({
+    get content() {
+      scannedBeforeAbort += 1;
+      if (scannedBeforeAbort === 300) aborted.abort();
+      return memory.content;
+    },
+    path: memory.path,
+    frontmatter: memory.frontmatter,
+  })) as unknown as MemoryFile[];
+
+  await assert.rejects(
+    selectArtifactMatches(artifactsWithProbe, "deploy runbook", 5, {
+      abortSignal: aborted.signal,
+    }),
+    (err: unknown) => err instanceof Error && err.name === "AbortError",
+  );
+  assert.ok(
+    scannedBeforeAbort < artifacts.length,
+    `scan stopped early (read ${scannedBeforeAbort} of ${artifacts.length})`,
+  );
+});
+
+test("artifact tokenizer drops stopwords and single characters", () => {
+  assert.deepEqual(tokenizeArtifactSearchText("The a deploy-runbook v2"), [
+    "deploy",
+    "runbook",
+    "v2",
+  ]);
+});

--- a/packages/remnic-core/src/artifact-search.ts
+++ b/packages/remnic-core/src/artifact-search.ts
@@ -63,25 +63,32 @@ export interface ArtifactSearchOptions {
 }
 
 /**
- * Rank `artifacts` by how many query tokens they contain, best first.
+ * Rank the artifact tier by how many query tokens each document contains, best
+ * first.
+ *
+ * `loadArtifacts` is a thunk rather than a value so the two cheap early exits —
+ * an already-cancelled caller, and a query with no searchable tokens — happen
+ * BEFORE the tier is read. Reading it can mean a full recursive filesystem scan
+ * on a cold cache, which a stopword-only query must never pay for.
  *
  * Yields to the event loop every `ARTIFACT_SCAN_YIELD_INTERVAL` documents and
  * checks the caller's signal there, so a pending recall section deadline can fire
  * mid-scan and an abandoned recall stops scanning instead of running to the end.
  */
 export async function selectArtifactMatches(
-  artifacts: MemoryFile[],
+  loadArtifacts: () => Promise<MemoryFile[]>,
   query: string,
   maxResults: number,
   options: ArtifactSearchOptions = {},
 ): Promise<MemoryFile[]> {
-  // An already-abandoned recall must not tokenize the tier at all; the in-loop
-  // checkpoint below only lands every ARTIFACT_SCAN_YIELD_INTERVAL documents, so
-  // a small tier would never observe the signal without this.
   throwIfAborted(options.abortSignal, "artifact search aborted");
   const tokens = tokenizeArtifactSearchText(query);
   if (tokens.length === 0) return [];
 
+  const artifacts = await loadArtifacts();
+  // The scan below never awaits real I/O, so this is the last chance to observe a
+  // signal that fired while the tier was being read.
+  throwIfAborted(options.abortSignal, "artifact search aborted");
   const hits: Array<{ score: number; memory: MemoryFile }> = [];
   let scanned = 0;
   for (const memory of artifacts) {

--- a/packages/remnic-core/src/artifact-search.ts
+++ b/packages/remnic-core/src/artifact-search.ts
@@ -75,6 +75,10 @@ export async function selectArtifactMatches(
   maxResults: number,
   options: ArtifactSearchOptions = {},
 ): Promise<MemoryFile[]> {
+  // An already-abandoned recall must not tokenize the tier at all; the in-loop
+  // checkpoint below only lands every ARTIFACT_SCAN_YIELD_INTERVAL documents, so
+  // a small tier would never observe the signal without this.
+  throwIfAborted(options.abortSignal, "artifact search aborted");
   const tokens = tokenizeArtifactSearchText(query);
   if (tokens.length === 0) return [];
 

--- a/packages/remnic-core/src/artifact-search.ts
+++ b/packages/remnic-core/src/artifact-search.ts
@@ -1,0 +1,104 @@
+/**
+ * Verbatim-artifact keyword scan — extracted from `storage.ts` so the scan can
+ * be made interruptible without growing that file (issue #2291).
+ *
+ * The scan re-tokenizes every stored artifact, and `fetchActiveArtifactsForNamespace`
+ * repeats it with a growing fetch limit. On a large artifact tier that is long
+ * enough to starve the event loop, which would stop a recall section deadline
+ * from ever firing — so the loop yields periodically and observes cancellation.
+ */
+
+import { throwIfAborted } from "./abort-error.js";
+import { yieldToEventLoop } from "./recall-qos.js";
+import type { MemoryFile } from "./types.js";
+
+const ARTIFACT_SEARCH_STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "but",
+  "by",
+  "for",
+  "from",
+  "has",
+  "have",
+  "i",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "that",
+  "the",
+  "this",
+  "to",
+  "was",
+  "were",
+  "with",
+]);
+
+/**
+ * Artifacts scored between two yields. Small enough that a deadline observes a
+ * sub-millisecond delay on a normal tier, large enough that the yields cost
+ * nothing measurable relative to tokenizing that many documents.
+ */
+const ARTIFACT_SCAN_YIELD_INTERVAL = 256;
+
+export function tokenizeArtifactSearchText(input: string): string[] {
+  return input
+    .toLowerCase()
+    .split(/[^a-z0-9]+/i)
+    .map((t) => t.trim())
+    .filter((t) => t.length >= 2)
+    .filter((t) => !ARTIFACT_SEARCH_STOPWORDS.has(t));
+}
+
+export interface ArtifactSearchOptions {
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * Rank `artifacts` by how many query tokens they contain, best first.
+ *
+ * Yields to the event loop every `ARTIFACT_SCAN_YIELD_INTERVAL` documents and
+ * checks the caller's signal there, so a pending recall section deadline can fire
+ * mid-scan and an abandoned recall stops scanning instead of running to the end.
+ */
+export async function selectArtifactMatches(
+  artifacts: MemoryFile[],
+  query: string,
+  maxResults: number,
+  options: ArtifactSearchOptions = {},
+): Promise<MemoryFile[]> {
+  const tokens = tokenizeArtifactSearchText(query);
+  if (tokens.length === 0) return [];
+
+  const hits: Array<{ score: number; memory: MemoryFile }> = [];
+  let scanned = 0;
+  for (const memory of artifacts) {
+    scanned += 1;
+    if (scanned % ARTIFACT_SCAN_YIELD_INTERVAL === 0) {
+      await yieldToEventLoop();
+      throwIfAborted(options.abortSignal, "artifact search aborted");
+    }
+    const indexedTokens = new Set(
+      tokenizeArtifactSearchText(`${memory.content} ${(memory.frontmatter.tags ?? []).join(" ")}`),
+    );
+    let score = 0;
+    for (const token of tokens) {
+      if (indexedTokens.has(token)) score += 1;
+    }
+    if (score > 0) {
+      hits.push({ score, memory });
+    }
+  }
+  // Ties keep corpus order: the comparator returns 0 for equal scores rather
+  // than an arbitrary sign, so repeated scans produce the same top-N.
+  hits.sort((a, b) => b.score - a.score);
+  return hits.slice(0, maxResults).map((h) => h.memory);
+}

--- a/packages/remnic-core/src/entity-recall-cancellation.ts
+++ b/packages/remnic-core/src/entity-recall-cancellation.ts
@@ -1,0 +1,58 @@
+/**
+ * Cancellation checkpoints for entity recall (issue #2291).
+ *
+ * Entity recall reads every entity and memory file for the recalled namespaces and
+ * then makes several synchronous passes over the result. Both halves need the same
+ * two things at every boundary, in the same shape, with the same abort message —
+ * so they live here rather than being restated at each of a dozen call sites.
+ */
+
+import { throwIfAborted } from "./abort-error.js";
+import { yieldToEventLoop } from "./recall-qos.js";
+
+const ABORT_MESSAGE = "entity recall aborted";
+
+/**
+ * Entities/memories processed between two yields during an index build. Matches
+ * the artifact scan's interval: large enough that the yields are free relative to
+ * the work, small enough that a section deadline is observed promptly.
+ */
+export const ENTITY_SCAN_YIELD_INTERVAL = 256;
+
+/** Stop at the caller's signal without yielding. */
+export function checkEntityRecallAbort(abortSignal?: AbortSignal): void {
+  throwIfAborted(abortSignal, ABORT_MESSAGE);
+}
+
+/**
+ * Hand the loop a macrotask, then stop if the caller gave up while it ran.
+ *
+ * A section deadline is a timer, so a synchronous pass over the corpus must be
+ * preceded by one of these or the deadline cannot fire during it.
+ */
+export async function yieldEntityRecallScan(abortSignal?: AbortSignal): Promise<void> {
+  await yieldToEventLoop();
+  throwIfAborted(abortSignal, ABORT_MESSAGE);
+}
+
+/**
+ * The same yield/abort pair, but only every `ENTITY_SCAN_YIELD_INTERVAL` items —
+ * for loops where yielding per item would cost more than the work itself.
+ */
+export async function yieldEntityRecallScanEvery(
+  processed: number,
+  abortSignal?: AbortSignal,
+): Promise<void> {
+  if (processed % ENTITY_SCAN_YIELD_INTERVAL !== 0) return;
+  await yieldEntityRecallScan(abortSignal);
+}
+
+/**
+ * Exit an entity-recall path with "no section", unless the caller has actually
+ * cancelled — in which case throw, so the bounded runner records a breach rather
+ * than a successful empty section.
+ */
+export function entityRecallSectionAbsent(abortSignal?: AbortSignal): null {
+  throwIfAborted(abortSignal, ABORT_MESSAGE);
+  return null;
+}

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -8,6 +8,7 @@ import { compareEntityTimestamps, normalizeEntityName, type StorageManager } fro
 import { normalizeEntityText, resolveRequestedEntitySectionKeys } from "./entity-schema.js";
 import type { EntityStructuredSection, MemoryFile, PluginConfig, TranscriptEntry } from "./types.js";
 import { containsPhrase } from "./entity-retrieval-boundaries.js";
+import { throwIfAborted } from "./abort-error.js";
 
 const ENTITY_INDEX_VERSION = 3;
 const RECENT_TRANSCRIPT_LOOKBACK_HOURS = 24;
@@ -81,6 +82,13 @@ export interface BuildEntityRecallSectionOptions {
   maxRelatedEntities: number;
   maxChars: number;
   transcriptEntries: TranscriptEntry[];
+  /**
+   * Cancels the build at its next checkpoint (issue #2291).  Entity recall reads
+   * every entity and memory file across the recalled namespaces, which is
+   * minutes of work on a large or slow store; without this the scan kept running
+   * after the recall that asked for it had been abandoned.
+   */
+  abortSignal?: AbortSignal;
 }
 
 function tokenize(value: string): string[] {
@@ -523,7 +531,9 @@ async function buildEntityMentionIndex(
   namespaceStorage?: (namespace: string) => Promise<StorageManager>,
   nativeChunksOverride?: NativeKnowledgeChunk[],
   resolvedStorages?: StorageManager[],
+  abortSignal?: AbortSignal,
 ): Promise<EntityMentionIndex> {
+  throwIfAborted(abortSignal, "entity recall aborted");
   const storages = resolvedStorages ?? await resolveEntityIndexStorages(
     storage,
     config,
@@ -539,6 +549,9 @@ async function buildEntityMentionIndex(
     Promise.all(storages.map((scopedStorage) => scopedStorage.readAllMemories())),
     nativeChunksOverride ? Promise.resolve(nativeChunksOverride) : readNativeChunks(config, recallNamespaces),
   ]);
+  // The bulk reads above cannot be interrupted mid-flight; stop before spending
+  // the (larger) indexing pass over their results.
+  throwIfAborted(abortSignal, "entity recall aborted");
   // Pair each entity with the storage that owns it (#1534): canonical ids must
   // reflect that store's aliases and historical migration mappings, never another
   // namespace's.
@@ -1020,6 +1033,11 @@ function formatEntityHintSection(
 }
 
 export async function buildEntityRecallSection(options: BuildEntityRecallSectionOptions): Promise<string | null> {
+  // Checkpoints sit at the real I/O boundaries below (persisted-index read,
+  // native-chunk read, storage resolution, index build).  The per-candidate
+  // formatting that follows never awaits real I/O, so a deadline that fires
+  // during a scan is observed here (issue #2291).
+  throwIfAborted(options.abortSignal, "entity recall aborted");
   const prefixedMode = detectEntityQueryMode(options.query);
   const persistedIndex = prefixedMode
     ? null
@@ -1029,6 +1047,7 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
       options.recallNamespaces,
       options.namespaceStorage,
     );
+  throwIfAborted(options.abortSignal, "entity recall aborted");
   let nativeChunks: NativeKnowledgeChunk[] | undefined;
   if (
     !prefixedMode &&
@@ -1066,6 +1085,7 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
   let index: EntityMentionIndex | undefined = namespaceCacheKey
     ? namespaceEntityIndexCache.get(namespaceCacheKey)
     : undefined;
+  throwIfAborted(options.abortSignal, "entity recall aborted");
   if (!index) {
     index = await buildEntityMentionIndex(
       options.storage,
@@ -1074,6 +1094,7 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
       options.namespaceStorage,
       nativeChunks,
       resolvedStorages,
+      options.abortSignal,
     );
     if (namespaceCacheKey) rememberNamespaceEntityIndex(namespaceCacheKey, index);
   }

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -1137,6 +1137,7 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
   throwIfAborted(options.abortSignal, "entity recall aborted");
   const explicitCandidates = resolveExplicitCandidates(index, options.query);
   await yieldToEventLoop();
+  throwIfAborted(options.abortSignal, "entity recall aborted");
   const queryCandidates = prefixedMode
     ? explicitCandidates
     : resolveLanguageIndependentExplicitCandidates(index, options.query);

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -8,16 +8,14 @@ import { compareEntityTimestamps, normalizeEntityName, type StorageManager } fro
 import { normalizeEntityText, resolveRequestedEntitySectionKeys } from "./entity-schema.js";
 import type { EntityStructuredSection, MemoryFile, PluginConfig, TranscriptEntry } from "./types.js";
 import { containsPhrase } from "./entity-retrieval-boundaries.js";
-import { throwIfAborted } from "./abort-error.js";
-import { yieldToEventLoop } from "./recall-qos.js";
+import {
+  checkEntityRecallAbort,
+  entityRecallSectionAbsent,
+  yieldEntityRecallScan,
+  yieldEntityRecallScanEvery,
+} from "./entity-recall-cancellation.js";
 
 const ENTITY_INDEX_VERSION = 3;
-/**
- * Entities/memories processed between two yields during an index build. Matches
- * the artifact scan's interval: large enough that the yields are free relative to
- * the work, small enough that a section deadline is observed promptly.
- */
-const ENTITY_SCAN_YIELD_INTERVAL = 256;
 const RECENT_TRANSCRIPT_LOOKBACK_HOURS = 24;
 const INSTRUCTION_LIKE_RE = /\b(always|never|must|should|remember to|do not|don't|process|workflow|template|checklist|instruction)\b/i;
 const METADATA_WRAPPER_RE = /^(source|context|metadata|notes?):/i;
@@ -540,7 +538,7 @@ async function buildEntityMentionIndex(
   resolvedStorages?: StorageManager[],
   abortSignal?: AbortSignal,
 ): Promise<EntityMentionIndex> {
-  throwIfAborted(abortSignal, "entity recall aborted");
+  checkEntityRecallAbort(abortSignal);
   const storages = resolvedStorages ?? await resolveEntityIndexStorages(
     storage,
     config,
@@ -558,7 +556,7 @@ async function buildEntityMentionIndex(
   ]);
   // The bulk reads above cannot be interrupted mid-flight; stop before spending
   // the (larger) indexing pass over their results.
-  throwIfAborted(abortSignal, "entity recall aborted");
+  checkEntityRecallAbort(abortSignal);
   // Pair each entity with the storage that owns it (#1534): canonical ids must
   // reflect that store's aliases and historical migration mappings, never another
   // namespace's.
@@ -574,10 +572,7 @@ async function buildEntityMentionIndex(
   const entities = new Map<string, EntityMentionIndexEntry>();
   for (const { entity, storage: entityStorage } of entityRecords) {
     scanned += 1;
-    if (scanned % ENTITY_SCAN_YIELD_INTERVAL === 0) {
-      await yieldToEventLoop();
-      throwIfAborted(abortSignal, "entity recall aborted");
-    }
+    await yieldEntityRecallScanEvery(scanned, abortSignal);
     const canonicalId =
       typeof entityStorage.normalizeEntityName === "function"
         ? entityStorage.normalizeEntityName(entity.name, entity.type)
@@ -621,10 +616,7 @@ async function buildEntityMentionIndex(
   scanned = 0;
   for (const memory of memories) {
     scanned += 1;
-    if (scanned % ENTITY_SCAN_YIELD_INTERVAL === 0) {
-      await yieldToEventLoop();
-      throwIfAborted(abortSignal, "entity recall aborted");
-    }
+    await yieldEntityRecallScanEvery(scanned, abortSignal);
     const entityRef = typeof memory.frontmatter.entityRef === "string" ? memory.frontmatter.entityRef : "";
     if (!entityRef) continue;
     const entry = entities.get(entityRef);
@@ -639,8 +631,7 @@ async function buildEntityMentionIndex(
   // (alias map, native-chunk merge, sort, two full serializations). Yield between
   // them so a section deadline can fire between passes instead of only after all
   // of them (issue #2291).
-  await yieldToEventLoop();
-  throwIfAborted(abortSignal, "entity recall aborted");
+  await yieldEntityRecallScan(abortSignal);
   const aliasIndex = buildAliasIndex([...entities.values()]);
   for (const chunk of nativeChunks) {
     const existingPseudo = entities.get(nativePseudoCanonicalId(chunk));
@@ -661,12 +652,11 @@ async function buildEntityMentionIndex(
     entities.set(pseudoEntry.canonicalId, pseudoEntry);
   }
 
-  await yieldToEventLoop();
-  throwIfAborted(abortSignal, "entity recall aborted");
+  await yieldEntityRecallScan(abortSignal);
   const sortedEntities = [...entities.values()].sort((left, right) => left.name.localeCompare(right.name));
-  await yieldToEventLoop();
+  await yieldEntityRecallScan(abortSignal);
   const previousEntities = previousIndex ? JSON.stringify(previousIndex.entities) : "";
-  await yieldToEventLoop();
+  await yieldEntityRecallScan(abortSignal);
   const nextEntities = JSON.stringify(sortedEntities);
   const entityStatusVersionAfter = shouldPersistIndex ? storage.getMemoryStatusVersion() : undefined;
   const canPersistIndex = shouldPersistIndex && entityStatusVersionBefore === entityStatusVersionAfter;
@@ -680,6 +670,10 @@ async function buildEntityMentionIndex(
     entities: sortedEntities,
   };
   if (canPersistIndex) {
+    // A build the caller has abandoned must not leave a persisted index behind:
+    // the write is I/O the timed-out recall no longer needs, and the next recall
+    // is already competing for the same disk.
+    checkEntityRecallAbort(abortSignal);
     await writeEntityIndexState(storage, index);
   }
   return index;
@@ -1069,7 +1063,7 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
   // native-chunk read, storage resolution, index build).  The per-candidate
   // formatting that follows never awaits real I/O, so a deadline that fires
   // during a scan is observed here (issue #2291).
-  throwIfAborted(options.abortSignal, "entity recall aborted");
+  checkEntityRecallAbort(options.abortSignal);
   const prefixedMode = detectEntityQueryMode(options.query);
   const persistedIndex = prefixedMode
     ? null
@@ -1079,7 +1073,7 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
       options.recallNamespaces,
       options.namespaceStorage,
     );
-  throwIfAborted(options.abortSignal, "entity recall aborted");
+  checkEntityRecallAbort(options.abortSignal);
   let nativeChunks: NativeKnowledgeChunk[] | undefined;
   if (
     !prefixedMode &&
@@ -1088,7 +1082,7 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
   ) {
     nativeChunks = await readNativeChunks(options.config, options.recallNamespaces);
     if (!hasFreshNativeExplicitMention(persistedIndex, nativeChunks, options.query)) {
-      return null;
+      return entityRecallSectionAbsent(options.abortSignal);
     }
   }
   const namespaceScoped =
@@ -1117,7 +1111,7 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
   let index: EntityMentionIndex | undefined = namespaceCacheKey
     ? namespaceEntityIndexCache.get(namespaceCacheKey)
     : undefined;
-  throwIfAborted(options.abortSignal, "entity recall aborted");
+  checkEntityRecallAbort(options.abortSignal);
   if (!index) {
     index = await buildEntityMentionIndex(
       options.storage,
@@ -1133,22 +1127,20 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
   // Candidate resolution is another synchronous pass over every entity and alias,
   // reached even on a cache hit that did no I/O at all — so yield here too, or a
   // cached corpus could still hold the loop past the section budget (issue #2291).
-  await yieldToEventLoop();
-  throwIfAborted(options.abortSignal, "entity recall aborted");
+  await yieldEntityRecallScan(options.abortSignal);
   const explicitCandidates = resolveExplicitCandidates(index, options.query);
-  await yieldToEventLoop();
-  throwIfAborted(options.abortSignal, "entity recall aborted");
+  await yieldEntityRecallScan(options.abortSignal);
   const queryCandidates = prefixedMode
     ? explicitCandidates
     : resolveLanguageIndependentExplicitCandidates(index, options.query);
   const mode = prefixedMode ?? (queryCandidates.length > 0 ? "direct" : null);
-  if (!mode) return null;
+  if (!mode) return entityRecallSectionAbsent(options.abortSignal);
 
   const candidates = queryCandidates.length > 0
     ? queryCandidates
     : resolveRecentTurnCandidates(index, options.transcriptEntries, options.recentTurns);
 
-  if (candidates.length === 0) return null;
+  if (candidates.length === 0) return entityRecallSectionAbsent(options.abortSignal);
 
   const queryTokens = tokenize(options.query);
   const candidateLimit = queryCandidates.length === 0 && mode === "follow_up"
@@ -1181,7 +1173,9 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
   );
 
   const section = formatEntityHintSection(enriched, queryTokens, mode, options.maxRelatedEntities, options.maxChars);
-  if (!section) return null;
+  // `entityRecallSectionAbsent` so a cancelled build is not recorded as a
+  // successful section that simply found no entities.
+  if (!section) return entityRecallSectionAbsent(options.abortSignal);
   return section;
 }
 

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -635,6 +635,12 @@ async function buildEntityMentionIndex(
     }
   }
 
+  // Each remaining phase is another synchronous pass over the whole index
+  // (alias map, native-chunk merge, sort, two full serializations). Yield between
+  // them so a section deadline can fire between passes instead of only after all
+  // of them (issue #2291).
+  await yieldToEventLoop();
+  throwIfAborted(abortSignal, "entity recall aborted");
   const aliasIndex = buildAliasIndex([...entities.values()]);
   for (const chunk of nativeChunks) {
     const existingPseudo = entities.get(nativePseudoCanonicalId(chunk));
@@ -655,8 +661,12 @@ async function buildEntityMentionIndex(
     entities.set(pseudoEntry.canonicalId, pseudoEntry);
   }
 
+  await yieldToEventLoop();
+  throwIfAborted(abortSignal, "entity recall aborted");
   const sortedEntities = [...entities.values()].sort((left, right) => left.name.localeCompare(right.name));
+  await yieldToEventLoop();
   const previousEntities = previousIndex ? JSON.stringify(previousIndex.entities) : "";
+  await yieldToEventLoop();
   const nextEntities = JSON.stringify(sortedEntities);
   const entityStatusVersionAfter = shouldPersistIndex ? storage.getMemoryStatusVersion() : undefined;
   const canPersistIndex = shouldPersistIndex && entityStatusVersionBefore === entityStatusVersionAfter;
@@ -1120,7 +1130,13 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
     );
     if (namespaceCacheKey) rememberNamespaceEntityIndex(namespaceCacheKey, index);
   }
+  // Candidate resolution is another synchronous pass over every entity and alias,
+  // reached even on a cache hit that did no I/O at all — so yield here too, or a
+  // cached corpus could still hold the loop past the section budget (issue #2291).
+  await yieldToEventLoop();
+  throwIfAborted(options.abortSignal, "entity recall aborted");
   const explicitCandidates = resolveExplicitCandidates(index, options.query);
+  await yieldToEventLoop();
   const queryCandidates = prefixedMode
     ? explicitCandidates
     : resolveLanguageIndependentExplicitCandidates(index, options.query);

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -9,8 +9,15 @@ import { normalizeEntityText, resolveRequestedEntitySectionKeys } from "./entity
 import type { EntityStructuredSection, MemoryFile, PluginConfig, TranscriptEntry } from "./types.js";
 import { containsPhrase } from "./entity-retrieval-boundaries.js";
 import { throwIfAborted } from "./abort-error.js";
+import { yieldToEventLoop } from "./recall-qos.js";
 
 const ENTITY_INDEX_VERSION = 3;
+/**
+ * Entities/memories processed between two yields during an index build. Matches
+ * the artifact scan's interval: large enough that the yields are free relative to
+ * the work, small enough that a section deadline is observed promptly.
+ */
+const ENTITY_SCAN_YIELD_INTERVAL = 256;
 const RECENT_TRANSCRIPT_LOOKBACK_HOURS = 24;
 const INSTRUCTION_LIKE_RE = /\b(always|never|must|should|remember to|do not|don't|process|workflow|template|checklist|instruction)\b/i;
 const METADATA_WRAPPER_RE = /^(source|context|metadata|notes?):/i;
@@ -560,8 +567,17 @@ async function buildEntityMentionIndex(
   );
   const memories = memorySets.flat();
 
+  // The two passes over the corpus below never await real I/O, so without an
+  // explicit yield they hold the event loop and no recall section deadline can
+  // fire during them (issue #2291).
+  let scanned = 0;
   const entities = new Map<string, EntityMentionIndexEntry>();
   for (const { entity, storage: entityStorage } of entityRecords) {
+    scanned += 1;
+    if (scanned % ENTITY_SCAN_YIELD_INTERVAL === 0) {
+      await yieldToEventLoop();
+      throwIfAborted(abortSignal, "entity recall aborted");
+    }
     const canonicalId =
       typeof entityStorage.normalizeEntityName === "function"
         ? entityStorage.normalizeEntityName(entity.name, entity.type)
@@ -602,7 +618,13 @@ async function buildEntityMentionIndex(
     });
   }
 
+  scanned = 0;
   for (const memory of memories) {
+    scanned += 1;
+    if (scanned % ENTITY_SCAN_YIELD_INTERVAL === 0) {
+      await yieldToEventLoop();
+      throwIfAborted(abortSignal, "entity recall aborted");
+    }
     const entityRef = typeof memory.frontmatter.entityRef === "string" ? memory.frontmatter.entityRef : "";
     if (!entityRef) continue;
     const entry = entities.get(entityRef);

--- a/packages/remnic-core/src/orchestration/namespace-read-fanout.ts
+++ b/packages/remnic-core/src/orchestration/namespace-read-fanout.ts
@@ -27,6 +27,7 @@ import { mergeArtifactRecallCandidates, tokenizeRecallQuery } from "./orchestrat
 import { qmdCollectionPathParts } from "./qmd-result-resolver.js";
 import { qmdCollectionNamespaceFromPrefix as computeQmdCollectionNamespaceFromPrefix } from "./orchestrator-namespace-scope.js";
 import { resolveNamespaceFromStorageDir } from "../scopes/scope-plan.js";
+import type { ArtifactRecallOptions } from "./recall-search-prefilter.js";
 import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions } from "../search/port.js";
 import type { MemoryFile, PluginConfig, QmdSearchResult } from "../types.js";
 import {
@@ -41,6 +42,7 @@ export interface NamespaceReadFanoutDeps {
     namespace: string,
     prompt: string,
     targetCount: number,
+    options?: ArtifactRecallOptions,
   ): Promise<MemoryFile[]>;
   loadNamespaceStorageDirHintsFromCatalog(): void;
   readonly namespaceCatalog: NamespaceCatalog;
@@ -338,12 +340,13 @@ export class NamespaceReadFanoutCoordinator {
     prompt: string,
     recallNamespaces: string[],
     targetCount: number,
+    options: ArtifactRecallOptions = {},
   ): Promise<MemoryFile[]> {
     if (targetCount <= 0) return [];
     const namespaces = Array.from(new Set(recallNamespaces));
     const filteredByNamespace = await Promise.all(
       namespaces.map((namespace) =>
-        this.deps.fetchActiveArtifactsForNamespace(namespace, prompt, targetCount),
+        this.deps.fetchActiveArtifactsForNamespace(namespace, prompt, targetCount, options),
       ),
     );
 

--- a/packages/remnic-core/src/orchestration/recall-internal-deps.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal-deps.ts
@@ -35,6 +35,7 @@ import type { VerifiedEpisodeResult } from "../verified-recall.js";
 import type { WorkProductLedgerSearchResult } from "../work-product-ledger.js";
 import type { GraphRecallRankedResult, GraphRecallShadowComparison } from "./graph-recall-coordinator.js";
 import type { RecallRerankCoordinator, RecallResultPartitionSink } from "./recall-rerank-coordinator.js";
+import type { ArtifactRecallOptions } from "./recall-search-prefilter.js";
 import type { RecallSectionAppendOptions, RecallSectionBuckets } from "./recall-section-coordinator.js";
 
 export interface RecallInternalDeps {
@@ -339,6 +340,7 @@ export interface RecallInternalDeps {
     prompt: string,
     recallNamespaces: string[],
     targetCount: number,
+    options?: ArtifactRecallOptions,
   ): Promise<MemoryFile[]>;
   recallAssemblyClockMs(): number;
   recordLastGraphRecallSnapshot(options: {

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -1025,13 +1025,10 @@ export class RecallInternalCoordinator {
             transcriptEntries,
             abortSignal: sectionSignal,
           }).catch((err) => {
-            // A cancelled build is the deadline/abort contract working, not a
-            // failure worth a warning on every aborted request.
-            if (isAbortError(err)) {
-              log.debug(`entity retrieval build cancelled: ${err}`);
-            } else {
-              log.warn(`entity retrieval build failed: ${err}`);
-            }
+            // Cancellation is the deadline/abort contract working; let the bounded
+            // runner record it as cancelled rather than as an empty section.
+            if (isAbortError(err)) throw err;
+            log.warn(`entity retrieval build failed: ${err}`);
             return null;
           });
         },

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -151,9 +151,14 @@ export class RecallInternalCoordinator {
       profileTraceClosed = true;
       this.deps.profiler.endTrace(profileTraceId); // persists to JSONL file
     };
+    // The static, config-derived figure the untouched sections report in their
+    // metrics. The bounded runner below resolves its own effective budget per
+    // section, against the request budget still left when that section starts.
+    const configuredCoreDeadlineMs = this.deps.config.recallCoreDeadlineMs ?? 75_000;
+    const recallOuterTimeoutMs = this.deps.config.recallOuterTimeoutMs ?? 75_000;
     const recallSectionDeadlineMs = resolveRecallCoreSectionDeadlineMs({
-      configuredCoreDeadlineMs: this.deps.config.recallCoreDeadlineMs ?? 75_000,
-      outerTimeoutMs: this.deps.config.recallOuterTimeoutMs ?? 75_000,
+      configuredCoreDeadlineMs,
+      remainingOuterMs: recallOuterTimeoutMs > 0 ? recallOuterTimeoutMs : null,
     });
     const enrichmentSectionDeadlineMs =
       this.deps.config.recallEnrichmentDeadlineMs ?? 25_000;
@@ -214,7 +219,9 @@ export class RecallInternalCoordinator {
       logger: log,
     });
     const runBoundedCoreSection = createBoundedCoreSectionRunner({
-      deadlineMs: recallSectionDeadlineMs,
+      configuredDeadlineMs: configuredCoreDeadlineMs,
+      outerDeadlineAtMs:
+        recallOuterTimeoutMs > 0 ? recallStart + recallOuterTimeoutMs : null,
       parentSignal: options.abortSignal,
       record: recordRecallSectionMetric,
       logger: log,

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -46,7 +46,11 @@ import {
   boundRecallContextComposition, composeRecallContext, contextBudgetForFooter,
   formatCuriosityFooter, selectCuriosityQuestion,
 } from "../recall-context-composition.js";
-import { createRecallSectionMetricRecorder } from "../recall-qos.js";
+import {
+  createBoundedCoreSectionRunner,
+  createRecallSectionMetricRecorder,
+  resolveRecallCoreSectionDeadlineMs,
+} from "../recall-qos.js";
 import { buildRecallQueryPolicy } from "../recall-query-policy.js";
 import { type GraphRecallExpandedEntry, type LastRecallSnapshot } from "../recall-state.js";
 import {
@@ -74,7 +78,7 @@ import { searchTrustZoneRecords } from "../trust-zones.js";
 import type { IdentityInjectionMode, MemoryFile, QmdSearchResult, RecallPlanMode } from "../types.js";
 import { type VerifiedEpisodeResult, compareVerifiedEpisodeResults, searchVerifiedEpisodes } from "../verified-recall.js";
 import { type WorkProductLedgerSearchResult, searchWorkProductLedgerEntries } from "../work-product-ledger.js";
-import { abortError } from "../abort-error.js";
+import { abortError, isAbortError } from "../abort-error.js";
 import {
   applyQueryAwareCandidateFilter,
   filterRecallCandidates,
@@ -147,7 +151,10 @@ export class RecallInternalCoordinator {
       profileTraceClosed = true;
       this.deps.profiler.endTrace(profileTraceId); // persists to JSONL file
     };
-    const recallSectionDeadlineMs = this.deps.config.recallCoreDeadlineMs ?? 75_000;
+    const recallSectionDeadlineMs = resolveRecallCoreSectionDeadlineMs({
+      configuredCoreDeadlineMs: this.deps.config.recallCoreDeadlineMs ?? 75_000,
+      outerTimeoutMs: this.deps.config.recallOuterTimeoutMs ?? 75_000,
+    });
     const enrichmentSectionDeadlineMs =
       this.deps.config.recallEnrichmentDeadlineMs ?? 25_000;
     // Wrap entire recall body in try/finally so profiling trace is always closed,
@@ -204,6 +211,12 @@ export class RecallInternalCoordinator {
     };
     const recordRecallSectionMetric = createRecallSectionMetricRecorder({
       timings,
+      logger: log,
+    });
+    const runBoundedCoreSection = createBoundedCoreSectionRunner({
+      deadlineMs: recallSectionDeadlineMs,
+      parentSignal: options.abortSignal,
+      record: recordRecallSectionMetric,
       logger: log,
     });
     const promptHash = createHash("sha256").update(prompt).digest("hex");
@@ -985,41 +998,44 @@ export class RecallInternalCoordinator {
         });
         return null;
       }
-      const t0 = Date.now();
-      const transcriptEntries = sessionKey
-        ? await readRecentEntityTranscriptEntries(
-            this.deps.transcript.readRecent(
-              entityRecentTranscriptLookbackHours,
-              sessionKey,
-            ),
+      return await runBoundedCoreSection(
+        "entityRetrieval",
+        null as string | null,
+        async (sectionSignal) => {
+          const transcriptEntries = sessionKey
+            ? await readRecentEntityTranscriptEntries(
+                this.deps.transcript.readRecent(
+                  entityRecentTranscriptLookbackHours,
+                  sessionKey,
+                ),
+                recentTurns,
+              )
+            : [];
+          return await buildEntityRecallSection({
+            config: this.deps.config,
+            storage: profileStorage,
+            namespaceStorage: (namespace) => this.deps.getStorage(namespace),
+            query: retrievalQuery,
+            recallNamespaces,
             recentTurns,
-          )
-        : [];
-      const section = await buildEntityRecallSection({
-        config: this.deps.config,
-        storage: profileStorage,
-        namespaceStorage: (namespace) => this.deps.getStorage(namespace),
-        query: retrievalQuery,
-        recallNamespaces,
-        recentTurns,
-        maxHints,
-        maxSupportingFacts,
-        maxRelatedEntities,
-        maxChars,
-        transcriptEntries,
-      }).catch((err) => {
-        log.warn(`entity retrieval build failed: ${err}`);
-        return null;
-      });
-      recordRecallSectionMetric({
-        section: "entityRetrieval",
-        priority: "core",
-        durationMs: Date.now() - t0,
-        deadlineMs: recallSectionDeadlineMs,
-        source: "fresh",
-        success: true,
-      });
-      return section;
+            maxHints,
+            maxSupportingFacts,
+            maxRelatedEntities,
+            maxChars,
+            transcriptEntries,
+            abortSignal: sectionSignal,
+          }).catch((err) => {
+            // A cancelled build is the deadline/abort contract working, not a
+            // failure worth a warning on every aborted request.
+            if (isAbortError(err)) {
+              log.debug(`entity retrieval build cancelled: ${err}`);
+            } else {
+              log.warn(`entity retrieval build failed: ${err}`);
+            }
+            return null;
+          });
+        },
+      );
     })();
 
     // 1b. Knowledge Index (v7.0)
@@ -1130,7 +1146,6 @@ export class RecallInternalCoordinator {
       )
         return [];
       if (!resolvePresentationCapabilities(this.deps.config).verbatimArtifacts) return [];
-      const t0 = Date.now();
       const targetCount = computeArtifactRecallLimit(
         recallMode,
         recallResultLimit,
@@ -1148,25 +1163,23 @@ export class RecallInternalCoordinator {
         });
         return [];
       }
-      const results = await this.deps.recallArtifactsAcrossNamespaces(
-        retrievalQuery,
-        recallNamespaces,
-        targetCount,
+      return await runBoundedCoreSection(
+        "artifacts",
+        [] as MemoryFile[],
+        async (sectionSignal) => {
+          const results = await this.deps.recallArtifactsAcrossNamespaces(
+            retrievalQuery,
+            recallNamespaces,
+            targetCount,
+            { abortSignal: sectionSignal },
+          );
+          return lifecycleCaps.extractionScopeClassification
+            ? results.filter((artifact) =>
+                canRecallToolScopedMemory(artifact.frontmatter, options.sourceConnector),
+              )
+            : results;
+        },
       );
-
-      recordRecallSectionMetric({
-        section: "artifacts",
-        priority: "core",
-        durationMs: Date.now() - t0,
-        deadlineMs: recallSectionDeadlineMs,
-        source: "fresh",
-        success: true,
-      });
-      return lifecycleCaps.extractionScopeClassification
-        ? results.filter((artifact) =>
-            canRecallToolScopedMemory(artifact.frontmatter, options.sourceConnector),
-          )
-        : results;
     })();
 
     const objectiveStatePromise = (async (): Promise<string | null> => {

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -78,7 +78,7 @@ import { searchTrustZoneRecords } from "../trust-zones.js";
 import type { IdentityInjectionMode, MemoryFile, QmdSearchResult, RecallPlanMode } from "../types.js";
 import { type VerifiedEpisodeResult, compareVerifiedEpisodeResults, searchVerifiedEpisodes } from "../verified-recall.js";
 import { type WorkProductLedgerSearchResult, searchWorkProductLedgerEntries } from "../work-product-ledger.js";
-import { abortError, isAbortError } from "../abort-error.js";
+import { abortError, isAbortError, raceAbort } from "../abort-error.js";
 import {
   applyQueryAwareCandidateFilter,
   filterRecallCandidates,
@@ -1009,13 +1009,20 @@ export class RecallInternalCoordinator {
         "entityRetrieval",
         null as string | null,
         async (sectionSignal) => {
+          // The transcript store is shared and takes no signal of its own, so the
+          // section stops WAITING on a stalled read rather than pretending to
+          // interrupt it — otherwise a cancelled section sits in this await.
           const transcriptEntries = sessionKey
-            ? await readRecentEntityTranscriptEntries(
-                this.deps.transcript.readRecent(
-                  entityRecentTranscriptLookbackHours,
-                  sessionKey,
+            ? await raceAbort(
+                readRecentEntityTranscriptEntries(
+                  this.deps.transcript.readRecent(
+                    entityRecentTranscriptLookbackHours,
+                    sessionKey,
+                  ),
+                  recentTurns,
                 ),
-                recentTurns,
+                sectionSignal,
+                "entity recall aborted",
               )
             : [];
           return await buildEntityRecallSection({

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -49,7 +49,6 @@ import {
 import {
   createBoundedCoreSectionRunner,
   createRecallSectionMetricRecorder,
-  resolveRecallCoreSectionDeadlineMs,
 } from "../recall-qos.js";
 import { buildRecallQueryPolicy } from "../recall-query-policy.js";
 import { type GraphRecallExpandedEntry, type LastRecallSnapshot } from "../recall-state.js";
@@ -151,15 +150,13 @@ export class RecallInternalCoordinator {
       profileTraceClosed = true;
       this.deps.profiler.endTrace(profileTraceId); // persists to JSONL file
     };
-    // The static, config-derived figure the untouched sections report in their
-    // metrics. The bounded runner below resolves its own effective budget per
+    // The CONFIGURED core budget, which is what the sections that run outside the
+    // bounded runner report in their metrics: nothing enforces a deadline for them,
+    // so reporting a derived figure would claim a bound that does not exist. The
+    // bounded runner below derives and reports its own effective budget per
     // section, against the request budget still left when that section starts.
-    const configuredCoreDeadlineMs = this.deps.config.recallCoreDeadlineMs ?? 75_000;
+    const recallSectionDeadlineMs = this.deps.config.recallCoreDeadlineMs ?? 75_000;
     const recallOuterTimeoutMs = this.deps.config.recallOuterTimeoutMs ?? 75_000;
-    const recallSectionDeadlineMs = resolveRecallCoreSectionDeadlineMs({
-      configuredCoreDeadlineMs,
-      remainingOuterMs: recallOuterTimeoutMs > 0 ? recallOuterTimeoutMs : null,
-    });
     const enrichmentSectionDeadlineMs =
       this.deps.config.recallEnrichmentDeadlineMs ?? 25_000;
     // Wrap entire recall body in try/finally so profiling trace is always closed,
@@ -219,7 +216,7 @@ export class RecallInternalCoordinator {
       logger: log,
     });
     const runBoundedCoreSection = createBoundedCoreSectionRunner({
-      configuredDeadlineMs: configuredCoreDeadlineMs,
+      configuredDeadlineMs: recallSectionDeadlineMs,
       outerDeadlineAtMs:
         recallOuterTimeoutMs > 0 ? recallStart + recallOuterTimeoutMs : null,
       parentSignal: options.abortSignal,

--- a/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
+++ b/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
@@ -40,6 +40,7 @@ import {
   fetchActiveArtifactsForNamespace as fetchActiveArtifactsForNamespaceHelper,
   searchEmbeddingFallback as searchEmbeddingFallbackHelper,
   searchQueryAwareFallback as searchQueryAwareFallbackHelper,
+  type ArtifactRecallOptions,
 } from "./recall-search-prefilter.js";
 import { shouldFilterSupersededFromRecall } from "../temporal-supersession.js";
 import { isValidAsOf, isValidityExpiredNow } from "../temporal-validity.js";
@@ -251,8 +252,15 @@ export class RecallSearchPipelineCoordinator {
     namespace: string,
     prompt: string,
     targetCount: number,
+    options: ArtifactRecallOptions = {},
   ): Promise<MemoryFile[]> {
-    return fetchActiveArtifactsForNamespaceHelper(this.deps, namespace, prompt, targetCount);
+    return fetchActiveArtifactsForNamespaceHelper(
+      this.deps,
+      namespace,
+      prompt,
+      targetCount,
+      options,
+    );
   }
 
   async buildQueryAwarePrefilter(

--- a/packages/remnic-core/src/orchestration/recall-search-prefilter.ts
+++ b/packages/remnic-core/src/orchestration/recall-search-prefilter.ts
@@ -67,7 +67,9 @@ export async function fetchActiveArtifactsForNamespace(
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
     throwIfRecallAborted(options.abortSignal);
-    const rawResults = await storage.searchArtifacts(prompt, fetchLimit);
+    const rawResults = await storage.searchArtifacts(prompt, fetchLimit, {
+      abortSignal: options.abortSignal,
+    });
     const sourceIds = Array.from(
       new Set(
         rawResults

--- a/packages/remnic-core/src/orchestration/recall-search-prefilter.ts
+++ b/packages/remnic-core/src/orchestration/recall-search-prefilter.ts
@@ -42,11 +42,22 @@ export interface PrefilterAndArtifactDeps {
   ): Promise<QmdSearchResult[]>;
 }
 
+/**
+ * Cancellation for the artifact recall path (issue #2291).  Artifact recall
+ * re-scans and re-tokenizes every stored artifact, up to `MAX_ATTEMPTS` times
+ * with a growing fetch limit; on a large or slow memory tree that is minutes of
+ * work that used to keep running after the caller had already given up.
+ */
+export interface ArtifactRecallOptions {
+  abortSignal?: AbortSignal;
+}
+
 export async function fetchActiveArtifactsForNamespace(
   deps: Pick<PrefilterAndArtifactDeps, "storageRouter" | "resolveArtifactSourceStatuses">,
   namespace: string,
   prompt: string,
   targetCount: number,
+  options: ArtifactRecallOptions = {},
 ): Promise<MemoryFile[]> {
   const storage = await deps.storageRouter.storageFor(namespace);
   let fetchLimit = computeArtifactCandidateFetchLimit(targetCount);
@@ -55,6 +66,7 @@ export async function fetchActiveArtifactsForNamespace(
   let bestFiltered: MemoryFile[] = [];
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+    throwIfRecallAborted(options.abortSignal);
     const rawResults = await storage.searchArtifacts(prompt, fetchLimit);
     const sourceIds = Array.from(
       new Set(
@@ -65,6 +77,9 @@ export async function fetchActiveArtifactsForNamespace(
           ),
       ),
     );
+    // The status snapshot rebuild reads every memory in the namespace; do not
+    // start one for a recall that has already been abandoned.
+    throwIfRecallAborted(options.abortSignal);
     const sourceStatus =
       sourceIds.length > 0
         ? await deps.resolveArtifactSourceStatuses(storage, sourceIds)

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -120,6 +120,7 @@ import { ConsolidationRunCoordinator } from "./orchestration/consolidation-run.j
 import { ExtractionPersistCoordinator } from "./orchestration/extraction-persist.js";
 import { RecallInternalCoordinator } from "./orchestration/recall-internal.js";
 import { RecallSearchPipelineCoordinator } from "./orchestration/recall-search-pipeline.js";
+import type { ArtifactRecallOptions } from "./orchestration/recall-search-prefilter.js";
 import { TurnIngestionCoordinator, type TurnIngestionOptions } from "./orchestration/turn-ingestion.js";
 import { RecallIntrospectionCoordinator } from "./orchestration/recall-introspection.js";
 import { OrchestratorInitCoordinator } from "./orchestration/orchestrator-init.js";
@@ -2460,11 +2461,10 @@ export class Orchestrator {
     namespace: string,
     prompt: string,
     targetCount: number,
+    options: ArtifactRecallOptions = {},
   ): Promise<MemoryFile[]> {
     return this.recallSearchPipelineCoordinator.fetchActiveArtifactsForNamespace(
-      namespace,
-      prompt,
-      targetCount,
+      namespace, prompt, targetCount, options,
     );
   }
 
@@ -2472,11 +2472,10 @@ export class Orchestrator {
     prompt: string,
     recallNamespaces: string[],
     targetCount: number,
+    options: ArtifactRecallOptions = {},
   ): Promise<MemoryFile[]> {
     return this.namespaceReadFanoutCoordinator.recallArtifactsAcrossNamespaces(
-      prompt,
-      recallNamespaces,
-      targetCount,
+      prompt, recallNamespaces, targetCount, options,
     );
   }
 

--- a/packages/remnic-core/src/recall-qos.test.ts
+++ b/packages/remnic-core/src/recall-qos.test.ts
@@ -1,9 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { throwIfAborted } from "./abort-error.js";
 import {
+  createBoundedCoreSectionRunner,
   createRecallSectionMetricRecorder,
   resolveRecallCoreSectionDeadlineMs,
   runRecallSectionWithinDeadline,
+  yieldToEventLoop,
   type RecallSectionMetric,
 } from "./recall-qos.js";
 
@@ -266,4 +269,58 @@ test("a zero budget on either side keeps the configured value", () => {
     resolveRecallCoreSectionDeadlineMs({ configuredCoreDeadlineMs: 75_000, outerTimeoutMs: 0 }),
     75_000,
   );
+});
+
+test("a bounded core section degrades on cancellation rather than rejecting", async () => {
+  // The phase this section belongs to is awaited through a race the caller's
+  // abort also wins, so a rejection here would be an unhandled rejection.
+  const metrics: RecallSectionMetric[] = [];
+  const caller = new AbortController();
+  const runSection = createBoundedCoreSectionRunner({
+    deadlineMs: 5_000,
+    parentSignal: caller.signal,
+    record: (metric) => metrics.push(metric),
+    logger: { warn: () => {} },
+  });
+
+  caller.abort();
+  const value = await runSection("artifacts", [] as string[], async (sectionSignal) => {
+    throwIfAborted(sectionSignal, "artifact search aborted");
+    return ["should not be reached"];
+  });
+
+  assert.deepEqual(value, []);
+  assert.equal(metrics[0]?.section, "artifacts");
+  assert.equal(metrics[0]?.success, false);
+  assert.match(metrics[0]?.timing ?? "", /^cancelled\(\d+ms\)$/);
+});
+
+test("a bounded core section still surfaces a non-abort failure", async () => {
+  const runSection = createBoundedCoreSectionRunner({
+    deadlineMs: 5_000,
+    record: () => {},
+    logger: { warn: () => {} },
+  });
+
+  await assert.rejects(
+    runSection("artifacts", [] as string[], async () => {
+      throw new Error("artifact tier unreadable");
+    }),
+    /artifact tier unreadable/,
+  );
+});
+
+test("yieldToEventLoop lets a pending timer run", async () => {
+  // The guarantee corpus scans depend on: without a yield the timer that carries
+  // a section deadline cannot fire while the scan holds the loop.
+  let timerFired = false;
+  const timer = setTimeout(() => {
+    timerFired = true;
+  }, 0);
+
+  await yieldToEventLoop();
+  await yieldToEventLoop();
+  clearTimeout(timer);
+
+  assert.equal(timerFired, true);
 });

--- a/packages/remnic-core/src/recall-qos.test.ts
+++ b/packages/remnic-core/src/recall-qos.test.ts
@@ -2,6 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   createRecallSectionMetricRecorder,
+  resolveRecallCoreSectionDeadlineMs,
+  runRecallSectionWithinDeadline,
   type RecallSectionMetric,
 } from "./recall-qos.js";
 
@@ -82,4 +84,186 @@ test("recall section metric recorder respects timing overrides and logs enrichme
     source: "skip",
     success: true,
   });
+});
+
+test("timed-out section metric reports the breach instead of a plain duration", () => {
+  const timings: Record<string, string> = {};
+  const calls: Array<{ level: "info" | "debug"; payload: unknown[] }> = [];
+  const recorder = createRecallSectionMetricRecorder({
+    timings,
+    logger: {
+      info: (_message: string, ...payload: unknown[]) => calls.push({ level: "info", payload }),
+      debug: (_message: string, ...payload: unknown[]) => calls.push({ level: "debug", payload }),
+    },
+  });
+
+  recorder({
+    section: "entityRetrieval",
+    priority: "core",
+    durationMs: 75_004,
+    deadlineMs: 75_000,
+    source: "timeout",
+    success: false,
+  });
+
+  assert.equal(timings.entityRetrieval, "timeout(75004ms)");
+  // A breach is not a success, so it must not be logged as one.
+  assert.equal(calls[0]?.level, "debug");
+});
+
+test("recall section deadline degrades to the fallback and cancels the section", async () => {
+  let observedSignal: AbortSignal | undefined;
+  let cancelledDuringWork = false;
+
+  // A real timer is the subject here, not a guessed wait: the section below
+  // never settles on its own, so the deadline always wins regardless of load.
+  const outcome = await runRecallSectionWithinDeadline({
+    deadlineMs: 15,
+    fallback: "degraded",
+    run: async (sectionSignal) => {
+      observedSignal = sectionSignal;
+      const cancelled = Promise.withResolvers<void>();
+      sectionSignal.addEventListener("abort", () => {
+        cancelledDuringWork = true;
+        cancelled.resolve();
+      });
+      await cancelled.promise;
+      return "late value";
+    },
+  });
+
+  assert.equal(outcome.timedOut, true);
+  assert.equal(outcome.value, "degraded");
+  assert.equal(observedSignal?.aborted, true);
+  assert.equal(cancelledDuringWork, true);
+});
+
+test("recall section deadline returns the real value when the section finishes in time", async () => {
+  const outcome = await runRecallSectionWithinDeadline({
+    deadlineMs: 5_000,
+    fallback: null as string | null,
+    run: async (sectionSignal) => {
+      assert.equal(sectionSignal.aborted, false);
+      return "section body";
+    },
+  });
+
+  assert.equal(outcome.timedOut, false);
+  assert.equal(outcome.value, "section body");
+});
+
+test("a zero deadline disables the bound rather than failing every section", async () => {
+  const released = Promise.withResolvers<void>();
+  const pending = runRecallSectionWithinDeadline({
+    deadlineMs: 0,
+    fallback: "degraded",
+    run: async () => {
+      await released.promise;
+      return "unbounded value";
+    },
+  });
+
+  // Two full event-loop turns: any 0ms timer would already have fired, so a
+  // still-pending section proves the bound was disabled rather than instant.
+  for (let turn = 0; turn < 2; turn += 1) {
+    const turned = Promise.withResolvers<void>();
+    setImmediate(turned.resolve);
+    await turned.promise;
+  }
+  released.resolve();
+
+  const outcome = await pending;
+  assert.equal(outcome.timedOut, false);
+  assert.equal(outcome.value, "unbounded value");
+});
+
+test("a caller abort propagates into the section signal", async () => {
+  const caller = new AbortController();
+  let cancelledDuringWork = false;
+
+  const pending = runRecallSectionWithinDeadline({
+    deadlineMs: 5_000,
+    fallback: "degraded",
+    parentSignal: caller.signal,
+    run: async (sectionSignal) => {
+      const cancelled = Promise.withResolvers<void>();
+      sectionSignal.addEventListener("abort", () => {
+        cancelledDuringWork = true;
+        cancelled.resolve();
+      });
+      await cancelled.promise;
+      return "cancelled";
+    },
+  });
+
+  caller.abort();
+  const outcome = await pending;
+
+  assert.equal(cancelledDuringWork, true);
+  assert.equal(outcome.timedOut, false);
+  assert.equal(outcome.value, "cancelled");
+});
+
+test("an already-aborted caller signal cancels the section before it does work", async () => {
+  const caller = new AbortController();
+  caller.abort();
+
+  const outcome = await runRecallSectionWithinDeadline({
+    deadlineMs: 5_000,
+    fallback: "degraded",
+    parentSignal: caller.signal,
+    run: async (sectionSignal) => {
+      assert.equal(sectionSignal.aborted, true);
+      return "observed";
+    },
+  });
+
+  assert.equal(outcome.value, "observed");
+});
+
+test("a section rejection surfaces to the caller instead of being swallowed", async () => {
+  await assert.rejects(
+    runRecallSectionWithinDeadline({
+      deadlineMs: 5_000,
+      fallback: "degraded",
+      run: async () => {
+        throw new Error("section exploded");
+      },
+    }),
+    /section exploded/,
+  );
+});
+
+test("the default core section budget is capped below the request ceiling", () => {
+  // Both settings default to 75s. Taken at face value the section deadline could
+  // never fire first, so degradation would be unreachable on default config.
+  assert.equal(
+    resolveRecallCoreSectionDeadlineMs({
+      configuredCoreDeadlineMs: 75_000,
+      outerTimeoutMs: 75_000,
+    }),
+    60_000,
+  );
+});
+
+test("an explicitly lowered core section budget is honored exactly", () => {
+  assert.equal(
+    resolveRecallCoreSectionDeadlineMs({
+      configuredCoreDeadlineMs: 5_000,
+      outerTimeoutMs: 75_000,
+    }),
+    5_000,
+  );
+});
+
+test("a zero budget on either side keeps the configured value", () => {
+  assert.equal(
+    resolveRecallCoreSectionDeadlineMs({ configuredCoreDeadlineMs: 0, outerTimeoutMs: 75_000 }),
+    0,
+  );
+  // No request ceiling means nothing to reserve headroom against.
+  assert.equal(
+    resolveRecallCoreSectionDeadlineMs({ configuredCoreDeadlineMs: 75_000, outerTimeoutMs: 0 }),
+    75_000,
+  );
 });

--- a/packages/remnic-core/src/recall-qos.test.ts
+++ b/packages/remnic-core/src/recall-qos.test.ts
@@ -237,15 +237,44 @@ test("a section rejection surfaces to the caller instead of being swallowed", as
   );
 });
 
-test("the default core section budget is capped below the request ceiling", () => {
+test("the default core section budget is capped below the remaining request budget", () => {
   // Both settings default to 75s. Taken at face value the section deadline could
   // never fire first, so degradation would be unreachable on default config.
   assert.equal(
     resolveRecallCoreSectionDeadlineMs({
       configuredCoreDeadlineMs: 75_000,
-      outerTimeoutMs: 75_000,
+      remainingOuterMs: 75_000,
     }),
     60_000,
+  );
+});
+
+test("the core section budget shrinks with the request budget already spent", () => {
+  // A section that starts 20s into a 75s request must finish inside the 55s left,
+  // not inside the original ceiling — otherwise the request is aborted wholesale.
+  assert.equal(
+    resolveRecallCoreSectionDeadlineMs({
+      configuredCoreDeadlineMs: 75_000,
+      remainingOuterMs: 55_000,
+    }),
+    44_000,
+  );
+});
+
+test("a request already over budget degrades its sections immediately", () => {
+  assert.equal(
+    resolveRecallCoreSectionDeadlineMs({
+      configuredCoreDeadlineMs: 75_000,
+      remainingOuterMs: 0,
+    }),
+    1,
+  );
+  assert.equal(
+    resolveRecallCoreSectionDeadlineMs({
+      configuredCoreDeadlineMs: 75_000,
+      remainingOuterMs: -5_000,
+    }),
+    1,
   );
 });
 
@@ -253,7 +282,7 @@ test("an explicitly lowered core section budget is honored exactly", () => {
   assert.equal(
     resolveRecallCoreSectionDeadlineMs({
       configuredCoreDeadlineMs: 5_000,
-      outerTimeoutMs: 75_000,
+      remainingOuterMs: 75_000,
     }),
     5_000,
   );
@@ -261,14 +290,31 @@ test("an explicitly lowered core section budget is honored exactly", () => {
 
 test("a zero budget on either side keeps the configured value", () => {
   assert.equal(
-    resolveRecallCoreSectionDeadlineMs({ configuredCoreDeadlineMs: 0, outerTimeoutMs: 75_000 }),
+    resolveRecallCoreSectionDeadlineMs({ configuredCoreDeadlineMs: 0, remainingOuterMs: 75_000 }),
     0,
   );
   // No request ceiling means nothing to reserve headroom against.
   assert.equal(
-    resolveRecallCoreSectionDeadlineMs({ configuredCoreDeadlineMs: 75_000, outerTimeoutMs: 0 }),
+    resolveRecallCoreSectionDeadlineMs({ configuredCoreDeadlineMs: 75_000, remainingOuterMs: null }),
     75_000,
   );
+});
+
+test("a bounded core section resolves its budget from the budget left when it starts", async () => {
+  const metrics: RecallSectionMetric[] = [];
+  const clockMs = 1_000_000;
+  const runSection = createBoundedCoreSectionRunner({
+    configuredDeadlineMs: 75_000,
+    // 75s request that started 20s ago: 55s left, so the section gets 80% of 55s.
+    outerDeadlineAtMs: clockMs + 55_000,
+    record: (metric) => metrics.push(metric),
+    logger: { warn: () => {} },
+    now: () => clockMs,
+  });
+
+  await runSection("entityRetrieval", null as string | null, async () => "section body");
+
+  assert.equal(metrics[0]?.deadlineMs, 44_000);
 });
 
 test("a bounded core section degrades on cancellation rather than rejecting", async () => {
@@ -277,7 +323,8 @@ test("a bounded core section degrades on cancellation rather than rejecting", as
   const metrics: RecallSectionMetric[] = [];
   const caller = new AbortController();
   const runSection = createBoundedCoreSectionRunner({
-    deadlineMs: 5_000,
+    configuredDeadlineMs: 5_000,
+    outerDeadlineAtMs: null,
     parentSignal: caller.signal,
     record: (metric) => metrics.push(metric),
     logger: { warn: () => {} },
@@ -297,7 +344,8 @@ test("a bounded core section degrades on cancellation rather than rejecting", as
 
 test("a bounded core section still surfaces a non-abort failure", async () => {
   const runSection = createBoundedCoreSectionRunner({
-    deadlineMs: 5_000,
+    configuredDeadlineMs: 5_000,
+    outerDeadlineAtMs: null,
     record: () => {},
     logger: { warn: () => {} },
   });

--- a/packages/remnic-core/src/recall-qos.ts
+++ b/packages/remnic-core/src/recall-qos.ts
@@ -1,5 +1,20 @@
-import { abortError } from "./abort-error.js";
+import { abortError, isAbortError } from "./abort-error.js";
 import { log, type LoggerBackend } from "./logger.js";
+
+/**
+ * Hand the event loop one macrotask.
+ *
+ * A recall section deadline is a timer, and a timer cannot fire while a
+ * synchronous scan holds the loop — so a provider that iterates the whole corpus
+ * must call this periodically or its budget is unenforceable (issue #2291).
+ * `setImmediate` (check phase) is used rather than a `0ms` timer so the yield
+ * cannot be starved by the timer queue it exists to let run.
+ */
+export function yieldToEventLoop(): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setImmediate(resolve);
+  return promise;
+}
 
 export type RecallSectionPriority = "core" | "enrichment";
 /**
@@ -207,6 +222,12 @@ export async function runRecallSectionWithinDeadline<T>(options: {
  * section as `timeout` — so a slow provider costs its own section, not the
  * response.
  *
+ * Cancellation degrades too, and must: the section signal fires on the caller's
+ * abort, and the phase this section belongs to is awaited through a race that the
+ * caller's abort also wins.  A rejection here would therefore land on a promise
+ * nobody is awaiting any more — an unhandled rejection rather than a signal.  The
+ * caller learns of its own abort from that race, not from a section result.
+ *
  * Only sections whose absence leaves recall coherent belong here: the fallback
  * IS the degraded contract.
  */
@@ -226,12 +247,29 @@ export function createBoundedCoreSectionRunner(options: {
     fallback: T,
     run: (sectionSignal: AbortSignal) => Promise<T>,
   ): Promise<T> => {
-    const outcome = await runRecallSectionWithinDeadline({
-      deadlineMs: options.deadlineMs,
-      fallback,
-      parentSignal: options.parentSignal,
-      run,
-    });
+    const startedAtMs = Date.now();
+    let outcome: RecallSectionDeadlineOutcome<T>;
+    try {
+      outcome = await runRecallSectionWithinDeadline({
+        deadlineMs: options.deadlineMs,
+        fallback,
+        parentSignal: options.parentSignal,
+        run,
+      });
+    } catch (err) {
+      if (!isAbortError(err)) throw err;
+      const durationMs = Date.now() - startedAtMs;
+      options.record({
+        section,
+        priority: "core",
+        durationMs,
+        deadlineMs: options.deadlineMs,
+        source: "skip",
+        success: false,
+        timing: `cancelled(${durationMs}ms)`,
+      });
+      return fallback;
+    }
     if (outcome.timedOut) {
       logger.warn(
         `recall section [${section}] exceeded its ${options.deadlineMs}ms core deadline ` +

--- a/packages/remnic-core/src/recall-qos.ts
+++ b/packages/remnic-core/src/recall-qos.ts
@@ -107,34 +107,48 @@ export function createRecallSectionMetricRecorder(options: {
 }
 
 /**
- * Fraction of a whole recall request that a single core section may consume.
- * The remainder is what makes degradation possible at all: time to assemble and
- * return the sections that did arrive before the outer timeout kills the request.
+ * Fraction of the request's REMAINING budget that a single core section may
+ * consume.  The remainder is what makes degradation possible at all: time to
+ * assemble and return the sections that did arrive before the outer timeout
+ * kills the request outright.
  */
 const CORE_SECTION_MAX_SHARE_OF_REQUEST = 0.8;
 
 /**
  * Effective per-section deadline for optional core recall providers.
  *
- * `recallCoreDeadlineMs` and `recallOuterTimeoutMs` both default to 75s, so a
- * section budget taken at face value can never fire before the request ceiling
- * that cancels everything — the caller loses the whole recall rather than one
- * section (issue #2291).  Capping the section at a share of the request keeps
- * graceful degradation reachable on default config, while an operator who lowers
- * `recallCoreDeadlineMs` still gets exactly what they asked for.
+ * Two things make the configured value unusable as-is (issue #2291):
  *
- * A zero/non-finite value on either side means "no bound" for that side and is
- * preserved, per the config contract that a zero budget disables the limit.
+ *  - `recallCoreDeadlineMs` and `recallOuterTimeoutMs` both default to 75s, so a
+ *    section budget taken at face value can never fire before the request ceiling
+ *    that cancels everything — the caller loses the whole recall rather than one
+ *    section.
+ *  - Sections start *after* planning, namespace resolution, and mode selection.
+ *    Capping against the original ceiling would let a section that starts 20s in
+ *    still be running when the request is aborted, which is the same failure.
+ *
+ * So the cap is taken against `remainingOuterMs` — the request budget left when
+ * the section actually starts. An operator who lowers `recallCoreDeadlineMs`
+ * below that still gets exactly what they asked for.
+ *
+ * `remainingOuterMs === null` means the request is unbounded and there is nothing
+ * to reserve headroom against. A non-positive remainder means the request is
+ * already over budget, so the section degrades immediately rather than starting
+ * work that cannot be delivered.
  */
 export function resolveRecallCoreSectionDeadlineMs(options: {
   configuredCoreDeadlineMs: number;
-  outerTimeoutMs: number;
+  remainingOuterMs: number | null;
 }): number {
   const configured = options.configuredCoreDeadlineMs;
   if (!Number.isFinite(configured) || configured <= 0) return configured;
-  const outer = options.outerTimeoutMs;
-  if (!Number.isFinite(outer) || outer <= 0) return configured;
-  return Math.min(configured, Math.floor(outer * CORE_SECTION_MAX_SHARE_OF_REQUEST));
+  const remaining = options.remainingOuterMs;
+  if (remaining === null || !Number.isFinite(remaining)) return configured;
+  if (remaining <= 0) return 1;
+  return Math.min(
+    configured,
+    Math.max(1, Math.floor(remaining * CORE_SECTION_MAX_SHARE_OF_REQUEST)),
+  );
 }
 
 export interface RecallSectionDeadlineOutcome<T> {
@@ -222,6 +236,12 @@ export async function runRecallSectionWithinDeadline<T>(options: {
  * section as `timeout` — so a slow provider costs its own section, not the
  * response.
  *
+ * The budget is resolved when each section STARTS, against the request budget
+ * still left at that moment (`outerDeadlineAtMs`), not against the original
+ * configured ceiling: sections begin after planning and namespace resolution, and
+ * a section sized to the full request would otherwise still be running when the
+ * request itself is aborted.
+ *
  * Cancellation degrades too, and must: the section signal fires on the caller's
  * abort, and the phase this section belongs to is awaited through a race that the
  * caller's abort also wins.  A rejection here would therefore land on a promise
@@ -232,38 +252,48 @@ export async function runRecallSectionWithinDeadline<T>(options: {
  * IS the degraded contract.
  */
 export function createBoundedCoreSectionRunner(options: {
-  deadlineMs: number;
+  configuredDeadlineMs: number;
+  /** Absolute time the whole request is aborted, or null when unbounded. */
+  outerDeadlineAtMs: number | null;
   parentSignal?: AbortSignal;
   record: (metric: RecallSectionMetric) => unknown;
   logger?: Pick<LoggerBackend, "warn">;
+  now?: () => number;
 }): <T>(
   section: string,
   fallback: T,
   run: (sectionSignal: AbortSignal) => Promise<T>,
 ) => Promise<T> {
   const logger = options.logger ?? log;
+  const now = options.now ?? Date.now;
   return async <T>(
     section: string,
     fallback: T,
     run: (sectionSignal: AbortSignal) => Promise<T>,
   ): Promise<T> => {
-    const startedAtMs = Date.now();
+    const startedAtMs = now();
+    const deadlineMs = resolveRecallCoreSectionDeadlineMs({
+      configuredCoreDeadlineMs: options.configuredDeadlineMs,
+      remainingOuterMs:
+        options.outerDeadlineAtMs === null ? null : options.outerDeadlineAtMs - startedAtMs,
+    });
     let outcome: RecallSectionDeadlineOutcome<T>;
     try {
       outcome = await runRecallSectionWithinDeadline({
-        deadlineMs: options.deadlineMs,
+        deadlineMs,
         fallback,
         parentSignal: options.parentSignal,
         run,
+        now,
       });
     } catch (err) {
       if (!isAbortError(err)) throw err;
-      const durationMs = Date.now() - startedAtMs;
+      const durationMs = now() - startedAtMs;
       options.record({
         section,
         priority: "core",
         durationMs,
-        deadlineMs: options.deadlineMs,
+        deadlineMs,
         source: "skip",
         success: false,
         timing: `cancelled(${durationMs}ms)`,
@@ -272,7 +302,7 @@ export function createBoundedCoreSectionRunner(options: {
     }
     if (outcome.timedOut) {
       logger.warn(
-        `recall section [${section}] exceeded its ${options.deadlineMs}ms core deadline ` +
+        `recall section [${section}] exceeded its ${deadlineMs}ms core deadline ` +
           `after ${outcome.durationMs}ms; recall continues without it`,
       );
     }
@@ -280,7 +310,7 @@ export function createBoundedCoreSectionRunner(options: {
       section,
       priority: "core",
       durationMs: outcome.durationMs,
-      deadlineMs: options.deadlineMs,
+      deadlineMs,
       source: outcome.timedOut ? "timeout" : "fresh",
       success: !outcome.timedOut,
     });

--- a/packages/remnic-core/src/recall-qos.ts
+++ b/packages/remnic-core/src/recall-qos.ts
@@ -1,7 +1,14 @@
+import { abortError } from "./abort-error.js";
 import { log, type LoggerBackend } from "./logger.js";
 
 export type RecallSectionPriority = "core" | "enrichment";
-export type RecallSectionSource = "fresh" | "stale" | "skip";
+/**
+ * `timeout` records a section that started, exceeded its deadline, and was
+ * degraded to its neutral value (issue #2291).  It is distinct from `skip`
+ * (never ran: disabled or zero-limit) so operators can tell a configuration
+ * choice from a budget breach in the section metric log.
+ */
+export type RecallSectionSource = "fresh" | "stale" | "skip" | "timeout";
 
 export interface RecallSectionMetric {
   section: string;
@@ -30,6 +37,9 @@ export interface RecallSectionMetricLog {
 function defaultTiming(metric: RecallSectionMetric): string {
   if (typeof metric.timing === "string" && metric.timing.length > 0) {
     return metric.timing;
+  }
+  if (metric.source === "timeout") {
+    return `timeout(${Math.max(0, Math.round(metric.durationMs))}ms)`;
   }
   if (metric.source === "skip") {
     return "skip";
@@ -78,5 +88,164 @@ export function createRecallSectionMetricRecorder(options: {
       }
     }
     return entry;
+  };
+}
+
+/**
+ * Fraction of a whole recall request that a single core section may consume.
+ * The remainder is what makes degradation possible at all: time to assemble and
+ * return the sections that did arrive before the outer timeout kills the request.
+ */
+const CORE_SECTION_MAX_SHARE_OF_REQUEST = 0.8;
+
+/**
+ * Effective per-section deadline for optional core recall providers.
+ *
+ * `recallCoreDeadlineMs` and `recallOuterTimeoutMs` both default to 75s, so a
+ * section budget taken at face value can never fire before the request ceiling
+ * that cancels everything — the caller loses the whole recall rather than one
+ * section (issue #2291).  Capping the section at a share of the request keeps
+ * graceful degradation reachable on default config, while an operator who lowers
+ * `recallCoreDeadlineMs` still gets exactly what they asked for.
+ *
+ * A zero/non-finite value on either side means "no bound" for that side and is
+ * preserved, per the config contract that a zero budget disables the limit.
+ */
+export function resolveRecallCoreSectionDeadlineMs(options: {
+  configuredCoreDeadlineMs: number;
+  outerTimeoutMs: number;
+}): number {
+  const configured = options.configuredCoreDeadlineMs;
+  if (!Number.isFinite(configured) || configured <= 0) return configured;
+  const outer = options.outerTimeoutMs;
+  if (!Number.isFinite(outer) || outer <= 0) return configured;
+  return Math.min(configured, Math.floor(outer * CORE_SECTION_MAX_SHARE_OF_REQUEST));
+}
+
+export interface RecallSectionDeadlineOutcome<T> {
+  /** The section's value, or `fallback` when the deadline was exceeded. */
+  value: T;
+  timedOut: boolean;
+  durationMs: number;
+}
+
+/**
+ * Run one recall section under a deadline, degrading to `fallback` instead of
+ * blocking the phase it belongs to (issue #2291).
+ *
+ * Before this existed, `deadlineMs` was recorded in the section metric but
+ * never enforced for core sections: a provider doing a multi-minute scan on a
+ * slow filesystem blocked the whole phase-one `Promise.all`, and kept scanning
+ * after the caller aborted.  Two guarantees fix that:
+ *
+ *  1. The returned promise settles within `deadlineMs`, with `timedOut: true`
+ *     and the caller's neutral value, so one slow optional provider degrades
+ *     independently rather than holding the response.
+ *  2. `run` receives a signal that fires on the deadline AND on the caller's
+ *     abort, so the section can stop its own work at its next checkpoint.
+ *
+ * `deadlineMs <= 0` (or non-finite) means unbounded, matching the config
+ * contract that a zero budget disables the limit.  The section signal is still
+ * created and still tracks the parent, so cancellation propagates either way.
+ */
+export async function runRecallSectionWithinDeadline<T>(options: {
+  deadlineMs: number;
+  fallback: T;
+  parentSignal?: AbortSignal;
+  run: (sectionSignal: AbortSignal) => Promise<T>;
+  now?: () => number;
+}): Promise<RecallSectionDeadlineOutcome<T>> {
+  const now = options.now ?? Date.now;
+  const startedAtMs = now();
+  const controller = new AbortController();
+  const parentSignal = options.parentSignal;
+  const onParentAbort = () => controller.abort();
+  if (parentSignal?.aborted) {
+    controller.abort();
+  } else if (parentSignal) {
+    parentSignal.addEventListener("abort", onParentAbort, { once: true });
+  }
+
+  const bounded = Number.isFinite(options.deadlineMs) && options.deadlineMs > 0;
+  let timer: NodeJS.Timeout | undefined;
+
+  try {
+    // Wrap in a tagged result rather than racing raw values against a sentinel:
+    // T is caller-chosen and must never be mistaken for the timeout marker.
+    const work = options.run(controller.signal).then(
+      (value) => ({ kind: "value" as const, value }),
+    );
+    if (!bounded) {
+      const settled = await work;
+      return { value: settled.value, timedOut: false, durationMs: now() - startedAtMs };
+    }
+    const deadline = Promise.withResolvers<{ kind: "timeout" }>();
+    // Deliberately NOT unref'd: the caller is awaiting this bound, so the timer
+    // must keep the loop alive until it fires or `finally` clears it.
+    timer = setTimeout(() => deadline.resolve({ kind: "timeout" }), options.deadlineMs);
+    const settled = await Promise.race([work, deadline.promise]);
+    if (settled.kind === "timeout") {
+      controller.abort(abortError("recall section deadline exceeded"));
+      // The abandoned work outlives this call; swallow its settlement so a
+      // late rejection is not reported as unhandled.
+      void work.catch(() => {});
+      return { value: options.fallback, timedOut: true, durationMs: now() - startedAtMs };
+    }
+    return { value: settled.value, timedOut: false, durationMs: now() - startedAtMs };
+  } finally {
+    clearTimeout(timer);
+    parentSignal?.removeEventListener("abort", onParentAbort);
+  }
+}
+
+/**
+ * Runs one *optional* core recall section, bounded and accounted for.
+ *
+ * Binds a section's deadline, the caller's abort signal, and the QoS recorder
+ * once so each provider is one call (issue #2291).  A breach degrades the
+ * section to `fallback`, warns with the section name and budget, and records the
+ * section as `timeout` — so a slow provider costs its own section, not the
+ * response.
+ *
+ * Only sections whose absence leaves recall coherent belong here: the fallback
+ * IS the degraded contract.
+ */
+export function createBoundedCoreSectionRunner(options: {
+  deadlineMs: number;
+  parentSignal?: AbortSignal;
+  record: (metric: RecallSectionMetric) => unknown;
+  logger?: Pick<LoggerBackend, "warn">;
+}): <T>(
+  section: string,
+  fallback: T,
+  run: (sectionSignal: AbortSignal) => Promise<T>,
+) => Promise<T> {
+  const logger = options.logger ?? log;
+  return async <T>(
+    section: string,
+    fallback: T,
+    run: (sectionSignal: AbortSignal) => Promise<T>,
+  ): Promise<T> => {
+    const outcome = await runRecallSectionWithinDeadline({
+      deadlineMs: options.deadlineMs,
+      fallback,
+      parentSignal: options.parentSignal,
+      run,
+    });
+    if (outcome.timedOut) {
+      logger.warn(
+        `recall section [${section}] exceeded its ${options.deadlineMs}ms core deadline ` +
+          `after ${outcome.durationMs}ms; recall continues without it`,
+      );
+    }
+    options.record({
+      section,
+      priority: "core",
+      durationMs: outcome.durationMs,
+      deadlineMs: options.deadlineMs,
+      source: outcome.timedOut ? "timeout" : "fresh",
+      success: !outcome.timedOut,
+    });
+    return outcome.value;
   };
 }

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -4357,7 +4357,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     options: ArtifactSearchOptions = {},
   ): Promise<MemoryFile[]> {
     return selectArtifactMatches(
-      await this.readAllArtifactsCached(),
+      () => this.readAllArtifactsCached(),
       query,
       maxResults,
       options,

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -16,6 +16,7 @@ import {
 import { appendFileSync, createReadStream, mkdirSync, readFileSync, statSync, type Dirent } from "node:fs";
 import { createHash, randomUUID } from "node:crypto";
 import { normalizeContent, computeContentHash } from "./content-hash.js";
+import { selectArtifactMatches, type ArtifactSearchOptions } from "./artifact-search.js";
 import path from "node:path";
 import { log } from "./logger.js";
 import { createMemorySnapshot } from "./memory-snapshot.js";
@@ -235,36 +236,6 @@ import {
 // stripCitation import removed: legacy rebuild fallback was replaced by a
 // skip-with-warning strategy (Finding 1 — Uhol).  See ensureFactHashIndexAuthoritative.
 
-const ARTIFACT_SEARCH_STOPWORDS = new Set([
-  "a",
-  "an",
-  "and",
-  "are",
-  "as",
-  "at",
-  "be",
-  "but",
-  "by",
-  "for",
-  "from",
-  "has",
-  "have",
-  "i",
-  "in",
-  "is",
-  "it",
-  "of",
-  "on",
-  "or",
-  "that",
-  "the",
-  "this",
-  "to",
-  "was",
-  "were",
-  "with",
-]);
-
 type SharedVersionKind = "memory-status" | "artifact-write" | "cold-write" | "memory-corpus" | "entity-mutation";
 
 type OfflineSyncDigestCacheEntry = {
@@ -321,15 +292,6 @@ export interface MemoryLifecycleEventWriteOptions {
   ruleVersion?: string;
   relatedMemoryIds?: string[];
   correlationId?: string;
-}
-
-function tokenizeArtifactSearchText(input: string): string[] {
-  return input
-    .toLowerCase()
-    .split(/[^a-z0-9]+/i)
-    .map((t) => t.trim())
-    .filter((t) => t.length >= 2)
-    .filter((t) => !ARTIFACT_SEARCH_STOPWORDS.has(t));
 }
 
 /**
@@ -4389,23 +4351,17 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     return this.memoryReadStore.readAllArtifactsCached();
   }
 
-  async searchArtifacts(query: string, maxResults: number): Promise<MemoryFile[]> {
-    const tokens = tokenizeArtifactSearchText(query);
-    if (tokens.length === 0) return [];
-
-    const artifacts = await this.readAllArtifactsCached();
-    const hits: Array<{ score: number; memory: MemoryFile }> = [];
-    for (const memory of artifacts) {
-      const indexedTokens = new Set(
-        tokenizeArtifactSearchText(`${memory.content} ${(memory.frontmatter.tags ?? []).join(" ")}`)
-      );
-      const score = tokens.reduce((sum, t) => sum + (indexedTokens.has(t) ? 1 : 0), 0);
-      if (score > 0) {
-        hits.push({ score, memory });
-      }
-    }
-    hits.sort((a, b) => b.score - a.score);
-    return hits.slice(0, maxResults).map((h) => h.memory);
+  async searchArtifacts(
+    query: string,
+    maxResults: number,
+    options: ArtifactSearchOptions = {},
+  ): Promise<MemoryFile[]> {
+    return selectArtifactMatches(
+      await this.readAllArtifactsCached(),
+      query,
+      maxResults,
+      options,
+    );
   }
 
   async writeEntity(

--- a/scripts/config-contract/grandfathered.json
+++ b/scripts/config-contract/grandfathered.json
@@ -1331,22 +1331,12 @@
   },
   {
     "kind": "undocumented-key",
-    "key": "recallCoreDeadlineMs",
-    "issue": "#1990"
-  },
-  {
-    "kind": "undocumented-key",
     "key": "recallDisclosureEscalation",
     "issue": "#1990"
   },
   {
     "kind": "undocumented-key",
     "key": "recallDisclosureEscalationThreshold",
-    "issue": "#1990"
-  },
-  {
-    "kind": "undocumented-key",
-    "key": "recallEnrichmentDeadlineMs",
     "issue": "#1990"
   },
   {
@@ -1402,11 +1392,6 @@
   {
     "kind": "undocumented-key",
     "key": "recallMmrTopN",
-    "issue": "#1990"
-  },
-  {
-    "kind": "undocumented-key",
-    "key": "recallOuterTimeoutMs",
     "issue": "#1990"
   },
   {

--- a/tests/entity-retrieval.test.ts
+++ b/tests/entity-retrieval.test.ts
@@ -2458,3 +2458,40 @@ test("entity recall completes normally when its abort signal never fires", async
 
   assert.match(section ?? "", /Signal Person/);
 });
+
+test("entity recall reports mid-build cancellation as an abort, not an empty section", async () => {
+  const { config, storage } = await buildHarness("engram-entity-midbuild-abort");
+  await writeEntity(
+    storage,
+    "Midbuild Person",
+    "person",
+    ["Midbuild Person owns the mid-build cancellation test."],
+    "Midbuild Person exists only to verify cancellation accounting.",
+  );
+
+  // Abort while the build is reading, i.e. exactly when a section deadline would
+  // fire. Returning null here would be recorded as a successful empty section and
+  // would hide the breach (issue #2291).
+  const aborted = new AbortController();
+  const readAllEntityFiles = storage.readAllEntityFiles.bind(storage);
+  storage.readAllEntityFiles = async () => {
+    aborted.abort();
+    return readAllEntityFiles();
+  };
+
+  await assert.rejects(
+    buildEntityRecallSection({
+      config,
+      storage,
+      query: "Who is Midbuild Person?",
+      recentTurns: 6,
+      maxHints: 2,
+      maxSupportingFacts: 6,
+      maxRelatedEntities: 3,
+      maxChars: 2400,
+      transcriptEntries: [],
+      abortSignal: aborted.signal,
+    }),
+    (err: unknown) => err instanceof Error && err.name === "AbortError",
+  );
+});

--- a/tests/entity-retrieval.test.ts
+++ b/tests/entity-retrieval.test.ts
@@ -2392,3 +2392,69 @@ test("orchestrator preserves zero-limit semantics for entity retrieval", async (
   assert.equal(context.includes("## entity_answer_hints"), false);
   assert.equal(context.includes("## Knowledge Index"), true);
 });
+
+test("entity recall stops at its first checkpoint when the caller has already aborted", async () => {
+  const { config, storage } = await buildHarness("engram-entity-preaborted");
+  await writeEntity(
+    storage,
+    "Aborted Person",
+    "person",
+    ["Aborted Person owns the cancellation test."],
+    "Aborted Person exists only to verify cancellation.",
+  );
+
+  // The scans below read every entity and memory file for the recalled
+  // namespaces (issue #2291): an already-abandoned recall must not start them.
+  let entityFileReads = 0;
+  const readAllEntityFiles = storage.readAllEntityFiles.bind(storage);
+  storage.readAllEntityFiles = async () => {
+    entityFileReads += 1;
+    return readAllEntityFiles();
+  };
+
+  const aborted = new AbortController();
+  aborted.abort();
+
+  await assert.rejects(
+    buildEntityRecallSection({
+      config,
+      storage,
+      query: "Who is Aborted Person?",
+      recentTurns: 6,
+      maxHints: 2,
+      maxSupportingFacts: 6,
+      maxRelatedEntities: 3,
+      maxChars: 2400,
+      transcriptEntries: [],
+      abortSignal: aborted.signal,
+    }),
+    (err: unknown) => err instanceof Error && err.name === "AbortError",
+  );
+  assert.equal(entityFileReads, 0);
+});
+
+test("entity recall completes normally when its abort signal never fires", async () => {
+  const { config, storage } = await buildHarness("engram-entity-signal-passthrough");
+  await writeEntity(
+    storage,
+    "Signal Person",
+    "person",
+    ["Signal Person owns the passthrough test."],
+    "Signal Person exists only to verify the signal is inert when unfired.",
+  );
+
+  const section = await buildEntityRecallSection({
+    config,
+    storage,
+    query: "Who is Signal Person?",
+    recentTurns: 6,
+    maxHints: 2,
+    maxSupportingFacts: 6,
+    maxRelatedEntities: 3,
+    maxChars: 2400,
+    transcriptEntries: [],
+    abortSignal: new AbortController().signal,
+  });
+
+  assert.match(section ?? "", /Signal Person/);
+});

--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -1506,3 +1506,88 @@ test("assembleRecallSections reserves a memory that fits its section cap without
   assert.deepEqual(assembled.includedMemoryPaths, ["facts/section-fit.md"]);
   assert.ok(assembled.finalChars <= 50);
 });
+
+function captureRecallTimings(
+  orchestrator: Orchestrator,
+): () => Record<string, string> {
+  let captured: Record<string, string> = {};
+  (orchestrator as any).emitTrace = (event: { kind: string; timings?: Record<string, string> }) => {
+    if (event.kind === "recall_summary" && event.timings) captured = event.timings;
+  };
+  return () => captured;
+}
+
+test("a stalled artifact provider degrades at the core deadline instead of holding recall", async () => {
+  const orchestrator = await makeOrchestrator("engram-recall-artifact-deadline-", {
+    verbatimArtifactsEnabled: true,
+    // A real timer, not a guessed wait: the stub below never settles on its own,
+    // so the deadline decides this test regardless of machine load.
+    recallCoreDeadlineMs: 25,
+  });
+  const recallTimings = captureRecallTimings(orchestrator);
+  (orchestrator as any).isRecallSectionEnabled = (id: string) =>
+    id === "verbatim-artifacts" || id === "memories";
+
+  let sectionSignal: AbortSignal | undefined;
+  let cancelledDuringScan = false;
+  (orchestrator as any).recallArtifactsAcrossNamespaces = async (
+    _prompt: string,
+    _namespaces: string[],
+    _targetCount: number,
+    options?: { abortSignal?: AbortSignal },
+  ) => {
+    sectionSignal = options?.abortSignal;
+    const cancelled = Promise.withResolvers<void>();
+    options?.abortSignal?.addEventListener("abort", () => {
+      cancelledDuringScan = true;
+      cancelled.resolve();
+    });
+    await cancelled.promise;
+    return [];
+  };
+
+  const context = await (orchestrator as any).recallInternal(
+    "which artifacts mention the deploy runbook?",
+    "agent:test:artifact-deadline",
+    { mode: "full" },
+  );
+
+  // The contract: recall returned at all, and the slow provider was told to stop.
+  assert.equal(typeof context, "string");
+  assert.ok(sectionSignal, "the artifact scan received a cancellation signal");
+  assert.equal(cancelledDuringScan, true);
+  assert.match(recallTimings().artifacts ?? "", /^timeout\(\d+ms\)$/);
+});
+
+test("a stalled entity provider degrades at the core deadline instead of holding recall", async () => {
+  const orchestrator = await makeOrchestrator("engram-recall-entity-deadline-", {
+    entityRetrievalEnabled: true,
+    recallCoreDeadlineMs: 25,
+  });
+  const recallTimings = captureRecallTimings(orchestrator);
+  (orchestrator as any).isRecallSectionEnabled = (id: string) =>
+    id === "entity-retrieval";
+
+  const scanStarted = Promise.withResolvers<void>();
+  // Stall the entity section's first read. On a large or slow memory tree the
+  // scans it fans out to take minutes; here one never returns, so only the
+  // deadline can release the response — the guarantee issue #2291 asked for.
+  (orchestrator as any).transcript = {
+    readRecent: async () => {
+      scanStarted.resolve();
+      await Promise.withResolvers<void>().promise;
+      return [];
+    },
+  };
+
+  const recallPromise = (orchestrator as any).recallInternal(
+    "what do we know about the deploy runbook?",
+    "agent:test:entity-deadline",
+    { mode: "full" },
+  );
+  await scanStarted.promise;
+
+  const context = await recallPromise;
+  assert.equal(typeof context, "string");
+  assert.match(recallTimings().entityRetrieval ?? "", /^timeout\(\d+ms\)$/);
+});


### PR DESCRIPTION
Fixes #2291.

## Still reproducible on main

`recallCoreDeadlineMs` was recorded in every core section metric and **never
enforced**. `entity-retrieval` and `verbatim-artifacts` scan the memory tree
across the recalled namespaces (`readAllEntityFiles` / `readAllMemories`, and up
to four growing `searchArtifacts` passes plus an artifact-source snapshot
rebuild), and neither received an `AbortSignal`. So on a large or slow store one
provider blocked the whole phase-one `Promise.all`, and kept scanning after the
caller had already given up.

## What changed

- **`runRecallSectionWithinDeadline`** (`recall-qos.ts`) races a section against
  its budget: on breach it returns the caller's neutral value with
  `timedOut: true` and aborts a child signal so the section can stop. `0`
  disables the bound, per the config contract.
- **`createBoundedCoreSectionRunner`** binds budget + caller signal + QoS
  recorder once, so each provider is one call. A breach logs a warning naming the
  section and the budget, and records the section under a new `timeout`
  `RecallSectionSource` — distinct from `skip` (never ran), so operators can tell
  a config choice from a budget breach.
- **`resolveRecallCoreSectionDeadlineMs`** caps a section at 80% of
  `recallOuterTimeoutMs`. This is the part that makes the fix work out of the
  box: both settings default to 75s, so an uncapped section budget can never fire
  before the request ceiling that cancels *everything* — the caller would still
  lose the whole recall. An explicitly lowered `recallCoreDeadlineMs` is honored
  exactly.
- **Cancellation threading**: the section signal now reaches
  `buildEntityRecallSection` (checked at its real I/O boundaries — persisted-index
  read, native-chunk read, storage resolution, index build) and
  `recallArtifactsAcrossNamespaces` → `fetchActiveArtifactsForNamespace` (checked
  per retry attempt and before the artifact-source snapshot rebuild).

## Deliberate limits

Checkpoints sit only where the event loop actually turns. The per-entity and
per-artifact loops are synchronous, so a `throwIfAborted` inside them could never
observe a timer that fires later — adding one there would be theater, so none was
added. A single in-flight bulk read (`readAllMemories`, `readAllArtifactsCached`)
still runs to completion; interrupting those needs a signal threaded to the
lowest-level fs reads, which is a separate change. The user-visible guarantee —
recall returns at the deadline with the section dropped — does not depend on it.

## Verification

- `packages/remnic-core/src/recall-qos.test.ts` — 12 pass. Deadline degradation +
  section cancellation, in-time passthrough, zero-deadline disables the bound
  (proved across two event-loop turns, no wall-clock sleep), caller-abort
  propagation, pre-aborted caller, section rejection still surfaces, the 80% cap.
- `tests/recall-hardening.test.ts` — 36 pass, including two new end-to-end tests:
  a stalled artifact provider and a stalled entity provider each degrade at the
  deadline while recall still returns, with `timeout(<ms>)` in the recall timings.
- `tests/entity-retrieval.test.ts` — 64 pass, including a pre-aborted signal
  rejecting before any entity file is read, and an unfired signal being inert.
- `npm run test:entity-hardening` — 338 pass.
- `npm run check-types` (root + all packages), `npm run lint`,
  `npm run check-config-contract`, `check-review-patterns`, `check-ratchets`,
  `check-docs-parity`, `check-dataset-hygiene`, `check-envelope-belt`,
  `plugin:inspect`, `pr-preflight-paths` — all pass.

No file grew past its ratchet ceiling: the bounded-section runner lives in
`recall-qos.ts` rather than inline in `recall-internal.ts`, and documenting the
three recall budget settings let three stale `undocumented-key` grandfather
entries be pruned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot recall path and timeout semantics for two core optional providers; behavior is degrade-in-place rather than fail-closed, but mis-tuned deadlines could silently omit entity/artifact context in production.
> 
> **Overview**
> Optional phase-one recall sections **entity-retrieval** and **verbatim-artifacts** are now run through a bounded core-section runner that actually enforces `recallCoreDeadlineMs` (and caller abort), instead of only logging the budget in metrics.
> 
> On breach the section is dropped (null / empty artifacts), recall continues, metrics record **`timeout(<ms>)`**, and a child **`AbortSignal`** propagates into entity index builds, artifact fetch retries, and interruptible keyword scans (with periodic event-loop yields so timers can fire). **`resolveRecallCoreSectionDeadlineMs`** caps each section at **80% of remaining `recallOuterTimeoutMs`** when the outer request is bounded, so default 75s/75s configs still allow degradation before the whole recall is killed.
> 
> Artifact matching logic moves to **`artifact-search.ts`**; entity recall gains shared cancellation helpers. Config reference documents **`recallCoreDeadlineMs`**, **`recallEnrichmentDeadlineMs`**, and **`recallOuterTimeoutMs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49551ec2a308e75aa543b9b6516015dfa6356df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable deadlines for core recall sections, enrichment, and overall recall requests.
  * Recall now cancels stalled work, returns available partial results, and reports timeout metrics.
  * Improved artifact search with ranked, capped, and interruptible matching.

* **Documentation**
  * Documented timeout settings, deadline calculation, fallback behavior, and metrics.

* **Bug Fixes**
  * Prevented slow entity and artifact retrieval from blocking completed recall responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->