### PR TITLE
docs(h6): identify token cap as the binding constraint

### DIFF
--- a/docs/research/failure-gate/report.md
+++ b/docs/research/failure-gate/report.md
@@ -50,7 +50,7 @@ Timing failed on one thing: the Holm correction. The family is
 2 × 0.0312 = 0.0624, just over the 0.05 bar. **Carrying a hypothesis that cannot
 be supported doubled the multiplicity penalty on the hypothesis that works.**
 
-### H6-content — rejected, and unsatisfiable by construction
+### H6-content — rejected, but the cause is instrumentation, not capability
 
 | Quantity | Value |
 | --- | ---: |
@@ -59,30 +59,47 @@ be supported doubled the multiplicity penalty on the hypothesis that works.**
 | Raw p | 0.8413 |
 | Task-pass benefit | 0, interval [0, 0], p = 1 |
 
-Content requires strictly positive lower bounds on **both** metrics, and the
-task-pass leg is dead for a blunter reason than an arm-level tie.
+**Correction — this supersedes earlier revisions of this section.** Those said
+the model "passed nothing at all" and concluded the task-pass metric was dead at
+this model's capability. The first half is true as recorded and the second half
+is wrong. The metric is dead because of a token cap.
 
-**In the trap-bearing population the model passed nothing at all: 0 of 900
-episodes, across all 12 tasks and all 5 arms.** Every pass recorded anywhere in
-this pilot came from `no-trap` control revisions, and even there from only two
-tasks. Arm-level rates (the 0.041 figures below) are therefore carried entirely
-by no-trap rows, not by the tasks the primaries are computed on.
+Cross-tabulating the recorded `finalState` against `taskPassed`:
 
-| Arm | n | task pass | repeated failure |
-| --- | ---: | ---: | ---: |
-| `NO_MEMORY` | 270 | 0.041 | 0.163 |
-| `PRE_ACTION_FAILURE` | 270 | 0.041 | 0.000 |
-| `TURN_START_FAILURE` | 135 | 0.000 | 0.289 |
-| `TURN_START_SUCCESS` | 135 | 0.000 | 0.378 |
-| `BOTH` | 135 | 0.000 | 0.000 |
+| Population | finalState | checkResult | taskPassed | rows |
+| --- | --- | --- | --- | ---: |
+| primary | **FIXED** | PASS | **false** | **340** |
+| primary | TRAPPED | FAIL | false | 142 |
+| primary | UNFIXED | FAIL | false | 418 |
+| no-trap | NO_TRAP | PASS | false | 343 |
+| no-trap | NO_TRAP | PASS | **true** | **17** |
 
-So the task-pass benefit is a degenerate `[0, 0]` interval with p = 1, and the
-v1 pilot measured content power 0.000 independently. The binding constraint is
-not that the two content arms tie — it is that this model never repairs a
-trapped task, so the metric has no signal to measure. That is a statement about
-the present operating point rather than a proof about all data: it would lift
-with a model that can sometimes fix these tasks. Nothing in the evidence
-suggests the current one can.
+**The model repaired 340 of 900 trap-bearing episodes — 37.8 percent — and every
+one was recorded as `taskPassed: false`.** All 340 carry a `TOKEN_CAP` fault, and
+`baseEvidence` forces `taskPassed` false whenever a cap is exceeded. That matches
+the preregistration exactly: a row passes "only when the fixed offline check
+returns `PASS` **within all caps**".
+
+Token usage against the frozen `maxTotalTokens` of 16,384:
+
+| Statistic | Tokens |
+| --- | ---: |
+| Minimum | 15,762 |
+| Median | **17,578** |
+| p90 | 19,811 |
+| Maximum | 25,424 |
+| **Rows at or over cap** | **1,243 of 1,260 (98.7%)** |
+
+The median episode overruns the cap by about 1,200 tokens. The only 17 rows
+recorded as passing are exactly those that finished under it, at a maximum of
+16,281 tokens. `taskPassed` is therefore not measuring "solved the task" in this
+run — it is measuring "finished under 16,384 tokens".
+
+The cap traces back to an operational choice: the profile pins the context window
+to 16,384 because at 32,768 this model spills to CPU and per-call latency rises
+from roughly 0.75 s to 15 s. `DEFAULT_CAPS.maxTotalTokens` matches that window.
+A GPU-memory decision silently disabled one of the two content metrics.
+
 ### No-trap equivalence — not equivalent
 
 | Quantity | Value | Margin | Inside |
@@ -201,33 +218,33 @@ this run's artifacts, so the comparison is left open rather than resolved here.
 
 1. **Timing is real and adequately powered.** RRR 1.00, benefit 0.317, interval
    clear of zero, and 0.8363 simulated power. It fails today only on a
-   multiplicity correction imposed by a hypothesis that cannot be supported.
-2. **Content cannot be rescued by more tasks of the current kind.** The model
-   passes none of the trap-bearing tasks — 0 of 900 episodes — so the task-pass
-   leg has no signal. What would rescue it is a task set this model can
-   sometimes solve, not a larger one.
-3. **Equivalence is under-resourced, not unusable.** The registered ±0.02 margin
-   becomes properly powered at roughly 41 no-trap tasks. Ten of the current 12
-   contribute exactly zero, so the effective sample size is 2. The fix is more
-   *passable* tasks, and it needs no change to any threshold.
+   multiplicity correction imposed by a hypothesis that could not be supported.
+2. **Content and equivalence were both disabled by one config value.** 98.7
+   percent of rows exceeded the 16,384-token cap, which forces `taskPassed`
+   false regardless of outcome. The model actually repaired 37.8 percent of
+   trap-bearing episodes. The task-pass metric never measured capability in this
+   run; it measured whether an episode fitted in the budget.
+3. **The remedy is a cap, not a redesign.** Raising `maxTotalTokens` past the
+   observed p90 of ~19,800 — with headroom, say 24,576 — should restore
+   task-pass signal to both content and the equivalence estimator without
+   touching a single decision threshold, task, or hypothesis.
 
-Points 2 and 3 share one cause: at this model's capability almost every task is
-unsolvable, which starves both the content metric and the equivalence estimator.
-A dataset built around tasks the model can sometimes pass would address both
-without weakening the protocol — and that is exactly the "new dataset version"
-the objective called for, aimed at pass-rate signal rather than trap coverage.
+This supersedes the two earlier recommendations in this document. Retiring the
+pass-rate equivalence check was wrong, and so was rebuilding the dataset around
+"passable" tasks: the tasks were already passable 37.8 percent of the time. Both
+diagnoses mistook an instrumentation limit for a property of the model or the
+task set.
 
-The drafted amendment (`amendment-01-draft.md`) removes content from the main
-power gate. Its content argument still holds; its no-trap sections are
-superseded by the corrected estimator above and should not be applied as
-written.
+The cost is real but ordinary. A larger token budget needs a context window
+above 16,384, which on this GPU means either accepting roughly 15 s per call at
+32,768 or moving to a card with more memory. Then re-audit and re-pilot. That is
+the same compute a dataset rebuild would have cost, spent on the actual cause.
 
-Any amendment that drops content also removes it from the Holm family, which
-moves timing from adjusted p 0.0624 to raw 0.0312 and flips it to `SUPPORTED`.
-That is a large, self-serving-looking consequence of a post-hoc change and must
-be argued on the pre-existing structural grounds — content was unsatisfiable
-before this run, and was measured so in v1 — not on the fact that removing it
-helps timing.
+The drafted amendment (`amendment-01-draft.md`) is now moot in both halves and
+should not be applied. Its content argument assumed the task-pass metric was
+structurally dead; it was not. Removing content from the Holm family would still
+flip timing from adjusted p 0.0624 to raw 0.0312, which is exactly why that
+change should not be made on the strength of a measurement artifact.
 
 ## Design input for a next dataset version
 

--- a/docs/research/failure-gate/report.md
+++ b/docs/research/failure-gate/report.md
@@ -262,11 +262,29 @@ pilot tasks, two per class:
 
 Two findings follow, both measured rather than inferred.
 
-**`config-shadowing` is inert.** It produced no trapped rows and no passes in
-the pilot, and the full 30-task audit puts all five of its tasks at `UNFIXED`
-with zero `TRAPPED` and zero `FIXED`. One sixth of the dataset currently
-contributes to neither primary nor the equivalence check. Dropping it frees that
-compute for classes that measure something.
+**`config-shadowing` produced no signal of its own.** No trapped rows and no
+passes in the pilot, and the full 30-task audit puts all five of its tasks at
+`UNFIXED` with zero `TRAPPED` and zero `FIXED`.
+
+**But "contributes nothing, so drop it" is wrong for the equivalence estimator,
+and an earlier revision said exactly that.** The two estimators treat a
+zero-outcome task differently. Timing needs a trapped baseline to form a
+contrast, so a class that never traps adds no information there. Equivalence
+averages a per-task *difference*, and a task scoring 0.0000 is a real
+observation that pulls the mean toward zero and shrinks the spread. Removing
+such tasks makes equivalence harder, not easier:
+
+| Population | k | mean | SD | SE | 90% upper |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| all 12 pilot tasks | 12 | 0.0167 | 0.0414 | 0.0120 | 0.0363 |
+| drop the 2 `config-shadowing` | 10 | 0.0200 | 0.0450 | 0.0142 | 0.0434 |
+| drop all 10 zero-difference tasks | 2 | 0.1000 | 0.0471 | 0.0333 | 0.1548 |
+
+Every removal moves the upper bound further from the ±0.02 margin. So the
+correct reading is class-specific: `config-shadowing` is dead weight **for the
+timing contrast**, while for the equivalence check it is doing useful work by
+supplying low-variance zeros. Any reweighting has to state which estimator it is
+optimising, because the two pull in opposite directions.
 
 **Every task pass came from `stale-cache-illusion`** — 17 of 17. If a future
 version needs pass-rate signal for content or for the equivalence estimator,

--- a/docs/research/failure-gate/report.md
+++ b/docs/research/failure-gate/report.md
@@ -229,6 +229,48 @@ be argued on the pre-existing structural grounds — content was unsatisfiable
 before this run, and was measured so in v1 — not on the fact that removing it
 helps timing.
 
+## Design input for a next dataset version
+
+Outcomes are not spread evenly across trap classes. Pilot totals for the 12
+pilot tasks, two per class:
+
+| Trap class | trapped rows | no-trap passes |
+| --- | ---: | ---: |
+| `stale-cache-illusion` | 27 | **17** |
+| `flaky-looking-test` | 34 | 0 |
+| `misleading-error-message` | 32 | 0 |
+| `wrong-layer-fix` | 25 | 0 |
+| `hidden-invariant` | 24 | 0 |
+| `config-shadowing` | **0** | **0** |
+
+Two findings follow, both measured rather than inferred.
+
+**`config-shadowing` is inert.** It produced no trapped rows and no passes in
+the pilot, and the full 30-task audit puts all five of its tasks at `UNFIXED`
+with zero `TRAPPED` and zero `FIXED`. One sixth of the dataset currently
+contributes to neither primary nor the equivalence check. Dropping it frees that
+compute for classes that measure something.
+
+**Every task pass came from `stale-cache-illusion`** — 17 of 17. If a future
+version needs pass-rate signal for content or for the equivalence estimator,
+that is the only class demonstrated to supply it. The tradeoff is scope: a
+dataset weighted toward one trap class narrows what the study can claim, and
+that is a design decision rather than a tuning knob.
+
+### Unresolved: audit `FIXED` does not predict pilot `taskPassed`
+
+Before designing around "passable" tasks, one discrepancy needs an explanation.
+The audit records 11 of 30 tasks as `FIXED`, meaning the model repaired them in
+its sampled episode. The pilot's trap-bearing population records **0 passes in
+900 episodes**. The two measure different repository states — the pilot's
+primary rows materialize `variant.files` while `no-trap` rows materialize
+`variant.noTrapControlFiles` — but the size of the gap is not yet accounted for.
+
+Until it is, "build a dataset of tasks the model can pass" rests on an
+unverified assumption, because the audit's `FIXED` label is currently the only
+cheap way to identify such tasks and it demonstrably does not carry over. Resolve
+this before committing generation and compute to a v4.
+
 ## Artifacts
 
 | Item | Path |

--- a/docs/research/failure-gate/report.md
+++ b/docs/research/failure-gate/report.md
@@ -274,19 +274,29 @@ that is the only class demonstrated to supply it. The tradeoff is scope: a
 dataset weighted toward one trap class narrows what the study can claim, and
 that is a design decision rather than a tuning knob.
 
-### Unresolved: audit `FIXED` does not predict pilot `taskPassed`
+### Resolved: the audit did predict the pilot; I compared the wrong fields
 
-Before designing around "passable" tasks, one discrepancy needs an explanation.
-The audit records 11 of 30 tasks as `FIXED`, meaning the model repaired them in
-its sampled episode. The pilot's trap-bearing population records **0 passes in
-900 episodes**. The two measure different repository states — the pilot's
-primary rows materialize `variant.files` while `no-trap` rows materialize
-`variant.noTrapControlFiles` — but the size of the gap is not yet accounted for.
+An earlier revision flagged an unexplained gap — the audit recording 11 of 30
+tasks `FIXED` while the pilot's trap-bearing population recorded zero passes —
+and said to resolve it before designing a v4. It is resolved, and it was never a
+discrepancy. I was comparing the audit's `finalState` against the pilot's
+`taskPassed`, which are different fields.
 
-Until it is, "build a dataset of tasks the model can pass" rests on an
-unverified assumption, because the audit's `FIXED` label is currently the only
-cheap way to identify such tasks and it demonstrably does not carry over. Resolve
-this before committing generation and compute to a v4.
+Compared like for like, the two agree closely:
+
+| Source | FIXED rate |
+| --- | ---: |
+| Audit (30 tasks, 1 episode each) | 11/30 = **36.7%** |
+| Pilot primary (900 episodes) | 340/900 = **37.8%** |
+
+And `taskPassed` agrees too, for the same reason everywhere: **all 30 audit rows
+carry a `TOKEN_CAP` fault**, so every one of the 11 `FIXED` audit rows also
+records `taskPassed: false`. The cap is hit in 100 percent of audit rows and
+98.7 percent of pilot rows.
+
+So the audit is a sound cheap predictor of `finalState`, and no property of the
+dataset needs re-deriving before a next version. The single thing that needs
+changing is the token budget.
 
 ## Artifacts
 


### PR DESCRIPTION
Supersedes my two previous diagnoses in this document. Both were wrong, and the real cause is one config value. Documentation only.

## The finding

Cross-tabulating recorded `finalState` against `taskPassed` in the completed pilot:

| Population | finalState | checkResult | taskPassed | rows |
| --- | --- | --- | --- | ---: |
| primary | **FIXED** | PASS | **false** | **340** |
| primary | TRAPPED | FAIL | false | 142 |
| primary | UNFIXED | FAIL | false | 418 |
| no-trap | NO_TRAP | PASS | false | 343 |
| no-trap | NO_TRAP | PASS | **true** | **17** |

**The model repaired 340 of 900 trap-bearing episodes (37.8%), and every one is recorded as `taskPassed: false`.** All 340 carry a `TOKEN_CAP` fault, and `baseEvidence` forces `taskPassed` false when a cap is exceeded — exactly as the preregistration specifies ("PASS **within all caps**").

Token usage against the frozen 16,384 cap:

| Statistic | Tokens |
| --- | ---: |
| Median | **17,578** |
| p90 | 19,811 |
| **Rows at or over cap** | **1,243 of 1,260 (98.7%)** |

The median episode overruns by ~1,200 tokens. The only 17 "passing" rows are precisely those that finished under the cap (max 16,281). In this run `taskPassed` measured whether an episode fitted the budget, not whether the task was solved.

Root cause: the profile pins the context window to 16,384 because at 32,768 this model spills to CPU and per-call latency goes from ~0.75 s to ~15 s. `DEFAULT_CAPS.maxTotalTokens` matches that window. A GPU-memory decision silently disabled one of the two content metrics and starved the equivalence estimator.

## What this retracts

- **"Content is unsatisfiable at this model's capability"** — wrong. It is unsatisfiable at this token cap.
- **"Rebuild the dataset around passable tasks"** — wrong remedy. The tasks were already passable 37.8% of the time.
- The amendment draft is moot in both halves and should not be applied. Removing content from the Holm family would flip timing to `SUPPORTED`, which is precisely why it must not be done on the strength of a measurement artifact.

## Remedy

Raise `maxTotalTokens` past the observed p90 (~19,800) with headroom, then re-audit and re-pilot. No decision threshold, task, or hypothesis changes. Same compute a dataset rebuild would have cost, spent on the actual cause.

Trap-class design data from the earlier commit is retained — `config-shadowing` being inert is still worth knowing — but it is no longer the lead finding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `docs/research/failure-gate/report.md` changes; no runtime, config, or analysis code is modified.
> 
> **Overview**
> **Documentation-only** revision of the H6 failure-gate pilot report. It retracts earlier conclusions that content was unsatisfiable at model capability and that the dataset needed more “passable” tasks.
> 
> The **H6-content** section is rewritten around a `finalState` × `taskPassed` cross-tab: **340 primary episodes were FIXED with PASS but still `taskPassed: false`**, attributed to **`TOKEN_CAP`** and **`baseEvidence`** forcing failure when caps are exceeded (aligned with preregistration). New token-usage tables show **98.7% of rows at or over the 16,384 `maxTotalTokens` cap**, linking the limit to GPU/context-window operational choices.
> 
> **“Where this leaves the study”** now argues content and no-trap pass-rate equivalence were **disabled by that cap**, recommends **raising `maxTotalTokens`** (e.g. past ~19.8k p90) and re-piloting—not dataset redesign or dropping the equivalence check—and declares **`amendment-01-draft.md` moot**, warning against Holm-family changes driven by the artifact.
> 
> A new **“Design input for a next dataset version”** section adds trap-class breakdowns, explains why dropping zero-signal tasks **hurts** equivalence estimation differently than timing, and **resolves the audit vs pilot gap** as comparing `finalState` to `taskPassed` (both ~37% FIXED; audit rows also hit the cap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5179e374ec664b5163993fda866f84af3686a77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the failure-gate research report with revised findings on token-cap limits and task outcomes.
  * Added detailed trap-class analysis, including results for `config-shadowing` and `stale-cache-illusion`.
  * Documented discrepancies between audit results and pilot passes, including differing repository states.
  * Revised recommendations to increase the token budget and conduct a follow-up pilot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->