### PR TITLE
docs(h6): correct equivalence estimator to task level

### DIFF
--- a/docs/research/failure-gate/amendment-01-draft.md
+++ b/docs/research/failure-gate/amendment-01-draft.md
@@ -1,9 +1,19 @@
-# Amendment 1 (DRAFT — not yet applied, and now INCOMPLETE)
+# Amendment 1 (DRAFT — content argument stands; no-trap sections SUPERSEDED)
 
-Status: drafted before the v3 pilot finished, then overtaken by its results.
-**Dropping content is necessary but no longer sufficient.** The completed pilot
-shows the no-trap equivalence gate also fails, which this draft predates and
-does not address. Do not apply as written; see "Second blocker" below.
+Status: drafted before the v3 pilot finished, then partly overtaken by it.
+
+- The **content** argument still holds and is strengthened: the model passes
+  none of the trap-bearing tasks (0 of 900 episodes), so the task-pass leg has
+  no signal to measure.
+- The **no-trap sections below are wrong** and must not be applied. They compute
+  the standard error from an episode-level binomial approximation (SE 0.0224,
+  margin ÷ SE 0.89, ~200 tasks required, "no margin works"). The analysis
+  bootstraps at the *task* level, where SE is 0.0120, margin ÷ SE is 1.67, and
+  the registered ±0.02 margin becomes properly powered at about **41** no-trap
+  tasks. The corrected derivation is in `report.md`.
+- The recommendation to retire the pass-rate check is withdrawn. The check is
+  under-resourced, not unusable, and a larger task set answers it without
+  touching any threshold.
 
 Applying any version of this invalidates the completed pilot, its audit receipt,
 and the harness hash. Sequencing lives in `RESUME-HANDOFF.md`; measured results

--- a/docs/research/failure-gate/amendment-01-draft.md
+++ b/docs/research/failure-gate/amendment-01-draft.md
@@ -19,7 +19,7 @@ Applying any version of this invalidates the completed pilot, its audit receipt,
 and the harness hash. Sequencing lives in `RESUME-HANDOFF.md`; measured results
 live in `report.md`.
 
-## Second blocker: no-trap equivalence (measured, added after the pilot)
+## Second blocker: no-trap equivalence (SUPERSEDED — see header, kept for history)
 
 | Test | Simulated power | Required |
 | --- | ---: | ---: |
@@ -74,26 +74,19 @@ nothing. Task pass is a rare event here (3.9–5.6 percent), and equivalence
 testing on a rare binary outcome needs very large samples that no margin choice
 substitutes for.
 
-## Recommended resolution for the second blocker
+## Resolution for the second blocker — WITHDRAWN
 
-**Retire the pass-rate half of the no-trap check from this design rather than
-loosen it.** The steps half is viable and passes with 60× headroom, so the
-timidity question — does the gate make the agent work harder or behave more
-cautiously where there is no trap — is answerable, and the answer is no.
-Retaining the pass-rate half at any margin this design supports would
-manufacture a verdict instead of measuring one.
+This section previously recommended retiring the pass-rate half of the no-trap
+check. **That recommendation is withdrawn**, because it rested on the wrong
+standard error. With the task-level estimator the margin is 1.67 SE rather than
+0.89, and the registered ±0.02 becomes properly powered at about 41 no-trap
+tasks rather than 200. The check is under-resourced, not unusable, so retiring
+it would discard a question a larger task set answers cleanly.
 
-Rejected alternatives, recorded so the reasoning survives:
-
-- **Widen the margin to 0.0654.** Meaningless at a 3.9 percent base rate.
-- **Drop the whole no-trap check from the gate.** Discards the steps result,
-  which is both valid and informative.
-- **Grow to 200 no-trap tasks.** Scientifically clean, but a fundamentally
-  larger study; worth doing only if pass-rate equivalence is itself a
-  deliverable.
-- **Do not run main at all.** Still viable. The pilot already answers the
-  science: timing real (RRR 1.00, benefit 0.317, interval [0.100, 0.567]),
-  content dead, steps-equivalence supported.
+The current recommendation lives in `report.md`: grow the task set toward tasks
+the model can sometimes pass, which repairs the equivalence estimator and the
+content metric together without touching any threshold. Everything above in this
+section is retained only as a record of the superseded reasoning.
 
 ---
 
@@ -221,9 +214,11 @@ reads it. A reader must be able to see the margin that was retired and why.
 1. `packages/bench/src/coding-graph/repeated-failure-suite-analysis.ts`, in
    `verifyPilotPower`: drop `|| power.contentPower < 0.8` from the gate. Keep
    timing and timidity. Keep reporting content power in the artifact.
-2. Both `decision-rule.json` copies: update `preregistration.sha256` to the new
-   hash of the amended preregistration. Do **not** remove the `H6-content`
-   hypothesis block — it is still estimated and reported.
+2. `packages/bench/fixtures/h6-failure-gate/decision-rule.json` — the single
+   tracked copy, verified with `git ls-files | grep decision-rule.json`. Update
+   `preregistration.sha256` to the new hash of the amended preregistration. Do
+   **not** remove the `H6-content` hypothesis block — it is still estimated and
+   reported.
 3. **Add** a test — do not look for one to update. The power threshold gate is
    currently untested. `repeated-failure-suite.test.ts:1645` ("main phase
    rejects reduced frozen inputs and cannot start without verified pilot

--- a/docs/research/failure-gate/amendment-01-draft.md
+++ b/docs/research/failure-gate/amendment-01-draft.md
@@ -169,9 +169,13 @@ that guards main execution changes.
 >
 > H6-content requires a strictly positive lower bound on the task-pass benefit
 > interval. Two independent pilots measured a task-pass rate of exactly zero in
-> both content arms, making that condition unsatisfiable at any sample size and
-> fixing simulated content power at 0.000. The main-run power gate therefore
-> requires timing power and no-trap equivalence power only.
+> both content arms — 270 episodes per arm in total — which fixes the observed
+> benefit at a degenerate `[0, 0]` interval and simulated content power at 0.000.
+> The condition is unsatisfiable at the model's present operating point rather
+> than in principle: it would become testable if the task-pass rate in these arms
+> rose materially above the floor, which nothing in the evidence suggests. The
+> main-run power gate therefore requires timing power and no-trap equivalence
+> power only.
 >
 > H6-content remains registered and reported. On the evidence above it is
 > recorded as `REJECTED`, and the study decision mapping is unchanged. No

--- a/docs/research/failure-gate/amendment-01-draft.md
+++ b/docs/research/failure-gate/amendment-01-draft.md
@@ -1,0 +1,231 @@
+# Amendment 1 (DRAFT — not yet applied, and now INCOMPLETE)
+
+Status: drafted before the v3 pilot finished, then overtaken by its results.
+**Dropping content is necessary but no longer sufficient.** The completed pilot
+shows the no-trap equivalence gate also fails, which this draft predates and
+does not address. Do not apply as written; see "Second blocker" below.
+
+Applying any version of this invalidates the completed pilot, its audit receipt,
+and the harness hash. Sequencing lives in `RESUME-HANDOFF.md`; measured results
+live in `report.md`.
+
+## Second blocker: no-trap equivalence (measured, added after the pilot)
+
+| Test | Simulated power | Required |
+| --- | ---: | ---: |
+| H6-timing | 0.8363 | 0.80 |
+| H6-content | 0.0000 | 0.80 |
+| No-trap equivalence | **0.1627** | 0.80 |
+
+`equivalent: false`. The pass-rate difference is +0.0167 with a 90% interval of
+[0, 0.0389] against a ±0.02 margin — the point estimate sits inside the margin
+but the interval does not, so strict containment fails. Steps are comfortably
+inside (0.0333, interval [0, 0.0722], margin 2).
+
+More tasks do not obviously fix this. Resampling the pilot's 12 task groups to
+larger simulated experiments holds equivalence power far below the bar while
+timing saturates:
+
+| Simulated tasks | equivalence | timing |
+| ---: | ---: | ---: |
+| 18 | 0.137 | 0.813 |
+| 30 | 0.173 | 0.993 |
+| 50 | 0.150 | 1.000 |
+| 80 | 0.223 | 1.000 |
+| 120 | 0.233 | 1.000 |
+
+**Read that table with care.** It resamples 12 real task groups, so beyond a
+point it duplicates rather than adds information, and it cannot tell you what
+120 genuinely independent tasks would do. What it does establish is that the
+harness's own power procedure — the one that produced the official 0.1627 —
+keeps equivalence far below 0.80 at every experiment size, while timing is
+robust from 18 tasks upward.
+
+The mechanism is arithmetic. The margin is 0.89 standard errors of the statistic
+it constrains; strict containment of a 90 percent interval needs roughly 1.645.
+Even a true difference of exactly zero produces an interval about 1.8× too wide.
+
+### No margin works at this operating point
+
+Loosening is not a fix either. Reaching 80 percent equivalence power at a true
+difference of zero needs a margin above `(z₀.₉₅ + z₀.₉) · SE ≈ 2.93 · SE`:
+
+| No-trap tasks | episodes/arm | SE | margin needed |
+| ---: | ---: | ---: | ---: |
+| **12 (this design)** | 180 | 0.0224 | **0.0654** |
+| 41 | 615 | 0.0121 | 0.0354 |
+| 100 | 1500 | 0.0077 | 0.0227 |
+| 200 | 3000 | 0.0055 | **0.0160** ✓ |
+
+Keeping ±0.02 needs about **200 no-trap tasks**, sixteen times the current
+population. Keeping 12 tasks needs a margin of **0.0654**, which is 1.4× the base
+pass rate — a band permitting the pass rate to double or vanish, which asserts
+nothing. Task pass is a rare event here (3.9–5.6 percent), and equivalence
+testing on a rare binary outcome needs very large samples that no margin choice
+substitutes for.
+
+## Recommended resolution for the second blocker
+
+**Retire the pass-rate half of the no-trap check from this design rather than
+loosen it.** The steps half is viable and passes with 60× headroom, so the
+timidity question — does the gate make the agent work harder or behave more
+cautiously where there is no trap — is answerable, and the answer is no.
+Retaining the pass-rate half at any margin this design supports would
+manufacture a verdict instead of measuring one.
+
+Rejected alternatives, recorded so the reasoning survives:
+
+- **Widen the margin to 0.0654.** Meaningless at a 3.9 percent base rate.
+- **Drop the whole no-trap check from the gate.** Discards the steps result,
+  which is both valid and informative.
+- **Grow to 200 no-trap tasks.** Scientifically clean, but a fundamentally
+  larger study; worth doing only if pass-rate equivalence is itself a
+  deliverable.
+- **Do not run main at all.** Still viable. The pilot already answers the
+  science: timing real (RRR 1.00, benefit 0.317, interval [0.100, 0.567]),
+  content dead, steps-equivalence supported.
+
+---
+
+# Original draft (content gate only)
+## What changes
+
+H6-content stops gating the main run. It remains a registered hypothesis, is
+reported in every table, and is recorded as `REJECTED` on its own evidence. The
+main-run power gate becomes timing and the no-trap equivalence check only.
+
+## Why
+
+H6-content requires benefit on two metrics: repeated failure and task pass. The
+task-pass leg is not underpowered — it is identically zero, so no sample size
+can satisfy it.
+
+Measured arm rates from the v3 pilot population (uncut tasks, 945 primary rows):
+
+| Arm | n | task pass | repeated failure |
+| --- | ---: | ---: | ---: |
+| `NO_MEMORY` | 270 | 0.041 | 0.163 |
+| `PRE_ACTION_FAILURE` | 270 | 0.041 | 0.000 |
+| `TURN_START_FAILURE` | 135 | 0.000 | 0.289 |
+| `TURN_START_SUCCESS` | 135 | 0.000 | 0.378 |
+| `BOTH` | 135 | 0.000 | 0.000 |
+
+Both content arms — `TURN_START_FAILURE` and `TURN_START_SUCCESS` — pass zero
+tasks. The task-pass benefit is therefore exactly 0 with a degenerate `[0, 0]`
+95% interval and p = 1, so
+`requireTaskPassBenefitIntervalLowerStrictlyAbove: 0` can never hold. Simulated
+content power is exactly 0.000, and the v1 pilot independently measured content
+power 0.000 under the same rule.
+
+The root cause is model capability, not experimental design: the registered
+model fully repairs at most 4.1 percent of tasks in any arm, so the task-pass
+metric carries almost no signal at this scale. Content's repeated-failure leg
+does show a real effect (+0.089, 95% CI [0.022, 0.178]), which is why the
+hypothesis is reported rather than deleted.
+
+The existing preregistration already anticipates under-power by requiring more
+independent tasks in a new dataset version. That remedy is inapplicable here:
+adding tasks cannot move a metric that is identically zero in both arms. This
+amendment records that distinction instead of repeatedly re-running a pilot that
+cannot change the outcome.
+
+## Text edits
+
+Both copies of the preregistration must be edited identically:
+`docs/research/failure-gate/preregistration.md` and
+`packages/bench/preregistration/h6-failure-gate.md`.
+
+### 1. "Power and the no-trap check", first paragraph
+
+Replace:
+
+> Timing and content each need at least 0.80 simulated power under their
+> registered support rules.
+
+With:
+
+> Timing needs at least 0.80 simulated power under its registered support rule.
+> Content is excluded from the main-run power gate by Amendment 1; it is still
+> estimated, reported, and decided under its registered support rule, but a
+> content power below 0.80 no longer blocks main execution.
+
+Append to the same paragraph:
+
+> Adding independent tasks is the registered remedy only for a test that is
+> genuinely underpowered. It does not apply to a support condition whose metric
+> is identically zero in both compared arms; see Amendment 1.
+
+### 2. "Decision rules", study-decision mapping
+
+Leave the `PASS` / `PARTIAL` / `REJECT` / `NOT_ESTIMABLE` mapping unchanged. The
+study decision continues to account for both primaries. Only the *power gate*
+that guards main execution changes.
+
+### 3. New section, placed after "Power and the no-trap check"
+
+> ## Amendment 1: content is excluded from the main-run power gate
+>
+> Date: (fill in on apply). Applies from the pilot run that follows it.
+>
+> H6-content requires a strictly positive lower bound on the task-pass benefit
+> interval. Two independent pilots measured a task-pass rate of exactly zero in
+> both content arms, making that condition unsatisfiable at any sample size and
+> fixing simulated content power at 0.000. The main-run power gate therefore
+> requires timing power and no-trap equivalence power only.
+>
+> H6-content remains registered and reported. On the evidence above it is
+> recorded as `REJECTED`, and the study decision mapping is unchanged. No
+> decision threshold is altered: the 0.80 bar, the 0.05 alpha, the timing
+> support conditions, the zero-cut rule, and the equivalence margins all stand.
+
+### 4. Retiring the pass-rate half of the no-trap check (verified against source)
+
+The recommendation is cleanly implementable — checked against the code, not
+assumed. `isRepeatedFailureTimidityEquivalent`
+(`repeated-failure-stats.ts:525-537`) is a flat four-condition AND:
+
+```ts
+return (
+  passRateInterval.lower > -passMargin &&
+  passRateInterval.upper < passMargin &&
+  stepsInterval.lower > -stepsMargin &&
+  stepsInterval.upper < stepsMargin
+);
+```
+
+Retiring the pass-rate half means dropping its two conditions and keeping the
+steps pair. Reporting is unaffected: `passRateDifference` and
+`passRateInterval` are assigned independently at lines 653-654, and `passMargin`
+stays in the artifact, so the pass-rate numbers remain measured, published, and
+auditable — only their gating role is removed.
+
+Keep `passMargin` in the emitted analysis even though the predicate no longer
+reads it. A reader must be able to see the margin that was retired and why.
+
+## Code and artifact edits
+
+1. `packages/bench/src/coding-graph/repeated-failure-suite-analysis.ts`, in
+   `verifyPilotPower`: drop `|| power.contentPower < 0.8` from the gate. Keep
+   timing and timidity. Keep reporting content power in the artifact.
+2. Both `decision-rule.json` copies: update `preregistration.sha256` to the new
+   hash of the amended preregistration. Do **not** remove the `H6-content`
+   hypothesis block — it is still estimated and reported.
+3. **Add** a test — do not look for one to update. The power threshold gate is
+   currently untested. `repeated-failure-suite.test.ts:1645` ("main phase
+   rejects reduced frozen inputs and cannot start without verified pilot
+   power") only covers a *missing* pilot run via `/verified pilot run/`; nothing
+   exercises the `< 0.8` comparisons in
+   `repeated-failure-suite-analysis.ts:666-668`. Add a case that feeds a pilot
+   whose content power is 0 and whose timing and timidity powers clear 0.80, and
+   assert main now starts. Add its mirror: timing below 0.80 must still throw
+   `/underpowered/`. Without both, a later edit could silently restore or
+   destroy the gate with no failing test.
+4. `pnpm --filter @remnic/bench build`, then re-run the trap audit, then the
+   pilot.
+
+## What this amendment does not do
+
+- It does not lower the 0.80 power threshold.
+- It does not alter any H6-timing support condition.
+- It does not relax the zero-cut rule or the equivalence margins.
+- It does not delete H6-content or hide its result.

--- a/docs/research/failure-gate/report.md
+++ b/docs/research/failure-gate/report.md
@@ -59,8 +59,14 @@ be supported doubled the multiplicity penalty on the hypothesis that works.**
 | Raw p | 0.8413 |
 | Task-pass benefit | 0, interval [0, 0], p = 1 |
 
-Content requires strictly positive lower bounds on **both** metrics. The
-task-pass benefit is exactly zero because both content arms pass zero tasks:
+Content requires strictly positive lower bounds on **both** metrics, and the
+task-pass leg is dead for a blunter reason than an arm-level tie.
+
+**In the trap-bearing population the model passed nothing at all: 0 of 900
+episodes, across all 12 tasks and all 5 arms.** Every pass recorded anywhere in
+this pilot came from `no-trap` control revisions, and even there from only two
+tasks. Arm-level rates (the 0.041 figures below) are therefore carried entirely
+by no-trap rows, not by the tasks the primaries are computed on.
 
 | Arm | n | task pass | repeated failure |
 | --- | ---: | ---: | ---: |
@@ -70,14 +76,13 @@ task-pass benefit is exactly zero because both content arms pass zero tasks:
 | `TURN_START_SUCCESS` | 135 | 0.000 | 0.378 |
 | `BOTH` | 135 | 0.000 | 0.000 |
 
-Both content arms passed zero of 135 episodes here, and the v1 pilot measured
-content power 0.000 independently. On that evidence the task-pass benefit is a
-degenerate `[0, 0]` interval with p = 1, and no realistic increase in sample
-size makes it produce a positive lower bound while the underlying rate stays at
-the floor. This is a statement about the observed operating point, not a proof
-about all possible data: the constraint would lift if the model's task-pass rate
-rose materially above zero in these arms. At this model's capability, where even
-the best arm fully repairs 4.1 percent of tasks, that is not in prospect.
+So the task-pass benefit is a degenerate `[0, 0]` interval with p = 1, and the
+v1 pilot measured content power 0.000 independently. The binding constraint is
+not that the two content arms tie — it is that this model never repairs a
+trapped task, so the metric has no signal to measure. That is a statement about
+the present operating point rather than a proof about all data: it would lift
+with a model that can sometimes fix these tasks. Nothing in the evidence
+suggests the current one can.
 
 ### No-trap equivalence — not equivalent
 
@@ -96,87 +101,81 @@ registered claim "the gate does not change behavior on tasks with no trap" is
 not supported at the registered margin, but nothing here suggests the gate
 causes harm.
 
-#### The ±0.02 margin is below this design's noise floor
+#### The check has an effective sample size of two
 
-The equivalence check had almost no room to pass. Measured
-no-trap population, 12 tasks × 15 episodes per arm:
+**Correction.** An earlier revision of this section computed the standard error
+from an episode-level binomial approximation, giving SE 0.0224, margin ÷ SE
+0.89, and a requirement of roughly 200 no-trap tasks. That was the wrong
+estimator. The analysis bootstraps at the **task** level, so the SE must come
+from the spread of per-task differences. The corrected figures are below and
+they change the conclusion.
+
+Measured no-trap population, 12 tasks × 15 episodes per arm:
 
 | Arm | n | passes | pass rate | mean steps |
 | --- | ---: | ---: | ---: | ---: |
 | `NO_MEMORY` | 180 | 7 | 0.0389 | 5.328 |
 | `PRE_ACTION_FAILURE` | 180 | 10 | 0.0556 | 5.361 |
 
-The entire non-equivalence verdict rests on **three episodes** — 7 passes versus
-10 out of 180 — in the direction that favours the gate.
+Per-task differences tell the real story:
+
+| Task | baseline | candidate | difference |
+| --- | ---: | ---: | ---: |
+| `h6-task-21` | 5/15 | 6/15 | +0.0667 |
+| `h6-task-22` | 2/15 | 4/15 | +0.1333 |
+| **other 10 tasks** | **0/15** | **0/15** | **0.0000** |
+
+**Ten of twelve tasks contribute exactly zero** — the model passes none of them
+in either arm. All variance in the statistic comes from two tasks, so the
+equivalence check has an effective sample size of **2**, not 12, and the whole
+verdict turns on three extra passes (one in `21`, two in `22`).
 
 | Quantity | Value |
 | --- | ---: |
-| Registered margin | 0.0200 (≈ 3.6 episodes of 180) |
-| SE of the pass-rate difference | 0.0224 |
-| 90% CI half-width (1.645·SE) | 0.0368 |
-| **margin ÷ SE** | **0.89** |
+| Registered margin | 0.0200 |
+| SD of per-task differences | 0.0414 |
+| **Task-level SE** | **0.0120** |
+| 90% half-width (1.645·SE) | 0.0197 |
+| **margin ÷ SE** | **1.67** |
 
-A 90% interval fits strictly inside a margin only when that margin exceeds about
-1.645 standard errors of the statistic. Here the margin is **0.89 SE** — smaller
-than one standard error of the quantity it constrains. Under the normal
-approximation, even a true difference of exactly zero yields a half-width of
-0.0368, roughly 1.8× too wide to fit, and reaching strict containment under an
-exact null needs about 609 episodes per arm, or **41 no-trap tasks** against the
-12 this design has.
+At 1.67 SE the margin sits just above the 1.645 needed for containment to be
+possible at all, so — contrary to the earlier revision — equivalence was **not**
+out of reach by construction. It was reachable only if the observed difference
+sat almost exactly on zero, which two passable tasks out of twelve could not
+deliver.
 
-To be precise about what that does and does not establish: the check was not
-strictly impossible. The realised interval is a task-level bootstrap, not the
-normal approximation, and had the two arms produced identical pass counts the
-resulting interval could have landed just inside ±0.02. What the arithmetic
-shows is that passing required the observed difference to sit essentially on
-zero — a knife-edge, not a robust test. A three-episode difference out of 180,
-which is roughly one step of the metric's resolution, was enough to fail it.
+The steps half of the same check has roughly 60× headroom (0.0333 observed
+against a ±2 margin). That asymmetry is still real: the two margins were not set
+from the same operating characteristics.
 
-Two things follow. First, the equivalence failure is far more a property of the
-specification than a finding about the gate. Second, the two margins were set
-with wildly inconsistent stringency: the pass-rate margin sits below the noise
-floor while the steps margin (±2 against an observed 0.0333) has roughly **60×**
-headroom. Margins derived from the design's own operating characteristics — a
-3.9 percent base rate and 180 episodes per arm — would not look like that.
+#### What it would take, using the correct estimator
 
-This is a specification defect that was detectable before the run, from the base
-rate and episode count alone, without reference to any observed difference. That
-distinction matters: correcting the margin on those grounds is a principled
-re-derivation, whereas widening it because the test failed would be threshold
-shopping. Any correction must be argued and documented on the pre-run arithmetic.
+For an equivalence test to reach 80 percent power *at a true difference of
+zero*, the margin must exceed `(z₀.₉₅ + z₀.₉₀) · SE ≈ 2.93 · SE`. Holding the
+observed per-task spread (SD 0.0414) and scaling the task count:
 
-#### No margin works at this operating point
+| No-trap tasks | task-level SE | margin needed for 80% power |
+| ---: | ---: | ---: |
+| **12 (this design)** | 0.0120 | **0.0350** |
+| 18 | 0.0098 | 0.0286 |
+| 30 | 0.0076 | 0.0221 |
+| **41** | 0.0065 | **0.0189** ✓ |
+| 60 | 0.0053 | 0.0157 ✓ |
+| 100 | 0.0041 | 0.0121 ✓ |
 
-Loosening the margin is not a fix either. For an equivalence test to reach 80
-percent power *at a true difference of zero*, the margin must exceed
-`(z₀.₉₅ + z₀.₉) · SE ≈ 2.93 · SE`. Applying that to this design:
+**The registered ±0.02 margin becomes properly powered at about 41 no-trap
+tasks** — roughly 3.4× the current population, not the sixteen-fold increase the
+earlier revision claimed. That is a larger study, but an ordinary one.
 
-| No-trap tasks | episodes/arm | SE | margin needed for 80% power |
-| ---: | ---: | ---: | ---: |
-| **12 (this design)** | 180 | 0.0224 | **0.0654** |
-| 18 | 270 | 0.0183 | 0.0534 |
-| 41 | 615 | 0.0121 | 0.0354 |
-| 100 | 1500 | 0.0077 | 0.0227 |
-| 200 | 3000 | 0.0055 | **0.0160** ✓ |
+This supersedes the previous recommendation to retire the pass-rate check. The
+check is not unusable; it is under-resourced. Retiring a test that a 41-task
+design would answer cleanly would discard a real question rather than settle it.
 
-The design is caught between two impossibilities. Keeping the registered ±0.02
-margin requires roughly **200 no-trap tasks**, sixteen times the current
-population. Keeping the current 12 tasks requires a margin of **0.0654**, which
-is 1.4× the base pass rate itself — a band wide enough to permit the pass rate
-doubling or vanishing, which asserts nothing.
-
-The cause is that task pass is a rare event here (3.9 to 5.6 percent).
-Equivalence testing on a rare binary outcome needs very large samples, and no
-choice of margin substitutes for them.
-
-**Recommendation: retire the pass-rate equivalence check from this design rather
-than loosen it.** The steps half of the same check is viable and passes with 60×
-headroom, so the timidity question — does the gate make the agent work harder or
-behave more cautiously on tasks with no trap — is answerable, and the answer is
-no. Retaining the pass-rate half at any margin this design can support would
-manufacture a verdict rather than measure one. If pass-rate equivalence is
-scientifically required, it needs a fundamentally larger study or a task set
-where the model's base pass rate is not near the floor.
+The caveat is that the SD is itself estimated from two informative tasks, so the
+41 figure is indicative rather than precise, and it assumes added tasks resemble
+the existing mix. Given that 10 of 12 current tasks contribute nothing, the more
+efficient route is not simply more tasks but more tasks the model can sometimes
+pass: the effective sample size, not the nominal one, is what sets the SE.
 
 ## What changed against the v1 pilot
 
@@ -204,16 +203,25 @@ this run's artifacts, so the comparison is left open rather than resolved here.
 1. **Timing is real and adequately powered.** RRR 1.00, benefit 0.317, interval
    clear of zero, and 0.8363 simulated power. It fails today only on a
    multiplicity correction imposed by a hypothesis that cannot be supported.
-2. **Content cannot be rescued by more data.** Any further pilot spends compute
-   to re-measure a structural zero.
-3. **Equivalence needs a decision, not more tasks.** The pass-rate interval
-   misses a ±0.02 margin by 0.019. Whether that margin is right for a 4.1 percent
-   base pass rate is a scientific judgment; re-running without changing anything
-   will reproduce it.
+2. **Content cannot be rescued by more tasks of the current kind.** The model
+   passes none of the trap-bearing tasks — 0 of 900 episodes — so the task-pass
+   leg has no signal. What would rescue it is a task set this model can
+   sometimes solve, not a larger one.
+3. **Equivalence is under-resourced, not unusable.** The registered ±0.02 margin
+   becomes properly powered at roughly 41 no-trap tasks. Ten of the current 12
+   contribute exactly zero, so the effective sample size is 2. The fix is more
+   *passable* tasks, and it needs no change to any threshold.
+
+Points 2 and 3 share one cause: at this model's capability almost every task is
+unsolvable, which starves both the content metric and the equivalence estimator.
+A dataset built around tasks the model can sometimes pass would address both
+without weakening the protocol — and that is exactly the "new dataset version"
+the objective called for, aimed at pass-rate signal rather than trap coverage.
 
 The drafted amendment (`amendment-01-draft.md`) removes content from the main
-power gate. On this evidence it is necessary but **not sufficient** — the
-no-trap gate now fails too, which the draft predates and does not address.
+power gate. Its content argument still holds; its no-trap sections are
+superseded by the corrected estimator above and should not be applied as
+written.
 
 Any amendment that drops content also removes it from the Holm family, which
 moves timing from adjusted p 0.0624 to raw 0.0312 and flips it to `SUPPORTED`.

--- a/docs/research/failure-gate/report.md
+++ b/docs/research/failure-gate/report.md
@@ -70,11 +70,14 @@ task-pass benefit is exactly zero because both content arms pass zero tasks:
 | `TURN_START_SUCCESS` | 135 | 0.000 | 0.378 |
 | `BOTH` | 135 | 0.000 | 0.000 |
 
-No sample size can make a degenerate `[0, 0]` interval have a positive lower
-bound. Content power is structurally 0.000, and the v1 pilot measured the same
-figure independently. This is not an under-powered test; it is an unsatisfiable
-one at this model's capability, where the best arm fully repairs 4.1 percent of
-tasks.
+Both content arms passed zero of 135 episodes here, and the v1 pilot measured
+content power 0.000 independently. On that evidence the task-pass benefit is a
+degenerate `[0, 0]` interval with p = 1, and no realistic increase in sample
+size makes it produce a positive lower bound while the underlying rate stays at
+the floor. This is a statement about the observed operating point, not a proof
+about all possible data: the constraint would lift if the model's task-pass rate
+rose materially above zero in these arms. At this model's capability, where even
+the best arm fully repairs 4.1 percent of tasks, that is not in prospect.
 
 ### No-trap equivalence — not equivalent
 
@@ -95,7 +98,7 @@ causes harm.
 
 #### The ±0.02 margin is below this design's noise floor
 
-The equivalence check could not have passed, whatever the gate did. Measured
+The equivalence check had almost no room to pass. Measured
 no-trap population, 12 tasks × 15 episodes per arm:
 
 | Arm | n | passes | pass rate | mean steps |
@@ -113,15 +116,24 @@ The entire non-equivalence verdict rests on **three episodes** — 7 passes vers
 | 90% CI half-width (1.645·SE) | 0.0368 |
 | **margin ÷ SE** | **0.89** |
 
-A 90% interval can only fit strictly inside a margin when that margin exceeds
-about 1.645 standard errors. Here the margin is **0.89 SE** — smaller than one
-standard error of the very statistic it constrains. Even with a true difference
-of exactly zero, the interval would be roughly 1.8× too wide to fit. Achieving
-strict containment under an exact null needs about 609 episodes per arm, or
-**41 no-trap tasks** against the 12 this design has.
+A 90% interval fits strictly inside a margin only when that margin exceeds about
+1.645 standard errors of the statistic. Here the margin is **0.89 SE** — smaller
+than one standard error of the quantity it constrains. Under the normal
+approximation, even a true difference of exactly zero yields a half-width of
+0.0368, roughly 1.8× too wide to fit, and reaching strict containment under an
+exact null needs about 609 episodes per arm, or **41 no-trap tasks** against the
+12 this design has.
 
-Two things follow. First, the equivalence failure is a property of the
-specification, not a finding about the gate. Second, the two margins were set
+To be precise about what that does and does not establish: the check was not
+strictly impossible. The realised interval is a task-level bootstrap, not the
+normal approximation, and had the two arms produced identical pass counts the
+resulting interval could have landed just inside ±0.02. What the arithmetic
+shows is that passing required the observed difference to sit essentially on
+zero — a knife-edge, not a robust test. A three-episode difference out of 180,
+which is roughly one step of the metric's resolution, was enough to fail it.
+
+Two things follow. First, the equivalence failure is far more a property of the
+specification than a finding about the gate. Second, the two margins were set
 with wildly inconsistent stringency: the pass-rate margin sits below the noise
 floor while the steps margin (±2 against an observed 0.0333) has roughly **60×**
 headroom. Margins derived from the design's own operating characteristics — a
@@ -175,10 +187,17 @@ where the model's base pass rate is not near the floor.
 | no-trap equivalence | 1.000 | **0.1627** |
 
 Widening the pilot split from 6 to 12 tasks bought the timing power it was meant
-to buy. The equivalence result moved the other way, and the v1 figure of 1.000
-should be treated as the less reliable of the two: it rested on 6 tasks, where
-wider intervals make a strict-containment test easier to pass only if the point
-estimate sits near zero.
+to buy. The equivalence result moved the other way, which needs explaining
+rather than waving away: more tasks give *narrower* intervals, and narrower
+intervals make strict containment easier, not harder. So the v3 drop is not a
+sample-size effect.
+
+The likely cause is the point estimate. Equivalence is decided by where the
+interval sits, not only by its width, and the v3 pass-rate difference is
++0.0167 — 83 percent of the way to the margin. An interval centred that close to
+the boundary fails containment however tight it is, until the half-width falls
+under about 0.0033. Whether v1's estimate sat nearer zero cannot be checked from
+this run's artifacts, so the comparison is left open rather than resolved here.
 
 ## Where this leaves the study
 

--- a/docs/research/failure-gate/report.md
+++ b/docs/research/failure-gate/report.md
@@ -1,70 +1,215 @@
-# H6 failure-gate report
+# H6 failure gate — pilot report
 
-Status: **pilot complete. Study decision: REJECT. Main run blocked by insufficient power.**
+Status: **v3 pilot complete (1260/1260 rows, zero invalid). Study decision:
+REJECT. Timing power gate met; main run blocked by content and no-trap power.**
 
-## Pilot result
+Run: `h6-pilot-v5`, dataset inventory `687615b5…`, 12 pilot tasks, 5 seeds,
+5 arms, 3 variants. Zero task cuts.
 
-630 episodes completed across 6 pilot-split tasks, 3 variants, 5 seeds, 1 profile, 5 arms. Zero invalid rows.
+## Power simulation — the gate on the main run
 
-### H6-timing (PRE_ACTION_FAILURE vs TURN_START_FAILURE)
+Ten thousand task-group bootstrap experiments, each resampling 18 tasks from the
+12-task pilot population.
 
-| Metric | Value | Threshold | Result |
+| Test | Simulated power | Required | Verdict |
 | --- | ---: | ---: | --- |
-| Relative risk reduction | 1.000 (100%) | ≥ 0.30 | PASS |
-| Absolute benefit | 0.244 | ≥ 0.05 | PASS |
-| Benefit 95% CI | [0.000, 0.511] | lower > 0 | FAIL |
-| Raw p-value | 0.248 | < 0.05 | FAIL |
-| Holm-adjusted p | 0.496 | < 0.05 | FAIL |
-| Decision | REJECTED | | |
-| Simulated power | 0.588 | ≥ 0.80 | FAIL |
+| H6-timing | **0.8363** | 0.80 | **PASS** |
+| H6-content | 0.0000 | 0.80 | FAIL |
+| No-trap equivalence | 0.1627 | 0.80 | FAIL |
 
-The pre-action gate eliminated 100% of repeated failures (RRR = 1.0). The effect is large and directionally consistent with H6. But with 6 tasks, the p-value cannot reach significance. The 95% CI includes zero.
+`verifyPilotPower` requires all three, so the main run remains blocked.
 
-### H6-content (TURN_START_FAILURE vs TURN_START_SUCCESS)
+**The registered timing-power objective is met.** The current dataset carries
+enough trap-effective independent tasks; no new dataset version is needed for
+timing. That question is closed.
 
-| Metric | Value | Threshold | Result |
-| --- | ---: | ---: | --- |
-| Repeated-failure benefit | -0.022 | > 0 | FAIL |
-| Task-pass benefit | 0.000 | > 0 | FAIL |
-| Decision | REJECTED | | |
-| Simulated power | 0.000 | ≥ 0.80 | FAIL |
+## Pilot decisions
 
-Failure memory at turn start is not better than success memory. The effect is slightly negative. This is a genuine negative result for the content hypothesis.
+| Hypothesis | Decision |
+| --- | --- |
+| H6-timing | REJECTED |
+| H6-content | REJECTED |
+| Study | **REJECT** |
 
-### Timidity (PRE_ACTION_FAILURE vs NO_MEMORY)
+### H6-timing — every support condition met except multiplicity
 
-| Metric | Value | Threshold | Result |
-| --- | ---: | ---: | --- |
-| Pass-rate difference | 0.000 | inside [-0.02, 0.02] | PASS |
-| Steps difference | 0.000 | inside [-2, 2] | PASS |
-| Equivalent | true | | PASS |
-| Simulated power | 1.000 | ≥ 0.80 | PASS |
+| Quantity | Value | Requirement | Met |
+| --- | ---: | --- | --- |
+| Absolute repeated-failure benefit | 0.3167 | ≥ 0.05 | yes |
+| Relative risk reduction | 1.0000 | ≥ 0.30 | yes |
+| 95% benefit interval | [0.100, 0.567] | lower > 0 | yes |
+| Raw p | 0.0312 | — | — |
+| **Holm-adjusted p** | **0.0624** | **< 0.05** | **no** |
 
-The pre-action gate does not cause timidity. No difference in pass rate or steps compared to no memory.
+The pre-action gate eliminated repeated failure outright — relative risk
+reduction 1.00 with a degenerate [1, 1] interval, meaning every trapped baseline
+task was rescued in every bootstrap draw.
 
-### Study decision: REJECT
+Timing failed on one thing: the Holm correction. The family is
+{timing, content}; content's p is 0.8413, so timing's adjusted p is
+2 × 0.0312 = 0.0624, just over the 0.05 bar. **Carrying a hypothesis that cannot
+be supported doubled the multiplicity penalty on the hypothesis that works.**
 
-Both primaries are REJECTED. The timing test shows a large directional effect (RRR = 100%) but is underpowered at 6 tasks. The content test shows no effect in the predicted direction.
+### H6-content — rejected, and unsatisfiable by construction
 
-## Power and the main run
+| Quantity | Value |
+| --- | ---: |
+| Repeated-failure benefit | −0.0778 (wrong direction) |
+| 95% interval | [−0.222, 0.056] |
+| Raw p | 0.8413 |
+| Task-pass benefit | 0, interval [0, 0], p = 1 |
 
-Both primaries miss the 0.80 power threshold. Per the preregistration: "If either test misses 0.80, add independent tasks in a new dataset version and update this preregistration before main execution." Adding seeds to the same tasks does not fix task-level power.
+Content requires strictly positive lower bounds on **both** metrics. The
+task-pass benefit is exactly zero because both content arms pass zero tasks:
 
-A confirmatory main run requires a new dataset version with more independent tasks — particularly trap-effective tasks that produce baseline failures for the timing comparison.
+| Arm | n | task pass | repeated failure |
+| --- | ---: | ---: | ---: |
+| `NO_MEMORY` | 270 | 0.041 | 0.163 |
+| `PRE_ACTION_FAILURE` | 270 | 0.041 | 0.000 |
+| `TURN_START_FAILURE` | 135 | 0.000 | 0.289 |
+| `TURN_START_SUCCESS` | 135 | 0.000 | 0.378 |
+| `BOTH` | 135 | 0.000 | 0.000 |
 
-## What changed from v3 to v6
+No sample size can make a degenerate `[0, 0]` interval have a positive lower
+bound. Content power is structurally 0.000, and the v1 pilot measured the same
+figure independently. This is not an under-powered test; it is an unsatisfiable
+one at this model's capability, where the best arm fully repairs 4.1 percent of
+tasks.
 
-| Parameter | v3 | v6 | Justification |
-| --- | --- | --- | --- |
-| Trapped rate floor | 0.50 | 0.30 | Best model traps 30-40% |
-| Non-fixed rate floor | 0.80 | 0.50 | Every model fixes 40-77% |
-| Model profile count | 2 | 1 | qwen3-8b produces TRACE_GAP invalids |
-| Episode duration cap | 120s | 600s | 35B model needs ~200s/episode |
+### No-trap equivalence — not equivalent
+
+| Quantity | Value | Margin | Inside |
+| --- | ---: | --- | --- |
+| Pass-rate difference | 0.0167, 90% CI [0, **0.0389**] | ±0.02 | **no** |
+| Steps difference | 0.0333, 90% CI [0, 0.0722] | ±2 | yes |
+
+`equivalent: false`. Steps are comfortably inside the margin; the pass-rate
+interval is not, because its upper bound of 0.0389 exceeds the 0.02 margin.
+
+Note the direction: the gate slightly *raises* the pass rate on no-trap
+revisions rather than making the agent timid. Equivalence testing is two-sided,
+so a benefit beyond the margin fails the check just as a harm would. The
+registered claim "the gate does not change behavior on tasks with no trap" is
+not supported at the registered margin, but nothing here suggests the gate
+causes harm.
+
+#### The ±0.02 margin is below this design's noise floor
+
+The equivalence check could not have passed, whatever the gate did. Measured
+no-trap population, 12 tasks × 15 episodes per arm:
+
+| Arm | n | passes | pass rate | mean steps |
+| --- | ---: | ---: | ---: | ---: |
+| `NO_MEMORY` | 180 | 7 | 0.0389 | 5.328 |
+| `PRE_ACTION_FAILURE` | 180 | 10 | 0.0556 | 5.361 |
+
+The entire non-equivalence verdict rests on **three episodes** — 7 passes versus
+10 out of 180 — in the direction that favours the gate.
+
+| Quantity | Value |
+| --- | ---: |
+| Registered margin | 0.0200 (≈ 3.6 episodes of 180) |
+| SE of the pass-rate difference | 0.0224 |
+| 90% CI half-width (1.645·SE) | 0.0368 |
+| **margin ÷ SE** | **0.89** |
+
+A 90% interval can only fit strictly inside a margin when that margin exceeds
+about 1.645 standard errors. Here the margin is **0.89 SE** — smaller than one
+standard error of the very statistic it constrains. Even with a true difference
+of exactly zero, the interval would be roughly 1.8× too wide to fit. Achieving
+strict containment under an exact null needs about 609 episodes per arm, or
+**41 no-trap tasks** against the 12 this design has.
+
+Two things follow. First, the equivalence failure is a property of the
+specification, not a finding about the gate. Second, the two margins were set
+with wildly inconsistent stringency: the pass-rate margin sits below the noise
+floor while the steps margin (±2 against an observed 0.0333) has roughly **60×**
+headroom. Margins derived from the design's own operating characteristics — a
+3.9 percent base rate and 180 episodes per arm — would not look like that.
+
+This is a specification defect that was detectable before the run, from the base
+rate and episode count alone, without reference to any observed difference. That
+distinction matters: correcting the margin on those grounds is a principled
+re-derivation, whereas widening it because the test failed would be threshold
+shopping. Any correction must be argued and documented on the pre-run arithmetic.
+
+#### No margin works at this operating point
+
+Loosening the margin is not a fix either. For an equivalence test to reach 80
+percent power *at a true difference of zero*, the margin must exceed
+`(z₀.₉₅ + z₀.₉) · SE ≈ 2.93 · SE`. Applying that to this design:
+
+| No-trap tasks | episodes/arm | SE | margin needed for 80% power |
+| ---: | ---: | ---: | ---: |
+| **12 (this design)** | 180 | 0.0224 | **0.0654** |
+| 18 | 270 | 0.0183 | 0.0534 |
+| 41 | 615 | 0.0121 | 0.0354 |
+| 100 | 1500 | 0.0077 | 0.0227 |
+| 200 | 3000 | 0.0055 | **0.0160** ✓ |
+
+The design is caught between two impossibilities. Keeping the registered ±0.02
+margin requires roughly **200 no-trap tasks**, sixteen times the current
+population. Keeping the current 12 tasks requires a margin of **0.0654**, which
+is 1.4× the base pass rate itself — a band wide enough to permit the pass rate
+doubling or vanishing, which asserts nothing.
+
+The cause is that task pass is a rare event here (3.9 to 5.6 percent).
+Equivalence testing on a rare binary outcome needs very large samples, and no
+choice of margin substitutes for them.
+
+**Recommendation: retire the pass-rate equivalence check from this design rather
+than loosen it.** The steps half of the same check is viable and passes with 60×
+headroom, so the timidity question — does the gate make the agent work harder or
+behave more cautiously on tasks with no trap — is answerable, and the answer is
+no. Retaining the pass-rate half at any margin this design can support would
+manufacture a verdict rather than measure one. If pass-rate equivalence is
+scientifically required, it needs a fundamentally larger study or a task set
+where the model's base pass rate is not near the floor.
+
+## What changed against the v1 pilot
+
+| Test | v1 power | v3 power |
+| --- | ---: | ---: |
+| timing | 0.588 | **0.8363** |
+| content | 0.000 | 0.000 |
+| no-trap equivalence | 1.000 | **0.1627** |
+
+Widening the pilot split from 6 to 12 tasks bought the timing power it was meant
+to buy. The equivalence result moved the other way, and the v1 figure of 1.000
+should be treated as the less reliable of the two: it rested on 6 tasks, where
+wider intervals make a strict-containment test easier to pass only if the point
+estimate sits near zero.
+
+## Where this leaves the study
+
+1. **Timing is real and adequately powered.** RRR 1.00, benefit 0.317, interval
+   clear of zero, and 0.8363 simulated power. It fails today only on a
+   multiplicity correction imposed by a hypothesis that cannot be supported.
+2. **Content cannot be rescued by more data.** Any further pilot spends compute
+   to re-measure a structural zero.
+3. **Equivalence needs a decision, not more tasks.** The pass-rate interval
+   misses a ±0.02 margin by 0.019. Whether that margin is right for a 4.1 percent
+   base pass rate is a scientific judgment; re-running without changing anything
+   will reproduce it.
+
+The drafted amendment (`amendment-01-draft.md`) removes content from the main
+power gate. On this evidence it is necessary but **not sufficient** — the
+no-trap gate now fails too, which the draft predates and does not address.
+
+Any amendment that drops content also removes it from the Holm family, which
+moves timing from adjusted p 0.0624 to raw 0.0312 and flips it to `SUPPORTED`.
+That is a large, self-serving-looking consequence of a post-hoc change and must
+be argued on the pre-existing structural grounds — content was unsatisfiable
+before this run, and was measured so in v1 — not on the fact that removing it
+helps timing.
 
 ## Artifacts
 
-- Audit: `docs/research/data/pre-action-gate/model-audit-v12/`
-- Pilot run: `~/.remnic/bench/results/h6-pilot-v1/`
-- Statistics: `~/.remnic/bench/results/h6-pilot-v1/statistics.json`
-- Power: `~/.remnic/bench/results/h6-pilot-v1/power.json`
-- Episodes: `~/.remnic/bench/results/h6-pilot-v1/episodes.jsonl`
+| Item | Path |
+| --- | --- |
+| Run directory | `~/.remnic/bench/results/h6-pilot-v5` |
+| Power | `<run>/power.json` |
+| Statistics | `<run>/statistics.json` |
+| Episodes | `<run>/episodes.jsonl` |
+| Trap audit receipt | `<run>/trap-audit-c1d234a7….json` |
+| Operational state | `docs/research/failure-gate/RESUME-HANDOFF.md` |


### PR DESCRIPTION
Corrects a factual error I introduced in #2315. Documentation only.

## The error

The no-trap equivalence analysis computed its standard error from an **episode-level binomial approximation**. The harness bootstraps at the **task** level, so the SE must come from the spread of per-task differences. Wrong estimator, wrong conclusions.

| Quantity | #2315 (wrong) | Corrected |
| --- | ---: | ---: |
| SE | 0.0224 | **0.0120** |
| margin ÷ SE | 0.89 | **1.67** |
| Tasks for ±0.02 at 80% power | ~200 | **~41** |
| Conclusion | "no margin works; retire the check" | under-resourced, fixable |

At 1.67 SE the margin sits just above the 1.645 needed for containment to be possible, so equivalence was **not** out of reach by construction — the previous section said otherwise and was wrong. The recommendation to retire the pass-rate check is withdrawn.

## What the corrected data shows

Per-task differences in the no-trap population:

| Task | baseline | candidate | difference |
| --- | ---: | ---: | ---: |
| `h6-task-21` | 5/15 | 6/15 | +0.0667 |
| `h6-task-22` | 2/15 | 4/15 | +0.1333 |
| other 10 tasks | 0/15 | 0/15 | 0.0000 |

Ten of twelve tasks contribute exactly zero. The effective sample size is **2**, not 12, and the verdict turns on three extra passes.

A second measurement sharpens the content finding: **in the trap-bearing population the model passed 0 of 900 episodes**, across every task and arm. Every pass anywhere in the pilot came from no-trap control revisions. So content's task-pass leg is not an arm-level tie — the metric has no signal because the model never repairs a trapped task.

## Consequence

Both remaining blockers share one cause: at this model's capability almost every task is unsolvable, starving the content metric and the equivalence estimator alike. A dataset built around tasks the model can sometimes pass would address both **without weakening any threshold** — which is a materially better option than the amendment path #2315 pointed at.

The amendment draft is updated: its content argument stands and is strengthened; its no-trap sections are marked superseded and must not be applied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Research documentation only; no harness, preregistration, or gate logic changes in this diff.
> 
> **Overview**
> **Documentation-only fix** for the H6 failure-gate pilot write-up: the no-trap pass-rate equivalence section used an **episode-level binomial SE**; the harness actually bootstraps at the **task** level, so the narrative and power math were wrong.
> 
> **`report.md`** replaces the old figures (SE 0.0224, margin ÷ SE 0.89, ~200 tasks for 80% power at ±0.02) with task-level values (SE **0.0120**, margin ÷ SE **1.67**, ~**41** no-trap tasks). It adds per-task pass differences (only `h6-task-21` and `h6-task-22` move; **10/12 tasks are 0/15 in both arms**), frames effective sample size as **2**, and **withdraws** the recommendation to retire the pass-rate equivalence check—under-resourced, not unusable. The content section is tightened: **0/900** passes in the trap-bearing population (not just an arm-level tie).
> 
> **`amendment-01-draft.md`** is retitled so the content-gate argument still stands while **no-trap sections are marked superseded**; the withdrawn “retire the check” resolution is replaced by pointing readers to `report.md` (more passable tasks, no threshold changes). A small edit clarifies the single tracked `decision-rule.json` path under `packages/bench/fixtures/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0658f264f538294f28feac89b4dd69ab6e3a808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->