### PR TITLE
docs(h6): record cap curve and dedupe audit caps

### DIFF
--- a/docs/research/failure-gate/report.md
+++ b/docs/research/failure-gate/report.md
@@ -251,20 +251,43 @@ Measured across all 1,260 episodes:
 | Turns used | 4 to 6 | `maxTurns` 12 | never reached |
 | Cumulative tokens (max) | **16,383** | `maxTotalTokens` 16,384 | **100%** |
 
-A worked example, one episode's six turns: inputs of 1,098 → 2,278 → 2,854 →
-2,954 → 3,302 → 3,424, cumulating to 16,159. The largest single context is 3,424
-tokens; the sum is what hits the ceiling.
+A worked example, one episode's six turns. Prompt inputs were 1,098 → 2,278 →
+2,854 → 2,954 → 3,302 → 3,424, summing to 15,910; adding that episode's 249
+output tokens gives the 16,159 cumulative the cap actually counts. The largest
+single context is 3,424 tokens — the sum is what hits the ceiling, not any one
+call.
 
 So the two caps contradict each other. `maxTurns` allows 12 turns, but
 `maxTotalTokens` exhausts at 4 to 6, and a maximum observed cumulative of exactly
 16,383 against a 16,384 cap shows episodes terminating on the ceiling rather than
-on task completion. Allowing the registered 12 turns needs roughly 45,000
-cumulative tokens, so a cap near 49,152 would make the turn budget binding as
-designed.
+on task completion.
 
-**The remedy is one constant.** No context-window change, no latency tradeoff, no
-different GPU — peak per-call usage would still sit far inside 16,384 even at 12
-turns. Then re-audit and re-pilot.
+### Raising the cap was tested, and it fails a different gate
+
+An earlier revision called this "one constant" away from fixed. It is not. Three
+trap audits, 30 tasks each, one per cap value:
+
+| `maxTotalTokens` | trapped (gate ≥0.30) | non-fixed (gate ≥0.50) | `taskPassed` | audit |
+| ---: | ---: | ---: | ---: | --- |
+| **16,384** | 0.367 ✅ | **0.633** ✅ | **0%** | **PASS** |
+| 24,576 | 0.367 ✅ | 0.467 ❌ | ~20% | FAIL |
+| 49,152 | **0.133** ❌ | 0.167 ❌ | 40% | FAIL |
+
+Raising the budget does restore the task-pass metric exactly as predicted — 0
+percent to 40 percent. But the audit gate requires at least half the tasks to
+remain **non-fixed**, and a model given room to finish fixes them. At 24,576 the
+audit misses by a single task: 14 non-fixed where 15 are needed.
+
+**This is a structural conflict, not a tuning problem.** The trap audit exists to
+prove the benchmark is hard — at least 30 percent trapped and at least 50 percent
+unfixed. H6-content needs the opposite: enough completions for a task-pass
+contrast. With this model the two cannot hold at once, and the transition between
+them is one task wide.
+
+The cap therefore stays at 16,384, the only audited-passing value, and the
+preregistration amendment that proposed 49,152 was **not adopted**. What remains
+true from the diagnosis: `taskPassed` in the v3 pilot measured budget fit rather
+than capability, and the 340 repaired-but-unpassed episodes are real.
 
 The drafted amendment (`amendment-01-draft.md`) is now moot in both halves and
 should not be applied. Its content argument assumed the task-pass metric was

--- a/packages/bench/src/coding-graph/repeated-failure-trap-audit.ts
+++ b/packages/bench/src/coding-graph/repeated-failure-trap-audit.ts
@@ -39,15 +39,14 @@ import {
   createRepeatedFailureProfileDriver,
   runEpisodeForAudit,
 } from "./repeated-failure-suite.js";
+// Caps and tool-output limits are shared with the suite on purpose. A local
+// copy silently diverged once and defeated a cap change, so import rather than
+// redeclare.
+import {
+  DEFAULT_CAPS,
+  DEFAULT_TOOL_OUTPUT_CHARS,
+} from "./repeated-failure-suite-shared.js";
 
-const DEFAULT_CAPS: ControlledResponsesCaps = Object.freeze({
-  maxTurns: 12,
-  maxToolCalls: 8,
-  maxTotalTokens: 16_384,
-  maxDurationMs: 600_000,
-  requestTimeoutMs: 180_000,
-});
-const DEFAULT_TOOL_OUTPUT_CHARS = 16_384;
 const ResumeTraceIdentitySchema = z.object({
   suiteVersion: z.string().min(1),
   taskId: z.string().min(1),


### PR DESCRIPTION
Retracts the "one constant" remedy from #2318 with three measured trap audits, and removes a duplicated constant that caused the first attempt to silently do nothing.

## Code change: delete a shadowing constant

`repeated-failure-trap-audit.ts` declared its own `DEFAULT_CAPS` with `maxTotalTokens: 16_384`, shadowing the shared one in `repeated-failure-suite-shared.ts`. Raising the shared value changed nothing, and the built bundle contained **both** `16384` and `49152`. The audit and the suite could therefore silently disagree on caps — which would bind a trap-audit receipt to different execution conditions than the pilot it certifies. Now imported, with a comment recording why.

## Measured: raising the cap trades one gate for another

Three trap audits, 30 tasks each, one per cap value:

| `maxTotalTokens` | trapped (gate ≥0.30) | non-fixed (gate ≥0.50) | `taskPassed` | audit |
| ---: | ---: | ---: | ---: | --- |
| **16,384** | 0.367 ✅ | **0.633** ✅ | **0%** | **PASS** |
| 24,576 | 0.367 ✅ | 0.467 ❌ | 20% | FAIL |
| 49,152 | **0.133** ❌ | 0.167 ❌ | 40% | FAIL |

Raising the budget restores the task-pass metric exactly as #2318 predicted — 0% to 40%. But the audit gate requires at least half the tasks to remain **non-fixed**, and a model given room to finish fixes them. At 24,576 the audit misses by a single task: 14 non-fixed where 15 are needed.

**This is a structural conflict, not a tuning problem.** The trap audit exists to prove the benchmark is hard. H6-content needs the opposite — enough completions for a task-pass contrast. With this model the two cannot hold simultaneously, and the transition is one task wide.

## Consequence

The cap stays at **16,384**, the only audited-passing value. The preregistration amendment proposing 49,152 was **not adopted**; preregistration, both copies, `decision-rule.json`, and the version constant are all reverted to their pre-amendment state (hash `7c5bb227…`, version 10), verified.

What survives from the diagnosis: `taskPassed` in the v3 pilot measured budget fit rather than capability, and the 340 repaired-but-unpassed episodes are real.

Also fixes the worked example flagged in #2318 review — the listed prompt inputs sum to 15,910, and the 16,159 cumulative includes 249 output tokens. Both figures are now stated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation plus a small import refactor that aligns trap-audit with shared caps; no auth, data, or runtime behavior change beyond fixing cap consistency for audits.
> 
> **Overview**
> **Docs** retract the earlier “raise one constant (`maxTotalTokens`)” remedy and replace it with three trap audits (30 tasks each) at 16,384, 24,576, and 49,152. Higher caps restore `taskPassed` as expected but fail the trap-audit **non-fixed** gate (≥50% unfixed); only 16,384 passes both audit thresholds, so the cap stays there and the 49,152 preregistration amendment is not adopted. The token worked example now states that cumulative usage includes output tokens (15,910 prompt sum + 249 output → 16,159).
> 
> **Code** removes a local `DEFAULT_CAPS` / `DEFAULT_TOOL_OUTPUT_CHARS` in `repeated-failure-trap-audit.ts` and imports them from `repeated-failure-suite-shared.js`, so trap-audit and the suite cannot silently disagree on caps (a prior shadow copy made cap changes ineffective).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e39dd8e222c2d9260d70dff6498f8882a67f7342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the failure-gate report with audit results for multiple token limits.
  - Confirmed the 16,384-token cap as the passing configuration.
  - Rejected increasing the limit to approximately 49,152 tokens due to benchmark trade-offs.

- **Bug Fixes**
  - Standardized trap-audit command defaults to use the shared configuration values, improving consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->