### PR TITLE
docs(contributors): refresh roster and drop openclaw-engram naming

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,14 +9,14 @@ Thanks to everyone who works on Remnic, once called `openclaw-engram`.
 ## Community contributors
 
 - [@100menotu001](https://github.com/100menotu001). First community PR. Synced QMD after `memory_store`. Scoped update and embed to one collection.
-- [@MrGPUs](https://github.com/MrGPUs). Added `openaiBaseUrl` for OpenAI-compatible hosts. Added `encoding_format` for vLLM and LiteLLM. Put entity facts in the extract prompt. Built compaction reset with BOOT.md.
+- [@MrGPUs](https://github.com/MrGPUs). Added `openaiBaseUrl` for OpenAI-compatible hosts. Added `encoding_format` for vLLM and LiteLLM. Put entity facts in the extract prompt. Built compaction reset with BOOT.md. Switched the OpenClaw hook to `prependSystemContext`, which keeps bootstrap files intact.
 - [@KenFab](https://github.com/KenFab). Fixed the `/v1` prefix for local LLM chat calls.
-- [@earlvanze](https://github.com/earlvanze) (Earl Co). Added the OpenClaw memory runtime shim. Fixed the `registerCommand` check. Built the admin dashboard and its container. Split dashboards from harnesses. Filled in Codex plugin metadata.
-- [@ramarivera](https://github.com/ramarivera) (Ramiro Rivera). Added the Pi recall-timeout circuit breaker. Capped startup probes. Made MCP output schemas object-rooted.
-- [@kopertop](https://github.com/kopertop) (Chris Moyer). Added the Claude Code market manifest. Put auth on the health probe. Added namespace targeting to the hooks.
+- [@earlvanze](https://github.com/earlvanze). Added the OpenClaw memory runtime shim. Fixed the `registerCommand` check. Built the admin dashboard and its container. Split dashboards from harnesses. Filled in Codex plugin metadata.
+- [@ramarivera](https://github.com/ramarivera). Added the Pi recall-timeout circuit breaker. Capped startup probes. Made MCP output schemas object-rooted.
+- [@kopertop](https://github.com/kopertop). Added the Claude Code market manifest. Put auth on the health probe. Added namespace targeting to the hooks.
 - [@rmichelena](https://github.com/rmichelena). Sent gateway task defaults through `taskModelChain`.
 - [@dfein38347g](https://github.com/dfein38347g). Moved Pi to one context inject at session start, to keep the KV cache stable.
-- [@geekboy1011](https://github.com/geekboy1011) (Tim Keller). Added QMD Docker support.
+- [@geekboy1011](https://github.com/geekboy1011). Added QMD Docker support.
 
 ## Agent contributors
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,27 +4,27 @@ Thanks to everyone who contributes to Remnic (formerly `openclaw-engram`).
 
 ## Maintainer
 
-- [@joshuaswarren](https://github.com/joshuaswarren) (Joshua Warren) — creator, architect, and lead maintainer. Designed the memory model (facts, entities, profile, corrections), the recall/extraction pipeline, the multi-host adapter architecture, and the à-la-carte packaging contract.
+- [@joshuaswarren](https://github.com/joshuaswarren) (Joshua Warren) - creator, architect, and lead maintainer. Designed the memory model (facts, entities, profile, corrections), the recall/extraction pipeline, the multi-host adapter architecture, and the à-la-carte packaging contract.
 
 ## Community Contributors
 
-- [@100menotu001](https://github.com/100menotu001) — first community PR: QMD sync after `memory_store`, with update/embed scoped to the collection
-- [@MrGPUs](https://github.com/MrGPUs) — `openaiBaseUrl` config for OpenAI-compatible providers, `encoding_format` for vLLM/LiteLLM embeddings, richer entity-aware extraction prompts, and compaction reset with BOOT.md injection
-- [@KenFab](https://github.com/KenFab) — consistent `/v1` prefix handling for local LLM chat completions endpoints
-- [@earlvanze](https://github.com/earlvanze) (Earl Co) — OpenClaw memory runtime capability shim, `registerCommand` validator compatibility fix, Remnic admin dashboard controls and container, dashboard/harness provider separation, admin console bearer-token autofill, and Codex plugin discovery metadata
-- [@ramarivera](https://github.com/ramarivera) (Ramiro Rivera) — Pi plugin recall-timeout circuit breaker, startup Remnic probe capping, and object-rooted MCP tool output schemas
-- [@kopertop](https://github.com/kopertop) (Chris Moyer) — Claude Code marketplace manifest, authenticated health probe, and namespace targeting in Claude Code hooks
-- [@rmichelena](https://github.com/rmichelena) — routing gateway task defaults through `taskModelChain`
-- [@dfein38347g](https://github.com/dfein38347g) — single context injection at Pi session start for KV cache stability
-- [@geekboy1011](https://github.com/geekboy1011) (Tim Keller) — QMD Docker integration
-- Craig Froelich — QMD sync triggering after `memory_store` and hybrid BM25 + vector search / recall optimization merges
+- [@100menotu001](https://github.com/100menotu001) - first community PR: QMD sync after `memory_store`, with update/embed scoped to the collection
+- [@MrGPUs](https://github.com/MrGPUs) - `openaiBaseUrl` config for OpenAI-compatible providers, `encoding_format` for vLLM/LiteLLM embeddings, richer entity-aware extraction prompts, and compaction reset with BOOT.md injection
+- [@KenFab](https://github.com/KenFab) - consistent `/v1` prefix handling for local LLM chat completions endpoints
+- [@earlvanze](https://github.com/earlvanze) (Earl Co) - OpenClaw memory runtime capability shim, `registerCommand` validator compatibility fix, Remnic admin dashboard controls and container, dashboard/harness provider separation, admin console bearer-token autofill, and Codex plugin discovery metadata
+- [@ramarivera](https://github.com/ramarivera) (Ramiro Rivera) - Pi plugin recall-timeout circuit breaker, startup Remnic probe capping, and object-rooted MCP tool output schemas
+- [@kopertop](https://github.com/kopertop) (Chris Moyer) - Claude Code marketplace manifest, authenticated health probe, and namespace targeting in Claude Code hooks
+- [@rmichelena](https://github.com/rmichelena) - routing gateway task defaults through `taskModelChain`
+- [@dfein38347g](https://github.com/dfein38347g) - single context injection at Pi session start for KV cache stability
+- [@geekboy1011](https://github.com/geekboy1011) (Tim Keller) - QMD Docker integration
+- Craig Froelich - QMD sync triggering after `memory_store` and hybrid BM25 + vector search / recall optimization merges
 
 ## Agent Contributors
 
 Remnic is developed with heavy agent assistance, and those contributions are
 credited rather than hidden. Commits co-authored by Claude (Opus and Sonnet),
 Codex, and operator-run agents such as `Sysop Agent` and `GPUCodeBot` appear
-throughout the history — notably the day-summary cron, model fallback chain,
+throughout the history - notably the day-summary cron, model fallback chain,
 and OAuth provider resolution work.
 
 We appreciate both human and AI-assisted contributions that improve

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,20 +9,20 @@ Thanks to everyone who works on Remnic, once called `openclaw-engram`.
 ## Community contributors
 
 - [@100menotu001](https://github.com/100menotu001). First community PR. Synced QMD after `memory_store`. Scoped update and embed to one collection.
-- [@MrGPUs](https://github.com/MrGPUs). Added `openaiBaseUrl` for OpenAI-compatible hosts. Added `encoding_format` for vLLM and LiteLLM. Put entity facts in the extract prompt. Built compaction reset with BOOT.md. Switched the OpenClaw hook to `prependSystemContext`, which keeps bootstrap files intact.
+- [@MrGPUs](https://github.com/MrGPUs). Added `openaiBaseUrl` for OpenAI-compatible hosts. Added `encoding_format` for vLLM and LiteLLM. Put entity facts in the extract prompt. Built compaction reset with BOOT.md. Switched the OpenClaw hook to `prependSystemContext`, which keeps bootstrap files intact. Reworked the recall pipeline with a configurable inject order and a budget.
 - [@KenFab](https://github.com/KenFab). Fixed the `/v1` prefix for local LLM chat calls.
 - [@earlvanze](https://github.com/earlvanze). Added the OpenClaw memory runtime shim. Fixed the `registerCommand` check. Built the admin dashboard and its container. Split dashboards from harnesses. Filled in Codex plugin metadata.
 - [@ramarivera](https://github.com/ramarivera). Added the Pi recall-timeout circuit breaker. Capped startup probes. Made MCP output schemas object-rooted.
 - [@kopertop](https://github.com/kopertop). Added the Claude Code market manifest. Put auth on the health probe. Added namespace targeting to the hooks.
-- [@rmichelena](https://github.com/rmichelena). Sent gateway task defaults through `taskModelChain`.
+- [@rmichelena](https://github.com/rmichelena). Sent gateway task defaults through `taskModelChain`. Resolved OAuth providers. Routed LCM through the task model chain. Reconciled the day-summary cron.
 - [@dfein38347g](https://github.com/dfein38347g). Moved Pi to one context inject at session start, to keep the KV cache stable.
 - [@geekboy1011](https://github.com/geekboy1011). Added QMD Docker support.
 
 ## Agent contributors
 
 Remnic is built with a lot of agent help, and that work is credited, not
-hidden. Commits co-authored by Claude, Codex, and operator-run agents run
-through the whole history. The day-summary cron, the model fallback chain, and
-OAuth setup all came in that way.
+hidden. Commits co-authored by Claude and Codex run through the whole history.
+Some community PRs land the same way, with a contributor's own coding agent as
+the commit author. Those are credited to the person who opened the PR.
 
 Human and AI-assisted work both count here.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,31 +1,28 @@
 # Contributors
 
-Thanks to everyone who contributes to Remnic (formerly `openclaw-engram`).
+Thanks to everyone who works on Remnic, once called `openclaw-engram`.
 
 ## Maintainer
 
-- [@joshuaswarren](https://github.com/joshuaswarren) (Joshua Warren) - creator, architect, and lead maintainer. Designed the memory model (facts, entities, profile, corrections), the recall/extraction pipeline, the multi-host adapter architecture, and the à-la-carte packaging contract.
+- [@joshuaswarren](https://github.com/joshuaswarren) (Joshua Warren). Creator, architect, and lead maintainer. Designed the memory model, the recall and extraction pipeline, the multi-host adapter split, and the à-la-carte packaging contract.
 
-## Community Contributors
+## Community contributors
 
-- [@100menotu001](https://github.com/100menotu001) - first community PR: QMD sync after `memory_store`, with update/embed scoped to the collection
-- [@MrGPUs](https://github.com/MrGPUs) - `openaiBaseUrl` config for OpenAI-compatible providers, `encoding_format` for vLLM/LiteLLM embeddings, richer entity-aware extraction prompts, and compaction reset with BOOT.md injection
-- [@KenFab](https://github.com/KenFab) - consistent `/v1` prefix handling for local LLM chat completions endpoints
-- [@earlvanze](https://github.com/earlvanze) (Earl Co) - OpenClaw memory runtime capability shim, `registerCommand` validator compatibility fix, Remnic admin dashboard controls and container, dashboard/harness provider separation, admin console bearer-token autofill, and Codex plugin discovery metadata
-- [@ramarivera](https://github.com/ramarivera) (Ramiro Rivera) - Pi plugin recall-timeout circuit breaker, startup Remnic probe capping, and object-rooted MCP tool output schemas
-- [@kopertop](https://github.com/kopertop) (Chris Moyer) - Claude Code marketplace manifest, authenticated health probe, and namespace targeting in Claude Code hooks
-- [@rmichelena](https://github.com/rmichelena) - routing gateway task defaults through `taskModelChain`
-- [@dfein38347g](https://github.com/dfein38347g) - single context injection at Pi session start for KV cache stability
-- [@geekboy1011](https://github.com/geekboy1011) (Tim Keller) - QMD Docker integration
-- Craig Froelich - QMD sync triggering after `memory_store` and hybrid BM25 + vector search / recall optimization merges
+- [@100menotu001](https://github.com/100menotu001). First community PR. Synced QMD after `memory_store`. Scoped update and embed to one collection.
+- [@MrGPUs](https://github.com/MrGPUs). Added `openaiBaseUrl` for OpenAI-compatible hosts. Added `encoding_format` for vLLM and LiteLLM. Put entity facts in the extract prompt. Built compaction reset with BOOT.md.
+- [@KenFab](https://github.com/KenFab). Fixed the `/v1` prefix for local LLM chat calls.
+- [@earlvanze](https://github.com/earlvanze) (Earl Co). Added the OpenClaw memory runtime shim. Fixed the `registerCommand` check. Built the admin dashboard and its container. Split dashboards from harnesses. Filled in Codex plugin metadata.
+- [@ramarivera](https://github.com/ramarivera) (Ramiro Rivera). Added the Pi recall-timeout circuit breaker. Capped startup probes. Made MCP output schemas object-rooted.
+- [@kopertop](https://github.com/kopertop) (Chris Moyer). Added the Claude Code market manifest. Put auth on the health probe. Added namespace targeting to the hooks.
+- [@rmichelena](https://github.com/rmichelena). Sent gateway task defaults through `taskModelChain`.
+- [@dfein38347g](https://github.com/dfein38347g). Moved Pi to one context inject at session start, to keep the KV cache stable.
+- [@geekboy1011](https://github.com/geekboy1011) (Tim Keller). Added QMD Docker support.
 
-## Agent Contributors
+## Agent contributors
 
-Remnic is developed with heavy agent assistance, and those contributions are
-credited rather than hidden. Commits co-authored by Claude (Opus and Sonnet),
-Codex, and operator-run agents such as `Sysop Agent` and `GPUCodeBot` appear
-throughout the history - notably the day-summary cron, model fallback chain,
-and OAuth provider resolution work.
+Remnic is built with a lot of agent help, and that work is credited, not
+hidden. Commits co-authored by Claude, Codex, and operator-run agents run
+through the whole history. The day-summary cron, the model fallback chain, and
+OAuth setup all came in that way.
 
-We appreciate both human and AI-assisted contributions that improve
-reliability, usability, and documentation.
+Human and AI-assisted work both count here.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,7 +4,7 @@ Thanks to everyone who works on Remnic, once called `openclaw-engram`.
 
 ## Maintainer
 
-- [@joshuaswarren](https://github.com/joshuaswarren) (Joshua Warren). Creator, architect, and lead maintainer. Designed the memory model, the recall and extraction pipeline, the multi-host adapter split, and the à-la-carte packaging contract.
+- [@joshuaswarren](https://github.com/joshuaswarren). Creator, architect, and lead maintainer. Designed the memory model, the recall and extraction pipeline, the multi-host adapter split, and the à-la-carte packaging contract.
 
 ## Community contributors
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,12 +9,12 @@ Thanks to everyone who works on Remnic, once called `openclaw-engram`.
 ## Community contributors
 
 - [@100menotu001](https://github.com/100menotu001). First community PR. Synced QMD after `memory_store`. Scoped update and embed to one collection.
-- [@MrGPUs](https://github.com/MrGPUs). Added `openaiBaseUrl` for OpenAI-compatible hosts. Added `encoding_format` for vLLM and LiteLLM. Put entity facts in the extract prompt. Built compaction reset with BOOT.md. Switched the OpenClaw hook to `prependSystemContext`, which keeps bootstrap files intact. Reworked the recall pipeline with a configurable inject order and a budget.
+- [@MrGPUs](https://github.com/MrGPUs). Added `openaiBaseUrl` for OpenAI-compatible hosts. Added `encoding_format` for vLLM and LiteLLM. Put entity facts in the extract prompt. Built compaction reset with BOOT.md. Switched the OpenClaw hook to `prependSystemContext`, which keeps bootstrap files intact. Reworked the recall pipeline with a configurable inject order and a budget. Moved extraction to chat completions for OpenAI-compatible endpoints.
 - [@KenFab](https://github.com/KenFab). Fixed the `/v1` prefix for local LLM chat calls.
 - [@earlvanze](https://github.com/earlvanze). Added the OpenClaw memory runtime shim. Fixed the `registerCommand` check. Built the admin dashboard and its container. Split dashboards from harnesses. Filled in Codex plugin metadata.
-- [@ramarivera](https://github.com/ramarivera). Added the Pi recall-timeout circuit breaker. Capped startup probes. Made MCP output schemas object-rooted.
+- [@ramarivera](https://github.com/ramarivera). Added the Pi recall-timeout circuit breaker. Capped startup probes. Made MCP output schemas object-rooted. Scoped MCP writes to the project from cwd. Made the Codex hooks cross-platform and wrote the Windows docs.
 - [@kopertop](https://github.com/kopertop). Added the Claude Code market manifest. Put auth on the health probe. Added namespace targeting to the hooks.
-- [@rmichelena](https://github.com/rmichelena). Sent gateway task defaults through `taskModelChain`. Resolved OAuth providers. Routed LCM through the task model chain. Reconciled the day-summary cron.
+- [@rmichelena](https://github.com/rmichelena). Built the task-specific gateway model chain. Sent gateway task defaults through it. Resolved OAuth providers. Routed LCM through the task model chain. Reconciled the day-summary cron.
 - [@dfein38347g](https://github.com/dfein38347g). Moved Pi to one context inject at session start, to keep the KV cache stable.
 - [@geekboy1011](https://github.com/geekboy1011). Added QMD Docker support.
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,12 +1,31 @@
 # Contributors
 
-Thanks to everyone who contributes to openclaw-engram.
+Thanks to everyone who contributes to Remnic (formerly `openclaw-engram`).
 
-## Early Contributors
+## Maintainer
 
-- [@100menotu001](https://github.com/100menotu001) — first community PRs and QMD sync reliability improvements
-- [@MrGPUs](https://github.com/MrGPUs) — OpenAI-compatible base URL configuration support
+- [@joshuaswarren](https://github.com/joshuaswarren) (Joshua Warren) — creator, architect, and lead maintainer. Designed the memory model (facts, entities, profile, corrections), the recall/extraction pipeline, the multi-host adapter architecture, and the à-la-carte packaging contract.
+
+## Community Contributors
+
+- [@100menotu001](https://github.com/100menotu001) — first community PR: QMD sync after `memory_store`, with update/embed scoped to the collection
+- [@MrGPUs](https://github.com/MrGPUs) — `openaiBaseUrl` config for OpenAI-compatible providers, `encoding_format` for vLLM/LiteLLM embeddings, richer entity-aware extraction prompts, and compaction reset with BOOT.md injection
 - [@KenFab](https://github.com/KenFab) — consistent `/v1` prefix handling for local LLM chat completions endpoints
-- [@earlvanze](https://github.com/earlvanze) — OpenClaw memory runtime capability shim and `registerCommand` validator compatibility fix
+- [@earlvanze](https://github.com/earlvanze) (Earl Co) — OpenClaw memory runtime capability shim, `registerCommand` validator compatibility fix, Remnic admin dashboard controls and container, dashboard/harness provider separation, admin console bearer-token autofill, and Codex plugin discovery metadata
+- [@ramarivera](https://github.com/ramarivera) (Ramiro Rivera) — Pi plugin recall-timeout circuit breaker, startup Remnic probe capping, and object-rooted MCP tool output schemas
+- [@kopertop](https://github.com/kopertop) (Chris Moyer) — Claude Code marketplace manifest, authenticated health probe, and namespace targeting in Claude Code hooks
+- [@rmichelena](https://github.com/rmichelena) — routing gateway task defaults through `taskModelChain`
+- [@dfein38347g](https://github.com/dfein38347g) — single context injection at Pi session start for KV cache stability
+- [@geekboy1011](https://github.com/geekboy1011) (Tim Keller) — QMD Docker integration
+- Craig Froelich — QMD sync triggering after `memory_store` and hybrid BM25 + vector search / recall optimization merges
 
-We appreciate both human and AI-assisted contributions that improve reliability, usability, and documentation.
+## Agent Contributors
+
+Remnic is developed with heavy agent assistance, and those contributions are
+credited rather than hidden. Commits co-authored by Claude (Opus and Sonnet),
+Codex, and operator-run agents such as `Sysop Agent` and `GPUCodeBot` appear
+throughout the history — notably the day-summary cron, model fallback chain,
+and OAuth provider resolution work.
+
+We appreciate both human and AI-assisted contributions that improve
+reliability, usability, and documentation.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,7 +15,7 @@ Thanks to everyone who works on Remnic, once called `openclaw-engram`.
 - [@ramarivera](https://github.com/ramarivera). Added the Pi recall-timeout circuit breaker. Capped startup probes. Made MCP output schemas object-rooted. Scoped MCP writes to the project from cwd. Made the Codex hooks cross-platform and wrote the Windows docs.
 - [@kopertop](https://github.com/kopertop). Added the Claude Code market manifest. Put auth on the health probe. Added namespace targeting to the hooks.
 - [@rmichelena](https://github.com/rmichelena). Built the task-specific gateway model chain. Sent gateway task defaults through it. Resolved OAuth providers. Routed LCM through the task model chain. Reconciled the day-summary cron.
-- [@dfein38347g](https://github.com/dfein38347g). Moved Pi to one context inject at session start, to keep the KV cache stable.
+- [@dfein38347g](https://github.com/dfein38347g). Made Pi recall once, on the first prompt, then inject that same cached context every turn. Keeps the KV cache prefix stable.
 - [@geekboy1011](https://github.com/geekboy1011). Added QMD Docker support.
 
 ## Agent contributors


### PR DESCRIPTION
## What

Rebuild `CONTRIBUTORS.md` from actual `git log` authorship. The file was stale: it named the project `openclaw-engram`, listed four contributors, and had no maintainer entry.

## Changes

- Renamed the project to Remnic, noting the former `openclaw-engram` name.
- Added a maintainer entry for @joshuaswarren (creator, architect, lead maintainer).
- Grew the community list from 4 to 9 entries, each describing what actually landed: @100menotu001, @MrGPUs, @KenFab, @earlvanze, @ramarivera, @kopertop, @rmichelena, @dfein38347g, @geekboy1011.
- Expanded the existing @MrGPUs and @earlvanze entries from one item each to their full contribution sets.
- Corrected the @100menotu001 entry to the work in PR #1 (QMD sync after `memory_store`, update/embed scoped to one collection).
- Added an agent contributors section, so co-authored agent work is credited rather than hidden.

## Verification

- Contributions derived from `git log --author=...` per contributor, not from memory.
- One local git identity in PR #1 maps to no GitHub account; that work is credited to the PR author (@100menotu001) instead of inventing a separate contributor.
- Docs-only change. No code, config, or test surface touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change to contributor acknowledgments; no runtime, config, or test surface.
> 
> **Overview**
> **Documentation-only** refresh of `CONTRIBUTORS.md` so contributor credit matches current project identity and `git log` authorship.
> 
> The intro now thanks people working on **Remnic**, with a note that the project was formerly `openclaw-engram`. The old “Early Contributors” block is replaced by a **Maintainer** section (@joshuaswarren) and a **Community contributors** list grown from four to nine GitHub users, each with short bullets on what landed (including fuller sets for @MrGPUs and @earlvanze and a corrected @100menotu001 credit for PR #1). A new **Agent contributors** section states that Claude/Codex co-authorship and agent-authored community PRs are credited to the human who opened the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c5c7132ad9b0adb0fead8b12ec24d64c7de2838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor documentation to reflect the Remnic project name and its former name.
  * Reorganized acknowledgments into maintainer, community contributor, and agent contributor sections.
  * Expanded contributor credits with links and descriptions of contributions.
  * Added recognition for Claude, Codex, and operator-run agent contributions.
  * Clarified the project’s contributor history and broader range of contributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->