### PR TITLE
fix(storage): thread cancellation into the shared full-corpus read primitives

### DIFF
--- a/.changeset/2307-cancellable-corpus-reads.md
+++ b/.changeset/2307-cancellable-corpus-reads.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Thread cancellation into the shared full-corpus read primitives. `readAllMemories`, `readAllEntityFiles`, `readAllArtifactsCached`, and the artifact source-status snapshot now accept an optional `abortSignal` and stop at their directory, batch, and attempt boundaries, so an abandoned or timed-out recall no longer leaves a whole-tree scan running. A cancelled read never publishes a partial corpus to any cache, and a coalesced `readAllMemories` scan is protected once a second reader joins it (issue #2307).

--- a/packages/remnic-core/src/corpus-read-cancellation.ts
+++ b/packages/remnic-core/src/corpus-read-cancellation.ts
@@ -1,0 +1,42 @@
+/**
+ * Cancellation contract for the shared full-corpus read primitives (issue #2307).
+ *
+ * `readAllArtifactsCached`, `readAllEntityFiles`, `readAllMemories`, and the
+ * artifact source-status snapshot each walk and parse an entire memory tree. Issue
+ * #2291 bounded the recall providers that call them, so a timed-out recall returns
+ * on time — but the scan underneath kept running, and for the primitives without
+ * in-flight coalescing every abandoned request started another one. On a large or
+ * network-mounted store those pile up into sustained I/O no live request needs.
+ *
+ * The mechanism is a plain optional parameter, not ambient async context: these
+ * primitives have dozens of callers across extraction, maintenance, wearables, and
+ * coding surfaces, and an ambient signal would silently attach a request's
+ * cancellation to background work that merely shares its async context. An
+ * explicit parameter is greppable, and a caller that does not opt in behaves
+ * exactly as before.
+ *
+ * Two invariants bind every implementation:
+ *
+ *  1. **Checked before the cache lookup.** A caller that has already given up gets
+ *     an `AbortError`, warm cache or not — the same contract the recall providers
+ *     follow, so cancellation never depends on cache state.
+ *  2. **A cancelled read never publishes.** Every checkpoint throws, so control
+ *     leaves before the cache write. A partial corpus must never be cached, or
+ *     served, as if it were complete.
+ */
+
+import { throwIfAborted } from "./abort-error.js";
+
+export interface CorpusReadOptions {
+  /**
+   * Stops the read at its next directory, batch, or attempt boundary. A single
+   * in-flight file read is not interrupted; the boundaries are what bound the
+   * work, and on a tree large enough to matter there are thousands of them.
+   */
+  abortSignal?: AbortSignal;
+}
+
+/** Stop a corpus read at a scan boundary when its caller has given up. */
+export function checkCorpusReadAbort(options?: CorpusReadOptions): void {
+  throwIfAborted(options?.abortSignal, "corpus read aborted");
+}

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -550,12 +550,12 @@ async function buildEntityMentionIndex(
   const entityStatusVersionBefore = shouldPersistIndex ? storage.getMemoryStatusVersion() : undefined;
   const [previousIndex, entityFileSets, memorySets, nativeChunks] = await Promise.all([
     shouldPersistIndex ? readEntityIndexState(storage) : Promise.resolve(null),
-    Promise.all(storages.map((scopedStorage) => scopedStorage.readAllEntityFiles())),
-    Promise.all(storages.map((scopedStorage) => scopedStorage.readAllMemories())),
+    Promise.all(storages.map((scopedStorage) => scopedStorage.readAllEntityFiles({ abortSignal }))),
+    Promise.all(storages.map((scopedStorage) => scopedStorage.readAllMemories({ abortSignal }))),
     nativeChunksOverride ? Promise.resolve(nativeChunksOverride) : readNativeChunks(config, recallNamespaces),
   ]);
-  // The bulk reads above cannot be interrupted mid-flight; stop before spending
-  // the (larger) indexing pass over their results.
+  // The bulk reads now stop at their own scan boundaries (issue #2307); this
+  // checkpoint still guards the (larger) indexing pass over their results.
   checkEntityRecallAbort(abortSignal);
   // Pair each entity with the storage that owns it (#1534): canonical ids must
   // reflect that store's aliases and historical migration mappings, never another

--- a/packages/remnic-core/src/in-flight-reads.ts
+++ b/packages/remnic-core/src/in-flight-reads.ts
@@ -68,6 +68,57 @@ export function deleteInFlightRead(
   }
 }
 
+export interface CoalescedScanCancellation {
+  /** The signal the shared scan itself observes. */
+  readonly scanSignal: AbortSignal;
+  /** Publish the scan to the registry and arm sole-waiter cancellation. */
+  arm(read: Promise<MemoryFile[]>): void;
+  /** Stop tracking the caller's signal (scan settled, or a joiner adopted it). */
+  detach(): void;
+}
+
+/**
+ * Cancellation lifecycle for a coalesced corpus scan (issue #2307).
+ *
+ * Lives beside the registry because the two are one mechanism: whether a scan may
+ * be cancelled depends entirely on whether anyone else has attached to it.
+ *
+ *  - The starter's signal may cancel the scan, because it is the only waiter.
+ *  - `getInFlightRead` calls `detachCancellation` the instant a second reader
+ *    joins, so the scan becomes uncancellable rather than refcounted. The failure
+ *    mode is a scan that outlives its starter, never a joiner holding a cancelled
+ *    read.
+ *  - On the starter's abort the slot is withdrawn BEFORE the controller fires, so
+ *    a reader arriving later cannot attach to a promise already doomed to reject
+ *    with someone else's `AbortError`; it starts a fresh scan instead.
+ */
+export function beginCoalescedScan(
+  baseDir: string,
+  keyId: string,
+  callerSignal?: AbortSignal,
+): CoalescedScanCancellation {
+  const controller = new AbortController();
+  let detached = false;
+  let onCallerAbort = () => {};
+  const detach = () => {
+    if (detached) return;
+    detached = true;
+    callerSignal?.removeEventListener("abort", onCallerAbort);
+  };
+  return {
+    scanSignal: controller.signal,
+    arm(read: Promise<MemoryFile[]>): void {
+      setInFlightRead(baseDir, keyId, read, detach);
+      onCallerAbort = () => {
+        deleteInFlightRead(baseDir, keyId, read);
+        controller.abort();
+      };
+      callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
+    },
+    detach,
+  };
+}
+
 /**
  * Drop EVERY in-flight slot for `baseDir` across all secure-store identities.
  * Used by mutations / invalidation / out-of-band corpus bumps: after the corpus

--- a/packages/remnic-core/src/in-flight-reads.ts
+++ b/packages/remnic-core/src/in-flight-reads.ts
@@ -129,6 +129,22 @@ export function beginCoalescedScan(
 }
 
 /**
+ * Register a scan promise directly, with no cancellation attached.
+ *
+ * For callers that own a promise rather than a scan they can abort — tests that
+ * seed a stale in-flight read, and any future producer outside `beginCoalescedScan`.
+ * The entry has no `cancel`, so waiters leaving is a no-op: an externally-owned
+ * promise is not this module's to abort.
+ */
+export function setInFlightRead(
+  baseDir: string,
+  keyId: string,
+  read: Promise<MemoryFile[]>,
+): void {
+  inFlightReadsByKey.set(composeKey(baseDir, keyId), { read, waiters: 1 });
+}
+
+/**
  * Delete the in-flight slot for one (baseDir, keyId). When `expected` is given,
  * only deletes if the slot still holds that exact promise (owner-only clear).
  */

--- a/packages/remnic-core/src/in-flight-reads.ts
+++ b/packages/remnic-core/src/in-flight-reads.ts
@@ -14,18 +14,17 @@ import type { MemoryFile } from "./types.js";
  * an unlocked manager's decrypted scan must NOT be handed to a locked or
  * differently-keyed manager for the same dir — that would bypass the keyId
  * isolation getCachedMemories enforces. Locked/plaintext stores use keyId "".
+ *
+ * Since issue #2307 the registry also owns the scan's CANCELLATION, because
+ * whether a shared scan may be cancelled is purely a question of who is still
+ * attached to it — see `beginCoalescedScan`.
  */
 type InFlightEntry = {
   read: Promise<MemoryFile[]>;
-  /**
-   * Detaches the starter's cancellation from the shared scan (issue #2307).
-   * Called the first time another reader joins: nobody may cancel a scan someone
-   * else is still waiting for, so the scan becomes uncancellable rather than
-   * being refcounted. One boolean's worth of state, and it only ever moves one
-   * way — the failure mode is a scan that outlives its starter, never a joiner
-   * left with a cancelled read.
-   */
-  detachCancellation?: () => void;
+  /** Readers still awaiting this scan. At zero the scan has no reason to finish. */
+  waiters: number;
+  /** Withdraw the slot and abort the scan. Absent for an uncancellable scan. */
+  cancel?: () => void;
 };
 
 const inFlightReadsByKey = new Map<string, InFlightEntry>();
@@ -36,21 +35,97 @@ function composeKey(baseDir: string, keyId: string): string {
   return `${baseDir}${DIR_SEP}${keyId}`;
 }
 
-export function getInFlightRead(baseDir: string, keyId = ""): Promise<MemoryFile[]> | undefined {
-  const entry = inFlightReadsByKey.get(composeKey(baseDir, keyId));
-  if (entry === undefined) return undefined;
-  entry.detachCancellation?.();
-  entry.detachCancellation = undefined;
-  return entry.read;
+/**
+ * A reader's attachment to a shared scan. `leave()` is idempotent per reader and
+ * must be called when that reader stops waiting — because its own signal fired, or
+ * because the scan settled.
+ */
+export interface CoalescedScanWaiter {
+  leave(): void;
 }
 
-export function setInFlightRead(
+/**
+ * Cancellation lifecycle for a coalesced corpus scan (issue #2307).
+ *
+ * The rule is reference counting, not ownership: **the scan is cancelled when its
+ * LAST waiter leaves, and never before.** One reader can therefore not cancel work
+ * another still needs, and two readers that both give up do not leave a full disk
+ * scan running for nobody — which was the abandoned I/O this whole change exists to
+ * remove.
+ *
+ * On the last leave the slot is withdrawn from the registry BEFORE the controller
+ * fires, so a reader arriving later cannot attach to a promise already doomed to
+ * reject with an `AbortError` it never asked for; it starts a fresh scan instead.
+ */
+export interface CoalescedScan extends CoalescedScanWaiter {
+  /** The signal the shared scan itself observes. */
+  readonly scanSignal: AbortSignal;
+  /** Publish the scan to the registry and arm cancellation. */
+  arm(read: Promise<MemoryFile[]>): void;
+}
+
+/** Build the per-reader `leave` closure: decrement once, cancel at zero. */
+function trackWaiter(entry: InFlightEntry, callerSignal?: AbortSignal): CoalescedScanWaiter {
+  let left = false;
+  const leave = () => {
+    if (left) return;
+    left = true;
+    callerSignal?.removeEventListener("abort", onAbort);
+    entry.waiters -= 1;
+    if (entry.waiters <= 0) entry.cancel?.();
+  };
+  // Named so the listener can be removed again; `once` alone would leak the
+  // reference for a reader that leaves normally.
+  function onAbort() {
+    leave();
+  }
+  callerSignal?.addEventListener("abort", onAbort, { once: true });
+  return { leave };
+}
+
+/**
+ * Attach to an existing scan for (baseDir, keyId), or `undefined` when none is in
+ * flight. The caller MUST `leave()` once it stops awaiting the returned promise.
+ */
+export function attachInFlightReader(
+  baseDir: string,
+  keyId = "",
+  callerSignal?: AbortSignal,
+): { read: Promise<MemoryFile[]>; waiter: CoalescedScanWaiter } | undefined {
+  const entry = inFlightReadsByKey.get(composeKey(baseDir, keyId));
+  if (entry === undefined) return undefined;
+  entry.waiters += 1;
+  return { read: entry.read, waiter: trackWaiter(entry, callerSignal) };
+}
+
+/** Start a cancellable coalesced scan as its first waiter. */
+export function beginCoalescedScan(
   baseDir: string,
   keyId: string,
-  read: Promise<MemoryFile[]>,
-  detachCancellation?: () => void,
-): void {
-  inFlightReadsByKey.set(composeKey(baseDir, keyId), { read, detachCancellation });
+  callerSignal?: AbortSignal,
+): CoalescedScan {
+  const controller = new AbortController();
+  let waiter: CoalescedScanWaiter | undefined;
+  return {
+    scanSignal: controller.signal,
+    arm(read: Promise<MemoryFile[]>): void {
+      // `waiters: 1` IS the starter; trackWaiter only builds its leave closure
+      // (attaching readers do their own increment).
+      const entry: InFlightEntry = {
+        read,
+        waiters: 1,
+        cancel: () => {
+          deleteInFlightRead(baseDir, keyId, read);
+          controller.abort();
+        },
+      };
+      inFlightReadsByKey.set(composeKey(baseDir, keyId), entry);
+      waiter = trackWaiter(entry, callerSignal);
+    },
+    leave(): void {
+      waiter?.leave();
+    },
+  };
 }
 
 /**
@@ -66,57 +141,6 @@ export function deleteInFlightRead(
   if (expected === undefined || inFlightReadsByKey.get(key)?.read === expected) {
     inFlightReadsByKey.delete(key);
   }
-}
-
-export interface CoalescedScanCancellation {
-  /** The signal the shared scan itself observes. */
-  readonly scanSignal: AbortSignal;
-  /** Publish the scan to the registry and arm sole-waiter cancellation. */
-  arm(read: Promise<MemoryFile[]>): void;
-  /** Stop tracking the caller's signal (scan settled, or a joiner adopted it). */
-  detach(): void;
-}
-
-/**
- * Cancellation lifecycle for a coalesced corpus scan (issue #2307).
- *
- * Lives beside the registry because the two are one mechanism: whether a scan may
- * be cancelled depends entirely on whether anyone else has attached to it.
- *
- *  - The starter's signal may cancel the scan, because it is the only waiter.
- *  - `getInFlightRead` calls `detachCancellation` the instant a second reader
- *    joins, so the scan becomes uncancellable rather than refcounted. The failure
- *    mode is a scan that outlives its starter, never a joiner holding a cancelled
- *    read.
- *  - On the starter's abort the slot is withdrawn BEFORE the controller fires, so
- *    a reader arriving later cannot attach to a promise already doomed to reject
- *    with someone else's `AbortError`; it starts a fresh scan instead.
- */
-export function beginCoalescedScan(
-  baseDir: string,
-  keyId: string,
-  callerSignal?: AbortSignal,
-): CoalescedScanCancellation {
-  const controller = new AbortController();
-  let detached = false;
-  let onCallerAbort = () => {};
-  const detach = () => {
-    if (detached) return;
-    detached = true;
-    callerSignal?.removeEventListener("abort", onCallerAbort);
-  };
-  return {
-    scanSignal: controller.signal,
-    arm(read: Promise<MemoryFile[]>): void {
-      setInFlightRead(baseDir, keyId, read, detach);
-      onCallerAbort = () => {
-        deleteInFlightRead(baseDir, keyId, read);
-        controller.abort();
-      };
-      callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
-    },
-    detach,
-  };
 }
 
 /**

--- a/packages/remnic-core/src/in-flight-reads.ts
+++ b/packages/remnic-core/src/in-flight-reads.ts
@@ -15,7 +15,20 @@ import type { MemoryFile } from "./types.js";
  * differently-keyed manager for the same dir — that would bypass the keyId
  * isolation getCachedMemories enforces. Locked/plaintext stores use keyId "".
  */
-const inFlightReadsByKey = new Map<string, Promise<MemoryFile[]>>();
+type InFlightEntry = {
+  read: Promise<MemoryFile[]>;
+  /**
+   * Detaches the starter's cancellation from the shared scan (issue #2307).
+   * Called the first time another reader joins: nobody may cancel a scan someone
+   * else is still waiting for, so the scan becomes uncancellable rather than
+   * being refcounted. One boolean's worth of state, and it only ever moves one
+   * way — the failure mode is a scan that outlives its starter, never a joiner
+   * left with a cancelled read.
+   */
+  detachCancellation?: () => void;
+};
+
+const inFlightReadsByKey = new Map<string, InFlightEntry>();
 
 const DIR_SEP = "\u0000";
 
@@ -24,11 +37,20 @@ function composeKey(baseDir: string, keyId: string): string {
 }
 
 export function getInFlightRead(baseDir: string, keyId = ""): Promise<MemoryFile[]> | undefined {
-  return inFlightReadsByKey.get(composeKey(baseDir, keyId));
+  const entry = inFlightReadsByKey.get(composeKey(baseDir, keyId));
+  if (entry === undefined) return undefined;
+  entry.detachCancellation?.();
+  entry.detachCancellation = undefined;
+  return entry.read;
 }
 
-export function setInFlightRead(baseDir: string, keyId: string, read: Promise<MemoryFile[]>): void {
-  inFlightReadsByKey.set(composeKey(baseDir, keyId), read);
+export function setInFlightRead(
+  baseDir: string,
+  keyId: string,
+  read: Promise<MemoryFile[]>,
+  detachCancellation?: () => void,
+): void {
+  inFlightReadsByKey.set(composeKey(baseDir, keyId), { read, detachCancellation });
 }
 
 /**
@@ -41,7 +63,7 @@ export function deleteInFlightRead(
   expected?: Promise<MemoryFile[]>,
 ): void {
   const key = composeKey(baseDir, keyId);
-  if (expected === undefined || inFlightReadsByKey.get(key) === expected) {
+  if (expected === undefined || inFlightReadsByKey.get(key)?.read === expected) {
     inFlightReadsByKey.delete(key);
   }
 }

--- a/packages/remnic-core/src/orchestration/namespace-read-fanout.ts
+++ b/packages/remnic-core/src/orchestration/namespace-read-fanout.ts
@@ -274,6 +274,10 @@ export class NamespaceReadFanoutCoordinator {
         checkCorpusReadAbort(options);
         const versionBefore = storage.getMemoryStatusVersion();
         const allMemories = await storage.readAllMemories(options);
+        // An abort landing between the read and the publish below would otherwise
+        // cache and return a snapshot to a caller that had already cancelled
+        // (issue #2307 review).
+        checkCorpusReadAbort(options);
         const versionAfter = storage.getMemoryStatusVersion();
         latestVersionAfter = versionAfter;
         latestStatuses = new Map(
@@ -473,12 +477,13 @@ export class NamespaceReadFanoutCoordinator {
 
   async readAllMemoriesForNamespaces(
     namespaces: string[],
+    options?: CorpusReadOptions,
   ): Promise<MemoryFile[]> {
     const uniq = Array.from(new Set(namespaces.filter(Boolean)));
     const lists = await Promise.all(
       uniq.map(async (ns) => {
         const sm = await this.deps.storageRouter.storageFor(ns);
-        return sm.readAllMemories();
+        return sm.readAllMemories(options);
       }),
     );
     return lists.flat();

--- a/packages/remnic-core/src/orchestration/namespace-read-fanout.ts
+++ b/packages/remnic-core/src/orchestration/namespace-read-fanout.ts
@@ -27,6 +27,7 @@ import { mergeArtifactRecallCandidates, tokenizeRecallQuery } from "./orchestrat
 import { qmdCollectionPathParts } from "./qmd-result-resolver.js";
 import { qmdCollectionNamespaceFromPrefix as computeQmdCollectionNamespaceFromPrefix } from "./orchestrator-namespace-scope.js";
 import { resolveNamespaceFromStorageDir } from "../scopes/scope-plan.js";
+import { checkCorpusReadAbort, type CorpusReadOptions } from "../corpus-read-cancellation.js";
 import type { ArtifactRecallOptions } from "./recall-search-prefilter.js";
 import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions } from "../search/port.js";
 import type { MemoryFile, PluginConfig, QmdSearchResult } from "../types.js";
@@ -247,7 +248,9 @@ export class NamespaceReadFanoutCoordinator {
   async resolveArtifactSourceStatuses(
     storage: StorageManager,
     sourceIds: string[],
+    options?: CorpusReadOptions,
   ): Promise<Map<string, "active" | "superseded" | "archived" | "missing">> {
+    checkCorpusReadAbort(options);
     const currentStatusVersion = storage.getMemoryStatusVersion();
     const cached = this.deps.artifactSourceStatusCache.get(storage);
     let snapshot = cached;
@@ -266,8 +269,11 @@ export class NamespaceReadFanoutCoordinator {
       let latestVersionAfter = storage.getMemoryStatusVersion();
 
       for (let attempt = 0; attempt < MAX_STABLE_READ_ATTEMPTS; attempt += 1) {
+        // Each attempt is a full corpus read; an abandoned caller must not buy a
+        // second or third one (issue #2307).
+        checkCorpusReadAbort(options);
         const versionBefore = storage.getMemoryStatusVersion();
-        const allMemories = await storage.readAllMemories();
+        const allMemories = await storage.readAllMemories(options);
         const versionAfter = storage.getMemoryStatusVersion();
         latestVersionAfter = versionAfter;
         latestStatuses = new Map(

--- a/packages/remnic-core/src/orchestration/recall-internal-deps.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal-deps.ts
@@ -17,6 +17,7 @@ import type { NamespaceCatalog } from "../namespaces/catalog.js";
 import type { NamespaceStorageRouter } from "../namespaces/storage.js";
 import type { ObjectiveStateSearchResult } from "../objective-state.js";
 import type { IntentDebugSnapshot, QmdRecallSnapshot, QueryAwarePrefilter } from "../orchestrator.js";
+import type { CorpusReadOptions } from "../corpus-read-cancellation.js";
 import type { ProfilingCollector } from "../profiling.js";
 import type { GraphRecallExpandedEntry, LastRecallBudgetSummary, LastRecallStore, RecallHandleHistoryStore } from "../recall-state.js";
 import type { RecallXraySnapshot } from "../recall-xray.js";
@@ -335,6 +336,7 @@ export interface RecallInternalDeps {
   ): void;
   readAllMemoriesForNamespaces(
     namespaces: string[],
+    options?: CorpusReadOptions,
   ): Promise<MemoryFile[]>;
   recallArtifactsAcrossNamespaces(
     prompt: string,

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -4414,7 +4414,10 @@ export class RecallInternalCoordinator {
       } else {
         const memories = await awaitAssemblyStep(
           "recent-memory-read",
-          () => this.deps.readAllMemoriesForNamespaces(recallNamespaces),
+          (stepSignal) =>
+            this.deps.readAllMemoriesForNamespaces(recallNamespaces, {
+              abortSignal: stepSignal,
+            }),
           [] as MemoryFile[],
         );
         if (memories.length > 0) {

--- a/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
+++ b/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
@@ -34,6 +34,7 @@ import { RerankCache, rerankLocalOrNoop, reorderByRankedKeys } from "../rerank.j
 import type { SearchBackend, SearchDegradation, SearchExecutionOptions, SearchQueryOptions } from "../search/port.js";
 import { SecureStoreLockedError } from "../secure-store/index.js";
 import { isPathInsideStorageRoot } from "../storage-paths.js";
+import type { CorpusReadOptions } from "../corpus-read-cancellation.js";
 import { extractTagsFromPrompt, isTemporalQuery, queryByDateRangeAsync, queryByTagsAsync, readIndexSnapshotAsync, recencyWindowFromPrompt } from "../temporal-index.js";
 import {
   buildQueryAwarePrefilter as buildQueryAwarePrefilterHelper,
@@ -206,6 +207,7 @@ export interface RecallSearchPipelineDeps {
   resolveArtifactSourceStatuses(
     storage: StorageManager,
     sourceIds: string[],
+    options?: CorpusReadOptions,
   ): Promise<Map<string, "active" | "superseded" | "archived" | "missing">>;
   resolveColdQmdResultForRecall(
     result: QmdSearchResult,

--- a/packages/remnic-core/src/orchestration/recall-search-prefilter.ts
+++ b/packages/remnic-core/src/orchestration/recall-search-prefilter.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { resolveIndexingCapabilities, resolveMemoryLifecycleCapabilities } from "../capabilities.js";
 import type { EmbeddingFallback } from "../embedding-fallback.js";
+import type { CorpusReadOptions } from "../corpus-read-cancellation.js";
 import type { StorageManager } from "../index.js";
 import type { NamespaceStorageRouter } from "../namespaces/storage.js";
 import {
@@ -27,6 +28,7 @@ export interface PrefilterAndArtifactDeps {
   resolveArtifactSourceStatuses(
     storage: StorageManager,
     sourceIds: string[],
+    options?: CorpusReadOptions,
   ): Promise<Map<string, "active" | "superseded" | "archived" | "missing">>;
   scopeQueryAwarePaths(
     paths: Set<string> | null,
@@ -84,7 +86,9 @@ export async function fetchActiveArtifactsForNamespace(
     throwIfRecallAborted(options.abortSignal);
     const sourceStatus =
       sourceIds.length > 0
-        ? await deps.resolveArtifactSourceStatuses(storage, sourceIds)
+        ? await deps.resolveArtifactSourceStatuses(storage, sourceIds, {
+            abortSignal: options.abortSignal,
+          })
         : new Map<string, "active" | "superseded" | "archived" | "missing">();
 
     const filtered: MemoryFile[] = [];

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -121,6 +121,7 @@ import { ExtractionPersistCoordinator } from "./orchestration/extraction-persist
 import { RecallInternalCoordinator } from "./orchestration/recall-internal.js";
 import { RecallSearchPipelineCoordinator } from "./orchestration/recall-search-pipeline.js";
 import type { ArtifactRecallOptions } from "./orchestration/recall-search-prefilter.js";
+import type { CorpusReadOptions } from "./corpus-read-cancellation.js";
 import { TurnIngestionCoordinator, type TurnIngestionOptions } from "./orchestration/turn-ingestion.js";
 import { RecallIntrospectionCoordinator } from "./orchestration/recall-introspection.js";
 import { OrchestratorInitCoordinator } from "./orchestration/orchestrator-init.js";
@@ -1872,10 +1873,10 @@ export class Orchestrator {
   private async resolveArtifactSourceStatuses(
     storage: StorageManager,
     sourceIds: string[],
+    options?: CorpusReadOptions,
   ): Promise<Map<string, "active" | "superseded" | "archived" | "missing">> {
     return this.namespaceReadFanoutCoordinator.resolveArtifactSourceStatuses(
-      storage,
-      sourceIds,
+      storage, sourceIds, options,
     );
   }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3971,9 +3971,8 @@ export class Orchestrator {
 
   private async readAllMemoriesForNamespaces(
     namespaces: string[],
+    options?: CorpusReadOptions,
   ): Promise<MemoryFile[]> {
-    return this.namespaceReadFanoutCoordinator.readAllMemoriesForNamespaces(
-      namespaces,
-    );
+    return this.namespaceReadFanoutCoordinator.readAllMemoriesForNamespaces(namespaces, options);
   }
 }

--- a/packages/remnic-core/src/storage-contract/corpus-read-cancellation.test.ts
+++ b/packages/remnic-core/src/storage-contract/corpus-read-cancellation.test.ts
@@ -225,6 +225,54 @@ test("readAllMemories: a joiner honours its own signal without cancelling the sh
   });
 });
 
+test("readAllMemories: the scan is cancelled once its LAST waiter leaves", async () => {
+  await withStorage("remnic-2307-memories-last-waiter-", async (sm) => {
+    await sm.writeMemory("fact", "last waiter memory");
+    sm.invalidateAllMemoriesCacheForDir();
+
+    // Two cancellable readers overlap and both give up. Neither may cancel alone,
+    // but with nobody left the scan must not run on for no one — that is the
+    // abandoned I/O this whole change removes (issue #2307 review).
+    const scanReached = Promise.withResolvers<void>();
+    const releaseScan = Promise.withResolvers<void>();
+    const inner = sm as unknown as {
+      collectActiveMemoryPaths: (...args: unknown[]) => Promise<string[]>;
+    };
+    const origCollect = inner.collectActiveMemoryPaths.bind(sm);
+    let held = false;
+    inner.collectActiveMemoryPaths = async (...args: unknown[]) => {
+      if (!held) {
+        held = true;
+        scanReached.resolve();
+        await releaseScan.promise;
+      }
+      return origCollect(...args);
+    };
+
+    const starterAbort = new AbortController();
+    const joinerAbort = new AbortController();
+    const starter = sm.readAllMemories({ abortSignal: starterAbort.signal });
+    await scanReached.promise;
+    const joiner = sm.readAllMemories({ abortSignal: joinerAbort.signal });
+
+    // First to leave must NOT cancel: the other reader still wants the result.
+    joinerAbort.abort();
+    await assert.rejects(joiner, isAbort);
+    starterAbort.abort();
+    releaseScan.resolve();
+
+    await assert.rejects(starter, isAbort);
+
+    // With the scan cancelled rather than completed, nothing was published: a
+    // fresh read has to scan again.
+    inner.collectActiveMemoryPaths = origCollect;
+    const spy = installScanSpy(sm);
+    const after = await sm.readAllMemories();
+    assert.equal(spy.scans(), 1, "the abandoned scan must not have published a cache entry");
+    assert.ok(after.some((m) => m.content === "last waiter memory"));
+  });
+});
+
 test("readAllMemories: a sole waiter's abort does stop the scan", async () => {
   await withStorage("remnic-2307-memories-sole-", async (sm) => {
     await sm.writeMemory("fact", "sole waiter memory");

--- a/packages/remnic-core/src/storage-contract/corpus-read-cancellation.test.ts
+++ b/packages/remnic-core/src/storage-contract/corpus-read-cancellation.test.ts
@@ -48,6 +48,41 @@ function installScanSpy(sm: StorageManager): { scans: () => number } {
   return { scans: () => count };
 }
 
+/**
+ * Hold the first disk scan open so a joiner provably attaches while it is in
+ * flight, and guarantee teardown: a failing assertion must not leave the patched
+ * method installed or a scan blocked for the rest of the run.
+ */
+function holdFirstScan(sm: StorageManager): {
+  reached: Promise<void>;
+  release: () => void;
+  restore: () => void;
+} {
+  const scanReached = Promise.withResolvers<void>();
+  const releaseScan = Promise.withResolvers<void>();
+  const inner = sm as unknown as {
+    collectActiveMemoryPaths: (...args: unknown[]) => Promise<string[]>;
+  };
+  const orig = inner.collectActiveMemoryPaths.bind(sm);
+  let held = false;
+  inner.collectActiveMemoryPaths = async (...args: unknown[]) => {
+    if (!held) {
+      held = true;
+      scanReached.resolve();
+      await releaseScan.promise;
+    }
+    return orig(...args);
+  };
+  return {
+    reached: scanReached.promise,
+    release: () => releaseScan.resolve(),
+    restore: () => {
+      releaseScan.resolve();
+      inner.collectActiveMemoryPaths = orig;
+    },
+  };
+}
+
 test("readAllMemories: an unfired signal changes nothing", async () => {
   await withStorage("remnic-2307-memories-inert-", async (sm) => {
     await sm.writeMemory("fact", "inert signal memory");
@@ -104,43 +139,39 @@ test("readAllMemories: a second reader protects the coalesced scan from the star
     await sm.writeMemory("fact", "joined memory");
     sm.invalidateAllMemoriesCacheForDir();
 
-    // Hold the scan open so the joiner provably attaches while it is in flight.
-    const scanReached = Promise.withResolvers<void>();
-    const releaseScan = Promise.withResolvers<void>();
-    const inner = sm as unknown as {
-      collectActiveMemoryPaths: (...args: unknown[]) => Promise<string[]>;
-    };
-    const origCollect = inner.collectActiveMemoryPaths.bind(sm);
-    let held = false;
-    inner.collectActiveMemoryPaths = async (...args: unknown[]) => {
-      if (!held) {
-        held = true;
-        scanReached.resolve();
-        await releaseScan.promise;
-      }
-      return origCollect(...args);
-    };
-
+    const hold = holdFirstScan(sm);
     const spy = installScanSpy(sm);
     const starterAbort = new AbortController();
     const starter = sm.readAllMemories({ abortSignal: starterAbort.signal });
-    await scanReached.promise;
-    const joiner = sm.readAllMemories();
-
-    starterAbort.abort();
-    releaseScan.resolve();
-
-    const joined = await joiner;
-    assert.ok(
-      joined.some((m) => m.content === "joined memory"),
-      "a joiner must never be handed a cancelled or truncated read",
+    // Observe the starter now: its rejection lands the instant it aborts, and this
+    // test awaits the joiner in between, so an unobserved promise would surface as
+    // an unhandled rejection rather than the assertion below.
+    const starterOutcome = starter.then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
     );
-    // The starter shares that same settled scan, so it succeeds too.
-    assert.deepEqual(
-      (await starter).map((m) => m.content),
-      joined.map((m) => m.content),
-    );
-    assert.equal(spy.scans(), 1, "the joiner reused the in-flight scan rather than starting its own");
+    try {
+      await hold.reached;
+      const joiner = sm.readAllMemories();
+
+      starterAbort.abort();
+      hold.release();
+
+      const joined = await joiner;
+      assert.ok(
+        joined.some((m) => m.content === "joined memory"),
+        "a joiner must never be handed a cancelled or truncated read",
+      );
+      // The joiner keeps the scan alive, so it completes — but the starter still
+      // gets its own AbortError, because it asked to be cancelled.
+      const outcome = await starterOutcome;
+      assert.equal(outcome.ok, false, "the starter must not be handed data it cancelled");
+      assert.ok(!outcome.ok && isAbort(outcome.error));
+      assert.equal(spy.scans(), 1, "the joiner reused the in-flight scan rather than starting its own");
+    } finally {
+      hold.restore();
+      await starterOutcome;
+    }
   });
 });
 
@@ -149,40 +180,30 @@ test("readAllMemories: a joiner arriving after the starter aborted starts a fres
     await sm.writeMemory("fact", "late joiner memory");
     sm.invalidateAllMemoriesCacheForDir();
 
-    // The starter's scan is doomed the instant its signal fires. Withdrawing it
-    // from the registry first is what stops a late joiner inheriting that
-    // AbortError for a request it never cancelled (issue #2307 review).
-    const scanReached = Promise.withResolvers<void>();
-    const releaseScan = Promise.withResolvers<void>();
-    const inner = sm as unknown as {
-      collectActiveMemoryPaths: (...args: unknown[]) => Promise<string[]>;
-    };
-    const origCollect = inner.collectActiveMemoryPaths.bind(sm);
-    let held = false;
-    inner.collectActiveMemoryPaths = async (...args: unknown[]) => {
-      if (!held) {
-        held = true;
-        scanReached.resolve();
-        await releaseScan.promise;
-      }
-      return origCollect(...args);
-    };
-
+    // The starter's scan is doomed the instant its signal fires while it is the
+    // sole waiter. Withdrawing it from the registry first is what stops a late
+    // joiner inheriting that AbortError for a request it never cancelled.
+    const hold = holdFirstScan(sm);
     const starterAbort = new AbortController();
     const starter = sm.readAllMemories({ abortSignal: starterAbort.signal });
-    await scanReached.promise;
-    starterAbort.abort();
+    try {
+      await hold.reached;
+      starterAbort.abort();
 
-    // Joins only AFTER the abort — must not attach to the doomed scan.
-    const lateJoiner = sm.readAllMemories();
-    releaseScan.resolve();
+      // Joins only AFTER the abort — must not attach to the doomed scan.
+      const lateJoiner = sm.readAllMemories();
+      hold.release();
 
-    await assert.rejects(starter, isAbort);
-    const joined = await lateJoiner;
-    assert.ok(
-      joined.some((m) => m.content === "late joiner memory"),
-      "a late joiner must get its own scan, not the starter's AbortError",
-    );
+      await assert.rejects(starter, isAbort);
+      const joined = await lateJoiner;
+      assert.ok(
+        joined.some((m) => m.content === "late joiner memory"),
+        "a late joiner must get its own scan, not the starter's AbortError",
+      );
+    } finally {
+      hold.restore();
+      await starter.catch(() => {});
+    }
   });
 });
 
@@ -191,37 +212,27 @@ test("readAllMemories: a joiner honours its own signal without cancelling the sh
     await sm.writeMemory("fact", "shared scan memory");
     sm.invalidateAllMemoriesCacheForDir();
 
-    const scanReached = Promise.withResolvers<void>();
-    const releaseScan = Promise.withResolvers<void>();
-    const inner = sm as unknown as {
-      collectActiveMemoryPaths: (...args: unknown[]) => Promise<string[]>;
-    };
-    const origCollect = inner.collectActiveMemoryPaths.bind(sm);
-    let held = false;
-    inner.collectActiveMemoryPaths = async (...args: unknown[]) => {
-      if (!held) {
-        held = true;
-        scanReached.resolve();
-        await releaseScan.promise;
-      }
-      return origCollect(...args);
-    };
-
+    const hold = holdFirstScan(sm);
     const starter = sm.readAllMemories();
-    await scanReached.promise;
-    const joinerAbort = new AbortController();
-    const joiner = sm.readAllMemories({ abortSignal: joinerAbort.signal });
-    joinerAbort.abort();
+    try {
+      await hold.reached;
+      const joinerAbort = new AbortController();
+      const joiner = sm.readAllMemories({ abortSignal: joinerAbort.signal });
+      joinerAbort.abort();
 
-    // The joiner stops waiting immediately, before the scan is even released.
-    await assert.rejects(joiner, isAbort);
+      // The joiner stops waiting immediately, before the scan is even released.
+      await assert.rejects(joiner, isAbort);
 
-    releaseScan.resolve();
-    const starterResult = await starter;
-    assert.ok(
-      starterResult.some((m) => m.content === "shared scan memory"),
-      "a joiner's cancellation must never reach the shared scan",
-    );
+      hold.release();
+      const starterResult = await starter;
+      assert.ok(
+        starterResult.some((m) => m.content === "shared scan memory"),
+        "a joiner's cancellation must never reach the shared scan",
+      );
+    } finally {
+      hold.restore();
+      await starter.catch(() => {});
+    }
   });
 });
 
@@ -232,44 +243,34 @@ test("readAllMemories: the scan is cancelled once its LAST waiter leaves", async
 
     // Two cancellable readers overlap and both give up. Neither may cancel alone,
     // but with nobody left the scan must not run on for no one — that is the
-    // abandoned I/O this whole change removes (issue #2307 review).
-    const scanReached = Promise.withResolvers<void>();
-    const releaseScan = Promise.withResolvers<void>();
-    const inner = sm as unknown as {
-      collectActiveMemoryPaths: (...args: unknown[]) => Promise<string[]>;
-    };
-    const origCollect = inner.collectActiveMemoryPaths.bind(sm);
-    let held = false;
-    inner.collectActiveMemoryPaths = async (...args: unknown[]) => {
-      if (!held) {
-        held = true;
-        scanReached.resolve();
-        await releaseScan.promise;
-      }
-      return origCollect(...args);
-    };
-
+    // abandoned I/O this whole change removes.
+    const hold = holdFirstScan(sm);
     const starterAbort = new AbortController();
     const joinerAbort = new AbortController();
     const starter = sm.readAllMemories({ abortSignal: starterAbort.signal });
-    await scanReached.promise;
-    const joiner = sm.readAllMemories({ abortSignal: joinerAbort.signal });
+    try {
+      await hold.reached;
+      const joiner = sm.readAllMemories({ abortSignal: joinerAbort.signal });
 
-    // First to leave must NOT cancel: the other reader still wants the result.
-    joinerAbort.abort();
-    await assert.rejects(joiner, isAbort);
-    starterAbort.abort();
-    releaseScan.resolve();
+      // First to leave must NOT cancel: the other reader still wants the result.
+      joinerAbort.abort();
+      await assert.rejects(joiner, isAbort);
+      starterAbort.abort();
+      hold.release();
 
-    await assert.rejects(starter, isAbort);
+      await assert.rejects(starter, isAbort);
 
-    // With the scan cancelled rather than completed, nothing was published: a
-    // fresh read has to scan again.
-    inner.collectActiveMemoryPaths = origCollect;
-    const spy = installScanSpy(sm);
-    const after = await sm.readAllMemories();
-    assert.equal(spy.scans(), 1, "the abandoned scan must not have published a cache entry");
-    assert.ok(after.some((m) => m.content === "last waiter memory"));
+      // With the scan cancelled rather than completed, nothing was published: a
+      // fresh read has to scan again.
+      hold.restore();
+      const spy = installScanSpy(sm);
+      const after = await sm.readAllMemories();
+      assert.equal(spy.scans(), 1, "the abandoned scan must not have published a cache entry");
+      assert.ok(after.some((m) => m.content === "last waiter memory"));
+    } finally {
+      hold.restore();
+      await starter.catch(() => {});
+    }
   });
 });
 
@@ -278,25 +279,18 @@ test("readAllMemories: a sole waiter's abort does stop the scan", async () => {
     await sm.writeMemory("fact", "sole waiter memory");
     sm.invalidateAllMemoriesCacheForDir();
 
-    const scanReached = Promise.withResolvers<void>();
-    const releaseScan = Promise.withResolvers<void>();
-    const inner = sm as unknown as {
-      collectActiveMemoryPaths: (...args: unknown[]) => Promise<string[]>;
-    };
-    const origCollect = inner.collectActiveMemoryPaths.bind(sm);
-    inner.collectActiveMemoryPaths = async (...args: unknown[]) => {
-      scanReached.resolve();
-      await releaseScan.promise;
-      return origCollect(...args);
-    };
-
+    const hold = holdFirstScan(sm);
     const aborted = new AbortController();
     const pending = sm.readAllMemories({ abortSignal: aborted.signal });
-    await scanReached.promise;
-    aborted.abort();
-    releaseScan.resolve();
-
-    await assert.rejects(pending, isAbort);
+    try {
+      await hold.reached;
+      aborted.abort();
+      hold.release();
+      await assert.rejects(pending, isAbort);
+    } finally {
+      hold.restore();
+      await pending.catch(() => {});
+    }
   });
 });
 

--- a/packages/remnic-core/src/storage-contract/corpus-read-cancellation.test.ts
+++ b/packages/remnic-core/src/storage-contract/corpus-read-cancellation.test.ts
@@ -121,6 +121,7 @@ test("readAllMemories: a second reader protects the coalesced scan from the star
       return origCollect(...args);
     };
 
+    const spy = installScanSpy(sm);
     const starterAbort = new AbortController();
     const starter = sm.readAllMemories({ abortSignal: starterAbort.signal });
     await scanReached.promise;
@@ -138,6 +139,88 @@ test("readAllMemories: a second reader protects the coalesced scan from the star
     assert.deepEqual(
       (await starter).map((m) => m.content),
       joined.map((m) => m.content),
+    );
+    assert.equal(spy.scans(), 1, "the joiner reused the in-flight scan rather than starting its own");
+  });
+});
+
+test("readAllMemories: a joiner arriving after the starter aborted starts a fresh scan", async () => {
+  await withStorage("remnic-2307-memories-late-joiner-", async (sm) => {
+    await sm.writeMemory("fact", "late joiner memory");
+    sm.invalidateAllMemoriesCacheForDir();
+
+    // The starter's scan is doomed the instant its signal fires. Withdrawing it
+    // from the registry first is what stops a late joiner inheriting that
+    // AbortError for a request it never cancelled (issue #2307 review).
+    const scanReached = Promise.withResolvers<void>();
+    const releaseScan = Promise.withResolvers<void>();
+    const inner = sm as unknown as {
+      collectActiveMemoryPaths: (...args: unknown[]) => Promise<string[]>;
+    };
+    const origCollect = inner.collectActiveMemoryPaths.bind(sm);
+    let held = false;
+    inner.collectActiveMemoryPaths = async (...args: unknown[]) => {
+      if (!held) {
+        held = true;
+        scanReached.resolve();
+        await releaseScan.promise;
+      }
+      return origCollect(...args);
+    };
+
+    const starterAbort = new AbortController();
+    const starter = sm.readAllMemories({ abortSignal: starterAbort.signal });
+    await scanReached.promise;
+    starterAbort.abort();
+
+    // Joins only AFTER the abort — must not attach to the doomed scan.
+    const lateJoiner = sm.readAllMemories();
+    releaseScan.resolve();
+
+    await assert.rejects(starter, isAbort);
+    const joined = await lateJoiner;
+    assert.ok(
+      joined.some((m) => m.content === "late joiner memory"),
+      "a late joiner must get its own scan, not the starter's AbortError",
+    );
+  });
+});
+
+test("readAllMemories: a joiner honours its own signal without cancelling the shared scan", async () => {
+  await withStorage("remnic-2307-memories-joiner-abort-", async (sm) => {
+    await sm.writeMemory("fact", "shared scan memory");
+    sm.invalidateAllMemoriesCacheForDir();
+
+    const scanReached = Promise.withResolvers<void>();
+    const releaseScan = Promise.withResolvers<void>();
+    const inner = sm as unknown as {
+      collectActiveMemoryPaths: (...args: unknown[]) => Promise<string[]>;
+    };
+    const origCollect = inner.collectActiveMemoryPaths.bind(sm);
+    let held = false;
+    inner.collectActiveMemoryPaths = async (...args: unknown[]) => {
+      if (!held) {
+        held = true;
+        scanReached.resolve();
+        await releaseScan.promise;
+      }
+      return origCollect(...args);
+    };
+
+    const starter = sm.readAllMemories();
+    await scanReached.promise;
+    const joinerAbort = new AbortController();
+    const joiner = sm.readAllMemories({ abortSignal: joinerAbort.signal });
+    joinerAbort.abort();
+
+    // The joiner stops waiting immediately, before the scan is even released.
+    await assert.rejects(joiner, isAbort);
+
+    releaseScan.resolve();
+    const starterResult = await starter;
+    assert.ok(
+      starterResult.some((m) => m.content === "shared scan memory"),
+      "a joiner's cancellation must never reach the shared scan",
     );
   });
 });
@@ -191,6 +274,38 @@ test("readAllEntityFiles: an already-aborted caller reads nothing and caches not
     // Nothing was published, so the corpus still reads correctly afterwards.
     const entities = await sm.readAllEntityFiles();
     assert.ok(entities.some((e) => e.name === "Cancelled Person"));
+  });
+});
+
+test("readAllEntityFiles: a mid-scan abort publishes no partial entity cache", async () => {
+  await withStorage("remnic-2307-entities-midscan-", async (sm) => {
+    await sm.writeEntity("First Person", "person", ["First Person owns this test."]);
+    await sm.writeEntity("Second Person", "person", ["Second Person owns this test too."]);
+
+    // Abort once the first entity file has been read: the post-loop checkpoint is
+    // what stops that partial batch reaching setCachedEntities.
+    const aborted = new AbortController();
+    const inner = sm as unknown as {
+      readStorageSecureFile: (filePath: string) => Promise<string>;
+    };
+    const origRead = inner.readStorageSecureFile.bind(sm);
+    let reads = 0;
+    inner.readStorageSecureFile = async (filePath: string) => {
+      reads += 1;
+      aborted.abort();
+      return origRead(filePath);
+    };
+
+    await assert.rejects(sm.readAllEntityFiles({ abortSignal: aborted.signal }), isAbort);
+    assert.ok(reads >= 1, "the scan started before it was cancelled");
+
+    inner.readStorageSecureFile = origRead;
+    const entities = await sm.readAllEntityFiles();
+    assert.deepEqual(
+      entities.map((e) => e.name).sort(),
+      ["First Person", "Second Person"],
+      "the aborted scan must not have cached a partial entity set",
+    );
   });
 });
 

--- a/packages/remnic-core/src/storage-contract/corpus-read-cancellation.test.ts
+++ b/packages/remnic-core/src/storage-contract/corpus-read-cancellation.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Issue #2307 — the shared full-corpus read primitives honour cancellation.
+ *
+ * Scenario matrix, applied to every primitive that walks a whole memory tree:
+ *   1. no signal                    → unchanged behaviour
+ *   2. signal that never fires      → unchanged behaviour
+ *   3. signal already aborted       → throws, nothing read
+ *   4. signal fires mid-scan        → throws, and NO partial corpus is cached
+ *   5. coalesced read with a joiner → the starter's abort must not cancel it
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { StorageManager } from "../storage.js";
+import { resetStaticCaches } from "./harness.js";
+
+const isAbort = (err: unknown) => err instanceof Error && err.name === "AbortError";
+
+async function withStorage(
+  prefix: string,
+  body: (sm: StorageManager, dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    resetStaticCaches();
+    const sm = new StorageManager(dir);
+    await sm.ensureDirectories();
+    await body(sm, dir);
+  } finally {
+    resetStaticCaches();
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/** Counts disk scans so "nothing was cached" is observable rather than assumed. */
+function installScanSpy(sm: StorageManager): { scans: () => number } {
+  const spy = sm as unknown as { _readAllMemoriesFromDisk: (...args: unknown[]) => Promise<unknown> };
+  const orig = spy._readAllMemoriesFromDisk.bind(sm);
+  let count = 0;
+  spy._readAllMemoriesFromDisk = async (...args: unknown[]) => {
+    count += 1;
+    return orig(...args);
+  };
+  return { scans: () => count };
+}
+
+test("readAllMemories: an unfired signal changes nothing", async () => {
+  await withStorage("remnic-2307-memories-inert-", async (sm) => {
+    await sm.writeMemory("fact", "inert signal memory");
+    const memories = await sm.readAllMemories({ abortSignal: new AbortController().signal });
+    assert.ok(memories.some((m) => m.content === "inert signal memory"));
+  });
+});
+
+test("readAllMemories: an already-aborted caller reads nothing at all", async () => {
+  await withStorage("remnic-2307-memories-preabort-", async (sm) => {
+    await sm.writeMemory("fact", "pre-abort memory");
+    sm.invalidateAllMemoriesCacheForDir();
+    const spy = installScanSpy(sm);
+    const aborted = new AbortController();
+    aborted.abort();
+
+    await assert.rejects(sm.readAllMemories({ abortSignal: aborted.signal }), isAbort);
+    assert.equal(spy.scans(), 0, "an abandoned caller must not start a disk scan");
+  });
+});
+
+test("readAllMemories: a mid-scan abort caches nothing", async () => {
+  await withStorage("remnic-2307-memories-midscan-", async (sm) => {
+    await sm.writeMemory("fact", "mid-scan memory");
+    sm.invalidateAllMemoriesCacheForDir();
+
+    // Abort once the walk has produced paths: the next per-batch checkpoint in the
+    // parse phase is a real boundary, not a synthetic one.
+    const aborted = new AbortController();
+    const inner = sm as unknown as {
+      collectActiveMemoryPaths: (...args: unknown[]) => Promise<string[]>;
+    };
+    const origCollect = inner.collectActiveMemoryPaths.bind(sm);
+    inner.collectActiveMemoryPaths = async (...args: unknown[]) => {
+      const paths = await origCollect(...args);
+      aborted.abort();
+      return paths;
+    };
+
+    await assert.rejects(sm.readAllMemories({ abortSignal: aborted.signal }), isAbort);
+
+    // The publish step is downstream of the checkpoint, so a truncated corpus must
+    // never have reached the cache: a fresh read has to scan again.
+    inner.collectActiveMemoryPaths = origCollect;
+    const spy = installScanSpy(sm);
+    const after = await sm.readAllMemories();
+    assert.equal(spy.scans(), 1, "the aborted read must not have published a cache entry");
+    assert.ok(after.some((m) => m.content === "mid-scan memory"), "the corpus is intact");
+  });
+});
+
+test("readAllMemories: a second reader protects the coalesced scan from the starter's abort", async () => {
+  await withStorage("remnic-2307-memories-joiner-", async (sm) => {
+    await sm.writeMemory("fact", "joined memory");
+    sm.invalidateAllMemoriesCacheForDir();
+
+    // Hold the scan open so the joiner provably attaches while it is in flight.
+    const scanReached = Promise.withResolvers<void>();
+    const releaseScan = Promise.withResolvers<void>();
+    const inner = sm as unknown as {
+      collectActiveMemoryPaths: (...args: unknown[]) => Promise<string[]>;
+    };
+    const origCollect = inner.collectActiveMemoryPaths.bind(sm);
+    let held = false;
+    inner.collectActiveMemoryPaths = async (...args: unknown[]) => {
+      if (!held) {
+        held = true;
+        scanReached.resolve();
+        await releaseScan.promise;
+      }
+      return origCollect(...args);
+    };
+
+    const starterAbort = new AbortController();
+    const starter = sm.readAllMemories({ abortSignal: starterAbort.signal });
+    await scanReached.promise;
+    const joiner = sm.readAllMemories();
+
+    starterAbort.abort();
+    releaseScan.resolve();
+
+    const joined = await joiner;
+    assert.ok(
+      joined.some((m) => m.content === "joined memory"),
+      "a joiner must never be handed a cancelled or truncated read",
+    );
+    // The starter shares that same settled scan, so it succeeds too.
+    assert.deepEqual(
+      (await starter).map((m) => m.content),
+      joined.map((m) => m.content),
+    );
+  });
+});
+
+test("readAllMemories: a sole waiter's abort does stop the scan", async () => {
+  await withStorage("remnic-2307-memories-sole-", async (sm) => {
+    await sm.writeMemory("fact", "sole waiter memory");
+    sm.invalidateAllMemoriesCacheForDir();
+
+    const scanReached = Promise.withResolvers<void>();
+    const releaseScan = Promise.withResolvers<void>();
+    const inner = sm as unknown as {
+      collectActiveMemoryPaths: (...args: unknown[]) => Promise<string[]>;
+    };
+    const origCollect = inner.collectActiveMemoryPaths.bind(sm);
+    inner.collectActiveMemoryPaths = async (...args: unknown[]) => {
+      scanReached.resolve();
+      await releaseScan.promise;
+      return origCollect(...args);
+    };
+
+    const aborted = new AbortController();
+    const pending = sm.readAllMemories({ abortSignal: aborted.signal });
+    await scanReached.promise;
+    aborted.abort();
+    releaseScan.resolve();
+
+    await assert.rejects(pending, isAbort);
+  });
+});
+
+test("readAllEntityFiles: an already-aborted caller reads nothing and caches nothing", async () => {
+  await withStorage("remnic-2307-entities-", async (sm) => {
+    await sm.writeEntity("Cancelled Person", "person", ["Cancelled Person owns this test."]);
+
+    let entityFileReads = 0;
+    const inner = sm as unknown as {
+      readStorageSecureFile: (filePath: string) => Promise<string>;
+    };
+    const origRead = inner.readStorageSecureFile.bind(sm);
+    inner.readStorageSecureFile = async (filePath: string) => {
+      entityFileReads += 1;
+      return origRead(filePath);
+    };
+
+    const aborted = new AbortController();
+    aborted.abort();
+    await assert.rejects(sm.readAllEntityFiles({ abortSignal: aborted.signal }), isAbort);
+    assert.equal(entityFileReads, 0, "an abandoned caller must not read entity files");
+
+    // Nothing was published, so the corpus still reads correctly afterwards.
+    const entities = await sm.readAllEntityFiles();
+    assert.ok(entities.some((e) => e.name === "Cancelled Person"));
+  });
+});
+
+test("searchArtifacts: an already-aborted caller never reads the artifact tier", async () => {
+  await withStorage("remnic-2307-artifacts-preabort-", async (sm) => {
+    await sm.writeArtifact("deploy runbook rollback quote", { sourceMemoryId: "src-1" });
+
+    let artifactReads = 0;
+    const inner = sm as unknown as {
+      readMemoryByPath: (filePath: string) => Promise<unknown>;
+    };
+    const origRead = inner.readMemoryByPath.bind(sm);
+    inner.readMemoryByPath = async (filePath: string) => {
+      artifactReads += 1;
+      return origRead(filePath);
+    };
+
+    const aborted = new AbortController();
+    aborted.abort();
+    await assert.rejects(
+      sm.searchArtifacts("deploy runbook", 5, { abortSignal: aborted.signal }),
+      isAbort,
+    );
+    assert.equal(artifactReads, 0, "an abandoned caller must not walk the artifact tier");
+  });
+});
+
+test("searchArtifacts: a mid-walk abort caches nothing", async () => {
+  await withStorage("remnic-2307-artifacts-midwalk-", async (sm) => {
+    await sm.writeArtifact("deploy runbook rollback quote", { sourceMemoryId: "src-1" });
+    await sm.writeArtifact("second deploy runbook quote", { sourceMemoryId: "src-2" });
+
+    // Abort from inside the walk, at the per-entry checkpoint.
+    const aborted = new AbortController();
+    const inner = sm as unknown as {
+      readMemoryByPath: (filePath: string) => Promise<unknown>;
+    };
+    const origRead = inner.readMemoryByPath.bind(sm);
+    let reads = 0;
+    inner.readMemoryByPath = async (filePath: string) => {
+      reads += 1;
+      aborted.abort();
+      return origRead(filePath);
+    };
+
+    await assert.rejects(
+      sm.searchArtifacts("deploy runbook", 5, { abortSignal: aborted.signal }),
+      isAbort,
+    );
+    assert.ok(reads >= 1, "the walk started before it was cancelled");
+
+    // A partial walk must not have been published as the artifact index: the next
+    // search sees every artifact.
+    inner.readMemoryByPath = origRead;
+    const matches = await sm.searchArtifacts("deploy runbook", 5);
+    assert.equal(matches.length, 2, "the aborted walk must not have cached a partial tier");
+  });
+});

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -73,7 +73,7 @@ import {
   updateCacheOnWrite,
 } from "./memory-cache.js";
 import {
-  getInFlightRead,
+  attachInFlightReader,
   beginCoalescedScan,
   deleteInFlightRead,
   deleteInFlightReadsForDir,
@@ -4495,14 +4495,18 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     // The in-flight slot get/set/delete also key on this snapshot so a mid-scan
     // key change can't orphan the slot registered under the old identity.
     const keyId = this.hotCacheKeyId();
-    const inFlight = getInFlightRead(this.baseDir, keyId);
+    const inFlight = attachInFlightReader(this.baseDir, keyId, options?.abortSignal);
     if (inFlight) {
-      // A joiner never cancels the shared scan, but it does stop waiting on it:
-      // its own signal must be honoured, or it would sit here for the full scan
-      // and then be handed data it no longer wants (issue #2307 review).
-      return this.rememberMemorySnapshots(
-        await raceAbort(inFlight, options?.abortSignal, "corpus read aborted"),
-      );
+      // A joiner never cancels the shared scan on its own, but it does stop waiting
+      // on it, and its departure counts: if it was the last waiter the scan is
+      // cancelled (issue #2307 review).
+      try {
+        return this.rememberMemorySnapshots(
+          await raceAbort(inFlight.read, options?.abortSignal, "corpus read aborted"),
+        );
+      } finally {
+        inFlight.waiter.leave();
+      }
     }
 
     // Sole-waiter cancellation lives with the registry that decides whether this
@@ -4526,7 +4530,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     try {
       return this.rememberMemorySnapshots(await readPromise);
     } finally {
-      scan.detach();
+      scan.leave();
       deleteInFlightRead(this.baseDir, keyId, readPromise);
     }
   }

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -16,6 +16,7 @@ import {
 import { appendFileSync, createReadStream, mkdirSync, readFileSync, statSync, type Dirent } from "node:fs";
 import { createHash, randomUUID } from "node:crypto";
 import { normalizeContent, computeContentHash } from "./content-hash.js";
+import { checkCorpusReadAbort, type CorpusReadOptions } from "./corpus-read-cancellation.js";
 import { selectArtifactMatches, type ArtifactSearchOptions } from "./artifact-search.js";
 import path from "node:path";
 import { log } from "./logger.js";
@@ -4347,8 +4348,8 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     return id;
   }
 
-  private async readAllArtifactsCached(): Promise<MemoryFile[]> {
-    return this.memoryReadStore.readAllArtifactsCached();
+  private async readAllArtifactsCached(options?: CorpusReadOptions): Promise<MemoryFile[]> {
+    return this.memoryReadStore.readAllArtifactsCached(options);
   }
 
   async searchArtifacts(
@@ -4357,7 +4358,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     options: ArtifactSearchOptions = {},
   ): Promise<MemoryFile[]> {
     return selectArtifactMatches(
-      () => this.readAllArtifactsCached(),
+      () => this.readAllArtifactsCached({ abortSignal: options.abortSignal }),
       query,
       maxResults,
       options,
@@ -4474,7 +4475,8 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     return memories;
   }
 
-  async readAllMemories(): Promise<MemoryFile[]> {
+  async readAllMemories(options?: CorpusReadOptions): Promise<MemoryFile[]> {
+    checkCorpusReadAbort(options);
     if (this.hotMemoriesCacheEnabled) {
       const cached = getCachedMemories(
         this.baseDir,
@@ -4495,22 +4497,40 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     const inFlight = getInFlightRead(this.baseDir, keyId);
     if (inFlight) return this.rememberMemorySnapshots(await inFlight);
 
+    // This caller STARTED the scan, so its cancellation may stop it — but only
+    // while it stays the sole waiter. `getInFlightRead` detaches this link the
+    // moment a second reader joins, because cancelling a scan someone else is
+    // waiting for would hand them a truncated corpus (issue #2307).
+    const scanAbort = new AbortController();
+    const callerSignal = options?.abortSignal;
+    const onCallerAbort = () => scanAbort.abort();
+    let detached = false;
+    const detachCancellation = () => {
+      if (detached) return;
+      detached = true;
+      callerSignal?.removeEventListener("abort", onCallerAbort);
+    };
+    callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
+
     const readPromise = (async (): Promise<MemoryFile[]> => {
       const version = this.getMemoryCorpusVersion();
-      const memories = await this._readAllMemoriesFromDisk();
+      const memories = await this._readAllMemoriesFromDisk({ abortSignal: scanAbort.signal });
       // Publish only if neither the corpus version NOR the key identity changed
       // during the scan. The version guard prevents clobbering a newer patched +
       // re-keyed entry; the keyId guard prevents publishing this key's decrypted
-      // corpus under a since-changed identity (Codex Medium, #1902).
+      // corpus under a since-changed identity (Codex Medium, #1902). A cancelled
+      // scan never arrives here — the checkpoints throw — so a partial corpus is
+      // never published.
       if (this.hotMemoriesCacheEnabled && this.getMemoryCorpusVersion() === version && this.hotCacheKeyId() === keyId) {
         setCachedMemories(this.baseDir, memories, version, keyId, this.hotCacheTtlMs());
       }
       return memories;
     })();
-    setInFlightRead(this.baseDir, keyId, readPromise);
+    setInFlightRead(this.baseDir, keyId, readPromise, detachCancellation);
     try {
       return this.rememberMemorySnapshots(await readPromise);
     } finally {
+      detachCancellation();
       deleteInFlightRead(this.baseDir, keyId, readPromise);
     }
   }
@@ -4769,7 +4789,9 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
    * active memory file paths without parsing frontmatter — safe on a 100k+
    * corpus, unlike readAllMemories().
    */
-  async collectActiveMemoryPaths(options?: { propagateReadErrors?: boolean }): Promise<string[]> {
+  async collectActiveMemoryPaths(
+    options?: { propagateReadErrors?: boolean } & CorpusReadOptions,
+  ): Promise<string[]> {
     return this.memoryReadStore.collectActiveMemoryPaths(options);
   }
 
@@ -4793,12 +4815,19 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     return `${this.getMemoryCorpusVersion()}:${this.readColdWriteVersion()}`;
   }
 
-  private async readParsedMemoriesFromPaths(filePaths: string[], batchSize?: number): Promise<MemoryFile[]> {
+  private async readParsedMemoriesFromPaths(
+    filePaths: string[],
+    batchSize?: number,
+    options?: CorpusReadOptions,
+  ): Promise<MemoryFile[]> {
     if (filePaths.length === 0) return [];
 
     const normalizedBatchSize = this.normalizeMemoryReadBatchSize(batchSize);
     const memories: MemoryFile[] = [];
     for (let i = 0; i < filePaths.length; i += normalizedBatchSize) {
+      // Per batch: the parse phase is as long as the walk on a large corpus, and
+      // an abandoned caller must not keep paying for it (issue #2307).
+      checkCorpusReadAbort(options);
       const batch = filePaths.slice(i, i + normalizedBatchSize);
       const results = await Promise.all(
         batch.map(async (fullPath) => {
@@ -4939,9 +4968,9 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     return this.memoryReadStore.readMemoriesWindow(options);
   }
 
-  private async _readAllMemoriesFromDisk(): Promise<MemoryFile[]> {
-    const filePaths = await this.collectActiveMemoryPaths();
-    return this.readParsedMemoriesFromPaths(filePaths, 50);
+  private async _readAllMemoriesFromDisk(options?: CorpusReadOptions): Promise<MemoryFile[]> {
+    const filePaths = await this.collectActiveMemoryPaths(options);
+    return this.readParsedMemoriesFromPaths(filePaths, 50, options);
   }
 
   async readAllColdMemories(): Promise<MemoryFile[]> {
@@ -6430,8 +6459,8 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
   // Scoring + Knowledge Index (Knowledge Graph v7.0)
   // ---------------------------------------------------------------------------
 
-  async readAllEntityFiles(): Promise<EntityFile[]> {
-    return this.entityStore.readAllEntityFiles();
+  async readAllEntityFiles(options?: CorpusReadOptions): Promise<EntityFile[]> {
+    return this.entityStore.readAllEntityFiles(options);
   }
 
   /**

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -16,6 +16,7 @@ import {
 import { appendFileSync, createReadStream, mkdirSync, readFileSync, statSync, type Dirent } from "node:fs";
 import { createHash, randomUUID } from "node:crypto";
 import { normalizeContent, computeContentHash } from "./content-hash.js";
+import { raceAbort } from "./abort-error.js";
 import { checkCorpusReadAbort, type CorpusReadOptions } from "./corpus-read-cancellation.js";
 import { selectArtifactMatches, type ArtifactSearchOptions } from "./artifact-search.js";
 import path from "node:path";
@@ -73,7 +74,7 @@ import {
 } from "./memory-cache.js";
 import {
   getInFlightRead,
-  setInFlightRead,
+  beginCoalescedScan,
   deleteInFlightRead,
   deleteInFlightReadsForDir,
   clearInFlightReads,
@@ -4495,26 +4496,21 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     // key change can't orphan the slot registered under the old identity.
     const keyId = this.hotCacheKeyId();
     const inFlight = getInFlightRead(this.baseDir, keyId);
-    if (inFlight) return this.rememberMemorySnapshots(await inFlight);
+    if (inFlight) {
+      // A joiner never cancels the shared scan, but it does stop waiting on it:
+      // its own signal must be honoured, or it would sit here for the full scan
+      // and then be handed data it no longer wants (issue #2307 review).
+      return this.rememberMemorySnapshots(
+        await raceAbort(inFlight, options?.abortSignal, "corpus read aborted"),
+      );
+    }
 
-    // This caller STARTED the scan, so its cancellation may stop it — but only
-    // while it stays the sole waiter. `getInFlightRead` detaches this link the
-    // moment a second reader joins, because cancelling a scan someone else is
-    // waiting for would hand them a truncated corpus (issue #2307).
-    const scanAbort = new AbortController();
-    const callerSignal = options?.abortSignal;
-    const onCallerAbort = () => scanAbort.abort();
-    let detached = false;
-    const detachCancellation = () => {
-      if (detached) return;
-      detached = true;
-      callerSignal?.removeEventListener("abort", onCallerAbort);
-    };
-    callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
-
+    // Sole-waiter cancellation lives with the registry that decides whether this
+    // scan is still cancellable at all — see `beginCoalescedScan` (issue #2307).
+    const scan = beginCoalescedScan(this.baseDir, keyId, options?.abortSignal);
     const readPromise = (async (): Promise<MemoryFile[]> => {
       const version = this.getMemoryCorpusVersion();
-      const memories = await this._readAllMemoriesFromDisk({ abortSignal: scanAbort.signal });
+      const memories = await this._readAllMemoriesFromDisk({ abortSignal: scan.scanSignal });
       // Publish only if neither the corpus version NOR the key identity changed
       // during the scan. The version guard prevents clobbering a newer patched +
       // re-keyed entry; the keyId guard prevents publishing this key's decrypted
@@ -4526,11 +4522,11 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       }
       return memories;
     })();
-    setInFlightRead(this.baseDir, keyId, readPromise, detachCancellation);
+    scan.arm(readPromise);
     try {
       return this.rememberMemorySnapshots(await readPromise);
     } finally {
-      detachCancellation();
+      scan.detach();
       deleteInFlightRead(this.baseDir, keyId, readPromise);
     }
   }
@@ -4860,6 +4856,10 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         if (memory !== null) memories.push(memory);
       }
     }
+    // Once more after the loop: a signal that fired during the LAST batch's await
+    // would otherwise let this return successfully, publishing to the cache and
+    // handing results to a caller that had already given up (issue #2307 review).
+    checkCorpusReadAbort(options);
     return memories;
   }
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -4528,7 +4528,16 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     })();
     scan.arm(readPromise);
     try {
-      return this.rememberMemorySnapshots(await readPromise);
+      // The starter races its own signal too. Refcounting means a sole waiter's
+      // abort rejects the scan itself, but while another reader keeps the scan
+      // alive the starter would otherwise sit here and be handed the full corpus
+      // after cancelling — the joiner path's contract, applied symmetrically
+      // (issue #2307 review). The scan is NOT aborted here: it belongs to the
+      // readers still waiting, and a completed scan is still worth caching for
+      // them.
+      return this.rememberMemorySnapshots(
+        await raceAbort(readPromise, options?.abortSignal, "corpus read aborted"),
+      );
     } finally {
       scan.leave();
       deleteInFlightRead(this.baseDir, keyId, readPromise);

--- a/packages/remnic-core/src/storage/entity-store.ts
+++ b/packages/remnic-core/src/storage/entity-store.ts
@@ -524,7 +524,9 @@ export class EntityStore {
           if (content !== null) entities.push(parseEntityFile(content, this.deps.entitySchemas));
         }
       }
-
+      // A signal that fired during the last batch's await would otherwise publish
+      // and return as if uncancelled (issue #2307 review).
+      checkCorpusReadAbort(options);
       setCachedEntities(this.deps.baseDir, entities, currentVersion, cacheKey);
       return entities;
     } catch (err) {

--- a/packages/remnic-core/src/storage/entity-store.ts
+++ b/packages/remnic-core/src/storage/entity-store.ts
@@ -12,6 +12,7 @@
 
 import { readdir, unlink } from "node:fs/promises";
 import path from "node:path";
+import { checkCorpusReadAbort, type CorpusReadOptions } from "../corpus-read-cancellation.js";
 import { normalizeEntityStructuredSection, sortStructuredSectionsBySchema } from "../entity-schema.js";
 import { withEntityCanonicalMutationLock } from "./entity-canonical-id-lock.js";
 import { log } from "../logger.js";
@@ -482,7 +483,8 @@ export class EntityStore {
    * Read all entity files and return lightweight EntityFile objects.
    * Parsing is fast (~50-100ms for ~1,800 files) since entity files are small.
    */
-  async readAllEntityFiles(): Promise<EntityFile[]> {
+  async readAllEntityFiles(options?: CorpusReadOptions): Promise<EntityFile[]> {
+    checkCorpusReadAbort(options);
     const currentVersion = this.deps.getMemoryStatusVersion();
     const cacheKey = [
       this.deps.getEntityCacheSecureStoreKey(),
@@ -503,6 +505,9 @@ export class EntityStore {
       const BATCH_SIZE = 100;
       const entities: EntityFile[] = [];
       for (let i = 0; i < mdFiles.length; i += BATCH_SIZE) {
+        // Per batch, so an abandoned caller stops within one batch of I/O instead
+        // of reading every entity file for a result nobody awaits (issue #2307).
+        checkCorpusReadAbort(options);
         const batch = mdFiles.slice(i, i + BATCH_SIZE);
         const results = await Promise.all(
           batch.map(async (entry) => {

--- a/packages/remnic-core/src/storage/memory-read-store.ts
+++ b/packages/remnic-core/src/storage/memory-read-store.ts
@@ -18,6 +18,8 @@ import { type BufferSurpriseEvent, type CompressionGuidelineOptimizerState, type
 import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
 import { isErrnoCode } from "../utils/errno.js";
 import { assertPathInsideRoot } from "../utils/path-containment.js";
+import { isAbortError } from "../abort-error.js";
+import { checkCorpusReadAbort, type CorpusReadOptions } from "../corpus-read-cancellation.js";
 import { isValidTranscriptDate } from "../wearables/day-store.js";
 import {
   isValidBufferSurpriseEvent,
@@ -147,7 +149,8 @@ export class MemoryReadStore {
     return days;
   }
 
-  async readAllArtifactsCached(): Promise<MemoryFile[]> {
+  async readAllArtifactsCached(options?: CorpusReadOptions): Promise<MemoryFile[]> {
+    checkCorpusReadAbort(options);
     if (
       this.deps.artifactIndexCache &&
       Date.now() - this.deps.artifactIndexCache.loadedAtMs <= this.deps.storageManagerClass.ARTIFACT_INDEX_CACHE_TTL_MS &&
@@ -162,6 +165,10 @@ export class MemoryReadStore {
         try {
           const entries = await readdir(dir, { withFileTypes: true });
           for (const entry of entries) {
+            // Per-entry, so a tree of any shape has a checkpoint: this scan has no
+            // in-flight dedup, so every abandoned recall used to start another
+            // full walk of it (issue #2307).
+            checkCorpusReadAbort(options);
             const fullPath = path.join(dir, entry.name);
             if (entry.isDirectory()) {
               await readDir(fullPath);
@@ -172,7 +179,10 @@ export class MemoryReadStore {
             if (!memory) continue;
             artifacts.push(memory);
           }
-        } catch {
+        } catch (err) {
+          // A cancelled scan must surface, not be swallowed as "directory doesn't
+          // exist yet" — otherwise a partial walk would be cached as complete.
+          if (isAbortError(err)) throw err;
           // Directory doesn't exist yet
         }
       };
@@ -183,6 +193,7 @@ export class MemoryReadStore {
     const MAX_REBUILD_RETRIES = 2;
     let latestArtifacts: MemoryFile[] = [];
     for (let attempt = 0; attempt <= MAX_REBUILD_RETRIES; attempt += 1) {
+      checkCorpusReadAbort(options);
       const versionBefore = this.deps.getArtifactWriteVersion();
       const artifacts = await scanArtifacts();
       const versionAfter = this.deps.getArtifactWriteVersion();
@@ -210,6 +221,7 @@ export class MemoryReadStore {
   private async collectContainedMarkdownPaths(
     startDirs: readonly string[],
     propagateReadErrors = false,
+    options?: CorpusReadOptions,
   ): Promise<string[]> {
     const filePaths: string[] = [];
 
@@ -226,6 +238,7 @@ export class MemoryReadStore {
     }
 
     const collectPaths = async (dir: string): Promise<void> => {
+      checkCorpusReadAbort(options);
       // Directory-level guard, isolated from per-entry handling: skip symlinked
       // or non-directory category dirs and assert the resolved dir stays inside
       // the memory root before reading. A failure here means the whole subtree
@@ -264,6 +277,10 @@ export class MemoryReadStore {
 
       const subdirs: string[] = [];
       for (const entry of entries) {
+        // Outside the per-entry try/catch below, which deliberately swallows
+        // non-propagatable errors — a cancellation must never be swallowed with
+        // them (issue #2307).
+        checkCorpusReadAbort(options);
         // Never follow symlinked entries out of the store.
         if (entry.isSymbolicLink()) continue;
         const fullPath = path.join(dir, entry.name);
@@ -300,7 +317,9 @@ export class MemoryReadStore {
     return filePaths;
   }
 
-  async collectActiveMemoryPaths(options?: { propagateReadErrors?: boolean }): Promise<string[]> {
+  async collectActiveMemoryPaths(
+    options?: { propagateReadErrors?: boolean } & CorpusReadOptions,
+  ): Promise<string[]> {
     // Scan EVERY supported memory category directory, not just the legacy four
     // (facts/procedures/reasoning-traces/corrections). Issue #1497: the QMD
     // filesystem-fallback recall path (orchestrator `recent_scan` ->
@@ -330,6 +349,7 @@ export class MemoryReadStore {
     return this.collectContainedMarkdownPaths(
       RECALL_FALLBACK_DIRS.map((dir) => path.join(this.deps.baseDir, dir)),
       options?.propagateReadErrors ?? false,
+      options,
     );
   }
 
@@ -342,10 +362,13 @@ export class MemoryReadStore {
    * of the recall fallback corpus (collectActiveMemoryPaths), whose scan is
    * intentionally unchanged.
    */
-  async collectColdMemoryPaths(options?: { propagateReadErrors?: boolean }): Promise<string[]> {
+  async collectColdMemoryPaths(
+    options?: { propagateReadErrors?: boolean } & CorpusReadOptions,
+  ): Promise<string[]> {
     return this.collectContainedMarkdownPaths(
       [this.deps.resolveTierRootDir("cold")],
       options?.propagateReadErrors ?? false,
+      options,
     );
   }
 

--- a/packages/remnic-core/src/storage/memory-read-store.ts
+++ b/packages/remnic-core/src/storage/memory-read-store.ts
@@ -198,6 +198,9 @@ export class MemoryReadStore {
       const artifacts = await scanArtifacts();
       const versionAfter = this.deps.getArtifactWriteVersion();
       latestArtifacts = artifacts;
+      // A signal that fired during the last file read of the walk would otherwise
+      // publish this scan and return it as if uncancelled (issue #2307 review).
+      checkCorpusReadAbort(options);
       if (versionAfter === versionBefore) {
         this.deps.artifactIndexCache = { memories: artifacts, loadedAtMs: Date.now(), writeVersion: versionAfter };
         return artifacts;
@@ -314,6 +317,9 @@ export class MemoryReadStore {
     for (const dir of startDirs) {
       await collectPaths(dir);
     }
+    // A signal that fired during the last directory read would otherwise return a
+    // truncated path list as if it were the whole corpus (issue #2307 review).
+    checkCorpusReadAbort(options);
     return filePaths;
   }
 


### PR DESCRIPTION
Fixes #2307. Follow-up to #2291 / #2306.

## The gap

#2306 bounded the optional recall providers, so a timed-out recall returns on time.
The scans underneath did not stop. For the primitives with **no in-flight dedup** —
`readAllArtifactsCached`, `readAllEntityFiles`, the artifact source-status snapshot
— every abandoned request started another full walk, so repeated timed-out recalls
against a large or network-mounted store accumulated obsolete scans and sustained
I/O no live request needed.

## Mechanism

One `CorpusReadOptions` carrying an optional `abortSignal`, threaded as a trailing
parameter (`packages/remnic-core/src/corpus-read-cancellation.ts`).

Deliberately **not** ambient async context, which #2307 listed as the alternative:
these primitives have callers across extraction, maintenance, wearables, and coding
surfaces, and an ambient signal would silently attach one request's cancellation to
background work that merely shares its async context. An explicit parameter is
greppable, and a caller that does not opt in behaves exactly as before.

Two invariants, uniform across all four primitives:

1. **Checked before the cache lookup** — an abandoned caller gets an `AbortError`
   whether the cache is warm or cold, so cancellation never depends on cache state.
   Same contract the recall providers already follow.
2. **A cancelled read never publishes** — every checkpoint throws, so control
   leaves before the cache write. A partial corpus is never cached, nor served as
   if it were complete.

Checkpoints sit at real boundaries, not synthetic ones: per directory entry in the
artifact walk and the memory path walk, per batch in the memory and entity parse
loops, per attempt in the artifact rebuild retry and the status-snapshot retry.
The artifact walk's catch-all no longer swallows an `AbortError` along with
"directory doesn't exist yet" — that would have cached a partial walk as complete.

## The subtle case: a coalesced read

`readAllMemories` coalesces overlapping reads onto one scan. Cancelling a shared
scan would hand every other waiter a truncated corpus, so the starter's signal is
linked to the scan **only while it stays the sole waiter**: `getInFlightRead`
detaches that link the moment a second reader joins. One boolean, moving one way
only — the failure mode is a scan that outlives its starter, never a joiner left
holding a cancelled read. Refcounting would allow cancellation in more cases; it is
not worth a second piece of mutable lifecycle state in a module that already
carries the keyId-isolation and version-guard invariants.

Note this coalescing is also why `readAllMemories` was never the main accumulator:
concurrent scans already collapsed to one. The pile-up #2307 describes came from
the three primitives without it.

## Verification

`packages/remnic-core/src/storage-contract/corpus-read-cancellation.test.ts` — 8
pass. The scenario matrix, per primitive: no signal; unfired signal; already
aborted (nothing read at all); aborted mid-scan (nothing cached, proven by a scan
spy showing the next read must re-scan); and for the coalesced read, both a joiner
protecting the scan and a sole waiter successfully cancelling it.

Mutation-checked rather than assumed:
- neutering `checkCorpusReadAbort` → 4 of 8 fail (the 4 that assert cancellation).
- removing the `detachCancellation` call in `getInFlightRead` → the joiner test,
  and only that test, fails.

Also green: `storage-contract` suite (88), `npm run test:entity-hardening` (339),
recall/artifact/memory-cache/cache-coherence suites (84), root and core
`tsc --noEmit`, `npm run lint`, `check-ratchets`, `check-config-contract`,
`check-review-patterns`, `lifecycle-matrix`, `check-envelope-belt`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot recall and storage read paths with coalesced-scan lifecycle changes; incorrect refcounting or cache publish on abort could cause stale partial corpora or extra I/O, but behavior is opt-in and heavily tested.
> 
> **Overview**
> Timed-out or abandoned recalls could return on time while **full-tree scans kept running** underneath, and primitives without in-flight dedup could stack duplicate walks. This change adds an explicit optional **`abortSignal`** on shared corpus reads so that work stops at directory, batch, and retry boundaries instead of running for no live caller.
> 
> **`CorpusReadOptions`** and **`checkCorpusReadAbort`** define the contract: abort is checked **before** cache hits (warm cache does not bypass cancellation), and **cancelled reads never write** partial results to memory, entity, or artifact caches. **`readAllMemories`**, **`readAllEntityFiles`**, **`readAllArtifactsCached`**, path collection, and the artifact source-status snapshot all honor that; recall paths (recent-memory read, entity index build, artifact status resolution) **forward** the recall step signal.
> 
> **Coalesced `readAllMemories`** is reworked in **`in-flight-reads`**: waiter refcounting cancels the shared scan only when the **last** waiter leaves; joiners are protected, and a late joiner after withdrawal starts a fresh scan. Starters still get **`AbortError`** via **`raceAbort`** when they cancel while others keep the scan alive.
> 
> New **`corpus-read-cancellation.test.ts`** covers pre-abort, mid-scan (no cache publish), and coalesced joiner / sole-waiter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94cbef33c45ed401a2cac7932afdd971ca2ea446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cancellation support for full-corpus reads and artifact searches.
  * Reads can stop during directory scans, batching, retries, and entity loading.
  * Shared reads remain available to other callers when one caller cancels.
* **Bug Fixes**
  * Prevented cancelled or incomplete reads from publishing partial cache results.
  * Ensured subsequent uncached reads return complete data after cancellation.
* **Tests**
  * Added coverage for pre-cancelled, mid-scan, shared, and sole-reader cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->