### PR TITLE
test(cli): preserve config rollback failure contract

### DIFF
--- a/tests/openclaw-upgrade-swap.test.ts
+++ b/tests/openclaw-upgrade-swap.test.ts
@@ -159,6 +159,34 @@ test("rollbackOpenclawUpgrade restores plugin and config from rollback artifacts
   assert.ok(notes.some((note) => note.includes("Restored OpenClaw config from backup")));
 });
 
+test("rollbackOpenclawUpgrade does not hide config restore failures after plugin restoration", async () => {
+  const tmp = await makeTmpDir();
+  const pluginDir = path.join(tmp, "extensions", "openclaw-remnic");
+  const rollbackDir = path.join(tmp, "rollback");
+  const configPath = path.join(tmp, "openclaw.json");
+  const configBackupPath = path.join(tmp, "backups", "openclaw.json");
+  const validConfig = '{"plugins":{"slots":{"memory":"openclaw-remnic"}}}\n';
+
+  writeMarker(pluginDir, "new-plugin");
+  writeMarker(rollbackDir, "old-plugin");
+  fs.mkdirSync(configPath, { recursive: true });
+  fs.mkdirSync(path.dirname(configBackupPath), { recursive: true });
+  fs.writeFileSync(configBackupPath, validConfig, "utf8");
+
+  assert.throws(
+    () =>
+      rollbackOpenclawUpgrade({
+        configBackupPath,
+        configPath,
+        pluginDir,
+        rollbackDir,
+      }),
+    /Failed to restore OpenClaw config from backup at /,
+  );
+  assert.equal(readMarker(pluginDir), "old-plugin");
+  assert.equal(fs.readFileSync(configBackupPath, "utf8"), validConfig);
+});
+
 test("rollbackOpenclawUpgrade falls back to the durable backup when rollback restore fails", async () => {
   const tmp = await makeTmpDir();
   const pluginDir = path.join(tmp, "extensions", "openclaw-remnic");


### PR DESCRIPTION
## Summary

- confirm that current OpenClaw local plugin rollback does not restore a prior user config snapshot
- add a regression test that keeps config restore failures visible after plugin restoration succeeds

## Upstream contract

OpenClaw main at `af708e6628954c024f9d6af81a1d6bd7b9e12e08` restores the tentative install index and managed npm markers after a failed config commit. It does not restore a prior config snapshot.

- [install record rollback](https://github.com/openclaw/openclaw/blob/af708e6628954c024f9d6af81a1d6bd7b9e12e08/src/plugins/install-record-commit.ts#L400-L505)
- [local plugin install flow](https://github.com/openclaw/openclaw/blob/af708e6628954c024f9d6af81a1d6bd7b9e12e08/src/plugins/install-package.ts#L381-L486)
- [plugin config documentation](https://github.com/openclaw/openclaw/blob/af708e6628954c024f9d6af81a1d6bd7b9e12e08/docs/tools/plugin.md#L48-L125)

Remnic's independent plugin and config restore contract remains correct. No production code change is required.

## Verification

- `pnpm exec tsx --test --test-name-pattern="does not hide config restore failures" tests/openclaw-upgrade-swap.test.ts`
- `pnpm exec tsx --test tests/openclaw-upgrade-swap.test.ts`
- `npm run preflight:quick`
- `npm test`
- adversarial diff review: no actionable findings

Closes #2354

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime behavior modifications.
> 
> **Overview**
> Adds a regression test for `rollbackOpenclawUpgrade` when OpenClaw config restore fails after the plugin rollback already succeeded (e.g. `configPath` is not writable as a file).
> 
> The test expects a thrown error matching **Failed to restore OpenClaw config from backup at**, while confirming the plugin was still rolled back to the prior copy and the backup file is unchanged. **No production code changes**—this documents Remnic’s rollback contract vs upstream OpenClaw behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6d4c7904266f5975e800d811837a245b94f04e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for upgrade rollback scenarios where plugin restoration succeeds but configuration restoration fails.
  * Verified that configuration errors are surfaced and backup data remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->