### PR TITLE
test(bench): align retry usage assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,15 +173,17 @@ jobs:
     # remnic pool only for same-repo PRs and main-ref runs; workflow_dispatch
     # on any other ref stays on hosted runners (codex P2 on #1608).
     runs-on: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')) && 'remnic' || 'ubuntu-latest' }}
-    timeout-minutes: 20
+    timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - shard: root
             groups: '--group root --group misc'
+            timeout: 20
           - shard: packages
             groups: '--group packages'
+            timeout: 30
     name: tests (${{ matrix.shard }})
     steps:
       - name: Checkout

--- a/packages/bench/src/coding-graph/repeated-failure-trap-audit.test.ts
+++ b/packages/bench/src/coding-graph/repeated-failure-trap-audit.test.ts
@@ -644,9 +644,23 @@ test("runTrapAudit rejects a tampered prior retry trace with unchanged usage", a
     assert.ok(traceDir);
     const retryTracePath = path.join(outputDir, "traces", traceDir, "attempt-1.json");
     const retryTrace = JSON.parse(await readFile(retryTracePath, "utf8")) as {
-      usage?: { input: number; output: number; total: number };
+      usage?: {
+        input: number;
+        output: number;
+        total: number;
+        cachedInput: number;
+        cacheWriteInput: number;
+        reasoningOutput: number;
+      };
     };
-    assert.deepEqual(retryTrace.usage, { input: 2, output: 1, total: 3 });
+    assert.deepEqual(retryTrace.usage, {
+      input: 2,
+      output: 1,
+      total: 3,
+      cachedInput: 0,
+      cacheWriteInput: 0,
+      reasoningOutput: 0,
+    });
     await writeFile(retryTracePath, `${JSON.stringify({ ...retryTrace, tampered: true })}\n`);
 
     await assert.rejects(


### PR DESCRIPTION
## Summary
- align the retry-trace assertion with the existing six-field usage contract
- let the tampered-trace regression reach the audit validator

## Verification
- `pnpm exec tsx --test --test-name-pattern='^runTrapAudit rejects a tampered prior retry trace with unchanged usage$' packages/bench/src/coding-graph/repeated-failure-trap-audit.test.ts` (1 passed, 0 failed)
- adversarial review found no actionable defect

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI timeout tuning only; no production logic, auth, or data paths.
> 
> **Overview**
> **CI** gives each test matrix shard its own job timeout via `matrix.timeout` (20 minutes for `root`, 30 for `packages`) instead of a single 20-minute cap for both.
> 
> **Bench audit test** updates the tampered retry-trace case so `retryTrace.usage` is asserted against the full six-field token usage shape (`cachedInput`, `cacheWriteInput`, `reasoningOutput` plus input/output/total). That matches what seeded traces emit and stops the test from failing on `deepEqual` before it exercises the tamper / `invalid trace evidence` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f7f258b7c2750713d93524e499543cff32ea9f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded retry trace validation to cover cached input, cache-write input, and reasoning output token usage.
  * Continued validating input, output, and total token usage.
* **Chores**
  * Improved automated test execution by allowing different test suites to use appropriate time limits, reducing failures caused by uniform timeout settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->