### PR TITLE
fix(plugin-codex): run POSIX hooks through sh

### DIFF
--- a/.changeset/codex-hook-bash-launcher.md
+++ b/.changeset/codex-hook-bash-launcher.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-codex": patch
+---
+
+Run Codex hooks with `sh`. The hooks now work when an install path does not preserve the launcher's executable mode.

--- a/.changeset/codex-hook-bash-launcher.md
+++ b/.changeset/codex-hook-bash-launcher.md
@@ -2,4 +2,4 @@
 "@remnic/plugin-codex": patch
 ---
 
-Run Codex hooks with `sh`. The hooks now work when an install path does not preserve the launcher's executable mode.
+Run POSIX Codex hooks with `sh`. The hooks now work when an install path does not preserve executable mode. Windows hooks still use PowerShell.

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -14,7 +14,8 @@ The hook command must start its own process. Package file metadata cannot
 control runtime behavior.
 
 Each POSIX command must invoke `sh`. It must quote the `${PLUGIN_ROOT}` path.
-This works with all package modes. Windows keeps its PowerShell command.
+This works with readable package modes, including mode `0644`. Windows keeps
+its PowerShell command.
 
 ## Current strategy
 

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -1,77 +1,32 @@
-# Theory: Localized and Path-Aware Conflict Recall
+# Theory: Codex hooks without executable mode
 
 ## Problem
 
-Remnic has the structure needed for precise conflict recall, but two decision paths ignore part of it.
+Codex runs Remnic hooks from commands in `hooks.json`.
 
-Contradiction checks used only a small text-search result set. They could miss a low-overlap fact for the same entity and category.
-
-Graph recall scores reached nodes without checking the supporting path. A valid candidate can receive full support through stale evidence.
+The source launcher uses executable mode `0755`. Some install paths do not
+preserve this mode. Direct startup then fails with `Permission denied`. Remnic
+cannot recall or observe.
 
 ## Operating theory
 
-Candidate discovery and decision authority must remain separate.
+The hook command must start its own process. Package file metadata cannot
+control runtime behavior.
 
-Issue #2327 uses `entityRef`, category, and structured attributes to find likely conflicts. The existing LLM verifier still makes the contradiction decision.
-
-Issue #2328 uses the existing graph path as evidence. It demotes a candidate when an intermediate memory is inactive or temporally invalid.
-
-Both changes must remain bounded and reversible. Disabled gates must preserve current behavior and avoid extra search, path, or corpus work.
+Each POSIX command must invoke `sh`. It must quote the `${PLUGIN_ROOT}` path.
+This works with all package modes. Windows keeps its PowerShell command.
 
 ## Current strategy
 
-Issue #2327 localizes contradiction candidates with bounded entity and category anchors. It merges them with namespace-scoped QMD results.
+Use `sh` for every POSIX event. Keep event names, matchers, timeouts, and
+Windows commands unchanged.
 
-The existing LLM verifier remains the decision authority. QMD unavailability emits a warning and keeps anchor candidates.
-
-Issue #2328 records one seed-scoped activation path. It chooses fewer hops, stronger landing weight, then lexical path order.
-
-The graph coordinator applies edge-confidence and intermediate-validity penalties before the namespace output cap. A bounded headroom cap limits state I/O.
-
-Optional path fields extend existing snapshots and renderers. Disabled output omits them and uses the exact legacy path.
-
-## Key discoveries
-
-Current `main` contains issue #2326. This satisfies issue #2328's dependency.
-
-Graph activation and path provenance need one winner rule. Equal-depth predecessor state must follow the strongest provenance winner.
-
-Archived memories move away from their original graph path. Basename identity maps their state back to existing edges.
-
-Historical recall already parses `asOf` once. Graph scoring must consume only the validated millisecond value.
-
-The orchestrator graph-expansion method is an active test and override seam. Production recall must route through that seam.
-
-Anchor snapshots must include hot and cold tiers. Each successful write or supersession must update the snapshot before the next batch item.
-
-Cold candidates require cold-aware mutation paths. Detection without mutation parity leaves conflicting memories active.
-
-Graph archive indexes reject symlinked roots. They use canonical roots, an archive-only generation, caller-local deadlines, and a 32-entry LRU.
-
-Large archive scans publish an unavailable sentinel for that generation. This prevents repeated high-I/O scans until an archive mutation occurs.
-
-Direct graph reads validate logical IDs. Active hot and cold copies use the same canonical merge rule as contradiction anchors.
-
-Contradiction retirement treats a false mutation result as ambiguous until fresh hot and cold reads prove a lost race.
-
-Only a readable active losing row can complete lost-race cleanup. Missing data and I/O failures preserve the anchor for retry.
-
-The path scorer inspects only intermediate nodes. It ignores seed and candidate status because existing filters own those decisions.
-
-Temporal invalidity follows `[valid_at, invalid_at)`. A node is invalid when `invalid_at <= asOf`.
-
-Missing path data or node state keeps multiplier `1`. Unknown evidence does not become negative evidence.
-
-Legacy memories without a status remain active for contradiction anchors. Explicit non-active states remain excluded.
+A manifest test checks every event. A runtime test copies the launcher, sets
+mode `0644`, and runs it through `sh`.
 
 ## Verification state
 
-The latest focused race and graph-loader run passes 51 tests. Core type checks, ratchets, and lifecycle coverage pass.
+The manifest test failed against the direct startup commands.
 
-`preflight:quick` passes after the current-head corrections. `test:entity-hardening` passes 339 tests.
-
-Historical recall now bypasses current-status filtering only for historically valid `superseded` candidates.
-
-Anchor snapshot read failures fail open with an empty snapshot. Failure state stays scoped to one storage instance.
-
-Independent graph and contradiction reviewers approved the current production behavior. Current-head CI is in progress.
+All 49 Codex hook tests pass. A copied launcher with mode `0644` starts and
+returns valid hook JSON.

--- a/packages/plugin-codex/README.md
+++ b/packages/plugin-codex/README.md
@@ -31,7 +31,7 @@ The package is **data + one small runtime materializer** (no runtime JS beyond t
 | File / dir | Purpose |
 |---|---|
 | `.codex-plugin/plugin.json` | Plugin manifest |
-| `hooks/hooks.json` + `hooks/bin/remnic-codex-hook.{cjs,sh,ps1}` | Codex session-lifecycle hooks (recall, observe, session-end, **pre-compact LCM flush**). A single cross-platform Node.js runner (`.cjs`) with thin POSIX (`.sh`) and Windows PowerShell (`.ps1`) launchers; `hooks.json` wires each event with both `command` and `commandWindows` so hooks work on macOS, Linux, and Windows. |
+| `hooks/hooks.json` + `hooks/bin/remnic-codex-hook.{cjs,sh,ps1}` | Codex session hooks for recall, observe, session end, and pre-compact LCM flush. `hooks.json` invokes the POSIX launcher through `sh`, so hooks still run when an install path does not preserve its executable mode. Windows uses the PowerShell launcher. |
 | `skills/` | `remnic-recall`, `remnic-remember`, `remnic-search`, `remnic-status`, `remnic-entities`, `remnic-memory-workflow` — invocable from Codex chats |
 | `memories_extensions/remnic/` | Codex phase-2 consolidation instructions — tells the Codex compactor sub-agent to treat Remnic's on-disk Markdown as an authoritative local memory source when it builds `MEMORY.md`. Local-only (no MCP, no network); runtime recall/observe still flow through the hooks above. |
 | `.mcp.json` | MCP server config pointing Codex at `http://localhost:4318/mcp` |
@@ -132,10 +132,10 @@ the foreground path reads it.
 
 Codex does not run non-managed command hooks until a human reviews and trusts
 them. The first time these hooks are enabled, Codex prints a startup warning
-directing you to run `/hooks` in the CLI; review the four Remnic entries
-(SessionStart / UserPromptSubmit / Stop / PreCompact) and approve them. Codex
-records trust against the current hook hash, so updates to `hooks.json` will
-re-trigger a review.
+directing you to run `/hooks` in the CLI. Review the five Remnic entries
+(SessionStart, PostToolUse, UserPromptSubmit, Stop, and PreCompact), then
+approve them. Codex records trust against the current hook hash, so updates
+to `hooks.json` will trigger a new review.
 
 For fleet / headless automation there is no non-interactive trust CLI today;
 pick one of:

--- a/packages/plugin-codex/hooks/bin/remnic-codex-hook.test.cjs
+++ b/packages/plugin-codex/hooks/bin/remnic-codex-hook.test.cjs
@@ -351,24 +351,25 @@ test("unknown event fails open with continue", async () => {
 
 // ── #1443 review fixes ──────────────────────────────────────────────────────
 
-test("hooks.json: every POSIX event invokes the launcher through sh", () => {
+const POSIX_HOOK_EVENTS = Object.freeze({
+  SessionStart: "session-start",
+  PostToolUse: "post-tool-observe",
+  UserPromptSubmit: "user-prompt-recall",
+  Stop: "session-end",
+  PreCompact: "pre-compact",
+});
+
+test("hooks.json: every POSIX event invokes the correct launcher event through sh", () => {
   const cfg = JSON.parse(
     fs.readFileSync(path.join(__dirname, "..", "hooks.json"), "utf8"),
   );
-  const events = [
-    "SessionStart",
-    "PostToolUse",
-    "UserPromptSubmit",
-    "Stop",
-    "PreCompact",
-  ];
-  for (const event of events) {
+  for (const [event, runnerEvent] of Object.entries(POSIX_HOOK_EVENTS)) {
     for (const matcher of cfg.hooks[event]) {
       for (const hook of matcher.hooks) {
-        assert.match(
+        assert.equal(
           hook.command,
-          /^sh "\$\{PLUGIN_ROOT\}\/hooks\/bin\/remnic-codex-hook\.sh"\s/,
-          `${event}.command must invoke the quoted \${PLUGIN_ROOT} launcher through sh`,
+          `sh "\${PLUGIN_ROOT}/hooks/bin/remnic-codex-hook.sh" ${runnerEvent}`,
+          `${event}.command must invoke the matching runner event through sh`,
         );
         assert.ok(hook.commandWindows, `${event} must declare commandWindows`);
         assert.match(
@@ -387,7 +388,7 @@ test("hooks.json: every POSIX event invokes the launcher through sh", () => {
 });
 
 test(
-  "hooks.json: POSIX command runs a packaged launcher without executable mode",
+  "hooks.json: every POSIX command runs a packaged launcher without executable mode",
   { skip: process.platform === "win32" },
   async () => {
     const home = mkHome();
@@ -403,41 +404,44 @@ test(
       const cfg = JSON.parse(
         fs.readFileSync(path.join(__dirname, "..", "hooks.json"), "utf8"),
       );
-      const command = cfg.hooks.SessionStart[0].hooks[0].command;
-      const child = spawn("sh", ["-c", command], {
-        env: {
-          ...process.env,
-          HOME: home,
-          USERPROFILE: home,
-          XDG_STATE_HOME: path.join(home, "state"),
-          PLUGIN_ROOT: pluginRoot,
-          REMNIC_CODEX_MATERIALIZE: "0",
-          OPENCLAW_REMNIC_ACCESS_TOKEN: "",
-          OPENCLAW_ENGRAM_ACCESS_TOKEN: "",
-          REMNIC_AUTH_TOKEN: "",
-          ENGRAM_AUTH_TOKEN: "",
-          REMNIC_HOOK_TOKEN: "",
-          REMNIC_DAEMON_URL: "",
-          ENGRAM_DAEMON_URL: "",
-        },
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-      let stdout = "";
-      let stderr = "";
-      child.stdout.on("data", (data) => {
-        stdout += data;
-      });
-      child.stderr.on("data", (data) => {
-        stderr += data;
-      });
-      child.stdin.end(JSON.stringify({ session_id: "mode-test", cwd: home }));
-      const exitCode = await new Promise((resolve, reject) => {
+      const runCommand = (command, sessionId) => new Promise((resolve, reject) => {
+        const child = spawn("sh", ["-c", command], {
+          env: {
+            ...process.env,
+            HOME: home,
+            USERPROFILE: home,
+            XDG_STATE_HOME: path.join(home, "state"),
+            PLUGIN_ROOT: pluginRoot,
+            REMNIC_CODEX_MATERIALIZE: "0",
+            OPENCLAW_REMNIC_ACCESS_TOKEN: "",
+            OPENCLAW_ENGRAM_ACCESS_TOKEN: "",
+            REMNIC_AUTH_TOKEN: "",
+            ENGRAM_AUTH_TOKEN: "",
+            REMNIC_HOOK_TOKEN: "",
+            REMNIC_DAEMON_URL: "",
+            ENGRAM_DAEMON_URL: "",
+          },
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        let stdout = "";
+        let stderr = "";
+        child.stdout.on("data", (data) => {
+          stdout += data;
+        });
+        child.stderr.on("data", (data) => {
+          stderr += data;
+        });
+        child.stdin.end(JSON.stringify({ session_id: sessionId, cwd: home }));
         child.on("error", reject);
-        child.on("close", resolve);
+        child.on("close", (exitCode) => resolve({ exitCode, stdout, stderr }));
       });
 
-      assert.equal(exitCode, 0, stderr);
-      assert.equal(JSON.parse(stdout).continue, true);
+      for (const [event, runnerEvent] of Object.entries(POSIX_HOOK_EVENTS)) {
+        const command = cfg.hooks[event][0].hooks[0].command;
+        const result = await runCommand(command, `${runnerEvent}-mode-test`);
+        assert.equal(result.exitCode, 0, `${event}: ${result.stderr}`);
+        assert.equal(JSON.parse(result.stdout).continue, true, event);
+      }
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/packages/plugin-codex/hooks/bin/remnic-codex-hook.test.cjs
+++ b/packages/plugin-codex/hooks/bin/remnic-codex-hook.test.cjs
@@ -351,26 +351,24 @@ test("unknown event fails open with continue", async () => {
 
 // ── #1443 review fixes ──────────────────────────────────────────────────────
 
-test("hooks.json: every event resolves via ${PLUGIN_ROOT} and uses powershell (#1443 review)", () => {
+test("hooks.json: every POSIX event invokes the launcher through sh", () => {
   const cfg = JSON.parse(
     fs.readFileSync(path.join(__dirname, "..", "hooks.json"), "utf8"),
   );
-  for (const event of ["SessionStart", "PostToolUse", "UserPromptSubmit", "Stop", "PreCompact"]) {
+  const events = [
+    "SessionStart",
+    "PostToolUse",
+    "UserPromptSubmit",
+    "Stop",
+    "PreCompact",
+  ];
+  for (const event of events) {
     for (const matcher of cfg.hooks[event]) {
       for (const hook of matcher.hooks) {
-        // Codex runs plugin hooks from the session cwd via sh -lc / cmd /C and
-        // substitutes ${PLUGIN_ROOT} (openai/codex discovery.rs + command_runner.rs),
-        // so the path must be PLUGIN_ROOT-relative AND quoted — an unquoted path
-        // would word-split on a plugin root containing spaces (e.g.
-        // C:\Users\Jane Doe).
-        assert.ok(
-          hook.command.startsWith('"${PLUGIN_ROOT}/hooks/bin/'),
-          `${event}.command must resolve via a quoted \${PLUGIN_ROOT}, got: ${hook.command}`,
-        );
         assert.match(
           hook.command,
-          /^"\$\{PLUGIN_ROOT\}\/hooks\/bin\/remnic-codex-hook\.sh"\s/,
-          `${event}.command path must be wrapped in double quotes`,
+          /^sh "\$\{PLUGIN_ROOT\}\/hooks\/bin\/remnic-codex-hook\.sh"\s/,
+          `${event}.command must invoke the quoted \${PLUGIN_ROOT} launcher through sh`,
         );
         assert.ok(hook.commandWindows, `${event} must declare commandWindows`);
         assert.match(
@@ -378,8 +376,6 @@ test("hooks.json: every event resolves via ${PLUGIN_ROOT} and uses powershell (#
           /-File "\$\{PLUGIN_ROOT\}\\hooks\\bin\\remnic-codex-hook\.ps1"\s/,
           `${event}.commandWindows must pass a quoted \${PLUGIN_ROOT} -File path`,
         );
-        // Use `powershell` not `pwsh` so stock Windows 10/11 works without
-        // PowerShell 7 installed (#1443 review).
         assert.match(
           hook.commandWindows,
           /^powershell\b/,
@@ -389,6 +385,64 @@ test("hooks.json: every event resolves via ${PLUGIN_ROOT} and uses powershell (#
     }
   }
 });
+
+test(
+  "hooks.json: POSIX command runs a packaged launcher without executable mode",
+  { skip: process.platform === "win32" },
+  async () => {
+    const home = mkHome();
+    try {
+      const pluginRoot = path.join(home, "plugin root");
+      const binDir = path.join(pluginRoot, "hooks", "bin");
+      fs.mkdirSync(binDir, { recursive: true });
+      for (const file of ["remnic-codex-hook.sh", "remnic-codex-hook.cjs"]) {
+        fs.copyFileSync(path.join(__dirname, file), path.join(binDir, file));
+      }
+      fs.chmodSync(path.join(binDir, "remnic-codex-hook.sh"), 0o644);
+
+      const cfg = JSON.parse(
+        fs.readFileSync(path.join(__dirname, "..", "hooks.json"), "utf8"),
+      );
+      const command = cfg.hooks.SessionStart[0].hooks[0].command;
+      const child = spawn("sh", ["-c", command], {
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          XDG_STATE_HOME: path.join(home, "state"),
+          PLUGIN_ROOT: pluginRoot,
+          REMNIC_CODEX_MATERIALIZE: "0",
+          OPENCLAW_REMNIC_ACCESS_TOKEN: "",
+          OPENCLAW_ENGRAM_ACCESS_TOKEN: "",
+          REMNIC_AUTH_TOKEN: "",
+          ENGRAM_AUTH_TOKEN: "",
+          REMNIC_HOOK_TOKEN: "",
+          REMNIC_DAEMON_URL: "",
+          ENGRAM_DAEMON_URL: "",
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (data) => {
+        stdout += data;
+      });
+      child.stderr.on("data", (data) => {
+        stderr += data;
+      });
+      child.stdin.end(JSON.stringify({ session_id: "mode-test", cwd: home }));
+      const exitCode = await new Promise((resolve, reject) => {
+        child.on("error", reject);
+        child.on("close", resolve);
+      });
+
+      assert.equal(exitCode, 0, stderr);
+      assert.equal(JSON.parse(stdout).continue, true);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  },
+);
 
 test("runner source: remnic→engram fallthrough is PATH-gated and Windows-shim aware (#1443 review)", () => {
   const src = fs.readFileSync(path.join(__dirname, "remnic-codex-hook.cjs"), "utf8");

--- a/packages/plugin-codex/hooks/hooks.json
+++ b/packages/plugin-codex/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${PLUGIN_ROOT}/hooks/bin/remnic-codex-hook.sh\" session-start",
+            "command": "sh \"${PLUGIN_ROOT}/hooks/bin/remnic-codex-hook.sh\" session-start",
             "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\hooks\\bin\\remnic-codex-hook.ps1\" session-start",
             "timeout": 45
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${PLUGIN_ROOT}/hooks/bin/remnic-codex-hook.sh\" post-tool-observe",
+            "command": "sh \"${PLUGIN_ROOT}/hooks/bin/remnic-codex-hook.sh\" post-tool-observe",
             "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\hooks\\bin\\remnic-codex-hook.ps1\" post-tool-observe",
             "timeout": 10
           }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${PLUGIN_ROOT}/hooks/bin/remnic-codex-hook.sh\" user-prompt-recall",
+            "command": "sh \"${PLUGIN_ROOT}/hooks/bin/remnic-codex-hook.sh\" user-prompt-recall",
             "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\hooks\\bin\\remnic-codex-hook.ps1\" user-prompt-recall",
             "timeout": 20
           }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${PLUGIN_ROOT}/hooks/bin/remnic-codex-hook.sh\" session-end",
+            "command": "sh \"${PLUGIN_ROOT}/hooks/bin/remnic-codex-hook.sh\" session-end",
             "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\hooks\\bin\\remnic-codex-hook.ps1\" session-end",
             "timeout": 30
           }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${PLUGIN_ROOT}/hooks/bin/remnic-codex-hook.sh\" pre-compact",
+            "command": "sh \"${PLUGIN_ROOT}/hooks/bin/remnic-codex-hook.sh\" pre-compact",
             "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\hooks\\bin\\remnic-codex-hook.ps1\" pre-compact",
             "timeout": 90
           }


### PR DESCRIPTION
## Summary

- Start each POSIX Codex hook with `sh`.
- Quote each `${PLUGIN_ROOT}` path.
- Keep the Windows PowerShell commands.
- Test mode `0644` and a path with spaces.

## Problem

Some installers remove executable file mode. Direct startup then fails. Remnic cannot run hooks.

## Verification

- `node --test packages/plugin-codex/hooks/bin/remnic-codex-hook.test.cjs` (49 passed)
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Codex hook invocation on Unix; hook runner logic and Windows paths are unchanged.
> 
> **Overview**
> POSIX Codex hook commands in `hooks.json` no longer execute `remnic-codex-hook.sh` directly; each event now runs **`sh "${PLUGIN_ROOT}/hooks/bin/remnic-codex-hook.sh" <event>`** so hooks still start when installers drop the launcher’s executable bit (e.g. mode `0644`). **Windows `commandWindows` entries are unchanged.**
> 
> Tests now assert exact `sh`-wrapped commands for all five events and add a non-Windows integration check that copies the launcher into a path with spaces, chmods the script to `0644`, and verifies every POSIX command exits 0 with valid hook JSON. README and changeset document the behavior; `THEORY.MD` was rewritten to match this fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc6145da13e9d177409e614058d2a15726371790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex hook startup on Unix systems where launcher executable permissions are not preserved.
  - Hooks now run reliably from installation paths containing spaces.
  - Windows hook behavior remains unchanged.

- **Documentation**
  - Updated Codex hook setup and trust guidance.
  - Clarified platform-specific hook execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->