### PR TITLE
fix(core): preserve Unicode content in dedup

### DIFF
--- a/.changeset/unicode-content-hash-dedup.md
+++ b/.changeset/unicode-content-hash-dedup.md
@@ -2,4 +2,4 @@
 "@remnic/core": patch
 ---
 
-Preserve Unicode letters, marks, and numbers in content hashes and statement deduplication. Normalize hashes to NFC and version the persisted hash index so legacy entries cannot suppress writes after the normalization change (#2186).
+Preserve Unicode letters, marks, and numbers in content hashes and statement deduplication. Normalize hashes to NFC, version persisted hash indexes, and migrate legacy fact/tombstone identities so stale entries cannot suppress writes or allow retired memories to resurrect (#2186).

--- a/.changeset/unicode-content-hash-dedup.md
+++ b/.changeset/unicode-content-hash-dedup.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Preserve Unicode letters, marks, and numbers in content hashes and statement deduplication. Normalize hashes to NFC and version the persisted hash index so legacy entries cannot suppress writes after the normalization change (#2186).

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -28,17 +28,19 @@ The system preserves ambiguous persisted identities but does not query them as a
 
 The tombstone store reads legacy sources from hot, cold, and archive storage.
 
-It reads source IDs in bounded batches but migrates every available batch before publishing its index.
+It reads source IDs in bounded batches and completes every available batch before publishing its index.
+
+The source resolver scans paths lazily. It caches the complete ID map when direct filename lookup cannot resolve a frontmatter ID.
 
 Unavailable sources remain unversioned. A later load retries them after the source becomes available.
 
-The migration preserves an explicit `contentHashSource` identity as the primary hash.
+Malformed JSONL prevents a migration rewrite. The store preserves every malformed row byte-for-byte.
 
-It also stores current body hash and normalized aliases when the source body is known.
+The migration preserves an explicit `contentHashSource` identity because the stored body cannot prove a distinct external identity.
 
-Source reconstruction retains persisted structured attributes because default writes include them in the content identity.
+The fact-hash index rebuild replaces a verified legacy body hash with the current body hash.
 
-The fact-hash index rebuild treats legacy hashes as authoritative only when the current body proves the same identity.
+It derives current body hashes for old files that have no stored hash.
 
 Ambiguous legacy hashes never suppress a current Unicode write.
 
@@ -56,8 +58,12 @@ Terminal sentence punctuation remains compatible with normalized exact matches.
 
 ## Verification state
 
-The focused migration and non-resurrection suite passes 101 tests.
+The focused migration and non-resurrection suite passes 105 tests.
 
-The core type check passes.
+The core type check and build pass.
 
-The final mandatory gates and complete workspace suite are running against the latest review fixes.
+`preflight:quick` and the 339-test entity hardening gate pass.
+
+The first complete workspace run found one stale normalizer-version expectation. Its focused test now passes.
+
+The complete workspace test rerun is pending.

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -1,65 +1,65 @@
-# Theory: Durable Dependency Revalidation
+# Theory: Safe Unicode Identity Migration
 
 ## Problem
 
-Remnic stores dependency links, but old lifecycle paths treated them as write-only metadata.
+Remnic used an ASCII-only normalizer for content hashes and duplicate checks.
 
-When support memory becomes invalid, a dependent claim can remain active and recallable.
+That normalizer erased CJK and other non-ASCII text. Distinct facts could share the empty-string hash.
 
-The primary mutation and the dependent revalidation must also survive different crash windows.
+Equivalent Unicode forms could also miss each other without canonical composition.
+
+Changing the normalizer fixes new writes but makes persisted identities stale.
+
+Tombstones and fact-hash indexes must migrate without trusting lossy legacy aliases.
 
 ## Operating theory
 
-Dependency propagation is an orchestration task. Storage changes one memory atomically. The extraction engine judges dependent claims.
+NFC normalization makes canonically equivalent Unicode text stable.
 
-Each trigger captures the source before mutation. It prepares a durable job before the source changes.
+Unicode letter, mark, and number classes retain meaningful text across scripts.
 
-After the primary mutation commits, the job becomes ready. A worker scans one namespace snapshot and one-hop link neighborhood.
+Legacy hashes are evidence only when the old and current normalized text are equal and non-empty.
 
-The worker revalidates all bounded dependents in one LLM call. `still_valid` keeps the memory active. `invalidated` supersedes it.
+An empty or changed legacy form cannot identify Unicode content safely.
 
-Malformed, missing, or uncertain verdicts preserve active memory. This keeps the failure mode fail-open for user data.
+The system preserves ambiguous persisted identities but does not query them as aliases for new content.
 
-## Durable state model
+## Migration strategy
 
-The queue uses explicit `prepared`, `ready`, `leased`, `retryable`, and terminal states.
+The tombstone store upgrades bounded legacy entries from known source memories.
 
-Preparation records the exact source snapshot and replacement identity. Reservations prevent one caller from canceling another caller's job.
+It records the migration version when a source is unavailable. Later loads do not repeat the same failed scan.
 
-Recovery first proves whether the primary mutation committed. It replays missing primary effects only from the captured snapshot.
+The migration preserves an explicit `contentHashSource` identity as the primary hash.
 
-Recovered consolidation work also repairs index visibility. It uses the captured source path for deindex and gates temporal index work by capability.
+It also stores current body hash and normalized aliases when the source body is known.
 
-The queue writes with atomic JSON replacement. Write failures return no preparation token, so callers do not report false durability.
+Source reconstruction retains persisted structured attributes because default writes include them in the content identity.
 
-## Trigger coverage
+The fact-hash index rebuild treats legacy hashes as authoritative only when the current body proves the same identity.
 
-Contradiction resolution captures the active hot or cold source before supersession.
+Ambiguous legacy hashes never suppress a current Unicode write.
 
-Temporal supersession prepares before mutation and retries preparation when a transient survivor lookup fails.
+Entity repair re-runs the tombstone gate with the final entity reference and structured attributes.
 
-Consolidation invalidate and merge paths prepare before mutation. Merge recovery verifies the survivor fingerprint before replay.
+## Deduplication strategy
 
-Startup recovery scans durable jobs. Shutdown drains extraction first, then waits for propagation work.
+Duplicate comparison tokenizes Unicode letters, marks, and numbers.
 
-## Rebase integration
+It supports scripts without whitespace, including Japanese and Korean.
 
-Current `main` moved supersession side effects and recovery work into focused modules.
+Only punctuation embedded between letters or numbers separates a phrase identity.
 
-The branch now uses those boundaries instead of restoring old monolithic code.
-
-Supersession remains active-only under the file lock. Exact replay repairs missing lifecycle, tombstone, audit, and cache effects.
-
-The final branch must preserve the storage ratchet. `storage.ts` and `orchestrator.ts` stay below their enforced line limits.
+Terminal sentence punctuation remains compatible with normalized exact matches.
 
 ## Verification state
 
-Core type checks pass. The focused replay suite passes 170 tests.
+The focused migration and non-resurrection suite passes 90 tests.
 
-The entity hardening gate passes. The lifecycle coverage suite passes 41 tests.
+The core type check passes.
 
-The complete second package shard passes 722 tests, with 17 skips and no failures.
+`preflight:quick` and `test:entity-hardening` pass after the final migration-source fix.
 
-The archive replay test and the active-state race regression both pass after the rebase fix.
+The complete workspace suite passes 18,422 tests, with 43 skips.
 
-The final sequential `preflight:quick` run passes.
+An adversarial branch review found no remaining branch-introduced defect.

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -26,23 +26,25 @@ The system preserves ambiguous persisted identities but does not query them as a
 
 ## Migration strategy
 
+Stored content has up to three verified identity forms: raw content, cited content, and the full attributed body.
+
+The persisted hash selects the historic identity form. The system computes a current hash only after that match.
+
+This rule preserves explicit `contentHashSource` identities and old full-body hashes without making legacy hashes global aliases.
+
+Tombstones can retain a current alias only when both forms come from the same source memory.
+
 The tombstone store reads legacy sources from hot, cold, and archive storage.
 
 It reads source IDs in bounded batches and completes every available batch before publishing its index.
-
-The source resolver scans paths lazily. It caches the complete ID map when direct filename lookup cannot resolve a frontmatter ID.
 
 Unavailable sources remain unversioned. A later load retries them after the source becomes available.
 
 Malformed JSONL prevents a migration rewrite. The store preserves every malformed row byte-for-byte.
 
-The migration preserves an explicit `contentHashSource` identity because the stored body cannot prove a distinct external identity.
+The fact-hash index and reconcile manifest use the same source-verified identity selection.
 
-The fact-hash index rebuild replaces a verified legacy body hash with the current body hash.
-
-It derives current body hashes for old files that have no stored hash.
-
-Ambiguous legacy hashes never suppress a current Unicode write.
+Ambiguous legacy hashes never suppress unrelated current Unicode content.
 
 Entity repair re-runs the tombstone gate with the final entity reference and structured attributes.
 
@@ -52,18 +54,16 @@ Duplicate comparison tokenizes Unicode letters, marks, and numbers.
 
 It supports scripts without whitespace, including Japanese and Korean.
 
-Only punctuation embedded between letters or numbers separates a phrase identity.
+Embedded punctuation records both the mark and its semantic character position.
 
 Terminal sentence punctuation remains compatible with normalized exact matches.
 
 ## Verification state
 
-The focused migration and non-resurrection suite passes 105 tests.
+The 65-test focused identity suite passes after the citation, attribute, and punctuation fixes.
 
-The core type check and build pass.
+The core type check passes.
 
-`preflight:quick` and the 339-test entity hardening gate pass.
+The storage line ratchet passes at 7,314 lines, below its 7,315-line ceiling.
 
-The first complete workspace run found one stale normalizer-version expectation. Its focused test now passes.
-
-The complete workspace test rerun is pending.
+The wider mandatory gates and complete workspace suite require a fresh run before merge.

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -40,9 +40,13 @@ It reads source IDs in bounded batches and completes every available batch befor
 
 Unavailable sources remain unversioned. A later load retries them after the source becomes available.
 
-Malformed JSONL prevents a migration rewrite. The store preserves every malformed row byte-for-byte.
+Malformed JSONL rows stay byte-for-byte while valid rows migrate in place.
 
-The fact-hash index and reconcile manifest use the same source-verified identity selection.
+The fact-hash index registers every stored identity form that matches an ambiguous legacy hash.
+
+This bounded set preserves recoverable explicit sources without making a lossy hash a global alias.
+
+The reconcile manifest uses the same source-verified identity selection.
 
 Ambiguous legacy hashes never suppress unrelated current Unicode content.
 
@@ -60,10 +64,12 @@ Terminal sentence punctuation remains compatible with normalized exact matches.
 
 ## Verification state
 
-The 65-test focused identity suite passes after the citation, attribute, and punctuation fixes.
+The 108-test focused identity suite passes after the corruption and ambiguous-source fixes.
 
 The core type check passes.
 
 The storage line ratchet passes at 7,314 lines, below its 7,315-line ceiling.
 
-The wider mandatory gates and complete workspace suite require a fresh run before merge.
+The mandatory preflight and entity-hardening gates passed before the final review fixes.
+
+They require one fresh run on the final commit before merge.

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -42,7 +42,7 @@ Unavailable sources remain unversioned. A later load retries them after the sour
 
 Unverified entries remain in the ledger and keyed tier.
 
-Their hash and normalized tiers stay hidden until source verification succeeds.
+Their exact, normalized, and semantic tiers stay hidden until source verification succeeds.
 
 Migration or ledger-read failures leave the tombstone store unloaded.
 

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -40,6 +40,10 @@ It reads source IDs in bounded batches and completes every available batch befor
 
 Unavailable sources remain unversioned. A later load retries them after the source becomes available.
 
+Migration or ledger-read failures leave the tombstone store unloaded.
+
+The failed call returns the error. The next call retries before any legacy identity becomes authoritative.
+
 Malformed JSONL rows stay byte-for-byte while valid rows migrate in place.
 
 The fact-hash index registers every stored identity form that matches an ambiguous legacy hash.
@@ -64,7 +68,7 @@ Terminal sentence punctuation remains compatible with normalized exact matches.
 
 ## Verification state
 
-The 108-test focused identity suite passes after the corruption and ambiguous-source fixes.
+The 110-test focused identity suite passes, including migration and ledger-read recovery.
 
 The core type check passes.
 

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -40,6 +40,10 @@ It reads source IDs in bounded batches and completes every available batch befor
 
 Unavailable sources remain unversioned. A later load retries them after the source becomes available.
 
+Unverified entries remain in the ledger and keyed tier.
+
+Their hash and normalized tiers stay hidden until source verification succeeds.
+
 Migration or ledger-read failures leave the tombstone store unloaded.
 
 The failed call returns the error. The next call retries before any legacy identity becomes authoritative.
@@ -68,7 +72,7 @@ Terminal sentence punctuation remains compatible with normalized exact matches.
 
 ## Verification state
 
-The 110-test focused identity suite passes, including migration and ledger-read recovery.
+The 111-test focused identity suite passes, including unavailable-source, migration, and ledger-read recovery.
 
 The core type check passes.
 

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -26,9 +26,11 @@ The system preserves ambiguous persisted identities but does not query them as a
 
 ## Migration strategy
 
-The tombstone store upgrades bounded legacy entries from known source memories.
+The tombstone store reads legacy sources from hot, cold, and archive storage.
 
-It records the migration version when a source is unavailable. Later loads do not repeat the same failed scan.
+It reads source IDs in bounded batches but migrates every available batch before publishing its index.
+
+Unavailable sources remain unversioned. A later load retries them after the source becomes available.
 
 The migration preserves an explicit `contentHashSource` identity as the primary hash.
 
@@ -54,12 +56,8 @@ Terminal sentence punctuation remains compatible with normalized exact matches.
 
 ## Verification state
 
-The focused migration and non-resurrection suite passes 90 tests.
+The focused migration and non-resurrection suite passes 101 tests.
 
 The core type check passes.
 
-`preflight:quick` and `test:entity-hardening` pass after the final migration-source fix.
-
-The complete workspace suite passes 18,422 tests, with 43 skips.
-
-An adversarial branch review found no remaining branch-introduced defect.
+The final mandatory gates and complete workspace suite are running against the latest review fixes.

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -269,6 +269,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
         const manifest = await buildReconcileManifest({
           files,
           parseMemory: parseFrontmatter,
+          citationTemplate: config.inlineSourceAttributionFormat,
           readFile: async (file) => {
             const readFile = io.readFile;
             if (!readFile) {
@@ -333,6 +334,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
         peerManifest = await buildReconcileManifest({
           files: peerFiles,
           parseMemory: parseFrontmatter,
+          citationTemplate: config?.inlineSourceAttributionFormat,
           cachedFiles: localManifests.get(ns)?.files,
           readFile: async (file) => {
             let remote: PeerFileContent | null;

--- a/packages/remnic-core/src/access-offline-manifest.ts
+++ b/packages/remnic-core/src/access-offline-manifest.ts
@@ -47,6 +47,7 @@ export async function createOfflineSyncManifestStream(
           file,
           async ({ path }) => storage.readOfflineSyncFile(nodePath.join(storage.dir, path)),
           parseMemory,
+          orchestrator.config.inlineSourceAttributionFormat,
         );
       }
     })(),

--- a/packages/remnic-core/src/access-service-offline-file-content.test.ts
+++ b/packages/remnic-core/src/access-service-offline-file-content.test.ts
@@ -194,6 +194,7 @@ test("offline manifest streams body-free active, archived, old, bad, and encrypt
       id: "active-memory",
       category: "fact",
       contentHash: activeContentHash,
+      normalizerVersion: 2,
       status: "active",
     });
     assert.notEqual(rowsByPath.get("facts/active.md")?.sha256, activeContentHash);

--- a/packages/remnic-core/src/access-service-offline-file-content.test.ts
+++ b/packages/remnic-core/src/access-service-offline-file-content.test.ts
@@ -194,7 +194,7 @@ test("offline manifest streams body-free active, archived, old, bad, and encrypt
       id: "active-memory",
       category: "fact",
       contentHash: activeContentHash,
-      normalizerVersion: 3,
+      normalizerVersion: 4,
       status: "active",
     });
     assert.notEqual(rowsByPath.get("facts/active.md")?.sha256, activeContentHash);

--- a/packages/remnic-core/src/access-service-offline-file-content.test.ts
+++ b/packages/remnic-core/src/access-service-offline-file-content.test.ts
@@ -194,7 +194,7 @@ test("offline manifest streams body-free active, archived, old, bad, and encrypt
       id: "active-memory",
       category: "fact",
       contentHash: activeContentHash,
-      normalizerVersion: 2,
+      normalizerVersion: 3,
       status: "active",
     });
     assert.notEqual(rowsByPath.get("facts/active.md")?.sha256, activeContentHash);

--- a/packages/remnic-core/src/content-hash.ts
+++ b/packages/remnic-core/src/content-hash.ts
@@ -19,6 +19,20 @@ export function normalizeContent(content: string): string {
     .trim();
 }
 
+/** Normalize content with the pre-Unicode ASCII-only normalizer. */
+export function normalizeLegacyContent(content: string): string {
+  return content
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Compute the SHA-256 hash used by pre-Unicode content indexes. */
+export function computeLegacyContentHash(content: string): string {
+  return createHash("sha256").update(normalizeLegacyContent(content)).digest("hex");
+}
+
 /** Normalize content and compute SHA-256 hash. */
 export function computeContentHash(content: string): string {
   return createHash("sha256").update(normalizeContent(content)).digest("hex");

--- a/packages/remnic-core/src/content-hash.ts
+++ b/packages/remnic-core/src/content-hash.ts
@@ -33,6 +33,24 @@ export function computeLegacyContentHash(content: string): string {
   return createHash("sha256").update(normalizeLegacyContent(content)).digest("hex");
 }
 
+/**
+ * Return true only when a persisted legacy hash can be proved to identify the
+ * same body under the current normalizer. Empty or changed legacy forms are
+ * ambiguous and must not be promoted to a current identity.
+ */
+export function isUnambiguousLegacyContentHash(
+  content: string,
+  contentHash: string,
+  currentNormalizedText: string = normalizeContent(content),
+): boolean {
+  const legacyNormalizedText = normalizeLegacyContent(content);
+  return (
+    legacyNormalizedText.length > 0 &&
+    legacyNormalizedText === currentNormalizedText &&
+    createHash("sha256").update(legacyNormalizedText).digest("hex") === contentHash
+  );
+}
+
 /** Normalize content and compute SHA-256 hash. */
 export function computeContentHash(content: string): string {
   return createHash("sha256").update(normalizeContent(content)).digest("hex");

--- a/packages/remnic-core/src/content-hash.ts
+++ b/packages/remnic-core/src/content-hash.ts
@@ -9,11 +9,12 @@
 
 import { createHash } from "node:crypto";
 
-/** Normalize content: lowercase, strip non-alphanumerics, collapse whitespace. */
+/** Normalize content: preserve Unicode letters, marks, and numbers. */
 export function normalizeContent(content: string): string {
   return content
+    .normalize("NFC")
     .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/[^\p{L}\p{M}\p{N}\s]/gu, " ")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/packages/remnic-core/src/dedup/index.test.ts
+++ b/packages/remnic-core/src/dedup/index.test.ts
@@ -96,6 +96,8 @@ test("dedup keeps duplicate and distinct pairs across Unicode scripts", async ()
       ["korean-punctuation.md", "mem-korean-punctuation", "홍차・커피"],
       ["korean-hyphen.md", "mem-korean-hyphen", "홍차-커피"],
       ["korean-joined.md", "mem-korean-joined", "홍차커피"],
+      ["japanese-boundary-a.md", "mem-japanese-boundary-a", "甲・乙丙"],
+      ["japanese-boundary-b.md", "mem-japanese-boundary-b", "甲乙・丙"],
     ] as const;
 
     for (const [fileName, id, content] of entries) {

--- a/packages/remnic-core/src/dedup/index.test.ts
+++ b/packages/remnic-core/src/dedup/index.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -14,25 +14,13 @@ test("findContradictions detects can versus cannot statements", async () => {
     await mkdir(factsDir);
     await writeFile(
       path.join(factsDir, "can.md"),
-      [
-        "---",
-        "id: mem-can",
-        "category: fact",
-        "---",
-        "The user can access production.",
-      ].join("\n"),
-      "utf8",
+      ["---", "id: mem-can", "category: fact", "---", "The user can access production."].join("\n"),
+      "utf8"
     );
     await writeFile(
       path.join(factsDir, "cannot.md"),
-      [
-        "---",
-        "id: mem-cannot",
-        "category: fact",
-        "---",
-        "The user cannot access production.",
-      ].join("\n"),
-      "utf8",
+      ["---", "id: mem-cannot", "category: fact", "---", "The user cannot access production."].join("\n"),
+      "utf8"
     );
 
     const result = findContradictions({ memoryDir, categories: ["facts"] });
@@ -58,14 +46,8 @@ test("dedup public numeric options are normalized before scanning", async () => 
     ] as const) {
       await writeFile(
         path.join(factsDir, fileName),
-        [
-          "---",
-          `id: ${id}`,
-          "category: fact",
-          "---",
-          content,
-        ].join("\n"),
-        "utf8",
+        ["---", `id: ${id}`, "category: fact", "---", content].join("\n"),
+        "utf8"
       );
     }
 
@@ -95,6 +77,48 @@ test("dedup public numeric options are normalized before scanning", async () => 
   }
 });
 
+test("dedup keeps duplicate and distinct pairs across Unicode scripts", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-dedup-unicode-"));
+
+  try {
+    const factsDir = path.join(memoryDir, "facts");
+    await mkdir(factsDir);
+    const entries = [
+      ["english-a.md", "mem-english-a", "The user prefers tea."],
+      ["english-b.md", "mem-english-b", "The user prefers tea."],
+      ["english-c.md", "mem-english-c", "The user prefers coffee."],
+      ["japanese-a.md", "mem-japanese-a", "利用者は紅茶を好む。"],
+      ["japanese-b.md", "mem-japanese-b", "利用者は紅茶を好む。"],
+      ["japanese-c.md", "mem-japanese-c", "利用者は珈琲を好む。"],
+      ["korean-a.md", "mem-korean-a", "사용자는홍차를좋아한다"],
+      ["korean-b.md", "mem-korean-b", "사용자는홍차를좋아한다"],
+      ["korean-c.md", "mem-korean-c", "사용자는커피를좋아한다"],
+      ["korean-punctuation.md", "mem-korean-punctuation", "홍차・커피"],
+      ["korean-joined.md", "mem-korean-joined", "홍차커피"],
+    ] as const;
+
+    for (const [fileName, id, content] of entries) {
+      await writeFile(
+        path.join(factsDir, fileName),
+        ["---", `id: ${id}`, "category: fact", "---", content].join("\n"),
+        "utf8"
+      );
+    }
+
+    const result = findDuplicates({ memoryDir, categories: ["facts"] });
+
+    assert.equal(result.scanned, entries.length);
+    assert.equal(result.duplicates.length, 3);
+    assert.deepEqual(result.duplicates.map(({ left, right }) => [left.id, right.id]).sort(), [
+      ["mem-english-a", "mem-english-b"],
+      ["mem-japanese-a", "mem-japanese-b"],
+      ["mem-korean-a", "mem-korean-b"],
+    ]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("dedup scans reject symlinked category directories outside memoryDir", async (t) => {
   if (process.platform === "win32") {
     t.skip("directory symlink setup is platform-specific");
@@ -107,24 +131,15 @@ test("dedup scans reject symlinked category directories outside memoryDir", asyn
   try {
     await writeFile(
       path.join(outsideDir, "outside.md"),
-      [
-        "---",
-        "id: outside",
-        "category: fact",
-        "---",
-        "Outside memory should not be scanned.",
-      ].join("\n"),
-      "utf8",
+      ["---", "id: outside", "category: fact", "---", "Outside memory should not be scanned."].join("\n"),
+      "utf8"
     );
     await symlink(outsideDir, path.join(memoryDir, "facts"), "dir");
 
-    assert.throws(
-      () => findDuplicates({ memoryDir, categories: ["facts"] }),
-      /symlinked memory category directory/,
-    );
+    assert.throws(() => findDuplicates({ memoryDir, categories: ["facts"] }), /symlinked memory category directory/);
     assert.throws(
       () => findContradictions({ memoryDir, categories: ["facts"] }),
-      /symlinked memory category directory/,
+      /symlinked memory category directory/
     );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/remnic-core/src/dedup/index.test.ts
+++ b/packages/remnic-core/src/dedup/index.test.ts
@@ -94,6 +94,7 @@ test("dedup keeps duplicate and distinct pairs across Unicode scripts", async ()
       ["korean-b.md", "mem-korean-b", "사용자는홍차를좋아한다"],
       ["korean-c.md", "mem-korean-c", "사용자는커피를좋아한다"],
       ["korean-punctuation.md", "mem-korean-punctuation", "홍차・커피"],
+      ["korean-hyphen.md", "mem-korean-hyphen", "홍차-커피"],
       ["korean-joined.md", "mem-korean-joined", "홍차커피"],
     ] as const;
 

--- a/packages/remnic-core/src/dedup/index.test.ts
+++ b/packages/remnic-core/src/dedup/index.test.ts
@@ -85,7 +85,7 @@ test("dedup keeps duplicate and distinct pairs across Unicode scripts", async ()
     await mkdir(factsDir);
     const entries = [
       ["english-a.md", "mem-english-a", "The user prefers tea."],
-      ["english-b.md", "mem-english-b", "The user prefers tea."],
+      ["english-b.md", "mem-english-b", "The user prefers tea"],
       ["english-c.md", "mem-english-c", "The user prefers coffee."],
       ["japanese-a.md", "mem-japanese-a", "利用者は紅茶を好む。"],
       ["japanese-b.md", "mem-japanese-b", "利用者は紅茶を好む。"],

--- a/packages/remnic-core/src/dedup/index.ts
+++ b/packages/remnic-core/src/dedup/index.ts
@@ -5,9 +5,10 @@
  * against existing memories. Can be used standalone or via curation.
  */
 
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import crypto from "node:crypto";
+import { normalizeRecallTokenSet } from "../recall-tokenization.js";
 import { ALL_CATEGORY_DIRS } from "../utils/category-dir.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -89,20 +90,11 @@ const DEFAULT_DEDUP_THRESHOLD = 0.85;
 const DEFAULT_MAX_LOAD = 10000;
 
 function normalizeThreshold(value: number | undefined, defaultValue: number): number {
-  return typeof value === "number" &&
-    Number.isFinite(value) &&
-    value >= 0 &&
-    value <= 1
-    ? value
-    : defaultValue;
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1 ? value : defaultValue;
 }
 
 function normalizeMaxLoad(value: number | undefined, defaultValue: number): number {
-  return typeof value === "number" &&
-    Number.isInteger(value) &&
-    value >= 0
-    ? value
-    : defaultValue;
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : defaultValue;
 }
 
 export function findDuplicates(options: DedupOptions): DedupResult {
@@ -163,26 +155,24 @@ export function findContradictions(options: ContradictionOptions): Contradiction
 // ── Similarity computation ───────────────────────────────────────────────────
 
 function computeSimilarity(a: string, b: string): number {
-  // Normalize
   const normA = normalize(a);
   const normB = normalize(b);
+  const unicodeBoundariesA = a.match(/[^\p{ASCII}\p{L}\p{M}\p{N}\s']/gu)?.join("") ?? "";
+  const unicodeBoundariesB = b.match(/[^\p{ASCII}\p{L}\p{M}\p{N}\s']/gu)?.join("") ?? "";
 
-  // Exact match
   if (normA === normB) return 1;
 
-  // Hash-based exact match
   if (hashContent(normA) === hashContent(normB)) return 0.99;
+  if (unicodeBoundariesA !== unicodeBoundariesB) return 0;
 
-  // Substring containment
   if (normA.length > 50 && normB.length > 50) {
     if (normA.includes(normB.slice(0, 40)) || normB.includes(normA.slice(0, 40))) {
       return 0.9;
     }
   }
 
-  // Word overlap (Jaccard)
-  const wordsA = new Set(normA.split(/\s+/));
-  const wordsB = new Set(normB.split(/\s+/));
+  const wordsA = tokenizeForSimilarity(normA);
+  const wordsB = tokenizeForSimilarity(normB);
   const intersection = new Set([...wordsA].filter((w) => wordsB.has(w)));
   const union = new Set([...wordsA, ...wordsB]);
 
@@ -192,23 +182,54 @@ function computeSimilarity(a: string, b: string): number {
 
 function normalize(text: string): string {
   return text
+    .normalize("NFC")
     .toLowerCase()
-    .replace(/[^\w\s']/g, "")
+    .replace(/[^\p{ASCII}\p{L}\p{M}\p{N}\s']/gu, " ")
+    .replace(/[^\p{L}\p{M}\p{N}\s']/gu, "")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function tokenizeForSimilarity(text: string): Set<string> {
+  if (/\p{Script=Hangul}/u.test(text)) {
+    const tokens = normalizeRecallTokenSet(text);
+    for (const segment of text.match(/\p{Script=Hangul}+/gu) ?? []) {
+      const chars = [...segment];
+      for (const size of [1, 2, 3, 4]) {
+        for (let index = 0; index <= chars.length - size; index += 1) {
+          tokens.add(chars.slice(index, index + size).join(""));
+        }
+      }
+    }
+    return tokens;
+  }
+  if (/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(text)) {
+    return normalizeRecallTokenSet(text);
+  }
+  return text.length === 0 ? new Set() : new Set(text.split(/\s+/));
 }
 
 // ── Contradiction detection ──────────────────────────────────────────────────
 
 const NEGATION_WORDS = new Set([
-  "not", "don't", "doesn't", "isn't", "aren't", "won't", "can't", "cannot",
-  "never", "no", "none", "neither", "nor", "nothing", "nowhere",
+  "not",
+  "don't",
+  "doesn't",
+  "isn't",
+  "aren't",
+  "won't",
+  "can't",
+  "cannot",
+  "never",
+  "no",
+  "none",
+  "neither",
+  "nor",
+  "nothing",
+  "nowhere",
 ]);
 
-function detectContradiction(
-  a: MemoryEntry,
-  b: MemoryEntry,
-): ContradictionPair | null {
+function detectContradiction(a: MemoryEntry, b: MemoryEntry): ContradictionPair | null {
   const normA = normalize(a.content);
   const normB = normalize(b.content);
 
@@ -271,11 +292,7 @@ function stripNegation(text: string): string {
 
 // ── Memory loading ───────────────────────────────────────────────────────────
 
-function loadMemories(
-  memoryDir: string,
-  categories?: string[],
-  maxLoad = 10000,
-): MemoryEntry[] {
+function loadMemories(memoryDir: string, categories?: string[], maxLoad = 10000): MemoryEntry[] {
   const result: MemoryEntry[] = [];
   const allCategories = categories ?? ALL_CATEGORY_DIRS;
   if (!fs.existsSync(memoryDir)) return result;
@@ -322,11 +339,7 @@ function hashContent(content: string): string {
   return crypto.createHash("sha256").update(content).digest("hex").slice(0, 16);
 }
 
-function readFileSafe(
-  filePath: string,
-  memoryRootReal: string,
-  categoryRootReal: string,
-): string | null {
+function readFileSafe(filePath: string, memoryRootReal: string, categoryRootReal: string): string | null {
   try {
     const fileStat = fs.lstatSync(filePath);
     if (fileStat.isSymbolicLink()) {
@@ -373,7 +386,7 @@ function walkMdFiles(
   dir: string,
   memoryRootReal: string,
   categoryRootReal: string,
-  callback: (filePath: string) => void,
+  callback: (filePath: string) => void
 ): void {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fullPath = path.join(dir, entry.name);

--- a/packages/remnic-core/src/dedup/index.ts
+++ b/packages/remnic-core/src/dedup/index.ts
@@ -157,11 +157,12 @@ export function findContradictions(options: ContradictionOptions): Contradiction
 function computeSimilarity(a: string, b: string): number {
   const normA = normalize(a);
   const normB = normalize(b);
-  const punctuationBoundariesA = a.match(/[^\p{L}\p{M}\p{N}\s']/gu)?.join("") ?? "";
-  const punctuationBoundariesB = b.match(/[^\p{L}\p{M}\p{N}\s']/gu)?.join("") ?? "";
+  const embeddedPunctuation = /(?<=[\p{L}\p{M}\p{N}])[^\p{L}\p{M}\p{N}\s']+(?=[\p{L}\p{M}\p{N}])/gu;
+  const punctuationBoundariesA = a.match(embeddedPunctuation)?.join("") ?? "";
+  const punctuationBoundariesB = b.match(embeddedPunctuation)?.join("") ?? "";
 
-  // Compare punctuation boundaries before normalization's exact/hash fast paths:
-  // a separated phrase must not become equal to its joined form.
+  // Compare embedded punctuation before normalization's exact/hash fast paths.
+  // Sentence-ending punctuation stays compatible; a separated phrase cannot collapse to its joined form.
   if (punctuationBoundariesA !== punctuationBoundariesB) return 0;
 
   if (normA === normB) return 1;

--- a/packages/remnic-core/src/dedup/index.ts
+++ b/packages/remnic-core/src/dedup/index.ts
@@ -157,12 +157,10 @@ export function findContradictions(options: ContradictionOptions): Contradiction
 function computeSimilarity(a: string, b: string): number {
   const normA = normalize(a);
   const normB = normalize(b);
-  const embeddedPunctuation = /(?<=[\p{L}\p{M}\p{N}])[^\p{L}\p{M}\p{N}\s']+(?=[\p{L}\p{M}\p{N}])/gu;
-  const punctuationBoundariesA = a.match(embeddedPunctuation)?.join("") ?? "";
-  const punctuationBoundariesB = b.match(embeddedPunctuation)?.join("") ?? "";
+  const punctuationBoundariesA = embeddedPunctuationSignature(a);
+  const punctuationBoundariesB = embeddedPunctuationSignature(b);
 
-  // Compare embedded punctuation before normalization's exact/hash fast paths.
-  // Sentence-ending punctuation stays compatible; a separated phrase cannot collapse to its joined form.
+  // Compare punctuation and positions before normalization's exact/hash paths.
   if (punctuationBoundariesA !== punctuationBoundariesB) return 0;
 
   if (normA === normB) return 1;
@@ -181,6 +179,39 @@ function computeSimilarity(a: string, b: string): number {
 
   if (union.size === 0) return 0;
   return intersection.size / union.size;
+}
+
+function embeddedPunctuationSignature(text: string): string {
+  const chars = [...text.normalize("NFC")];
+  const significant = /[\p{L}\p{M}\p{N}]/u;
+  const ignored = /[\s']/u;
+  const boundaries: string[] = [];
+  let position = 0;
+  for (let index = 0; index < chars.length;) {
+    const char = chars[index];
+    if (char === undefined) break;
+    if (significant.test(char)) {
+      position++;
+      index++;
+      continue;
+    }
+    if (ignored.test(char)) {
+      index++;
+      continue;
+    }
+    const start = index;
+    while (index < chars.length) {
+      const next = chars[index];
+      if (next === undefined || significant.test(next) || ignored.test(next)) break;
+      index++;
+    }
+    const before = chars[start - 1];
+    const after = chars[index];
+    if (before && after && significant.test(before) && significant.test(after)) {
+      boundaries.push(`${position}:${chars.slice(start, index).join("")}`);
+    }
+  }
+  return boundaries.join("\u0000");
 }
 
 function normalize(text: string): string {

--- a/packages/remnic-core/src/dedup/index.ts
+++ b/packages/remnic-core/src/dedup/index.ts
@@ -157,14 +157,16 @@ export function findContradictions(options: ContradictionOptions): Contradiction
 function computeSimilarity(a: string, b: string): number {
   const normA = normalize(a);
   const normB = normalize(b);
-  const unicodeBoundariesA = a.match(/[^\p{ASCII}\p{L}\p{M}\p{N}\s']/gu)?.join("") ?? "";
-  const unicodeBoundariesB = b.match(/[^\p{ASCII}\p{L}\p{M}\p{N}\s']/gu)?.join("") ?? "";
+  const punctuationBoundariesA = a.match(/[^\p{L}\p{M}\p{N}\s']/gu)?.join("") ?? "";
+  const punctuationBoundariesB = b.match(/[^\p{L}\p{M}\p{N}\s']/gu)?.join("") ?? "";
+
+  // Compare punctuation boundaries before normalization's exact/hash fast paths:
+  // a separated phrase must not become equal to its joined form.
+  if (punctuationBoundariesA !== punctuationBoundariesB) return 0;
 
   if (normA === normB) return 1;
 
   if (hashContent(normA) === hashContent(normB)) return 0.99;
-  if (unicodeBoundariesA !== unicodeBoundariesB) return 0;
-
   if (normA.length > 50 && normB.length > 50) {
     if (normA.includes(normB.slice(0, 40)) || normB.includes(normA.slice(0, 40))) {
       return 0.9;

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -356,9 +356,10 @@ describe("TombstoneStore — Unicode migration safety", () => {
     );
   });
 
-  it("marks a missing migration source once and skips the request after restart", async () => {
+  it("retries a missing migration source after restart and upgrades when it appears", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "tomb-migration-missing-source-"));
     const filePath = path.join(dir, "tombstones.jsonl");
+    const source = "The user prefers café.";
     await writeFile(
       filePath,
       `${JSON.stringify({
@@ -366,8 +367,8 @@ describe("TombstoneStore — Unicode migration safety", () => {
         kind: "tombstone",
         reason: "correction",
         sourceMemoryId: "fact-missing-source",
-        contentHash: computeLegacyContentHash("missing source"),
-        normalizedText: normalizeLegacyContent("missing source"),
+        contentHash: computeLegacyContentHash(source),
+        normalizedText: normalizeLegacyContent(source),
         namespace: "default",
         createdAt: "2026-01-01T00:00:00.000Z",
         createdBy: "user_correction",
@@ -375,6 +376,7 @@ describe("TombstoneStore — Unicode migration safety", () => {
       "utf8",
     );
     let requests = 0;
+    let sourceAvailable = false;
     const options = {
       enabled: true,
       semanticMatch: false,
@@ -383,19 +385,74 @@ describe("TombstoneStore — Unicode migration safety", () => {
       normalizeText: normalizeContent,
       sourceContentsForMemoryIds: async () => {
         requests += 1;
-        return new Map<string, string>();
+        return new Map<string, string>(
+          sourceAvailable ? [["fact-missing-source", source]] : [],
+        );
       },
     };
     const first = new TombstoneStore(filePath, "default", options, makeIo());
     await first.load();
     assert.equal(requests, 1);
-    const persisted = JSON.parse(await readFile(filePath, "utf8").then((text) => text.trim())) as {
-      legacyMigrationAttemptedVersion?: number;
-    };
-    assert.equal(persisted.legacyMigrationAttemptedVersion, 2);
+    assert.equal(first.lookup({ namespace: "default", contentHash: computeHash(source) }), null);
+
+    sourceAvailable = true;
     const restarted = new TombstoneStore(filePath, "default", options, makeIo());
     await restarted.load();
-    assert.equal(requests, 1);
+    assert.equal(requests, 2);
+    assert.equal(
+      restarted.lookup({ namespace: "default", contentHash: computeHash(source) })?.matchedTier,
+      "exact",
+    );
+  });
+
+  it("migrates every legacy entry before one load becomes authoritative", async (t) => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-migration-all-batches-"));
+    t.after(() => rm(dir, { recursive: true, force: true }));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const sources = new Map([
+      ["fact-first", "利用者は紅茶を好む。"],
+      ["fact-second", "利用者は珈琲を好む。"],
+    ]);
+    const entries = [...sources].map(([sourceMemoryId, content], index) => ({
+      id: `tomb-batch-${index}`,
+      kind: "tombstone",
+      reason: "correction",
+      sourceMemoryId,
+      contentHash: computeLegacyContentHash(content),
+      normalizedText: normalizeLegacyContent(content),
+      namespace: "default",
+      createdAt: `2026-01-0${index + 1}T00:00:00.000Z`,
+      createdBy: "user_correction",
+    }));
+    await writeFile(filePath, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, "utf8");
+    const requestedBatches: string[][] = [];
+    const store = new TombstoneStore(
+      filePath,
+      "default",
+      {
+        enabled: true,
+        semanticMatch: false,
+        semanticThreshold: 0.9,
+        hashContent: computeHash,
+        normalizeText: normalizeContent,
+        legacyMigrationLimit: 1,
+        sourceContentsForMemoryIds: async (sourceMemoryIds) => {
+          requestedBatches.push([...sourceMemoryIds]);
+          return new Map(sourceMemoryIds.map((id) => [id, sources.get(id) as string]));
+        },
+      },
+      makeIo(),
+    );
+
+    await store.load();
+
+    assert.deepEqual(requestedBatches, [["fact-first"], ["fact-second"]]);
+    for (const content of sources.values()) {
+      assert.equal(
+        store.lookup({ namespace: "default", contentHash: computeHash(content) })?.matchedTier,
+        "exact",
+      );
+    }
   });
 });
 

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -1,28 +1,20 @@
 import { describe, it } from "node:test";
+import { createHash } from "node:crypto";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, writeFile, rm, mkdir, appendFile, utimes } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { spawn } from "node:child_process";
 import { statSync } from "node:fs";
 import path from "node:path";
-import { createHash } from "node:crypto";
+import {
+  computeContentHash as computeHash,
+  normalizeContent,
+} from "../content-hash.js";
 import {
   TombstoneStore,
   parseTombstoneLine,
   type TombstoneFileIo,
 } from "./tombstones.js";
-
-// Mirror the dedup normalizer EXACTLY — these are the wired injections.
-function normalizeContent(content: string): string {
-  return content
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-function computeHash(content: string): string {
-  return createHash("sha256").update(normalizeContent(content)).digest("hex");
-}
 
 function makeIo(): TombstoneFileIo {
   return {
@@ -131,6 +123,78 @@ describe("TombstoneStore — append/lookup round-trip", () => {
       contentHash: computeHash("something completely different"),
     });
     assert.equal(match, null);
+  });
+});
+
+describe("TombstoneStore — Unicode normalizer migration", () => {
+  it("migrates a legacy Japanese identity before indexing, then survives restart", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-unicode-migration-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const japanese = "利用者は紅茶を好む。";
+    const legacyNormalize = (content: string) =>
+      content.toLowerCase().replace(/[^a-z0-9\s]/g, " ").replace(/\s+/g, " ").trim();
+    const legacyEntry = {
+      id: "tomb-legacy-japanese",
+      kind: "tombstone" as const,
+      reason: "correction" as const,
+      sourceMemoryId: "fact-japanese",
+      contentHash: createHash("sha256").update(legacyNormalize(japanese)).digest("hex"),
+      normalizedText: legacyNormalize(japanese),
+      namespace: "default",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      createdBy: "user_correction" as const,
+    };
+    const legacyAscii = {
+      ...legacyEntry,
+      id: "tomb-legacy-ascii",
+      sourceMemoryId: "fact-ascii",
+      contentHash: createHash("sha256").update(legacyNormalize("ASCII survives")).digest("hex"),
+      normalizedText: legacyNormalize("ASCII survives"),
+    };
+    await writeFile(
+      filePath,
+      `${JSON.stringify(legacyEntry)}\n${JSON.stringify(legacyAscii)}\n`,
+      "utf8",
+    );
+    const options = {
+      enabled: true,
+      semanticMatch: false,
+      semanticThreshold: 0.9,
+      hashContent: computeHash,
+      normalizeText: normalizeContent,
+      sourceContentsForMemoryIds: async (ids: readonly string[]) =>
+        new Map(ids.filter((id) => id === "fact-japanese").map((id) => [id, japanese])),
+    };
+    const store = new TombstoneStore(filePath, "default", options, makeIo());
+    await store.load();
+    assert.equal(
+      store.lookup({ namespace: "default", contentHash: computeHash(japanese) })?.matchedTier,
+      "exact",
+    );
+    assert.equal(
+      store.lookup({ namespace: "default", normalizedText: normalizeContent(japanese) })?.matchedTier,
+      "normalized",
+    );
+    assert.equal(
+      store.lookup({ namespace: "default", contentHash: computeHash("ASCII survives") })?.matchedTier,
+      "exact",
+    );
+    assert.equal(store.snapshot().find((entry) => entry.id === legacyEntry.id)?.normalizerVersion, 2);
+
+    const restarted = new TombstoneStore(filePath, "default", options, makeIo());
+    await restarted.load();
+    assert.equal(
+      restarted.lookup({ namespace: "default", contentHash: computeHash(japanese) })?.matchedTier,
+      "exact",
+    );
+    assert.equal(
+      restarted.lookup({ namespace: "default", normalizedText: normalizeContent(japanese) })?.matchedTier,
+      "normalized",
+    );
+    assert.equal(
+      restarted.lookup({ namespace: "default", contentHash: computeHash("ASCII survives") })?.matchedTier,
+      "exact",
+    );
   });
 });
 
@@ -500,6 +564,101 @@ describe("TombstoneStore — cross-process write lock (issue #1639)", () => {
     assert.equal(lines2.length, 1);
     // Our fresh lock was released on completion (the stale one was broken).
     await rm(lockPath, { force: true });
+  });
+
+  it("does not deadlock when mtime freshness sees legacy entries before append or rebuild", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-migration-deadlock-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const japanese = "利用者は紅茶を好む。";
+    const legacyNormalize = (content: string) =>
+      content.toLowerCase().replace(/[^a-z0-9\s]/g, " ").replace(/\s+/g, " ").trim();
+    const legacyEntry = {
+      id: "tomb-legacy-before-append",
+      kind: "tombstone" as const,
+      reason: "correction" as const,
+      sourceMemoryId: "fact-legacy-before-append",
+      contentHash: createHash("sha256").update(legacyNormalize(japanese)).digest("hex"),
+      normalizedText: legacyNormalize(japanese),
+      namespace: "default",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      createdBy: "user_correction" as const,
+    };
+    let resolveSources = false;
+    const options = {
+      enabled: true,
+      semanticMatch: false,
+      semanticThreshold: 0.9,
+      hashContent: computeHash,
+      normalizeText: normalizeContent,
+      sourceContentsForMemoryIds: async (ids: readonly string[]) =>
+        resolveSources
+          ? new Map(ids.map((id) => [id, japanese]))
+          : new Map<string, string>(),
+    };
+    await mkdir(path.dirname(filePath), { recursive: true });
+    const withTurnTimeout = async <T>(operation: Promise<T>, message: string): Promise<T> => {
+      let settled = false;
+      const timeout = new Promise<never>((_, reject) => {
+        let turns = 0;
+        const check = () => {
+          if (settled) return;
+          turns += 1;
+          if (turns >= 1_000) reject(new Error(message));
+          else setImmediate(check);
+        };
+        setImmediate(check);
+      });
+      try {
+        return await Promise.race([operation, timeout]);
+      } finally {
+        settled = true;
+      }
+    };
+    await writeFile(filePath, `${JSON.stringify(legacyEntry)}\n`, "utf8");
+    const store = new TombstoneStore(filePath, "default", options, makeReadMergeWriteIo());
+    await store.load();
+    resolveSources = true;
+
+    const peerEntry = {
+      ...legacyEntry,
+      id: "tomb-peer-before-append",
+      sourceMemoryId: "fact-peer",
+    };
+    await appendFile(filePath, `${JSON.stringify(peerEntry)}\n`, "utf8");
+    const appendMtime = new Date(Date.now() + 2_000);
+    await utimes(filePath, appendMtime, appendMtime);
+    const appended = await withTurnTimeout(
+      store.appendTombstone({
+        reason: "correction",
+        createdBy: "user_correction",
+        sourceMemoryId: "fact-new",
+        rawContent: "A new fact after the peer append.",
+      }),
+      "append migration deadlock",
+    );
+    assert.match(appended, /^tomb-/);
+
+    const rebuildPeer = {
+      ...legacyEntry,
+      id: "tomb-peer-before-rebuild",
+      sourceMemoryId: "fact-peer-rebuild",
+    };
+    await appendFile(filePath, `${JSON.stringify(rebuildPeer)}\n`, "utf8");
+    const rebuildMtime = new Date(Date.now() + 4_000);
+    await utimes(filePath, rebuildMtime, rebuildMtime);
+    const rebuilt = await withTurnTimeout(
+      store.rebuild([
+        {
+          memoryId: "fact-rebuild",
+          rawContent: japanese,
+          reason: "correction" as const,
+          createdBy: "user_correction" as const,
+          createdAt: "2026-01-02T00:00:00.000Z",
+        },
+      ]),
+      "rebuild migration deadlock",
+    );
+    assert.equal(rebuilt, 1);
   });
 
   it("rebuild preserves a peer's revocation appended before rebuild acquired the lock (cursor/codex #1639)", async () => {

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -418,7 +418,7 @@ describe("TombstoneStore — Unicode migration safety", () => {
     assert.equal(entry?.currentContentHashAlias, undefined);
   });
 
-  it("preserves malformed JSONL rows instead of rewriting a partial migration", async () => {
+  it("migrates valid rows while preserving malformed JSONL rows", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "tomb-corrupt-migration-"));
     const filePath = path.join(dir, "tombstones.jsonl");
     const source = "The user prefers café.";
@@ -451,8 +451,11 @@ describe("TombstoneStore — Unicode migration safety", () => {
     );
     await store.load();
 
-    assert.equal(await readFile(filePath, "utf8"), original);
-    assert.equal(store.snapshot()[0]?.normalizerVersion, undefined);
+    const rewritten = await readFile(filePath, "utf8");
+    assert.equal(rewritten.split("\n")[1], "{not-json}");
+    assert.equal(rewritten.endsWith("{not-json}\n"), true);
+    assert.equal(store.snapshot()[0]?.normalizerVersion, 2);
+    assert.equal(store.snapshot()[0]?.contentHash, computeHash(source));
     assert.equal(store.stats().corruptedLines, 1);
   });
 

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -165,7 +165,7 @@ describe("TombstoneStore — Unicode normalizer migration", () => {
       hashContent: computeHash,
       normalizeText: normalizeContent,
       sourceContentsForMemoryIds: async (ids: readonly string[]) =>
-        new Map(ids.filter((id) => id === "fact-japanese").map((id) => [id, japanese])),
+        new Map(ids.map((id) => [id, id === "fact-japanese" ? japanese : "ASCII survives"])),
     };
     const store = new TombstoneStore(filePath, "default", options, makeIo());
     await store.load();
@@ -391,6 +391,61 @@ describe("TombstoneStore — Unicode migration safety", () => {
     assert.equal(
       store.lookup({ namespace: "default", contentHash: computeHash(source) })?.matchedTier,
       "exact",
+    );
+  });
+
+  it("withholds unverified legacy hash tiers until the source becomes available", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-unverified-legacy-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const source = "The user prefers café.";
+    const collision = "The user prefers caf.";
+    const legacyEntry = {
+      id: "tomb-unverified-legacy",
+      kind: "tombstone" as const,
+      reason: "correction" as const,
+      sourceMemoryId: "fact-unverified-legacy",
+      contentHash: computeLegacyContentHash(source),
+      normalizedText: normalizeLegacyContent(source),
+      namespace: "default",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      createdBy: "user_correction" as const,
+    };
+    await writeFile(filePath, `${JSON.stringify(legacyEntry)}\n`, "utf8");
+    let sourceAvailable = false;
+    const store = new TombstoneStore(
+      filePath,
+      "default",
+      {
+        enabled: true,
+        semanticMatch: false,
+        semanticThreshold: 0.9,
+        hashContent: computeHash,
+        normalizeText: normalizeContent,
+        sourceContentsForMemoryIds: async () =>
+          sourceAvailable
+            ? new Map<string, string>([[legacyEntry.sourceMemoryId, source]])
+            : new Map(),
+      },
+      makeIo(),
+    );
+
+    await store.load();
+    assert.equal(store.snapshot()[0]?.normalizerVersion, undefined);
+    assert.equal(
+      store.lookup({ namespace: "default", contentHash: computeHash(collision) }),
+      null,
+    );
+
+    sourceAvailable = true;
+    store.invalidate();
+    await store.load();
+    assert.equal(
+      store.lookup({ namespace: "default", contentHash: computeHash(source) })?.matchedTier,
+      "exact",
+    );
+    assert.equal(
+      store.lookup({ namespace: "default", contentHash: computeHash(collision) }),
+      null,
     );
   });
 
@@ -842,6 +897,7 @@ describe("TombstoneStore — corrupted line skipped with counter, not crash", ()
       sourceMemoryId: "fact-1",
       contentHash: computeHash("good content"),
       normalizedText: normalizeContent("good content"),
+      normalizerVersion: 2,
       namespace: "default",
       createdAt: "2026-01-01T00:00:00.000Z",
       createdBy: "user_correction",

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -8,7 +8,9 @@ import { statSync } from "node:fs";
 import path from "node:path";
 import {
   computeContentHash as computeHash,
+  computeLegacyContentHash,
   normalizeContent,
+  normalizeLegacyContent,
 } from "../content-hash.js";
 import {
   TombstoneStore,
@@ -230,15 +232,170 @@ describe("TombstoneStore — Unicode normalizer migration", () => {
     const query = {
       namespace: "default",
       contentHash: override,
-      legacyContentHash: createHash("sha256").update(legacyNormalize(source)).digest("hex"),
       normalizedText: normalizeContent(source),
-      legacyNormalizedText: legacyNormalize(source),
     };
     assert.equal(store.lookup(query)?.matchedTier, "exact");
 
     const restarted = new TombstoneStore(filePath, "default", options, makeIo());
     await restarted.load();
     assert.equal(restarted.lookup(query)?.matchedTier, "exact");
+  });
+});
+
+describe("TombstoneStore — Unicode migration safety", () => {
+  it("does not cross-block unrelated pure-CJK tombstones through an empty legacy alias", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-cjk-alias-safety-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const first = "利用者は紅茶を好む。";
+    const unrelated = "利用者は珈琲を好む。";
+    const legacyHash = computeLegacyContentHash(first);
+    await writeFile(
+      filePath,
+      `${JSON.stringify({
+        id: "tomb-cjk-first",
+        kind: "tombstone",
+        reason: "correction",
+        sourceMemoryId: "fact-cjk-first",
+        contentHash: legacyHash,
+        normalizedText: normalizeLegacyContent(first),
+        namespace: "default",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        createdBy: "user_correction",
+      })}\n`,
+      "utf8",
+    );
+    const store = new TombstoneStore(
+      filePath,
+      "default",
+      {
+        enabled: true,
+        semanticMatch: false,
+        semanticThreshold: 0.9,
+        hashContent: computeHash,
+        normalizeText: normalizeContent,
+        sourceContentsForMemoryIds: async () =>
+          new Map<string, string>([["fact-cjk-first", first]]),
+      },
+      makeIo(),
+    );
+    await store.load();
+    assert.equal(
+      store.lookup({ namespace: "default", contentHash: computeHash(first) })?.matchedTier,
+      "exact",
+    );
+    assert.equal(
+      store.lookup({
+        namespace: "default",
+        contentHash: computeHash(unrelated),
+      }),
+      null,
+    );
+  });
+
+  it("blocks the same pure-CJK body without cross-blocking an unrelated body", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-cjk-override-safety-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const source = "東京の会社は紅茶を好む。";
+    await writeFile(
+      filePath,
+      `${JSON.stringify({
+        id: "tomb-cjk-override",
+        kind: "tombstone",
+        reason: "correction",
+        sourceMemoryId: "fact-cjk-override",
+        contentHash: computeLegacyContentHash(source),
+        normalizedText: normalizeLegacyContent(source),
+        namespace: "default",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        createdBy: "user_correction",
+      })}\n`,
+      "utf8",
+    );
+    const store = new TombstoneStore(
+      filePath,
+      "default",
+      {
+        enabled: true,
+        semanticMatch: false,
+        semanticThreshold: 0.9,
+        hashContent: computeHash,
+        normalizeText: normalizeContent,
+        sourceContentsForMemoryIds: async () =>
+          new Map<string, string>([["fact-cjk-override", source]]),
+      },
+      makeIo(),
+    );
+    await store.load();
+    assert.equal(
+      store.lookup({ namespace: "default", normalizedText: normalizeContent(source) })?.matchedTier,
+      "normalized",
+    );
+    assert.equal(
+      store.lookup({ namespace: "default", normalizedText: normalizeContent("大阪の会社は珈琲を好む。") }),
+      null,
+    );
+  });
+
+  it("rejects invalid legacy migration limits and accepts zero", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-migration-limit-"));
+    const options = {
+      enabled: true,
+      semanticMatch: false,
+      semanticThreshold: 0.9,
+      hashContent: computeHash,
+      normalizeText: normalizeContent,
+    };
+    for (const limit of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      assert.throws(
+        () => new TombstoneStore(path.join(dir, `${String(limit)}.jsonl`), "default", { ...options, legacyMigrationLimit: limit }, makeIo()),
+        /legacyMigrationLimit must be a finite non-negative integer/,
+      );
+    }
+    assert.doesNotThrow(
+      () => new TombstoneStore(path.join(dir, "zero.jsonl"), "default", { ...options, legacyMigrationLimit: 0 }, makeIo()),
+    );
+  });
+
+  it("marks a missing migration source once and skips the request after restart", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-migration-missing-source-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    await writeFile(
+      filePath,
+      `${JSON.stringify({
+        id: "tomb-missing-source",
+        kind: "tombstone",
+        reason: "correction",
+        sourceMemoryId: "fact-missing-source",
+        contentHash: computeLegacyContentHash("missing source"),
+        normalizedText: normalizeLegacyContent("missing source"),
+        namespace: "default",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        createdBy: "user_correction",
+      })}\n`,
+      "utf8",
+    );
+    let requests = 0;
+    const options = {
+      enabled: true,
+      semanticMatch: false,
+      semanticThreshold: 0.9,
+      hashContent: computeHash,
+      normalizeText: normalizeContent,
+      sourceContentsForMemoryIds: async () => {
+        requests += 1;
+        return new Map<string, string>();
+      },
+    };
+    const first = new TombstoneStore(filePath, "default", options, makeIo());
+    await first.load();
+    assert.equal(requests, 1);
+    const persisted = JSON.parse(await readFile(filePath, "utf8").then((text) => text.trim())) as {
+      legacyMigrationAttemptedVersion?: number;
+    };
+    assert.equal(persisted.legacyMigrationAttemptedVersion, 2);
+    const restarted = new TombstoneStore(filePath, "default", options, makeIo());
+    await restarted.load();
+    assert.equal(requests, 1);
   });
 });
 

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -196,6 +196,50 @@ describe("TombstoneStore — Unicode normalizer migration", () => {
       "exact",
     );
   });
+
+  it("preserves an explicit pre-upgrade contentHashSource identity after migration and restart", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-content-hash-source-migration-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const source = "利用者は紅茶を好む。";
+    const override = computeHash("external contentHashSource identity");
+    const legacyNormalize = (content: string) =>
+      content.toLowerCase().replace(/[^a-z0-9\s]/g, " ").replace(/\s+/g, " ").trim();
+    const legacyEntry = {
+      id: "tomb-legacy-override",
+      kind: "tombstone" as const,
+      reason: "correction" as const,
+      sourceMemoryId: "fact-override",
+      contentHash: override,
+      normalizedText: legacyNormalize(source),
+      namespace: "default",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      createdBy: "user_correction" as const,
+    };
+    await writeFile(filePath, `${JSON.stringify(legacyEntry)}\n`, "utf8");
+    const options = {
+      enabled: true,
+      semanticMatch: false,
+      semanticThreshold: 0.9,
+      hashContent: computeHash,
+      normalizeText: normalizeContent,
+      sourceContentsForMemoryIds: async () =>
+        new Map<string, string>([["fact-override", source]]),
+    };
+    const store = new TombstoneStore(filePath, "default", options, makeIo());
+    await store.load();
+    const query = {
+      namespace: "default",
+      contentHash: override,
+      legacyContentHash: createHash("sha256").update(legacyNormalize(source)).digest("hex"),
+      normalizedText: normalizeContent(source),
+      legacyNormalizedText: legacyNormalize(source),
+    };
+    assert.equal(store.lookup(query)?.matchedTier, "exact");
+
+    const restarted = new TombstoneStore(filePath, "default", options, makeIo());
+    await restarted.load();
+    assert.equal(restarted.lookup(query)?.matchedTier, "exact");
+  });
 });
 
 describe("TombstoneStore — revocation supersedes tombstone", () => {
@@ -603,7 +647,7 @@ describe("TombstoneStore — cross-process write lock (issue #1639)", () => {
         const check = () => {
           if (settled) return;
           turns += 1;
-          if (turns >= 1_000) reject(new Error(message));
+          if (turns >= 100_000) reject(new Error(message));
           else setImmediate(check);
         };
         setImmediate(check);

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -292,6 +292,108 @@ describe("TombstoneStore — Unicode migration safety", () => {
     );
   });
 
+  it("does not publish legacy identities when migration fails and retries on the next load", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-migration-retry-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const source = "利用者は緑茶を好む。";
+    const legacyEntry = {
+      id: "tomb-migration-retry",
+      kind: "tombstone" as const,
+      reason: "correction" as const,
+      sourceMemoryId: "fact-migration-retry",
+      contentHash: computeLegacyContentHash(source),
+      normalizedText: normalizeLegacyContent(source),
+      namespace: "default",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      createdBy: "user_correction" as const,
+    };
+    await writeFile(filePath, `${JSON.stringify(legacyEntry)}\n`, "utf8");
+    let sourceReadAttempts = 0;
+    const store = new TombstoneStore(
+      filePath,
+      "default",
+      {
+        enabled: true,
+        semanticMatch: false,
+        semanticThreshold: 0.9,
+        hashContent: computeHash,
+        normalizeText: normalizeContent,
+        sourceContentsForMemoryIds: async () => {
+          sourceReadAttempts += 1;
+          if (sourceReadAttempts === 1) throw new Error("transient source read failure");
+          return new Map<string, string>([[legacyEntry.sourceMemoryId, source]]);
+        },
+      },
+      makeIo(),
+    );
+
+    await assert.rejects(store.load(), /transient source read failure/);
+    assert.deepEqual(store.snapshot(), []);
+    assert.equal(
+      store.lookup({ namespace: "default", contentHash: computeHash(source) }),
+      null,
+    );
+
+    await store.load();
+    assert.equal(sourceReadAttempts, 2);
+    assert.equal(
+      store.lookup({ namespace: "default", contentHash: computeHash(source) })?.matchedTier,
+      "exact",
+    );
+  });
+
+  it("does not publish an empty index after a transient ledger read failure", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-load-retry-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const source = "Current tombstone identity";
+    const entry = {
+      id: "tomb-load-retry",
+      kind: "tombstone" as const,
+      reason: "correction" as const,
+      sourceMemoryId: "fact-load-retry",
+      contentHash: computeHash(source),
+      normalizedText: normalizeContent(source),
+      normalizerVersion: 2,
+      namespace: "default",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      createdBy: "user_correction" as const,
+    };
+    await writeFile(filePath, `${JSON.stringify(entry)}\n`, "utf8");
+    let readAttempts = 0;
+    const io = makeIo();
+    io.read = async (target) => {
+      readAttempts += 1;
+      if (readAttempts === 1) {
+        const error = new Error("transient ledger read failure") as NodeJS.ErrnoException;
+        error.code = "EACCES";
+        throw error;
+      }
+      return readFile(target, "utf8");
+    };
+    const store = new TombstoneStore(
+      filePath,
+      "default",
+      {
+        enabled: true,
+        semanticMatch: false,
+        semanticThreshold: 0.9,
+        hashContent: computeHash,
+        normalizeText: normalizeContent,
+      },
+      io,
+    );
+
+    await assert.rejects(store.load(), /transient ledger read failure/);
+    assert.deepEqual(store.snapshot(), []);
+
+    await store.load();
+    assert.equal(readAttempts, 2);
+    assert.equal(
+      store.lookup({ namespace: "default", contentHash: computeHash(source) })?.matchedTier,
+      "exact",
+    );
+  });
+
   it("replaces a mixed-Unicode legacy hash instead of blocking its ASCII collision", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "tomb-mixed-unicode-alias-safety-"));
     const filePath = path.join(dir, "tombstones.jsonl");

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -417,10 +417,11 @@ describe("TombstoneStore — Unicode migration safety", () => {
       "default",
       {
         enabled: true,
-        semanticMatch: false,
+        semanticMatch: true,
         semanticThreshold: 0.9,
         hashContent: computeHash,
         normalizeText: normalizeContent,
+        semanticSimilarity: () => 1,
         sourceContentsForMemoryIds: async () =>
           sourceAvailable
             ? new Map<string, string>([[legacyEntry.sourceMemoryId, source]])
@@ -433,6 +434,10 @@ describe("TombstoneStore — Unicode migration safety", () => {
     assert.equal(store.snapshot()[0]?.normalizerVersion, undefined);
     assert.equal(
       store.lookup({ namespace: "default", contentHash: computeHash(collision) }),
+      null,
+    );
+    assert.equal(
+      store.lookup({ namespace: "default", normalizedText: normalizeContent(collision) }),
       null,
     );
 

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -1,11 +1,11 @@
-import { describe, it } from "node:test";
-import { createHash } from "node:crypto";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, writeFile, rm, mkdir, appendFile, utimes } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
+import { appendFile, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
+import { describe, it } from "node:test";
 import {
   computeContentHash as computeHash,
   computeLegacyContentHash,
@@ -336,6 +336,45 @@ describe("TombstoneStore — Unicode migration safety", () => {
       store.lookup({ namespace: "default", contentHash: computeHash(asciiCollision) }),
       null,
     );
+  });
+
+  it("migrates the raw source identity when a stored fact has structured attributes", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-attribute-source-migration-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const source = "利用者は紅茶を好む。";
+    const storedBody = `${source}\n[Attributes: topic: 紅茶]`;
+    await writeFile(
+      filePath,
+      `${JSON.stringify({
+        id: "tomb-attribute-source",
+        kind: "tombstone",
+        reason: "correction",
+        sourceMemoryId: "fact-attribute-source",
+        contentHash: computeLegacyContentHash(source),
+        normalizedText: normalizeLegacyContent(source),
+        namespace: "default",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        createdBy: "user_correction",
+      })}\n`,
+      "utf8"
+    );
+    const store = new TombstoneStore(
+      filePath,
+      "default",
+      {
+        enabled: true,
+        semanticMatch: false,
+        semanticThreshold: 0.9,
+        hashContent: computeHash,
+        normalizeText: normalizeContent,
+        sourceContentsForMemoryIds: async () => new Map([["fact-attribute-source", [storedBody, source]]]),
+      },
+      makeIo()
+    );
+    await store.load();
+
+    assert.equal(store.lookup({ namespace: "default", contentHash: computeHash(source) })?.matchedTier, "exact");
+    assert.equal(store.snapshot()[0]?.normalizerVersion, 2);
   });
 
   it("does not finalize migration from a body with an unrecognized stale citation", async () => {

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -292,6 +292,131 @@ describe("TombstoneStore — Unicode migration safety", () => {
     );
   });
 
+  it("replaces a mixed-Unicode legacy hash instead of blocking its ASCII collision", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-mixed-unicode-alias-safety-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const source = "The user prefers café.";
+    const asciiCollision = "The user prefers caf.";
+    await writeFile(
+      filePath,
+      `${JSON.stringify({
+        id: "tomb-mixed-unicode",
+        kind: "tombstone",
+        reason: "correction",
+        sourceMemoryId: "fact-mixed-unicode",
+        contentHash: computeLegacyContentHash(source),
+        normalizedText: normalizeLegacyContent(source),
+        namespace: "default",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        createdBy: "user_correction",
+      })}\n`,
+      "utf8",
+    );
+    const store = new TombstoneStore(
+      filePath,
+      "default",
+      {
+        enabled: true,
+        semanticMatch: false,
+        semanticThreshold: 0.9,
+        hashContent: computeHash,
+        normalizeText: normalizeContent,
+        sourceContentsForMemoryIds: async () =>
+          new Map<string, string>([["fact-mixed-unicode", source]]),
+      },
+      makeIo(),
+    );
+    await store.load();
+
+    assert.equal(
+      store.lookup({ namespace: "default", contentHash: computeHash(source) })?.matchedTier,
+      "exact",
+    );
+    assert.equal(
+      store.lookup({ namespace: "default", contentHash: computeHash(asciiCollision) }),
+      null,
+    );
+  });
+
+  it("does not finalize migration from a body with an unrecognized stale citation", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-stale-citation-migration-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const source = "The user prefers café.";
+    const storedBody = `${source} [legacy-source:planner]`;
+    await writeFile(
+      filePath,
+      `${JSON.stringify({
+        id: "tomb-stale-citation",
+        kind: "tombstone",
+        reason: "correction",
+        sourceMemoryId: "fact-stale-citation",
+        contentHash: computeLegacyContentHash(source),
+        normalizedText: normalizeLegacyContent(source),
+        namespace: "default",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        createdBy: "user_correction",
+      })}\n`,
+      "utf8",
+    );
+    const store = new TombstoneStore(
+      filePath,
+      "default",
+      {
+        enabled: true,
+        semanticMatch: false,
+        semanticThreshold: 0.9,
+        hashContent: computeHash,
+        normalizeText: normalizeContent,
+        sourceContentsForMemoryIds: async () =>
+          new Map<string, string>([["fact-stale-citation", storedBody]]),
+      },
+      makeIo(),
+    );
+    await store.load();
+
+    const entry = store.snapshot()[0];
+    assert.equal(entry?.normalizerVersion, undefined);
+    assert.equal(entry?.currentContentHashAlias, undefined);
+  });
+
+  it("preserves malformed JSONL rows instead of rewriting a partial migration", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "tomb-corrupt-migration-"));
+    const filePath = path.join(dir, "tombstones.jsonl");
+    const source = "The user prefers café.";
+    const valid = JSON.stringify({
+      id: "tomb-corrupt-migration",
+      kind: "tombstone",
+      reason: "correction",
+      sourceMemoryId: "fact-corrupt-migration",
+      contentHash: computeLegacyContentHash(source),
+      normalizedText: normalizeLegacyContent(source),
+      namespace: "default",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      createdBy: "user_correction",
+    });
+    const original = `${valid}\n{not-json}\n`;
+    await writeFile(filePath, original, "utf8");
+    const store = new TombstoneStore(
+      filePath,
+      "default",
+      {
+        enabled: true,
+        semanticMatch: false,
+        semanticThreshold: 0.9,
+        hashContent: computeHash,
+        normalizeText: normalizeContent,
+        sourceContentsForMemoryIds: async () =>
+          new Map<string, string>([["fact-corrupt-migration", source]]),
+      },
+      makeIo(),
+    );
+    await store.load();
+
+    assert.equal(await readFile(filePath, "utf8"), original);
+    assert.equal(store.snapshot()[0]?.normalizerVersion, undefined);
+    assert.equal(store.stats().corruptedLines, 1);
+  });
+
   it("blocks the same pure-CJK body without cross-blocking an unrelated body", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "tomb-cjk-override-safety-"));
     const filePath = path.join(dir, "tombstones.jsonl");

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -354,21 +354,14 @@ export class TombstoneStore {
       raw = await this.io.read(this.filePath);
     } catch (err) {
       const code = (err as NodeJS.ErrnoException)?.code;
-      if (code !== "ENOENT") {
-        // Rebuild repairs unreadable/corrupt state; loading remains fail-open.
-      }
+      if (code !== "ENOENT") throw err;
       this.loaded = true;
       return;
     }
     const initial = this.parseEntries(raw);
-    let migrated = initial;
-    if (migrateLegacy) {
-      try {
-        migrated = await this.migrateLegacyEntries(initial);
-      } catch {
-        // Keep loading the old entry if source lookup or atomic rewrite fails.
-      }
-    }
+    const migrated = migrateLegacy
+      ? await this.migrateLegacyEntries(initial)
+      : initial;
     this.resetIndex();
     for (const entry of migrated.entries) this.indexEntry(entry);
     this.corruptedLines = migrated.corruptedLines;
@@ -425,12 +418,7 @@ export class TombstoneStore {
     }
     return await serializeMutations(`tombstone:${this.filePath}`, () =>
       this.withWriteLock(async () => {
-        let latestRaw: string;
-        try {
-          latestRaw = await this.io.read(this.filePath);
-        } catch {
-          return initial;
-        }
+        const latestRaw = await this.io.read(this.filePath);
         const latest = this.parseEntries(latestRaw);
         let changed = false;
         const migrateEntry = (entry: TombstoneEntry): TombstoneEntry => {

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -41,6 +41,7 @@
 // ---------------------------------------------------------------------------
 
 import { serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
+import { computeLegacyContentHash, normalizeLegacyContent } from "../content-hash.js";
 
 /** Why a tombstone was emitted. */
 export type TombstoneReason =
@@ -76,6 +77,10 @@ export interface TombstoneEntry {
   contentHash: string;
   /** The normalized form used for the hash and normalized lookup tier. */
   normalizedText: string;
+  /** Legacy pre-Unicode exact identity retained for migration aliases. */
+  legacyContentHash?: string;
+  /** Legacy pre-Unicode normalized identity retained for migration aliases. */
+  legacyNormalizedText?: string;
   /** Version of the normalizer that produced contentHash/normalizedText. */
   normalizerVersion?: number;
   entityRef?: string;
@@ -108,7 +113,11 @@ export interface TombstoneMatch {
  * remains for direct/unit callers; `lookup` checks the union of both. */
 export interface TombstoneLookupQuery {
   contentHash?: string;
+  /** Legacy pre-Unicode exact identity alias. */
+  legacyContentHash?: string;
   normalizedText?: string;
+  /** Legacy pre-Unicode normalized identity alias. */
+  legacyNormalizedText?: string;
   entityRef?: string;
   /** Single supersession key (direct/unit callers). */
   supersessionKey?: string;
@@ -249,6 +258,8 @@ export function parseTombstoneLine(line: string): TombstoneEntry | null {
     createdAt: e.createdAt,
     createdBy: e.createdBy,
   };
+  if (typeof e.legacyContentHash === "string") out.legacyContentHash = e.legacyContentHash;
+  if (typeof e.legacyNormalizedText === "string") out.legacyNormalizedText = e.legacyNormalizedText;
   if (typeof e.normalizerVersion === "number" && Number.isInteger(e.normalizerVersion)) {
     out.normalizerVersion = e.normalizerVersion;
   }
@@ -391,9 +402,14 @@ export class TombstoneStore {
     entries: TombstoneEntry[];
     corruptedLines: number;
   }): Promise<{ entries: TombstoneEntry[]; corruptedLines: number }> {
+    const configuredLimit = this.options.legacyMigrationLimit;
     const limit = Math.max(
       0,
-      Math.floor(this.options.legacyMigrationLimit ?? DEFAULT_LEGACY_MIGRATION_LIMIT),
+      Math.floor(
+        configuredLimit === undefined || !Number.isFinite(configuredLimit)
+          ? DEFAULT_LEGACY_MIGRATION_LIMIT
+          : configuredLimit
+      )
     );
     if (limit === 0 || !this.options.sourceContentsForMemoryIds) return initial;
     const sourceMemoryIds: string[] = [];
@@ -433,12 +449,28 @@ export class TombstoneStore {
           if (source === undefined) return entry;
           changed = true;
           migratedCount += 1;
-          return {
-            ...entry,
-            normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
-            contentHash: this.options.hashContent(source),
-            normalizedText: this.options.normalizeText(source),
-          };
+          const currentHash = this.options.hashContent(source);
+          const currentNormalizedText = this.options.normalizeText(source);
+          const legacyHash = computeLegacyContentHash(source);
+          const legacyNormalizedText = normalizeLegacyContent(source);
+          const legacyIdentityMatches = entry.contentHash === currentHash || entry.contentHash === legacyHash;
+          return legacyIdentityMatches
+            ? {
+                ...entry,
+                normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
+                contentHash: currentHash,
+                normalizedText: currentNormalizedText,
+                ...(entry.contentHash === currentHash
+                  ? {}
+                  : { legacyContentHash: legacyHash, legacyNormalizedText }),
+              }
+            : {
+                ...entry,
+                normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
+                normalizedText: currentNormalizedText,
+                legacyContentHash: legacyHash,
+                legacyNormalizedText,
+              };
         });
         if (!changed) return latest;
         const serialized =
@@ -483,7 +515,11 @@ export class TombstoneStore {
     // mismatch, and misses its own still-active tombstone (resurrection).
     const ns = entry.namespace;
     if (entry.contentHash) this.byHash.set(`${ns}\0${entry.contentHash}`, entry.id);
+    if (entry.legacyContentHash) this.byHash.set(`${ns}\0${entry.legacyContentHash}`, entry.id);
     if (entry.normalizedText) this.byNormalized.set(`${ns}\0${entry.normalizedText}`, entry.id);
+    if (entry.legacyNormalizedText) {
+      this.byNormalized.set(`${ns}\0${entry.legacyNormalizedText}`, entry.id);
+    }
     if (entry.entityRef && entry.supersessionKey) {
       this.byKey.set(keyedTierKey(ns, entry.entityRef, entry.supersessionKey), entry.id);
     }
@@ -568,14 +604,21 @@ export class TombstoneStore {
     await this.load();
     const createdAt = input.createdAt ?? new Date().toISOString();
     const id = newTombstoneId();
+    const currentHash = this.options.hashContent(input.rawContent);
+    const legacyHash = computeLegacyContentHash(input.rawContent);
     const entry: TombstoneEntry = {
       id,
       kind: "tombstone",
       reason: input.reason,
       sourceMemoryId: input.sourceMemoryId,
-      contentHash: input.contentHash ?? this.options.hashContent(input.rawContent),
+      contentHash: input.contentHash ?? currentHash,
       normalizedText: this.options.normalizeText(input.rawContent),
-      normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
+      ...(legacyHash !== currentHash
+        ? {
+            legacyContentHash: legacyHash,
+            legacyNormalizedText: normalizeLegacyContent(input.rawContent),
+          }
+        : {}),
       ...(input.entityRef ? { entityRef: input.entityRef } : {}),
       ...(input.supersessionKey ? { supersessionKey: input.supersessionKey } : {}),
       ...(input.operationKey ? { operationKey: input.operationKey } : {}),
@@ -707,8 +750,9 @@ export class TombstoneStore {
     // the backing file is shared. The namespace equality check below is kept
     // as defense-in-depth.
     const ns = query.namespace;
-    if (query.contentHash) {
-      const id = this.byHash.get(`${ns}\0${query.contentHash}`);
+    for (const contentHash of [query.contentHash, query.legacyContentHash]) {
+      if (!contentHash) continue;
+      const id = this.byHash.get(`${ns}\0${contentHash}`);
       if (id && !this.revokedIds.has(id)) {
         const entry = this.byId.get(id);
         if (entry && entry.namespace === ns) {
@@ -717,8 +761,9 @@ export class TombstoneStore {
       }
     }
     // Tier 2: normalized text.
-    if (query.normalizedText) {
-      const id = this.byNormalized.get(`${ns}\0${query.normalizedText}`);
+    for (const normalizedText of [query.normalizedText, query.legacyNormalizedText]) {
+      if (!normalizedText) continue;
+      const id = this.byNormalized.get(`${ns}\0${normalizedText}`);
       if (id && !this.revokedIds.has(id)) {
         const entry = this.byId.get(id);
         if (entry && entry.namespace === ns) {
@@ -860,7 +905,11 @@ export class TombstoneStore {
           }
         }
         const rebuilt: TombstoneEntry[] = retiredMemories.map((m) => {
-          const recomputedHash = this.options.hashContent(m.rawContent);
+          const currentHash = this.options.hashContent(m.rawContent);
+          const legacyHash = computeLegacyContentHash(m.rawContent);
+          const persistedHash = m.contentHash;
+          const preserveOverride =
+            persistedHash !== undefined && persistedHash !== currentHash && persistedHash !== legacyHash;
           return {
             id:
               existingBySource.get(`${m.memoryId}\u{0000}${m.supersessionKey ?? ""}`) ??
@@ -868,9 +917,15 @@ export class TombstoneStore {
             kind: "tombstone" as const,
             reason: m.reason,
             sourceMemoryId: m.memoryId,
-            contentHash: m.contentHash === recomputedHash ? m.contentHash : recomputedHash,
+            contentHash: preserveOverride ? persistedHash : currentHash,
             normalizedText: this.options.normalizeText(m.rawContent),
             normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
+            ...(legacyHash !== currentHash
+              ? {
+                  legacyContentHash: legacyHash,
+                  legacyNormalizedText: normalizeLegacyContent(m.rawContent),
+                }
+              : {}),
             ...(m.entityRef ? { entityRef: m.entityRef } : {}),
             ...(m.supersessionKey ? { supersessionKey: m.supersessionKey } : {}),
             namespace: this.namespace,
@@ -1012,6 +1067,8 @@ export function applyTombstoneResurrectionGate(
   },
   query: {
     normalizedText: string;
+    legacyContentHash?: string;
+    legacyNormalizedText?: string;
     supersessionKeys: string[];
     namespace: string;
   },
@@ -1020,7 +1077,9 @@ export function applyTombstoneResurrectionGate(
   if (!(fm.status === undefined || fm.status === "active" || fm.status === "pending_review")) return null;
   const match = store.lookup({
     contentHash: fm.contentHash,
+    legacyContentHash: query.legacyContentHash,
     normalizedText: query.normalizedText,
+    legacyNormalizedText: query.legacyNormalizedText,
     ...(fm.entityRef ? { entityRef: fm.entityRef } : {}),
     ...(query.supersessionKeys.length > 0 ? { supersessionKeys: query.supersessionKeys } : {}),
     namespace: query.namespace,

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -613,6 +613,7 @@ export class TombstoneStore {
       sourceMemoryId: input.sourceMemoryId,
       contentHash: input.contentHash ?? currentHash,
       normalizedText: this.options.normalizeText(input.rawContent),
+      normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
       ...(legacyHash !== currentHash
         ? {
             legacyContentHash: legacyHash,

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -137,12 +137,12 @@ export interface TombstoneStoreOptions {
    */
   semanticSimilarity?: (a: string, b: string) => number;
   /**
-   * Resolve source content for a bounded set of legacy sourceMemoryIds.
+   * Resolve source identity candidates for bounded legacy sourceMemoryIds.
    * StorageManager reads the corpus before the tombstone write lock.
    */
   readonly sourceContentsForMemoryIds?: (
     sourceMemoryIds: readonly string[],
-  ) => Promise<ReadonlyMap<string, string>>;
+  ) => Promise<ReadonlyMap<string, string | readonly string[]>>;
   /** Maximum number of legacy entries considered during one load. */
   readonly legacyMigrationLimit?: number;
   /**
@@ -417,13 +417,11 @@ export class TombstoneStore {
       sourceMemoryIds.push(entry.sourceMemoryId);
     }
     if (sourceMemoryIds.length === 0) return initial;
-    const sourceContents = new Map<string, string>();
+    const sourceContents = new Map<string, string | readonly string[]>();
     for (let offset = 0; offset < sourceMemoryIds.length; offset += limit) {
       const batch = sourceMemoryIds.slice(offset, offset + limit);
       const fetched = await this.options.sourceContentsForMemoryIds(batch);
-      for (const [sourceMemoryId, content] of fetched) {
-        sourceContents.set(sourceMemoryId, content);
-      }
+      for (const [sourceMemoryId, content] of fetched) sourceContents.set(sourceMemoryId, content);
     }
     return await serializeMutations(`tombstone:${this.filePath}`, () =>
       this.withWriteLock(async () => {
@@ -444,19 +442,25 @@ export class TombstoneStore {
           ) {
             return entry;
           }
-          const source = sourceContents.get(entry.sourceMemoryId);
+          const resolved = sourceContents.get(entry.sourceMemoryId);
+          if (resolved === undefined) return entry;
+          const candidates = typeof resolved === "string" ? [resolved] : resolved;
+          const matches = candidates.filter((source) =>
+            entry.contentHash === this.options.hashContent(source) ||
+            entry.contentHash === computeLegacyContentHash(source)
+          );
+          const source = matches[0];
           if (source === undefined) return entry;
           const currentHash = this.options.hashContent(source);
-          const currentNormalizedText = this.options.normalizeText(source);
-          const sourceIdentifiesEntry =
-            entry.contentHash === currentHash ||
-            entry.contentHash === computeLegacyContentHash(source);
-          if (!sourceIdentifiesEntry) return entry;
+          const alias = matches
+            .map((candidate) => this.options.hashContent(candidate))
+            .find((hash) => hash !== currentHash);
           changed = true;
           return {
             ...entry,
             contentHash: currentHash,
-            normalizedText: currentNormalizedText,
+            ...(alias ? { currentContentHashAlias: alias } : {}),
+            normalizedText: this.options.normalizeText(source),
             normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
           };
         });

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -72,10 +72,12 @@ export interface TombstoneEntry {
   reason: TombstoneReason;
   /** The memory that was retired. */
   sourceMemoryId: string;
-  /** sha256 of the retired memory's rawContent (rule 23). */
+  /** sha256 of the retired memory's normalized content. */
   contentHash: string;
-  /** `ContentHashIndex.normalizeContent(rawContent)` — the pre-hash form. */
+  /** The normalized form used for the hash and normalized lookup tier. */
   normalizedText: string;
+  /** Version of the normalizer that produced contentHash/normalizedText. */
+  normalizerVersion?: number;
   entityRef?: string;
   /** Structured-attribute supersession key when one existed. */
   supersessionKey?: string;
@@ -132,6 +134,15 @@ export interface TombstoneStoreOptions {
    */
   semanticSimilarity?: (a: string, b: string) => number;
   /**
+   * Resolve source content for a bounded set of legacy sourceMemoryIds.
+   * StorageManager reads the corpus before the tombstone write lock.
+   */
+  readonly sourceContentsForMemoryIds?: (
+    sourceMemoryIds: readonly string[],
+  ) => Promise<ReadonlyMap<string, string>>;
+  /** Maximum number of legacy entries considered during one load. */
+  readonly legacyMigrationLimit?: number;
+  /**
    * Cross-process write-lock timings for the tombstone JSONL mutation lock
    * (issue #1639). The secure-store append is a read-merge-write (read
    * encrypted → decrypt → concat → re-encrypt → atomic rename), so two
@@ -167,6 +178,9 @@ export interface TombstoneStats {
   /** Whether the in-memory index matches the on-disk file (rebuild check). */
   loaded: boolean;
 }
+
+const TOMBSTONE_NORMALIZER_VERSION = 2;
+const DEFAULT_LEGACY_MIGRATION_LIMIT = 10_000;
 
 const TOMBSTONE_PREFIX = "tomb";
 
@@ -235,6 +249,9 @@ export function parseTombstoneLine(line: string): TombstoneEntry | null {
     createdAt: e.createdAt,
     createdBy: e.createdBy,
   };
+  if (typeof e.normalizerVersion === "number" && Number.isInteger(e.normalizerVersion)) {
+    out.normalizerVersion = e.normalizerVersion;
+  }
   if (typeof e.operationKey === "string") out.operationKey = e.operationKey;
   if (typeof e.entityRef === "string") out.entityRef = e.entityRef;
   if (typeof e.supersessionKey === "string") out.supersessionKey = e.supersessionKey;
@@ -318,39 +335,120 @@ export class TombstoneStore {
     }
   }
 
-  private async loadInternal(): Promise<void> {
-    // Record the file's mtime so the staleness probe does not immediately
-    // invalidate on the next access (fileMtimeMs starts at 0; without this,
-    // any non-zero mtime would trigger a spurious reload). Done before the
-    // read so an ENOENT still records 0.
+  private async loadInternal(migrateLegacy = true): Promise<void> {
+    // Record the file mtime before reading so an ENOENT still records 0 and
+    // a successful load does not immediately trigger a staleness reload.
     this.recordFileMtime();
     let raw: string;
     try {
       raw = await this.io.read(this.filePath);
     } catch (err) {
-      // ENOENT is fine — fresh store. Other errors leave the store empty
-      // rather than crashing the write path (rule 34 spirit: degrade to
-      // "no tombstones known" rather than blocking all writes).
       const code = (err as NodeJS.ErrnoException)?.code;
       if (code !== "ENOENT") {
-        // Swallow — the write path must not crash on a corrupt tombstone file.
-        // Rebuild will repair on the next doctor/maintenance run.
+        // Rebuild repairs unreadable/corrupt state; loading remains fail-open.
       }
       this.loaded = true;
       return;
     }
+    const initial = this.parseEntries(raw);
+    let migrated = initial;
+    if (migrateLegacy) {
+      try {
+        migrated = await this.migrateLegacyEntries(initial);
+      } catch {
+        // Keep loading the old entry if source lookup or atomic rewrite fails.
+      }
+    }
     this.resetIndex();
-    let corrupted = 0;
+    for (const entry of migrated.entries) this.indexEntry(entry);
+    this.corruptedLines = migrated.corruptedLines;
+    this.loaded = true;
+  }
+
+  private parseEntries(raw: string): {
+    entries: TombstoneEntry[];
+    corruptedLines: number;
+  } {
+    const entries: TombstoneEntry[] = [];
+    let corruptedLines = 0;
     for (const line of raw.split("\n")) {
       const entry = parseTombstoneLine(line);
       if (!entry) {
-        if (line.trim().length > 0) corrupted += 1;
+        if (line.trim().length > 0) corruptedLines += 1;
         continue;
       }
-      this.indexEntry(entry);
+      entries.push(entry);
     }
-    this.corruptedLines = corrupted;
-    this.loaded = true;
+    return { entries, corruptedLines };
+  }
+
+  /**
+   * Re-index pre-Unicode records once from a bounded batch of retired source
+   * content fetched before the write lock. The rewrite is serialized under
+   * the same lock as append/revoke.
+   */
+  private async migrateLegacyEntries(initial: {
+    entries: TombstoneEntry[];
+    corruptedLines: number;
+  }): Promise<{ entries: TombstoneEntry[]; corruptedLines: number }> {
+    const limit = Math.max(
+      0,
+      Math.floor(this.options.legacyMigrationLimit ?? DEFAULT_LEGACY_MIGRATION_LIMIT),
+    );
+    if (limit === 0 || !this.options.sourceContentsForMemoryIds) return initial;
+    const sourceMemoryIds: string[] = [];
+    const requested = new Set<string>();
+    for (const entry of initial.entries) {
+      if (entry.kind !== "tombstone" || entry.normalizerVersion === TOMBSTONE_NORMALIZER_VERSION) {
+        continue;
+      }
+      if (requested.has(entry.sourceMemoryId)) continue;
+      requested.add(entry.sourceMemoryId);
+      sourceMemoryIds.push(entry.sourceMemoryId);
+      if (sourceMemoryIds.length >= limit) break;
+    }
+    if (sourceMemoryIds.length === 0) return initial;
+    const sourceContents = await this.options.sourceContentsForMemoryIds(sourceMemoryIds);
+    return await serializeMutations(`tombstone:${this.filePath}`, () =>
+      this.withWriteLock(async () => {
+        let latestRaw: string;
+        try {
+          latestRaw = await this.io.read(this.filePath);
+        } catch {
+          return initial;
+        }
+        const latest = this.parseEntries(latestRaw);
+        let changed = false;
+        let migratedCount = 0;
+        const migrated = latest.entries.map((entry) => {
+          if (
+            entry.kind !== "tombstone" ||
+            entry.normalizerVersion === TOMBSTONE_NORMALIZER_VERSION ||
+            !requested.has(entry.sourceMemoryId) ||
+            migratedCount >= limit
+          ) {
+            return entry;
+          }
+          const source = sourceContents.get(entry.sourceMemoryId);
+          if (source === undefined) return entry;
+          changed = true;
+          migratedCount += 1;
+          return {
+            ...entry,
+            normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
+            contentHash: this.options.hashContent(source),
+            normalizedText: this.options.normalizeText(source),
+          };
+        });
+        if (!changed) return latest;
+        const serialized =
+          migrated.map((entry) => JSON.stringify(entry)).join("\n") +
+          (migrated.length > 0 ? "\n" : "");
+        await this.io.write(this.filePath, serialized);
+        this.markWritten();
+        return { entries: migrated, corruptedLines: 0 };
+      }),
+    );
   }
 
   private resetIndex(): void {
@@ -400,15 +498,11 @@ export class TombstoneStore {
 
   /**
    * Cross-process staleness probe (#1579). If the file's mtime advanced since
-   * the last load/own-write, a peer process appended and our in-memory index is
-   * stale — invalidate AND reload in place so the next lookup sees the new
-   * entries. Best-effort: a stat error is swallowed (the loaded index is
-   * retained rather than crashing the write path). No-op when no `stat` was
-   * injected or when the mtime is unchanged. After our own append/revoke/rebuild
-   * `markWritten` records the new mtime, so this probe does not fire for our
-   * own writes (only for peer-process appends).
+   * the last load/own-write, a peer process appended and our in-memory index
+   * is stale — invalidate and reload before the next access. Mutation callers
+   * pass `migrate: false` to avoid nested serializer/lock acquisition.
    */
-  async ensureFreshAgainstDisk(): Promise<void> {
+  async ensureFreshAgainstDisk(options: { migrate?: boolean } = {}): Promise<void> {
     if (!this.io.stat) return;
     let mtimeMs: number;
     try {
@@ -419,7 +513,11 @@ export class TombstoneStore {
     if (mtimeMs === this.fileMtimeMs && this.loaded) return;
     this.fileMtimeMs = mtimeMs;
     this.invalidate();
-    await this.load();
+    if (options.migrate === false) {
+      await this.loadInternal(false);
+    } else {
+      await this.load();
+    }
   }
 
   /**
@@ -477,6 +575,7 @@ export class TombstoneStore {
       sourceMemoryId: input.sourceMemoryId,
       contentHash: input.contentHash ?? this.options.hashContent(input.rawContent),
       normalizedText: this.options.normalizeText(input.rawContent),
+      normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
       ...(input.entityRef ? { entityRef: input.entityRef } : {}),
       ...(input.supersessionKey ? { supersessionKey: input.supersessionKey } : {}),
       ...(input.operationKey ? { operationKey: input.operationKey } : {}),
@@ -487,6 +586,7 @@ export class TombstoneStore {
     await this.serializeAppend(entry);
     this.indexEntry(entry);
     this.markWritten();
+    await this.migrateLoadedLegacyEntries();
     return id;
   }
 
@@ -513,6 +613,7 @@ export class TombstoneStore {
     await this.serializeAppend(entry);
     this.indexEntry(entry);
     this.markWritten();
+    await this.migrateLoadedLegacyEntries();
     return id;
   }
 
@@ -526,10 +627,31 @@ export class TombstoneStore {
     // disk first, so indexEntry builds on the peer's just-appended entries.
     return serializeMutations(`tombstone:${this.filePath}`, () =>
       this.withWriteLock(async () => {
-        await this.ensureFreshAgainstDisk();
+        await this.ensureFreshAgainstDisk({ migrate: false });
         await this.io.append(this.filePath, line);
       }),
     );
+  }
+
+  private async migrateLoadedLegacyEntries(): Promise<void> {
+    const initial = {
+      entries: [...this.entries],
+      corruptedLines: this.corruptedLines,
+    };
+    if (!initial.entries.some(
+      (entry) => entry.kind === "tombstone" && entry.normalizerVersion !== TOMBSTONE_NORMALIZER_VERSION,
+    )) {
+      return;
+    }
+    try {
+      const migrated = await this.migrateLegacyEntries(initial);
+      this.resetIndex();
+      for (const entry of migrated.entries) this.indexEntry(entry);
+      this.corruptedLines = migrated.corruptedLines;
+      this.loaded = true;
+    } catch {
+      // The durable mutation already succeeded; defer migration to next load.
+    }
   }
 
   /**
@@ -714,7 +836,7 @@ export class TombstoneStore {
     // interleave in-process either.
     const rebuiltCount = await serializeMutations(`tombstone:${this.filePath}`, () =>
       this.withWriteLock(async () => {
-        await this.ensureFreshAgainstDisk();
+        await this.ensureFreshAgainstDisk({ migrate: false });
         // Preserve existing revocations (all namespaces — ids are globally
         // unique) so a rebuild does not silently un-revoke.
         const existingRevocations = this.entries.filter((e) => e.kind === "revocation");
@@ -737,21 +859,25 @@ export class TombstoneStore {
             existingBySource.set(`${e.sourceMemoryId}\u{0000}${e.supersessionKey ?? ""}`, e.id);
           }
         }
-        const rebuilt: TombstoneEntry[] = retiredMemories.map((m) => ({
-          id:
-            existingBySource.get(`${m.memoryId}\u{0000}${m.supersessionKey ?? ""}`) ??
-            newTombstoneId(),
-          kind: "tombstone" as const,
-          reason: m.reason,
-          sourceMemoryId: m.memoryId,
-          contentHash: m.contentHash ?? this.options.hashContent(m.rawContent),
-          normalizedText: this.options.normalizeText(m.rawContent),
-          ...(m.entityRef ? { entityRef: m.entityRef } : {}),
-          ...(m.supersessionKey ? { supersessionKey: m.supersessionKey } : {}),
-          namespace: this.namespace,
-          createdAt: m.createdAt,
-          createdBy: m.createdBy,
-        }));
+        const rebuilt: TombstoneEntry[] = retiredMemories.map((m) => {
+          const recomputedHash = this.options.hashContent(m.rawContent);
+          return {
+            id:
+              existingBySource.get(`${m.memoryId}\u{0000}${m.supersessionKey ?? ""}`) ??
+              newTombstoneId(),
+            kind: "tombstone" as const,
+            reason: m.reason,
+            sourceMemoryId: m.memoryId,
+            contentHash: m.contentHash === recomputedHash ? m.contentHash : recomputedHash,
+            normalizedText: this.options.normalizeText(m.rawContent),
+            normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
+            ...(m.entityRef ? { entityRef: m.entityRef } : {}),
+            ...(m.supersessionKey ? { supersessionKey: m.supersessionKey } : {}),
+            namespace: this.namespace,
+            createdAt: m.createdAt,
+            createdBy: m.createdBy,
+          };
+        });
         // Sort deterministically (rule 38): createdAt, then id for stability.
         rebuilt.sort((a, b) =>
           a.createdAt === b.createdAt
@@ -777,6 +903,7 @@ export class TombstoneStore {
         return rebuilt.length;
       }),
     );
+    await this.migrateLoadedLegacyEntries();
     return rebuiltCount;
   }
 }

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -79,8 +79,6 @@ export interface TombstoneEntry {
   currentContentHashAlias?: string;
   /** Current normalized body used by the normalized lookup tier. */
   normalizedText: string;
-  /** Version at which migration was attempted but the source was unavailable. */
-  legacyMigrationAttemptedVersion?: number;
   /** Version of the current body identity fields. */
   normalizerVersion?: number;
   entityRef?: string;
@@ -257,12 +255,6 @@ export function parseTombstoneLine(line: string): TombstoneEntry | null {
   if (typeof e.currentContentHashAlias === "string") {
     out.currentContentHashAlias = e.currentContentHashAlias;
   }
-  if (
-    typeof e.legacyMigrationAttemptedVersion === "number" &&
-    Number.isInteger(e.legacyMigrationAttemptedVersion)
-  ) {
-    out.legacyMigrationAttemptedVersion = e.legacyMigrationAttemptedVersion;
-  }
   if (typeof e.normalizerVersion === "number" && Number.isInteger(e.normalizerVersion)) {
     out.normalizerVersion = e.normalizerVersion;
   }
@@ -401,9 +393,9 @@ export class TombstoneStore {
   }
 
   /**
-   * Re-index pre-Unicode records once from a bounded batch of retired source
-   * content fetched before the write lock. The rewrite is serialized under
-   * the same lock as append/revoke.
+   * Re-index pre-Unicode records from retired source content.
+   * Source reads stay bounded, but every batch finishes before the store
+   * publishes its in-memory index. Missing sources remain eligible on restart.
    */
   private async migrateLegacyEntries(initial: {
     entries: TombstoneEntry[];
@@ -416,18 +408,23 @@ export class TombstoneStore {
     for (const entry of initial.entries) {
       if (
         entry.kind !== "tombstone" ||
-        entry.normalizerVersion === TOMBSTONE_NORMALIZER_VERSION ||
-        entry.legacyMigrationAttemptedVersion === TOMBSTONE_NORMALIZER_VERSION
+        entry.normalizerVersion === TOMBSTONE_NORMALIZER_VERSION
       ) {
         continue;
       }
       if (requested.has(entry.sourceMemoryId)) continue;
       requested.add(entry.sourceMemoryId);
       sourceMemoryIds.push(entry.sourceMemoryId);
-      if (sourceMemoryIds.length >= limit) break;
     }
     if (sourceMemoryIds.length === 0) return initial;
-    const sourceContents = await this.options.sourceContentsForMemoryIds(sourceMemoryIds);
+    const sourceContents = new Map<string, string>();
+    for (let offset = 0; offset < sourceMemoryIds.length; offset += limit) {
+      const batch = sourceMemoryIds.slice(offset, offset + limit);
+      const fetched = await this.options.sourceContentsForMemoryIds(batch);
+      for (const [sourceMemoryId, content] of fetched) {
+        sourceContents.set(sourceMemoryId, content);
+      }
+    }
     return await serializeMutations(`tombstone:${this.filePath}`, () =>
       this.withWriteLock(async () => {
         let latestRaw: string;
@@ -438,26 +435,17 @@ export class TombstoneStore {
         }
         const latest = this.parseEntries(latestRaw);
         let changed = false;
-        let migratedCount = 0;
         const migrated = latest.entries.map((entry) => {
           if (
             entry.kind !== "tombstone" ||
             entry.normalizerVersion === TOMBSTONE_NORMALIZER_VERSION ||
-            entry.legacyMigrationAttemptedVersion === TOMBSTONE_NORMALIZER_VERSION ||
-            !requested.has(entry.sourceMemoryId) ||
-            migratedCount >= limit
+            !requested.has(entry.sourceMemoryId)
           ) {
             return entry;
           }
           const source = sourceContents.get(entry.sourceMemoryId);
+          if (source === undefined) return entry;
           changed = true;
-          migratedCount += 1;
-          if (source === undefined) {
-            return {
-              ...entry,
-              legacyMigrationAttemptedVersion: TOMBSTONE_NORMALIZER_VERSION,
-            };
-          }
           const currentHash = this.options.hashContent(source);
           const currentNormalizedText = this.options.normalizeText(source);
           const legacyIdentityIsSafe = isUnambiguousLegacyContentHash(

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -41,7 +41,7 @@
 // ---------------------------------------------------------------------------
 
 import { serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
-import { computeLegacyContentHash, normalizeLegacyContent } from "../content-hash.js";
+import { isUnambiguousLegacyContentHash } from "../content-hash.js";
 
 /** Why a tombstone was emitted. */
 export type TombstoneReason =
@@ -73,15 +73,15 @@ export interface TombstoneEntry {
   reason: TombstoneReason;
   /** The memory that was retired. */
   sourceMemoryId: string;
-  /** sha256 of the retired memory's normalized content. */
+  /** sha256 of the retired identity; explicit contentHashSource may define it. */
   contentHash: string;
-  /** The normalized form used for the hash and normalized lookup tier. */
+  /** Current body hash retained alongside an ambiguous or explicit primary hash. */
+  currentContentHashAlias?: string;
+  /** Current normalized body used by the normalized lookup tier. */
   normalizedText: string;
-  /** Legacy pre-Unicode exact identity retained for migration aliases. */
-  legacyContentHash?: string;
-  /** Legacy pre-Unicode normalized identity retained for migration aliases. */
-  legacyNormalizedText?: string;
-  /** Version of the normalizer that produced contentHash/normalizedText. */
+  /** Version at which migration was attempted but the source was unavailable. */
+  legacyMigrationAttemptedVersion?: number;
+  /** Version of the current body identity fields. */
   normalizerVersion?: number;
   entityRef?: string;
   /** Structured-attribute supersession key when one existed. */
@@ -113,16 +113,12 @@ export interface TombstoneMatch {
  * remains for direct/unit callers; `lookup` checks the union of both. */
 export interface TombstoneLookupQuery {
   contentHash?: string;
-  /** Legacy pre-Unicode exact identity alias. */
-  legacyContentHash?: string;
   normalizedText?: string;
-  /** Legacy pre-Unicode normalized identity alias. */
-  legacyNormalizedText?: string;
   entityRef?: string;
   /** Single supersession key (direct/unit callers). */
   supersessionKey?: string;
   /** All derived supersession keys (write chokepoint). The keyed tier is
-   *  checked for each; the first active match wins. */
+   * checked for each; the first active match wins. */
   supersessionKeys?: string[];
   namespace: string;
 }
@@ -258,8 +254,15 @@ export function parseTombstoneLine(line: string): TombstoneEntry | null {
     createdAt: e.createdAt,
     createdBy: e.createdBy,
   };
-  if (typeof e.legacyContentHash === "string") out.legacyContentHash = e.legacyContentHash;
-  if (typeof e.legacyNormalizedText === "string") out.legacyNormalizedText = e.legacyNormalizedText;
+  if (typeof e.currentContentHashAlias === "string") {
+    out.currentContentHashAlias = e.currentContentHashAlias;
+  }
+  if (
+    typeof e.legacyMigrationAttemptedVersion === "number" &&
+    Number.isInteger(e.legacyMigrationAttemptedVersion)
+  ) {
+    out.legacyMigrationAttemptedVersion = e.legacyMigrationAttemptedVersion;
+  }
   if (typeof e.normalizerVersion === "number" && Number.isInteger(e.normalizerVersion)) {
     out.normalizerVersion = e.normalizerVersion;
   }
@@ -307,6 +310,10 @@ export class TombstoneStore {
     private readonly options: TombstoneStoreOptions,
     private readonly io: TombstoneFileIo,
   ) {
+    const limit = this.options.legacyMigrationLimit;
+    if (limit !== undefined && (!Number.isFinite(limit) || !Number.isInteger(limit) || limit < 0)) {
+      throw new Error("legacyMigrationLimit must be a finite non-negative integer");
+    }
     this.lockStaleMs = this.options.lockStaleMs ?? 30_000;
     this.lockMaxWaitMs = this.options.lockMaxWaitMs ?? 5_000;
     this.lockHeartbeatMs =
@@ -402,20 +409,16 @@ export class TombstoneStore {
     entries: TombstoneEntry[];
     corruptedLines: number;
   }): Promise<{ entries: TombstoneEntry[]; corruptedLines: number }> {
-    const configuredLimit = this.options.legacyMigrationLimit;
-    const limit = Math.max(
-      0,
-      Math.floor(
-        configuredLimit === undefined || !Number.isFinite(configuredLimit)
-          ? DEFAULT_LEGACY_MIGRATION_LIMIT
-          : configuredLimit
-      )
-    );
+    const limit = this.options.legacyMigrationLimit ?? DEFAULT_LEGACY_MIGRATION_LIMIT;
     if (limit === 0 || !this.options.sourceContentsForMemoryIds) return initial;
     const sourceMemoryIds: string[] = [];
     const requested = new Set<string>();
     for (const entry of initial.entries) {
-      if (entry.kind !== "tombstone" || entry.normalizerVersion === TOMBSTONE_NORMALIZER_VERSION) {
+      if (
+        entry.kind !== "tombstone" ||
+        entry.normalizerVersion === TOMBSTONE_NORMALIZER_VERSION ||
+        entry.legacyMigrationAttemptedVersion === TOMBSTONE_NORMALIZER_VERSION
+      ) {
         continue;
       }
       if (requested.has(entry.sourceMemoryId)) continue;
@@ -440,37 +443,40 @@ export class TombstoneStore {
           if (
             entry.kind !== "tombstone" ||
             entry.normalizerVersion === TOMBSTONE_NORMALIZER_VERSION ||
+            entry.legacyMigrationAttemptedVersion === TOMBSTONE_NORMALIZER_VERSION ||
             !requested.has(entry.sourceMemoryId) ||
             migratedCount >= limit
           ) {
             return entry;
           }
           const source = sourceContents.get(entry.sourceMemoryId);
-          if (source === undefined) return entry;
           changed = true;
           migratedCount += 1;
+          if (source === undefined) {
+            return {
+              ...entry,
+              legacyMigrationAttemptedVersion: TOMBSTONE_NORMALIZER_VERSION,
+            };
+          }
           const currentHash = this.options.hashContent(source);
           const currentNormalizedText = this.options.normalizeText(source);
-          const legacyHash = computeLegacyContentHash(source);
-          const legacyNormalizedText = normalizeLegacyContent(source);
-          const legacyIdentityMatches = entry.contentHash === currentHash || entry.contentHash === legacyHash;
-          return legacyIdentityMatches
-            ? {
-                ...entry,
-                normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
-                contentHash: currentHash,
-                normalizedText: currentNormalizedText,
-                ...(entry.contentHash === currentHash
-                  ? {}
-                  : { legacyContentHash: legacyHash, legacyNormalizedText }),
-              }
-            : {
-                ...entry,
-                normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
-                normalizedText: currentNormalizedText,
-                legacyContentHash: legacyHash,
-                legacyNormalizedText,
-              };
+          const legacyIdentityIsSafe = isUnambiguousLegacyContentHash(
+            source,
+            entry.contentHash,
+            currentNormalizedText,
+          );
+          const migratedEntry: TombstoneEntry = {
+            ...entry,
+            normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
+            normalizedText: currentNormalizedText,
+          };
+          if (entry.contentHash === currentHash) return migratedEntry;
+          if (legacyIdentityIsSafe) {
+            migratedEntry.contentHash = currentHash;
+          } else {
+            migratedEntry.currentContentHashAlias = currentHash;
+          }
+          return migratedEntry;
         });
         if (!changed) return latest;
         const serialized =
@@ -515,11 +521,10 @@ export class TombstoneStore {
     // mismatch, and misses its own still-active tombstone (resurrection).
     const ns = entry.namespace;
     if (entry.contentHash) this.byHash.set(`${ns}\0${entry.contentHash}`, entry.id);
-    if (entry.legacyContentHash) this.byHash.set(`${ns}\0${entry.legacyContentHash}`, entry.id);
-    if (entry.normalizedText) this.byNormalized.set(`${ns}\0${entry.normalizedText}`, entry.id);
-    if (entry.legacyNormalizedText) {
-      this.byNormalized.set(`${ns}\0${entry.legacyNormalizedText}`, entry.id);
+    if (entry.currentContentHashAlias) {
+      this.byHash.set(`${ns}\0${entry.currentContentHashAlias}`, entry.id);
     }
+    if (entry.normalizedText) this.byNormalized.set(`${ns}\0${entry.normalizedText}`, entry.id);
     if (entry.entityRef && entry.supersessionKey) {
       this.byKey.set(keyedTierKey(ns, entry.entityRef, entry.supersessionKey), entry.id);
     }
@@ -605,21 +610,18 @@ export class TombstoneStore {
     const createdAt = input.createdAt ?? new Date().toISOString();
     const id = newTombstoneId();
     const currentHash = this.options.hashContent(input.rawContent);
-    const legacyHash = computeLegacyContentHash(input.rawContent);
+    const currentNormalizedText = this.options.normalizeText(input.rawContent);
     const entry: TombstoneEntry = {
       id,
+      ...(input.contentHash && input.contentHash !== currentHash
+        ? { currentContentHashAlias: currentHash }
+        : {}),
       kind: "tombstone",
       reason: input.reason,
       sourceMemoryId: input.sourceMemoryId,
       contentHash: input.contentHash ?? currentHash,
-      normalizedText: this.options.normalizeText(input.rawContent),
+      normalizedText: currentNormalizedText,
       normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
-      ...(legacyHash !== currentHash
-        ? {
-            legacyContentHash: legacyHash,
-            legacyNormalizedText: normalizeLegacyContent(input.rawContent),
-          }
-        : {}),
       ...(input.entityRef ? { entityRef: input.entityRef } : {}),
       ...(input.supersessionKey ? { supersessionKey: input.supersessionKey } : {}),
       ...(input.operationKey ? { operationKey: input.operationKey } : {}),
@@ -751,9 +753,8 @@ export class TombstoneStore {
     // the backing file is shared. The namespace equality check below is kept
     // as defense-in-depth.
     const ns = query.namespace;
-    for (const contentHash of [query.contentHash, query.legacyContentHash]) {
-      if (!contentHash) continue;
-      const id = this.byHash.get(`${ns}\0${contentHash}`);
+    if (query.contentHash) {
+      const id = this.byHash.get(`${ns}\0${query.contentHash}`);
       if (id && !this.revokedIds.has(id)) {
         const entry = this.byId.get(id);
         if (entry && entry.namespace === ns) {
@@ -762,9 +763,8 @@ export class TombstoneStore {
       }
     }
     // Tier 2: normalized text.
-    for (const normalizedText of [query.normalizedText, query.legacyNormalizedText]) {
-      if (!normalizedText) continue;
-      const id = this.byNormalized.get(`${ns}\0${normalizedText}`);
+    if (query.normalizedText) {
+      const id = this.byNormalized.get(`${ns}\0${query.normalizedText}`);
       if (id && !this.revokedIds.has(id)) {
         const entry = this.byId.get(id);
         if (entry && entry.namespace === ns) {
@@ -907,26 +907,24 @@ export class TombstoneStore {
         }
         const rebuilt: TombstoneEntry[] = retiredMemories.map((m) => {
           const currentHash = this.options.hashContent(m.rawContent);
-          const legacyHash = computeLegacyContentHash(m.rawContent);
+          const currentNormalizedText = this.options.normalizeText(m.rawContent);
           const persistedHash = m.contentHash;
+          const legacyIdentityIsSafe =
+            persistedHash !== undefined &&
+            isUnambiguousLegacyContentHash(m.rawContent, persistedHash, currentNormalizedText);
           const preserveOverride =
-            persistedHash !== undefined && persistedHash !== currentHash && persistedHash !== legacyHash;
+            persistedHash !== undefined && persistedHash !== currentHash && !legacyIdentityIsSafe;
           return {
             id:
               existingBySource.get(`${m.memoryId}\u{0000}${m.supersessionKey ?? ""}`) ??
               newTombstoneId(),
+            ...(preserveOverride ? { currentContentHashAlias: currentHash } : {}),
             kind: "tombstone" as const,
             reason: m.reason,
             sourceMemoryId: m.memoryId,
             contentHash: preserveOverride ? persistedHash : currentHash,
-            normalizedText: this.options.normalizeText(m.rawContent),
+            normalizedText: currentNormalizedText,
             normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
-            ...(legacyHash !== currentHash
-              ? {
-                  legacyContentHash: legacyHash,
-                  legacyNormalizedText: normalizeLegacyContent(m.rawContent),
-                }
-              : {}),
             ...(m.entityRef ? { entityRef: m.entityRef } : {}),
             ...(m.supersessionKey ? { supersessionKey: m.supersessionKey } : {}),
             namespace: this.namespace,
@@ -1068,8 +1066,6 @@ export function applyTombstoneResurrectionGate(
   },
   query: {
     normalizedText: string;
-    legacyContentHash?: string;
-    legacyNormalizedText?: string;
     supersessionKeys: string[];
     namespace: string;
   },
@@ -1078,9 +1074,7 @@ export function applyTombstoneResurrectionGate(
   if (!(fm.status === undefined || fm.status === "active" || fm.status === "pending_review")) return null;
   const match = store.lookup({
     contentHash: fm.contentHash,
-    legacyContentHash: query.legacyContentHash,
     normalizedText: query.normalizedText,
-    legacyNormalizedText: query.legacyNormalizedText,
     ...(fm.entityRef ? { entityRef: fm.entityRef } : {}),
     ...(query.supersessionKeys.length > 0 ? { supersessionKeys: query.supersessionKeys } : {}),
     namespace: query.namespace,

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -436,16 +436,21 @@ export class TombstoneStore {
             entry.contentHash === this.options.hashContent(source) ||
             entry.contentHash === computeLegacyContentHash(source)
           );
-          const source = matches[0];
+          const explicitPrimary =
+            matches.length === 0 &&
+            entry.contentHash !== this.options.hashContent(entry.normalizedText);
+          const source = matches[0] ?? (explicitPrimary ? candidates[0] : undefined);
           if (source === undefined) return entry;
           const currentHash = this.options.hashContent(source);
-          const alias = matches
-            .map((candidate) => this.options.hashContent(candidate))
-            .find((hash) => hash !== currentHash);
+          const alias = explicitPrimary
+            ? currentHash
+            : matches
+              .map((candidate) => this.options.hashContent(candidate))
+              .find((hash) => hash !== currentHash);
           changed = true;
           return {
             ...entry,
-            contentHash: currentHash,
+            contentHash: explicitPrimary ? entry.contentHash : currentHash,
             ...(alias ? { currentContentHashAlias: alias } : {}),
             normalizedText: this.options.normalizeText(source),
             normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
@@ -499,11 +504,13 @@ export class TombstoneStore {
     // entry — otherwise A's lookup finds B's id, rejects it on namespace
     // mismatch, and misses its own still-active tombstone (resurrection).
     const ns = entry.namespace;
-    if (entry.contentHash) this.byHash.set(`${ns}\0${entry.contentHash}`, entry.id);
-    if (entry.currentContentHashAlias) {
-      this.byHash.set(`${ns}\0${entry.currentContentHashAlias}`, entry.id);
+    if (entry.normalizerVersion === TOMBSTONE_NORMALIZER_VERSION) {
+      if (entry.contentHash) this.byHash.set(`${ns}\0${entry.contentHash}`, entry.id);
+      if (entry.currentContentHashAlias) {
+        this.byHash.set(`${ns}\0${entry.currentContentHashAlias}`, entry.id);
+      }
+      if (entry.normalizedText) this.byNormalized.set(`${ns}\0${entry.normalizedText}`, entry.id);
     }
-    if (entry.normalizedText) this.byNormalized.set(`${ns}\0${entry.normalizedText}`, entry.id);
     if (entry.entityRef && entry.supersessionKey) {
       this.byKey.set(keyedTierKey(ns, entry.entityRef, entry.supersessionKey), entry.id);
     }

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -432,9 +432,8 @@ export class TombstoneStore {
           return initial;
         }
         const latest = this.parseEntries(latestRaw);
-        if (latest.corruptedLines > 0) return latest;
         let changed = false;
-        const migrated = latest.entries.map((entry) => {
+        const migrateEntry = (entry: TombstoneEntry): TombstoneEntry => {
           if (
             entry.kind !== "tombstone" ||
             entry.normalizerVersion === TOMBSTONE_NORMALIZER_VERSION ||
@@ -463,14 +462,20 @@ export class TombstoneStore {
             normalizedText: this.options.normalizeText(source),
             normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
           };
-        });
+        };
+        const serialized = latestRaw
+          .split("\n")
+          .map((line) => {
+            const entry = parseTombstoneLine(line);
+            if (!entry) return line;
+            const migrated = migrateEntry(entry);
+            return migrated === entry ? line : JSON.stringify(migrated);
+          })
+          .join("\n");
         if (!changed) return latest;
-        const serialized =
-          migrated.map((entry) => JSON.stringify(entry)).join("\n") +
-          (migrated.length > 0 ? "\n" : "");
         await this.io.write(this.filePath, serialized);
         this.markWritten();
-        return { entries: migrated, corruptedLines: 0 };
+        return this.parseEntries(serialized);
       }),
     );
   }

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -41,7 +41,7 @@
 // ---------------------------------------------------------------------------
 
 import { serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
-import { isUnambiguousLegacyContentHash } from "../content-hash.js";
+import { computeLegacyContentHash } from "../content-hash.js";
 
 /** Why a tombstone was emitted. */
 export type TombstoneReason =
@@ -434,6 +434,7 @@ export class TombstoneStore {
           return initial;
         }
         const latest = this.parseEntries(latestRaw);
+        if (latest.corruptedLines > 0) return latest;
         let changed = false;
         const migrated = latest.entries.map((entry) => {
           if (
@@ -445,26 +446,19 @@ export class TombstoneStore {
           }
           const source = sourceContents.get(entry.sourceMemoryId);
           if (source === undefined) return entry;
-          changed = true;
           const currentHash = this.options.hashContent(source);
           const currentNormalizedText = this.options.normalizeText(source);
-          const legacyIdentityIsSafe = isUnambiguousLegacyContentHash(
-            source,
-            entry.contentHash,
-            currentNormalizedText,
-          );
-          const migratedEntry: TombstoneEntry = {
+          const sourceIdentifiesEntry =
+            entry.contentHash === currentHash ||
+            entry.contentHash === computeLegacyContentHash(source);
+          if (!sourceIdentifiesEntry) return entry;
+          changed = true;
+          return {
             ...entry,
-            normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
+            contentHash: currentHash,
             normalizedText: currentNormalizedText,
+            normalizerVersion: TOMBSTONE_NORMALIZER_VERSION,
           };
-          if (entry.contentHash === currentHash) return migratedEntry;
-          if (legacyIdentityIsSafe) {
-            migratedEntry.contentHash = currentHash;
-          } else {
-            migratedEntry.currentContentHashAlias = currentHash;
-          }
-          return migratedEntry;
         });
         if (!changed) return latest;
         const serialized =
@@ -897,11 +891,10 @@ export class TombstoneStore {
           const currentHash = this.options.hashContent(m.rawContent);
           const currentNormalizedText = this.options.normalizeText(m.rawContent);
           const persistedHash = m.contentHash;
-          const legacyIdentityIsSafe =
-            persistedHash !== undefined &&
-            isUnambiguousLegacyContentHash(m.rawContent, persistedHash, currentNormalizedText);
           const preserveOverride =
-            persistedHash !== undefined && persistedHash !== currentHash && !legacyIdentityIsSafe;
+            persistedHash !== undefined &&
+            persistedHash !== currentHash &&
+            persistedHash !== computeLegacyContentHash(m.rawContent);
           return {
             id:
               existingBySource.get(`${m.memoryId}\u{0000}${m.supersessionKey ?? ""}`) ??

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -789,6 +789,7 @@ export class TombstoneStore {
       let best: { id: string; reason: TombstoneReason; score: number } | null = null;
       for (const entry of this.entries) {
         if (entry.kind !== "tombstone") continue;
+        if (entry.normalizerVersion !== TOMBSTONE_NORMALIZER_VERSION) continue;
         if (entry.namespace !== query.namespace) continue;
         if (this.revokedIds.has(entry.id)) continue;
         if (!entry.normalizedText) continue;

--- a/packages/remnic-core/src/reconcile/manifest.test.ts
+++ b/packages/remnic-core/src/reconcile/manifest.test.ts
@@ -2,6 +2,7 @@ import * as assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { test } from "node:test";
 import { ContentHashIndex } from "../storage/content-hash-index.js";
+import { computeLegacyContentHash } from "../content-hash.js";
 import { parseFrontmatter } from "../storage.js";
 import { type ReconcileManifest, buildReconcileManifest, collapseActiveFactDuplicates } from "./manifest.js";
 import { planReconciliation } from "./plan.js";
@@ -47,6 +48,7 @@ test("reconcile manifest keeps file identity separate from canonical semantic id
     id: "fact-a",
     category: "fact",
     contentHash: semanticHash,
+    normalizerVersion: 2,
     status: "active",
   });
 });
@@ -69,6 +71,55 @@ test("reconcile manifest hashes parsed legacy content and uses effective lifecyc
   assert.equal(manifest.files[0]?.memory?.status, "archived");
   assert.equal(manifest.files[1]?.memory?.contentHash, ContentHashIndex.computeHash("Legacy fact body"));
   assert.equal(manifest.files[1]?.memory?.status, "active");
+});
+
+test("reconcile manifest reparses cached pre-version identities after Unicode migration", async () => {
+  const content = "The user prefers café.";
+  const legacyHash = computeLegacyContentHash(content);
+  const serialized = memoryFile({ id: "legacy-unicode", content, contentHash: legacyHash });
+  const file = { path: "facts/legacy-unicode.md", sha256: fileHash(serialized) };
+  let reads = 0;
+
+  const manifest = await buildReconcileManifest({
+    files: [file],
+    parseMemory: parseFrontmatter,
+    readFile: async () => {
+      reads += 1;
+      return serialized;
+    },
+    cachedFiles: [{
+      ...file,
+      memory: {
+        id: "legacy-unicode",
+        category: "fact",
+        contentHash: legacyHash,
+        status: "active",
+      },
+    }],
+  });
+
+  assert.equal(reads, 1);
+  assert.deepEqual(manifest.files[0]?.memory?.contentHashAliases, [
+    ContentHashIndex.computeHash(content),
+  ]);
+});
+
+test("reconcile manifest publishes a current alias for a pure-CJK legacy identity", async () => {
+  const content = "利用者は紅茶を好む。";
+  const serialized = memoryFile({
+    id: "legacy-cjk",
+    content,
+    contentHash: computeLegacyContentHash(content),
+  });
+  const manifest = await buildReconcileManifest({
+    files: [{ path: "facts/legacy-cjk.md", sha256: fileHash(serialized) }],
+    parseMemory: parseFrontmatter,
+    readFile: async () => serialized,
+  });
+
+  assert.deepEqual(manifest.files[0]?.memory?.contentHashAliases, [
+    ContentHashIndex.computeHash(content),
+  ]);
 });
 
 test("reconcile manifest keeps file identity when memory bytes cannot be trusted", async () => {
@@ -146,6 +197,41 @@ test("semantic collapse prevents different active fact paths from transferring b
   assert.equal(collapsed.byNamespace[0]?.identical, 1);
   assert.equal(collapsed.byNamespace[0]?.pull, 0);
   assert.equal(collapsed.byNamespace[0]?.push, 0);
+});
+
+test("semantic collapse matches legacy and current Unicode identities across replicas", async () => {
+  const content = "The user prefers café.";
+  const localSerialized = memoryFile({
+    id: "legacy-id",
+    content,
+    contentHash: computeLegacyContentHash(content),
+  });
+  const peerSerialized = memoryFile({
+    id: "current-id",
+    content,
+    contentHash: ContentHashIndex.computeHash(content),
+  });
+  const localFile = { path: "facts/legacy-id.md", sha256: fileHash(localSerialized) };
+  const peerFile = { path: "facts/current-id.md", sha256: fileHash(peerSerialized) };
+  const build = async (file: typeof localFile, raw: string) =>
+    await buildReconcileManifest({
+      files: [file],
+      parseMemory: parseFrontmatter,
+      readFile: async () => raw,
+    });
+  const local = await build(localFile, localSerialized);
+  const peer = await build(peerFile, peerSerialized);
+  const plan = planReconciliation([{ namespace: "default", local: [localFile], peer: [peerFile] }]);
+
+  const collapsed = collapseActiveFactDuplicates(
+    plan,
+    new Map([["default", local]]),
+    new Map([["default", peer]]),
+  );
+
+  assert.equal(collapsed.converged, true);
+  assert.equal(collapsed.entries.length, 1);
+  assert.equal(collapsed.entries[0]?.reason, "semantic_duplicate");
 });
 
 test("semantic collapse classifies a later one-sided metadata edit from its per-side base", () => {

--- a/packages/remnic-core/src/reconcile/manifest.test.ts
+++ b/packages/remnic-core/src/reconcile/manifest.test.ts
@@ -1,9 +1,10 @@
 import * as assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { test } from "node:test";
-import { ContentHashIndex } from "../storage/content-hash-index.js";
 import { computeLegacyContentHash } from "../content-hash.js";
+import { attachCitation, formatCitation } from "../source-attribution.js";
 import { parseFrontmatter } from "../storage.js";
+import { ContentHashIndex } from "../storage/content-hash-index.js";
 import { type ReconcileManifest, buildReconcileManifest, collapseActiveFactDuplicates } from "./manifest.js";
 import { planReconciliation } from "./plan.js";
 
@@ -48,7 +49,7 @@ test("reconcile manifest keeps file identity separate from canonical semantic id
     id: "fact-a",
     category: "fact",
     contentHash: semanticHash,
-    normalizerVersion: 3,
+    normalizerVersion: 4,
     status: "active",
   });
 });
@@ -124,6 +125,51 @@ test("reconcile manifest replaces a pure-CJK legacy identity with its current ha
     ContentHashIndex.computeHash(content),
   );
   assert.equal("contentHashAliases" in (manifest.files[0]?.memory ?? {}), false);
+});
+
+test("reconcile manifest recovers a raw hash source beneath citation and attributes", async () => {
+  const content = "The user prefers café.";
+  const cited = attachCitation(content, {
+    agent: "planner",
+    session: "agent:planner:main",
+    ts: "2026-08-11T00:00:00.000Z",
+  });
+  const storedBody = `${cited}\n[Attributes: topic: coffee]`;
+  const serialized = memoryFile({
+    id: "legacy-enriched",
+    content: storedBody,
+    contentHash: computeLegacyContentHash(content),
+  });
+  const manifest = await buildReconcileManifest({
+    files: [{ path: "facts/legacy-enriched.md", sha256: fileHash(serialized) }],
+    parseMemory: parseFrontmatter,
+    readFile: async () => serialized,
+  });
+
+  assert.equal(manifest.files[0]?.memory?.contentHash, ContentHashIndex.computeHash(content));
+});
+
+test("reconcile manifest recovers raw identity beneath a configured citation", async () => {
+  const content = "The user prefers café.";
+  const citationTemplate = "[src:{agent}/{sessionId}@{date}]";
+  const storedBody = `${content} ${formatCitation({
+    agent: "planner",
+    session: "agent:planner:main",
+    ts: "2026-08-11T00:00:00.000Z",
+  }, citationTemplate)}`;
+  const serialized = memoryFile({
+    id: "legacy-custom-citation",
+    content: storedBody,
+    contentHash: computeLegacyContentHash(content),
+  });
+  const manifest = await buildReconcileManifest({
+    files: [{ path: "facts/legacy-custom-citation.md", sha256: fileHash(serialized) }],
+    parseMemory: parseFrontmatter,
+    readFile: async () => serialized,
+    citationTemplate,
+  });
+
+  assert.equal(manifest.files[0]?.memory?.contentHash, ContentHashIndex.computeHash(content));
 });
 
 test("reconcile manifest does not add a legacy alias to a current Unicode identity", async () => {

--- a/packages/remnic-core/src/reconcile/manifest.test.ts
+++ b/packages/remnic-core/src/reconcile/manifest.test.ts
@@ -48,7 +48,7 @@ test("reconcile manifest keeps file identity separate from canonical semantic id
     id: "fact-a",
     category: "fact",
     contentHash: semanticHash,
-    normalizerVersion: 2,
+    normalizerVersion: 3,
     status: "active",
   });
 });
@@ -99,12 +99,14 @@ test("reconcile manifest reparses cached pre-version identities after Unicode mi
   });
 
   assert.equal(reads, 1);
-  assert.deepEqual(manifest.files[0]?.memory?.contentHashAliases, [
+  assert.equal(
+    manifest.files[0]?.memory?.contentHash,
     ContentHashIndex.computeHash(content),
-  ]);
+  );
+  assert.equal("contentHashAliases" in (manifest.files[0]?.memory ?? {}), false);
 });
 
-test("reconcile manifest publishes a current alias for a pure-CJK legacy identity", async () => {
+test("reconcile manifest replaces a pure-CJK legacy identity with its current hash", async () => {
   const content = "利用者は紅茶を好む。";
   const serialized = memoryFile({
     id: "legacy-cjk",
@@ -117,9 +119,32 @@ test("reconcile manifest publishes a current alias for a pure-CJK legacy identit
     readFile: async () => serialized,
   });
 
-  assert.deepEqual(manifest.files[0]?.memory?.contentHashAliases, [
+  assert.equal(
+    manifest.files[0]?.memory?.contentHash,
     ContentHashIndex.computeHash(content),
-  ]);
+  );
+  assert.equal("contentHashAliases" in (manifest.files[0]?.memory ?? {}), false);
+});
+
+test("reconcile manifest does not add a legacy alias to a current Unicode identity", async () => {
+  const unicode = "The user prefers café.";
+  const ascii = "The user prefers caf.";
+  const serialized = memoryFile({
+    id: "current-unicode",
+    content: unicode,
+    contentHash: ContentHashIndex.computeHash(unicode),
+  });
+  const manifest = await buildReconcileManifest({
+    files: [{ path: "facts/current-unicode.md", sha256: fileHash(serialized) }],
+    parseMemory: parseFrontmatter,
+    readFile: async () => serialized,
+  });
+
+  assert.notEqual(
+    manifest.files[0]?.memory?.contentHash,
+    ContentHashIndex.computeHash(ascii),
+  );
+  assert.equal("contentHashAliases" in (manifest.files[0]?.memory ?? {}), false);
 });
 
 test("reconcile manifest keeps file identity when memory bytes cannot be trusted", async () => {

--- a/packages/remnic-core/src/reconcile/manifest.ts
+++ b/packages/remnic-core/src/reconcile/manifest.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { computeLegacyContentHash, normalizeLegacyContent } from "../content-hash.js";
 import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import { ContentHashIndex, type ContentHashPathEntry } from "../storage/content-hash-index.js";
 import type { MemoryFrontmatter, MemoryStatus } from "../types.js";
@@ -14,11 +15,14 @@ import {
 
 export const RECONCILE_MANIFEST_FORMAT = "remnic-reconcile-manifest";
 export const RECONCILE_MANIFEST_SCHEMA_VERSION = 1;
+const CONTENT_HASH_NORMALIZER_VERSION = 2;
 
 export interface ReconcileMemoryIdentity {
   id: string;
   category: string;
   contentHash: string;
+  contentHashAliases?: string[];
+  normalizerVersion?: number;
   status: MemoryStatus;
 }
 
@@ -65,15 +69,28 @@ function parsedMemoryIdentity(
   if (!isMemoryPath(filePath)) return undefined;
   const parsed = parseMemory(Buffer.isBuffer(raw) ? raw.toString("utf8") : raw);
   if (!parsed?.frontmatter.id) return undefined;
+
   const storedHash = parsed.frontmatter.contentHash;
+  const bodyHash = ContentHashIndex.computeHash(parsed.content);
   const contentHash =
     storedHash && SHA256_PATTERN.test(storedHash)
       ? storedHash.toLowerCase()
-      : ContentHashIndex.computeHash(parsed.content);
+      : bodyHash;
+  const legacyNormalized = normalizeLegacyContent(parsed.content);
+  const legacyHash = computeLegacyContentHash(parsed.content);
+  const aliases = new Set<string>();
+  if (contentHash === legacyHash) aliases.add(bodyHash);
+  if (legacyNormalized.length > 0 && contentHash === bodyHash) {
+    aliases.add(legacyHash);
+  }
+  aliases.delete(contentHash);
+
   return {
     id: parsed.frontmatter.id,
     category: parsed.frontmatter.category,
     contentHash,
+    normalizerVersion: CONTENT_HASH_NORMALIZER_VERSION,
+    ...(aliases.size > 0 ? { contentHashAliases: [...aliases] } : {}),
     status: inferMemoryStatus(parsed.frontmatter, filePath),
   };
 }
@@ -107,7 +124,11 @@ export async function buildReconcileManifest(options: BuildReconcileManifestOpti
   const files: ReconcileManifestFile[] = [];
   for (const file of options.files) {
     const cached = cachedByPath.get(file.path);
-    if (cached?.sha256.toLowerCase() === file.sha256.toLowerCase()) {
+    if (
+      cached?.sha256.toLowerCase() === file.sha256.toLowerCase() &&
+      (cached.memory === undefined ||
+        cached.memory.normalizerVersion === CONTENT_HASH_NORMALIZER_VERSION)
+    ) {
       files.push({ ...file, ...(cached.memory ? { memory: cached.memory } : {}) });
       continue;
     }
@@ -132,10 +153,17 @@ function activeFactByPath(manifest: ReconcileManifest | undefined): Map<string, 
   return result;
 }
 
-function contentHashRows(files: Iterable<ActiveFactManifestFile>): ContentHashPathEntry[] {
+function memoryIdentityHashes(memory: ReconcileMemoryIdentity): string[] {
+  return [memory.contentHash, ...(memory.contentHashAliases ?? [])];
+}
+
+function contentHashRows(
+  files: Iterable<ActiveFactManifestFile>,
+  contentHash: string,
+): ContentHashPathEntry[] {
   const rows: ContentHashPathEntry[] = [];
   for (const file of files) {
-    rows.push({ path: file.path, contentHash: file.memory.contentHash });
+    rows.push({ path: file.path, contentHash });
   }
   return rows;
 }
@@ -194,35 +222,47 @@ export function collapseActiveFactDuplicates(
     const peerByHash = new Map<string, ActiveFactManifestFile[]>();
 
     for (const file of localByPath.values()) {
-      const hash = file.memory.contentHash;
-      const bucket = localByHash.get(hash) ?? [];
-      bucket.push(file);
-      localByHash.set(hash, bucket);
+      for (const hash of memoryIdentityHashes(file.memory)) {
+        const bucket = localByHash.get(hash) ?? [];
+        bucket.push(file);
+        localByHash.set(hash, bucket);
+      }
     }
     for (const file of peerByPath.values()) {
-      const hash = file.memory.contentHash;
-      const bucket = peerByHash.get(hash) ?? [];
-      bucket.push(file);
-      peerByHash.set(hash, bucket);
+      for (const hash of memoryIdentityHashes(file.memory)) {
+        const bucket = peerByHash.get(hash) ?? [];
+        bucket.push(file);
+        peerByHash.set(hash, bucket);
+      }
     }
 
     const removed = new Set<ReconcilePlanEntry>();
     const replacements: ReconcilePlanEntry[] = [];
+    const processedPathPairs = new Set<string>();
     for (const hash of new Set([...localByHash.keys(), ...peerByHash.keys()])) {
       const localCandidates = (localByHash.get(hash) ?? []).filter((file) => {
         const opposite = peerFilesByPath.get(file.path);
         const activeOpposite = peerByPath.get(file.path);
-        return opposite === undefined || activeOpposite?.memory.contentHash === hash;
+        return opposite === undefined || (
+          activeOpposite !== undefined &&
+          memoryIdentityHashes(activeOpposite.memory).includes(hash)
+        );
       });
       const peerCandidates = (peerByHash.get(hash) ?? []).filter((file) => {
         const opposite = localFilesByPath.get(file.path);
         const activeOpposite = localByPath.get(file.path);
-        return opposite === undefined || activeOpposite?.memory.contentHash === hash;
+        return opposite === undefined || (
+          activeOpposite !== undefined &&
+          memoryIdentityHashes(activeOpposite.memory).includes(hash)
+        );
       });
-      const localPath = ContentHashIndex.resolvePathByHash(hash, contentHashRows(localCandidates));
-      const peerPath = ContentHashIndex.resolvePathByHash(hash, contentHashRows(peerCandidates));
+      const localPath = ContentHashIndex.resolvePathByHash(hash, contentHashRows(localCandidates, hash));
+      const peerPath = ContentHashIndex.resolvePathByHash(hash, contentHashRows(peerCandidates, hash));
 
       if (localPath && peerPath && localPath !== peerPath) {
+        const pathPair = `${localPath}\0${peerPath}`;
+        if (processedPathPairs.has(pathPair)) continue;
+        processedPathPairs.add(pathPair);
         const localFile = localByPath.get(localPath);
         const peerFile = peerByPath.get(peerPath);
         if (!localFile || !peerFile) continue;

--- a/packages/remnic-core/src/reconcile/manifest.ts
+++ b/packages/remnic-core/src/reconcile/manifest.ts
@@ -15,13 +15,12 @@ import {
 
 export const RECONCILE_MANIFEST_FORMAT = "remnic-reconcile-manifest";
 export const RECONCILE_MANIFEST_SCHEMA_VERSION = 1;
-const CONTENT_HASH_NORMALIZER_VERSION = 2;
+const CONTENT_HASH_NORMALIZER_VERSION = 3;
 
 export interface ReconcileMemoryIdentity {
   id: string;
   category: string;
   contentHash: string;
-  contentHashAliases?: string[];
   normalizerVersion?: number;
   status: MemoryStatus;
 }
@@ -70,27 +69,23 @@ function parsedMemoryIdentity(
   const parsed = parseMemory(Buffer.isBuffer(raw) ? raw.toString("utf8") : raw);
   if (!parsed?.frontmatter.id) return undefined;
 
-  const storedHash = parsed.frontmatter.contentHash;
+  const storedHash =
+    parsed.frontmatter.contentHash &&
+    SHA256_PATTERN.test(parsed.frontmatter.contentHash)
+      ? parsed.frontmatter.contentHash.toLowerCase()
+      : undefined;
   const bodyHash = ContentHashIndex.computeHash(parsed.content);
-  const contentHash =
-    storedHash && SHA256_PATTERN.test(storedHash)
-      ? storedHash.toLowerCase()
-      : bodyHash;
-  const legacyNormalized = normalizeLegacyContent(parsed.content);
   const legacyHash = computeLegacyContentHash(parsed.content);
-  const aliases = new Set<string>();
-  if (contentHash === legacyHash) aliases.add(bodyHash);
-  if (legacyNormalized.length > 0 && contentHash === bodyHash) {
-    aliases.add(legacyHash);
-  }
-  aliases.delete(contentHash);
+  const contentHash =
+    storedHash === undefined || storedHash === legacyHash
+      ? bodyHash
+      : storedHash;
 
   return {
     id: parsed.frontmatter.id,
     category: parsed.frontmatter.category,
     contentHash,
     normalizerVersion: CONTENT_HASH_NORMALIZER_VERSION,
-    ...(aliases.size > 0 ? { contentHashAliases: [...aliases] } : {}),
     status: inferMemoryStatus(parsed.frontmatter, filePath),
   };
 }
@@ -154,7 +149,7 @@ function activeFactByPath(manifest: ReconcileManifest | undefined): Map<string, 
 }
 
 function memoryIdentityHashes(memory: ReconcileMemoryIdentity): string[] {
-  return [memory.contentHash, ...(memory.contentHashAliases ?? [])];
+  return [memory.contentHash];
 }
 
 function contentHashRows(

--- a/packages/remnic-core/src/reconcile/manifest.ts
+++ b/packages/remnic-core/src/reconcile/manifest.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 import { computeLegacyContentHash, normalizeLegacyContent } from "../content-hash.js";
 import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import { ContentHashIndex, type ContentHashPathEntry } from "../storage/content-hash-index.js";
+import { DEFAULT_CITATION_FORMAT, stripCitationForTemplate } from "../source-attribution.js";
+import { storedContentIdentityCandidates } from "../structured-attributes.js";
 import type { MemoryFrontmatter, MemoryStatus } from "../types.js";
 import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
 import {
@@ -15,7 +17,7 @@ import {
 
 export const RECONCILE_MANIFEST_FORMAT = "remnic-reconcile-manifest";
 export const RECONCILE_MANIFEST_SCHEMA_VERSION = 1;
-const CONTENT_HASH_NORMALIZER_VERSION = 3;
+const CONTENT_HASH_NORMALIZER_VERSION = 4;
 
 export interface ReconcileMemoryIdentity {
   id: string;
@@ -46,6 +48,7 @@ export interface BuildReconcileManifestOptions {
   readFile: (file: ReconcileFileState) => Promise<Buffer | string | null>;
   parseMemory: ReconcileMemoryParser;
   cachedFiles?: Iterable<ReconcileManifestFile>;
+  citationTemplate?: string;
 }
 
 const SHA256_PATTERN = /^[a-f0-9]{64}$/i;
@@ -64,6 +67,7 @@ function parsedMemoryIdentity(
   filePath: string,
   raw: Buffer | string,
   parseMemory: ReconcileMemoryParser,
+  citationTemplate: string,
 ): ReconcileMemoryIdentity | undefined {
   if (!isMemoryPath(filePath)) return undefined;
   const parsed = parseMemory(Buffer.isBuffer(raw) ? raw.toString("utf8") : raw);
@@ -74,12 +78,21 @@ function parsedMemoryIdentity(
     SHA256_PATTERN.test(parsed.frontmatter.contentHash)
       ? parsed.frontmatter.contentHash.toLowerCase()
       : undefined;
-  const bodyHash = ContentHashIndex.computeHash(parsed.content);
-  const legacyHash = computeLegacyContentHash(parsed.content);
-  const contentHash =
-    storedHash === undefined || storedHash === legacyHash
-      ? bodyHash
-      : storedHash;
+  const candidates = storedContentIdentityCandidates(parsed.content, (content) =>
+    stripCitationForTemplate(content, citationTemplate)
+  );
+  const bodyHash = ContentHashIndex.computeHash(candidates[0] ?? "");
+  const currentMatch = candidates.find(
+    (content) => ContentHashIndex.computeHash(content) === storedHash
+  );
+  const legacyMatch = [...candidates].reverse().find(
+    (content) => computeLegacyContentHash(content) === storedHash
+  );
+  const contentHash = currentMatch
+    ? ContentHashIndex.computeHash(currentMatch)
+    : legacyMatch
+      ? ContentHashIndex.computeHash(legacyMatch)
+      : storedHash ?? bodyHash;
 
   return {
     id: parsed.frontmatter.id,
@@ -94,6 +107,7 @@ export async function buildReconcileManifestFile(
   file: ReconcileFileState,
   readFile: (file: ReconcileFileState) => Promise<Buffer | string | null>,
   parseMemory: ReconcileMemoryParser,
+  citationTemplate = DEFAULT_CITATION_FORMAT,
 ): Promise<ReconcileManifestFile> {
   let raw: Buffer | string | null = null;
   if (isMemoryPath(file.path)) {
@@ -106,7 +120,7 @@ export async function buildReconcileManifestFile(
   if (raw !== null && createHash("sha256").update(raw).digest("hex") !== file.sha256.toLowerCase()) {
     raw = null;
   }
-  const memory = raw === null ? undefined : parsedMemoryIdentity(file.path, raw, parseMemory);
+  const memory = raw === null ? undefined : parsedMemoryIdentity(file.path, raw, parseMemory, citationTemplate);
   return { ...file, ...(memory ? { memory } : {}) };
 }
 
@@ -128,7 +142,12 @@ export async function buildReconcileManifest(options: BuildReconcileManifestOpti
       continue;
     }
 
-    files.push(await buildReconcileManifestFile(file, options.readFile, options.parseMemory));
+    files.push(await buildReconcileManifestFile(
+      file,
+      options.readFile,
+      options.parseMemory,
+      options.citationTemplate,
+    ));
   }
   files.sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
   return {

--- a/packages/remnic-core/src/storage-contract/content-hash.test.ts
+++ b/packages/remnic-core/src/storage-contract/content-hash.test.ts
@@ -128,6 +128,19 @@ test("content-hash: normalizeContent produces stable text for equivalent inputs"
   assert.equal(a, b, "normalizeContent must collapse whitespace consistently");
 });
 
+test("content-hash: distinct Japanese facts keep distinct hashes", () => {
+  assert.notEqual(
+    ContentHashIndex.computeHash("利用者は紅茶を好む。"),
+    ContentHashIndex.computeHash("利用者は珈琲を好む。"),
+  );
+});
+
+test("content-hash: NFC and NFD forms share one hash", () => {
+  const nfc = "Café au lait";
+  const nfd = "Cafe\u0301 au lait";
+  assert.equal(ContentHashIndex.computeHash(nfc), ContentHashIndex.computeHash(nfd));
+});
+
 test("content-hash: the frontmatter contentHash matches computeHash of the raw content", async () => {
   const { storage, cleanup } = await makeStorage();
   try {

--- a/packages/remnic-core/src/storage-fact-hash-index-defer.test.ts
+++ b/packages/remnic-core/src/storage-fact-hash-index-defer.test.ts
@@ -900,7 +900,7 @@ test("#2016: rebuildUnderLock refuses to publish while a peer holds the lock (no
     await mkdir(stateDir, { recursive: true });
     // A peer already committed a hash to disk.
     const peerHash = ContentHashIndex.computeHash("peer-committed-fact");
-    await writeFile(path.join(stateDir, "fact-hashes.txt"), `${peerHash}\n`);
+    await writeFile(path.join(stateDir, "fact-hashes.txt"), `# remnic-content-hash-index:v2\n${peerHash}\n`);
     // The peer holds the advisory lock (fresh, non-stale, not stale-breakable).
     const lockPath = path.join(stateDir, "fact-hashes.txt.lock");
     await writeFile(lockPath, `99999 peer-owner ${new Date().toISOString()}\n`);

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -3019,6 +3019,31 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       // guarantees the tombstone tiers can never drift from dedup.
       hashContent: ContentHashIndex.computeHash,
       normalizeText: ContentHashIndex.normalizeContent,
+      sourceContentsForMemoryIds: async (sourceMemoryIds) => {
+        const requested = new Set(sourceMemoryIds);
+        const matchingPaths: string[] = [];
+        const found = new Set<string>();
+        const collectMatches = (filePaths: readonly string[]): void => {
+          for (const filePath of filePaths) {
+            const id = path.basename(filePath, ".md");
+            if (!requested.has(id) || found.has(id)) continue;
+            matchingPaths.push(filePath);
+            found.add(id);
+          }
+        };
+        collectMatches(await this.collectActiveMemoryPaths());
+        if (found.size < requested.size) {
+          collectMatches(await this.collectColdMemoryPaths());
+        }
+        const contents = new Map<string, string>();
+        for (const memory of await this.readParsedMemoriesFromPaths(matchingPaths, 50)) {
+          contents.set(
+            memory.frontmatter.id,
+            stripCitationForTemplate(memory.content, this.citationTemplate),
+          );
+        }
+        return contents;
+      },
     };
     const io: TombstoneFileIo = {
       read: (filePath) => this.readStorageSecureFile(filePath),
@@ -3263,13 +3288,14 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     }
     this.factHashIndexAuthoritative = false;
     this.factHashIndexAuthoritativePromise = (async () => {
-      // Round 11: ALWAYS rebuild the fact-hash index from the durable corpus on
-      // first use per process — no on-disk "ready" marker is written or trusted,
-      // so a deferred write, crash, or multi-process interleave can never leave a
-      // stale index trusted. The scan AND publish run under the SAME per-index
-      // cross-process lock the reconciling saves use (rebuildUnderLock), so the
-      // rebuild can never overwrite a peer's newer lock-merged or deferred
-      // additions with an unlocked overwrite.
+      // ALWAYS rebuild the index from the durable corpus on first use per
+      // process, preserving the #2016 crash/restart invariant. Markerless
+      // legacy indexes additionally require body-derived hashes because their
+      // frontmatter.contentHash values may use the old normalizer.
+      //
+      // The scan and publish run under the SAME per-index cross-process lock
+      // used by reconcile saves, so migration cannot overwrite a peer's newer
+      // additions with an unlocked write.
       //
       // PR #2016 (findings 1-2): bounded-retry the LOCKED rebuild so transient
       // contention (a peer mid reconcile-save) clears within a short budget
@@ -3284,7 +3310,9 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       const baseMs = this.factHashIndexLockOptions.retryBaseMs ?? FACT_HASH_INDEX_REBUILD_RETRY_BASE_MS;
       let published = false;
       for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-        published = await factHashIndex.rebuildUnderLock(() => this.rebuildFactHashIndexFromCorpus(factHashIndex));
+        published = await factHashIndex.rebuildUnderLock(() =>
+          this.rebuildFactHashIndexFromCorpus(factHashIndex)
+        );
         if (published || attempt === maxAttempts - 1) break;
         const wait = Math.min(baseMs * 2 ** attempt, CONTENT_HASH_INDEX_RETRY_MAX_DELAY_MS);
         await new Promise<void>((resolve) => setTimeout(resolve, wait));
@@ -3365,38 +3393,42 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     }
   }
   /**
-   * The content-hash the corpus rebuild registers for `memory`, or null when the
-   * body carries a citation from an unknown/custom template that cannot be
-   * safely stripped. Shared by the authoritative rebuild and the fact-only
-   * corpus confirmation (`hasFactContentHash`) so both derive the identical
-   * hash for a given stored body.
-   *
-   * Preference order:
-   *  1. frontmatter.contentHash — the raw pre-citation hash writeMemory records
-   *     for facts (issue #369 round 8); matches hasFactContentHash(rawFact).
-   *  2. Reconstruct from the stored body: strip the "[Attributes: …]" suffix
-   *     writeMemory appends for structuredAttributes (registration hashed the
-   *     raw canonical content WITHOUT it — a no-op when absent), then strip a
-   *     recognised citation and hash the bare body, or hash a citation-free
-   *     body as-is.
-   *  3. A body with a citation from an unknown/custom template → null: a
-   *     false-negative miss beats a wrong hash that would permanently suppress
-   *     legitimate duplicate writes.
+   * The content hash the corpus rebuild registers for `memory`, or null when
+   * the body has an unknown citation and no persisted hash exists.
+   * Reconstruct from the authoritative body first. Preserve an intentional
+   * `contentHashSource` override when frontmatter differs from both the
+   * current and the legacy pre-Unicode body hash.
    */
   private corpusRegisteredHash(memory: MemoryFile): string | null {
-    if (memory.frontmatter.contentHash) {
-      return memory.frontmatter.contentHash;
-    }
     const content = stripAttributesSuffix(memory.content);
     const stripped = stripCitationForTemplate(content, this.citationTemplate);
-    if (stripped !== content) {
-      return ContentHashIndex.computeHash(sanitizeMemoryContent(stripped).text);
+    const canonicalContent = stripped !== content || !hasCitation(content)
+      ? sanitizeMemoryContent(stripped !== content ? stripped : content).text
+      : null;
+    const persistedHash = memory.frontmatter.contentHash;
+    if (canonicalContent === null) return persistedHash ?? null;
+
+    const currentHash = ContentHashIndex.computeHash(canonicalContent);
+    if (
+      !persistedHash ||
+      persistedHash === currentHash ||
+      persistedHash === this.legacyCorpusHash(canonicalContent)
+    ) {
+      return currentHash;
     }
-    if (!hasCitation(content)) {
-      return ContentHashIndex.computeHash(sanitizeMemoryContent(content).text);
-    }
-    return null;
+    return persistedHash;
   }
+
+  /** Compute the pre-Unicode hash used by markerless legacy indexes. */
+  private legacyCorpusHash(content: string): string {
+    const normalized = content
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    return createHash("sha256").update(normalized).digest("hex");
+  }
+
   private get questionsDir(): string {
     return path.join(this.baseDir, "questions");
   }
@@ -3987,15 +4019,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
 
   private factContentHashForRemoval(memory: MemoryFile): string | null {
     if (memory.frontmatter.category !== "fact") return null;
-    if (typeof memory.frontmatter.contentHash === "string" && memory.frontmatter.contentHash.length > 0) {
-      return memory.frontmatter.contentHash;
-    }
-    const configuredHashSource = stripCitationMarkersForHashRemoval(memory.content, this.citationTemplate);
-    const hashSource =
-      configuredHashSource !== memory.content
-        ? configuredHashSource
-        : stripDefaultCitationMarkersWithoutRegex(memory.content);
-    return ContentHashIndex.computeHash(sanitizeMemoryContent(hashSource).text);
+    return this.corpusRegisteredHash(memory);
   }
 
   private async addActiveFactContentHash(memory: MemoryFile): Promise<void> {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -119,7 +119,6 @@ import {
   sortStructuredSectionsBySchema,
 } from "./entity-schema.js";
 import {
-  hasCitation,
   hasCitationForTemplate,
   stripCitationForTemplate,
   DEFAULT_CITATION_FORMAT,
@@ -3013,33 +3012,43 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
   }
 
   private buildTombstoneStore(): TombstoneStore {
-    const sourcePathsPromise = this.memoryReadStore.collectTombstoneMigrationPaths();
+    let sourcePathsPromise: Promise<string[]> | undefined;
+    let sourceContentsByIdPromise: Promise<Map<string, string>> | undefined;
     const options: TombstoneStoreOptions = {
       enabled: this.tombstonesConfig.enabled,
       semanticMatch: this.tombstonesConfig.semanticMatch,
       semanticThreshold: this.tombstonesConfig.semanticThreshold,
-      // Wire the SAME helpers the dedup index uses (rule 23 / checklist §13):
-      // hashContent = ContentHashIndex.computeHash, normalizeText =
-      // ContentHashIndex.normalizeContent. Importing them here (not copying)
-      // guarantees the tombstone tiers can never drift from dedup.
       hashContent: ContentHashIndex.computeHash,
       normalizeText: ContentHashIndex.normalizeContent,
       sourceContentsForMemoryIds: async (sourceMemoryIds) => {
         const requested = new Set(sourceMemoryIds);
-        const matchingPaths: string[] = [];
-        const found = new Set<string>();
-        const collectMatches = (filePaths: readonly string[]): void => {
-          for (const filePath of filePaths) {
-            const id = path.basename(filePath, ".md");
-            if (!requested.has(id) || found.has(id)) continue;
-            matchingPaths.push(filePath);
-            found.add(id);
-          }
-        };
-        collectMatches(await sourcePathsPromise);
+        const sourcePaths = await (sourcePathsPromise ??=
+          this.memoryReadStore.collectTombstoneMigrationPaths());
+        const directPaths = sourcePaths.filter((filePath) =>
+          requested.has(path.basename(filePath, ".md"))
+        );
         const contents = new Map<string, string>();
-        for (const memory of await this.readParsedMemoriesFromPaths(matchingPaths, 50)) {
-          contents.set(memory.frontmatter.id, stripCitationForTemplate(memory.content, this.citationTemplate));
+        for (const memory of await this.readParsedMemoriesFromPaths(directPaths, 50)) {
+          const id = memory.frontmatter.id;
+          if (requested.has(id) && !contents.has(id)) {
+            contents.set(id, stripCitationForTemplate(memory.content, this.citationTemplate));
+          }
+        }
+        if (contents.size === requested.size) return contents;
+        sourceContentsByIdPromise ??= (async () => {
+          const allContents = new Map<string, string>();
+          for (const memory of await this.readParsedMemoriesFromPaths(sourcePaths, 50)) {
+            const id = memory.frontmatter.id;
+            if (!allContents.has(id)) {
+              allContents.set(id, stripCitationForTemplate(memory.content, this.citationTemplate));
+            }
+          }
+          return allContents;
+        })();
+        const allContents = await sourceContentsByIdPromise;
+        for (const id of requested) {
+          const content = allContents.get(id);
+          if (content !== undefined) contents.set(id, content);
         }
         return contents;
       },
@@ -3048,7 +3057,6 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       read: (filePath) => this.readStorageSecureFile(filePath),
       append: (filePath, content) => this.appendStorageSecureFile(filePath, content),
       write: (filePath, content) => this.writeStorageSecureFile(filePath, content),
-      // stat lets the store own its cross-process staleness probe (#1579).
       stat: (filePath) => statSync(filePath),
     };
     return new TombstoneStore(this.tombstonesPath, this.tombstonesConfig.namespace, options, io);
@@ -3375,10 +3383,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       if (inferMemoryStatus(memory.frontmatter, memory.path) !== "active") continue;
       const hashes = this.corpusRegisteredHashes(memory);
       if (hashes.length === 0) {
-        // Body carries a citation from an unknown/custom template we cannot
-        // safely strip — skip rather than register a wrong hash. A
-        // false-negative miss beats a wrong entry that would permanently
-        // suppress legitimate duplicate writes (see corpusRegisteredHashes).
+        // Skip bodies whose configured citation cannot be stripped safely.
         legacyRecovered++;
         continue;
       }
@@ -3393,25 +3398,23 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       );
     }
   }
-  /**
-   * Returns persisted identities plus a current body alias when the legacy hash matches.
-   * The current alias prevents upgrade duplicates while retaining the old identity.
-   */
+  /** Returns the current body identity while preserving explicit external identities. */
   private corpusRegisteredHashes(memory: MemoryFile): string[] {
-    const content = stripAttributesSuffix(memory.content);
-    const stripped = stripCitationForTemplate(content, this.citationTemplate);
-    const canonicalContent =
-      stripped !== content || !hasCitation(content)
-        ? sanitizeMemoryContent(stripped !== content ? stripped : content).text
-        : null;
     const persistedHash = memory.frontmatter.contentHash;
-    if (canonicalContent === null) return persistedHash ? [persistedHash] : [];
-
+    const content = stripAttributesSuffix(memory.content);
+    const hasKnownCitation = hasCitationForTemplate(content, this.citationTemplate);
+    const stripped = hasKnownCitation
+      ? stripCitationForTemplate(content, this.citationTemplate)
+      : content;
+    if (hasKnownCitation && stripped === content) return persistedHash ? [persistedHash] : [];
+    const canonicalContent = sanitizeMemoryContent(stripped).text;
     const currentHash = ContentHashIndex.computeHash(canonicalContent);
-    if (!persistedHash || persistedHash === currentHash) return [currentHash];
-
-    if (persistedHash === computeLegacyContentHash(canonicalContent)) {
-      return [persistedHash, currentHash];
+    if (!persistedHash) return [currentHash];
+    if (
+      persistedHash === currentHash ||
+      persistedHash === computeLegacyContentHash(canonicalContent)
+    ) {
+      return [currentHash];
     }
     return [persistedHash];
   }

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -13,7 +13,11 @@ import {
 } from "node:fs/promises";
 import { appendFileSync, createReadStream, mkdirSync, readFileSync, statSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { normalizeContent, computeContentHash } from "./content-hash.js";
+import {
+  computeContentHash,
+  computeLegacyContentHash,
+  normalizeContent,
+} from "./content-hash.js";
 import { raceAbort } from "./abort-error.js";
 import { checkCorpusReadAbort, type CorpusReadOptions } from "./corpus-read-cancellation.js";
 import { selectArtifactMatches, type ArtifactSearchOptions } from "./artifact-search.js";
@@ -3032,15 +3036,10 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
           }
         };
         collectMatches(await this.collectActiveMemoryPaths());
-        if (found.size < requested.size) {
-          collectMatches(await this.collectColdMemoryPaths());
-        }
+        if (found.size < requested.size) collectMatches(await this.collectColdMemoryPaths());
         const contents = new Map<string, string>();
         for (const memory of await this.readParsedMemoriesFromPaths(matchingPaths, 50)) {
-          contents.set(
-            memory.frontmatter.id,
-            stripCitationForTemplate(memory.content, this.citationTemplate),
-          );
+          contents.set(memory.frontmatter.id, stripCitationForTemplate(stripAttributesSuffix(memory.content), this.citationTemplate));
         }
         return contents;
       },
@@ -3402,9 +3401,10 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
   private corpusRegisteredHash(memory: MemoryFile): string | null {
     const content = stripAttributesSuffix(memory.content);
     const stripped = stripCitationForTemplate(content, this.citationTemplate);
-    const canonicalContent = stripped !== content || !hasCitation(content)
-      ? sanitizeMemoryContent(stripped !== content ? stripped : content).text
-      : null;
+    const canonicalContent =
+      stripped !== content || !hasCitation(content)
+        ? sanitizeMemoryContent(stripped !== content ? stripped : content).text
+        : null;
     const persistedHash = memory.frontmatter.contentHash;
     if (canonicalContent === null) return persistedHash ?? null;
 
@@ -3412,21 +3412,11 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     if (
       !persistedHash ||
       persistedHash === currentHash ||
-      persistedHash === this.legacyCorpusHash(canonicalContent)
+      persistedHash === computeLegacyContentHash(canonicalContent)
     ) {
       return currentHash;
     }
     return persistedHash;
-  }
-
-  /** Compute the pre-Unicode hash used by markerless legacy indexes. */
-  private legacyCorpusHash(content: string): string {
-    const normalized = content
-      .toLowerCase()
-      .replace(/[^a-z0-9\s]/g, " ")
-      .replace(/\s+/g, " ")
-      .trim();
-    return createHash("sha256").update(normalized).digest("hex");
   }
 
   private get questionsDir(): string {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -15,7 +15,7 @@ import { appendFileSync, createReadStream, mkdirSync, readFileSync, statSync } f
 import { createHash } from "node:crypto";
 import {
   computeContentHash,
-  computeLegacyContentHash,
+  isUnambiguousLegacyContentHash,
   normalizeContent,
 } from "./content-hash.js";
 import { raceAbort } from "./abort-error.js";
@@ -3039,7 +3039,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         if (found.size < requested.size) collectMatches(await this.collectColdMemoryPaths());
         const contents = new Map<string, string>();
         for (const memory of await this.readParsedMemoriesFromPaths(matchingPaths, 50)) {
-          contents.set(memory.frontmatter.id, stripCitationForTemplate(stripAttributesSuffix(memory.content), this.citationTemplate));
+          contents.set(memory.frontmatter.id, stripCitationForTemplate(memory.content, this.citationTemplate));
         }
         return contents;
       },
@@ -3412,7 +3412,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     if (
       !persistedHash ||
       persistedHash === currentHash ||
-      persistedHash === computeLegacyContentHash(canonicalContent)
+      isUnambiguousLegacyContentHash(canonicalContent, persistedHash)
     ) {
       return currentHash;
     }
@@ -3809,10 +3809,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     let tombstoneBlocked = false;
     let gateRef: string | undefined;
     let statusBeforeBlock: MemoryFrontmatter["status"];
-    // Closure so the post-persist repair can RE-RUN it when a journal move
-    // changed the final entityRef: a verdict is only valid for the ref it was
-    // computed under, so reset and re-evaluate (parked mappings fall BACK to
-    // the legacy claimant; entity-independent tiers re-block in the lookup).
+    // Re-run after journal moves that change the final entityRef.
     const applyTombstoneGate = async (): Promise<void> => {
       if (tombstoneBlocked) {
         if (fm.entityRef === gateRef) return;
@@ -3821,11 +3818,9 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         delete fm.blockedBy;
         delete fm.tombstoneBlockTier;
       }
-      // Status semantics (thread ObteQ: pending_review candidates included,
-      // terminal statuses respected) live in applyTombstoneResurrectionGate.
       if (category !== "fact" || factHashSourceForTombstone === null) return;
       const statusBefore = fm.status;
-      const match = await this.entityRefRepair.gate(fm, factHashSourceForTombstone, options.structuredAttributes);
+      const match = await this.entityRefRepair.gate(fm, sanitized.text, options.structuredAttributes);
       if (match) {
         gateRef = fm.entityRef;
         statusBeforeBlock = statusBefore;

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -3013,6 +3013,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
   }
 
   private buildTombstoneStore(): TombstoneStore {
+    const sourcePathsPromise = this.memoryReadStore.collectTombstoneMigrationPaths();
     const options: TombstoneStoreOptions = {
       enabled: this.tombstonesConfig.enabled,
       semanticMatch: this.tombstonesConfig.semanticMatch,
@@ -3035,16 +3036,10 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
             found.add(id);
           }
         };
-        collectMatches(await this.collectActiveMemoryPaths());
-        if (found.size < requested.size) collectMatches(await this.collectColdMemoryPaths());
+        collectMatches(await sourcePathsPromise);
         const contents = new Map<string, string>();
         for (const memory of await this.readParsedMemoriesFromPaths(matchingPaths, 50)) {
           contents.set(memory.frontmatter.id, stripCitationForTemplate(memory.content, this.citationTemplate));
-        }
-        for (const memory of contents.size < requested.size ? await this.readArchivedMemories() : []) {
-          const id = memory.frontmatter.id;
-          if (!requested.has(id) || contents.has(id)) continue;
-          contents.set(id, stripCitationForTemplate(memory.content, this.citationTemplate));
         }
         return contents;
       },

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -15,7 +15,7 @@ import { appendFileSync, createReadStream, mkdirSync, readFileSync, statSync } f
 import { createHash } from "node:crypto";
 import {
   computeContentHash,
-  isUnambiguousLegacyContentHash,
+  computeLegacyContentHash,
   normalizeContent,
 } from "./content-hash.js";
 import { raceAbort } from "./abort-error.js";
@@ -3041,6 +3041,11 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         for (const memory of await this.readParsedMemoriesFromPaths(matchingPaths, 50)) {
           contents.set(memory.frontmatter.id, stripCitationForTemplate(memory.content, this.citationTemplate));
         }
+        for (const memory of contents.size < requested.size ? await this.readArchivedMemories() : []) {
+          const id = memory.frontmatter.id;
+          if (!requested.has(id) || contents.has(id)) continue;
+          contents.set(id, stripCitationForTemplate(memory.content, this.citationTemplate));
+        }
         return contents;
       },
     };
@@ -3373,17 +3378,19 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       // citation-strip reconstruction below, hashing the stored persist body
       // (title + steps) exactly as buildProcedurePersistBody registered it.
       if (inferMemoryStatus(memory.frontmatter, memory.path) !== "active") continue;
-      const hash = this.corpusRegisteredHash(memory);
-      if (hash === null) {
+      const hashes = this.corpusRegisteredHashes(memory);
+      if (hashes.length === 0) {
         // Body carries a citation from an unknown/custom template we cannot
         // safely strip — skip rather than register a wrong hash. A
         // false-negative miss beats a wrong entry that would permanently
-        // suppress legitimate duplicate writes (see corpusRegisteredHash).
+        // suppress legitimate duplicate writes (see corpusRegisteredHashes).
         legacyRecovered++;
         continue;
       }
-      factHashIndex.addByHash(hash);
-      if (memory.frontmatter.category === "fact") this.factOnlyHashes.add(hash);
+      for (const hash of hashes) {
+        factHashIndex.addByHash(hash);
+        if (memory.frontmatter.category === "fact") this.factOnlyHashes.add(hash);
+      }
     }
     if (legacyRecovered > 0) {
       log.info(
@@ -3392,13 +3399,10 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     }
   }
   /**
-   * The content hash the corpus rebuild registers for `memory`, or null when
-   * the body has an unknown citation and no persisted hash exists.
-   * Reconstruct from the authoritative body first. Preserve an intentional
-   * `contentHashSource` override when frontmatter differs from both the
-   * current and the legacy pre-Unicode body hash.
+   * Returns persisted identities plus a current body alias when the legacy hash matches.
+   * The current alias prevents upgrade duplicates while retaining the old identity.
    */
-  private corpusRegisteredHash(memory: MemoryFile): string | null {
+  private corpusRegisteredHashes(memory: MemoryFile): string[] {
     const content = stripAttributesSuffix(memory.content);
     const stripped = stripCitationForTemplate(content, this.citationTemplate);
     const canonicalContent =
@@ -3406,17 +3410,15 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         ? sanitizeMemoryContent(stripped !== content ? stripped : content).text
         : null;
     const persistedHash = memory.frontmatter.contentHash;
-    if (canonicalContent === null) return persistedHash ?? null;
+    if (canonicalContent === null) return persistedHash ? [persistedHash] : [];
 
     const currentHash = ContentHashIndex.computeHash(canonicalContent);
-    if (
-      !persistedHash ||
-      persistedHash === currentHash ||
-      isUnambiguousLegacyContentHash(canonicalContent, persistedHash)
-    ) {
-      return currentHash;
+    if (!persistedHash || persistedHash === currentHash) return [currentHash];
+
+    if (persistedHash === computeLegacyContentHash(canonicalContent)) {
+      return [persistedHash, currentHash];
     }
-    return persistedHash;
+    return [persistedHash];
   }
 
   private get questionsDir(): string {
@@ -3997,26 +3999,28 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     for (const memory of existing) {
       if (memory.frontmatter.category !== "fact") continue;
       if (inferMemoryStatus(memory.frontmatter, memory.path) !== "active") continue;
-      if (this.corpusRegisteredHash(memory) === targetHash) return true;
+      if (this.corpusRegisteredHashes(memory).includes(targetHash)) return true;
     }
     return false;
   }
 
-  private factContentHashForRemoval(memory: MemoryFile): string | null {
-    if (memory.frontmatter.category !== "fact") return null;
-    return this.corpusRegisteredHash(memory);
+  private factContentHashesForRemoval(memory: MemoryFile): string[] {
+    if (memory.frontmatter.category !== "fact") return [];
+    return this.corpusRegisteredHashes(memory);
   }
 
   private async addActiveFactContentHash(memory: MemoryFile): Promise<void> {
     if (memory.frontmatter.category !== "fact") return;
     if (inferMemoryStatus(memory.frontmatter, memory.path) !== "active") return;
-    const hash = this.factContentHashForRemoval(memory);
-    if (!hash) return;
+    const hashes = this.factContentHashesForRemoval(memory);
+    if (hashes.length === 0) return;
 
     await this.ensureFactHashIndexAuthoritative();
     const factHashIndex = await this.getFactHashIndex();
-    factHashIndex.addByHash(hash);
-    this.factOnlyHashes.add(hash);
+    for (const hash of hashes) {
+      factHashIndex.addByHash(hash);
+      this.factOnlyHashes.add(hash);
+    }
     // PR #2016 thread SDzOP: flush through the SAME cross-process locked
     // reconcile the write/batch/rebuild paths use, never the unlocked whole-file
     // save() — an unlocked overwrite drops a concurrent extraction's appended
@@ -4054,16 +4058,19 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
   private async syncFactHashIndexAfterRewrite(before: MemoryFile, after: MemoryFile): Promise<void> {
     if (before.frontmatter.category !== "fact" && after.frontmatter.category !== "fact") return;
 
-    const beforeHash = this.factContentHashForRemoval(before);
-    const afterHash = this.factContentHashForRemoval(after);
+    const beforeHashes = this.factContentHashesForRemoval(before);
+    const afterHashes = this.factContentHashesForRemoval(after);
     const beforeStatus = inferMemoryStatus(before.frontmatter, before.path);
     const afterStatus = inferMemoryStatus(after.frontmatter, after.path);
-    if (beforeHash === afterHash && beforeStatus === afterStatus) return;
+    const hashesChanged =
+      beforeHashes.length !== afterHashes.length ||
+      beforeHashes.some((hash, index) => hash !== afterHashes[index]);
+    if (!hashesChanged && beforeStatus === afterStatus) return;
 
-    if (beforeStatus === "active" && beforeHash && (beforeHash !== afterHash || afterStatus !== "active")) {
+    if (beforeStatus === "active" && beforeHashes.length > 0 && (hashesChanged || afterStatus !== "active")) {
       await this.removeFactContentHashesForMemories([before]);
     }
-    if (afterStatus === "active" && afterHash && (beforeHash !== afterHash || beforeStatus !== "active")) {
+    if (afterStatus === "active" && afterHashes.length > 0 && (hashesChanged || beforeStatus !== "active")) {
       await this.addActiveFactContentHash(after);
     }
   }
@@ -4076,11 +4083,10 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         .map((memory) => memory.frontmatter.id)
         .filter((id): id is string => typeof id === "string" && id.length > 0)
     );
-    const removedHashes = new Map<MemoryFile, string>();
+    const removedHashes = new Set<string>();
     for (const memory of memories) {
-      const hash = this.factContentHashForRemoval(memory);
-      if (hash) {
-        removedHashes.set(memory, hash);
+      for (const hash of this.factContentHashesForRemoval(memory)) {
+        removedHashes.add(hash);
       }
     }
     if (removedHashes.size === 0) return;
@@ -4091,13 +4097,12 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       if (memory.frontmatter.category !== "fact") continue;
       if (removedIds.has(memory.frontmatter.id)) continue;
       if (inferMemoryStatus(memory.frontmatter, memory.path) !== "active") continue;
-      const hash = this.factContentHashForRemoval(memory);
-      if (hash) {
+      for (const hash of this.factContentHashesForRemoval(memory)) {
         remainingActiveHashes.add(hash);
       }
     }
 
-    for (const hash of removedHashes.values()) {
+    for (const hash of removedHashes) {
       if (!remainingActiveHashes.has(hash)) {
         factHashIndex.removeByHash(hash);
         this.factOnlyHashes.delete(hash);
@@ -4126,8 +4131,9 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
    */
   removeFactOnlyHashForMemory(memory: MemoryFile): void {
     if (memory.frontmatter.category !== "fact") return;
-    const hash = this.factContentHashForRemoval(memory);
-    if (hash) this.factOnlyHashes.delete(hash);
+    for (const hash of this.factContentHashesForRemoval(memory)) {
+      this.factOnlyHashes.delete(hash);
+    }
   }
 
   async isFactContentHashAuthoritative(): Promise<boolean> {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1061,7 +1061,7 @@ const FACT_HASH_INDEX_REBUILD_RETRY_BASE_MS = 50;
 // the coding surfaces + wearable service). Imported here so internal callers
 // (snapshotBeforeWrite, snapshotForProvenance) resolve, and re-exported to
 // keep the public storage API stable for existing callers (wearables, dist).
-import { assemblePersistedBody, stripAttributesSuffix } from "./structured-attributes.js";
+import { assemblePersistedBody, storedContentIdentityCandidates, stripAttributesSuffix } from "./structured-attributes.js";
 export { stripAttributesSuffix };
 
 // `normalizeAttributePairs` moved to ./structured-attributes.ts (issue #1989
@@ -3013,7 +3013,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
 
   private buildTombstoneStore(): TombstoneStore {
     let sourcePathsPromise: Promise<string[]> | undefined;
-    let sourceContentsByIdPromise: Promise<Map<string, string>> | undefined;
+    let sourceContentsByIdPromise: Promise<Map<string, readonly string[]>> | undefined;
     const options: TombstoneStoreOptions = {
       enabled: this.tombstonesConfig.enabled,
       semanticMatch: this.tombstonesConfig.semanticMatch,
@@ -3027,20 +3027,20 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
         const directPaths = sourcePaths.filter((filePath) =>
           requested.has(path.basename(filePath, ".md"))
         );
-        const contents = new Map<string, string>();
+        const contents = new Map<string, readonly string[]>();
         for (const memory of await this.readParsedMemoriesFromPaths(directPaths, 50)) {
           const id = memory.frontmatter.id;
           if (requested.has(id) && !contents.has(id)) {
-            contents.set(id, stripCitationForTemplate(memory.content, this.citationTemplate));
+            contents.set(id, this.storedContentIdentityCandidates(memory.content));
           }
         }
         if (contents.size === requested.size) return contents;
         sourceContentsByIdPromise ??= (async () => {
-          const allContents = new Map<string, string>();
+          const allContents = new Map<string, readonly string[]>();
           for (const memory of await this.readParsedMemoriesFromPaths(sourcePaths, 50)) {
             const id = memory.frontmatter.id;
             if (!allContents.has(id)) {
-              allContents.set(id, stripCitationForTemplate(memory.content, this.citationTemplate));
+              allContents.set(id, this.storedContentIdentityCandidates(memory.content));
             }
           }
           return allContents;
@@ -3398,25 +3398,26 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       );
     }
   }
+  private storedContentIdentityCandidates(content: string): string[] {
+    return storedContentIdentityCandidates(content, (value) =>
+      hasCitationForTemplate(value, this.citationTemplate) ? stripCitationForTemplate(value, this.citationTemplate) : value
+    );
+  }
+
   /** Returns the current body identity while preserving explicit external identities. */
   private corpusRegisteredHashes(memory: MemoryFile): string[] {
     const persistedHash = memory.frontmatter.contentHash;
-    const content = stripAttributesSuffix(memory.content);
-    const hasKnownCitation = hasCitationForTemplate(content, this.citationTemplate);
-    const stripped = hasKnownCitation
-      ? stripCitationForTemplate(content, this.citationTemplate)
-      : content;
-    if (hasKnownCitation && stripped === content) return persistedHash ? [persistedHash] : [];
-    const canonicalContent = sanitizeMemoryContent(stripped).text;
-    const currentHash = ContentHashIndex.computeHash(canonicalContent);
-    if (!persistedHash) return [currentHash];
-    if (
-      persistedHash === currentHash ||
-      persistedHash === computeLegacyContentHash(canonicalContent)
-    ) {
-      return [currentHash];
-    }
-    return [persistedHash];
+    const candidates = this.storedContentIdentityCandidates(memory.content)
+      .map((content) => sanitizeMemoryContent(content).text);
+    const currentMatch = candidates.find(
+      (content) => ContentHashIndex.computeHash(content) === persistedHash
+    );
+    if (currentMatch) return [ContentHashIndex.computeHash(currentMatch)];
+    if (!persistedHash) return [ContentHashIndex.computeHash(candidates[0] ?? "")];
+    const legacyMatch = [...candidates].reverse().find(
+      (content) => computeLegacyContentHash(content) === persistedHash
+    );
+    return [legacyMatch ? ContentHashIndex.computeHash(legacyMatch) : persistedHash];
   }
 
   private get questionsDir(): string {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -3409,15 +3409,15 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     const persistedHash = memory.frontmatter.contentHash;
     const candidates = this.storedContentIdentityCandidates(memory.content)
       .map((content) => sanitizeMemoryContent(content).text);
-    const currentMatch = candidates.find(
-      (content) => ContentHashIndex.computeHash(content) === persistedHash
-    );
-    if (currentMatch) return [ContentHashIndex.computeHash(currentMatch)];
-    if (!persistedHash) return [ContentHashIndex.computeHash(candidates[0] ?? "")];
-    const legacyMatch = [...candidates].reverse().find(
+    const currentHashes = candidates.map((content) => ContentHashIndex.computeHash(content));
+    if (persistedHash && currentHashes.includes(persistedHash)) return [persistedHash];
+    if (!persistedHash) return [currentHashes[0] ?? ContentHashIndex.computeHash("")];
+    const legacyMatches = candidates.filter(
       (content) => computeLegacyContentHash(content) === persistedHash
     );
-    return [legacyMatch ? ContentHashIndex.computeHash(legacyMatch) : persistedHash];
+    return legacyMatches.length > 0
+      ? [...new Set(legacyMatches.map((content) => ContentHashIndex.computeHash(content)))]
+      : [persistedHash];
   }
 
   private get questionsDir(): string {

--- a/packages/remnic-core/src/storage/content-hash-index.ts
+++ b/packages/remnic-core/src/storage/content-hash-index.ts
@@ -5,15 +5,11 @@
 // part of its public API.
 import { mkdir, stat } from "node:fs/promises";
 import path from "node:path";
+import { computeContentHash, normalizeContent } from "../content-hash.js";
 import { log } from "../logger.js";
+import { SecureStoreLockedError, readMaybeEncryptedFile, writeMaybeEncryptedFile } from "../secure-store/secure-fs.js";
 import { isErrnoCode } from "../utils/errno.js";
 import { withHeldFileLock } from "../utils/serialize-mutations.js";
-import { normalizeContent, computeContentHash } from "../content-hash.js";
-import {
-  SecureStoreLockedError,
-  readMaybeEncryptedFile,
-  writeMaybeEncryptedFile,
-} from "../secure-store/secure-fs.js";
 
 /**
  * Stale threshold (ms) for the per-file advisory lock guarding a fact-hash
@@ -23,6 +19,23 @@ import {
  * without breaking a legitimately in-progress publish.
  */
 const CONTENT_HASH_INDEX_LOCK_STALE_MS = 30_000;
+/** Version marker for the normalized Unicode hash index format. */
+const CONTENT_HASH_INDEX_FORMAT_HEADER = "# remnic-content-hash-index:v2";
+
+function parseHashIndex(raw: string): { versioned: boolean; hashes: Set<string> } {
+  const lines = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines[0] !== CONTENT_HASH_INDEX_FORMAT_HEADER) {
+    return { versioned: false, hashes: new Set() };
+  }
+  return { versioned: true, hashes: new Set(lines.slice(1)) };
+}
+
+function serializeHashIndex(hashes: Set<string>): string {
+  return `${CONTENT_HASH_INDEX_FORMAT_HEADER}\n${[...hashes].join("\n")}\n`;
+}
 
 /**
  * Durable-retry policy for a deferred content-hash reconcile save whose
@@ -70,7 +83,7 @@ export interface ContentHashIndexLockOptions {
 export class FactHashIndexNotAuthoritativeError extends Error {
   constructor(stateDir: string) {
     super(
-      `fact-hash index is not authoritative: the cross-process rebuild lock for ${stateDir} could not be acquired within the bounded retry budget`,
+      `fact-hash index is not authoritative: the cross-process rebuild lock for ${stateDir} could not be acquired within the bounded retry budget`
     );
     this.name = "FactHashIndexNotAuthoritativeError";
   }
@@ -98,6 +111,8 @@ export interface ContentHashPathEntry {
 export class ContentHashIndex {
   private hashes: Set<string> = new Set();
   private dirty = false;
+  /** True when load() found the pre-Unicode, markerless on-disk format. */
+  private formatMigrationRequired = false;
   /**
    * Hashes explicitly removed since the last successful save (issue #1909 review
    * round 8 thread 3). Tracked separately so `saveMergingWithDisk` can be
@@ -140,7 +155,6 @@ export class ContentHashIndex {
    * without an O(file-size) read on the hot path.
    */
   private lastSyncedFingerprint: DiskFingerprint | null = null;
-
   constructor(
     stateDir: string,
     secureStoreKeyProvider: () => Buffer | null = () => null,
@@ -154,16 +168,24 @@ export class ContentHashIndex {
     this.memoryDir = memoryDir;
     this.lockOptions = lockOptions;
   }
+  /** Whether a caller with an authoritative corpus must rebuild this legacy index. */
+  get requiresFormatMigration(): boolean {
+    return this.formatMigrationRequired;
+  }
 
   /** Load existing hashes from disk. Safe to call multiple times. */
   async load(): Promise<void> {
     try {
       const raw = await readMaybeEncryptedFile(this.filePath, this.secureStoreKeyProvider(), this.memoryDir);
-      for (const line of raw.split("\n")) {
-        const trimmed = line.trim();
-        if (trimmed.length > 0) {
-          this.hashes.add(trimmed);
-        }
+      const parsed = parseHashIndex(raw);
+      this.formatMigrationRequired = !parsed.versioned;
+      if (!parsed.versioned) {
+        // Hashes from the pre-NFC format are unsafe after normalization changes.
+        // Ignore them until an authoritative corpus rebuild publishes v2.
+        this.hashes.clear();
+        log.warn(`content-hash index: ignored legacy unversioned index at ${this.filePath}`);
+      } else {
+        for (const hash of parsed.hashes) this.hashes.add(hash);
       }
       log.debug(`content-hash index: loaded ${this.hashes.size} hashes`);
     } catch (err) {
@@ -292,14 +314,9 @@ export class ContentHashIndex {
     // what we published; late deltas stay pending. Mirrors saveMergingWithDisk.
     const publishedAdded = new Set<string>(this.added);
     const publishedRemoved = new Set<string>(this.removed);
-    const serialized = [...this.hashes].join("\n") + "\n";
-    await writeMaybeEncryptedFile(
-      this.filePath,
-      serialized,
-      this.secureStoreWriteKeyProvider(),
-      {},
-      this.memoryDir
-    );
+    const serialized = serializeHashIndex(this.hashes);
+    await writeMaybeEncryptedFile(this.filePath, serialized, this.secureStoreWriteKeyProvider(), {}, this.memoryDir);
+    this.formatMigrationRequired = false;
     // Consume ONLY the deltas this overwrite published; anything that arrived
     // during the awaits above remains pending for the next save.
     for (const h of publishedAdded) this.added.delete(h);
@@ -360,15 +377,16 @@ export class ContentHashIndex {
       const publishedRemoved = new Set<string>(this.removed);
       const merged = new Set<string>(publishedAdded);
       try {
-        const raw = await readMaybeEncryptedFile(
-          this.filePath,
-          this.secureStoreKeyProvider(),
-          this.memoryDir
-        );
-        for (const line of raw.split("\n")) {
-          const trimmed = line.trim();
-          // Keep prior/concurrent on-disk hashes EXCEPT the ones we removed.
-          if (trimmed.length > 0 && !publishedRemoved.has(trimmed)) merged.add(trimmed);
+        const raw = await readMaybeEncryptedFile(this.filePath, this.secureStoreKeyProvider(), this.memoryDir);
+        const parsed = parseHashIndex(raw);
+        if (parsed.versioned) {
+          for (const hash of parsed.hashes) {
+            // Keep prior/concurrent on-disk hashes EXCEPT the ones we removed.
+            if (!publishedRemoved.has(hash)) merged.add(hash);
+          }
+        } else {
+          // Do not carry hashes from the pre-NFC format into a v2 write.
+          log.warn(`content-hash index: discarded legacy unversioned entries from ${this.filePath}`);
         }
       } catch (err) {
         if (err instanceof SecureStoreLockedError) throw err;
@@ -378,11 +396,12 @@ export class ContentHashIndex {
       await mkdir(path.dirname(this.filePath), { recursive: true });
       await writeMaybeEncryptedFile(
         this.filePath,
-        [...merged].join("\n") + "\n",
+        serializeHashIndex(merged),
         this.secureStoreWriteKeyProvider(),
         {},
         this.memoryDir
       );
+      this.formatMigrationRequired = false;
       // Consume ONLY the deltas we just published; deltas that arrived during
       // the awaits above remain pending.
       for (const h of publishedAdded) this.added.delete(h);
@@ -415,7 +434,7 @@ export class ContentHashIndex {
           // the retry keeps re-attempting the locked publish until the addition
           // lands on disk.
           log.warn(
-            `content-hash index: lock not acquired for ${this.filePath}; deferring reconcile save (dirty retained, scheduling durable retry)`,
+            `content-hash index: lock not acquired for ${this.filePath}; deferring reconcile save (dirty retained, scheduling durable retry)`
           );
           this.scheduleReconcileRetry();
           return;
@@ -431,7 +450,7 @@ export class ContentHashIndex {
           // Published cleanly: any pending deferred retry is now satisfied.
           this.cancelReconcileRetry();
         }
-      },
+      }
     );
     log.debug(`content-hash index: reconcile-saved ${this.hashes.size} hashes`);
   }
@@ -479,7 +498,7 @@ export class ContentHashIndex {
           // so overwriting now could clobber its addition. Leave the index as-is
           // and let the caller retry the authoritative rebuild on next use.
           log.warn(
-            `content-hash index: lock not acquired for ${this.filePath}; deferring authoritative rebuild (index left non-authoritative, retried on next use)`,
+            `content-hash index: lock not acquired for ${this.filePath}; deferring authoritative rebuild (index left non-authoritative, retried on next use)`
           );
           return;
         }
@@ -488,7 +507,7 @@ export class ContentHashIndex {
         // is a full overwrite that supersedes any pending add/remove deltas.
         await this.save();
         published = true;
-      },
+      }
     );
     return published;
   }
@@ -572,7 +591,7 @@ export class ContentHashIndex {
     if (this.reconcileRetryAttempts >= maxAttempts) {
       log.warn(
         `content-hash index: exhausted ${maxAttempts} deferred reconcile-save retries for ${this.filePath}; ` +
-          `${this.added.size} addition(s) remain dirty in-memory (a process restart rebuilds the index from the durable corpus)`,
+          `${this.added.size} addition(s) remain dirty in-memory (a process restart rebuilds the index from the durable corpus)`
       );
       this.reconcileRetryAttempts = 0;
       this.settleReconcileRetry();
@@ -681,10 +700,7 @@ export class ContentHashIndex {
    * one hash per line and `has(content)` keeps its existing raw-content contract.
    * Reconciliation supplies short-lived manifest rows where hash and path coexist.
    */
-  static resolvePathByHash(
-    hash: string,
-    entries: Iterable<ContentHashPathEntry>,
-  ): string | undefined {
+  static resolvePathByHash(hash: string, entries: Iterable<ContentHashPathEntry>): string | undefined {
     const canonicalHash = hash.toLowerCase();
     if (!/^[a-f0-9]{64}$/.test(canonicalHash)) return undefined;
     let canonicalPath: string | undefined;

--- a/packages/remnic-core/src/storage/entity-ref-repair.ts
+++ b/packages/remnic-core/src/storage/entity-ref-repair.ts
@@ -11,7 +11,6 @@
  * leave disk in the state peers/caches were told about.
  */
 import { unlink } from "node:fs/promises";
-import { computeLegacyContentHash, normalizeLegacyContent } from "../content-hash.js";
 import { log } from "../logger.js";
 import type { MemoryFile, MemoryFrontmatter } from "../types.js";
 import * as entityRefs from "./entity-canonical-id-references.js";
@@ -61,7 +60,7 @@ export class EntityRefRepair {
    */
   async gate(
     fm: MemoryFrontmatter,
-    hashSource: string,
+    canonicalBody: string,
     structuredAttributes?: Record<string, string>,
   ): Promise<TombstoneMatch | null> {
     if (!this.deps.tombstonesEnabled()) return null;
@@ -74,9 +73,7 @@ export class EntityRefRepair {
           ? supersessionKeysForFact({ entityRef: fm.entityRef, structuredAttributes })
           : [];
       const match = applyTombstoneResurrectionGate(store, fm, {
-        normalizedText: ContentHashIndex.normalizeContent(hashSource),
-        legacyContentHash: computeLegacyContentHash(hashSource),
-        legacyNormalizedText: normalizeLegacyContent(hashSource),
+        normalizedText: ContentHashIndex.normalizeContent(canonicalBody),
         supersessionKeys,
         namespace: this.deps.tombstonesNamespace(),
       });
@@ -112,7 +109,7 @@ export class EntityRefRepair {
         frontmatter: fm,
         rewrite: async () => {
           if (opts.regateFact && fm.category === "fact") {
-            await this.gate(fm, body, undefined);
+            await this.gate(fm, body, fm.structuredAttributes);
           }
           // Blocked-capture surface: a repair rewrite of a tombstone-blocked
           // record must keep TombstoneBlockedCaptureIndex consistent.

--- a/packages/remnic-core/src/storage/entity-ref-repair.ts
+++ b/packages/remnic-core/src/storage/entity-ref-repair.ts
@@ -11,6 +11,7 @@
  * leave disk in the state peers/caches were told about.
  */
 import { unlink } from "node:fs/promises";
+import { computeLegacyContentHash, normalizeLegacyContent } from "../content-hash.js";
 import { log } from "../logger.js";
 import type { MemoryFile, MemoryFrontmatter } from "../types.js";
 import * as entityRefs from "./entity-canonical-id-references.js";
@@ -74,6 +75,8 @@ export class EntityRefRepair {
           : [];
       const match = applyTombstoneResurrectionGate(store, fm, {
         normalizedText: ContentHashIndex.normalizeContent(hashSource),
+        legacyContentHash: computeLegacyContentHash(hashSource),
+        legacyNormalizedText: normalizeLegacyContent(hashSource),
         supersessionKeys,
         namespace: this.deps.tombstonesNamespace(),
       });

--- a/packages/remnic-core/src/storage/memory-read-store.ts
+++ b/packages/remnic-core/src/storage/memory-read-store.ts
@@ -378,6 +378,15 @@ export class MemoryReadStore {
     );
   }
 
+  async collectTombstoneMigrationPaths(): Promise<string[]> {
+    const tiers = await Promise.all([
+      this.collectActiveMemoryPaths(),
+      this.collectColdMemoryPaths(),
+      this.collectContainedMarkdownPaths([path.join(this.deps.baseDir, "archive")]),
+    ]);
+    return tiers.flat();
+  }
+
   async readMemoriesWindow(options: {
     maxMemories?: number;
     batchSize?: number;

--- a/packages/remnic-core/src/storage/tombstone-blocked-capture-index.ts
+++ b/packages/remnic-core/src/storage/tombstone-blocked-capture-index.ts
@@ -7,15 +7,15 @@ import { log } from "../logger.js";
 import type { MemoryFile, MemoryFrontmatter } from "../types.js";
 import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
 import { isErrnoCode } from "../utils/errno.js";
-import { withHeldFileLock } from "../utils/serialize-mutations.js";
+import type { withHeldFileLock } from "../utils/serialize-mutations.js";
 import {
   CONTENT_HASH_INDEX_RETRY_MAX_DELAY_MS,
   ContentHashIndex,
   type ContentHashIndexLockOptions,
 } from "./content-hash-index.js";
 import {
-  buildExplicitCaptureDedupKey,
   TombstoneBlockedCaptureWriteLock,
+  buildExplicitCaptureDedupKey,
 } from "./tombstone-blocked-capture-mutation.js";
 import type { OfflineSyncMemoryParser } from "./tombstone-blocked-capture-sync.js";
 export {
@@ -38,7 +38,6 @@ const MARKER_PROCESS_START_TOLERANCE_MS = 2_000;
 const DOTNET_UNIX_EPOCH_TICKS = 621_355_968_000_000_000;
 const MARKER_PROCESS_STARTED_AT_MS = Date.now() - process.uptime() * 1000;
 
-
 type RebuildMarker = {
   path: string;
   committed: boolean;
@@ -48,7 +47,6 @@ type RebuildMarker = {
   processStartedAtMs?: number;
   malformed?: boolean;
 };
-
 
 export type TombstoneBlockedCaptureIndexOptions = {
   readonly stateDir: string;
@@ -326,7 +324,7 @@ export class TombstoneBlockedCaptureIndex {
         await index.load();
         const rebuildMarkers = await this.getRebuildMarkers();
         const clearableRebuildMarkers = await this.getClearableRebuildMarkerPaths(rebuildMarkers);
-        let persisted = true;
+        let persisted = !index.requiresFormatMigration;
         try {
           await stat(this.indexPath());
           if (rebuildMarkers.length > 0) persisted = false;
@@ -505,10 +503,7 @@ export class TombstoneBlockedCaptureIndex {
     if (rebuildMarker) await this.markRebuildCommitted(rebuildMarker);
     const rebuilt = await this.rebuild(await this.getIndex());
     if (rebuilt) {
-      await this.clearRebuildRequired([
-        ...clearableExistingMarkers,
-        marker,
-      ]);
+      await this.clearRebuildRequired([...clearableExistingMarkers, marker]);
     }
     await this.setAuthoritative(rebuilt);
   }

--- a/packages/remnic-core/src/structured-attributes.ts
+++ b/packages/remnic-core/src/structured-attributes.ts
@@ -39,6 +39,17 @@ export function stripAttributesSuffix(content: string): string {
   if (inner.includes("]") || inner.includes("\n")) return content.trim();
   return trimmed.slice(0, markerIndex).trim();
 }
+
+/** Return stored-body identity forms, from raw semantic content to full body. */
+export function storedContentIdentityCandidates(
+  content: string,
+  stripCitation: (value: string) => string,
+): string[] {
+  const fullBody = content.trim();
+  const bodyWithoutAttributes = stripAttributesSuffix(fullBody);
+  const rawBody = stripCitation(bodyWithoutAttributes);
+  return [...new Set([rawBody, bodyWithoutAttributes, fullBody])];
+}
 // ---------------------------------------------------------------------------
 // Persisted-body assembly (issue #1989 PR2)
 // ---------------------------------------------------------------------------

--- a/tests/non-resurrection.test.ts
+++ b/tests/non-resurrection.test.ts
@@ -406,7 +406,7 @@ test("#1579 doctor visibility: getTombstoneStats reports the active count", asyn
   }
 });
 
-test("legacy migration preserves structured attributes in the retired content identity", async () => {
+test("legacy migration recovers raw source identity beneath structured attributes", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-tombstone-attributes-"));
   const content = "利用者は紅茶を好む。";
   const attributes = { region: "東京" };
@@ -416,6 +416,7 @@ test("legacy migration preserves structured attributes in the retired content id
     const { id: sourceMemoryId } = await seed.writeMemory("fact", content, {
       source: "test",
       structuredAttributes: attributes,
+      contentHashSource: content,
     });
     const retired = await readBack(seed, sourceMemoryId);
     assert.match(retired.content, /\[Attributes:/);
@@ -428,8 +429,8 @@ test("legacy migration preserves structured attributes in the retired content id
         reason: "supersession",
         createdBy: "supersession",
         sourceMemoryId,
-        contentHash: computeLegacyContentHash(retired.content),
-        normalizedText: normalizeLegacyContent(retired.content),
+        contentHash: computeLegacyContentHash(content),
+        normalizedText: normalizeLegacyContent(content),
         namespace: NAMESPACE,
         createdAt: "2026-08-11T00:00:00.000Z",
       })}\n`,
@@ -441,6 +442,7 @@ test("legacy migration preserves structured attributes in the retired content id
     const result = await restarted.writeMemory("fact", content, {
       source: "extraction",
       structuredAttributes: attributes,
+      contentHashSource: content,
     });
     assert.equal(result.tombstoneBlocked, true);
     assertBlocked(await readBack(restarted, result.id), "exact");

--- a/tests/non-resurrection.test.ts
+++ b/tests/non-resurrection.test.ts
@@ -467,7 +467,7 @@ test("legacy migration resolves retired source content from archive storage", as
     const archiveDir = path.join(dir, "archive", "facts");
     await mkdir(archiveDir, { recursive: true });
     await writeFile(
-      path.join(archiveDir, `${sourceMemoryId}.md`),
+      path.join(archiveDir, "retired-record.md"),
       [
         "---",
         `id: ${sourceMemoryId}`,

--- a/tests/non-resurrection.test.ts
+++ b/tests/non-resurrection.test.ts
@@ -456,6 +456,11 @@ test("legacy migration resolves retired source content from archive storage", as
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-tombstone-archive-source-"));
   const content = "The user prefers café.";
   const sourceMemoryId = "fact-archived-source";
+  class ArchiveProbeStorage extends StorageManager {
+    override async readArchivedMemories(): Promise<never> {
+      throw new Error("migration must not parse the complete archive");
+    }
+  }
   try {
     const seed = new StorageManager(dir);
     await seed.ensureDirectories();
@@ -490,7 +495,7 @@ test("legacy migration resolves retired source content from archive storage", as
       "utf8",
     );
 
-    const restarted = new StorageManager(dir);
+    const restarted = new ArchiveProbeStorage(dir);
     enableTombstones(restarted);
     const result = await restarted.writeMemory("fact", content, { source: "extraction" });
 

--- a/tests/non-resurrection.test.ts
+++ b/tests/non-resurrection.test.ts
@@ -20,9 +20,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { StorageManager } from "../src/storage.ts";
 import { computeSupersessionKey } from "../packages/remnic-core/src/temporal-supersession.ts";
+import { computeLegacyContentHash, normalizeLegacyContent } from "../packages/remnic-core/src/content-hash.ts";
 
 const NAMESPACE = "test";
 
@@ -400,6 +401,52 @@ test("#1579 doctor visibility: getTombstoneStats reports the active count", asyn
     assert.equal(stats!.count, 2);
     assert.equal(stats!.revoked, 0);
     assert.ok(stats!.loaded);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("legacy migration preserves structured attributes in the retired content identity", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-tombstone-attributes-"));
+  const content = "利用者は紅茶を好む。";
+  const attributes = { region: "東京" };
+  try {
+    const seed = new StorageManager(dir);
+    await seed.ensureDirectories();
+    const { id: sourceMemoryId } = await seed.writeMemory("fact", content, {
+      source: "test",
+      structuredAttributes: attributes,
+    });
+    const retired = await readBack(seed, sourceMemoryId);
+    assert.match(retired.content, /\[Attributes:/);
+
+    await writeFile(
+      path.join(dir, "state", "tombstones.jsonl"),
+      `${JSON.stringify({
+        id: "tomb-legacy-attributes",
+        kind: "tombstone",
+        reason: "supersession",
+        createdBy: "supersession",
+        sourceMemoryId,
+        contentHash: computeLegacyContentHash(retired.content),
+        normalizedText: normalizeLegacyContent(retired.content),
+        namespace: NAMESPACE,
+        createdAt: "2026-08-11T00:00:00.000Z",
+      })}\n`,
+      "utf8",
+    );
+
+    const restarted = new StorageManager(dir);
+    enableTombstones(restarted);
+    const result = await restarted.writeMemory("fact", content, {
+      source: "extraction",
+      structuredAttributes: attributes,
+    });
+    assert.equal(result.tombstoneBlocked, true);
+    assertBlocked(await readBack(restarted, result.id), "exact");
+
+    const migrated = await readFile(path.join(dir, "state", "tombstones.jsonl"), "utf8");
+    assert.match(migrated, /"normalizerVersion":2/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/non-resurrection.test.ts
+++ b/tests/non-resurrection.test.ts
@@ -20,7 +20,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { StorageManager } from "../src/storage.ts";
 import { computeSupersessionKey } from "../packages/remnic-core/src/temporal-supersession.ts";
 import { computeLegacyContentHash, normalizeLegacyContent } from "../packages/remnic-core/src/content-hash.ts";
@@ -447,6 +447,55 @@ test("legacy migration preserves structured attributes in the retired content id
 
     const migrated = await readFile(path.join(dir, "state", "tombstones.jsonl"), "utf8");
     assert.match(migrated, /"normalizerVersion":2/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("legacy migration resolves retired source content from archive storage", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-tombstone-archive-source-"));
+  const content = "The user prefers café.";
+  const sourceMemoryId = "fact-archived-source";
+  try {
+    const seed = new StorageManager(dir);
+    await seed.ensureDirectories();
+    const archiveDir = path.join(dir, "archive", "facts");
+    await mkdir(archiveDir, { recursive: true });
+    await writeFile(
+      path.join(archiveDir, `${sourceMemoryId}.md`),
+      [
+        "---",
+        `id: ${sourceMemoryId}`,
+        "category: fact",
+        "status: archived",
+        "---",
+        "",
+        content,
+      ].join("\n"),
+      "utf8",
+    );
+    await writeFile(
+      path.join(dir, "state", "tombstones.jsonl"),
+      `${JSON.stringify({
+        id: "tomb-archived-source",
+        kind: "tombstone",
+        reason: "correction",
+        createdBy: "user_correction",
+        sourceMemoryId,
+        contentHash: computeLegacyContentHash(content),
+        normalizedText: normalizeLegacyContent(content),
+        namespace: NAMESPACE,
+        createdAt: "2026-08-11T00:00:00.000Z",
+      })}\n`,
+      "utf8",
+    );
+
+    const restarted = new StorageManager(dir);
+    enableTombstones(restarted);
+    const result = await restarted.writeMemory("fact", content, { source: "extraction" });
+
+    assert.equal(result.tombstoneBlocked, true);
+    assertBlocked(await readBack(restarted, result.id), "exact");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/storage-fact-hash-index.test.ts
+++ b/tests/storage-fact-hash-index.test.ts
@@ -8,6 +8,7 @@ import { ContentHashIndex, StorageManager } from "../src/storage.ts";
 import { clearMemoryCache } from "../src/memory-cache.ts";
 import { sanitizeMemoryContent } from "../src/sanitize.ts";
 import { attachCitation } from "../src/source-attribution.ts";
+import { computeLegacyContentHash } from "../packages/remnic-core/src/content-hash.ts";
 
 test("legacy hash-index entries cannot suppress writes after Unicode normalization migration", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-migration-"));
@@ -243,22 +244,19 @@ test("rebuild preserves an explicit contentHashSource override", async () => {
   }
 });
 
-test("rebuild preserves an ambiguous pure-CJK contentHashSource instead of claiming the body hash", async () => {
-  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-cjk-override-rebuild-"));
-  const body = "保存された本文は紅茶についてです。";
-  const override = "外部の識別子は珈琲についてです。";
-  const legacyBody = body.toLowerCase().replace(/[^a-z0-9\s]/g, " ").replace(/\s+/g, " ").trim();
-  const legacyOverride = override.toLowerCase().replace(/[^a-z0-9\s]/g, " ").replace(/\s+/g, " ").trim();
-  const legacyHash = createHash("sha256").update(legacyOverride).digest("hex");
-  const bodyHash = ContentHashIndex.computeHash(body);
+test("rebuild adds and removes the current alias for a mixed-Unicode legacy fact", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-mixed-unicode-"));
+  const body = "The user prefers café.";
+  const legacyHash = computeLegacyContentHash(body);
+  const currentHash = ContentHashIndex.computeHash(body);
   try {
     const factsDir = path.join(dir, "facts", "2026-08-11");
     await mkdir(factsDir, { recursive: true });
     await writeFile(
-      path.join(factsDir, "ambiguous-override.md"),
+      path.join(factsDir, "legacy-cafe.md"),
       [
         "---",
-        "id: ambiguous-override",
+        "id: legacy-cafe",
         "category: fact",
         "created: 2026-08-11T00:00:00.000Z",
         "updated: 2026-08-11T00:00:00.000Z",
@@ -271,14 +269,52 @@ test("rebuild preserves an ambiguous pure-CJK contentHashSource instead of claim
       "utf8",
     );
 
-    assert.equal(legacyBody, legacyOverride);
-    assert.equal(legacyBody, "");
-
+    assert.notEqual(legacyHash, currentHash);
     const storage = new StorageManager(dir);
-    assert.equal(await storage.hasFactContentHash(body), false);
+    assert.equal(await storage.hasFactContentHash(body), true);
     const rebuilt = await readFile(path.join(dir, "state", "fact-hashes.txt"), "utf8");
     assert.match(rebuilt, new RegExp(`^${legacyHash}$`, "mu"));
-    assert.doesNotMatch(rebuilt, new RegExp(`^${bodyHash}$`, "mu"));
+    assert.match(rebuilt, new RegExp(`^${currentHash}$`, "mu"));
+
+    const memory = (await storage.readAllMemories()).find((entry) => entry.frontmatter.id === "legacy-cafe");
+    assert.ok(memory);
+    await storage.removeFactContentHashesForMemories([memory]);
+    assert.equal(await storage.hasFactContentHash(body), false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("rebuild adds the current body alias for an ambiguous pure-CJK legacy hash", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-cjk-rebuild-"));
+  const body = "保存された本文は紅茶についてです。";
+  const legacyHash = computeLegacyContentHash(body);
+  const bodyHash = ContentHashIndex.computeHash(body);
+  try {
+    const factsDir = path.join(dir, "facts", "2026-08-11");
+    await mkdir(factsDir, { recursive: true });
+    await writeFile(
+      path.join(factsDir, "legacy-cjk.md"),
+      [
+        "---",
+        "id: legacy-cjk",
+        "category: fact",
+        "created: 2026-08-11T00:00:00.000Z",
+        "updated: 2026-08-11T00:00:00.000Z",
+        `contentHash: ${legacyHash}`,
+        "---",
+        "",
+        body,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const storage = new StorageManager(dir);
+    assert.equal(await storage.hasFactContentHash(body), true);
+    const rebuilt = await readFile(path.join(dir, "state", "fact-hashes.txt"), "utf8");
+    assert.match(rebuilt, new RegExp(`^${legacyHash}$`, "mu"));
+    assert.match(rebuilt, new RegExp(`^${bodyHash}$`, "mu"));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/storage-fact-hash-index.test.ts
+++ b/tests/storage-fact-hash-index.test.ts
@@ -329,6 +329,42 @@ test("rebuild replaces an ambiguous pure-CJK legacy hash with the current body h
 });
 
 
+test("rebuild upgrades a legacy hash that includes structured attributes", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-attribute-rebuild-"));
+  const body = "The user prefers café.";
+  const storedBody = `${body}\n[Attributes: topic: coffee]`;
+  const legacyHash = computeLegacyContentHash(storedBody);
+  const currentHash = ContentHashIndex.computeHash(storedBody);
+  try {
+    const factsDir = path.join(dir, "facts", "2026-08-11");
+    await mkdir(factsDir, { recursive: true });
+    await writeFile(
+      path.join(factsDir, "legacy-attributes.md"),
+      [
+        "---",
+        "id: legacy-attributes",
+        "category: fact",
+        "created: 2026-08-11T00:00:00.000Z",
+        "updated: 2026-08-11T00:00:00.000Z",
+        `contentHash: ${legacyHash}`,
+        "---",
+        "",
+        storedBody,
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const storage = new StorageManager(dir);
+    assert.equal(await storage.hasFactContentHash(storedBody), true);
+    const rebuilt = await readFile(path.join(dir, "state", "fact-hashes.txt"), "utf8");
+    assert.doesNotMatch(rebuilt, new RegExp(`^${legacyHash}$`, "mu"));
+    assert.match(rebuilt, new RegExp(`^${currentHash}$`, "mu"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("rebuild from disk: fact written without contentHashSource uses body hash via frontmatter.contentHash", async () => {
   // NOTE: StorageManager.writeMemory always sets contentHash in frontmatter
   // (using the body as the hash source when no contentHashSource is given).

--- a/tests/storage-fact-hash-index.test.ts
+++ b/tests/storage-fact-hash-index.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { mkdtemp, mkdir, writeFile, rm, readFile, unlink } from "node:fs/promises";
 import { ContentHashIndex, StorageManager } from "../src/storage.ts";
 import { clearMemoryCache } from "../src/memory-cache.ts";
@@ -217,6 +218,82 @@ test("rebuild from disk: fact with frontmatter.contentHash is found via rawBody 
       false,
       "citedBody should NOT be found after rebuild",
     );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("rebuild preserves an explicit contentHashSource override", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-override-rebuild-"));
+  const body = "The stored body has a separate external identity.";
+  const override = "External identity for this fact.";
+  try {
+    const storage = new StorageManager(dir);
+    await storage.writeMemory("fact", body, {
+      source: "test",
+      contentHashSource: override,
+    });
+
+    await unlink(path.join(dir, "state", "fact-hashes.txt")).catch(() => {});
+    const restarted = new StorageManager(dir);
+    assert.equal(await restarted.hasFactContentHash(override), true);
+    assert.equal(await restarted.hasFactContentHash(body), false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("restart migration republishes the current hash for a Unicode fact", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-unicode-restart-"));
+  const unicodeFact = "利用者は紅茶を好む。";
+  const legacyNormalized = unicodeFact
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const staleFrontmatterHash = createHash("sha256").update(legacyNormalized).digest("hex");
+  const currentHash = ContentHashIndex.computeHash(unicodeFact);
+
+  try {
+    const factsDir = path.join(dir, "facts", "2026-08-11");
+    await mkdir(factsDir, { recursive: true });
+    await writeFile(
+      path.join(factsDir, "unicode-legacy.md"),
+      [
+        "---",
+        "id: unicode-legacy",
+        "category: fact",
+        "created: 2026-08-11T00:00:00.000Z",
+        "updated: 2026-08-11T00:00:00.000Z",
+        `contentHash: ${staleFrontmatterHash}`,
+        "---",
+        "",
+        unicodeFact,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const stateDir = path.join(dir, "state");
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(path.join(stateDir, "fact-hashes.txt"), `${staleFrontmatterHash}\n`, "utf8");
+
+    const restarted = new StorageManager(dir);
+    assert.equal(await restarted.hasFactContentHash(unicodeFact), true);
+
+    const republished = await readFile(path.join(stateDir, "fact-hashes.txt"), "utf8");
+    assert.notEqual(currentHash, staleFrontmatterHash);
+    assert.match(republished, /^# remnic-content-hash-index:v2\n/u);
+    assert.match(republished, new RegExp(`^${currentHash}$`, "m"));
+    assert.doesNotMatch(republished, new RegExp(`^${staleFrontmatterHash}$`, "m"));
+    const secondRestart = new StorageManager(dir);
+    assert.equal(
+      await secondRestart.hasFactContentHash(unicodeFact),
+      true,
+      "the current Unicode hash must survive a second restart",
+    );
+    const republishedAgain = await readFile(path.join(stateDir, "fact-hashes.txt"), "utf8");
+    assert.match(republishedAgain, new RegExp(`^${currentHash}$`, "m"));
+    assert.doesNotMatch(republishedAgain, new RegExp(`^${staleFrontmatterHash}$`, "m"));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/storage-fact-hash-index.test.ts
+++ b/tests/storage-fact-hash-index.test.ts
@@ -8,6 +8,68 @@ import { clearMemoryCache } from "../src/memory-cache.ts";
 import { sanitizeMemoryContent } from "../src/sanitize.ts";
 import { attachCitation } from "../src/source-attribution.ts";
 
+test("legacy hash-index entries cannot suppress writes after Unicode normalization migration", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-migration-"));
+  const stateDir = path.join(dir, "state");
+  const content = "利用者は紅茶を好む。";
+
+  try {
+    await mkdir(stateDir, { recursive: true });
+    // Seed a pre-versioned file with a hash that matches the new content.
+    // A legacy entry is not authoritative after the normalization change.
+    await writeFile(path.join(stateDir, "fact-hashes.txt"), `${ContentHashIndex.computeHash(content)}\n`, "utf8");
+
+    const index = new ContentHashIndex(stateDir);
+    await index.load();
+    assert.equal(index.has(content), false);
+
+    index.add(content);
+    await index.saveMergingWithDisk();
+
+    const migrated = new ContentHashIndex(stateDir);
+    await migrated.load();
+    assert.equal(migrated.has(content), true);
+    assert.match(await readFile(path.join(stateDir, "fact-hashes.txt"), "utf8"), /^# remnic-content-hash-index:v2\n/u);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("legacy tombstone-blocked hash indexes rebuild before answering authoritatively", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-tombstone-hash-migration-"));
+  const content = "利用者はこの記憶を再取得しない。";
+  const sourceConnector = "openclaw";
+
+  try {
+    const storage = new StorageManager(dir);
+    const { id } = await storage.writeMemory("fact", content, {
+      source: "explicit-inline-review",
+      sourceConnector,
+      status: "pending_review",
+    });
+    const pending = (await storage.readAllMemories()).find((memory) => memory.frontmatter.id === id);
+    assert.ok(pending);
+    await storage.writeMemoryFrontmatter(pending, {
+      status: "pending_review",
+      blockedBy: "legacy-tombstone",
+      tombstoneBlockTier: "exact",
+    });
+    assert.equal((await storage.checkTombstoneBlockedExplicitCapture(content, "fact", sourceConnector)).has, true);
+
+    const indexPath = path.join(dir, "state", "tombstone-blocked-capture", "fact-hashes.txt");
+    const versioned = await readFile(indexPath, "utf8");
+    await writeFile(indexPath, versioned.split("\n").slice(1).join("\n"), "utf8");
+    clearMemoryCache(dir);
+
+    const restarted = new StorageManager(dir);
+    const result = await restarted.checkTombstoneBlockedExplicitCapture(content, "fact", sourceConnector);
+    assert.deepEqual(result, { has: true, authoritative: true });
+    assert.match(await readFile(indexPath, "utf8"), /^# remnic-content-hash-index:v2\n/u);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("concurrent fact hash lookups wait for a single shared index load", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "engram-fact-hash-"));
   const content = "User prefers pourover coffee.";

--- a/tests/storage-fact-hash-index.test.ts
+++ b/tests/storage-fact-hash-index.test.ts
@@ -244,9 +244,10 @@ test("rebuild preserves an explicit contentHashSource override", async () => {
   }
 });
 
-test("rebuild adds and removes the current alias for a mixed-Unicode legacy fact", async () => {
+test("rebuild replaces the legacy hash for a mixed-Unicode fact", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-mixed-unicode-"));
   const body = "The user prefers café.";
+  const asciiCollision = "The user prefers caf.";
   const legacyHash = computeLegacyContentHash(body);
   const currentHash = ContentHashIndex.computeHash(body);
   try {
@@ -269,23 +270,30 @@ test("rebuild adds and removes the current alias for a mixed-Unicode legacy fact
       "utf8",
     );
 
-    assert.notEqual(legacyHash, currentHash);
+    assert.equal(legacyHash, ContentHashIndex.computeHash(asciiCollision));
     const storage = new StorageManager(dir);
     assert.equal(await storage.hasFactContentHash(body), true);
+    assert.equal(await storage.hasFactContentHash(asciiCollision), false);
     const rebuilt = await readFile(path.join(dir, "state", "fact-hashes.txt"), "utf8");
-    assert.match(rebuilt, new RegExp(`^${legacyHash}$`, "mu"));
+    assert.doesNotMatch(rebuilt, new RegExp(`^${legacyHash}$`, "mu"));
     assert.match(rebuilt, new RegExp(`^${currentHash}$`, "mu"));
 
     const memory = (await storage.readAllMemories()).find((entry) => entry.frontmatter.id === "legacy-cafe");
     assert.ok(memory);
     await storage.removeFactContentHashesForMemories([memory]);
-    assert.equal(await storage.hasFactContentHash(body), false);
+    const afterRemoval = new Set(
+      (await readFile(path.join(dir, "state", "fact-hashes.txt"), "utf8"))
+        .split(/\r?\n/u)
+        .filter(Boolean),
+    );
+    assert.equal(afterRemoval.has(legacyHash), false);
+    assert.equal(afterRemoval.has(currentHash), false);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
 });
 
-test("rebuild adds the current body alias for an ambiguous pure-CJK legacy hash", async () => {
+test("rebuild replaces an ambiguous pure-CJK legacy hash with the current body hash", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-cjk-rebuild-"));
   const body = "保存された本文は紅茶についてです。";
   const legacyHash = computeLegacyContentHash(body);
@@ -313,7 +321,7 @@ test("rebuild adds the current body alias for an ambiguous pure-CJK legacy hash"
     const storage = new StorageManager(dir);
     assert.equal(await storage.hasFactContentHash(body), true);
     const rebuilt = await readFile(path.join(dir, "state", "fact-hashes.txt"), "utf8");
-    assert.match(rebuilt, new RegExp(`^${legacyHash}$`, "mu"));
+    assert.doesNotMatch(rebuilt, new RegExp(`^${legacyHash}$`, "mu"));
     assert.match(rebuilt, new RegExp(`^${bodyHash}$`, "mu"));
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/tests/storage-fact-hash-index.test.ts
+++ b/tests/storage-fact-hash-index.test.ts
@@ -243,61 +243,47 @@ test("rebuild preserves an explicit contentHashSource override", async () => {
   }
 });
 
-test("restart migration republishes the current hash for a Unicode fact", async () => {
-  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-unicode-restart-"));
-  const unicodeFact = "利用者は紅茶を好む。";
-  const legacyNormalized = unicodeFact
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  const staleFrontmatterHash = createHash("sha256").update(legacyNormalized).digest("hex");
-  const currentHash = ContentHashIndex.computeHash(unicodeFact);
-
+test("rebuild preserves an ambiguous pure-CJK contentHashSource instead of claiming the body hash", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-cjk-override-rebuild-"));
+  const body = "保存された本文は紅茶についてです。";
+  const override = "外部の識別子は珈琲についてです。";
+  const legacyBody = body.toLowerCase().replace(/[^a-z0-9\s]/g, " ").replace(/\s+/g, " ").trim();
+  const legacyOverride = override.toLowerCase().replace(/[^a-z0-9\s]/g, " ").replace(/\s+/g, " ").trim();
+  const legacyHash = createHash("sha256").update(legacyOverride).digest("hex");
+  const bodyHash = ContentHashIndex.computeHash(body);
   try {
     const factsDir = path.join(dir, "facts", "2026-08-11");
     await mkdir(factsDir, { recursive: true });
     await writeFile(
-      path.join(factsDir, "unicode-legacy.md"),
+      path.join(factsDir, "ambiguous-override.md"),
       [
         "---",
-        "id: unicode-legacy",
+        "id: ambiguous-override",
         "category: fact",
         "created: 2026-08-11T00:00:00.000Z",
         "updated: 2026-08-11T00:00:00.000Z",
-        `contentHash: ${staleFrontmatterHash}`,
+        `contentHash: ${legacyHash}`,
         "---",
         "",
-        unicodeFact,
+        body,
         "",
       ].join("\n"),
       "utf8",
     );
-    const stateDir = path.join(dir, "state");
-    await mkdir(stateDir, { recursive: true });
-    await writeFile(path.join(stateDir, "fact-hashes.txt"), `${staleFrontmatterHash}\n`, "utf8");
 
-    const restarted = new StorageManager(dir);
-    assert.equal(await restarted.hasFactContentHash(unicodeFact), true);
+    assert.equal(legacyBody, legacyOverride);
+    assert.equal(legacyBody, "");
 
-    const republished = await readFile(path.join(stateDir, "fact-hashes.txt"), "utf8");
-    assert.notEqual(currentHash, staleFrontmatterHash);
-    assert.match(republished, /^# remnic-content-hash-index:v2\n/u);
-    assert.match(republished, new RegExp(`^${currentHash}$`, "m"));
-    assert.doesNotMatch(republished, new RegExp(`^${staleFrontmatterHash}$`, "m"));
-    const secondRestart = new StorageManager(dir);
-    assert.equal(
-      await secondRestart.hasFactContentHash(unicodeFact),
-      true,
-      "the current Unicode hash must survive a second restart",
-    );
-    const republishedAgain = await readFile(path.join(stateDir, "fact-hashes.txt"), "utf8");
-    assert.match(republishedAgain, new RegExp(`^${currentHash}$`, "m"));
-    assert.doesNotMatch(republishedAgain, new RegExp(`^${staleFrontmatterHash}$`, "m"));
+    const storage = new StorageManager(dir);
+    assert.equal(await storage.hasFactContentHash(body), false);
+    const rebuilt = await readFile(path.join(dir, "state", "fact-hashes.txt"), "utf8");
+    assert.match(rebuilt, new RegExp(`^${legacyHash}$`, "mu"));
+    assert.doesNotMatch(rebuilt, new RegExp(`^${bodyHash}$`, "mu"));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
 });
+
 
 test("rebuild from disk: fact written without contentHashSource uses body hash via frontmatter.contentHash", async () => {
   // NOTE: StorageManager.writeMemory always sets contentHash in frontmatter

--- a/tests/storage-fact-hash-index.test.ts
+++ b/tests/storage-fact-hash-index.test.ts
@@ -328,6 +328,41 @@ test("rebuild replaces an ambiguous pure-CJK legacy hash with the current body h
   }
 });
 
+test("rebuild preserves every recoverable identity behind an ambiguous legacy hash", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-ambiguous-source-"));
+  const rawBody = "利用者は紅茶を好む。";
+  const citationTemplate = "【出典：{agent}／{sessionId}】";
+  const storedBody = `${rawBody} 【出典：計画／主】`;
+  const legacyHash = computeLegacyContentHash(rawBody);
+  try {
+    const factsDir = path.join(dir, "facts", "2026-08-11");
+    await mkdir(factsDir, { recursive: true });
+    await writeFile(
+      path.join(factsDir, "legacy-ambiguous-source.md"),
+      [
+        "---",
+        "id: legacy-ambiguous-source",
+        "category: fact",
+        "created: 2026-08-11T00:00:00.000Z",
+        "updated: 2026-08-11T00:00:00.000Z",
+        `contentHash: ${legacyHash}`,
+        "---",
+        "",
+        storedBody,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const storage = new StorageManager(dir);
+    storage.citationTemplate = citationTemplate;
+    assert.equal(await storage.hasFactContentHash(rawBody), true);
+    assert.equal(await storage.hasFactContentHash(storedBody), true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 
 test("rebuild upgrades a legacy hash that includes structured attributes", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-fact-hash-attribute-rebuild-"));


### PR DESCRIPTION
## Summary

- preserve Unicode letters, combining marks, and numbers when computing content hashes
- normalize canonical equivalents to NFC and version the durable hash index so legacy hashes cannot suppress new writes
- make statement dedup Unicode-aware, including CJK/Hangul tokenization and punctuation-boundary safety
- rebuild tombstone-blocked capture indexes before treating migrated state as authoritative

Closes #2186

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Dependency / release

## Validation

- [x] Added/updated regression tests for behavior changes
- [x] `pnpm --filter @remnic/core check-types`
- [x] Focused 108-test Unicode/hash/index suite
- [x] `pnpm run check:ratchets`
- [x] `bash scripts/check-review-patterns.sh`
- [x] `pnpm run test:entity-hardening`
- [x] Full root `pnpm run check-types && pnpm run build && pnpm test` (18,455 tests; 0 failures)

## Risk assessment

- No secrets or tokens added.
- Existing ASCII normalization remains equivalent.
- The persisted index format intentionally advances to v2; markerless legacy hashes are ignored until an authoritative corpus rebuild publishes v2, preventing stale collisions.
- NFC and NFD forms now converge by design.

## Notes for reviewers

Please review the hash-index migration and CJK/Hangul similarity boundary behavior closely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches durable identity, dedup, and tombstone non-resurrection paths, including on-disk hash-index and tombstone migrations that can suppress or unblock writes.
> 
> **Overview**
> Fixes content hashing and statement dedup so Unicode letters, marks, and numbers are preserved under **NFC**, instead of being stripped by the old ASCII-only normalizer (which collapsed distinct CJK facts onto empty hashes).
> 
> **Migrates persisted identities safely.** Tombstones and the fact-hash index are versioned; legacy hashes are only remapped after source-verified matching of raw/cited/attributed body forms. Ambiguous legacy aliases stay unpublished so they cannot suppress unrelated Unicode writes or resurrect retired memories. Reconcile manifests use the same identity selection.
> 
> **Makes statement dedup CJK-aware**, with Hangul/Japanese tokenization and embedded-punctuation boundary checks so scripts without whitespace compare correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087c16438ade09b3cb936d2cfa66525f2e46e4f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content hashing now preserves Unicode text and treats NFC/NFD representations consistently.
  * Improved duplicate detection for Japanese, Korean, and other CJK content.
  * Added compatibility handling for content created with older hashing behavior.
* **Bug Fixes**
  * Prevented legacy hash entries from incorrectly suppressing new writes.
  * Improved index rebuilding and persistence during concurrent updates or temporary lock failures.
  * Preserved tombstone and resurrection behavior during hash migrations.
* **Tests**
  * Added coverage for Unicode normalization, migration, restart persistence, and CJK deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->